### PR TITLE
Add ember-cli commands for starting & stopping the hub

### DIFF
--- a/packages/hub/bin/cardstack-hub.js
+++ b/packages/hub/bin/cardstack-hub.js
@@ -24,6 +24,7 @@ function commandLineOptions() {
     .option('-d --allow-dev-dependencies', 'Allow the hub to load devDependencies')
     .option('-c --containerized', 'Run the hub in container mode (temporary feature flag)')
     .option('-l --leave-services-running', 'Leave dockerized services running, to improve future startup time')
+    .option('--heartbeat', 'Shut down after not receiving a heartbeat from ember-cli')
     .parse(process.argv);
 
   if (commander.args.length < 1) {

--- a/packages/hub/commands/clean.js
+++ b/packages/hub/commands/clean.js
@@ -1,10 +1,6 @@
 const {spawn} = require('child_process');
 
 const {waitForExit} = require('../util/process');
-const crawlPackages = require('../docker-host/crawl-module-linkages');
-const buildAppImage = require('../docker-host/build-image');
-const startHubContainer = require('../docker-host/start-hub-container');
-const {connect} = require('../docker-host/hub-connection');
 
 module.exports = {
   name: 'hub:clean',
@@ -14,7 +10,7 @@ module.exports = {
 
   availableOptions: [],
 
-  async run(args) {
+  async run() {
     this.ui.writeLine("Cleaning up old hub containers...");
     let proc = spawn('docker', ['container', 'prune', '-f', '--filter', 'label=com.cardstack'], {stdio: 'inherit'});
     await waitForExit(proc);

--- a/packages/hub/commands/clean.js
+++ b/packages/hub/commands/clean.js
@@ -1,0 +1,22 @@
+const {spawn} = require('child_process');
+
+const {waitForExit} = require('../util/process');
+const crawlPackages = require('../docker-host/crawl-module-linkages');
+const buildAppImage = require('../docker-host/build-image');
+const startHubContainer = require('../docker-host/start-hub-container');
+const {connect} = require('../docker-host/hub-connection');
+
+module.exports = {
+  name: 'hub:clean',
+  description: "Cleans up Docker artifacts left by running the hub",
+
+  works: 'insideProject',
+
+  availableOptions: [],
+
+  async run(args) {
+    this.ui.writeLine("Cleaning up old hub containers...");
+    let proc = spawn('docker', ['container', 'prune', '-f', '--filter', 'label=com.cardstack'], {stdio: 'inherit'});
+    await waitForExit(proc);
+  }
+};

--- a/packages/hub/commands/prune.js
+++ b/packages/hub/commands/prune.js
@@ -3,8 +3,8 @@ const {spawn} = require('child_process');
 const {waitForExit} = require('../util/process');
 
 module.exports = {
-  name: 'hub:clean',
-  description: "Cleans up Docker artifacts left by running the hub",
+  name: 'hub:prune',
+  description: "Cleans up unused Docker artifacts left by running the hub",
 
   works: 'insideProject',
 
@@ -13,6 +13,9 @@ module.exports = {
   async run() {
     this.ui.writeLine("Cleaning up old hub containers...");
     let proc = spawn('docker', ['container', 'prune', '-f', '--filter', 'label=com.cardstack'], {stdio: 'inherit'});
+    await waitForExit(proc);
+    this.ui.writeLine("Cleaning up old hub images...");
+    proc = spawn('docker', ['image', 'prune', '-f', '--filter', 'label=com.cardstack'], {stdio: 'inherit'});
     await waitForExit(proc);
   }
 };

--- a/packages/hub/commands/start.js
+++ b/packages/hub/commands/start.js
@@ -41,11 +41,11 @@ module.exports = {
     } else {
       this.ui.writeLine(`The hub container has been started. Use "docker logs -f ${container_id}" to see its output`);
       this.ui.writeLine("Waiting for the hub to fully boot...");
+      let connection;
       try {
-        var connection = await connect();
+        connection = await connect();
       } catch (e) {
         this.ui.writeLine("The hub seems to have crashed while starting up:");
-        console.log(e);
         let logs = spawn('docker', ['logs', container_id]);
         logs.stderr.pipe(this.ui.errorStream, {end: false});
         return waitForExit(logs);

--- a/packages/hub/commands/start.js
+++ b/packages/hub/commands/start.js
@@ -1,0 +1,39 @@
+const {waitForExit} = require('../util/process');
+const crawlPackages = require('../docker-host/crawl-module-linkages');
+const buildAppImage = require('../docker-host/build-image');
+const startHubContainer = require('../docker-host/start-hub-container');
+const {connect} = require('../docker-host/hub-connection');
+
+module.exports = {
+  name: 'hub:start',
+  description: "Starts the Cardstack hub in a Docker container",
+
+  works: 'insideProject',
+
+  availableOptions: [
+    /*{
+      name: 'follow',
+      aliases: ['f'],
+      type: Boolean
+      default: false
+    }*/
+  ],
+
+  async run(args) {
+    let packages = await crawlPackages(this.project.root);
+    let proc = buildAppImage(packages, this.project.pkg.name);
+    this.ui.writeLine("Building your docker image...");
+    proc.stdout.pipe(process.stdout);
+    proc.stderr.pipe(process.stderr);
+    await waitForExit(proc);
+
+    this.ui.writeLine("Starting hub container...");
+    let container_id = await startHubContainer();
+
+    if (args.follow) {
+      this.ui.writeLine('not yet implemented');
+    } else {
+      this.ui.writeLine(`The hub has started. Use "docker logs -f ${container_id}" to see its output`);
+    }
+  }
+};

--- a/packages/hub/commands/stop.js
+++ b/packages/hub/commands/stop.js
@@ -1,9 +1,3 @@
-const {spawn} = require('child_process');
-
-const {waitForExit} = require('../util/process');
-const crawlPackages = require('../docker-host/crawl-module-linkages');
-const buildAppImage = require('../docker-host/build-image');
-const startHubContainer = require('../docker-host/start-hub-container');
 const {connect} = require('../docker-host/hub-connection');
 
 module.exports = {
@@ -14,7 +8,7 @@ module.exports = {
 
   availableOptions: [],
 
-  async run(args) {
+  async run() {
     let hub;
     try {
       hub = await connect();

--- a/packages/hub/commands/stop.js
+++ b/packages/hub/commands/stop.js
@@ -1,0 +1,28 @@
+const {spawn} = require('child_process');
+
+const {waitForExit} = require('../util/process');
+const crawlPackages = require('../docker-host/crawl-module-linkages');
+const buildAppImage = require('../docker-host/build-image');
+const startHubContainer = require('../docker-host/start-hub-container');
+const {connect} = require('../docker-host/hub-connection');
+
+module.exports = {
+  name: 'hub:stop',
+  description: "Stops the Cardstack Hub's Docker container",
+
+  works: 'insideProject',
+
+  availableOptions: [],
+
+  async run(args) {
+    let hub;
+    try {
+      hub = await connect();
+    } catch (e) {
+      throw new Error("There doesn't seem to be a hub running");
+    }
+
+    this.ui.writeLine("Sending shutdown message to hub...");
+    hub.shutdown();
+  }
+};

--- a/packages/hub/docker-container/ember-connection.js
+++ b/packages/hub/docker-container/ember-connection.js
@@ -13,7 +13,7 @@ module.exports = class EmberConnector {
       this.stopLater = _.debounce(this._stop.bind(this), HUB_HEARTBEAT_TIMEOUT);
     }
 
-    var that = this;
+    let that = this;
 
     this._server = nssocket.createServer(async function(socket) {
       log.info('Connection established from ember-cli');

--- a/packages/hub/docker-container/ember-connection.js
+++ b/packages/hub/docker-container/ember-connection.js
@@ -26,7 +26,10 @@ module.exports = class EmberConnector {
       });
 
       // Ember-cli may shut us down manually.
-      socket.data('shutdown', ()=>orchestrator.stop());
+      socket.data('shutdown', function() {
+        console.log('Received shutdown message from ember-cli');
+        orchestrator.stop()
+      });
 
       if (heartbeat) {
         // Or, if it crashes or is killed it will stop sending the heartbeat

--- a/packages/hub/docker-container/ember-connection.js
+++ b/packages/hub/docker-container/ember-connection.js
@@ -27,8 +27,8 @@ module.exports = class EmberConnector {
 
       // Ember-cli may shut us down manually.
       socket.data('shutdown', function() {
-        console.log('Received shutdown message from ember-cli');
-        orchestrator.stop()
+        log.info('Received shutdown message from ember-cli');
+        orchestrator.stop();
       });
 
       if (heartbeat) {

--- a/packages/hub/docker-container/orchestrator.js
+++ b/packages/hub/docker-container/orchestrator.js
@@ -78,6 +78,7 @@ async function ensureElasticsearch() {
       '-d',
       '--network', NETWORK_NAME,
       '--network-alias', 'elasticsearch',
+      '--label', 'com.cardstack',
       '--label', 'com.cardstack.service=elasticsearch',
       '--publish', '9200:9200',
       'cardstack/elasticsearch:dev'

--- a/packages/hub/docker-container/orchestrator.js
+++ b/packages/hub/docker-container/orchestrator.js
@@ -76,7 +76,6 @@ async function ensureElasticsearch() {
   await execFile('docker', [
       'run',
       '-d',
-      '--rm',
       '--network', NETWORK_NAME,
       '--network-alias', 'elasticsearch',
       '--label', 'com.cardstack.service=elasticsearch',

--- a/packages/hub/docker-host/build-image.js
+++ b/packages/hub/docker-host/build-image.js
@@ -12,6 +12,7 @@ module.exports = function buildAppImage(packages, appName) {
 
   let proc = spawn('docker', [
       'build',
+      '--label', 'com.cardstack',
       '-t', 'cardstack-app',
       '-'
   ]);

--- a/packages/hub/docker-host/hub-connection.js
+++ b/packages/hub/docker-host/hub-connection.js
@@ -17,7 +17,7 @@ class HubConnection {
     let beat = () => {
       log.trace('Sending heartbeat to hub');
       this.connection.send('heartbeat');
-    }
+    };
     beat();
     setInterval(beat, HUB_HEARTBEAT_INTERVAL);
   }
@@ -73,4 +73,4 @@ async function _connect() {
 module.exports = {
   HubConnection,
   connect
-}
+};

--- a/packages/hub/docker-host/hub-connection.js
+++ b/packages/hub/docker-host/hub-connection.js
@@ -32,6 +32,10 @@ class HubConnection {
       this.connection.send('subscribeReady');
     });
   }
+
+  shutdown() {
+    this.connection.send('shutdown');
+  }
 }
 
 async function connect() {

--- a/packages/hub/docker-host/hub-connection.js
+++ b/packages/hub/docker-host/hub-connection.js
@@ -1,0 +1,57 @@
+const {promisify} = require('util');
+const timeout = promisify(setTimeout);
+
+const nssocket = require('nssocket');
+const log = require('@cardstack/plugin-utils/logger')('hub/hub-connection');
+
+const HUB_HEARTBEAT_INTERVAL = 1 * 1000;
+
+class HubConnection {
+  constructor(connection) {
+    this.connection = connection;
+    this.ready = new Promise(function(resolve, reject) {
+      this.connection.data('ready', function() {
+        log.info('Ready message received from hub container');
+        resolve();
+      });
+      this.connection.on('close', reject);
+    });
+  }
+
+  startHeartbeat(){
+    let beat = function() {
+      log.trace('Sending heartbeat to hub');
+      this.connection.send('heartbeat');
+    }
+    beat();
+    setInterval(beat, HUB_HEARTBEAT_INTERVAL);
+  }
+}
+
+async function connect() {
+  let connection = new nssocket.NsSocket();
+  connection.connect(6785);
+
+  return new Promise(function(resolve, reject) {
+    log.trace("Attempting to connect to the hub's heartbeat port");
+
+    async function onClose() {
+      await timeout(50);
+      resolve(connect());
+    }
+
+    connection.on('close', onClose);
+    connection.data('shake', function() {
+      log.trace("Hub heartbeat connection established");
+      connection.removeListener('close', onClose);
+      resolve(connection);
+    });
+    connection.on('error', reject);
+    connection.send('hand');
+  });
+}
+
+module.exports = {
+  HubConnection,
+  connect
+}

--- a/packages/hub/docker-host/proxy-to-hub.js
+++ b/packages/hub/docker-host/proxy-to-hub.js
@@ -1,0 +1,10 @@
+const Koa = require('koa');
+const proxy = require('koa-proxy');
+
+module.exports = function() {
+  let app = new Koa();
+  app.use(proxy({
+    host: 'http://localhost:3000'
+  }));
+  return app.callback();
+}

--- a/packages/hub/docker-host/proxy-to-hub.js
+++ b/packages/hub/docker-host/proxy-to-hub.js
@@ -7,4 +7,4 @@ module.exports = function() {
     host: 'http://localhost:3000'
   }));
   return app.callback();
-}
+};

--- a/packages/hub/docker-host/start-hub-container.js
+++ b/packages/hub/docker-host/start-hub-container.js
@@ -12,6 +12,8 @@ module.exports = async function spawnHubContainer(/*projectRoot*/) {
   let {stdout} = await execFile('docker', [
     'run',
     '-d',
+    '--label', 'com.cardstack',
+    '--label', 'com.cardstack.service=hub',
     '--publish', '3000:3000',
     '--publish', '6785:6785',
     '--mount', 'type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock',

--- a/packages/hub/docker-host/start-hub-container.js
+++ b/packages/hub/docker-host/start-hub-container.js
@@ -1,52 +1,17 @@
 const crypto = require('crypto');
 const {promisify} = require('util');
 const child_process = require('child_process');
-const {spawn} = child_process;
 const execFile = promisify(child_process.execFile);
-
-const Koa = require('koa');
-const proxy = require('koa-proxy');
-const StdBuffer = require('./stdbuffer');
-const buildAppImage = require('./build-image');
-const log = require('@cardstack/plugin-utils/logger')('hub/spawn-hub');
-const {waitForExit} = require('../util/process');
-const crawlPackages = require('./crawl-module-linkages');
-const {connect} = require('./hub-connection');
-
-const HUB_HEARTBEAT_INTERVAL = 1 * 1000;
-
-module.exports = async function() {
-  let container_id = await spawnHubContainer();
-
-  console.log('container id', container_id);
-  let logs = new StdBuffer(spawn('docker', ['logs', '-f', container_id]));
-
-  try {
-    await connect();
-  } catch (e) {
-    if (e.code === "ECONNREFUSED") {
-      log.error("The hub container failed to start:");
-      log.error(logs.err);
-      throw new Error('Hub failed to start');
-    } else {
-      throw e;
-    }
-  }
-
-  return container_id;
-};
 
 
 // Spawns the hub container, and returns an object for getting its stdio
 // We should, later, live bind code in as well.
-async function spawnHubContainer(/*projectRoot*/) {
+module.exports = async function spawnHubContainer(/*projectRoot*/) {
   let key = crypto.randomBytes(32).toString('base64');
-
 
   let {stdout} = await execFile('docker', [
     'run',
     '-d',
-    '--rm',
     '--publish', '3000:3000',
     '--publish', '6785:6785',
     '--mount', 'type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock',

--- a/packages/hub/docker-host/start-hub-container.js
+++ b/packages/hub/docker-host/start-hub-container.js
@@ -20,4 +20,4 @@ module.exports = async function spawnHubContainer(/*projectRoot*/) {
   ]);
 
   return stdout.trim();
-}
+};

--- a/packages/hub/docker-host/start-hub-container.js
+++ b/packages/hub/docker-host/start-hub-container.js
@@ -3,28 +3,26 @@ const {promisify} = require('util');
 const child_process = require('child_process');
 const {spawn} = child_process;
 const execFile = promisify(child_process.execFile);
-const timeout = promisify(setTimeout);
 
 const Koa = require('koa');
 const proxy = require('koa-proxy');
-const nssocket = require('nssocket');
 const StdBuffer = require('./stdbuffer');
 const buildAppImage = require('./build-image');
 const log = require('@cardstack/plugin-utils/logger')('hub/spawn-hub');
 const {waitForExit} = require('../util/process');
 const crawlPackages = require('./crawl-module-linkages');
+const {connect} = require('./hub-connection');
 
 const HUB_HEARTBEAT_INTERVAL = 1 * 1000;
 
-module.exports = async function(project) {
-  let packages = await crawlPackages(project.root);
-  await waitForExit(buildAppImage(packages, project.pkg.name));
+module.exports = async function() {
+  let container_id = await spawnHubContainer();
 
-  let logs = await spawnHubContainer(project.root);
+  console.log('container id', container_id);
+  let logs = new StdBuffer(spawn('docker', ['logs', '-f', container_id]));
 
-  let hub;
   try {
-    hub = await socketToHub();
+    await connect();
   } catch (e) {
     if (e.code === "ECONNREFUSED") {
       log.error("The hub container failed to start:");
@@ -35,38 +33,9 @@ module.exports = async function(project) {
     }
   }
 
-  await new Promise(function(resolve) {
-    hub.data('ready', resolve);
-  });
-
-  log.info('Ready message received from hub container');
-
-  startHeartbeat(hub);
+  return container_id;
 };
 
-
-async function socketToHub() {
-  let hub = new nssocket.NsSocket();
-  hub.connect(6785);
-
-  return new Promise(function(resolve, reject) {
-    log.trace("Attempting to connect to the hub's heartbeat port");
-
-    async function onClose() {
-      await timeout(50);
-      resolve(socketToHub());
-    }
-
-    hub.on('close', onClose);
-    hub.data('shake', function() {
-      log.trace("Hub heartbeat connection established");
-      hub.removeListener('close', onClose);
-      resolve(hub);
-    });
-    hub.on('error', reject);
-    hub.send('hand');
-  });
-}
 
 // Spawns the hub container, and returns an object for getting its stdio
 // We should, later, live bind code in as well.
@@ -85,16 +54,5 @@ async function spawnHubContainer(/*projectRoot*/) {
     'cardstack-app'
   ]);
 
-  let container_id = stdout.trim();
-
-  return new StdBuffer(spawn('docker', ['logs', '-f', container_id]));
-}
-
-function startHeartbeat(hub) {
-  let beat = function() {
-    log.trace('Sending heartbeat to hub container');
-    hub.send('heartbeat');
-  };
-  beat();
-  setInterval(beat, HUB_HEARTBEAT_INTERVAL);
+  return stdout.trim();
 }

--- a/packages/hub/docker-host/start-hub-container.js
+++ b/packages/hub/docker-host/start-hub-container.js
@@ -42,12 +42,6 @@ module.exports = async function(project) {
   log.info('Ready message received from hub container');
 
   startHeartbeat(hub);
-
-  let app = new Koa();
-  app.use(proxy({
-    host: 'http://localhost:3000'
-  }));
-  return app.callback();
 };
 
 

--- a/packages/hub/index.js
+++ b/packages/hub/index.js
@@ -6,14 +6,12 @@ const log = require('@cardstack/plugin-utils/logger')('hub/ember-cli');
 // only sometimes load, because of feature flag
 let BroccoliConnector;
 let Funnel;
-let startHubContainer;
 let proxyToHub;
 let connect;
 
 const CONTAINER_MODE = process.env.CONTAINERIZED_HUB != null;
 
 if (CONTAINER_MODE) {
-  startHubContainer = require('./docker-host/start-hub-container');
   proxyToHub = require('./docker-host/proxy-to-hub');
   connect = require('./docker-host/hub-connection').connect;
 } else {
@@ -28,7 +26,7 @@ let addon = {
   name: '@cardstack/hub',
 
   includedCommands() {
-    if (true) {
+    if (CONTAINER_MODE) {
       return {
         'hub:build': require('./commands/build'),
         'hub:start': require('./commands/start')

--- a/packages/hub/index.js
+++ b/packages/hub/index.js
@@ -28,7 +28,8 @@ let addon = {
   includedCommands() {
     if (CONTAINER_MODE) {
       return {
-        'hub:build': require('./commands/build')
+        'hub:build': require('./commands/build'),
+        'hub:start': require('./commands/start')
       };
     } else {
       return {};

--- a/packages/hub/index.js
+++ b/packages/hub/index.js
@@ -29,7 +29,9 @@ let addon = {
     if (CONTAINER_MODE) {
       return {
         'hub:build': require('./commands/build'),
-        'hub:start': require('./commands/start')
+        'hub:start': require('./commands/start'),
+        'hub:stop': require('./commands/stop'),
+        'hub:clean': require('./commands/clean')
       };
     } else {
       return {};
@@ -104,8 +106,7 @@ let addon = {
       try {
         await connect();
       } catch (e) {
-        this.ui.writeError(new Error('Could not connect to cardstack/hub. Please use "ember hub:start" to start the hub'));
-        throw e;
+        throw new Error('Could not connect to cardstack/hub. Please use "ember hub:start" to start the hub');
       }
       app.use('/cardstack', proxyToHub());
     } else {

--- a/packages/hub/index.js
+++ b/packages/hub/index.js
@@ -31,7 +31,7 @@ let addon = {
         'hub:build': require('./commands/build'),
         'hub:start': require('./commands/start'),
         'hub:stop': require('./commands/stop'),
-        'hub:clean': require('./commands/clean')
+        'hub:prune': require('./commands/prune')
       };
     } else {
       return {};

--- a/packages/hub/main.js
+++ b/packages/hub/main.js
@@ -47,7 +47,10 @@ async function makeServer(projectDir, encryptionKeys, seedModels, opts = {}) {
 
     // Eventually we'll pass a connection instance into the hub, for triggering rebuilds.
     // For now, it just has the side effect of shutting the hub down properly when it's time.
-    new EmberConnection(orchestrator);
+    new EmberConnection({
+      orchestrator,
+      heartbeat: opts.heartbeat
+    });
     await orchestrator.ready;
   }
 


### PR DESCRIPTION
Note - these changes still only apply to commands using the `CONTAINERIZED_HUB=true` feature flag.

This adds:
- `ember hub:start` - Start a hub container
- `ember hub:stop` - Stop the hub container
- `ember hub:prune` - Clean up old hub containers & images

`ember serve` no longer starts the hub, instead it prompts the user to use `ember hub:start`.

I was originally using the `--rm` flag to automatically clean up containers when they stopped. But, this made it hard to get logs for crashed containers. So, I removed it, and added the `hub:prune` command to clean up unused images and containers.
It's called `prune`, not `clean`, because it leaves any running containers, or any tagged images (the `cardstack-app:latest` is applied only to the most recent image build).