### PR TITLE
Data source plugin API changes to support embedded records

### DIFF
--- a/packages/authentication/node-tests/stub-authenticators/authenticators/by-email.js
+++ b/packages/authentication/node-tests/stub-authenticators/authenticators/by-email.js
@@ -7,10 +7,13 @@ module.exports = class {
     if (email == null) {
       throw new Error("email is required", { status: 400 });
     }
-    let { models } = await userSearcher.search({ filter: { email: { exact: email } } });
-    if (models.length > 0) {
+    let { data } = await userSearcher.search({
+      filter: { email: { exact: email } },
+      page: { size: 1 }
+    });
+    if (data.length > 0) {
       return {
-        data: models[0],
+        data: data[0],
         meta: {
           preloaded: true
         }

--- a/packages/authentication/node-tests/stub-authenticators/authenticators/by-email.js
+++ b/packages/authentication/node-tests/stub-authenticators/authenticators/by-email.js
@@ -10,7 +10,10 @@ module.exports = class {
     let { models } = await userSearcher.search({ filter: { email: { exact: email } } });
     if (models.length > 0) {
       return {
-        preloadedUser: models[0]
+        data: models[0],
+        meta: {
+          preloaded: true
+        }
       };
     }
   }

--- a/packages/authentication/node-tests/stub-authenticators/authenticators/has-default-template.js
+++ b/packages/authentication/node-tests/stub-authenticators/authenticators/has-default-template.js
@@ -3,7 +3,7 @@ module.exports = class HasDefaultTemplate {
     return new this();
   }
   constructor() {
-    this.defaultUserTemplate = '{ "id": "{{upstreamId}}", "type": "users" }';
+    this.defaultUserTemplate = '{ "data": { "id": "{{upstreamId}}", "type": "users" } }';
   }
   async authenticate(payload /*, userSearcher */) {
     return payload;

--- a/packages/core-types/cardstack/field-types/belongs-to.js
+++ b/packages/core-types/cardstack/field-types/belongs-to.js
@@ -11,14 +11,9 @@ module.exports = {
     }
     return true;
   },
-  defaultMapping(allFields) {
+  defaultMapping() {
     return {
-      type: "object",
-      properties: Object.assign(
-        {},
-        allFields.get('id').mapping(allFields),
-        allFields.get('type').mapping(allFields)
-      )
+      type: "object"
     };
   },
   default: { data: null },

--- a/packages/core-types/cardstack/field-types/has-many.js
+++ b/packages/core-types/cardstack/field-types/has-many.js
@@ -15,14 +15,9 @@ module.exports = {
     return true;
   },
 
-  defaultMapping(allFields) {
+  defaultMapping() {
     return {
-      type: "nested",
-      properties: Object.assign(
-        {},
-        allFields.get('id').mapping(allFields),
-        allFields.get('type').mapping(allFields)
-      )
+      type: "nested"
     };
   },
   default: { data: [] },

--- a/packages/core-types/cardstack/field-types/string-array.js
+++ b/packages/core-types/cardstack/field-types/string-array.js
@@ -1,0 +1,13 @@
+let StringType = require('./string');
+
+module.exports = {
+  valid(value) {
+    return Array.isArray(value) && value.every(item => StringType.valid(item));
+  },
+
+  // Arrays of primitive values in elasticsearch don't need any
+  // special mapping. Every scalar type can also automatically be an
+  // array, and it's all the same to Elasticsearch.
+  defaultMapping: StringType.defaultMapping,
+  sortFieldName: StringType.sortFieldName
+};

--- a/packages/drupal-auth/cardstack/authenticator.js
+++ b/packages/drupal-auth/cardstack/authenticator.js
@@ -43,7 +43,7 @@ module.exports = class {
 
       if (params.userIdField) {
         log.debug("Searching for %s=%s", params.userIdField, response.body.id);
-        let { models } = await userSearcher.search({
+        let { data: models } = await userSearcher.search({
           filter: {
             type,
             [params.userIdField]: { exact: response.body.id }

--- a/packages/drupal/indexer.js
+++ b/packages/drupal/indexer.js
@@ -117,6 +117,10 @@ class Updater {
     };
   }
 
+  async read() {
+    throw new Error("Drupal indexer doesn't implement resource embedding yet");
+  }
+
   _makeField(propName, propDef, fields) {
     let canonicalName = drupalToCardstackField(propName);
     if (!fields[canonicalName]) {

--- a/packages/elasticsearch/client.js
+++ b/packages/elasticsearch/client.js
@@ -126,7 +126,7 @@ module.exports = class SearchClient {
     return branchPrefix;
   }
 
-  async jsonapiToSearchDoc(id, jsonapiDoc, schema, branch, sourceId) {
+  async jsonapiToSearchDoc(type, id, jsonapiDoc, schema, branch, sourceId) {
     // we store the id as a regular field in elasticsearch here, because
     // we use elasticsearch's own built-in _id for our own composite key
     // that takes into account branches.
@@ -141,10 +141,7 @@ module.exports = class SearchClient {
     // response, as opposed to the searchDoc itself which is mangled
     // for searchability.
     let pristine = {
-      data: {
-        id: jsonapiDoc.id,
-        type: jsonapiDoc.type
-      }
+      data: { id, type }
     };
 
     if (jsonapiDoc.attributes) {

--- a/packages/elasticsearch/node-tests/indexer-test.js
+++ b/packages/elasticsearch/node-tests/indexer-test.js
@@ -238,7 +238,6 @@ describe('elasticsearch/indexer', function() {
 
     found = await searcher.get('master', 'articles', article.id);
     expect(found).is.ok;
-    debugger;
     expect(found).has.deep.property('data.relationships.author.data.id', 'x');
     expect(found).has.property('included');
     expect(found.included).length(1);

--- a/packages/elasticsearch/node-tests/searcher-test.js
+++ b/packages/elasticsearch/node-tests/searcher-test.js
@@ -186,8 +186,9 @@ describe('elasticsearch/searcher', function() {
     let { data: models } = await searcher.search('master', {
       queryString: 'magic'
     });
-    expect(models).to.have.length(1);
+    expect(models.filter(m => m.type === 'articles')).to.have.length(1);
     expect(models).includes.something.with.deep.property('attributes.hello', 'magic words');
+    expect(models.filter(m => m.type === 'comments')).to.have.length(4);
   });
 
   it('can be searched via queryString, negative result', async function() {
@@ -706,7 +707,7 @@ describe('elasticsearch/searcher', function() {
     expect(response.data).length(0);
   });
 
-  it('can filter searchable belongs-to by an attribute', async function() {
+  it('can filter searchable has-many by an attribute', async function() {
     let response = await searcher.search('master', {
       filter: {
         'searchable-members.first-name': 'Quint'

--- a/packages/elasticsearch/node-tests/searcher-test.js
+++ b/packages/elasticsearch/node-tests/searcher-test.js
@@ -155,7 +155,7 @@ describe('elasticsearch/searcher', function() {
   });
 
   it('returns properly formatted records', async function() {
-    let model = await searcher.get('master', 'people', '1');
+    let model = (await searcher.get('master', 'people', '1')).data;
     let meta = model.meta;
     expect(Object.keys(meta).sort()).deep.equals(['version']);
     delete model.meta;
@@ -545,7 +545,7 @@ describe('elasticsearch/searcher', function() {
 
   it('can get an individual record', async function() {
     let model = await searcher.get('master', 'articles', '1');
-    expect(model).has.deep.property('attributes.hello', 'magic words');
+    expect(model).has.deep.property('data.attributes.hello', 'magic words');
   });
 
   it('can do analyzed term matching', async function() {

--- a/packages/elasticsearch/node-tests/searcher-test.js
+++ b/packages/elasticsearch/node-tests/searcher-test.js
@@ -146,7 +146,7 @@ describe('elasticsearch/searcher', function() {
   });
 
   it('can be searched for all content', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       page: { size: 1000 }
     });
     expect(models.filter(m => m.type === 'comments')).to.have.length(20);
@@ -183,7 +183,7 @@ describe('elasticsearch/searcher', function() {
   });
 
   it('can be searched via queryString', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       queryString: 'magic'
     });
     expect(models).to.have.length(1);
@@ -191,14 +191,14 @@ describe('elasticsearch/searcher', function() {
   });
 
   it('can be searched via queryString, negative result', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       queryString: 'thisisanunusedterm'
     });
     expect(models).to.have.length(0);
   });
 
   it('can filter by type', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         type: 'articles'
       }
@@ -208,7 +208,7 @@ describe('elasticsearch/searcher', function() {
   });
 
   it('can sort by type', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         type: ['articles', 'people']
       },
@@ -219,7 +219,7 @@ describe('elasticsearch/searcher', function() {
   });
 
   it('can sort by type in reverse', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         type: ['articles', 'people']
       },
@@ -231,7 +231,7 @@ describe('elasticsearch/searcher', function() {
 
 
   it('can filter by id', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         id: '1',
         type: ['articles', 'people']
@@ -243,7 +243,7 @@ describe('elasticsearch/searcher', function() {
   });
 
   it('can sort by id', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         type: ['articles', 'people']
       },
@@ -253,7 +253,7 @@ describe('elasticsearch/searcher', function() {
   });
 
   it('can sort by id in reverse', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         type: ['articles', 'people']
       },
@@ -264,7 +264,7 @@ describe('elasticsearch/searcher', function() {
 
 
   it('can filter a field by one term', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         'first-name': 'Quint'
       }
@@ -274,7 +274,7 @@ describe('elasticsearch/searcher', function() {
   });
 
   it('can filter a field by multiple terms', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         'first-name': ['Quint', 'Arthur']
       }
@@ -283,7 +283,7 @@ describe('elasticsearch/searcher', function() {
   });
 
   it('can use OR expressions in filters', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         or: [
           { 'first-name': ['Quint'], type: 'people' },
@@ -297,7 +297,7 @@ describe('elasticsearch/searcher', function() {
   });
 
   it('can use AND expressions in filters', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         and: [
           { 'favorite-color': 'red' },
@@ -311,7 +311,7 @@ describe('elasticsearch/searcher', function() {
 
 
   it('can filter by range', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         age: {
           range: {
@@ -325,7 +325,7 @@ describe('elasticsearch/searcher', function() {
   });
 
   it('can filter by field existence (string)', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         'favorite-color': {
           exists: 'true'
@@ -338,7 +338,7 @@ describe('elasticsearch/searcher', function() {
   });
 
   it('can filter by field nonexistence (string)', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         'favorite-color': {
           exists: 'false'
@@ -351,7 +351,7 @@ describe('elasticsearch/searcher', function() {
   });
 
   it('can filter by field existence (bool)', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         'favorite-color': {
           exists: true
@@ -364,7 +364,7 @@ describe('elasticsearch/searcher', function() {
   });
 
   it('can filter by field nonexistence (bool)', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         'favorite-color': {
           exists: false
@@ -377,7 +377,7 @@ describe('elasticsearch/searcher', function() {
   });
 
   it('can search within a field with custom indexing behavior', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         description: 'fox'
       }
@@ -408,7 +408,7 @@ describe('elasticsearch/searcher', function() {
   });
 
   it('can sort', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         type: 'people'
       },
@@ -419,7 +419,7 @@ describe('elasticsearch/searcher', function() {
 
 
   it('can sort reverse', async function() {
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         type: 'people'
       },
@@ -432,7 +432,7 @@ describe('elasticsearch/searcher', function() {
     // string fields are only sortable because of the sortFieldName
     // in @cardstack/core-field-types/string. So this is a test that
     // we're using that capability.
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         type: 'people'
       },
@@ -446,7 +446,7 @@ describe('elasticsearch/searcher', function() {
     // string fields are only sortable because of the sortFieldName
     // in @cardstack/core-field-types/string. So this is a test that
     // we're using that capability.
-    let { models } = await searcher.search('master', {
+    let { data: models } = await searcher.search('master', {
       filter: {
         type: 'people'
       },
@@ -477,39 +477,39 @@ describe('elasticsearch/searcher', function() {
         size: 7
       }
     });
-    expect(response.models).length(7);
-    expect(response.page).has.property('total', 20);
-    expect(response.page).has.property('cursor');
+    expect(response.data).length(7);
+    expect(response.meta.page).has.property('total', 20);
+    expect(response.meta.page).has.property('cursor');
 
-    let allModels = response.models;
-
-    response = await searcher.search('master', {
-      filter: { type: 'comments' },
-      page: {
-        size: 7,
-        cursor: response.page.cursor
-      }
-    });
-
-    expect(response.models).length(7);
-    expect(response.page).has.property('total', 20);
-    expect(response.page).has.property('cursor');
-
-    allModels = allModels.concat(response.models);
+    let allModels = response.data;
 
     response = await searcher.search('master', {
       filter: { type: 'comments' },
       page: {
         size: 7,
-        cursor: response.page.cursor
+        cursor: response.meta.page.cursor
       }
     });
 
-    expect(response.models).length(6);
-    expect(response.page).has.property('total', 20);
-    expect(response.page).not.has.property('cursor');
+    expect(response.data).length(7);
+    expect(response.meta.page).has.property('total', 20);
+    expect(response.meta.page).has.property('cursor');
 
-    allModels = allModels.concat(response.models);
+    allModels = allModels.concat(response.data);
+
+    response = await searcher.search('master', {
+      filter: { type: 'comments' },
+      page: {
+        size: 7,
+        cursor: response.meta.page.cursor
+      }
+    });
+
+    expect(response.data).length(6);
+    expect(response.meta.page).has.property('total', 20);
+    expect(response.meta.page).not.has.property('cursor');
+
+    allModels = allModels.concat(response.data);
 
     expect(uniq(allModels.map(m => m.id))).length(20);
   });
@@ -521,25 +521,25 @@ describe('elasticsearch/searcher', function() {
         size: 10
       }
     });
-    expect(response.models).length(10);
-    expect(response.page).has.property('total', 20);
-    expect(response.page).has.property('cursor');
+    expect(response.data).length(10);
+    expect(response.meta.page).has.property('total', 20);
+    expect(response.meta.page).has.property('cursor');
 
-    let allModels = response.models;
+    let allModels = response.data;
 
     response = await searcher.search('master', {
       filter: { type: 'comments' },
       page: {
         size: 10,
-        cursor: response.page.cursor
+        cursor: response.meta.page.cursor
       }
     });
 
-    expect(response.models).length(10);
-    expect(response.page).has.property('total', 20);
-    expect(response.page).not.has.property('cursor');
+    expect(response.data).length(10);
+    expect(response.meta.page).has.property('total', 20);
+    expect(response.meta.page).not.has.property('cursor');
 
-    allModels = allModels.concat(response.models);
+    allModels = allModels.concat(response.data);
     expect(uniq(allModels.map(m => m.id))).length(20);
   });
 
@@ -554,8 +554,8 @@ describe('elasticsearch/searcher', function() {
         hello: 'magic'
       }
     });
-    expect(response.models).length(1);
-    expect(response.models[0]).has.deep.property('attributes.hello', 'magic words');
+    expect(response.data).length(1);
+    expect(response.data[0]).has.deep.property('attributes.hello', 'magic words');
   });
 
   it('matches reordered phrase when using analyzed field', async function() {
@@ -564,7 +564,7 @@ describe('elasticsearch/searcher', function() {
         hello: 'words magic'
       }
     });
-    expect(response.models).length(1);
+    expect(response.data).length(1);
   });
 
   it('does not match reordered phrase when using exact field', async function() {
@@ -573,7 +573,7 @@ describe('elasticsearch/searcher', function() {
         hello: { exact: 'words magic' }
       }
     });
-    expect(response.models).length(0);
+    expect(response.data).length(0);
   });
 
 
@@ -583,8 +583,8 @@ describe('elasticsearch/searcher', function() {
         hello: { exact: 'magic words' }
       }
     });
-    expect(response.models).length(1);
-    expect(response.models[0]).has.deep.property('attributes.hello', 'magic words');
+    expect(response.data).length(1);
+    expect(response.data[0]).has.deep.property('attributes.hello', 'magic words');
   });
 
   it('incomplete phrase does not match', async function() {
@@ -593,7 +593,7 @@ describe('elasticsearch/searcher', function() {
         hello: { exact: 'magic words extra' }
       }
     });
-    expect(response.models).length(0);
+    expect(response.data).length(0);
   });
 
 
@@ -603,8 +603,8 @@ describe('elasticsearch/searcher', function() {
         hello: { exact: ['something else', 'magic words'] }
       }
     });
-    expect(response.models).length(1);
-    expect(response.models[0]).has.deep.property('attributes.hello', 'magic words');
+    expect(response.data).length(1);
+    expect(response.data[0]).has.deep.property('attributes.hello', 'magic words');
   });
 
   it('can filter non-searchable belongsTo by id', async function() {
@@ -613,7 +613,7 @@ describe('elasticsearch/searcher', function() {
         'article.id': { exact: '1' }
       }
     });
-    expect(response.models).length(4);
+    expect(response.data).length(4);
   });
 
   it('can filter searchable belongsTo by id', async function() {
@@ -622,7 +622,7 @@ describe('elasticsearch/searcher', function() {
         'searchable-article.id': { exact: '1' }
       }
     });
-    expect(response.models).length(4);
+    expect(response.data).length(4);
   });
 
   it('can filter non-searchable belongsTo by multiple ids', async function() {
@@ -631,7 +631,7 @@ describe('elasticsearch/searcher', function() {
         'article.id': { exact: ['1', '2'] }
       }
     });
-    expect(response.models).length(6);
+    expect(response.data).length(6);
   });
 
   it('can filter searchable belongsTo by multiple ids', async function() {
@@ -640,7 +640,7 @@ describe('elasticsearch/searcher', function() {
         'searchable-article.id': { exact: ['1', '2'] }
       }
     });
-    expect(response.models).length(6);
+    expect(response.data).length(6);
   });
 
   it('can filter non-searchable hasMany by id', async function() {
@@ -649,7 +649,7 @@ describe('elasticsearch/searcher', function() {
         'members.id': { exact: '1' }
       }
     });
-    expect(response.models).length(1);
+    expect(response.data).length(1);
   });
 
   it('can filter searchable hasMany by id', async function() {
@@ -658,7 +658,7 @@ describe('elasticsearch/searcher', function() {
         'searchable-members.id': { exact: '1' }
       }
     });
-    expect(response.models).length(1);
+    expect(response.data).length(1);
   });
 
   it('can filter non-searchable hasMany by multiple id', async function() {
@@ -667,7 +667,7 @@ describe('elasticsearch/searcher', function() {
         'members.id': { exact: ['1', 'bogus'] }
       }
     });
-    expect(response.models).length(1);
+    expect(response.data).length(1);
   });
 
   it('can filter searchable hasMany by multiple id', async function() {
@@ -676,7 +676,7 @@ describe('elasticsearch/searcher', function() {
         'searchable-members.id': { exact: ['1', 'bogus'] }
       }
     });
-    expect(response.models).length(1);
+    expect(response.data).length(1);
   });
 
   it('belongs-to attributes are not indexed by default', async function() {
@@ -685,7 +685,7 @@ describe('elasticsearch/searcher', function() {
         'article.hello': 'magic'
       }
     });
-    expect(response.models).length(0);
+    expect(response.data).length(0);
   });
 
   it('can filter searchable belongs-to by an attribute', async function() {
@@ -694,7 +694,7 @@ describe('elasticsearch/searcher', function() {
         'searchable-article.hello': 'magic'
       }
     });
-    expect(response.models).length(4);
+    expect(response.data).length(4);
   });
 
   it('hasMany attributes are not indexed by default', async function() {
@@ -703,7 +703,7 @@ describe('elasticsearch/searcher', function() {
         'members.first-name': 'Quint'
       }
     });
-    expect(response.models).length(0);
+    expect(response.data).length(0);
   });
 
   it('can filter searchable belongs-to by an attribute', async function() {
@@ -712,7 +712,7 @@ describe('elasticsearch/searcher', function() {
         'searchable-members.first-name': 'Quint'
       }
     });
-    expect(response.models).length(1);
+    expect(response.data).length(1);
   });
 
 });

--- a/packages/elasticsearch/node-tests/searcher-test.js
+++ b/packages/elasticsearch/node-tests/searcher-test.js
@@ -64,7 +64,7 @@ describe('elasticsearch/searcher', function() {
         fieldType: '@cardstack/core-types::belongs-to'
       }).withRelated('related-types', [ factory.getResource('content-types', 'articles') ])
     ]).withAttributes({
-      searchableRelationships: ['searchable-article']
+      defaultIncludes: ['searchable-article']
     });
 
     factory.addResource('articles', '1').withAttributes({
@@ -126,7 +126,7 @@ describe('elasticsearch/searcher', function() {
         fieldType: '@cardstack/core-types::has-many'
       }).withRelated('related-types', [factory.getResource('content-types', 'people')])
     ]).withAttributes({
-      searchableRelationships: ['searchable-members']
+      defaultIncludes: ['searchable-members']
     });
 
     factory.addResource('teams').withRelated('members', [

--- a/packages/elasticsearch/searcher.js
+++ b/packages/elasticsearch/searcher.js
@@ -39,7 +39,7 @@ class Searcher {
       }
       throw err;
     }
-    return toJSONAPI(type, document);
+    return toJSONAPI(type, document).data;
   }
 
   async search(branch, { queryString, filter, sort, page }) {
@@ -127,7 +127,7 @@ class Searcher {
     }
 
     let models = documents.map(
-      document => toJSONAPI(document._type, document._source)
+      document => toJSONAPI(document._type, document._source).data
     );
     return {
       models,

--- a/packages/elasticsearch/searcher.js
+++ b/packages/elasticsearch/searcher.js
@@ -217,12 +217,12 @@ class Searcher {
   async _fieldFilter(branch, schema, aboveSegments, key, value) {
     let field;
 
-    if (key === 'cardstack_source') {
+    if (['cardstack_source', 'cardstack_references'].includes(key)) {
       // this is an internal field (meaning it's not visible in the
       // jsonapi records themselves) that we make available for
       // filtering. The schema-cache uses this to avoid shadowing seed
       // models, for example.
-      field = { queryFieldName: 'cardstack_source', sortFieldName: 'cardstack_source' };
+      field = { queryFieldName: key, sortFieldName: key };
     } else {
       field = schema.fields.get(key);
     }

--- a/packages/elasticsearch/searcher.js
+++ b/packages/elasticsearch/searcher.js
@@ -126,11 +126,19 @@ class Searcher {
       page.cursor = encodeURIComponent(JSON.stringify(last.sort));
     }
 
+    let includes = [];
     let data = documents.map(
-      document => toJSONAPI(document._type, document._source).data
+      document => {
+        let jsonapi = toJSONAPI(document._type, document._source);
+        if (jsonapi.includes) {
+          includes = includes.concat(jsonapi.includes);
+        }
+        return jsonapi.data;
+      }
     );
     return {
       data,
+      includes,
       meta: { page },
     };
   }

--- a/packages/elasticsearch/searcher.js
+++ b/packages/elasticsearch/searcher.js
@@ -116,22 +116,22 @@ class Searcher {
 
   _assembleResponse(result, requestedSize) {
     let documents = result.hits.hits;
-    let pagination = {
+    let page = {
       total: result.hits.total
     };
 
     if (documents.length > requestedSize) {
       documents = documents.slice(0, requestedSize);
       let last = documents[documents.length - 1];
-      pagination.cursor = encodeURIComponent(JSON.stringify(last.sort));
+      page.cursor = encodeURIComponent(JSON.stringify(last.sort));
     }
 
-    let models = documents.map(
+    let data = documents.map(
       document => toJSONAPI(document._type, document._source).data
     );
     return {
-      models,
-      page: pagination
+      data,
+      meta: { page },
     };
   }
 

--- a/packages/elasticsearch/searcher.js
+++ b/packages/elasticsearch/searcher.js
@@ -189,7 +189,7 @@ class Searcher {
       }
       let here = aboveSegments.concat(field.queryFieldName);
 
-      if (field.mapping(schema.fields)[field.id].type === 'nested') {
+      if (field.fieldType === '@cardstack/core-types::has-many') {
         return {
           nested: {
             path: here.join('.'),

--- a/packages/elasticsearch/searcher.js
+++ b/packages/elasticsearch/searcher.js
@@ -126,19 +126,19 @@ class Searcher {
       page.cursor = encodeURIComponent(JSON.stringify(last.sort));
     }
 
-    let includes = [];
+    let included = [];
     let data = documents.map(
       document => {
         let jsonapi = toJSONAPI(document._type, document._source);
-        if (jsonapi.includes) {
-          includes = includes.concat(jsonapi.includes);
+        if (jsonapi.included) {
+          included = included.concat(jsonapi.included);
         }
         return jsonapi.data;
       }
     );
     return {
       data,
-      includes,
+      included,
       meta: { page },
     };
   }

--- a/packages/elasticsearch/searcher.js
+++ b/packages/elasticsearch/searcher.js
@@ -39,7 +39,7 @@ class Searcher {
       }
       throw err;
     }
-    return toJSONAPI(type, document).data;
+    return toJSONAPI(type, document);
   }
 
   async search(branch, { queryString, filter, sort, page }) {

--- a/packages/elasticsearch/to-jsonapi.js
+++ b/packages/elasticsearch/to-jsonapi.js
@@ -1,64 +1,7 @@
 /*
    This converts a document from elaticsearch to a JSONAPI document.
-
-   The conversion is necessary because in ES we flatten down the
-   attributes and relationships, we store some derived fields (to
-   enable different kinds of searches), and we may rewrite field names
-   (to allow us to have different mapping types on different
-   branches simultaneously in one index).
-
-   This function is designed to be synchronous and referentially
-   transparent -- any information needed to do the conversion must be
-   in the document itself.
-
-   We should benchmark this in a meaningful scenario to see if it
-   would be better to precompute this transformation and store it
-   within a non-indexed, stored field in ES.
 */
 
 module.exports = function searchDocToJSONAPI(type, document) {
-  let rewrites = document.cardstack_rewrites;
-  let attributes;
-  let relationships;
-  let top = { type };
-  Object.keys(document).forEach(fieldName => {
-    if (fieldName === 'cardstack_rewrites' || fieldName === 'cardstack_meta' || fieldName === 'cardstack_source' || fieldName === 'cardstack_generation') {
-      return;
-    }
-    let outputName = fieldName;
-    let rewrite = rewrites[fieldName];
-    if (rewrite) {
-      if (rewrite.delete) {
-        return;
-      }
-      if (rewrite.rename) {
-        outputName = rewrite.rename;
-      }
-    }
-    if (rewrite && rewrite.isRelationship) {
-      if (!relationships) {
-        relationships = {};
-      }
-      relationships[outputName] = { data: document[fieldName] };
-    } else {
-      if (outputName === 'id') {
-        top.id = document[fieldName];
-      } else {
-        if (!attributes) {
-          attributes = {};
-        }
-        attributes[outputName] = document[fieldName];
-      }
-    }
-  });
-  if (attributes) {
-    top.attributes = attributes;
-  }
-  if (relationships) {
-    top.relationships = relationships;
-  }
-  if (document.cardstack_meta) {
-    top.meta = document.cardstack_meta;
-  }
-  return top;
+  return document.cardstack_pristine;
 };

--- a/packages/email-auth/cardstack/authenticator.js
+++ b/packages/email-auth/cardstack/authenticator.js
@@ -10,7 +10,7 @@ module.exports = declareInjections({
 class {
   async authenticate({ email, referer, secret }, { messageSinkId, subject, from, textTemplate, htmlTemplate }, userSearcher) {
     if (email) {
-      let { models } = await userSearcher.search({
+      let { data: models } = await userSearcher.search({
         filter: {
           email: {
             exact: email

--- a/packages/email-auth/cardstack/authenticator.js
+++ b/packages/email-auth/cardstack/authenticator.js
@@ -48,16 +48,19 @@ class {
           html
         });
         return {
-          partialSession: {
+          data: {
             attributes: {
               message: 'Check your email',
               state: 'pending-email'
             }
+          },
+          meta: {
+            partialSession: true
           }
         };
       } else {
         return {
-          user: {
+          data: {
             type: 'users',
             attributes: {
               email
@@ -78,7 +81,8 @@ class {
       }
       let user = await userSearcher.get('users', userId);
       if (user) {
-        return { preloadedUser: user };
+        user.meta = { preloaded: true };
+        return user;
       }
     }
   }

--- a/packages/email-auth/node-tests/email-auth-test.js
+++ b/packages/email-auth/node-tests/email-auth-test.js
@@ -74,14 +74,15 @@ describe('email-auth', function() {
     });
     expect(response).hasStatus(200);
     expect(response.body).has.deep.property('data.id');
-    expect(response.body).has.deep.property('meta.token');
+    expect(response.body).has.deep.property('data.meta.token');
 
     await env.lookup('hub:indexers').update({ realTime: true });
 
-    response = await request.get('/').set('authorization', `Bearer ${response.body.meta.token}`);
+    response = await request.get('/').set('authorization', `Bearer ${response.body.data.meta.token}`);
     expect(response).hasStatus(200);
-    expect(response.body.user).has.property('type', 'users');
-    expect(response.body.user.attributes).deep.equals({
+    expect(response.body.user).has.property('data');
+    expect(response.body.user.data).has.property('type', 'users');
+    expect(response.body.user.data.attributes).deep.equals({
       email: 'arthur@example.com',
     });
   });

--- a/packages/ephemeral/indexer.js
+++ b/packages/ephemeral/indexer.js
@@ -100,4 +100,8 @@ class Updater {
       identity: this.storage.identity
     };
   }
+
+  async read(type, id /*, isSchema */) {
+    return this.storage.lookup(type, id);
+  }
 }

--- a/packages/git/node-tests/config-test.js
+++ b/packages/git/node-tests/config-test.js
@@ -91,7 +91,7 @@ describe('git/config', function() {
     env = await createDefaultEnvironment(`${__dirname}/..`, factory.getModels());
 
     let response = await env.lookup('hub:searchers').search('master', { filter: { type: 'articles' } });
-    expect(response.models.map(m => m.id)).deep.equals(['2']);
+    expect(response.data.map(m => m.id)).deep.equals(['2']);
   });
 
   it('respects branchPrefix when creating', async function () {
@@ -161,7 +161,7 @@ describe('git/config', function() {
     env = await createDefaultEnvironment(`${__dirname}/..`, factory.getModels());
 
     let response = await env.lookup('hub:searchers').search('master', { filter: { type: 'articles' } });
-    expect(response.models.map(m => m.id)).deep.equals(['2']);
+    expect(response.data.map(m => m.id)).deep.equals(['2']);
   });
 
 

--- a/packages/git/node-tests/indexer-test.js
+++ b/packages/git/node-tests/indexer-test.js
@@ -345,7 +345,7 @@ describe('git/indexer', function() {
   });
 
   it('supports default-includes', async function() {
-    let { repo, head } = await makeRepo(root, {
+    await makeRepo(root, {
       'schema/content-types/articles.json': JSON.stringify({
         attributes: {
           'default-includes': ['author']

--- a/packages/git/node-tests/indexer-test.js
+++ b/packages/git/node-tests/indexer-test.js
@@ -403,7 +403,7 @@ describe('git/indexer', function() {
     await indexer.update();
 
     let contents = await ea.documentContents('master', 'articles', 'hello-world');
-    throw new Error("Finish implementing me");
+    expect(contents).has.deep.property('author.name', 'Q');
   });
 
 

--- a/packages/git/node-tests/indexer-test.js
+++ b/packages/git/node-tests/indexer-test.js
@@ -344,6 +344,69 @@ describe('git/indexer', function() {
     }
   });
 
+  it('supports default-includes', async function() {
+    let { repo, head } = await makeRepo(root, {
+      'schema/content-types/articles.json': JSON.stringify({
+        attributes: {
+          'default-includes': ['author']
+        },
+        relationships: {
+          fields: {
+            data: [
+              { type: 'fields', id: 'title' },
+              { type: 'fields', id: 'author' }
+            ]
+          }
+        }
+      }),
+      'schema/content-types/people.json': JSON.stringify({
+        relationships: {
+          fields: {
+            data: [
+              { type: 'fields', id: 'name' }
+            ]
+          }
+        }
+      }),
+      'schema/fields/title.json': JSON.stringify({
+        attributes: {
+          'field-type': '@cardstack/core-types::string'
+        }
+      }),
+      'schema/fields/author.json': JSON.stringify({
+        attributes: {
+          'field-type': '@cardstack/core-types::belongs-to'
+        }
+      }),
+      'schema/fields/name.json': JSON.stringify({
+        attributes: {
+          'field-type': '@cardstack/core-types::string'
+        }
+      }),
+      'contents/articles/hello-world.json': JSON.stringify({
+        attributes: {
+          title: 'Hello world'
+        },
+        relationships: {
+          author: {
+            data: { type: 'people', id: 'person1' }
+          }
+        }
+      }),
+      'contents/people/person1.json': JSON.stringify({
+        attributes: {
+          name: 'Q'
+        }
+      })
+    });
+
+    await indexer.update();
+
+    let contents = await ea.documentContents('master', 'articles', 'hello-world');
+    throw new Error("Finish implementing me");
+  });
+
+
 });
 
 describe('git/indexer failures', function() {

--- a/packages/git/node-tests/indexer-test.js
+++ b/packages/git/node-tests/indexer-test.js
@@ -2,11 +2,15 @@ const Change = require('../change');
 const temp = require('@cardstack/test-support/temp-helper');
 const { commitOpts, makeRepo } = require('./support');
 const ElasticAssert = require('@cardstack/elasticsearch/node-tests/assertions');
-const toJSONAPI = require('@cardstack/elasticsearch/to-jsonapi');
+const _toJSONAPI = require('@cardstack/elasticsearch/to-jsonapi');
 const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
 const { Registry, Container } = require('@cardstack/di');
 const logger = require('@cardstack/plugin-utils/logger');
 const fs = require('fs');
+
+function toJSONAPI(type, doc) {
+  return _toJSONAPI(type, doc).data;
+}
 
 describe('git/indexer', function() {
   let root, indexer, ea, dataSource;

--- a/packages/hub/bootstrap-schema.js
+++ b/packages/hub/bootstrap-schema.js
@@ -13,7 +13,8 @@ const models = [
           { type: 'fields', id: 'fields' },
           { type: 'fields', id: 'is-built-in' },
           { type: 'fields', id: 'routing-field' },
-          { type: 'fields', id: 'searchable-relationships' }
+          { type: 'fields', id: 'searchable-relationships' },
+          { type: 'fields', id: 'default-includes' }
         ]
       }
     }
@@ -179,6 +180,13 @@ const models = [
   {
     type: 'fields',
     id: 'searchable-relationships',
+    attributes: {
+      'field-type': '@cardstack/core-types::string-array'
+    }
+  },
+  {
+    type: 'fields',
+    id: 'default-includes',
     attributes: {
       'field-type': '@cardstack/core-types::string-array'
     }

--- a/packages/hub/bootstrap-schema.js
+++ b/packages/hub/bootstrap-schema.js
@@ -13,7 +13,6 @@ const models = [
           { type: 'fields', id: 'fields' },
           { type: 'fields', id: 'is-built-in' },
           { type: 'fields', id: 'routing-field' },
-          { type: 'fields', id: 'searchable-relationships' },
           { type: 'fields', id: 'default-includes' }
         ]
       }

--- a/packages/hub/bootstrap-schema.js
+++ b/packages/hub/bootstrap-schema.js
@@ -12,7 +12,8 @@ const models = [
           { type: 'fields', id: 'data-source' },
           { type: 'fields', id: 'fields' },
           { type: 'fields', id: 'is-built-in' },
-          { type: 'fields', id: 'routing-field' }
+          { type: 'fields', id: 'routing-field' },
+          { type: 'fields', id: 'searchable-relationships' }
         ]
       }
     }
@@ -173,6 +174,13 @@ const models = [
     id: 'routing-field',
     attributes: {
       'field-type': '@cardstack/core-types::string'
+    }
+  },
+  {
+    type: 'fields',
+    id: 'searchable-relationships',
+    attributes: {
+      'field-type': '@cardstack/core-types::string-array'
     }
   },
   {

--- a/packages/hub/indexers.js
+++ b/packages/hub/indexers.js
@@ -241,7 +241,7 @@ class Operations {
   }
   async save(type, id, doc){
     let { bulkOps, branch, log, schema, client, sourceId, nonce } = opsPrivate.get(this);
-    let searchDoc = await client.jsonapiToSearchDoc(id, doc, schema, branch, sourceId);
+    let searchDoc = await client.jsonapiToSearchDoc(type, id, doc, schema, branch, sourceId);
     if (nonce) {
       searchDoc.cardstack_generation = nonce;
     }

--- a/packages/hub/indexers.js
+++ b/packages/hub/indexers.js
@@ -380,9 +380,9 @@ class BranchUpdate {
       pristine.data.relationships = jsonapiDoc.relationships;
 
       if (!searchTree) {
-        // we are the root document, so our own configured searchTree
-        // determines which relationships to recurse into
-        searchTree = this.schema.types.get(type).searchTree;
+        // we are the root document, so our own configured default
+        // includes determines which relationships to recurse into
+        searchTree = this.schema.types.get(type).includesTree;
       }
 
       let ourIncludes;

--- a/packages/hub/indexers.js
+++ b/packages/hub/indexers.js
@@ -440,7 +440,7 @@ class BranchUpdate {
                 ourReferences.push(`${type}/${id}`);
                 let resource = await this.read(type, id);
                 if (resource) {
-                  return this._prepareSearchDoc(type, id, resource, searchTree[attribute], ourIncludes);
+                  return this._prepareSearchDoc(type, id, resource, searchTree[attribute], ourIncludes, ourReferences);
                 }
               }));
               related = related.filter(Boolean);
@@ -449,7 +449,7 @@ class BranchUpdate {
               ourReferences.push(`${value.data.type}/${value.data.id}`);
               let resource = await this.read(value.data.type, value.data.id);
               if (resource) {
-                related = await this._prepareSearchDoc(resource.type, resource.id, resource, searchTree[attribute], ourIncludes);
+                related = await this._prepareSearchDoc(resource.type, resource.id, resource, searchTree[attribute], ourIncludes, ourReferences);
               } else {
                 pristine.data.relationships[attribute].data = null;
               }

--- a/packages/hub/indexers.js
+++ b/packages/hub/indexers.js
@@ -401,11 +401,20 @@ class BranchUpdate {
             if (Array.isArray(value.data)) {
               related = await Promise.all(value.data.map(async ({ type, id }) => {
                 let resource = await this.read(type, id);
-                return this._prepareSearchDoc(type, id, resource, searchTree[attribute], ourIncludes);
+                if (resource) {
+                  return this._prepareSearchDoc(type, id, resource, searchTree[attribute], ourIncludes);
+                }
               }));
+              related = related.filter(Boolean);
+              pristine.data.relationships[attribute].data = related.map(r => ({ type: r.type, id: r.id }));
             } else {
               let resource = await this.read(value.data.type, value.data.id);
-              related = await this._prepareSearchDoc(resource.type, resource.id, resource, searchTree[attribute], ourIncludes);
+              if (resource) {
+                related = await this._prepareSearchDoc(resource.type, resource.id, resource, searchTree[attribute], ourIncludes);
+              } else {
+                pristine.data.relationships[attribute].data = null;
+              }
+
             }
           } else {
             related = value.data;

--- a/packages/hub/indexers.js
+++ b/packages/hub/indexers.js
@@ -421,7 +421,7 @@ class BranchUpdate {
       }
     }
     if (jsonapiDoc.relationships) {
-      pristine.data.relationships = jsonapiDoc.relationships;
+      let relationships = pristine.data.relationships = Object.assign({}, jsonapiDoc.relationships);
 
       if (!searchTree) {
         // we are the root document, so our own configured default
@@ -444,14 +444,14 @@ class BranchUpdate {
                 }
               }));
               related = related.filter(Boolean);
-              pristine.data.relationships[attribute].data = related.map(r => ({ type: r.type, id: r.id }));
+              relationships[attribute] = Object.assign({}, relationships[attribute], { data: related.map(r => ({ type: r.type, id: r.id })) });
             } else {
               ourReferences.push(`${value.data.type}/${value.data.id}`);
               let resource = await this.read(value.data.type, value.data.id);
               if (resource) {
                 related = await this._prepareSearchDoc(resource.type, resource.id, resource, searchTree[attribute], ourIncludes, ourReferences);
               } else {
-                pristine.data.relationships[attribute].data = null;
+                relationships[attribute] = Object.assign({}, relationships[attribute], { data: null });
               }
 
             }

--- a/packages/hub/messengers.js
+++ b/packages/hub/messengers.js
@@ -28,8 +28,8 @@ class Messengers {
       }
 
       let schema = await this.schemaCache.schemaForControllingBranch();
-      let Plugin = schema.plugins.lookupFeatureFactoryAndAssert('messengers', sink.attributes['messenger-type']);
-      let messenger = Plugin.create(Object.assign({ sinkId },  sink.attributes.params));
+      let Plugin = schema.plugins.lookupFeatureFactoryAndAssert('messengers', sink.data.attributes['messenger-type']);
+      let messenger = Plugin.create(Object.assign({ sinkId },  sink.data.attributes.params));
 
       this.messengerCache[sinkId] = messenger;
 

--- a/packages/hub/node-tests/indexers-test.js
+++ b/packages/hub/node-tests/indexers-test.js
@@ -18,12 +18,12 @@ describe('hub/indexers', function() {
   it("indexes seed models", async function() {
     // this seed model comes from createDefaultEnvironment
     let response = await env.lookup('hub:searchers').search('master', { filter: { type: 'plugin-configs' }});
-    expect(response.models.map(m => m.id)).includes('@cardstack/hub');
+    expect(response.data.map(m => m.id)).includes('@cardstack/hub');
   });
 
   it("indexes bootstrap models", async function() {
     let response = await env.lookup('hub:searchers').search('master', { filter: { type: 'content-types' }});
-    expect(response.models.map(m => m.id)).includes('content-types');
+    expect(response.data.map(m => m.id)).includes('content-types');
   });
 
 });

--- a/packages/hub/node-tests/middleware-stack-test.js
+++ b/packages/hub/node-tests/middleware-stack-test.js
@@ -86,7 +86,7 @@ describe('middleware-stack', function() {
 
     it('can dynamically remove middleware', async function() {
       let config = await env.lookup('hub:searchers').get('master', 'plugin-configs', 'stub-middleware');
-      await env.lookup('hub:writers').delete('master', env.session, config.meta.version, config.type, config.id);
+      await env.lookup('hub:writers').delete('master', env.session, config.data.meta.version, config.data.type, config.data.id);
       await env.lookup('hub:indexers').update({ realTime: true });
       let response = await request.get('/first');
       expect(response).hasStatus(404);

--- a/packages/hub/node-tests/searchers-test.js
+++ b/packages/hub/node-tests/searchers-test.js
@@ -73,15 +73,15 @@ describe('hub/searchers', function() {
   it("searchers#search finds record via internal searcher", async function() {
     await setup({});
     let response = await env.lookup('hub:searchers').search('master', { filter: { 'example-flavor': { exact: 'chocolate' } } });
-    expect(response.models).length(1);
-    expect(response.models[0].attributes['example-flavor']).to.equal('chocolate');
+    expect(response.data).length(1);
+    expect(response.data[0].attributes['example-flavor']).to.equal('chocolate');
   });
 
   it("a plugin's searchers#search can run before the internal searcher", async function() {
     await setup({ injectFirst: 'vanilla' });
     let response = await env.lookup('hub:searchers').search('master', { filter: { 'example-flavor': { exact: 'chocolate' } } });
-    expect(response.models).length(1);
-    expect(response.models[0].attributes['example-flavor']).to.equal('vanilla');
+    expect(response.data).length(1);
+    expect(response.data[0].attributes['example-flavor']).to.equal('vanilla');
   });
 
 });

--- a/packages/hub/node-tests/searchers-test.js
+++ b/packages/hub/node-tests/searchers-test.js
@@ -55,19 +55,19 @@ describe('hub/searchers', function() {
   it("searchers#get finds record via internal searcher", async function() {
     await setup({});
     let response = await env.lookup('hub:searchers').get('master', 'examples', chocolate.id);
-    expect(response.attributes['example-flavor']).to.equal('chocolate');
+    expect(response.data.attributes['example-flavor']).to.equal('chocolate');
   });
 
   it("a plugin's searcher#get can run before the internal searcher", async function() {
     await setup({ injectFirst: 'vanilla' });
     let response = await env.lookup('hub:searchers').get('master', 'examples', chocolate.id);
-    expect(response.attributes['example-flavor']).to.equal('vanilla');
+    expect(response.data.attributes['example-flavor']).to.equal('vanilla');
   });
 
   it("a plugin's searcher#get can run after the internal searcher", async function() {
     await setup({ injectSecond: 'vanilla' });
     let response = await env.lookup('hub:searchers').get('master', 'examples', '10000');
-    expect(response.attributes['example-flavor']).to.equal('vanilla');
+    expect(response.data.attributes['example-flavor']).to.equal('vanilla');
   });
 
   it("searchers#search finds record via internal searcher", async function() {

--- a/packages/hub/schema-cache.js
+++ b/packages/hub/schema-cache.js
@@ -127,7 +127,7 @@ class SchemaCache {
   async _load(branch) {
     this.log.debug("initiating schema load on branch %s", branch);
     try {
-      let { models, page } = await this.searcher.search(branch, {
+      let { data: models, meta: { page } } = await this.searcher.search(branch, {
         filter: {
           type: this.schemaLoader.ownTypes(),
           not: {

--- a/packages/hub/schema/content-type.js
+++ b/packages/hub/schema/content-type.js
@@ -50,6 +50,13 @@ module.exports = class ContentType {
     } else {
       this.searchTree = Object.create(null);
     }
+
+    if (model.attributes && model.attributes['default-includes']) {
+      this.includesTree = buildSearchTree(model.attributes['default-includes']);
+    } else {
+      this.includesTree = Object.create(null);
+    }
+
     this.allFields = allFields;
   }
 

--- a/packages/hub/schema/content-type.js
+++ b/packages/hub/schema/content-type.js
@@ -44,6 +44,12 @@ module.exports = class ContentType {
       return Object.values(constraint.fieldInputs).some(field => this.fields.get(field.id));
     });
     this.routingField = model.attributes && model.attributes['routing-field'];
+
+    if (model.attributes && model.attributes['searchable-relationships']) {
+      this.searchTree = buildSearchTree(model.attributes['searchable-relationships']);
+    } else {
+      this.searchTree = Object.create(null);
+    }
     this.allFields = allFields;
   }
 
@@ -118,7 +124,7 @@ module.exports = class ContentType {
   mapping() {
     let properties = {};
     for (let field of this.fields.values()) {
-      Object.assign(properties, field.mapping(this.allFields));
+      Object.assign(properties, field.mapping(this.searchTree, this.allFields));
     }
     return { properties };
   }
@@ -171,4 +177,19 @@ function tagFieldErrors(field, errors) {
     }
   });
   return errors;
+}
+
+function buildSearchTree(searchableRelationships) {
+  let root = Object.create(null);
+  for (let path of searchableRelationships) {
+    let segments = path.split('.');
+    let pointer = root;
+    for (let segment of segments) {
+      if (!pointer[segment]) {
+        pointer[segment] = Object.create(null);
+      }
+      pointer = pointer[segment];
+    }
+  }
+  return root;
 }

--- a/packages/hub/schema/content-type.js
+++ b/packages/hub/schema/content-type.js
@@ -45,12 +45,6 @@ module.exports = class ContentType {
     });
     this.routingField = model.attributes && model.attributes['routing-field'];
 
-    if (model.attributes && model.attributes['searchable-relationships']) {
-      this.searchTree = buildSearchTree(model.attributes['searchable-relationships']);
-    } else {
-      this.searchTree = Object.create(null);
-    }
-
     if (model.attributes && model.attributes['default-includes']) {
       this.includesTree = buildSearchTree(model.attributes['default-includes']);
     } else {
@@ -131,7 +125,7 @@ module.exports = class ContentType {
   mapping() {
     let properties = {};
     for (let field of this.fields.values()) {
-      Object.assign(properties, field.mapping(this.searchTree, this.allFields));
+      Object.assign(properties, field.mapping(this.includesTree, this.allFields));
     }
     return { properties };
   }

--- a/packages/hub/schema/index.js
+++ b/packages/hub/schema/index.js
@@ -26,6 +26,10 @@ class Schema {
     }
   }
 
+  isSchemaType(type) {
+    return this.schemaLoader.ownTypes().includes(type);
+  }
+
   // derives a new schema by adding, updating, or removing
   // models. Takes a list of { type, id, document } objects. A null document
   // means deletion.
@@ -33,7 +37,7 @@ class Schema {
     let models = this._originalModels;
     for (let change of changes) {
       let { type, id, document } = change;
-      if (!this.schemaLoader.ownTypes().includes(type)) {
+      if (!this.isSchemaType(type)) {
         // not a schema model, so we can ignore it
         continue;
       }

--- a/packages/hub/schema/index.js
+++ b/packages/hub/schema/index.js
@@ -137,6 +137,7 @@ class Schema {
         this._mapping[contentType.id] = contentType.mapping();
         this._mapping[contentType.id].properties.cardstack_source = { type: 'keyword' };
         this._mapping[contentType.id].properties.cardstack_generation = { type: 'keyword' };
+        this._mapping[contentType.id].properties.cardstack_pristine = { type: 'object', enabled: false };
       }
     }
     return this._mapping;

--- a/packages/hub/schema/index.js
+++ b/packages/hub/schema/index.js
@@ -142,6 +142,7 @@ class Schema {
         this._mapping[contentType.id].properties.cardstack_source = { type: 'keyword' };
         this._mapping[contentType.id].properties.cardstack_generation = { type: 'keyword' };
         this._mapping[contentType.id].properties.cardstack_pristine = { type: 'object', enabled: false };
+        this._mapping[contentType.id].properties.cardstack_references = { type: 'keyword' };
       }
     }
     return this._mapping;

--- a/packages/jsonapi/middleware.js
+++ b/packages/jsonapi/middleware.js
@@ -1,10 +1,11 @@
 const Error = require('@cardstack/plugin-utils/error');
 const qs = require('qs');
-const { merge, flatten } = require('lodash');
+const { merge, flatten, uniq, uniqBy } = require('lodash');
 const koaJSONBody = require('koa-json-body');
 const logger = require('@cardstack/plugin-utils/logger');
 const { declareInjections } = require('@cardstack/di');
 const { URL } = require('url');
+const defaultIncludes = {};
 
 module.exports = declareInjections({
   searcher: 'hub:searchers',
@@ -74,8 +75,6 @@ class Handler {
     this.prefix = options.prefix || '';
     this.log = log;
     this._includes = null;
-    this.includedSets = null;
-    this.includedResources = null;
   }
 
   get session() {
@@ -84,10 +83,14 @@ class Handler {
 
   get includes() {
     if (!this._includes) {
-      if (this.query.include) {
-        this._includes = this.query.include.split(',').map(part => part.split('.'));
+      if (this.query.include != null) {
+        if (this.query.include) {
+          this._includes = this.query.include.split(',').map(part => part.split('.'));
+        } else {
+          this._includes = [];
+        }
       } else {
-        this._includes = [];
+        this._includes = defaultIncludes;
       }
     }
     return this._includes;
@@ -143,7 +146,9 @@ class Handler {
   async handleIndividualGET(type, id) {
     let body = await this._lookupRecord(type, id);
     this.ctxt.body = body;
-    if (this.includes.length === 0) {
+    if (this.includes === defaultIncludes) {
+      // leave alone whatever includes were already on the document we
+      // got out of the search index.
       return;
     }
     await this._loadAllIncluded([body.data]);
@@ -180,7 +185,7 @@ class Handler {
   }
 
   async handleCollectionGET(type) {
-    let { data: models, meta: { page } } = await this.searcher.search(this.branch, {
+    let { data: models, meta: { page }, included } = await this.searcher.search(this.branch, {
       filter: this.filterExpression(type),
       sort: this.query.sort,
       page: this.query.page,
@@ -193,7 +198,20 @@ class Handler {
       };
     }
     this.ctxt.body = body;
-    await this._loadAllIncluded(models);
+    if (this.includes === defaultIncludes) {
+      if (included) {
+        // the default includes out of the searcher are not guaranteed
+        // to be deduplicated
+        body.included = uniqBy(models.concat(included), r => `${r.type}/${r.id}`).slice(models.length);
+      }
+    } else {
+      if (included && included.length > 0) {
+        // we don't need to do any deduplication here because
+        // loadAllIncluded is going to take over.
+        body.included = included;
+      }
+      await this._loadAllIncluded(models);
+    }
   }
 
   async handleCollectionPOST(type) {
@@ -212,14 +230,33 @@ class Handler {
   }
 
   async _lookupRecord(type, id) {
-    if (this.includedResources) {
-      let record = this.includedResources[`${type}/${id}`];
-      if (record) {
-        return record;
-      }
-    }
     let record = await this.searcher.get(this.branch, type, id);
     return record;
+  }
+
+  async _cachedLookupRecord(type, id, cache) {
+    let key = `${type}/${id}`;
+    {
+      let cached = cache[key];
+      if (cached) {
+        return cached;
+      }
+    }
+    let resource = await this._lookupRecord(type, id);
+    if (resource) {
+      if (!cache[key]) {
+        cache[key] = resource.data;
+      }
+      if (resource.included) {
+        for (let inner of resource.included) {
+          let innerKey = `${inner.type}/${inner.id}`;
+          if (!cache[innerKey]) {
+            cache[innerKey] = inner;
+          }
+        }
+      }
+      return cache[key];
+    }
   }
 
   _mandatoryBodyData() {
@@ -246,61 +283,68 @@ class Handler {
   async _loadAllIncluded(root) {
     // this is a map from each requested include path to a promise
     // that resolves with the list of resources in that set
-    this.includedSets = Object.create(null);
+    let sets = Object.create(null);
 
     // this is a map from type/id strings to each of the resources we
-    // have already loaded
-    this.includedResources = Object.create(null);
+    // have already loaded.
+    let cache = Object.create(null);
+    for (let resource of root) {
+      cache[`${resource.type}/${resource.id}`] = resource;
+    }
 
     // some included models may have already come along with the
     // document we got out of the searcher
     if (this.ctxt.body.included) {
       for (let resource of this.ctxt.body.included) {
-        this.includedResources[`${resource.type}/${resource.id}`] = resource;
+        cache[`${resource.type}/${resource.id}`] = resource;
       }
     }
 
-    this.includes.forEach(segments => this._loadIncluded(root, segments));
-    await Promise.all(Object.values(this.includedSets));
-    this.ctxt.body.included = Object.keys(this.includedResources).map(k => this.includedResources[k].data);
+    this.includes.forEach(segments => this._loadIncluded(root, segments, cache, sets));
+
+    // this uniq works because our cache works as an identity map
+    let included = uniq(root.concat(flatten(await Promise.all(Object.values(sets)))));
+
+    if (included.length > root.length) {
+      this.ctxt.body.included = included.slice(root.length);
+    } else {
+      delete this.ctxt.body.included;
+    }
   }
 
-  async _loadIncluded(root, segments) {
+  async _loadIncluded(root, segments, cache, sets) {
     let name = segments.join('.');
-    if (this.includedSets[name]) {
-      return this.includedSets[name];
+    if (sets[name]) {
+      return sets[name];
     }
 
-    return this.includedSets[name] = (async () => {
+    return sets[name] = (async () => {
       let tail = segments[segments.length - 1];
       let sourceSet;
       if (segments.length === 1) {
         sourceSet = root;
       } else {
-        sourceSet = await this._loadIncluded(root, segments.slice(0, -1));
+        sourceSet = await this._loadIncluded(root, segments.slice(0, -1), cache, sets);
       }
-      let resources = flatten(await Promise.all(sourceSet.map(record => {
+
+      // TODO: we could correlate all the things that need to be
+      // fetched at this level into a single query, or at least a
+      // single query per type.
+      let lists = await Promise.all(sourceSet.map(async record => {
         if (!record.relationships || !record.relationships[tail]) {
           return [];
         }
         let data = record.relationships[tail].data;
         if (Array.isArray(data)) {
-          return Promise.all(data.map(ref => this._lookupRecord(ref.type, ref.id)));
+          return Promise.all(data.map(ref => this._cachedLookupRecord(ref.type, ref.id, cache)));
         } else if (data) {
-          return this._lookupRecord(data.type, data.id).then(record => [record]);
+          let resource = await this._cachedLookupRecord(data.type, data.id, cache);
+          return [resource];
         } else {
           return [];
         }
-      })));
-      for (let resource of resources) {
-        this.includedResources[`${resource.data.type}/${resource.data.id}`] = resource;
-        if (resource.included) {
-          for (let inner of resource.included) {
-            this.includedResources[`${inner.data.type}/${inner.data.id}`] = { data: inner };
-          }
-        }
-      }
-      return resources.map(r => r.data);
+      }));
+      return flatten(lists);
     })();
   }
 }

--- a/packages/jsonapi/middleware.js
+++ b/packages/jsonapi/middleware.js
@@ -180,7 +180,7 @@ class Handler {
   }
 
   async handleCollectionGET(type) {
-    let { models, page } = await this.searcher.search(this.branch, {
+    let { data: models, meta: { page } } = await this.searcher.search(this.branch, {
       filter: this.filterExpression(type),
       sort: this.query.sort,
       page: this.query.page,

--- a/packages/jsonapi/node-tests/middleware-test.js
+++ b/packages/jsonapi/node-tests/middleware-test.js
@@ -39,8 +39,7 @@ describe('jsonapi/middleware', function() {
 
     factory.addResource('content-types', 'events')
       .withAttributes({
-        defaultIncludes: ['similar-articles.author', 'previous.previous'],
-        searchableRelationships: ['similar-articles.author', 'previous.previous']
+        defaultIncludes: ['similar-articles.author', 'previous.previous']
       })
       .withRelated('fields', [
         factory.getResource('fields', 'title'),
@@ -560,10 +559,6 @@ describe('jsonapi/middleware', function() {
       let response = await request.get('/api/events?include=next&filter[id][]=4&filter[id][]=5');
       expect(response).hasStatus(200);
       expect(response.body).not.has.property('included');
-    });
-
-    it('distinguishes default-includes vs searchable-relationships', function() {
-      expect(false).is.ok;
     });
 
   });

--- a/packages/plugin-utils/session.js
+++ b/packages/plugin-utils/session.js
@@ -1,4 +1,10 @@
 class Session {
+
+  // payload must have at least `id` and `type` (which together are
+  // the jsonapi reference to the current user's resource.
+  //
+  // optionalUser can be a jsonapi document representing that user (a
+  // full document, including the top-level `data` property)
   constructor(payload, userSearcher, optionalUser, optionalGroupIds) {
     this.payload = payload;
     this.userSearcher = userSearcher;

--- a/packages/postgresql/name-mapper.js
+++ b/packages/postgresql/name-mapper.js
@@ -1,0 +1,68 @@
+const { kebabCase, snakeCase } = require('lodash');
+
+module.exports = class NameMapper {
+  constructor(renameTables, renameColumns) {
+    this.renameTables = renameTables || Object.create(null);
+    this.renameColumns = renameColumns || Object.create(null);
+  }
+
+  typeNameFor(schema, table) {
+    // The default schema in postgres is called 'public'. We can
+    // conventionally strip that off the type names, while keeping
+    // it on for more exotic schemas.
+
+    // json-api uses kebab case but database tables use underscores
+    let tableDasherized = kebabCase(table);
+    let defaultName;
+    if (schema !== 'public') {
+      defaultName = `${schema}.${tableDasherized}`;
+    } else {
+      defaultName = tableDasherized;
+    }
+    let renamed = this.renameTables[defaultName];
+    if (renamed != null) {
+      return renamed;
+    } else {
+      return defaultName;
+    }
+  }
+
+  tableForType(type) {
+    let originalName = Object.keys(this.renameTables).find(k => this.renameTables[k] === type) || type;
+    let m = /([^.]+)\.([^.]+)/.exec(originalName);
+    if (m) {
+      return { schema: m[1], table: snakeCase(m[2]) };
+    } else {
+      return { schema: 'public', table: snakeCase(originalName) };
+    }
+  }
+
+  fieldNameFor(schema, table, column) {
+    let key = table;
+    if (schema !== 'public') {
+      key = `${schema}.${table}`;
+    }
+    let tableSection = this.renameColumns[key];
+    if (tableSection) {
+      let renamed = tableSection[column];
+      if (renamed) {
+        return renamed;
+      }
+    }
+    return kebabCase(column);
+  }
+
+  columnNameFor(schema, table, fieldName) {
+    let key = table;
+    if (schema !== 'public') {
+      key = `${schema}.${table}`;
+    }
+    let remappedColumns = this.renameColumns[key];
+    if (remappedColumns) {
+      return Object.keys(remappedColumns).find(k => remappedColumns[k] === fieldName) || fieldName;
+    } else {
+      return snakeCase(fieldName);
+    }
+  }
+
+};

--- a/packages/postgresql/node-tests/indexer-test.js
+++ b/packages/postgresql/node-tests/indexer-test.js
@@ -177,5 +177,8 @@ describe('postgresql/indexer', function() {
     expect(model).has.deep.property('attributes.length', null);
   });
 
+  it('supports default includes', async function() {
+    throw new Error("Unimplemented");
+  });
 
 });

--- a/packages/postgresql/node-tests/indexer-test.js
+++ b/packages/postgresql/node-tests/indexer-test.js
@@ -8,15 +8,17 @@ const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
 describe('postgresql/indexer', function() {
   let pgClient, client, env, dataSource;
 
-  beforeEach(async function() {
+  async function setup() {
     pgClient = new Client({ database: 'postgres', host: 'localhost', user: 'postgres', port: 5444 });
     await pgClient.connect();
     await pgClient.query(`create database test1`);
 
     client = new Client({ database: 'test1', host: 'localhost', user: 'postgres', port: 5444 });
     await client.connect();
-    await client.query('create table articles (id varchar primary key, title varchar, length integer, published boolean)');
+    await client.query('create table editors (id varchar primary key, name varchar)');
+    await client.query('create table articles (id varchar primary key, title varchar, length integer, published boolean, topic varchar, editor varchar references editors(id))');
     await client.query('insert into articles values ($1, $2, $3, $4)', ['0', 'hello world', 100, true]);
+    await client.query('insert into articles values ($1, $2, $3, $4)', ['1', null, null, false]);
 
     let factory = new JSONAPIFactory();
 
@@ -41,144 +43,168 @@ describe('postgresql/indexer', function() {
     env = await createDefaultEnvironment(`${__dirname}/..`, factory.getModels());
 
     await env.lookup('hub:indexers').update({ realTime: true });
-  });
+  }
 
-  afterEach(async function() {
+  async function teardown() {
     await destroyDefaultEnvironment(env);
     await client.end();
     await pgClient.query(`select pg_drop_replication_slot(slot_name) from pg_replication_slots;`);
     await pgClient.query(`drop database test1`);
     await pgClient.end();
+  }
+
+  describe('read-only tests', function() {
+    before(setup);
+    after(teardown);
+
+    it('has a database', async function() {
+      let result = await client.query('select title from articles where id=$1', ['0']);
+      expect(result.rows).has.length(1);
+      expect(result.rows[0].title).to.equal('hello world');
+    });
+
+    it('discovers content types', async function() {
+      let doc = await env.lookup('hub:searchers').get('master', 'content-types', 'articles');
+      expect(doc).is.ok;
+      let model = doc.data;
+      expect(model).is.ok;
+      expect(model).has.deep.property('relationships.fields.data');
+      expect(model.relationships.fields.data).collectionContains({ id: 'title' });
+      expect(model.relationships.fields.data).not.collectionContains({ id: 'id' });
+      expect(model.relationships['data-source'].data).has.property('id', dataSource.id);
+    });
+
+    it('discovers initial records', async function() {
+      let doc = await env.lookup('hub:searchers').get('master', 'articles', '0');
+      expect(doc).is.ok;
+      let model = doc.data;
+      expect(model).is.ok;
+      expect(model).has.deep.property('attributes.title', 'hello world');
+    });
+
+    it('can read an integer column', async function() {
+      let doc = await env.lookup('hub:searchers').get('master', 'articles', '0');
+      expect(doc).is.ok;
+      let model = doc.data;
+      expect(model).has.deep.property('attributes.length', 100);
+    });
+
+    it('can read a boolean column', async function() {
+      let doc = await env.lookup('hub:searchers').get('master', 'articles', '1');
+      expect(doc).is.ok;
+      let model = doc.data;
+      expect(model).has.deep.property('attributes.published', false);
+    });
+
+    it('can read null string', async function() {
+      let doc = await env.lookup('hub:searchers').get('master', 'articles', '1');
+      expect(doc).is.ok;
+      let model = doc.data;
+      expect(model).has.deep.property('attributes.title', null);
+    });
+
+    it('can read null integer', async function() {
+      let doc = await env.lookup('hub:searchers').get('master', 'articles', '1');
+      expect(doc).is.ok;
+      let model = doc.data;
+      expect(model).has.deep.property('attributes.length', null);
+    });
+
+    it('can rename tables', async function() {
+      let doc = await env.lookup('hub:searchers').get('master', 'content-types', 'real-editors');
+      expect(doc).is.ok;
+    });
+
+    it('can rename columns', async function() {
+      let doc = await env.lookup('hub:searchers').get('master', 'content-types', 'articles');
+      expect(doc).is.ok;
+      expect(doc.data.relationships.fields.data.map(f => f.id)).contains('real-topic');
+    });
+
+
+    it('can customize discovered schema', async function() {
+      let doc = await env.lookup('hub:searchers').get('master', 'content-types', 'articles');
+      expect(doc.data.attributes).has.property('default-includes');
+      expect(doc.data.attributes['default-includes']).deep.equals(['editors']);
+    });
+
+    it('supports default includes', async function() {
+      throw new Error("Unimplemented");
+    });
+
   });
 
-  it('has a database', async function() {
-    let result = await client.query('select title from articles where id=$1', ['0']);
-    expect(result.rows).has.length(1);
-    expect(result.rows[0].title).to.equal('hello world');
+  describe('read/write tests', function() {
+    beforeEach(setup);
+    afterEach(teardown);
+
+    it('discovers new records', async function() {
+      await client.query('insert into articles values ($1, $2)', ['2', 'second article']);
+      await env.lookup('hub:indexers').update({ realTime: true });
+      let doc = await env.lookup('hub:searchers').get('master', 'articles', '2');
+      expect(doc).is.ok;
+      let model = doc.data;
+      expect(model).is.ok;
+      expect(model).has.deep.property('attributes.title', 'second article');
+    });
+
+
+    it('updates records', async function() {
+      await client.query('update articles set title=$1 where id=$2', ['I was updated', '0']);
+      await env.lookup('hub:indexers').update({ realTime: true });
+      let doc = await env.lookup('hub:searchers').get('master', 'articles', '0');
+      expect(doc).is.ok;
+      let model = doc.data;
+      expect(model).is.ok;
+      expect(model).has.deep.property('attributes.title', 'I was updated');
+    });
+
+    it('deletes records', async function() {
+      await client.query('delete from articles where id=$1', ['0']);
+      await env.lookup('hub:indexers').update({ realTime: true });
+      try {
+        await env.lookup('hub:searchers').get('master', 'articles', '0');
+        throw new Error("should not get here");
+      } catch (err) {
+        expect(err.status).to.equal(404);
+      }
+    });
+
+    it('discovers newly added content type', async function() {
+      await client.query('create table humans (id varchar primary key, name varchar)');
+      await env.lookup('hub:indexers').update({ realTime: true });
+      let doc = await env.lookup('hub:searchers').get('master', 'content-types', 'humans');
+      expect(doc).is.ok;
+      let model = doc.data;
+      expect(model).is.ok;
+      expect(model).has.deep.property('relationships.fields.data');
+      expect(model.relationships.fields.data).collectionContains({ id: 'name' });
+    });
+
+    it('removes deleted content type', async function() {
+      await client.query('drop table articles');
+      await env.lookup('hub:indexers').update({ realTime: true });
+      try {
+        await env.lookup('hub:searchers').get('master', 'content-types', 'articles');
+        throw new Error("should not get here");
+      } catch (err) {
+        expect(err.status).to.equal(404);
+      }
+    });
+
+    it('discovers newly added column', async function() {
+      await client.query('alter table articles add column author varchar');
+      await client.query('update articles set author=$1 where id=$2', ['Arthur', '0']);
+      await env.lookup('hub:indexers').update({ realTime: true });
+      let doc = await env.lookup('hub:searchers').get('master', 'content-types', 'articles');
+      expect(doc).is.ok;
+      let model = doc.data;
+      expect(model).has.deep.property('relationships.fields.data');
+      expect(model.relationships.fields.data).collectionContains({ id: 'author' });
+      doc = await env.lookup('hub:searchers').get('master', 'articles', '0');
+      expect(doc).has.deep.property('data.attributes.author', 'Arthur');
+    });
+
+
   });
-
-  it('discovers content types', async function() {
-    let doc = await env.lookup('hub:searchers').get('master', 'content-types', 'articles');
-    expect(doc).is.ok;
-    let model = doc.data;
-    expect(model).is.ok;
-    expect(model).has.deep.property('relationships.fields.data');
-    expect(model.relationships.fields.data).collectionContains({ id: 'title' });
-    expect(model.relationships.fields.data).not.collectionContains({ id: 'id' });
-    expect(model.relationships['data-source'].data).has.property('id', dataSource.id);
-  });
-
-  it('discovers initial records', async function() {
-    let doc = await env.lookup('hub:searchers').get('master', 'articles', '0');
-    expect(doc).is.ok;
-    let model = doc.data;
-    expect(model).is.ok;
-    expect(model).has.deep.property('attributes.title', 'hello world');
-  });
-
-  it('discovers new records', async function() {
-    await client.query('insert into articles values ($1, $2)', ['1', 'second article']);
-    await env.lookup('hub:indexers').update({ realTime: true });
-    let doc = await env.lookup('hub:searchers').get('master', 'articles', '1');
-    expect(doc).is.ok;
-    let model = doc.data;
-    expect(model).is.ok;
-    expect(model).has.deep.property('attributes.title', 'second article');
-  });
-
-
-  it('updates records', async function() {
-    await client.query('update articles set title=$1 where id=$2', ['I was updated', '0']);
-    await env.lookup('hub:indexers').update({ realTime: true });
-    let doc = await env.lookup('hub:searchers').get('master', 'articles', '0');
-    expect(doc).is.ok;
-    let model = doc.data;
-    expect(model).is.ok;
-    expect(model).has.deep.property('attributes.title', 'I was updated');
-  });
-
-  it('deletes records', async function() {
-    await client.query('delete from articles where id=$1', ['0']);
-    await env.lookup('hub:indexers').update({ realTime: true });
-    try {
-      await env.lookup('hub:searchers').get('master', 'articles', '0');
-      throw new Error("should not get here");
-    } catch (err) {
-      expect(err.status).to.equal(404);
-    }
-  });
-
-  it('discovers newly added content type', async function() {
-    await client.query('create table humans (id varchar primary key, name varchar)');
-    await env.lookup('hub:indexers').update({ realTime: true });
-    let doc = await env.lookup('hub:searchers').get('master', 'content-types', 'humans');
-    expect(doc).is.ok;
-    let model = doc.data;
-    expect(model).is.ok;
-    expect(model).has.deep.property('relationships.fields.data');
-    expect(model.relationships.fields.data).collectionContains({ id: 'name' });
-  });
-
-  it('removes deleted content type', async function() {
-    await client.query('drop table articles');
-    await env.lookup('hub:indexers').update({ realTime: true });
-    try {
-      await env.lookup('hub:searchers').get('master', 'content-types', 'articles');
-      throw new Error("should not get here");
-    } catch (err) {
-      expect(err.status).to.equal(404);
-    }
-  });
-
-  it('discovers newly added column', async function() {
-    await client.query('alter table articles add column author varchar');
-    await client.query('update articles set author=$1 where id=$2', ['Arthur', '0']);
-    await env.lookup('hub:indexers').update({ realTime: true });
-    let doc = await env.lookup('hub:searchers').get('master', 'content-types', 'articles');
-    expect(doc).is.ok;
-    let model = doc.data;
-    expect(model).has.deep.property('relationships.fields.data');
-    expect(model.relationships.fields.data).collectionContains({ id: 'author' });
-    doc = await env.lookup('hub:searchers').get('master', 'articles', '0');
-    expect(doc).has.deep.property('data.attributes.author', 'Arthur');
-  });
-
-  it('can read an integer column', async function() {
-    let doc = await env.lookup('hub:searchers').get('master', 'articles', '0');
-    expect(doc).is.ok;
-    let model = doc.data;
-    expect(model).has.deep.property('attributes.length', 100);
-  });
-
-  it('can read a boolean column', async function() {
-    await client.query('insert into articles (id, published) values ($1, $2)', ['1', false]);
-    await env.lookup('hub:indexers').update({ realTime: true });
-    let doc = await env.lookup('hub:searchers').get('master', 'articles', '1');
-    expect(doc).is.ok;
-    let model = doc.data;
-    expect(model).has.deep.property('attributes.published', false);
-  });
-
-  it('can read null string', async function() {
-    await client.query('insert into articles (id) values ($1)', ['1']);
-    await env.lookup('hub:indexers').update({ realTime: true });
-    let doc = await env.lookup('hub:searchers').get('master', 'articles', '1');
-    expect(doc).is.ok;
-    let model = doc.data;
-    expect(model).has.deep.property('attributes.title', null);
-  });
-
-  it('can read null integer', async function() {
-    await client.query('insert into articles (id) values ($1)', ['1']);
-    await env.lookup('hub:indexers').update({ realTime: true });
-    let doc = await env.lookup('hub:searchers').get('master', 'articles', '1');
-    expect(doc).is.ok;
-    let model = doc.data;
-    expect(model).has.deep.property('attributes.length', null);
-  });
-
-  it('supports default includes', async function() {
-    throw new Error("Unimplemented");
-  });
-
 });

--- a/packages/postgresql/node-tests/indexer-test.js
+++ b/packages/postgresql/node-tests/indexer-test.js
@@ -58,7 +58,9 @@ describe('postgresql/indexer', function() {
   });
 
   it('discovers content types', async function() {
-    let model = await env.lookup('hub:searchers').get('master', 'content-types', 'articles');
+    let doc = await env.lookup('hub:searchers').get('master', 'content-types', 'articles');
+    expect(doc).is.ok;
+    let model = doc.data;
     expect(model).is.ok;
     expect(model).has.deep.property('relationships.fields.data');
     expect(model.relationships.fields.data).collectionContains({ id: 'title' });
@@ -67,7 +69,9 @@ describe('postgresql/indexer', function() {
   });
 
   it('discovers initial records', async function() {
-    let model = await env.lookup('hub:searchers').get('master', 'articles', '0');
+    let doc = await env.lookup('hub:searchers').get('master', 'articles', '0');
+    expect(doc).is.ok;
+    let model = doc.data;
     expect(model).is.ok;
     expect(model).has.deep.property('attributes.title', 'hello world');
   });
@@ -75,7 +79,9 @@ describe('postgresql/indexer', function() {
   it('discovers new records', async function() {
     await client.query('insert into articles values ($1, $2)', ['1', 'second article']);
     await env.lookup('hub:indexers').update({ realTime: true });
-    let model = await env.lookup('hub:searchers').get('master', 'articles', '1');
+    let doc = await env.lookup('hub:searchers').get('master', 'articles', '1');
+    expect(doc).is.ok;
+    let model = doc.data;
     expect(model).is.ok;
     expect(model).has.deep.property('attributes.title', 'second article');
   });
@@ -84,7 +90,9 @@ describe('postgresql/indexer', function() {
   it('updates records', async function() {
     await client.query('update articles set title=$1 where id=$2', ['I was updated', '0']);
     await env.lookup('hub:indexers').update({ realTime: true });
-    let model = await env.lookup('hub:searchers').get('master', 'articles', '0');
+    let doc = await env.lookup('hub:searchers').get('master', 'articles', '0');
+    expect(doc).is.ok;
+    let model = doc.data;
     expect(model).is.ok;
     expect(model).has.deep.property('attributes.title', 'I was updated');
   });
@@ -103,7 +111,9 @@ describe('postgresql/indexer', function() {
   it('discovers newly added content type', async function() {
     await client.query('create table humans (id varchar primary key, name varchar)');
     await env.lookup('hub:indexers').update({ realTime: true });
-    let model = await env.lookup('hub:searchers').get('master', 'content-types', 'humans');
+    let doc = await env.lookup('hub:searchers').get('master', 'content-types', 'humans');
+    expect(doc).is.ok;
+    let model = doc.data;
     expect(model).is.ok;
     expect(model).has.deep.property('relationships.fields.data');
     expect(model.relationships.fields.data).collectionContains({ id: 'name' });
@@ -124,36 +134,46 @@ describe('postgresql/indexer', function() {
     await client.query('alter table articles add column author varchar');
     await client.query('update articles set author=$1 where id=$2', ['Arthur', '0']);
     await env.lookup('hub:indexers').update({ realTime: true });
-    let model = await env.lookup('hub:searchers').get('master', 'content-types', 'articles');
+    let doc = await env.lookup('hub:searchers').get('master', 'content-types', 'articles');
+    expect(doc).is.ok;
+    let model = doc.data;
     expect(model).has.deep.property('relationships.fields.data');
     expect(model.relationships.fields.data).collectionContains({ id: 'author' });
-    model = await env.lookup('hub:searchers').get('master', 'articles', '0');
-    expect(model).has.deep.property('attributes.author', 'Arthur');
+    doc = await env.lookup('hub:searchers').get('master', 'articles', '0');
+    expect(doc).has.deep.property('data.attributes.author', 'Arthur');
   });
 
   it('can read an integer column', async function() {
-    let model = await env.lookup('hub:searchers').get('master', 'articles', '0');
+    let doc = await env.lookup('hub:searchers').get('master', 'articles', '0');
+    expect(doc).is.ok;
+    let model = doc.data;
     expect(model).has.deep.property('attributes.length', 100);
   });
 
   it('can read a boolean column', async function() {
     await client.query('insert into articles (id, published) values ($1, $2)', ['1', false]);
     await env.lookup('hub:indexers').update({ realTime: true });
-    let model = await env.lookup('hub:searchers').get('master', 'articles', '1');
+    let doc = await env.lookup('hub:searchers').get('master', 'articles', '1');
+    expect(doc).is.ok;
+    let model = doc.data;
     expect(model).has.deep.property('attributes.published', false);
   });
 
   it('can read null string', async function() {
     await client.query('insert into articles (id) values ($1)', ['1']);
     await env.lookup('hub:indexers').update({ realTime: true });
-    let model = await env.lookup('hub:searchers').get('master', 'articles', '1');
+    let doc = await env.lookup('hub:searchers').get('master', 'articles', '1');
+    expect(doc).is.ok;
+    let model = doc.data;
     expect(model).has.deep.property('attributes.title', null);
   });
 
   it('can read null integer', async function() {
     await client.query('insert into articles (id) values ($1)', ['1']);
     await env.lookup('hub:indexers').update({ realTime: true });
-    let model = await env.lookup('hub:searchers').get('master', 'articles', '1');
+    let doc = await env.lookup('hub:searchers').get('master', 'articles', '1');
+    expect(doc).is.ok;
+    let model = doc.data;
     expect(model).has.deep.property('attributes.length', null);
   });
 

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@cardstack/plugin-utils": "^0.2.4",
+    "jsonpatch": "^3.0.1",
     "lodash": "^4.17.4",
     "pg": "^7.0.3"
   },

--- a/packages/postgresql/yarn.lock
+++ b/packages/postgresql/yarn.lock
@@ -10,6 +10,10 @@ js-string-escape@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
 
+jsonpatch@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jsonpatch/-/jsonpatch-3.0.1.tgz#97225367c1c3c5bf1641be59b2f73be19759f06f"
+
 lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"

--- a/packages/test-support/env.js
+++ b/packages/test-support/env.js
@@ -13,7 +13,7 @@ exports.createDefaultEnvironment = async function(projectDir, initialModels = []
     let user = factory.addResource('users', 'the-default-test-user').withAttributes({
       fullName: 'Default Test Environment',
       email: 'test@example.com'
-    });
+    }).asDocument();
 
     let session = new Session(
       { id: 'the-default-test-user', type: 'users'},
@@ -38,7 +38,7 @@ exports.createDefaultEnvironment = async function(projectDir, initialModels = []
         mayUpdateResource: true,
         mayDeleteResource: true,
         mayWriteField: true
-      }).withRelated('who', factory.addResource('groups', user.id));
+      }).withRelated('who', factory.addResource('groups', user.data.id));
 
     container = await wireItUp(projectDir, crypto.randomBytes(32), factory.getModels(), {
       allowDevDependencies: true,
@@ -64,7 +64,7 @@ exports.createDefaultEnvironment = async function(projectDir, initialModels = []
 
     Object.assign(container, {
       session,
-      user: user.data,
+      user,
       async setUserId(id) {
         let schema = await this.lookup('hub:schema-cache').schemaForControllingBranch();
         let m = schema.plugins.lookupFeatureAndAssert('middleware', '@cardstack/test-support/authenticator');

--- a/packages/test-support/jsonapi-factory.js
+++ b/packages/test-support/jsonapi-factory.js
@@ -117,6 +117,9 @@ class ResourceFactory {
     this.data.relationships[dasherize(fieldName)] = { data };
     return this;
   }
+  asDocument() {
+    return { data: this.data };
+  }
 }
 
 function dasherize(camelCase) {

--- a/tests/stub-searcher/searcher.js
+++ b/tests/stub-searcher/searcher.js
@@ -24,7 +24,10 @@ module.exports = class StubSearcher {
   async search(branch, query, next) {
     if (this.params.injectFirst) {
       return {
-        models: [ makeModel('examples', '2', this.params.injectFirst) ]
+        data: [ makeModel('examples', '2', this.params.injectFirst) ],
+        meta: {
+          page: {}
+        }
       };
     }
     return next();

--- a/tests/stub-searcher/searcher.js
+++ b/tests/stub-searcher/searcher.js
@@ -9,7 +9,7 @@ module.exports = class StubSearcher {
 
   async get(branch, type, id, next) {
     if (this.params.injectFirst) {
-      return makeModel(type, id, this.params.injectFirst);
+      return { data: makeModel(type, id, this.params.injectFirst) };
     }
 
     let result = await next();
@@ -17,7 +17,7 @@ module.exports = class StubSearcher {
       return result;
     }
     if (this.params.injectSecond) {
-      return makeModel(type, id, this.params.injectSecond);
+      return { data: makeModel(type, id, this.params.injectSecond) };
     }
   }
 


### PR DESCRIPTION
This PR introduces a `default-includes` attribute on the `content-types` type. It can contain a list of paths to related resources that should be included by default when both indexing and serving content.

Since default-included resources are embedded even within the search index, this makes it possible to do deep searches against them, like `?filter[comments.author.name]=X`. It also makes it much cheaper to serve these requests to end users, since all included resources will already be embedded in a single document.

To support this feature, I made some breaking changes.

 - filters against relationships now always require a field name. Previously, you could say `?filter[author]=1` because we assumed `id` (and only supported `id`). But now you would say `?filter[author.id]=1`, and if `author` is in `default-includes` you could also say `?filter[author.name]=Tomster`.

 - Indexer plugins are required to implement a `read` method on their Updater. This is used to obtain consistent reads of embedded resources during indexing.

 - the `get` method on Searcher plugins now returns a complete JSON:API document (including the top level `data` property) instead of just a standalone resource object. This gives us room for also returning `included`.

 - we now precompute the "pristine" JSON:API document for each resource at the time when we index it, rather than rewriting on the fly from in-search-index format to JSON:API format.

Users with existing elasticsearch indices should delete them and allow them to be recreated, in order to match the changed search index format.