### PR TITLE
Prefix JSONAPI middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,11 +67,11 @@ install:
   - travis_wait lerna bootstrap
   - wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
-  - ./elasticsearch-${ES_VERSION}/bin/elasticsearch 2>&1 >> /dev/null &
+  - ./elasticsearch-${ES_VERSION}/bin/elasticsearch 2>&1 > /tmp/es.log &
 
 before_script:
  - export DISPLAY=:99; sh -e /etc/init.d/xvfb start; sleep 3
- - wget -q --waitretry=1 --retry-connrefused -T 1 -O - http://127.0.0.1:9200
+ - wget -q --waitretry=1 --retry-connrefused -T 1 -O - http://127.0.0.1:9200 || cat /tmp/es.log
 
 script:
   - yarn test

--- a/packages/ephemeral/node-tests/ephemeral-test.js
+++ b/packages/ephemeral/node-tests/ephemeral-test.js
@@ -56,7 +56,7 @@ describe('ephemeral-storage', function() {
   });
 
   it('can create a new record', async function() {
-    let response = await request.post('/posts').send({
+    let response = await request.post('/api/posts').send({
       data: {
         type: "posts",
         attributes: {
@@ -71,16 +71,16 @@ describe('ephemeral-storage', function() {
 
     await env.lookup('hub:indexers').update({ realTime: true });
 
-    response = await request.get(`/posts/${response.body.data.id}`);
+    response = await request.get(`/api/posts/${response.body.data.id}`);
     expect(response).hasStatus(200);
     expect(response.body).has.deep.property('data.attributes.title', 'hello');
   });
 
   it('can update a record', async function() {
-    let response = await request.get('/posts/first-post');
+    let response = await request.get('/api/posts/first-post');
     expect(response).hasStatus(200);
     expect(response.body).has.deep.property('data.meta.version');
-    response = await request.patch('/posts/first-post').send({
+    response = await request.patch('/api/posts/first-post').send({
       data: {
         attributes: {
           body: 'Updated body'
@@ -98,7 +98,7 @@ describe('ephemeral-storage', function() {
 
     await env.lookup('hub:indexers').update({ realTime: true });
 
-    response = await request.get('/posts/first-post');
+    response = await request.get('/api/posts/first-post');
     expect(response).hasStatus(200);
     expect(response.body.data.attributes).deep.equals({
       body: 'Updated body',
@@ -107,10 +107,10 @@ describe('ephemeral-storage', function() {
   });
 
   it('enforces meta.version consistency during update', async function() {
-    let response = await request.get('/posts/first-post');
+    let response = await request.get('/api/posts/first-post');
     expect(response).hasStatus(200);
     expect(response.body).has.deep.property('data.meta.version');
-    response = await request.patch('/posts/first-post').send({
+    response = await request.patch('/api/posts/first-post').send({
       data: {
         attributes: {
           body: 'Updated body'
@@ -125,24 +125,24 @@ describe('ephemeral-storage', function() {
 
 
   it('can delete a record', async function() {
-    let response = await request.get('/posts/first-post');
+    let response = await request.get('/api/posts/first-post');
     expect(response).hasStatus(200);
     expect(response.body).has.deep.property('data.meta.version');
-    response = await request.delete('/posts/first-post').set('If-Match', response.body.data.meta.version);
+    response = await request.delete('/api/posts/first-post').set('If-Match', response.body.data.meta.version);
     expect(response).hasStatus(204);
 
     await env.lookup('hub:indexers').update({ realTime: true });
 
-    response = await request.get('/posts/first-post');
+    response = await request.get('/api/posts/first-post');
     expect(response).hasStatus(404);
   });
 
 
   it('enforces meta.version consistency during delete', async function() {
-    let response = await request.get('/posts/first-post');
+    let response = await request.get('/api/posts/first-post');
     expect(response).hasStatus(200);
     expect(response.body).has.deep.property('data.meta.version');
-    response = await request.delete('/posts/first-post').set('If-Match', 'not-valid');
+    response = await request.delete('/api/posts/first-post').set('If-Match', 'not-valid');
     expect(response).hasStatus(409);
   });
 

--- a/packages/jsonapi/node-tests/middleware-test.js
+++ b/packages/jsonapi/node-tests/middleware-test.js
@@ -6,6 +6,7 @@ const {
 } = require('@cardstack/test-support/env');
 const { currentVersion } = require('./support');
 const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
+const log = require('@cardstack/plugin-utils/logger')('jsonapi-test');
 
 describe('jsonapi/middleware', function() {
 
@@ -56,6 +57,10 @@ describe('jsonapi/middleware', function() {
 
     let app = new Koa();
     env = await createDefaultEnvironment(__dirname + '/../', factory.getModels());
+    app.use(async function(ctxt, next) {
+      await next();
+      log.info('%s %s %s', ctxt.request.method, ctxt.request.originalUrl, ctxt.response.status);
+    });
     app.use(env.lookup('hub:middleware-stack').middleware());
     request = supertest(app.callback());
   }
@@ -73,7 +78,7 @@ describe('jsonapi/middleware', function() {
     after(sharedTeardown);
 
     it('can get an individual resource', async function() {
-      let response = await request.get('/articles/0');
+      let response = await request.get('/api/articles/0');
       expect(response).hasStatus(200);
       expect(response.body).deep.property('data.id', '0');
       expect(response.body).deep.property('data.attributes.title', 'Hello world');
@@ -81,13 +86,13 @@ describe('jsonapi/middleware', function() {
     });
 
     it('returns 404 for missing individual resource', async function() {
-      let response = await request.get('/articles/98766');
+      let response = await request.get('/api/articles/98766');
       expect(response).hasStatus(404);
       expect(response.body).to.have.deep.property('errors[0].detail', 'No such resource master/articles/98766');
     });
 
     it('can get a collection resource', async function() {
-      let response = await request.get('/articles');
+      let response = await request.get('/api/articles');
       expect(response).hasStatus(200);
       expect(response.body).to.have.property('data');
       expect(response.body).to.have.deep.property('meta.total', 2);
@@ -97,7 +102,7 @@ describe('jsonapi/middleware', function() {
     });
 
     it('can sort a collection resource', async function() {
-      let response = await request.get('/articles?sort=title');
+      let response = await request.get('/api/articles?sort=title');
       expect(response).hasStatus(200);
       expect(response.body).to.have.property('data');
       expect(response.body).has.deep.property('data[0].attributes.title', 'Hello world');
@@ -105,7 +110,7 @@ describe('jsonapi/middleware', function() {
     });
 
     it('can reverse sort a collection resource', async function() {
-      let response = await request.get('/articles?sort=-title');
+      let response = await request.get('/api/articles?sort=-title');
       expect(response).hasStatus(200);
       expect(response.body).has.property('data');
       expect(response.body).has.deep.property('data[1].attributes.title', 'Hello world');
@@ -113,7 +118,7 @@ describe('jsonapi/middleware', function() {
     });
 
     it('can filter a collection resource', async function() {
-      let response = await request.get('/articles?filter[title]=world');
+      let response = await request.get('/api/articles?filter[title]=world');
       expect(response).hasStatus(200);
       expect(response.body).has.property('data');
       expect(response.body.data).length(1);
@@ -121,7 +126,7 @@ describe('jsonapi/middleware', function() {
     });
 
     it('can use query string', async function() {
-      let response = await request.get('/articles?q=second');
+      let response = await request.get('/api/articles?q=second');
       expect(response).hasStatus(200);
       expect(response.body).has.property('data');
       expect(response.body.data).length(1);
@@ -129,20 +134,22 @@ describe('jsonapi/middleware', function() {
     });
 
     it('can paginate a collection resource', async function() {
-      let response = await request.get('/articles?page[size]=1&sort=title');
+      let response = await request.get('/api/articles?page[size]=1&sort=title');
       expect(response).hasStatus(200, 'first request');
       expect(response.body.data).length(1);
       expect(response.body).has.deep.property('data[0].attributes.title', 'Hello world');
       expect(response.body).has.deep.property('links.next');
 
-      response = await request.get(response.body.links.next);
+      let nextLink = makeRelativeLink(response, response.body.links.next);
+
+      response = await request.get(nextLink);
       expect(response).hasStatus(200, 'second request');
       expect(response.body).has.deep.property('data[0].attributes.title', 'Second');
       expect(response.body.data).length(1);
     });
 
     it('gets 403 when creating unknown resource', async function() {
-      let response = await request.post('/bogus').send({
+      let response = await request.post('/api/bogus').send({
         data: {
           type: 'bogus',
           attributes: {
@@ -155,21 +162,21 @@ describe('jsonapi/middleware', function() {
     });
 
     it('gets 400 when creating a resource with no body', async function() {
-      let response = await request.post('/articles');
+      let response = await request.post('/api/articles');
       expect(response.status).to.equal(400);
       expect(response.body).has.deep.property('errors[0].detail', 'A body with a top-level "data" property is required');
     });
 
     it('gets 400 when creating a resource with no data property', async function() {
-      let response = await request.post('/articles').send({datum: {}});
+      let response = await request.post('/api/articles').send({datum: {}});
       expect(response.status).to.equal(400);
       expect(response.body).has.deep.property('errors[0].detail', 'A body with a top-level "data" property is required');
     });
 
     it('gets 404 when patching a missing resource', async function() {
-      let version = await currentVersion(request, '/articles/0');
+      let version = await currentVersion(request, '/api/articles/0');
 
-      let response = await request.patch('/articles/100').send({
+      let response = await request.patch('/api/articles/100').send({
         data: {
           id: '100',
           type: 'articles',
@@ -184,20 +191,20 @@ describe('jsonapi/middleware', function() {
     });
 
     it('refuses to delete without version', async function() {
-      let response = await request.delete('/articles/0');
+      let response = await request.delete('/api/articles/0');
       expect(response).hasStatus(400);
       expect(response.body).has.deep.property('errors[0].detail', "version is required");
       expect(response.body).has.deep.property('errors[0].source.header', 'If-Match');
     });
 
     it('refuses to delete with invalid version', async function() {
-      let response = await request.delete('/articles/0').set('If-Match', 'xxx');
+      let response = await request.delete('/api/articles/0').set('If-Match', 'xxx');
       expect(response).hasStatus(409);
       expect(response.body).has.deep.property('errors[0].source.header', 'If-Match');
     });
 
     it('validates schema during POST', async function() {
-      let response = await request.post('/articles').send({
+      let response = await request.post('/api/articles').send({
         data: {
           type: 'articles',
           attributes: {
@@ -220,8 +227,8 @@ describe('jsonapi/middleware', function() {
     });
 
     it('validates schema during PATCH', async function() {
-      let version = await currentVersion(request, '/articles/0');
-      let response = await request.patch('/articles/0').send({
+      let version = await currentVersion(request, '/api/articles/0');
+      let response = await request.patch('/api/articles/0').send({
         data: {
           id: '0',
           type: 'articles',
@@ -254,7 +261,7 @@ describe('jsonapi/middleware', function() {
     afterEach(sharedTeardown);
 
     it('can create a new resource', async function() {
-      let response = await request.post('/articles').send({
+      let response = await request.post('/api/articles').send({
         data: {
           type: 'articles',
           attributes: {
@@ -272,16 +279,16 @@ describe('jsonapi/middleware', function() {
 
       await env.lookup('hub:indexers').update({ realTime: true });
 
-      response = await request.get(response.headers.location);
+      response = await request.get(makeRelativeLink(response, response.headers.location));
       expect(response).hasStatus(200);
       expect(response.body).has.deep.property('data.attributes.title', 'I am new', 'second time');
 
     });
 
     it('can update an existing resource', async function() {
-      let version = await currentVersion(request, '/articles/0');
+      let version = await currentVersion(request, '/api/articles/0');
 
-      let response = await request.patch('/articles/0').send({
+      let response = await request.patch('/api/articles/0').send({
         data: {
           id: '0',
           type: 'articles',
@@ -298,7 +305,7 @@ describe('jsonapi/middleware', function() {
 
       await env.lookup('hub:indexers').update({ realTime: true });
 
-      response = await request.get('/articles/0');
+      response = await request.get('/api/articles/0');
       expect(response).hasStatus(200);
       expect(response).has.deep.property('body.data.attributes.title', 'Updated title', 'second time');
       expect(response).has.deep.property('body.data.attributes.body', "This is the first article", 'second time');
@@ -306,14 +313,14 @@ describe('jsonapi/middleware', function() {
     });
 
     it('can delete a resource', async function() {
-      let version = await currentVersion(request, '/articles/0');
+      let version = await currentVersion(request, '/api/articles/0');
 
-      let response = await request.delete('/articles/0').set('If-Match', version);
+      let response = await request.delete('/api/articles/0').set('If-Match', version);
       expect(response).hasStatus(204);
 
       await env.lookup('hub:indexers').update({ realTime: true });
 
-      response = await request.get('/articles/0');
+      response = await request.get('/api/articles/0');
       expect(response).hasStatus(404);
     });
 
@@ -326,7 +333,7 @@ describe('jsonapi/middleware', function() {
 
     it('applies authorization during create', async function() {
       await env.setUserId(null);
-      let response = await request.post('/articles').send({
+      let response = await request.post('/api/articles').send({
         data: {
           type: 'articles',
           attributes: {
@@ -340,8 +347,8 @@ describe('jsonapi/middleware', function() {
 
     it('applies authorization during update', async function() {
       await env.setUserId(null);
-      let version = await currentVersion(request, '/articles/0');
-      let response = await request.patch('/articles/0').send({
+      let version = await currentVersion(request, '/api/articles/0');
+      let response = await request.patch('/api/articles/0').send({
         data: {
           id: '0',
           type: 'articles',
@@ -356,11 +363,20 @@ describe('jsonapi/middleware', function() {
 
     it('applies authorization during delete', async function() {
       await env.setUserId(null);
-      let version = await currentVersion(request, '/articles/0');
-      let response = await request.delete('/articles/0').set('If-Match', version);
+      let version = await currentVersion(request, '/api/articles/0');
+      let response = await request.delete('/api/articles/0').set('If-Match', version);
       expect(response).hasStatus(401);
     });
 
 
   });
 });
+
+function makeRelativeLink(response, url) {
+  let host = response.req.getHeader('host');
+  let origin = `http://${host}`;
+  if (url.indexOf(origin) !== 0) {
+    throw new Error(`expected ${url} to have origin ${origin}`);
+  }
+  return url.replace(origin, '');
+}

--- a/packages/models/addon/adapter.js
+++ b/packages/models/addon/adapter.js
@@ -6,5 +6,5 @@ import AdapterMixin from 'ember-resource-metadata/adapter-mixin';
 import Branchable from '@cardstack/tools/mixins/branch-adapter';
 
 export default DS.JSONAPIAdapter.extend(AdapterMixin, Branchable, {
-  namespace: 'cardstack'
+  namespace: 'cardstack/api'
 });

--- a/packages/models/tests/dummy/app/adapters/post.js
+++ b/packages/models/tests/dummy/app/adapters/post.js
@@ -1,5 +1,5 @@
 import DS from 'ember-data';
 
 export default DS.JSONAPIAdapter.extend({
-  namespace: '/cardstack'
+  namespace: 'cardstack/api'
 });

--- a/packages/tools/tests/dummy/app/adapters/page.js
+++ b/packages/tools/tests/dummy/app/adapters/page.js
@@ -3,5 +3,5 @@ import Branchable from '@cardstack/tools/mixins/branch-adapter';
 import DS from 'ember-data';
 
 export default DS.JSONAPIAdapter.extend(AdapterMixin, Branchable, {
-  namespace: 'cardstack'
+  namespace: 'cardstack/api'
 });


### PR DESCRIPTION
The jsonapi middleware doesn't play nicely with others because it matches every possible path, so no other middleware can ever be sorted after it.

This change gives it a default prefix of /api, so

    /cardstack/articles/1

now becomes

    /cardstack/api/articles/1

While fixing this I also uncovered two places where we were returning relative URLs that should have been absolute (the Location header and the next link used for pagination).