### PR TITLE
Allow x-requested-with header

### DIFF
--- a/packages/jsonapi/middleware.js
+++ b/packages/jsonapi/middleware.js
@@ -51,7 +51,7 @@ function jsonapiMiddleware(searcher, writers, indexers) {
     ctxt.response.set('Access-Control-Allow-Origin', '*');
     if (ctxt.request.method === 'OPTIONS') {
       ctxt.response.set('Access-Control-Allow-Methods', 'GET,POST,PATCH,DELETE,OPTIONS');
-      ctxt.response.set('Access-Control-Allow-Headers', 'Authorization, Content-Type, If-Match');
+      ctxt.response.set('Access-Control-Allow-Headers', 'Authorization, Content-Type, If-Match, X-Requested-With');
       ctxt.status = 200;
       return;
     }


### PR DESCRIPTION
I'm not sure if this is the best fix since my knowledge of CORS is limited.

It looks like jQuery adds the [X-Requested-With](https://stackoverflow.com/questions/17478731/whats-the-point-of-the-x-requested-with-header) header.

CORS requests from Electron get rejected because of this. 