### PR TITLE
Improvements to auth infrastructure and the github-auth plugin

### DIFF
--- a/packages/authentication/addon/cardstack-authenticator.js
+++ b/packages/authentication/addon/cardstack-authenticator.js
@@ -10,9 +10,9 @@ export default Base.extend({
   restore(rawSession) {
     return new RSVP.Promise((resolve, reject) => {
       let validSession =
-        rawSession && rawSession.meta &&
-        rawSession.meta.validUntil &&
-        rawSession.meta.validUntil > Date.now() / 1000;
+        rawSession && rawSession.data && rawSession.data.meta &&
+        rawSession.data.meta.validUntil &&
+        rawSession.data.meta.validUntil > Date.now() / 1000;
 
       let partialSession =
         rawSession.data &&

--- a/packages/authentication/index.js
+++ b/packages/authentication/index.js
@@ -1,9 +1,38 @@
 /* eslint-env node */
 'use strict';
 
+const Handlebars = require('handlebars');
+const log = require('@cardstack/plugin-utils/logger')('auth');
+
 module.exports = {
   name: '@cardstack/authentication',
   isDevelopingAddon() {
     return process.env.CARDSTACK_DEV;
+  },
+
+  // this is part of our public API to other cardstack plugins.
+  // Authenticators get this behavior automatically, but Searchers or
+  // Indexers may also want to support it, and can use this function
+  // for it.
+  rewriteExternalUser(externalUser, source) {
+    let userTemplate = source.userTemplate || source.authenticator.defaultUserTemplate;
+    log.debug("external user %j", externalUser);
+    let rewritten;
+    if (!userTemplate) {
+      rewritten = Object.assign({}, externalUser);
+    } else {
+      let compiled = Handlebars.compile(userTemplate);
+      let stringRewritten = compiled(externalUser);
+      try {
+        rewritten = JSON.parse(stringRewritten);
+      } catch (err) {
+        log.error("user-template resulted in invalid json: %s", stringRewritten);
+        throw err;
+      }
+    }
+    log.debug("rewritten user %j", rewritten);
+    return rewritten;
   }
+
+
 };

--- a/packages/authentication/node-tests/authentication-test.js
+++ b/packages/authentication/node-tests/authentication-test.js
@@ -28,51 +28,51 @@ describe('authentication/middleware', function() {
       fullName: "Arthur Faulkner"
     });
 
-    factory.addResource('authentication-sources', 'echo').withAttributes({
-      authenticatorType: 'stub-authenticators::echo'
+    factory.addResource('data-sources', 'echo').withAttributes({
+      sourceType: 'stub-authenticators::echo'
     });
 
-    factory.addResource('authentication-sources', 'returns-nothing').withAttributes({
-      authenticatorType: 'stub-authenticators::returns-nothing'
+    factory.addResource('data-sources', 'returns-nothing').withAttributes({
+      sourceType: 'stub-authenticators::returns-nothing'
     });
 
-    factory.addResource('authentication-sources', 'by-email').withAttributes({
-      authenticatorType: 'stub-authenticators::by-email',
+    factory.addResource('data-sources', 'by-email').withAttributes({
+      sourceType: 'stub-authenticators::by-email',
       params: {
         hidden: true
       }
     });
 
-    factory.addResource('authentication-sources', 'always-invalid').withAttributes({
-      authenticatorType: 'stub-authenticators::always-invalid'
+    factory.addResource('data-sources', 'always-invalid').withAttributes({
+      sourceType: 'stub-authenticators::always-invalid'
     });
 
-    factory.addResource('authentication-sources', 'config-echo-quint').withAttributes({
-      authenticatorType: 'stub-authenticators::config-echo',
+    factory.addResource('data-sources', 'config-echo-quint').withAttributes({
+      sourceType: 'stub-authenticators::config-echo',
       params: {
         data: { id: quint.id, type: 'users' }
       }
     });
 
-    factory.addResource('authentication-sources', 'config-echo-arthur').withAttributes({
-      authenticatorType: 'stub-authenticators::config-echo',
+    factory.addResource('data-sources', 'config-echo-arthur').withAttributes({
+      sourceType: 'stub-authenticators::config-echo',
       params: {
         data: { id: arthur.id, type: 'users' }
       }
     });
 
-    factory.addResource('authentication-sources', 'id-rewriter').withAttributes({
-      authenticatorType: 'stub-authenticators::echo',
+    factory.addResource('data-sources', 'id-rewriter').withAttributes({
+      sourceType: 'stub-authenticators::echo',
       userTemplate: '{ "data": { "id": "{{upstreamId}}", "type": "users" }}'
     });
 
-    factory.addResource('authentication-sources', 'has-default-template').withAttributes({
-      authenticatorType: 'stub-authenticators::has-default-template'
+    factory.addResource('data-sources', 'has-default-template').withAttributes({
+      sourceType: 'stub-authenticators::has-default-template'
     });
 
 
-    factory.addResource('authentication-sources', 'create-via-template').withAttributes({
-      authenticatorType: 'stub-authenticators::echo',
+    factory.addResource('data-sources', 'create-via-template').withAttributes({
+      sourceType: 'stub-authenticators::echo',
       userTemplate: `{"data":{
         "id": "my-prefix-{{id}}",
         "type": "users",
@@ -84,8 +84,8 @@ describe('authentication/middleware', function() {
       mayCreateUser: true
     });
 
-    factory.addResource('authentication-sources', 'create-via-template-no-id').withAttributes({
-      authenticatorType: 'stub-authenticators::echo',
+    factory.addResource('data-sources', 'create-via-template-no-id').withAttributes({
+      sourceType: 'stub-authenticators::echo',
       userTemplate: `{"data":{
         "type": "users",
         "attributes": {
@@ -97,8 +97,8 @@ describe('authentication/middleware', function() {
     });
 
 
-    factory.addResource('authentication-sources', 'update-user').withAttributes({
-      authenticatorType: 'stub-authenticators::echo',
+    factory.addResource('data-sources', 'update-user').withAttributes({
+      sourceType: 'stub-authenticators::echo',
       mayUpdateUser: true
     });
 
@@ -180,19 +180,21 @@ describe('authentication/middleware', function() {
     describe('token endpoints', async function() {
 
       it('supports CORS preflight', async function() {
-        let response = await request.options('/auth/foo');
+        let response = await request.options('/auth/echo');
         expect(response).hasStatus(200);
         expect(response.headers['access-control-allow-methods']).matches(/POST/);
       });
 
       it('supports CORS', async function() {
-        let response = await request.post('/auth/foo').send({});
+        let response = await request.post('/auth/echo').send({});
         expect(response.headers['access-control-allow-origin']).equals('*');
       });
 
       it('returns not found for missing module', async function() {
-        let response = await request.post('/auth/foo').send({});
-        expect(response).hasStatus(404);
+        await logger.expectWarn(/Did not locate authentication source "foo"/, async () => {
+          let response = await request.post('/auth/foo').send({});
+          expect(response).hasStatus(404);
+        });
       });
 
       it('finds authenticator', async function() {

--- a/packages/authentication/node-tests/stub-authenticators/authenticators/by-email.js
+++ b/packages/authentication/node-tests/stub-authenticators/authenticators/by-email.js
@@ -3,7 +3,7 @@ module.exports = class {
   static create() {
     return new this();
   }
-  async authenticate({ email }, config, userSearcher) {
+  async authenticate({ email }, userSearcher) {
     if (email == null) {
       throw new Error("email is required", { status: 400 });
     }

--- a/packages/authentication/node-tests/stub-authenticators/authenticators/config-echo.js
+++ b/packages/authentication/node-tests/stub-authenticators/authenticators/config-echo.js
@@ -1,11 +1,14 @@
 module.exports = class {
-  static create() {
-    return new this();
+  static create(params) {
+    return new this(params);
   }
-  async authenticate(payload, config /*, userSearcher */) {
-    return config;
+  constructor(params) {
+    this.params = params;
   }
-  async exposeConfig(params) {
-    return params;
+  async authenticate() {
+    return this.params;
+  }
+  async exposeConfig() {
+    return { data: this.params.data };
   }
 };

--- a/packages/email-auth/cardstack/authenticator.js
+++ b/packages/email-auth/cardstack/authenticator.js
@@ -8,7 +8,8 @@ module.exports = declareInjections({
 },
 
 class {
-  async authenticate({ email, referer, secret }, { messageSinkId, subject, from, textTemplate, htmlTemplate }, userSearcher) {
+  async authenticate({ email, referer, secret }, userSearcher) {
+    let { messageSinkId, subject, from, textTemplate, htmlTemplate } = this;
     if (email) {
       let { data: models } = await userSearcher.search({
         filter: {

--- a/packages/email-auth/node-tests/email-auth-test.js
+++ b/packages/email-auth/node-tests/email-auth-test.js
@@ -28,8 +28,8 @@ describe('email-auth', function() {
       messengerType: '@cardstack/test-support/messenger'
     });
 
-    factory.addResource('authentication-sources', 'email-auth').withAttributes({
-      authenticatorType: '@cardstack/email-auth',
+    factory.addResource('data-sources', 'email-auth').withAttributes({
+      sourceType: '@cardstack/email-auth',
       mayCreateUser: true,
       params: {
         messageSinkId: 'the-sink'

--- a/packages/github-auth/README.md
+++ b/packages/github-auth/README.md
@@ -11,9 +11,9 @@ This README outlines the details of collaborating on this Ember addon.
 
 ## Running
 
-To run the demo app and interact with GitHub, you need to register your app via https://github.com/settings/developers and get a client ID & secret.
+To run the demo app and interact with GitHub, you need to register your app via https://github.com/settings/developers and get a client ID & secret. Set them via the environment variables `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`. This allows this plugin to act as an OAuth2 client that speaks to GitHub on behalf of users who authorize it.
 
-Set them via the environment variables `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`.
+For the present, you also need a user token that the Hub can use to represent itself. You can use a [Personal Access Token](https://github.com/settings/tokens). Set is via the environment variable `GITHUB_TOKEN`.
 
 * `ember serve`
 * Visit your app at [http://localhost:4200](http://localhost:4200).

--- a/packages/github-auth/README.md
+++ b/packages/github-auth/README.md
@@ -11,6 +11,10 @@ This README outlines the details of collaborating on this Ember addon.
 
 ## Running
 
+To run the demo app and interact with GitHub, you need to register your app via https://github.com/settings/developers and get a client ID & secret.
+
+Set them via the environment variables `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`.
+
 * `ember serve`
 * Visit your app at [http://localhost:4200](http://localhost:4200).
 

--- a/packages/github-auth/cardstack/authenticator.js
+++ b/packages/github-auth/cardstack/authenticator.js
@@ -2,6 +2,9 @@ const Error = require('@cardstack/plugin-utils/error');
 const request = require('./lib/request');
 
 module.exports = class {
+  static create(...args) {
+    return new this(...args);
+  }
   async authenticate(payload, params /*, userSearcher */) {
     if (!payload.authorizationCode) {
       throw new Error("missing required field 'authorizationCode'", {
@@ -55,9 +58,7 @@ module.exports = class {
     if (userResponse.response.statusCode !== 200) {
       throw new Error(responseBody.error, { status: response.statusCode });
     }
-    return {
-      user: userResponse.body
-    };
+    return userResponse.body;
   }
 
   exposeConfig(params) {

--- a/packages/github-auth/cardstack/authenticator.js
+++ b/packages/github-auth/cardstack/authenticator.js
@@ -5,7 +5,12 @@ module.exports = class {
   static create(...args) {
     return new this(...args);
   }
-  async authenticate(payload, params /*, userSearcher */) {
+  constructor(params) {
+    this.clientId = params['client-id'];
+    this.clientSecret = params['client-secret'];
+    this.defaultUserTemplate =  "{ \"data\": { \"id\": \"{{login}}\", \"type\": \"github-users\", \"attributes\": { \"name\": \"{{name}}\", \"email\":\"{{email}}\", \"avatar-url\":\"{{avatar_url}}\" }}}";
+  }
+  async authenticate(payload /*, userSearcher */) {
     if (!payload.authorizationCode) {
       throw new Error("missing required field 'authorizationCode'", {
         status: 400
@@ -13,8 +18,8 @@ module.exports = class {
     }
 
     let payloadToGitHub = {
-      client_id: params['client-id'],
-      client_secret: params['client-secret'],
+      client_id: this.clientId,
+      client_secret: this.clientSecret,
       code: payload.authorizationCode
     };
     if (payload.state) {
@@ -61,13 +66,10 @@ module.exports = class {
     return userResponse.body;
   }
 
-  exposeConfig(params) {
+  exposeConfig() {
     return {
-      clientId: params['client-id']
+      clientId: this.clientId
     };
   }
 
-  constructor() {
-    this.defaultUserTemplate =  "{ \"id\": \"{{login}}\", \"type\": \"github-users\", \"attributes\": { \"name\": \"{{name}}\", \"email\":\"{{email}}\", \"avatar-url\":\"{{avatar_url}}\" }}";
-  }
 };

--- a/packages/github-auth/cardstack/indexer.js
+++ b/packages/github-auth/cardstack/indexer.js
@@ -1,0 +1,101 @@
+const { isEqual } = require('lodash');
+const log = require('@cardstack/plugin-utils/logger')('github-auth/indexer');
+
+module.exports = class Indexer {
+
+  static create(...args) {
+    return new this(...args);
+  }
+
+  constructor({ dataSource, provideUserSchema }) {
+    if (provideUserSchema === false) {
+      this.disabled = true;
+    } else {
+      if (dataSource.userTemplate){
+        log.warn("If you use a custom user-template on the github-auth data source, you should probably also set params.provideUserSchema=false and provide your own user model");
+      }
+    }
+  }
+
+  async branches() {
+    return ['master'];
+  }
+
+  async beginUpdate() {
+    return new Updater(this.disabled);
+  }
+};
+
+class Updater {
+
+  constructor(disabled) {
+    this.disabled = disabled;
+  }
+
+  async schema() {
+    if (this.disabled) {
+      return [];
+    }
+
+    return [
+      {
+        type: 'content-types',
+        id: 'github-users',
+        attributes: {
+        },
+        relationships: {
+          'fields': { data: [
+            { type: 'fields', id: 'name' },
+            { type: 'fields', id: 'email' },
+            { type: 'fields', id: 'avatar-url' }
+          ] }
+        }
+      },
+      {
+        type: 'fields',
+        id: 'name',
+        attributes: {
+          'field-type': '@cardstack/core-types::string'
+        }
+      },
+      {
+        type: 'fields',
+        id: 'email',
+        attributes: {
+          'field-type': '@cardstack/core-types::string'
+        }
+      },
+      {
+        type: 'fields',
+        id: 'avatar-url',
+        attributes: {
+          'field-type': '@cardstack/core-types::string'
+        }
+      },
+    ];
+  }
+
+  async updateContent(meta, hints, ops) {
+    let schema = await this.schema();
+    if (meta) {
+      let { lastSchema } = meta;
+      if (isEqual(lastSchema, schema)) {
+        return;
+      }
+    }
+    await ops.beginReplaceAll();
+    for (let model of schema) {
+      await ops.save(model.type, model.id, model);
+    }
+    await ops.finishReplaceAll();
+    return {
+      lastSchema: schema
+    };
+  }
+
+  async read(type, id, isSchema) {
+    if (isSchema) {
+      return (await this.schema()).find(model => model.type === type && model.id === model.id);
+    }
+  }
+}

--- a/packages/github-auth/cardstack/searcher.js
+++ b/packages/github-auth/cardstack/searcher.js
@@ -1,4 +1,5 @@
 const request = require('./lib/request');
+const { rewriteExternalUser } = require('@cardstack/authentication');
 
 module.exports = class GitHubSearcher {
   static create(...args) {
@@ -11,7 +12,7 @@ module.exports = class GitHubSearcher {
 
   async get(branch, type, id, next) {
     if (type === 'github-users') {
-      return { data: await this._getUser(id) };
+      return this._getUser(id);
     }
     return next();
   }
@@ -33,19 +34,8 @@ module.exports = class GitHubSearcher {
       }
     };
     let response = await request(options);
-    return this._rewriteUser(response.body);
+    return rewriteExternalUser(response.body, this.dataSource);
   }
 
-  _rewriteUser(ghUser) {
-    return {
-      id: ghUser.login,
-      type: 'github-users',
-      attributes: {
-        name: ghUser.name,
-        'avatar-url': ghUser.avatar_url,
-        email: ghUser.email
-      }
-    };
-  }
 
 };

--- a/packages/github-auth/cardstack/searcher.js
+++ b/packages/github-auth/cardstack/searcher.js
@@ -8,7 +8,7 @@ module.exports = class GitHubSearcher {
 
   async get(branch, type, id, next) {
     if (type === 'github-users') {
-      return this._getUser(id);
+      return { data: this._getUser(id) };
     }
     return next();
   }

--- a/packages/github-auth/cardstack/searcher.js
+++ b/packages/github-auth/cardstack/searcher.js
@@ -1,14 +1,17 @@
 const request = require('./lib/request');
 
 module.exports = class GitHubSearcher {
-  constructor({ ownToken, permissionRepos }) {
-    this.ownToken = ownToken;
-    this.permissionRepos = permissionRepos;
+  static create(...args) {
+    return new this(...args);
+  }
+  constructor({ token, dataSource }) {
+    this.token = token;
+    this.dataSource = dataSource;
   }
 
   async get(branch, type, id, next) {
     if (type === 'github-users') {
-      return { data: this._getUser(id) };
+      return { data: await this._getUser(id) };
     }
     return next();
   }
@@ -26,7 +29,7 @@ module.exports = class GitHubSearcher {
       headers: {
         'Accept': 'application/json',
         'User-Agent': '@cardstack/github-auth',
-        Authorization: `token ${this.ownToken}`
+        Authorization: `token ${this.token}`
       }
     };
     let response = await request(options);

--- a/packages/github-auth/package.json
+++ b/packages/github-auth/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@cardstack/authentication": "^0.2.10",
+    "@cardstack/plugin-utils": "^0.2.10",
     "ember-cli-babel": "^6.8.2",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-concurrency": "^0.7.19",
@@ -31,6 +32,7 @@
   },
   "devDependencies": {
     "@cardstack/eslint-config": "^0.2.4",
+    "@cardstack/jsonapi": "^0.2.10",
     "@cardstack/test-support": "^0.2.10",
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "^2.12.0",

--- a/packages/github-auth/package.json
+++ b/packages/github-auth/package.json
@@ -28,10 +28,12 @@
     "ember-cli-babel": "^6.8.2",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-concurrency": "^0.7.19",
+    "lodash": "^4.17.4",
     "torii": "https://github.com/ef4/torii#925ea3149cc9e35b77e39450cd634c65200768ce"
   },
   "devDependencies": {
     "@cardstack/eslint-config": "^0.2.4",
+    "@cardstack/models": "^0.2.10",
     "@cardstack/jsonapi": "^0.2.10",
     "@cardstack/test-support": "^0.2.10",
     "broccoli-asset-rev": "^2.4.5",

--- a/packages/github-auth/package.json
+++ b/packages/github-auth/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@cardstack/eslint-config": "^0.2.4",
+    "@cardstack/test-support": "^0.2.10",
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "^2.12.0",
     "ember-cli-dependency-checker": "^1.3.0",
@@ -41,6 +42,7 @@
     "ember-cli-shims": "^1.0.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-data": "^2.14.10",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.1.1",
     "ember-load-initializers": "^0.6.3",

--- a/packages/github-auth/tests/dummy/app/templates/application.hbs
+++ b/packages/github-auth/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,7 @@
-{{!-- The following component displays Ember's default welcome message. --}}
-{{welcome-page}}
-{{!-- Feel free to remove this! --}}
-
-{{outlet}}
+{{#cardstack-session as |session|}}
+  {{#if session.isAuthenticated }}
+    <button {{action session.logout}}>Logout {{session.user.name}}</button>
+  {{else}}
+    {{github-login}}
+  {{/if}}
+{{/cardstack-session}}

--- a/packages/github-auth/tests/dummy/app/templates/application.hbs
+++ b/packages/github-auth/tests/dummy/app/templates/application.hbs
@@ -2,6 +2,8 @@
   {{#if session.isAuthenticated }}
     <button {{action session.logout}}>Logout {{session.user.name}}</button>
   {{else}}
-    {{github-login}}
+    {{#github-login as |login|}}
+      <button {{action login}}>Login</button>
+    {{/github-login}}
   {{/if}}
 {{/cardstack-session}}

--- a/packages/github-auth/tests/dummy/cardstack/seeds/development/ephemeral.js
+++ b/packages/github-auth/tests/dummy/cardstack/seeds/development/ephemeral.js
@@ -1,0 +1,24 @@
+/* eslint-env node */
+
+module.exports = [
+  {
+    type: 'plugin-configs',
+    id: '@cardstack/ephemeral'
+  },
+  {
+    type: 'data-sources',
+    id: 'default',
+    attributes: {
+      'source-type': '@cardstack/ephemeral'
+    }
+  },
+  {
+    type: 'plugin-configs',
+    id: '@cardstack/hub',
+    relationships: {
+      'default-data-source': {
+        data: { type: 'data-sources', id: 'default' }
+      }
+    }
+  }
+];

--- a/packages/github-auth/tests/dummy/cardstack/seeds/development/ephemeral.js
+++ b/packages/github-auth/tests/dummy/cardstack/seeds/development/ephemeral.js
@@ -1,4 +1,5 @@
 /* eslint-env node */
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
 
 module.exports = [
   {
@@ -9,7 +10,10 @@ module.exports = [
     type: 'data-sources',
     id: 'default',
     attributes: {
-      'source-type': '@cardstack/ephemeral'
+      'source-type': '@cardstack/ephemeral',
+      params: {
+        initialModels: initialModels()
+      }
     }
   },
   {
@@ -22,3 +26,16 @@ module.exports = [
     }
   }
 ];
+
+function initialModels() {
+  let factory = new JSONAPIFactory();
+  factory.addResource('authentication-sources', 'github')
+    .withAttributes({
+      authenticatorType: '@cardstack/github-auth',
+      params: {
+        'client-id': process.env.GITHUB_CLIENT_ID,
+        'client-secret': process.env.GITHUB_CLIENT_SECRET
+      }
+    })
+  return factory.getModels()
+}

--- a/packages/github-auth/tests/dummy/cardstack/seeds/development/ephemeral.js
+++ b/packages/github-auth/tests/dummy/cardstack/seeds/development/ephemeral.js
@@ -29,12 +29,13 @@ module.exports = [
 
 function initialModels() {
   let factory = new JSONAPIFactory();
-  factory.addResource('authentication-sources', 'github')
+  factory.addResource('data-sources', 'github')
     .withAttributes({
-      authenticatorType: '@cardstack/github-auth',
+      sourceType: '@cardstack/github-auth',
       params: {
         'client-id': process.env.GITHUB_CLIENT_ID,
-        'client-secret': process.env.GITHUB_CLIENT_SECRET
+        'client-secret': process.env.GITHUB_CLIENT_SECRET,
+        token: process.env.GITHUB_TOKEN
       }
     })
   return factory.getModels()

--- a/packages/github-auth/tests/dummy/cardstack/seeds/development/githut-auth.js
+++ b/packages/github-auth/tests/dummy/cardstack/seeds/development/githut-auth.js
@@ -1,0 +1,8 @@
+/* eslint-env node */
+
+module.exports = [
+  {
+    type: 'plugin-configs',
+    id: '@cardstack/github-auth'
+  }
+];

--- a/packages/github-auth/tests/dummy/cardstack/seeds/development/jsonapi.js
+++ b/packages/github-auth/tests/dummy/cardstack/seeds/development/jsonapi.js
@@ -1,0 +1,8 @@
+/* eslint-env node */
+
+module.exports = [
+  {
+    type: 'plugin-configs',
+    id: '@cardstack/jsonapi'
+  }
+];

--- a/packages/github-auth/tests/dummy/cardstack/seeds/development/models.js
+++ b/packages/github-auth/tests/dummy/cardstack/seeds/development/models.js
@@ -1,0 +1,8 @@
+/* eslint-env node */
+
+module.exports = [
+  {
+    type: 'plugin-configs',
+    id: '@cardstack/models'
+  }
+];

--- a/packages/github-auth/yarn.lock
+++ b/packages/github-auth/yarn.lock
@@ -261,6 +261,14 @@ babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+babel-code-frame@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
+  dependencies:
+    chalk "^1.1.3"
+    esutils "^2.0.2"
+    js-tokens "^3.0.2"
+
 babel-core@^5.0.0:
   version "5.8.38"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-5.8.38.tgz#1fcaee79d7e61b750b00b8e54f6dfc9d0af86558"
@@ -486,6 +494,14 @@ babel-plugin-eval@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz#a2faed25ce6be69ade4bfec263f70169195950da"
 
+babel-plugin-feature-flags@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-feature-flags/-/babel-plugin-feature-flags-0.3.1.tgz#9c827cf9a4eb9a19f725ccb239e85cab02036fc1"
+
+babel-plugin-filter-imports@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-0.3.1.tgz#e7859b56886b175dd2616425d277b219e209ea8b"
+
 babel-plugin-htmlbars-inline-precompile@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.2.3.tgz#cd365e278af409bfa6be7704c4354beee742446b"
@@ -573,6 +589,16 @@ babel-plugin-transform-es2015-block-scoping@^6.23.0:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
     lodash "^4.2.0"
+
+babel-plugin-transform-es2015-block-scoping@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f"
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
 
 babel-plugin-transform-es2015-classes@^6.23.0:
   version "6.24.1"
@@ -813,6 +839,13 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
 babel-template@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
@@ -822,6 +855,16 @@ babel-template@^6.24.1:
     babel-types "^6.24.1"
     babylon "^6.11.0"
     lodash "^4.2.0"
+
+babel-template@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    lodash "^4.17.4"
 
 babel-traverse@^6.24.1:
   version "6.24.1"
@@ -837,6 +880,20 @@ babel-traverse@^6.24.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
+babel-traverse@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    debug "^2.6.8"
+    globals "^9.18.0"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
+
 babel-types@^6.19.0, babel-types@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
@@ -846,6 +903,23 @@ babel-types@^6.19.0, babel-types@^6.24.1:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
+babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
+  dependencies:
+    babel-runtime "^6.26.0"
+    esutils "^2.0.2"
+    lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
+
+babel6-plugin-strip-class-callcheck@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/babel6-plugin-strip-class-callcheck/-/babel6-plugin-strip-class-callcheck-6.0.0.tgz#de841c1abebbd39f78de0affb2c9a52ee228fddf"
+
+babel6-plugin-strip-heimdall@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/babel6-plugin-strip-heimdall/-/babel6-plugin-strip-heimdall-6.0.1.tgz#35f80eddec1f7fffdc009811dfbd46d9965072b6"
+
 babylon@^5.8.38:
   version "5.8.38"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-5.8.38.tgz#ec9b120b11bf6ccd4173a18bf217e60b79859ffd"
@@ -853,6 +927,10 @@ babylon@^5.8.38:
 babylon@^6.11.0, babylon@^6.15.0:
   version "6.17.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.1.tgz#17f14fddf361b695981fe679385e4f1c01ebd86f"
+
+babylon@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
 backbone@^1.1.2:
   version "1.3.3"
@@ -1106,6 +1184,17 @@ broccoli-debug@^0.6.1, broccoli-debug@^0.6.2:
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
 
+broccoli-file-creator@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-1.1.1.tgz#1b35b67d215abdfadd8d49eeb69493c39e6c3450"
+  dependencies:
+    broccoli-kitchen-sink-helpers "~0.2.0"
+    broccoli-plugin "^1.1.0"
+    broccoli-writer "~0.1.1"
+    mkdirp "^0.5.1"
+    rsvp "~3.0.6"
+    symlink-or-copy "^1.0.1"
+
 broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-filter/-/broccoli-filter-1.2.4.tgz#409afb94b9a3a6da9fac8134e91e205f40cc7330"
@@ -1124,7 +1213,7 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
-broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6:
+broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli-funnel@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
   dependencies:
@@ -1143,7 +1232,7 @@ broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-kitchen-sink-helpers@^0.2.5:
+broccoli-kitchen-sink-helpers@^0.2.5, broccoli-kitchen-sink-helpers@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz#a5e0986ed8d76fb5984b68c3f0450d3a96e36ecc"
   dependencies:
@@ -1196,6 +1285,10 @@ broccoli-middleware@^1.0.0-beta.8:
     handlebars "^4.0.4"
     mime "^1.2.11"
 
+broccoli-node-info@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/broccoli-node-info/-/broccoli-node-info-1.1.0.tgz#3aa2e31e07e5bdb516dd25214f7c45ba1c459412"
+
 broccoli-persistent-filter@^1.0.1, broccoli-persistent-filter@^1.0.3, broccoli-persistent-filter@^1.1.6:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-1.3.1.tgz#d02556a135c77dfb859bba7844bc3539be7168e1"
@@ -1241,7 +1334,7 @@ broccoli-plugin@1.1.0:
     rimraf "^2.3.4"
     symlink-or-copy "^1.0.1"
 
-broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
+broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz#bee704a8e42da08cb58e513aaa436efb7f0ef1ee"
   dependencies:
@@ -1250,7 +1343,23 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-slow-trees@^3.0.1:
+broccoli-rollup@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/broccoli-rollup/-/broccoli-rollup-1.3.0.tgz#43a0a7798555bab54217009eb470a4ff5a056df0"
+  dependencies:
+    broccoli-plugin "^1.2.1"
+    es6-map "^0.1.4"
+    fs-extra "^0.30.0"
+    fs-tree-diff "^0.5.2"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    md5-hex "^1.3.0"
+    node-modules-path "^1.0.1"
+    rollup "^0.41.4"
+    symlink-or-copy "^1.1.8"
+    walk-sync "^0.3.1"
+
+broccoli-slow-trees@3.0.1, broccoli-slow-trees@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/broccoli-slow-trees/-/broccoli-slow-trees-3.0.1.tgz#9bf2a9e2f8eb3ed3a3f2abdde988da437ccdc9b4"
   dependencies:
@@ -1289,6 +1398,17 @@ broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
     symlink-or-copy "^1.1.8"
     walk-sync "^0.3.0"
 
+broccoli-test-helper@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/broccoli-test-helper/-/broccoli-test-helper-1.2.0.tgz#d01005d8611fd73ebe1b29552bf052ff59badfb4"
+  dependencies:
+    broccoli "^1.1.0"
+    fixturify "^0.3.2"
+    fs-tree-diff "^0.5.6"
+    mktemp "^0.4.0"
+    rimraf "^2.5.4"
+    walk-sync "^0.3.1"
+
 broccoli-uglify-sourcemap@^1.0.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-1.5.2.tgz#04f84ab0db539031fa868ccfa563c9932d50cedb"
@@ -1302,6 +1422,33 @@ broccoli-uglify-sourcemap@^1.0.0:
     symlink-or-copy "^1.0.1"
     uglify-js "^2.7.0"
     walk-sync "^0.1.3"
+
+broccoli-writer@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/broccoli-writer/-/broccoli-writer-0.1.1.tgz#d4d71aa8f2afbc67a3866b91a2da79084b96ab2d"
+  dependencies:
+    quick-temp "^0.1.0"
+    rsvp "^3.0.6"
+
+broccoli@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/broccoli/-/broccoli-1.1.3.tgz#98405e86b7b0e6c268fb8302a006d834d17ed292"
+  dependencies:
+    broccoli-node-info "1.1.0"
+    broccoli-slow-trees "3.0.1"
+    broccoli-source "^1.1.0"
+    commander "^2.5.0"
+    connect "^3.3.3"
+    copy-dereference "^1.0.0"
+    findup-sync "^1.0.0"
+    handlebars "^4.0.4"
+    heimdalljs-logger "^0.1.7"
+    mime "^1.2.11"
+    rimraf "^2.4.3"
+    rsvp "^3.5.0"
+    sane "^1.4.1"
+    tmp "0.0.31"
+    underscore.string "^3.2.2"
 
 browserslist@^2.1.2:
   version "2.1.4"
@@ -1332,7 +1479,7 @@ bytes@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.3.0.tgz#d5b680a165b6201739acb611542aabc2d8ceb070"
 
-calculate-cache-key-for-tree@^1.0.0:
+calculate-cache-key-for-tree@^1.0.0, calculate-cache-key-for-tree@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/calculate-cache-key-for-tree/-/calculate-cache-key-for-tree-1.1.0.tgz#0c3e42c9c134f3c9de5358c0f16793627ea976d6"
   dependencies:
@@ -1533,6 +1680,12 @@ commander@2.9.0, commander@^2.5.0, commander@^2.6.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+common-tags@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.4.0.tgz#1187be4f3d4cf0c0427d43f74eef1f73501614c0"
+  dependencies:
+    babel-runtime "^6.18.0"
+
 commoner@~0.10.3:
   version "0.10.8"
   resolved "https://registry.yarnpkg.com/commoner/-/commoner-0.10.8.tgz#34fc3672cd24393e8bb47e70caa0293811f4f2c5"
@@ -1603,6 +1756,15 @@ configstore@^3.0.0:
     write-file-atomic "^2.0.0"
     xdg-basedir "^3.0.0"
 
+connect@^3.3.3:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/connect/-/connect-3.6.5.tgz#fb8dde7ba0763877d0ec9df9dac0b4b40e72c7da"
+  dependencies:
+    debug "2.6.9"
+    finalhandler "1.0.6"
+    parseurl "~1.3.2"
+    utils-merge "1.0.1"
+
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
@@ -1672,7 +1834,7 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cross-spawn@^5.0.1, cross-spawn@^5.1.0:
+cross-spawn@^5.0.0, cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -1723,6 +1885,12 @@ debug@2.6.7:
 debug@2.6.8, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.0, debug@^2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+  dependencies:
+    ms "2.0.0"
+
+debug@2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
@@ -1857,7 +2025,7 @@ ember-cli-babel@^5.1.10, ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-c
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.3.0, ember-cli-babel@^6.8.2:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.3.0, ember-cli-babel@^6.4.1, ember-cli-babel@^6.8.2:
   version "6.8.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz#eac2785964f4743f4c815cd53c6288f00cc087d7"
   dependencies:
@@ -2154,6 +2322,43 @@ ember-concurrency@^0.7.19:
     ember-getowner-polyfill "^1.1.0"
     ember-maybe-import-regenerator "^0.1.4"
 
+ember-data@^2.14.10:
+  version "2.15.3"
+  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-2.15.3.tgz#05fb271bb6576c3e2d93e9363810e91b1953468c"
+  dependencies:
+    amd-name-resolver "0.0.7"
+    babel-plugin-feature-flags "^0.3.1"
+    babel-plugin-filter-imports "^0.3.1"
+    babel-plugin-transform-es2015-block-scoping "^6.24.1"
+    babel6-plugin-strip-class-callcheck "^6.0.0"
+    babel6-plugin-strip-heimdall "^6.0.1"
+    broccoli-babel-transpiler "^6.0.0"
+    broccoli-debug "^0.6.2"
+    broccoli-file-creator "^1.0.0"
+    broccoli-funnel "^1.2.0"
+    broccoli-merge-trees "^1.0.0"
+    broccoli-rollup "^1.2.0"
+    broccoli-test-helper "^1.2.0"
+    calculate-cache-key-for-tree "^1.1.0"
+    chalk "^1.1.1"
+    co "^4.6.0"
+    common-tags "^1.4.0"
+    ember-cli-babel "^6.4.1"
+    ember-cli-path-utils "^1.0.0"
+    ember-cli-string-utils "^1.0.0"
+    ember-cli-test-info "^1.0.0"
+    ember-cli-version-checker "^1.1.4"
+    ember-inflector "^2.0.0"
+    ember-runtime-enumerable-includes-polyfill "^2.0.0"
+    exists-sync "0.0.3"
+    git-repo-info "^1.1.2"
+    heimdalljs "^0.3.0"
+    inflection "^1.8.0"
+    npm-git-info "^1.0.0"
+    semver "^5.1.0"
+    silent-error "^1.0.0"
+    testem "1.15.0"
+
 ember-disable-prototype-extensions@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.0.tgz#86081c8cf6741f26e4b89e2b004f761174313e01"
@@ -2180,6 +2385,12 @@ ember-getowner-polyfill@^1.1.0:
     ember-cli-babel "^5.1.6"
     ember-cli-version-checker "^1.2.0"
     ember-factory-for-polyfill "^1.1.0"
+
+ember-inflector@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-2.0.1.tgz#e9ac469ffa17992a43276bb1c9b8d87992b10d37"
+  dependencies:
+    ember-cli-babel "^6.0.0"
 
 ember-load-initializers@^0.6.3:
   version "0.6.3"
@@ -2218,6 +2429,13 @@ ember-router-generator@^1.0.0:
   resolved "https://registry.yarnpkg.com/ember-router-generator/-/ember-router-generator-1.2.3.tgz#8ed2ca86ff323363120fc14278191e9e8f1315ee"
   dependencies:
     recast "^0.11.3"
+
+ember-runtime-enumerable-includes-polyfill@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-runtime-enumerable-includes-polyfill/-/ember-runtime-enumerable-includes-polyfill-2.0.0.tgz#6e9ba118bc909d1d7762de1b03a550d8955308a9"
+  dependencies:
+    ember-cli-babel "^6.0.0"
+    ember-cli-version-checker "^1.1.6"
 
 ember-source@~2.12.0:
   version "2.12.2"
@@ -2348,7 +2566,7 @@ es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
     es5-ext "^0.10.14"
     es6-symbol "^3.1"
 
-es6-map@^0.1.3:
+es6-map@^0.1.3, es6-map@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
   dependencies:
@@ -2687,6 +2905,18 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
+finalhandler@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.6.tgz#007aea33d1a4d3e42017f624848ad58d212f814f"
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.2"
+    statuses "~1.3.1"
+    unpipe "~1.0.0"
+
 finalhandler@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.3.tgz#ef47e77950e999780e86022a560e3217e0d0cc89"
@@ -2718,6 +2948,15 @@ findup-sync@^0.4.2, findup-sync@^0.4.3:
     micromatch "^2.3.7"
     resolve-dir "^0.1.0"
 
+findup-sync@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-1.0.0.tgz#6f7e4b57b6ee3a4037b4414eaedea3f58f71e0ec"
+  dependencies:
+    detect-file "^0.1.0"
+    is-glob "^2.0.1"
+    micromatch "^2.3.7"
+    resolve-dir "^0.1.0"
+
 fireworm@^0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/fireworm/-/fireworm-0.7.1.tgz#ccf20f7941f108883fcddb99383dbe6e1861c758"
@@ -2727,6 +2966,13 @@ fireworm@^0.7.0:
     lodash.debounce "^3.1.1"
     lodash.flatten "^3.0.2"
     minimatch "^3.0.2"
+
+fixturify@^0.3.2:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/fixturify/-/fixturify-0.3.4.tgz#c676de404a7f8ee8e64d0b76118e62ec95ab7b25"
+  dependencies:
+    fs-extra "^0.30.0"
+    matcher-collection "^1.0.4"
 
 flat-cache@^1.2.1:
   version "1.2.2"
@@ -2897,7 +3143,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-git-repo-info@^1.4.1:
+git-repo-info@^1.1.2, git-repo-info@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/git-repo-info/-/git-repo-info-1.4.1.tgz#2a072823254aaf62fcf0766007d7b6651bd41943"
 
@@ -2958,6 +3204,10 @@ globals@^6.4.0:
 globals@^9.0.0, globals@^9.14.0:
   version "9.17.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.17.0.tgz#0c0ca696d9b9bb694d2e5470bd37777caad50286"
+
+globals@^9.18.0:
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -3077,6 +3327,12 @@ heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3:
   dependencies:
     rsvp "~3.2.1"
 
+heimdalljs@^0.3.0:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.3.3.tgz#e92d2c6f77fd46d5bf50b610d28ad31755054d0b"
+  dependencies:
+    rsvp "~3.2.1"
+
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
@@ -3145,7 +3401,7 @@ indexof@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
 
-inflection@^1.7.0, inflection@^1.7.1:
+inflection@^1.7.0, inflection@^1.7.1, inflection@^1.8.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.12.0.tgz#a200935656d6f5f6bc4dc7502e1aecb703228416"
 
@@ -3423,6 +3679,10 @@ js-tokens@1.0.1:
 js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
+
+js-tokens@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
 js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.5.1, js-yaml@^3.6.1:
   version "3.8.4"
@@ -3750,7 +4010,7 @@ lodash@^3.10.0, lodash@^3.10.1, lodash@^3.9.3:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3819,7 +4079,13 @@ matcher-collection@^1.0.0, matcher-collection@^1.0.1:
   dependencies:
     minimatch "^3.0.2"
 
-md5-hex@^1.0.2:
+matcher-collection@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/matcher-collection/-/matcher-collection-1.0.5.tgz#2ee095438372cb8884f058234138c05c644ec339"
+  dependencies:
+    minimatch "^3.0.2"
+
+md5-hex@^1.0.2, md5-hex@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/md5-hex/-/md5-hex-1.3.0.tgz#d2c4afe983c4370662179b8cad145219135046c4"
   dependencies:
@@ -3938,7 +4204,7 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mktemp@~0.4.0:
+mktemp@^0.4.0, mktemp@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"
 
@@ -4003,7 +4269,7 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
-node-modules-path@^1.0.0:
+node-modules-path@^1.0.0, node-modules-path@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/node-modules-path/-/node-modules-path-1.0.1.tgz#40096b08ce7ad0ea14680863af449c7c75a5d1c8"
 
@@ -4048,6 +4314,10 @@ normalize-path@^2.0.1:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
     remove-trailing-separator "^1.0.1"
+
+npm-git-info@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/npm-git-info/-/npm-git-info-1.0.3.tgz#a933c42ec321e80d3646e0d6e844afe94630e1d5"
 
 npm-package-arg@^4.1.1:
   version "4.2.1"
@@ -4231,6 +4501,10 @@ parseurl@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
 
+parseurl@~1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
+
 path-exists@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-1.0.0.tgz#d5a8998eb71ef37a74c34eb0d9eba6e878eea081"
@@ -4352,7 +4626,7 @@ qs@6.4.0, qs@^6.4.0, qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
-quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quick-temp@^0.1.8:
+quick-temp@^0.1.0, quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quick-temp@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/quick-temp/-/quick-temp-0.1.8.tgz#bab02a242ab8fb0dd758a3c9776b32f9a5d94408"
   dependencies:
@@ -4477,6 +4751,10 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
 
 regenerator-runtime@^0.9.5:
   version "0.9.6"
@@ -4638,9 +4916,19 @@ rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 
+rollup@^0.41.4:
+  version "0.41.6"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.41.6.tgz#e0d05497877a398c104d816d2733a718a7a94e2a"
+  dependencies:
+    source-map-support "^0.4.0"
+
 rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.4.0, rsvp@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.5.0.tgz#a62c573a4ae4e1dfd0697ebc6242e79c681eaa34"
+
+rsvp@~3.0.6:
+  version "3.0.21"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.0.21.tgz#49c588fe18ef293bcd0ab9f4e6756e6ac433359f"
 
 rsvp@~3.2.1:
   version "3.2.1"
@@ -4674,7 +4962,7 @@ safe-json-parse@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/safe-json-parse/-/safe-json-parse-1.0.1.tgz#3e76723e38dfdda13c9b1d29a1e07ffee4b30b57"
 
-sane@^1.1.1, sane@^1.6.0:
+sane@^1.1.1, sane@^1.4.1, sane@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/sane/-/sane-1.7.0.tgz#b3579bccb45c94cf20355cc81124990dfd346e30"
   dependencies:
@@ -4854,6 +5142,12 @@ source-map-support@^0.2.10:
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.2.10.tgz#ea5a3900a1c1cb25096a0ae8cc5c2b4b10ded3dc"
   dependencies:
     source-map "0.1.32"
+
+source-map-support@^0.4.0:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+  dependencies:
+    source-map "^0.5.6"
 
 source-map-support@^0.4.2:
   version "0.4.15"
@@ -5068,6 +5362,36 @@ temp@0.8.3:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
 
+testem@1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/testem/-/testem-1.15.0.tgz#2e3a9e7ac29f16a20f718eb0c4b12e7a44900675"
+  dependencies:
+    backbone "^1.1.2"
+    bluebird "^3.4.6"
+    charm "^1.0.0"
+    commander "^2.6.0"
+    consolidate "^0.14.0"
+    cross-spawn "^5.0.0"
+    express "^4.10.7"
+    fireworm "^0.7.0"
+    glob "^7.0.4"
+    http-proxy "^1.13.1"
+    js-yaml "^3.2.5"
+    lodash.assignin "^4.1.0"
+    lodash.clonedeep "^4.4.1"
+    lodash.find "^4.5.1"
+    mkdirp "^0.5.1"
+    mustache "^2.2.1"
+    node-notifier "^5.0.1"
+    npmlog "^4.0.0"
+    printf "^0.2.3"
+    rimraf "^2.4.4"
+    socket.io "1.6.0"
+    spawn-args "^0.2.0"
+    styled_string "0.0.1"
+    tap-parser "^5.1.0"
+    xmldom "^0.1.19"
+
 testem@^1.15.0:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/testem/-/testem-1.16.1.tgz#ef8b2c793a47082ca1791e2a49d3f22bf1d4ca28"
@@ -5128,6 +5452,12 @@ tmp@0.0.28:
   dependencies:
     os-tmpdir "~1.0.1"
 
+tmp@0.0.31:
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
+  dependencies:
+    os-tmpdir "~1.0.1"
+
 tmp@^0.0.29:
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.29.tgz#f25125ff0dd9da3ccb0c2dd371ee1288bb9128c0"
@@ -5142,7 +5472,7 @@ to-array@0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890"
 
-to-fast-properties@^1.0.0, to-fast-properties@^1.0.1:
+to-fast-properties@^1.0.0, to-fast-properties@^1.0.1, to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
@@ -5236,7 +5566,7 @@ ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
 
-underscore.string@~3.3.4:
+underscore.string@^3.2.2, underscore.string@~3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.3.4.tgz#2c2a3f9f83e64762fdc45e6ceac65142864213db"
   dependencies:
@@ -5284,6 +5614,10 @@ util-deprecate@^1.0.2, util-deprecate@~1.0.1:
 utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
+
+utils-merge@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
 uuid@^3.0.0:
   version "3.0.1"

--- a/packages/hub/bootstrap-schema.js
+++ b/packages/hub/bootstrap-schema.js
@@ -102,25 +102,11 @@ const models = [
       fields: {
         data: [
           { type: 'fields', id: 'source-type' },
-          { type: 'fields', id: 'params' }
-        ]
-      }
-    }
-  },
-  {
-    type: 'content-types',
-    id: 'authentication-sources',
-    attributes: {
-      'is-built-in': true
-    },
-    relationships: {
-      fields: {
-        data: [
-          { type: 'fields', id: 'authenticator-type' },
           { type: 'fields', id: 'params' },
           { type: 'fields', id: 'user-template' },
           { type: 'fields', id: 'may-create-user' },
-          { type: 'fields', id: 'may-update-user' }
+          { type: 'fields', id: 'may-update-user' },
+          { type: 'fields', id: 'token-expiry-seconds' }
         ]
       }
     }
@@ -206,6 +192,13 @@ const models = [
   },
   {
     type: 'fields',
+    id: 'token-expiry-seconds',
+    attributes: {
+      'field-type': '@cardstack/core-types::integer'
+    }
+  },
+  {
+    type: 'fields',
     id: 'source-type',
     attributes: {
       'field-type': '@cardstack/core-types::string'
@@ -223,13 +216,6 @@ const models = [
     id: 'user-template',
     attributes: {
       'field-type': '@cardstack/handlebars'
-    }
-  },
-  {
-    type: 'fields',
-    id: 'authenticator-type',
-    attributes: {
-      'field-type': '@cardstack/core-types::string'
     }
   },
   {

--- a/packages/jsonapi/middleware.js
+++ b/packages/jsonapi/middleware.js
@@ -6,6 +6,7 @@ const logger = require('@cardstack/plugin-utils/logger');
 const { declareInjections } = require('@cardstack/di');
 const { URL } = require('url');
 const defaultIncludes = {};
+const { withJsonErrorHandling } = Error;
 
 module.exports = declareInjections({
   searcher: 'hub:searchers',
@@ -125,7 +126,7 @@ class Handler {
 
   async run() {
     this.ctxt.response.set('Content-Type', 'application/vnd.api+json');
-    try {
+    await withJsonErrorHandling(this.ctxt, async () => {
       let segments = this.ctxt.request.path.split('/').map(decodeURIComponent);
       let kind;
       if (segments.length == 2) {
@@ -139,18 +140,7 @@ class Handler {
       if (method) {
         await method.apply(this, segments.slice(1));
       }
-    } catch (err) {
-      if (!err.isCardstackError) {
-        this.log.debug("passing error onward %s", err);
-        throw err;
-      }
-      let errors = [err];
-      if (err.additionalErrors) {
-        errors = errors.concat(err.additionalErrors);
-      }
-      this.ctxt.body = { errors };
-      this.ctxt.status = errors[0].status;
-    }
+    });
   }
 
   async handleIndividualGET(type, id) {

--- a/packages/plugin-utils/error.js
+++ b/packages/plugin-utils/error.js
@@ -27,5 +27,21 @@ class E extends Error {
       source: this.source
     };
   }
+
+  static async withJsonErrorHandling(ctxt, fn) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (!err.isCardstackError) {
+        throw err;
+      }
+      let errors = [err];
+      if (err.additionalErrors) {
+        errors = errors.concat(err.additionalErrors);
+      }
+      ctxt.body = { errors };
+      ctxt.status = errors[0].status;
+    }
+  }
 }
 module.exports = E;


### PR DESCRIPTION
This eliminates "authentication-source" as a separate built-in type in favor of unifying it with "data-source". My motivation is that in general authentication sources can also be data source (the data they provide is user & group models). 

The github-auth plugin shows how that looks. It provides an Authenticator, plus a Searcher that can get individual user records, and an Indexer that can emit default schema for the user records.