### PR TITLE
Fix 'Cannot find module 'C' issue

### DIFF
--- a/packages/di/index.js
+++ b/packages/di/index.js
@@ -132,11 +132,14 @@ class Resolver {
   }
   retrieve(specifier) {
     let module;
-    let [type, name] = specifier.split(':');
+    let [type, name, rest] = specifier.split(':');
     if (type === 'hub') {
       module = this.hubPath + '/' + name;
     } else if (/^plugin-/.test(type)) {
       module = name;
+      if (rest) {
+        module = `${module}:${rest}`;
+      }
     }
 
     if (module) {

--- a/packages/hub/plugin-loader.js
+++ b/packages/hub/plugin-loader.js
@@ -277,6 +277,10 @@ class ActivePlugins {
       f => f.type === featureType && f.name === (featureName || TOP_FEATURE)
     );
     if (feature) {
+      // On Windows, the "Cannot find module 'C'" issue originates here.
+      // loadPath may contain a ':' (eg. c:\path\to\module.js) so using
+      // a ':' as a delimeter may not be the best choice. Changing it now
+      // may break things elsewhere though.
       return `plugin-${featureType}:${feature.loadPath}`;
     }
   }


### PR DESCRIPTION
Ran across this issue when getting the [stupendous-rentals](https://github.com/cardstack/stupendous-rentals) demo running on my Windows 10 machine. This fix worked for me but see my comment in plugin-loader.js where I believe the problem originates.