### PR TITLE
Allow plugin to specify expiry of auth token

### DIFF
--- a/packages/authentication/cardstack/middleware.js
+++ b/packages/authentication/cardstack/middleware.js
@@ -147,7 +147,7 @@ class Authentication {
 
     ctxt.body = {
       data: user,
-      meta: await this.createToken({ id: user.id, type: user.type }, 86400)
+      meta: await this.createToken({ id: user.id, type: user.type }, source.attributes['token-expiry'] || 86400)
     };
     ctxt.status = 200;
   }


### PR DESCRIPTION
Allow auth through query params along with header, and allow plugin to specify expiry of auth token