### PR TITLE
Start containerizing @cardstack/hub

### DIFF
--- a/packages/hub/bin/server.js
+++ b/packages/hub/bin/server.js
@@ -9,11 +9,8 @@ async function runServer(options, seedModels) {
   let {
     sessionsKey,
     port,
-    allowDevDependencies
   } = options;
-  let app = await makeServer(process.cwd(), sessionsKey, seedModels, {
-    allowDevDependencies
-  });
+  let app = await makeServer(process.cwd(), sessionsKey, seedModels, options);
   app.listen(port);
   log.info("server listening on %s", port);
 }
@@ -21,8 +18,9 @@ async function runServer(options, seedModels) {
 function commandLineOptions() {
   commander
     .usage('[options] <seed-config-directory>')
-    .option('-p --port <port>', 'Server listen port.', 3000)
-    .option('-d --allow-dev-dependencies', 'Allow the hub to load devDependencies.', 3000)
+    .option('-p --port <port>', 'Server listen port', 3000)
+    .option('-d --allow-dev-dependencies', 'Allow the hub to load devDependencies')
+    .option('-c --containerized', 'Run the hub in container mode (temporary feature flag)')
     .parse(process.argv);
 
   if (commander.args.length < 1) {

--- a/packages/hub/ember-connection.js
+++ b/packages/hub/ember-connection.js
@@ -35,4 +35,4 @@ module.exports = class EmberConnector {
     this._server.listen(6785);
     log.info('Listening for connections from ember-cli...');
   }
-}
+};

--- a/packages/hub/ember-connection.js
+++ b/packages/hub/ember-connection.js
@@ -2,11 +2,12 @@ const nssocket = require('nssocket');
 const _ = require('lodash');
 
 const orchestrator = require('./orchestrator');
+const log = require('@cardstack/plugin-utils/logger')('ember-connection');
 
 const HUB_HEARTBEAT_TIMEOUT = 1.5 * 1000; // longer than the heartbeat interval of 1 second
 
 const stopLater = _.debounce(function() {
-  console.log('No heartbeat from ember-cli! Shutting down.');
+  log.info('No heartbeat from ember-cli! Shutting down.');
   orchestrator.stop();
 }, HUB_HEARTBEAT_TIMEOUT);
 
@@ -14,7 +15,7 @@ const stopLater = _.debounce(function() {
 module.exports = class EmberConnector {
   constructor(readyPromise) {
     this._server = nssocket.createServer(async function(socket) {
-      console.log('connection established from ember-cli');
+      log.info('connection established from ember-cli');
       await readyPromise;
 
       // Ember-cli may shut us down manually.
@@ -32,6 +33,6 @@ module.exports = class EmberConnector {
     });
 
     this._server.listen(6785);
-    console.log('Listening for connections from ember-cli...');
+    log.info('Listening for connections from ember-cli...');
   }
 }

--- a/packages/hub/ember-connection.js
+++ b/packages/hub/ember-connection.js
@@ -1,0 +1,6 @@
+
+module.exports = class EmberConnector {
+  constructor(readyPromise) {
+    console.log('ok, totally listening for ember-cli connections');
+  }
+}

--- a/packages/hub/ember-connection.js
+++ b/packages/hub/ember-connection.js
@@ -29,7 +29,16 @@ module.exports = class EmberConnector {
 
       // Our listeners are set up, and whoever instantiated us said we're good,
       // so tell ember-cli everything is ready.
-      socket.send('ready');
+      try {
+        socket.send('ready');
+      } catch (err) {
+        // This happens if ember-cli stopped while we were awaiting readyPromise
+        if (/bad socket/.test(err)) {
+          log.warn('Ember-cli shut down while the hub was starting. *sigh*');
+        } else {
+          throw err;
+        }
+      }
 
       // If we never hear the initial heartbeat from ember-cli, we want to shut down
       stopLater();

--- a/packages/hub/ember-connection.js
+++ b/packages/hub/ember-connection.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const orchestrator = require('./orchestrator');
 const log = require('@cardstack/plugin-utils/logger')('ember-connection');
 
-const HUB_HEARTBEAT_TIMEOUT = 1.5 * 1000; // longer than the heartbeat interval of 1 second
+const HUB_HEARTBEAT_TIMEOUT = 7.5 * 1000; // longer than the heartbeat interval of 1 second
 
 const stopLater = _.debounce(function() {
   log.info('No heartbeat from ember-cli! Shutting down.');
@@ -22,7 +22,10 @@ module.exports = class EmberConnector {
       // Or, if it crashes or is killed it will stop sending the heartbeat
       // and we can clean ourselves up.
       socket.data('shutdown', orchestrator.stop);
-      socket.data('heartbeat', stopLater);
+      socket.data('heartbeat', function(){
+        log.trace('Received a heartbeat from ember-cli');
+        stopLater();
+      });
 
       // Our listeners are set up, and whoever instantiated us said we're good,
       // so tell ember-cli everything is ready.

--- a/packages/hub/ember-connection.js
+++ b/packages/hub/ember-connection.js
@@ -1,6 +1,37 @@
+const nssocket = require('nssocket');
+const _ = require('lodash');
+
+const orchestrator = require('./orchestrator');
+
+const HUB_HEARTBEAT_TIMEOUT = 1.5 * 1000; // longer than the heartbeat interval of 1 second
+
+const stopLater = _.debounce(function() {
+  console.log('No heartbeat from ember-cli! Shutting down.');
+  orchestrator.stop();
+}, HUB_HEARTBEAT_TIMEOUT);
+
 
 module.exports = class EmberConnector {
   constructor(readyPromise) {
-    console.log('ok, totally listening for ember-cli connections');
+    this._server = nssocket.createServer(async function(socket) {
+      console.log('connection established from ember-cli');
+      await readyPromise;
+
+      // Ember-cli may shut us down manually.
+      // Or, if it crashes or is killed it will stop sending the heartbeat
+      // and we can clean ourselves up.
+      socket.data('shutdown', orchestrator.stop);
+      socket.data('heartbeat', stopLater);
+
+      // Our listeners are set up, and whoever instantiated us said we're good,
+      // so tell ember-cli everything is ready.
+      socket.send('ready');
+
+      // If we never hear the initial heartbeat from ember-cli, we want to shut down
+      stopLater();
+    });
+
+    this._server.listen(6785);
+    console.log('Listening for connections from ember-cli...');
   }
 }

--- a/packages/hub/index.js
+++ b/packages/hub/index.js
@@ -13,8 +13,8 @@ const CONTAINER_MODE = process.env.CONTAINERIZED_HUB != null;
 if (CONTAINER_MODE) {
   startAndProxyToHubContainer = require('./start-hub-container');
 } else {
- BroccoliConnector = require('./broccoli-connector');
- Funnel = require('broccoli-funnel');
+  BroccoliConnector = require('./broccoli-connector');
+  Funnel = require('broccoli-funnel');
 }
 
 // TODO: move into configuration

--- a/packages/hub/index.js
+++ b/packages/hub/index.js
@@ -2,14 +2,25 @@ const { makeServer } = require('./main');
 const path = require('path');
 const crypto = require('crypto');
 const fs = require('fs');
-const Funnel = require('broccoli-funnel');
 const log = require('@cardstack/plugin-utils/logger')('hub/main');
-const BroccoliConnector = require('./broccoli-connector');
+// only sometimes load, because of feature flag
+let BroccoliConnector;
+let Funnel;
+let startAndProxyToHubContainer;
+
+const CONTAINER_MODE = process.env.CONTAINERIZED_HUB != null;
+
+if (CONTAINER_MODE) {
+  startAndProxyToHubContainer = require('./start-hub-container');
+} else {
+ BroccoliConnector = require('./broccoli-connector');
+ Funnel = require('broccoli-funnel');
+}
 
 // TODO: move into configuration
 const defaultBranch = 'master';
 
-module.exports = {
+let addon = {
   name: '@cardstack/hub',
 
   init() {
@@ -25,7 +36,9 @@ module.exports = {
       global.__cardstack_hub_running_in_ember_cli = true;
       this._active = true;
     }
-    this._broccoliConnector = new BroccoliConnector();
+    if (!CONTAINER_MODE) {
+      this._broccoliConnector = new BroccoliConnector();
+    }
   },
 
   included(app){
@@ -36,7 +49,9 @@ module.exports = {
     this._super.apply(this, arguments);
     if (!this._active){ return; }
 
-    app.import('vendor/cardstack/generated.js');
+    if (!CONTAINER_MODE) {
+      app.import('vendor/cardstack/generated.js');
+    }
 
     if (!process.env.ELASTICSEARCH_PREFIX) {
       process.env.ELASTICSEARCH_PREFIX = this.project.pkg.name.replace(/^[^a-zA-Z]*/, '').replace(/[^a-zA-Z0-9]/g, '_') + '_' + env;
@@ -46,43 +61,24 @@ module.exports = {
     // hooks won't resolve until the hub does its first codegen build,
     // and the middleware hooks won't run until after that.
 
-    let seedPath = path.join(path.dirname(this.project.configPath()), '..', 'cardstack', 'seeds', env);
-    let useDevDeps;
-    if (env === 'test') {
-      useDevDeps = true;
+    if (CONTAINER_MODE) {
+      this._hubProxy = startAndProxyToHubContainer();
     } else {
-      // if the hub is a runtime dependency, it should only load other
-      // plugins that are also runtime dependencies. If it's a
-      // devDependency, it will also load other plugins that are
-      // devDependencies.
-      let { pkg } = this.project;
-      useDevDeps = !(pkg.dependencies && pkg.dependencies['@cardstack/hub']);
-    }
-    this._hubMiddleware = this._makeServer(seedPath, this.project.ui, useDevDeps, env);
-  },
+      let seedPath = path.join(path.dirname(this.project.configPath()), '..', 'cardstack', 'seeds', env);
+      let useDevDeps;
+      if (env === 'test') {
+        useDevDeps = true;
+      } else {
+        // if the hub is a runtime dependency, it should only load other
+        // plugins that are also runtime dependencies. If it's a
+        // devDependency, it will also load other plugins that are
+        // devDependencies.
+        let { pkg } = this.project;
+        useDevDeps = !(pkg.dependencies && pkg.dependencies['@cardstack/hub']);
+      }
 
-  buildError: function(error) {
-    if (this._broccoliConnector) {
-      this._broccoliConnector.buildFailed(error);
+      this._hubMiddleware = this._makeServer(seedPath, this.project.ui, useDevDeps, env);
     }
-  },
-
-  postBuild: function(results) {
-    if (this._broccoliConnector) {
-      this._broccoliConnector.buildSucceeded(results);
-    }
-  },
-
-  treeForVendor() {
-    if (!this._active){
-      this._super.apply(this, arguments);
-      return;
-    }
-
-    return new Funnel(this._broccoliConnector.tree, {
-      srcDir: defaultBranch,
-      destDir: 'cardstack'
-    });
   },
 
   // The serverMiddleware hook is well-behaved and will wait for us to
@@ -93,7 +89,11 @@ module.exports = {
       return;
     }
 
-    app.use('/cardstack', await this._hubMiddleware);
+    if (CONTAINER_MODE) {
+      app.use('/cardstack', await this._hubProxy);
+    } else {
+      app.use('/cardstack', await this._hubMiddleware);
+    }
   },
 
   // testemMiddleware will not wait for a promise, so we need to
@@ -127,9 +127,35 @@ module.exports = {
         res.end();
       }
     });
-  },
+  }
+};
 
-  async _makeServer(seedDir, ui, allowDevDependencies, env) {
+if (!CONTAINER_MODE) {
+  addon.buildError = function(error) {
+    if (this._broccoliConnector) {
+      this._broccoliConnector.buildFailed(error);
+    }
+  };
+
+  addon.postBuild = function(results) {
+    if (this._broccoliConnector) {
+      this._broccoliConnector.buildSucceeded(results);
+    }
+  };
+
+  addon.treeForVendor = function() {
+    if (!this._active){
+      this._super.apply(this, arguments);
+      return;
+    }
+
+    return new Funnel(this._broccoliConnector.tree, {
+      srcDir: defaultBranch,
+      destDir: 'cardstack'
+    });
+  };
+
+  addon._makeServer = async function(seedDir, ui, allowDevDependencies, env) {
     log.debug("Looking for seed files in %s", seedDir);
     let seedModels;
     try {
@@ -173,6 +199,7 @@ module.exports = {
       this._broccoliConnector.setSource(Promise.reject(err));
       throw err;
     }
-  }
+  };
+}
 
-};
+module.exports = addon;

--- a/packages/hub/index.js
+++ b/packages/hub/index.js
@@ -62,7 +62,7 @@ let addon = {
     // and the middleware hooks won't run until after that.
 
     if (CONTAINER_MODE) {
-      this._hubProxy = startAndProxyToHubContainer();
+      this._hubProxy = startAndProxyToHubContainer(this.project.root);
     } else {
       let seedPath = path.join(path.dirname(this.project.configPath()), '..', 'cardstack', 'seeds', env);
       let useDevDeps;

--- a/packages/hub/index.js
+++ b/packages/hub/index.js
@@ -2,7 +2,7 @@ const { makeServer } = require('./main');
 const path = require('path');
 const crypto = require('crypto');
 const fs = require('fs');
-const log = require('@cardstack/plugin-utils/logger')('hub/main');
+const log = require('@cardstack/plugin-utils/logger')('hub/ember-cli');
 // only sometimes load, because of feature flag
 let BroccoliConnector;
 let Funnel;

--- a/packages/hub/index.js
+++ b/packages/hub/index.js
@@ -90,6 +90,7 @@ let addon = {
     }
 
     if (CONTAINER_MODE) {
+      // FIXME: this prevents shutdown while it's pending, even in response to a user SIGINT
       app.use('/cardstack', await this._hubProxy);
     } else {
       app.use('/cardstack', await this._hubMiddleware);

--- a/packages/hub/main.js
+++ b/packages/hub/main.js
@@ -44,10 +44,12 @@ async function makeServer(projectDir, encryptionKeys, seedModels, opts = {}) {
     await orchestration;
   }
 
+  log.info('Starting main hub server');
   let container = await wireItUp(projectDir, encryptionKeys, seedModels, opts);
   let app = new Koa();
   app.use(httpLogging);
   app.use(container.lookup('hub:middleware-stack').middleware());
+  log.info('Main hub initialized');
   return app;
 }
 

--- a/packages/hub/main.js
+++ b/packages/hub/main.js
@@ -38,7 +38,9 @@ async function makeServer(projectDir, encryptionKeys, seedModels, opts = {}) {
   if (opts.containerized) {
     log.debug('Running in container mode');
     let orchestration = orchestrator.start();
-    let connection = new EmberConnection(orchestration);
+    // Eventually we'll pass a connection instance into the hub, for triggering rebuilds.
+    // For now, it just has the side effect of shutting the hub down properly when it's time.
+    new EmberConnection(orchestration);
     await orchestration;
   }
 

--- a/packages/hub/main.js
+++ b/packages/hub/main.js
@@ -1,5 +1,7 @@
 const Koa = require('koa');
 const { Registry, Container } = require('@cardstack/di');
+const orchestrator = require('./orchestrator');
+const EmberConnection = require('./ember-connection');
 
 const logger = require('@cardstack/plugin-utils/logger');
 const log = logger('server');
@@ -33,6 +35,13 @@ async function wireItUp(projectDir, encryptionKeys, seedModels, opts = {}) {
 }
 
 async function makeServer(projectDir, encryptionKeys, seedModels, opts = {}) {
+  if (opts.containerized) {
+    console.log('Running in container mode...');
+    let orchestration = orchestrator.start();
+    let connection = new EmberConnection(orchestration);
+    await orchestration;
+  }
+
   let container = await wireItUp(projectDir, encryptionKeys, seedModels, opts);
   let app = new Koa();
   app.use(httpLogging);

--- a/packages/hub/main.js
+++ b/packages/hub/main.js
@@ -1,7 +1,8 @@
 const Koa = require('koa');
 const { Registry, Container } = require('@cardstack/di');
-const orchestrator = require('./orchestrator');
-const EmberConnection = require('./ember-connection');
+// lazy load only in container mode, since they uses node 8 features
+let EmberConnection;
+let orchestrator;
 
 const logger = require('@cardstack/plugin-utils/logger');
 const log = logger('server');
@@ -37,6 +38,9 @@ async function wireItUp(projectDir, encryptionKeys, seedModels, opts = {}) {
 async function makeServer(projectDir, encryptionKeys, seedModels, opts = {}) {
   if (opts.containerized) {
     log.debug('Running in container mode');
+    // lazy loading
+    orchestrator = orchestrator || require('./orchestrator');
+    EmberConnection = EmberConnection || require('./ember-connection');
     let orchestration = orchestrator.start();
     // Eventually we'll pass a connection instance into the hub, for triggering rebuilds.
     // For now, it just has the side effect of shutting the hub down properly when it's time.

--- a/packages/hub/main.js
+++ b/packages/hub/main.js
@@ -36,7 +36,7 @@ async function wireItUp(projectDir, encryptionKeys, seedModels, opts = {}) {
 
 async function makeServer(projectDir, encryptionKeys, seedModels, opts = {}) {
   if (opts.containerized) {
-    console.log('Running in container mode...');
+    log.debug('Running in container mode');
     let orchestration = orchestrator.start();
     let connection = new EmberConnection(orchestration);
     await orchestration;

--- a/packages/hub/orchestrator.js
+++ b/packages/hub/orchestrator.js
@@ -10,7 +10,6 @@ function stop() {
   process.exit();
 }
 
-
 module.exports = {
   start,
   stop

--- a/packages/hub/orchestrator.js
+++ b/packages/hub/orchestrator.js
@@ -1,11 +1,12 @@
+const log = require('@cardstack/plugin-utils/logger')('orchestrator');
 
 function start() {
-  console.log('totally starting everything up');
+  log.info('totally starting everything up');
   return Promise.resolve();
 }
 
 function stop() {
-  console.log('ok, everything totally shut down successfully');
+  log.info('ok, everything totally shut down successfully');
   process.exit();
 }
 

--- a/packages/hub/orchestrator.js
+++ b/packages/hub/orchestrator.js
@@ -1,16 +1,145 @@
+const {spawn, exec} = require('child_process');
+const getContainerId = require('docker-container-id');
+const request = require('superagent');
 const log = require('@cardstack/plugin-utils/logger')('orchestrator');
+const timeout = require('util').promisify(setTimeout);
 
-function start() {
-  log.info('totally starting everything up');
-  return Promise.resolve();
-}
+const NETWORK_NAME = "cardstack-network";
+const ELASTICSEARCH_STARTUP_TIMEOUT = 60 * 1000; // 60 seconds
 
-function stop() {
-  log.info('ok, everything totally shut down successfully');
-  process.exit();
-}
 
 module.exports = {
-  start,
-  stop
+  async start() {
+    await ensureNetwork();
+    await ensureElasticsearch();
+    log.info('Docker orchestration is finished, everything should be in order');
+  },
+
+  async stop() {
+    await destroyElasticsearch();
+    await destroyNetwork();
+    log.info('All other docker artifacts successfully removed. Shutting down...');
+    process.exit();
+  }
 };
+
+
+
+async function ensureNetwork() {
+  await new Promise(function(resolve) {
+    let proc = spawn('docker', [
+        'network', 'create', NETWORK_NAME
+    ], {stdio: 'inherit'});
+    proc.on('exit', resolve);
+  });
+
+  let own_id = await getContainerId();
+
+  await new Promise(function(resolve) {
+    let proc = spawn('docker', [
+        'network', 'connect', NETWORK_NAME, own_id
+    ], {stdio: 'inherit'});
+    proc.on('exit', resolve);
+  });
+}
+
+async function destroyNetwork() {
+  let own_id = await getContainerId();
+
+  await new Promise(function(resolve) {
+    let proc = spawn('docker', [
+        'network', 'disconnect', NETWORK_NAME, own_id
+    ], {stdio: 'inherit'});
+    proc.on('exit', resolve);
+  });
+
+  await new Promise(function(resolve) {
+    let proc = spawn('docker', [
+        'network', 'rm', NETWORK_NAME
+    ], {stdio: 'inherit'});
+    proc.on('exit', resolve);
+  });
+}
+
+
+async function ensureElasticsearch() {
+  return new Promise(async function(resolve, reject) {
+    let proc = spawn('docker', [
+        'run',
+        '-d',
+        '--rm',
+        '--network', NETWORK_NAME,
+        '--network-alias', 'elasticsearch',
+        '--label', 'com.cardstack.service=elasticsearch',
+        '--publish', '9200:9200',
+        'cardstack/elasticsearch'
+    ], { stdio: 'inherit' });
+
+    proc.on('error', reject);
+    proc.on('exit', function(code) {
+      if (code !== 0) {
+        reject("Attempt to run elasticsearch exited with code: "+code);
+      }
+    });
+
+    let begin_time = Date.now();
+    let end_time = begin_time + ELASTICSEARCH_STARTUP_TIMEOUT;
+
+    log.info('Waiting for elasticsearch container to start up...');
+
+    while (Date.now() < end_time) {
+      if (await isElasticsearchReady()) {
+        let startup_time = Date.now() - begin_time;
+        log.debug('elasticsearch now serving requests, after '+Math.round(startup_time / 1000)+' seconds');
+        resolve();
+        return;
+      } else {
+        log.trace('elasticsearch not responsive yet...');
+        await timeout(500);
+      }
+    }
+    reject("Elasticsearch container not accepting requests after "+ELASTICSEARCH_STARTUP_TIMEOUT+"ms.");
+  });
+}
+
+function isElasticsearchReady() {
+  return new Promise(function (resolve) {
+    request
+      .get('http://elasticsearch:9200')
+      .end(function(err) {
+        if(err) {
+          resolve(false);
+        } else {
+          resolve(true);
+        }
+      });
+  });
+}
+
+async function destroyElasticsearch() {
+  let container_id = await getServiceContainerId('elasticsearch');
+
+  return new Promise(function(resolve, reject) {
+    let proc = spawn('docker', [
+        'stop', container_id
+    ], { stdio: 'inherit' });
+    proc.on('exit', resolve);
+  });
+}
+
+function getServiceContainerId(serviceName) {
+  return new Promise(function(resolve, reject) {
+    exec(
+      `docker ps -q -f "label=com.cardstack.service=${serviceName}"`,
+      function(err, output) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(output.trim());
+        }
+      }
+    );
+  });
+}
+
+

--- a/packages/hub/orchestrator.js
+++ b/packages/hub/orchestrator.js
@@ -1,8 +1,10 @@
-const {spawn, exec} = require('child_process');
+const util = require('util');
+const child_process = require('child_process');
 const getContainerId = require('docker-container-id');
 const request = require('superagent');
 const log = require('@cardstack/plugin-utils/logger')('orchestrator');
 const timeout = require('util').promisify(setTimeout);
+const execFile = util.promisify(child_process.execFile);
 
 const NETWORK_NAME = "cardstack-network";
 const ELASTICSEARCH_STARTUP_TIMEOUT = 60 * 1000; // 60 seconds
@@ -26,80 +28,59 @@ module.exports = {
 
 
 async function ensureNetwork() {
-  await new Promise(function(resolve) {
-    let proc = spawn('docker', [
-        'network', 'create', NETWORK_NAME
-    ], {stdio: 'inherit'});
-    proc.on('exit', resolve);
-  });
+  try {
+    await execFile('docker', ['network', 'create', NETWORK_NAME]);
+  } catch (error) {
+    // We probably just failed here because the network already exists
+    if (error.code === 1) {
+      log.warn('Error creating docker network:');
+      log.warn(error.stderr);
+    } else {
+      throw error;
+    }
+  }
 
   let own_id = await getContainerId();
 
-  await new Promise(function(resolve) {
-    let proc = spawn('docker', [
-        'network', 'connect', NETWORK_NAME, own_id
-    ], {stdio: 'inherit'});
-    proc.on('exit', resolve);
-  });
+  await execFile('docker', ['network', 'connect', NETWORK_NAME, own_id]);
 }
 
 async function destroyNetwork() {
   let own_id = await getContainerId();
 
-  await new Promise(function(resolve) {
-    let proc = spawn('docker', [
-        'network', 'disconnect', NETWORK_NAME, own_id
-    ], {stdio: 'inherit'});
-    proc.on('exit', resolve);
-  });
-
-  await new Promise(function(resolve) {
-    let proc = spawn('docker', [
-        'network', 'rm', NETWORK_NAME
-    ], {stdio: 'inherit'});
-    proc.on('exit', resolve);
-  });
+  await execFile('docker', ['network', 'disconnect', NETWORK_NAME, own_id]);
+  await execFile('docker', ['network', 'rm', NETWORK_NAME]);
 }
 
 
 async function ensureElasticsearch() {
-  return new Promise(async function(resolve, reject) {
-    let proc = spawn('docker', [
-        'run',
-        '-d',
-        '--rm',
-        '--network', NETWORK_NAME,
-        '--network-alias', 'elasticsearch',
-        '--label', 'com.cardstack.service=elasticsearch',
-        '--publish', '9200:9200',
-        'cardstack/elasticsearch'
-    ], { stdio: 'inherit' });
+  await execFile('docker', [
+      'run',
+      '-d',
+      '--rm',
+      '--network', NETWORK_NAME,
+      '--network-alias', 'elasticsearch',
+      '--label', 'com.cardstack.service=elasticsearch',
+      '--publish', '9200:9200',
+      'cardstack/elasticsearch'
+  ]);
 
-    proc.on('error', reject);
-    proc.on('exit', function(code) {
-      if (code !== 0) {
-        reject("Attempt to run elasticsearch exited with code: "+code);
-      }
-    });
+  log.info('Waiting for elasticsearch container to start up...');
 
-    let begin_time = Date.now();
-    let end_time = begin_time + ELASTICSEARCH_STARTUP_TIMEOUT;
+  let begin_time = Date.now();
+  let end_time = begin_time + ELASTICSEARCH_STARTUP_TIMEOUT;
 
-    log.info('Waiting for elasticsearch container to start up...');
-
-    while (Date.now() < end_time) {
-      if (await isElasticsearchReady()) {
-        let startup_time = Date.now() - begin_time;
-        log.debug('elasticsearch now serving requests, after '+Math.round(startup_time / 1000)+' seconds');
-        resolve();
-        return;
-      } else {
-        log.trace('elasticsearch not responsive yet...');
-        await timeout(500);
-      }
+  while (Date.now() < end_time) {
+    if (await isElasticsearchReady()) {
+      let startup_time = Date.now() - begin_time;
+      log.debug(`Elasticsearch now serving requests, after ${Math.round(startup_time / 1000)} seconds`);
+      return;
+    } else {
+      log.trace('elasticsearch not responsive yet...');
+      await timeout(500);
     }
-    reject("Elasticsearch container not accepting requests after "+ELASTICSEARCH_STARTUP_TIMEOUT+"ms.");
-  });
+  }
+  throw `Elasticsearch container not accepting requests after ${ELASTICSEARCH_STARTUP_TIMEOUT}ms.`;
 }
 
 function isElasticsearchReady() {
@@ -119,27 +100,12 @@ function isElasticsearchReady() {
 async function destroyElasticsearch() {
   let container_id = await getServiceContainerId('elasticsearch');
 
-  return new Promise(function(resolve, reject) {
-    let proc = spawn('docker', [
-        'stop', container_id
-    ], { stdio: 'inherit' });
-    proc.on('exit', resolve);
-  });
+  await execFile('docker', ['stop', container_id]);
 }
 
-function getServiceContainerId(serviceName) {
-  return new Promise(function(resolve, reject) {
-    exec(
-      `docker ps -q -f "label=com.cardstack.service=${serviceName}"`,
-      function(err, output) {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(output.trim());
-        }
-      }
-    );
-  });
+async function getServiceContainerId(serviceName) {
+  let {stdout} = await execFile('docker', ['ps', '-q', '-f', `label=com.cardstack.service=${serviceName}`]);
+  return stdout.trim();
 }
 
 

--- a/packages/hub/orchestrator.js
+++ b/packages/hub/orchestrator.js
@@ -1,0 +1,16 @@
+
+function start() {
+  console.log('totally starting everything up');
+  return Promise.resolve();
+}
+
+function stop() {
+  console.log('ok, everything totally shut down successfully');
+  process.exit();
+}
+
+
+module.exports = {
+  start,
+  stop
+};

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -33,6 +33,7 @@
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
     "nssocket": "^0.6.0",
+    "path-is-inside": "^1.0.2",
     "quick-temp": "^0.1.8",
     "resolve": "^1.3.3"
   },

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -30,6 +30,7 @@
     "koa-compose": "^3.2.1",
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
+    "nssocket": "^0.6.0",
     "quick-temp": "^0.1.8",
     "resolve": "^1.3.3"
   },

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -23,6 +23,7 @@
     "commander": "^2.9.0",
     "dag-map": "^2.0.2",
     "denodeify": "^1.2.1",
+    "docker-container-id": "^1.0.1",
     "ember-cli-babel": "^6.8.2",
     "handlebars": "^4.0.6",
     "jsondiffpatch": "^0.2.4",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -36,7 +36,8 @@
     "nssocket": "^0.6.0",
     "path-is-inside": "^1.0.2",
     "quick-temp": "^0.1.8",
-    "resolve": "^1.3.3"
+    "resolve": "^1.3.3",
+    "superagent": "^2.3.0"
   },
   "devDependencies": {
     "@cardstack/eslint-config": "^0.2.4",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -24,6 +24,7 @@
     "dag-map": "^2.0.2",
     "denodeify": "^1.2.1",
     "docker-container-id": "^1.0.1",
+    "dockerfilejs": "^1.0.6",
     "ember-cli-babel": "^6.8.2",
     "handlebars": "^4.0.6",
     "jsondiffpatch": "^0.2.4",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -28,6 +28,7 @@
     "jsondiffpatch": "^0.2.4",
     "koa": "2",
     "koa-compose": "^3.2.1",
+    "koa-proxy": "^0.9.0",
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
     "nssocket": "^0.6.0",

--- a/packages/hub/start-hub-container.js
+++ b/packages/hub/start-hub-container.js
@@ -1,5 +1,5 @@
 module.exports = function() {
   return function noop(_req, _res, next) {
     return next();
-  }
+  };
 };

--- a/packages/hub/start-hub-container.js
+++ b/packages/hub/start-hub-container.js
@@ -1,5 +1,54 @@
-module.exports = function() {
-  return function noop(_req, _res, next) {
-    return next();
+const {spawn} = require('child_process');
+const crypto = require('crypto');
+const Koa = require('koa');
+const proxy = require('koa-proxy');
+const nssocket = require('nssocket');
+
+const log = require('@cardstack/plugin-utils/logger')('hub/spawn-hub');
+
+const HUB_HEARTBEAT_INTERVAL = 1 * 1000;
+
+module.exports = async function() {
+  let key = crypto.randomBytes(32).toString('base64');
+
+  let proc = spawn('docker', [
+    'run',
+    '-d',
+    '--rm',
+    '--publish', '3000:3000',
+    '--publish', '6785:6785',
+    '--mount', 'type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock',
+    '--mount', 'type=bind,src=/Users/aaron/dev/cardstack/packages/hub,dst=/hub/app/node_modules/@cardstack/hub',
+    '-e', 'ELASTICSEARCH=http://localhost:9200',
+    '-e', `CARDSTACK_SESSIONS_KEY=${key}`,
+    'cardstack-app'
+  ], {
+    stdio: 'inherit'
+  });
+
+  await new Promise(function(resolve) {
+    proc.on('exit', resolve);
+  });
+
+  let hub = new nssocket.NsSocket();
+  hub.connect(6785);
+
+  await new Promise(function(resolve) {
+    hub.data('ready', resolve);
+  });
+
+  log.info('Ready message received from hub container');
+
+  let beat = function() {
+    log.trace('Sending heartbeat to hub container');
+    hub.send('heartbeat');
   };
+  beat();
+  setInterval(beat, HUB_HEARTBEAT_INTERVAL);
+
+  let app = new Koa();
+  app.use(proxy({
+    host: 'http://localhost:3000'
+  }));
+  return app.callback();
 };

--- a/packages/hub/start-hub-container.js
+++ b/packages/hub/start-hub-container.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+  return function noop(_req, _res, next) {
+    return next();
+  }
+};

--- a/packages/hub/start-hub-container.js
+++ b/packages/hub/start-hub-container.js
@@ -19,7 +19,6 @@ module.exports = async function() {
     '--publish', '6785:6785',
     '--mount', 'type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock',
     '--mount', 'type=bind,src=/Users/aaron/dev/cardstack/packages/hub,dst=/hub/app/node_modules/@cardstack/hub',
-    '-e', 'ELASTICSEARCH=http://localhost:9200',
     '-e', `CARDSTACK_SESSIONS_KEY=${key}`,
     'cardstack-app'
   ], {

--- a/packages/hub/start-hub-container.js
+++ b/packages/hub/start-hub-container.js
@@ -1,13 +1,16 @@
 const crypto = require('crypto');
 const path = require('path');
 const {promisify} = require('util');
-const execFile = promisify(require('child_process').execFile);
+const child_process = require('child_process');
+const {spawn} = child_process;
+const execFile = promisify(child_process.execFile);
 const realpath = promisify(require('fs').realpath);
 
 const Koa = require('koa');
 const proxy = require('koa-proxy');
 const nssocket = require('nssocket');
 const path_is_inside = require('path-is-inside');
+const Dockerfile = require('dockerfilejs').Dockerfile;
 const resolve = promisify(require('resolve'));
 const log = require('@cardstack/plugin-utils/logger')('hub/spawn-hub');
 
@@ -27,6 +30,8 @@ module.exports = async function(projectRoot) {
   }
 
   let key = crypto.randomBytes(32).toString('base64');
+
+  await buildAppImage();
 
   await execFile('docker', [
     'run',
@@ -61,6 +66,44 @@ module.exports = async function(projectRoot) {
   }));
   return app.callback();
 };
+
+async function buildAppImage() {
+  let proc = spawn('docker', [
+      'build',
+      '-t', 'cardstack-app',
+      '-f', '-',
+      '.'
+  ],{
+    cwd: '/Users/aaron/dev/basic-cardstack',
+    stdio: 'pipe'
+  });
+
+
+  let file = new Dockerfile();
+
+  file.from('cardstack/hub')
+    .workdir('/hub/app')
+    .copy({src: ['package.json', 'yarn.lock'], dest: '/hub/app/'})
+    .run('yarn install --frozen-lockfile')
+    .copy({src: '.', dest: '/hub/app'})
+    .env({
+      ELASTICSEARCH: 'http://elasticsearch:9200',
+      DEBUG: 'cardstack/*'
+    })
+    .cmd({command:'node', params: [
+      '/hub/app/node_modules/@cardstack/hub/bin/server.js',
+      '/hub/app/cardstack/seeds/development',
+      '-d',
+      '--containerized'
+    ]});
+
+  proc.stdin.end(file.render());
+
+  await new Promise(function(resolve, reject) {
+    proc.on('error', reject);
+    proc.on('exit', resolve);
+  });
+}
 
 async function linkedHubPath(projectRoot) {
   let hubPath = path.dirname(await resolve('@cardstack/hub/package.json', {basedir: projectRoot}));

--- a/packages/hub/start-hub-container.js
+++ b/packages/hub/start-hub-container.js
@@ -40,8 +40,7 @@ module.exports = async function(projectRoot) {
     'cardstack-app'
   ]);
 
-  let hub = new nssocket.NsSocket();
-  hub.connect(6785);
+  let hub = await socketToHub();
 
   await new Promise(function(resolve) {
     hub.data('ready', resolve);
@@ -74,4 +73,21 @@ async function linkedHubPath(projectRoot) {
   } else {
     return false;
   }
+}
+
+async function socketToHub() {
+  let hub = new nssocket.NsSocket();
+  hub.connect(6785);
+
+  return new Promise(function(resolve) {
+    hub.data('shake', function() {
+      resolve(hub);
+    });
+    hub.on('close', function() {
+      resolve(socketToHub());
+    });
+    hub.send('hand');
+  });
+
+
 }

--- a/packages/hub/yarn.lock
+++ b/packages/hub/yarn.lock
@@ -1179,6 +1179,10 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+docker-container-id@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/docker-container-id/-/docker-container-id-1.0.1.tgz#851ca4b7d6390551252118fe0f31cb8276dea109"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"

--- a/packages/hub/yarn.lock
+++ b/packages/hub/yarn.lock
@@ -1994,6 +1994,10 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
+path-is-inside@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"

--- a/packages/hub/yarn.lock
+++ b/packages/hub/yarn.lock
@@ -1183,6 +1183,10 @@ docker-container-id@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/docker-container-id/-/docker-container-id-1.0.1.tgz#851ca4b7d6390551252118fe0f31cb8276dea109"
 
+dockerfilejs@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/dockerfilejs/-/dockerfilejs-1.0.6.tgz#f731a23d9abe989bd85e6353372ab3cc164c9123"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"

--- a/packages/hub/yarn.lock
+++ b/packages/hub/yarn.lock
@@ -2622,7 +2622,7 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
-superagent@^2.0.0:
+superagent@^2.0.0, superagent@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/superagent/-/superagent-2.3.0.tgz#703529a0714e57e123959ddefbce193b2e50d115"
   dependencies:

--- a/packages/hub/yarn.lock
+++ b/packages/hub/yarn.lock
@@ -2,6 +2,52 @@
 # yarn lockfile v1
 
 
+"@cardstack/core-types@^0.2.8":
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/@cardstack/core-types/-/core-types-0.2.8.tgz#53e4557d3d9065e89e0f5c7e25dea79cc09c98ed"
+  dependencies:
+    ember-cli-babel "^6.8.2"
+    ember-cli-htmlbars "^1.1.1"
+    ember-cli-postcss "https://github.com/ef4/ember-cli-postcss#0550adab2c0c0ab856efec6a4da8164eadd01e47"
+    moment-timezone "^0.5.11"
+    postcss-cssnext "^2.10.0"
+    postcss-import "^9.1.0"
+
+"@cardstack/di@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@cardstack/di/-/di-0.2.4.tgz#7aea90f148fe62b48fa976a1b733d8f8a65b94d5"
+  dependencies:
+    "@glimmer/di" "^0.2.0"
+    resolve "^1.3.3"
+
+"@cardstack/elasticsearch@^0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@cardstack/elasticsearch/-/elasticsearch-0.2.6.tgz#1b7bfbaff967c3c2250a83c5194e079ceb80902b"
+  dependencies:
+    "@cardstack/di" "^0.2.4"
+    "@cardstack/plugin-utils" "^0.2.4"
+    elasticsearch "^12.1.3"
+
+"@cardstack/eslint-config@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@cardstack/eslint-config/-/eslint-config-0.2.4.tgz#340148408b2a3b45b2c8baef344c644c403ac591"
+
+"@cardstack/handlebars@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@cardstack/handlebars/-/handlebars-0.2.4.tgz#58cab1709b164330b904f9befa5d24d8a4c8bbea"
+  dependencies:
+    handlebars "^4.0.6"
+
+"@cardstack/plugin-utils@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@cardstack/plugin-utils/-/plugin-utils-0.2.4.tgz#da4b7394dc32f7d011a3c170befb64884f1229b3"
+  dependencies:
+    ms "2.0.0"
+
+"@glimmer/di@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
+
 accepts@^1.2.2:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.3.tgz#c3ca7434938648c3e0d9c1e328dd68b622c284ca"
@@ -43,6 +89,16 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  dependencies:
+    color-convert "^1.9.0"
+
+any-promise@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-0.1.0.tgz#830b680aa7e56f33451d4b049f3bd8044498ee27"
+
 any-promise@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
@@ -50,6 +106,10 @@ any-promise@^1.1.0:
 array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
+
+asap@~2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
 async-disk-cache@^1.2.1:
   version "1.3.2"
@@ -79,6 +139,17 @@ async@^2.4.1:
   resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
   dependencies:
     lodash "^4.14.0"
+
+autoprefixer@^6.0.2:
+  version "6.7.7"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.7.7.tgz#1dbd1c835658e35ce3f9984099db00585c782014"
+  dependencies:
+    browserslist "^1.7.6"
+    caniuse-db "^1.0.30000634"
+    normalize-range "^0.1.2"
+    num2fraction "^1.2.2"
+    postcss "^5.2.16"
+    postcss-value-parser "^3.2.3"
 
 babel-code-frame@^6.22.0:
   version "6.22.0"
@@ -558,7 +629,15 @@ babylon@^6.11.0, babylon@^6.15.0:
   version "6.17.2"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.2.tgz#201d25ef5f892c41bae49488b08db0dd476e9f5c"
 
-balanced-match@^0.4.1:
+balanced-match@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.1.0.tgz#b504bd05869b39259dd0c5efc35d843176dccc4a"
+
+balanced-match@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.2.1.tgz#7bc658b4bed61eee424ad74f75f5c3e2c4df3cc7"
+
+balanced-match@^0.4.1, balanced-match@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
@@ -569,6 +648,10 @@ balanced-match@^0.4.1:
 blank-object@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/blank-object/-/blank-object-1.0.2.tgz#f990793fbe9a8c8dd013fb3219420bec81d5f4b9"
+
+bower@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/bower/-/bower-1.8.0.tgz#55dbebef0ad9155382d9e9d3e497c1372345b44a"
 
 brace-expansion@^1.1.7:
   version "1.1.7"
@@ -591,6 +674,17 @@ broccoli-babel-transpiler@^6.1.2:
     json-stable-stringify "^1.0.0"
     rsvp "^3.5.0"
     workerpool "^2.2.1"
+
+broccoli-caching-writer@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/broccoli-caching-writer/-/broccoli-caching-writer-3.0.3.tgz#0bd2c96a9738d6a6ab590f07ba35c5157d7db476"
+  dependencies:
+    broccoli-kitchen-sink-helpers "^0.3.1"
+    broccoli-plugin "^1.2.1"
+    debug "^2.1.1"
+    rimraf "^2.2.8"
+    rsvp "^3.0.17"
+    walk-sync "^0.3.0"
 
 broccoli-concat@^3.2.2:
   version "3.2.2"
@@ -621,7 +715,7 @@ broccoli-debug@^0.6.1, broccoli-debug@^0.6.2:
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
 
-broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.2.0:
+broccoli-funnel@1.2.0, broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
   dependencies:
@@ -647,6 +741,13 @@ broccoli-kitchen-sink-helpers@^0.3.1:
     glob "^5.0.10"
     mkdirp "^0.5.1"
 
+broccoli-merge-trees@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz#10aea46dd5cebcc8b8f7d5a54f0a84a4f0bb90b9"
+  dependencies:
+    broccoli-plugin "^1.3.0"
+    merge-trees "^1.0.1"
+
 broccoli-merge-trees@^1.0.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz#a001519bb5067f06589d91afa2942445a2d0fdb5"
@@ -659,6 +760,43 @@ broccoli-merge-trees@^1.0.0:
     heimdalljs-logger "^0.1.7"
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
+
+broccoli-persistent-filter@1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.2.tgz#17af1278a25ff2556f9d7d23e115accfad3a7ce7"
+  dependencies:
+    async-disk-cache "^1.2.1"
+    async-promise-queue "^1.0.3"
+    broccoli-plugin "^1.0.0"
+    crypto "0.0.3"
+    fs-tree-diff "^0.5.2"
+    hash-for-dep "^1.0.2"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    mkdirp "^0.5.1"
+    promise-map-series "^0.2.1"
+    rimraf "^2.6.1"
+    rsvp "^3.0.18"
+    symlink-or-copy "^1.0.1"
+    walk-sync "^0.3.1"
+
+broccoli-persistent-filter@^1.0.3, broccoli-persistent-filter@^1.4.0:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz#3511bc52fc53740cda51621f58a28152d9911bc1"
+  dependencies:
+    async-disk-cache "^1.2.1"
+    async-promise-queue "^1.0.3"
+    broccoli-plugin "^1.0.0"
+    fs-tree-diff "^0.5.2"
+    hash-for-dep "^1.0.2"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    mkdirp "^0.5.1"
+    promise-map-series "^0.2.1"
+    rimraf "^2.6.1"
+    rsvp "^3.0.18"
+    symlink-or-copy "^1.0.1"
+    walk-sync "^0.3.1"
 
 broccoli-persistent-filter@^1.1.6:
   version "1.3.1"
@@ -678,24 +816,6 @@ broccoli-persistent-filter@^1.1.6:
     symlink-or-copy "^1.0.1"
     walk-sync "^0.3.1"
 
-broccoli-persistent-filter@^1.4.0:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz#3511bc52fc53740cda51621f58a28152d9911bc1"
-  dependencies:
-    async-disk-cache "^1.2.1"
-    async-promise-queue "^1.0.3"
-    broccoli-plugin "^1.0.0"
-    fs-tree-diff "^0.5.2"
-    hash-for-dep "^1.0.2"
-    heimdalljs "^0.2.1"
-    heimdalljs-logger "^0.1.7"
-    mkdirp "^0.5.1"
-    promise-map-series "^0.2.1"
-    rimraf "^2.6.1"
-    rsvp "^3.0.18"
-    symlink-or-copy "^1.0.1"
-    walk-sync "^0.3.1"
-
 broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz#bee704a8e42da08cb58e513aaa436efb7f0ef1ee"
@@ -704,6 +824,25 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
     quick-temp "^0.1.3"
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
+
+broccoli-postcss-single@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/broccoli-postcss-single/-/broccoli-postcss-single-1.4.0.tgz#9941bd9f86cc0b32622551656ca3b0e71888a00a"
+  dependencies:
+    broccoli-caching-writer "3.0.3"
+    include-path-searcher "0.1.0"
+    mkdirp "0.5.1"
+    object-assign "4.1.1"
+    postcss "6.0.0"
+
+broccoli-postcss@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/broccoli-postcss/-/broccoli-postcss-3.5.0.tgz#206210ad03e07f8c68b44f9c3f8f2ce7209de0f0"
+  dependencies:
+    broccoli-funnel "1.2.0"
+    broccoli-persistent-filter "1.4.2"
+    object-assign "4.1.1"
+    postcss "6.0.8"
 
 broccoli-source@^1.1.0:
   version "1.1.0"
@@ -728,6 +867,13 @@ broccoli-stew@^1.3.3:
     symlink-or-copy "^1.1.8"
     walk-sync "^0.3.0"
 
+browserslist@^1.0.0, browserslist@^1.3.6, browserslist@^1.7.6:
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
+  dependencies:
+    caniuse-db "^1.0.30000639"
+    electron-to-chromium "^1.2.7"
+
 browserslist@^2.1.2:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.1.4.tgz#cc526af4a1312b7d2e05653e56d0c8ab70c0e053"
@@ -748,6 +894,19 @@ can-symlink@^1.0.0:
   resolved "https://registry.yarnpkg.com/can-symlink/-/can-symlink-1.0.0.tgz#97b607d8a84bb6c6e228b902d864ecb594b9d219"
   dependencies:
     tmp "0.0.28"
+
+caniuse-api@^1.5.3:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-1.6.1.tgz#b534e7c734c4f81ec5fbe8aca2ad24354b962c6c"
+  dependencies:
+    browserslist "^1.3.6"
+    caniuse-db "^1.0.30000529"
+    lodash.memoize "^4.1.2"
+    lodash.uniq "^4.5.0"
+
+caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
+  version "1.0.30000733"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000733.tgz#3a625bc41c7a9f99d59d64552857dd1af0edd9d4"
 
 caniuse-lite@^1.0.30000670:
   version "1.0.30000679"
@@ -770,7 +929,7 @@ chalk@^0.5.1:
     strip-ansi "^0.3.0"
     supports-color "^0.2.0"
 
-chalk@^1.1.0, chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -780,6 +939,14 @@ chalk@^1.1.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.1, chalk@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -788,6 +955,10 @@ cliui@^2.1.0:
     right-align "^0.1.1"
     wordwrap "0.0.2"
 
+clone@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.2.tgz#260b7a99ebb1edfe247538175f783243cb19d149"
+
 clone@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
@@ -795,6 +966,41 @@ clone@^2.0.0:
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+
+color-convert@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd"
+
+color-convert@^1.3.0, color-convert@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  dependencies:
+    color-name "^1.1.1"
+
+color-name@^1.0.0, color-name@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+
+color-string@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-0.3.0.tgz#27d46fb67025c5c2fa25993bfbf579e47841b991"
+  dependencies:
+    color-name "^1.0.0"
+
+color@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-0.10.1.tgz#c04188df82a209ddebccecdacd3ec320f193739f"
+  dependencies:
+    color-convert "^0.5.3"
+    color-string "^0.3.0"
+
+color@^0.11.0, color@^0.11.3, color@^0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/color/-/color-0.11.4.tgz#6d7b5c74fb65e841cd48792ad1ed5e07b904d764"
+  dependencies:
+    clone "^1.0.2"
+    color-convert "^1.3.0"
+    color-string "^0.3.0"
 
 combined-stream@^1.0.5:
   version "1.0.5"
@@ -847,6 +1053,19 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+crypto@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/crypto/-/crypto-0.0.3.tgz#470a81b86be4c5ee17acc8207a1f5315ae20dbb0"
+
+css-color-function@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/css-color-function/-/css-color-function-1.3.0.tgz#72c767baf978f01b8a8a94f42f17ba5d22a776fc"
+  dependencies:
+    balanced-match "0.1.0"
+    color "^0.11.0"
+    debug "~0.7.4"
+    rgb "~0.1.0"
+
 dag-map@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/dag-map/-/dag-map-2.0.2.tgz#9714b472de82a1843de2fba9b6876938cab44c68"
@@ -856,6 +1075,10 @@ debug@*, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.0, debug@^2.6.8:
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
     ms "2.0.0"
+
+debug@~0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
 
 decamelize@^1.0.0:
   version "1.2.0"
@@ -899,6 +1122,19 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
+elasticsearch@^12.1.3:
+  version "12.1.3"
+  resolved "https://registry.yarnpkg.com/elasticsearch/-/elasticsearch-12.1.3.tgz#5108e67ae5d83e5e7f30d3d294fd7017df0e3771"
+  dependencies:
+    chalk "^1.0.0"
+    forever-agent "^0.6.0"
+    lodash "^4.12.0"
+    promise "^7.1.1"
+
+electron-to-chromium@^1.2.7:
+  version "1.3.21"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.21.tgz#a967ebdcfe8ed0083fc244d1894022a8e8113ea2"
+
 electron-to-chromium@^1.3.11:
   version "1.3.13"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.13.tgz#1b3a5eace6e087bb5e257a100b0cbfe81b2891fc"
@@ -919,6 +1155,32 @@ ember-cli-babel@^6.8.2:
     broccoli-source "^1.1.0"
     clone "^2.0.0"
     ember-cli-version-checker "^2.0.0"
+
+ember-cli-htmlbars@^1.1.1:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.4.tgz#461289724b34af372a6a0c4b6635819156963353"
+  dependencies:
+    broccoli-persistent-filter "^1.0.3"
+    ember-cli-version-checker "^1.0.2"
+    hash-for-dep "^1.0.2"
+    json-stable-stringify "^1.0.0"
+    strip-bom "^2.0.0"
+
+"ember-cli-postcss@git+https://github.com/ef4/ember-cli-postcss.git#0550adab2c0c0ab856efec6a4da8164eadd01e47":
+  version "3.5.0"
+  resolved "git+https://github.com/ef4/ember-cli-postcss.git#0550adab2c0c0ab856efec6a4da8164eadd01e47"
+  dependencies:
+    bower "1.8.0"
+    broccoli-merge-trees "2.0.0"
+    broccoli-postcss "3.5.0"
+    broccoli-postcss-single "1.4.0"
+    merge "1.2.0"
+
+ember-cli-version-checker@^1.0.2:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz#0bc2d134c830142da64bf9627a0eded10b61ae72"
+  dependencies:
+    semver "^5.3.0"
 
 ember-cli-version-checker@^2.0.0:
   version "2.0.0"
@@ -943,13 +1205,17 @@ escape-html@~1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2:
+escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+
+eventemitter2@~0.4.14:
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-0.4.14.tgz#8f61b75cde012b2e9eb284d4545583b5643b61ab"
 
 exists-sync@0.0.4:
   version "0.0.4"
@@ -981,6 +1247,14 @@ fast-sourcemap-concat@^1.0.1:
 find-index@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-index/-/find-index-1.1.0.tgz#53007c79cd30040d6816d79458e8837d5c5705ef"
+
+flatten@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
+
+forever-agent@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
 form-data@1.0.0-rc4:
   version "1.0.0-rc4"
@@ -1091,6 +1365,14 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+
 hash-for-dep@^1.0.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/hash-for-dep/-/hash-for-dep-1.1.2.tgz#e3347ed92960eb0bb53a2c6c2b70e36d75b7cd0c"
@@ -1136,6 +1418,14 @@ http-errors@^1.2.8, http-errors@~1.6.1:
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
 
+include-path-searcher@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/include-path-searcher/-/include-path-searcher-0.1.0.tgz#c0cf2ddfa164fb2eae07bc7ca43a7f191cb4d7bd"
+
+indexes-of@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -1167,6 +1457,10 @@ is-generator-function@^1.0.3:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.6.tgz#9e71653cd15fff341c79c4151460a131d31e9fc4"
 
+is-utf8@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -1175,6 +1469,10 @@ isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
+isnumeric@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/isnumeric/-/isnumeric-0.2.0.tgz#a2347ba360de19e33d0ffd590fddf7755cbf2e64"
+
 istextorbinary@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/istextorbinary/-/istextorbinary-2.1.0.tgz#dbed2a6f51be2f7475b68f89465811141b758874"
@@ -1182,6 +1480,10 @@ istextorbinary@2.1.0:
     binaryextensions "1 || 2"
     editions "^1.1.1"
     textextensions "1 || 2"
+
+js-base64@^2.1.9:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.3.2.tgz#a79a923666372b580f8e27f51845c6f7e8fbfbaf"
 
 js-tokens@^3.0.0:
   version "3.0.1"
@@ -1295,6 +1597,18 @@ lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
 
+lazy@~1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/lazy/-/lazy-1.0.11.tgz#daa068206282542c088288e975c297c1ae77b690"
+
+lodash._reinterpolate@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
+
+lodash.memoize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+
 lodash.merge@^4.3.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
@@ -1303,11 +1617,24 @@ lodash.omit@^4.1.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
 
-lodash.uniq@^4.2.0:
+lodash.template@^4.2.4:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0"
+  dependencies:
+    lodash._reinterpolate "~3.0.0"
+    lodash.templatesettings "^4.0.0"
+
+lodash.templatesettings@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz#2b4d4e95ba440d915ff08bc899e4553666713316"
+  dependencies:
+    lodash._reinterpolate "~3.0.0"
+
+lodash.uniq@^4.2.0, lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0:
+lodash@^4.12.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -1326,6 +1653,10 @@ matcher-collection@^1.0.0:
   resolved "https://registry.yarnpkg.com/matcher-collection/-/matcher-collection-1.0.4.tgz#2f66ae0869996f29e43d0b62c83dd1d43e581755"
   dependencies:
     minimatch "^3.0.2"
+
+math-expression-evaluator@^1.2.14:
+  version "1.2.17"
+  resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
 
 md5-hex@^1.0.2:
   version "1.3.0"
@@ -1346,6 +1677,21 @@ memory-streams@^0.1.0:
   resolved "https://registry.yarnpkg.com/memory-streams/-/memory-streams-0.1.2.tgz#273ff777ab60fec599b116355255282cca2c50c2"
   dependencies:
     readable-stream "~1.0.2"
+
+merge-trees@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-trees/-/merge-trees-1.0.1.tgz#ccbe674569787f9def17fd46e6525f5700bbd23e"
+  dependencies:
+    can-symlink "^1.0.0"
+    fs-tree-diff "^0.5.4"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    rimraf "^2.4.3"
+    symlink-or-copy "^1.0.0"
+
+merge@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
 methods@1.x, methods@^1.1.1, methods@~1.1.0:
   version "1.1.2"
@@ -1375,7 +1721,7 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -1385,6 +1731,16 @@ mktemp@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"
 
+moment-timezone@^0.5.11:
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.13.tgz#99ce5c7d827262eb0f1f702044177f60745d7b90"
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0":
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -1393,11 +1749,26 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
+normalize-range@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
+
+nssocket@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/nssocket/-/nssocket-0.6.0.tgz#59f96f6ff321566f33c70f7dbeeecdfdc07154fa"
+  dependencies:
+    eventemitter2 "~0.4.14"
+    lazy "~1.0.11"
+
+num2fraction@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-object-assign@4.1.1, object-assign@^4.1.0:
+object-assign@4.1.1, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -1412,6 +1783,10 @@ once@^1.3.0:
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
+
+onecolor@~2.4.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/onecolor/-/onecolor-2.4.2.tgz#a53ec3ff171c3446016dd5210d1a1b544bf7d874"
 
 only@0.0.2:
   version "0.0.2"
@@ -1454,6 +1829,314 @@ path-to-regexp@^1.2.0:
   dependencies:
     isarray "0.0.1"
 
+pify@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+
+pixrem@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/pixrem/-/pixrem-3.0.2.tgz#30d1bafb4c3bdce8e9bb4bd56a13985619320c34"
+  dependencies:
+    browserslist "^1.0.0"
+    postcss "^5.0.0"
+    reduce-css-calc "^1.2.7"
+
+pleeease-filters@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/pleeease-filters/-/pleeease-filters-3.0.1.tgz#4dfe0e8f1046613517c64b728bc80608a7ebf22f"
+  dependencies:
+    onecolor "~2.4.0"
+    postcss "^5.0.4"
+
+postcss-apply@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-apply/-/postcss-apply-0.3.0.tgz#a2f37c5bdfa881e4c15f4f245ec0cd96dd2e70d5"
+  dependencies:
+    balanced-match "^0.4.1"
+    postcss "^5.0.21"
+
+postcss-attribute-case-insensitive@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-1.0.1.tgz#ceb73777e106167eb233f1938c9bd9f2e697308d"
+  dependencies:
+    postcss "^5.1.1"
+    postcss-selector-parser "^2.2.0"
+
+postcss-calc@^5.0.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-5.3.1.tgz#77bae7ca928ad85716e2fda42f261bf7c1d65b5e"
+  dependencies:
+    postcss "^5.0.2"
+    postcss-message-helpers "^2.0.0"
+    reduce-css-calc "^1.2.6"
+
+postcss-color-function@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-color-function/-/postcss-color-function-2.0.1.tgz#9ad226f550e8a7c7f8b8a77860545b6dd7f55241"
+  dependencies:
+    css-color-function "^1.2.0"
+    postcss "^5.0.4"
+    postcss-message-helpers "^2.0.0"
+    postcss-value-parser "^3.3.0"
+
+postcss-color-gray@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-color-gray/-/postcss-color-gray-3.0.1.tgz#74432ede66dd83b1d1363565c68b376e18ff6770"
+  dependencies:
+    color "^0.11.3"
+    postcss "^5.0.4"
+    postcss-message-helpers "^2.0.0"
+    reduce-function-call "^1.0.1"
+
+postcss-color-hex-alpha@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-color-hex-alpha/-/postcss-color-hex-alpha-2.0.0.tgz#44fd6ecade66028648c881cb6504cdcbfdc6cd09"
+  dependencies:
+    color "^0.10.1"
+    postcss "^5.0.4"
+    postcss-message-helpers "^2.0.0"
+
+postcss-color-hsl@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/postcss-color-hsl/-/postcss-color-hsl-1.0.5.tgz#f53bb1c348310ce307ad89e3181a864738b5e687"
+  dependencies:
+    postcss "^5.2.0"
+    postcss-value-parser "^3.3.0"
+    units-css "^0.4.0"
+
+postcss-color-hwb@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-color-hwb/-/postcss-color-hwb-2.0.1.tgz#d63afaf9b70cb595f900a29c9fe57bf2a32fabec"
+  dependencies:
+    color "^0.11.4"
+    postcss "^5.0.4"
+    postcss-message-helpers "^2.0.0"
+    reduce-function-call "^1.0.1"
+
+postcss-color-rebeccapurple@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-2.0.1.tgz#74c6444e7cbb7d85613b5f7286df7a491608451c"
+  dependencies:
+    color "^0.11.4"
+    postcss "^5.0.4"
+
+postcss-color-rgb@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/postcss-color-rgb/-/postcss-color-rgb-1.1.4.tgz#f29243e22e8e8c13434474092372d4ce605be8bc"
+  dependencies:
+    postcss "^5.2.0"
+    postcss-value-parser "^3.3.0"
+
+postcss-color-rgba-fallback@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-color-rgba-fallback/-/postcss-color-rgba-fallback-2.2.0.tgz#6d29491be5990a93173d47e7c76f5810b09402ba"
+  dependencies:
+    postcss "^5.0.0"
+    postcss-value-parser "^3.0.2"
+    rgb-hex "^1.0.0"
+
+postcss-cssnext@^2.10.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/postcss-cssnext/-/postcss-cssnext-2.11.0.tgz#31e68f001e409604da703b66de14b8b8c8c9f2b1"
+  dependencies:
+    autoprefixer "^6.0.2"
+    caniuse-api "^1.5.3"
+    chalk "^1.1.1"
+    pixrem "^3.0.0"
+    pleeease-filters "^3.0.0"
+    postcss "^5.0.4"
+    postcss-apply "^0.3.0"
+    postcss-attribute-case-insensitive "^1.0.1"
+    postcss-calc "^5.0.0"
+    postcss-color-function "^2.0.0"
+    postcss-color-gray "^3.0.0"
+    postcss-color-hex-alpha "^2.0.0"
+    postcss-color-hsl "^1.0.5"
+    postcss-color-hwb "^2.0.0"
+    postcss-color-rebeccapurple "^2.0.0"
+    postcss-color-rgb "^1.1.4"
+    postcss-color-rgba-fallback "^2.0.0"
+    postcss-custom-media "^5.0.0"
+    postcss-custom-properties "^5.0.0"
+    postcss-custom-selectors "^3.0.0"
+    postcss-font-family-system-ui "^1.0.1"
+    postcss-font-variant "^2.0.0"
+    postcss-image-set-polyfill "^0.3.3"
+    postcss-initial "^1.3.1"
+    postcss-media-minmax "^2.1.0"
+    postcss-nesting "^2.0.5"
+    postcss-pseudo-class-any-link "^1.0.0"
+    postcss-pseudoelements "^3.0.0"
+    postcss-replace-overflow-wrap "^1.0.0"
+    postcss-selector-matches "^2.0.0"
+    postcss-selector-not "^2.0.0"
+
+postcss-custom-media@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-custom-media/-/postcss-custom-media-5.0.1.tgz#138d25a184bf2eb54de12d55a6c01c30a9d8bd81"
+  dependencies:
+    postcss "^5.0.0"
+
+postcss-custom-properties@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-5.0.2.tgz#9719d78f2da9cf9f53810aebc23d4656130aceb1"
+  dependencies:
+    balanced-match "^0.4.2"
+    postcss "^5.0.0"
+
+postcss-custom-selectors@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-custom-selectors/-/postcss-custom-selectors-3.0.0.tgz#8f81249f5ed07a8d0917cf6a39fe5b056b7f96ac"
+  dependencies:
+    balanced-match "^0.2.0"
+    postcss "^5.0.0"
+    postcss-selector-matches "^2.0.0"
+
+postcss-font-family-system-ui@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-font-family-system-ui/-/postcss-font-family-system-ui-1.0.2.tgz#3e1a5e3fb7e31e5e9e71439ccb0e8014556927c7"
+  dependencies:
+    lodash "^4.17.4"
+    postcss "^5.2.12"
+    postcss-value-parser "^3.3.0"
+
+postcss-font-variant@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-font-variant/-/postcss-font-variant-2.0.1.tgz#7ca29103f59fa02ca3ace2ca22b2f756853d4ef8"
+  dependencies:
+    postcss "^5.0.4"
+
+postcss-image-set-polyfill@^0.3.3:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/postcss-image-set-polyfill/-/postcss-image-set-polyfill-0.3.5.tgz#0f193413700cf1f82bd39066ef016d65a4a18181"
+  dependencies:
+    postcss "^6.0.1"
+    postcss-media-query-parser "^0.2.3"
+
+postcss-import@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-9.1.0.tgz#95fe9876a1e79af49fbdc3589f01fe5aa7cc1e80"
+  dependencies:
+    object-assign "^4.0.1"
+    postcss "^5.0.14"
+    postcss-value-parser "^3.2.3"
+    promise-each "^2.2.0"
+    read-cache "^1.0.0"
+    resolve "^1.1.7"
+
+postcss-initial@^1.3.1:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/postcss-initial/-/postcss-initial-1.5.3.tgz#20c3e91c96822ddb1bed49508db96d56bac377d0"
+  dependencies:
+    lodash.template "^4.2.4"
+    postcss "^5.0.19"
+
+postcss-media-minmax@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/postcss-media-minmax/-/postcss-media-minmax-2.1.2.tgz#444c5cf8926ab5e4fd8a2509e9297e751649cdf8"
+  dependencies:
+    postcss "^5.0.4"
+
+postcss-media-query-parser@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
+
+postcss-message-helpers@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz#a4f2f4fab6e4fe002f0aed000478cdf52f9ba60e"
+
+postcss-nesting@^2.0.5:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/postcss-nesting/-/postcss-nesting-2.3.1.tgz#94a6b6a4ef707fbec20a87fee5c957759b4e01cf"
+  dependencies:
+    postcss "^5.0.19"
+
+postcss-pseudo-class-any-link@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-1.0.0.tgz#903239196401d335fe73ac756186fa62e693af26"
+  dependencies:
+    postcss "^5.0.3"
+    postcss-selector-parser "^1.1.4"
+
+postcss-pseudoelements@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-pseudoelements/-/postcss-pseudoelements-3.0.0.tgz#6c682177c7900ba053b6df17f8c590284c7b8bbc"
+  dependencies:
+    postcss "^5.0.4"
+
+postcss-replace-overflow-wrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-1.0.0.tgz#f0a03b31eab9636a6936bfd210e2aef1b434a643"
+  dependencies:
+    postcss "^5.0.16"
+
+postcss-selector-matches@^2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/postcss-selector-matches/-/postcss-selector-matches-2.0.5.tgz#fa0f43be57b68e77aa4cd11807023492a131027f"
+  dependencies:
+    balanced-match "^0.4.2"
+    postcss "^5.0.0"
+
+postcss-selector-not@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-selector-not/-/postcss-selector-not-2.0.0.tgz#c73ad21a3f75234bee7fee269e154fd6a869798d"
+  dependencies:
+    balanced-match "^0.2.0"
+    postcss "^5.0.0"
+
+postcss-selector-parser@^1.1.4:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-1.3.3.tgz#d2ee19df7a64f8ef21c1a71c86f7d4835c88c281"
+  dependencies:
+    flatten "^1.0.2"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
+postcss-selector-parser@^2.2.0:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz#f9437788606c3c9acee16ffe8d8b16297f27bb90"
+  dependencies:
+    flatten "^1.0.2"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
+postcss-value-parser@^3.0.2, postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
+
+postcss@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.0.tgz#ef75a67e75fe2bfff53971045697202c018b2e81"
+  dependencies:
+    chalk "^1.1.3"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
+
+postcss@6.0.8:
+  version "6.0.8"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.8.tgz#89067a9ce8b11f8a84cbc5117efc30419a0857b3"
+  dependencies:
+    chalk "^2.0.1"
+    source-map "^0.5.6"
+    supports-color "^4.2.0"
+
+postcss@^5.0.0, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.19, postcss@^5.0.2, postcss@^5.0.21, postcss@^5.0.3, postcss@^5.0.4, postcss@^5.1.1, postcss@^5.2.0, postcss@^5.2.12, postcss@^5.2.16:
+  version "5.2.17"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.17.tgz#cf4f597b864d65c8a492b2eabe9d706c879c388b"
+  dependencies:
+    chalk "^1.1.3"
+    js-base64 "^2.1.9"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
+
+postcss@^6.0.1:
+  version "6.0.11"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.11.tgz#f48db210b1d37a7f7ab6499b7a54982997ab6f72"
+  dependencies:
+    chalk "^2.1.0"
+    source-map "^0.5.7"
+    supports-color "^4.4.0"
+
 private@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
@@ -1462,11 +2145,23 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
+promise-each@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/promise-each/-/promise-each-2.2.0.tgz#3353174eff2694481037e04e01f77aa0fb6d1b60"
+  dependencies:
+    any-promise "^0.1.0"
+
 promise-map-series@^0.2.1:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/promise-map-series/-/promise-map-series-0.2.3.tgz#c2d377afc93253f6bd03dbb77755eb88ab20a847"
   dependencies:
     rsvp "^3.0.14"
+
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  dependencies:
+    asap "~2.0.3"
 
 qs@^6.1.0:
   version "6.4.0"
@@ -1479,6 +2174,12 @@ quick-temp@^0.1.3, quick-temp@^0.1.5, quick-temp@^0.1.8:
     mktemp "~0.4.0"
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
+
+read-cache@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
+  dependencies:
+    pify "^2.3.0"
 
 readable-stream@^2.0.5:
   version "2.2.9"
@@ -1500,6 +2201,20 @@ readable-stream@~1.0.2:
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
+
+reduce-css-calc@^1.2.6, reduce-css-calc@^1.2.7:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz#747c914e049614a4c9cfbba629871ad1d2927716"
+  dependencies:
+    balanced-match "^0.4.2"
+    math-expression-evaluator "^1.2.14"
+    reduce-function-call "^1.0.1"
+
+reduce-function-call@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
+  dependencies:
+    balanced-match "^0.4.2"
 
 regenerate@^1.2.1:
   version "1.3.2"
@@ -1551,6 +2266,20 @@ resolve@^1.1.6, resolve@^1.3.3:
   dependencies:
     path-parse "^1.0.5"
 
+resolve@^1.1.7:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
+  dependencies:
+    path-parse "^1.0.5"
+
+rgb-hex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/rgb-hex/-/rgb-hex-1.0.0.tgz#bfaf8cd9cd9164b5a26d71eb4f15a0965324b3c1"
+
+rgb@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/rgb/-/rgb-0.1.0.tgz#be27b291e8feffeac1bd99729721bfa40fc037b5"
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
@@ -1567,7 +2296,7 @@ rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.18, rsvp@~3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.2.1.tgz#07cb4a5df25add9e826ebc67dcc9fd89db27d84a"
 
-rsvp@^3.5.0:
+rsvp@^3.0.17, rsvp@^3.5.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
 
@@ -1607,6 +2336,10 @@ source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
+source-map@^0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
 sprintf-js@^1.0.3:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
@@ -1637,6 +2370,12 @@ strip-ansi@^3.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+strip-bom@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
+  dependencies:
+    is-utf8 "^0.2.0"
+
 superagent@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/superagent/-/superagent-2.3.0.tgz#703529a0714e57e123959ddefbce193b2e50d115"
@@ -1666,6 +2405,18 @@ supports-color@^0.2.0:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+
+supports-color@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
+  dependencies:
+    has-flag "^1.0.0"
+
+supports-color@^4.0.0, supports-color@^4.2.0, supports-color@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
+  dependencies:
+    has-flag "^2.0.0"
 
 symlink-or-copy@^1.0.0, symlink-or-copy@^1.0.1, symlink-or-copy@^1.1.8:
   version "1.1.8"
@@ -1726,6 +2477,17 @@ underscore.string@~3.3.4:
     sprintf-js "^1.0.3"
     util-deprecate "^1.0.2"
 
+uniq@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
+
+units-css@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/units-css/-/units-css-0.4.0.tgz#d6228653a51983d7c16ff28f8b9dc3b1ffed3a07"
+  dependencies:
+    isnumeric "^0.2.0"
+    viewport-dimensions "^0.2.0"
+
 username-sync@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/username-sync/-/username-sync-1.0.1.tgz#1cde87eefcf94b8822984d938ba2b797426dae1f"
@@ -1737,6 +2499,10 @@ util-deprecate@^1.0.2, util-deprecate@~1.0.1:
 vary@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.1.tgz#67535ebb694c1d52257457984665323f587e8d37"
+
+viewport-dimensions@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz#de740747db5387fd1725f5175e91bac76afdf36c"
 
 walk-sync@^0.2.7:
   version "0.2.7"

--- a/packages/hub/yarn.lock
+++ b/packages/hub/yarn.lock
@@ -55,6 +55,13 @@ accepts@^1.2.2:
     mime-types "~2.1.11"
     negotiator "0.6.1"
 
+ajv@^4.9.1:
+  version "4.11.8"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
+  dependencies:
+    co "^4.6.0"
+    json-stable-stringify "^1.0.1"
+
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
@@ -111,6 +118,18 @@ asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
+asn1@~0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
+
+assert-plus@1.0.0, assert-plus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+
+assert-plus@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
+
 async-disk-cache@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/async-disk-cache/-/async-disk-cache-1.3.2.tgz#ac53d6152843df202c9406e28d774362608d74dd"
@@ -140,6 +159,10 @@ async@^2.4.1:
   dependencies:
     lodash "^4.14.0"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+
 autoprefixer@^6.0.2:
   version "6.7.7"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.7.7.tgz#1dbd1c835658e35ce3f9984099db00585c782014"
@@ -150,6 +173,14 @@ autoprefixer@^6.0.2:
     num2fraction "^1.2.2"
     postcss "^5.2.16"
     postcss-value-parser "^3.2.3"
+
+aws-sign2@~0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
+
+aws4@^1.2.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
 babel-code-frame@^6.22.0:
   version "6.22.0"
@@ -641,6 +672,12 @@ balanced-match@^0.4.1, balanced-match@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
+bcrypt-pbkdf@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
+  dependencies:
+    tweetnacl "^0.14.3"
+
 "binaryextensions@1 || 2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.0.0.tgz#e597d1a7a6a3558a2d1c7241a16c99965e6aa40f"
@@ -648,6 +685,12 @@ balanced-match@^0.4.1, balanced-match@^0.4.2:
 blank-object@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/blank-object/-/blank-object-1.0.2.tgz#f990793fbe9a8c8dd013fb3219420bec81d5f4b9"
+
+boom@2.x.x:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
+  dependencies:
+    hoek "2.x.x"
 
 bower@1.8.0:
   version "1.8.0"
@@ -912,6 +955,10 @@ caniuse-lite@^1.0.30000670:
   version "1.0.30000679"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000679.tgz#0fb5bb3658d4d4448f8f86a1c48df15664aa05ef"
 
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+
 center-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
@@ -963,6 +1010,12 @@ clone@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
 
+co-request@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/co-request/-/co-request-0.2.1.tgz#6428c002ad4229b3eda6725022aeccf273bee3fb"
+  dependencies:
+    request "*"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -1002,7 +1055,7 @@ color@^0.11.0, color@^0.11.3, color@^0.11.4:
     color-convert "^1.3.0"
     color-string "^0.3.0"
 
-combined-stream@^1.0.5:
+combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
   dependencies:
@@ -1049,9 +1102,15 @@ core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
-core-util-is@~1.0.0:
+core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cryptiles@2.x.x:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
+  dependencies:
+    boom "2.x.x"
 
 crypto@0.0.3:
   version "0.0.3"
@@ -1069,6 +1128,12 @@ css-color-function@^1.2.0:
 dag-map@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/dag-map/-/dag-map-2.0.2.tgz#9714b472de82a1843de2fba9b6876938cab44c68"
+
+dashdash@^1.12.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+  dependencies:
+    assert-plus "^1.0.0"
 
 debug@*, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.0, debug@^2.6.8:
   version "2.6.8"
@@ -1113,6 +1178,12 @@ detect-indent@^4.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
   dependencies:
     repeating "^2.0.0"
+
+ecc-jsbn@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
+  dependencies:
+    jsbn "~0.1.0"
 
 editions@^1.1.1:
   version "1.3.3"
@@ -1166,9 +1237,9 @@ ember-cli-htmlbars@^1.1.1:
     json-stable-stringify "^1.0.0"
     strip-bom "^2.0.0"
 
-"ember-cli-postcss@git+https://github.com/ef4/ember-cli-postcss.git#0550adab2c0c0ab856efec6a4da8164eadd01e47":
+"ember-cli-postcss@https://github.com/ef4/ember-cli-postcss#0550adab2c0c0ab856efec6a4da8164eadd01e47":
   version "3.5.0"
-  resolved "git+https://github.com/ef4/ember-cli-postcss.git#0550adab2c0c0ab856efec6a4da8164eadd01e47"
+  resolved "https://github.com/ef4/ember-cli-postcss#0550adab2c0c0ab856efec6a4da8164eadd01e47"
   dependencies:
     bower "1.8.0"
     broccoli-merge-trees "2.0.0"
@@ -1221,9 +1292,13 @@ exists-sync@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/exists-sync/-/exists-sync-0.0.4.tgz#9744c2c428cc03b01060db454d4b12f0ef3c8879"
 
-extend@^3.0.0:
+extend@^3.0.0, extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
+
+extsprintf@1.3.0, extsprintf@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
 
 fast-ordered-set@^1.0.0, fast-ordered-set@^1.0.2:
   version "1.0.3"
@@ -1252,7 +1327,7 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-forever-agent@^0.6.0:
+forever-agent@^0.6.0, forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
@@ -1263,6 +1338,14 @@ form-data@1.0.0-rc4:
     async "^1.5.2"
     combined-stream "^1.0.5"
     mime-types "^2.1.10"
+
+form-data@~2.1.1:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.5"
+    mime-types "^2.1.12"
 
 formidable@^1.0.17:
   version "1.1.1"
@@ -1310,6 +1393,12 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
+getpass@^0.1.1:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
+  dependencies:
+    assert-plus "^1.0.0"
+
 glob@^5.0.10:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
@@ -1353,6 +1442,17 @@ handlebars@^4.0.6:
   optionalDependencies:
     uglify-js "^2.6"
 
+har-schema@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
+
+har-validator@~4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
+  dependencies:
+    ajv "^4.9.1"
+    har-schema "^1.0.5"
+
 has-ansi@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-0.1.0.tgz#84f265aae8c0e6a88a12d7022894b7568894c62e"
@@ -1382,6 +1482,15 @@ hash-for-dep@^1.0.2:
     heimdalljs-logger "^0.1.7"
     resolve "^1.1.6"
 
+hawk@~3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
+  dependencies:
+    boom "2.x.x"
+    cryptiles "2.x.x"
+    hoek "2.x.x"
+    sntp "1.x.x"
+
 heimdalljs-logger@^0.1.7:
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz#d76ada4e45b7bb6f786fc9c010a68eb2e2faf176"
@@ -1394,6 +1503,10 @@ heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3:
   resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.2.4.tgz#34ead16eab422c94803065d33abeba1f7b24a910"
   dependencies:
     rsvp "~3.2.1"
+
+hoek@2.x.x:
+  version "2.16.3"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -1417,6 +1530,18 @@ http-errors@^1.2.8, http-errors@~1.6.1:
     inherits "2.0.3"
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
+
+http-signature@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
+  dependencies:
+    assert-plus "^0.2.0"
+    jsprim "^1.2.2"
+    sshpk "^1.7.0"
+
+iconv-lite@^0.2.11:
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.2.11.tgz#1ce60a3a57864a292d1321ff4609ca4bb965adc8"
 
 include-path-searcher@0.1.0:
   version "0.1.0"
@@ -1457,6 +1582,10 @@ is-generator-function@^1.0.3:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.6.tgz#9e71653cd15fff341c79c4151460a131d31e9fc4"
 
+is-typedarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
@@ -1472,6 +1601,10 @@ isarray@~1.0.0:
 isnumeric@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/isnumeric/-/isnumeric-0.2.0.tgz#a2347ba360de19e33d0ffd590fddf7755cbf2e64"
+
+isstream@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
 istextorbinary@2.1.0:
   version "2.1.0"
@@ -1489,6 +1622,10 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
+jsbn@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
@@ -1497,11 +1634,19 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
-json-stable-stringify@^1.0.0:
+json-schema@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+
+json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   dependencies:
     jsonify "~0.0.0"
+
+json-stringify-safe@~5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
 json5@^0.5.0:
   version "0.5.1"
@@ -1522,6 +1667,15 @@ jsonfile@^2.1.0:
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+
+jsprim@^1.2.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
+  dependencies:
+    assert-plus "1.0.0"
+    extsprintf "1.3.0"
+    json-schema "0.2.3"
+    verror "1.10.0"
 
 keygrip@~1.0.1:
   version "1.0.1"
@@ -1563,6 +1717,13 @@ koa-convert@^1.2.0:
 koa-is-json@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/koa-is-json/-/koa-is-json-1.0.0.tgz#273c07edcdcb8df6a2c1ab7d59ee76491451ec14"
+
+koa-proxy@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/koa-proxy/-/koa-proxy-0.9.0.tgz#4fd13b0f2eea9be097445bf7b7b4398856a22ef6"
+  dependencies:
+    co-request "^0.2.0"
+    iconv-lite "^0.2.11"
 
 koa@2:
   version "2.2.0"
@@ -1701,11 +1862,21 @@ mime-db@~1.27.0:
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
 
+mime-db@~1.30.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
+
 mime-types@^2.0.7, mime-types@^2.1.10, mime-types@~2.1.11, mime-types@~2.1.15:
   version "2.1.15"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.15.tgz#a4ebf5064094569237b8cf70046776d09fc92aed"
   dependencies:
     mime-db "~1.27.0"
+
+mime-types@^2.1.12, mime-types@~2.1.7:
+  version "2.1.17"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
+  dependencies:
+    mime-db "~1.30.0"
 
 mime@^1.3.4:
   version "1.3.6"
@@ -1768,6 +1939,10 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
+oauth-sign@~0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+
 object-assign@4.1.1, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -1828,6 +2003,10 @@ path-to-regexp@^1.2.0:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
   dependencies:
     isarray "0.0.1"
+
+performance-now@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
 
 pify@^2.3.0:
   version "2.3.0"
@@ -2163,7 +2342,11 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-qs@^6.1.0:
+punycode@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+qs@^6.1.0, qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
@@ -2260,6 +2443,33 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
+request@*:
+  version "2.81.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
+  dependencies:
+    aws-sign2 "~0.6.0"
+    aws4 "^1.2.1"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~2.1.1"
+    har-validator "~4.2.1"
+    hawk "~3.1.3"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    oauth-sign "~0.8.1"
+    performance-now "^0.2.0"
+    qs "~6.4.0"
+    safe-buffer "^5.0.1"
+    stringstream "~0.0.4"
+    tough-cookie "~2.3.0"
+    tunnel-agent "^0.6.0"
+    uuid "^3.0.0"
+
 resolve@^1.1.6, resolve@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
@@ -2316,6 +2526,12 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
+sntp@1.x.x:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
+  dependencies:
+    hoek "2.x.x"
+
 source-map-support@^0.4.2:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.15.tgz#03202df65c06d2bd8c7ec2362a193056fef8d3b1"
@@ -2344,6 +2560,20 @@ sprintf-js@^1.0.3:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
 
+sshpk@^1.7.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.1.tgz#512df6da6287144316dc4c18fe1cf1d940739be3"
+  dependencies:
+    asn1 "~0.2.3"
+    assert-plus "^1.0.0"
+    dashdash "^1.12.0"
+    getpass "^0.1.1"
+  optionalDependencies:
+    bcrypt-pbkdf "^1.0.0"
+    ecc-jsbn "~0.1.1"
+    jsbn "~0.1.0"
+    tweetnacl "~0.14.0"
+
 "statuses@>= 1.3.1 < 2", statuses@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
@@ -2357,6 +2587,10 @@ string_decoder@~1.0.0:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.1.tgz#62e200f039955a6810d8df0a33ffc0f013662d98"
   dependencies:
     safe-buffer "^5.0.1"
+
+stringstream@~0.0.4:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
 strip-ansi@^0.3.0:
   version "0.3.0"
@@ -2436,6 +2670,12 @@ to-fast-properties@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
+tough-cookie@~2.3.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
+  dependencies:
+    punycode "^1.4.1"
+
 tree-sync@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-sync/-/tree-sync-1.2.2.tgz#2cf76b8589f59ffedb58db5a3ac7cb013d0158b7"
@@ -2449,6 +2689,16 @@ tree-sync@^1.2.2:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  dependencies:
+    safe-buffer "^5.0.1"
+
+tweetnacl@^0.14.3, tweetnacl@~0.14.0:
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
 type-is@^1.5.5:
   version "1.6.15"
@@ -2496,9 +2746,21 @@ util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
+uuid@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
 vary@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.1.tgz#67535ebb694c1d52257457984665323f587e8d37"
+
+verror@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+  dependencies:
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
 
 viewport-dimensions@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This PR gets the ball rolling on containerizing the hub.

All new behavior is behind feature flags. The code now actually runs in two places - some natively in the ember-cli process on your host, some inside docker containers.

The entry point for the containerized code is `bin/server.js`, feature-flagged with the `--containerized` cli switch.

The ember-cli plugin code will build & launch the container if the `CONTAINERIZED_HUB` environment variable is set.

You can test this with my [`basic-cardstack`](https://github.com/courajs/basic-cardstack) app. Clone that, `yarn install`, `npm start`, and it should work!