### PR TITLE
Make it possible to define custom captions for fields

### DIFF
--- a/packages/hub/bootstrap-schema.js
+++ b/packages/hub/bootstrap-schema.js
@@ -30,7 +30,8 @@ const models = [
           { type: 'fields', id: 'field-type' },
           { type: 'fields', id: 'related-types' },
           { type: 'fields', id: 'default-at-create' },
-          { type: 'fields', id: 'default-at-update' }
+          { type: 'fields', id: 'default-at-update' },
+          { type: 'fields', id: 'caption' }
         ]
       }
     }
@@ -318,6 +319,13 @@ const models = [
   {
     type: 'fields',
     id: 'field-type',
+    attributes: {
+      'field-type': '@cardstack/core-types::string'
+    }
+  },
+  {
+    type: 'fields',
+    id: 'caption',
     attributes: {
       'field-type': '@cardstack/core-types::string'
     }

--- a/packages/hub/schema/field.js
+++ b/packages/hub/schema/field.js
@@ -9,6 +9,7 @@ module.exports = class Field {
       throw new Error(`field ${model.id} has no field-type attribute`);
     }
     this.fieldType = model.attributes['field-type'];
+    this.caption = model.attributes.caption || humanize(model.id);
     this.searchable = model.attributes.searchable == null ? true : model.attributes.searchable;
 
     // Default values are modeled as relationships to separate models
@@ -260,4 +261,17 @@ function recursiveMappings(searchTree, allFields) {
     outputList.push(allFields.get('type').mapping(searchTree, allFields));
   }
   return Object.assign({}, ...outputList);
+}
+
+function humanize(string) {
+  // First regex taken from Ember.String.capitalize
+  // Would be great to "merge" this with the cs-humanize helper
+  // in the rendering package
+  return string.replace(/(^|\/)([a-z])/g, function(match) {
+    return match.toUpperCase();
+  }).replace(/([a-z])([A-Z])/g, function(all, low, upper) {
+    return `${low} ${upper}`;
+  }).replace(/-([a-zA-Z])/g, function(all, follower){
+    return ` ${follower.toUpperCase()}`;
+  });
 }

--- a/packages/models/cardstack/code-generator.js
+++ b/packages/models/cardstack/code-generator.js
@@ -36,7 +36,7 @@ define('@cardstack/models/generated/{{modelName}}', ['exports', '@cardstack/mode
            {{camelize field.id}}:  _emberData.default.{{relationship-method field}}("{{type}}"),
          {{/with}}
        {{else}}
-        {{camelize field.id}}: _emberData.default.attr({ fieldType: "{{field.fieldType}}"}),
+        {{camelize field.id}}: _emberData.default.attr({ fieldType: "{{field.fieldType}}", caption: "{{field.caption}}" }),
        {{/if}}
      {{/each}}
    }){{#if routingField}}.reopenClass({ routingField: "{{routingField}}" }){{/if}};

--- a/packages/rendering/addon/-private/meta-for-field.js
+++ b/packages/rendering/addon/-private/meta-for-field.js
@@ -1,6 +1,9 @@
+import { camelize } from '@ember/string';
+
 export default function metaForField(content, fieldName) {
   if (!content) { return; }
 
+  fieldName = camelize(fieldName);
   try {
     return content.constructor.metaForProperty(fieldName);
   } catch (err) {

--- a/packages/rendering/addon/-private/meta-for-field.js
+++ b/packages/rendering/addon/-private/meta-for-field.js
@@ -1,0 +1,11 @@
+export default function metaForField(content, fieldName) {
+  if (!content) { return; }
+
+  try {
+    return content.constructor.metaForProperty(fieldName);
+  } catch (err) {
+    return;
+  }
+
+}
+

--- a/packages/rendering/addon/-private/strip-namespace.js
+++ b/packages/rendering/addon/-private/strip-namespace.js
@@ -1,0 +1,10 @@
+export default function stripNamespace(type) {
+  // Right now the actual field editor components get flattened down
+  // out of their namespaces, so we throw away everything but the
+  // last bit of their names here. This problem is easier to solve
+  // once I can integrate a module-unification resolver, so I'm
+  // leaving it like this for now.
+  let parts = type.split(/[/:]/g);
+  return parts[parts.length - 1];
+}
+

--- a/packages/rendering/addon/components/cs-field-group.js
+++ b/packages/rendering/addon/components/cs-field-group.js
@@ -1,18 +1,24 @@
-import Ember from 'ember';
 import layout from '../templates/components/cs-field-group';
-const { guidFor } = Ember;
+import { humanize } from '../helpers/cs-humanize';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { guidFor } from "@ember/object/internals"
 
 const limit = 7;
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   tagName: '',
 
-  id: Ember.computed('content', 'name', function() {
+  id: computed('content', 'name', function() {
     return `${guidFor(this.get('content'))}/cs-field-group/${this.get('name')}`;
   }),
 
-  fieldNames: Ember.computed('fields', function() {
+  groupCaption: computed('caption', 'name', function() {
+    return this.get('caption') || humanize(this.get('name'));
+  }),
+
+  fieldNames: computed('fields', function() {
     let fields = this.get('fields');
     if (!Array.isArray(fields)) {
       fields = fields.split(/\s*,\s*/g);
@@ -23,11 +29,12 @@ export default Ember.Component.extend({
     return fields;
   }),
 
-  fieldInfo: Ember.computed('content', 'fieldName', function() {
+  fieldInfo: computed('content', 'fieldName', function() {
     return {
       name: this.get('name'),
       content: this.get('content'),
-      grouped: this.get('fieldNames')
+      grouped: this.get('fieldNames'),
+      caption: this.get('groupCaption')
     };
   })
 

--- a/packages/rendering/addon/components/cs-field.js
+++ b/packages/rendering/addon/components/cs-field.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import layout from '../templates/components/cs-field';
 const { guidFor } = Ember;
 import { fieldType } from '../helpers/cs-field-type';
+import { fieldCaption } from '../helpers/cs-field-caption';
 import injectOptional from 'ember-inject-optional';
 
 export default Ember.Component.extend({
@@ -15,6 +16,10 @@ export default Ember.Component.extend({
 
   fieldType: Ember.computed('content', 'fieldName', function() {
     return fieldType(this.get('content'), this.get('fieldName'));
+  }),
+
+  fieldCaption: Ember.computed('content', 'fieldName', function() {
+    return fieldCaption(this.get('content'), this.get('fieldName'));
   }),
 
   fieldConfig: Ember.computed('fieldType', function() {
@@ -32,10 +37,11 @@ export default Ember.Component.extend({
     return `field-renderers/${this.get('fieldType')}-renderer`;
   }),
 
-  fieldInfo: Ember.computed('content', 'fieldName', function() {
+  fieldInfo: Ember.computed('content', 'fieldName', 'fieldCaption', function() {
     return {
       name: this.get('fieldName'),
-      content: this.get('content')
+      content: this.get('content'),
+      caption: this.get('fieldCaption')
     };
   }),
 }).reopenClass({

--- a/packages/rendering/addon/helpers/cs-field-caption.js
+++ b/packages/rendering/addon/helpers/cs-field-caption.js
@@ -1,6 +1,10 @@
-import Ember from 'ember';
+import { helper } from 'ember-helper';
 import metaForField from '../-private/meta-for-field';
 import stripNamespace from '../-private/strip-namespace';
+
+export default helper(function([content, fieldName]) {
+  return fieldCaption(content, fieldName);
+});
 
 export function fieldCaption(content, fieldName) {
   let meta = metaForField(content, fieldName);
@@ -16,4 +20,3 @@ export function fieldCaption(content, fieldName) {
   return caption;
 }
 
-export default Ember.Helper.helper(fieldCaption);

--- a/packages/rendering/addon/helpers/cs-field-caption.js
+++ b/packages/rendering/addon/helpers/cs-field-caption.js
@@ -1,0 +1,19 @@
+import Ember from 'ember';
+import metaForField from '../-private/meta-for-field';
+import stripNamespace from '../-private/strip-namespace';
+
+export function fieldCaption(content, fieldName) {
+  let meta = metaForField(content, fieldName);
+  if (!meta) {
+    return;
+  }
+
+  let caption = meta.options && meta.options.caption;
+  if (caption) {
+    caption = stripNamespace(caption);
+  }
+
+  return caption;
+}
+
+export default Ember.Helper.helper(fieldCaption);

--- a/packages/rendering/addon/helpers/cs-field-type.js
+++ b/packages/rendering/addon/helpers/cs-field-type.js
@@ -1,23 +1,19 @@
 import Ember from 'ember';
+import metaForField from '../-private/meta-for-field';
+import stripNamespace from '../-private/strip-namespace';
 
 export function fieldType(content, fieldName) {
-  if (!content) { return; }
-  let meta;
-
-  try {
-    meta = content.constructor.metaForProperty(fieldName);
-  } catch (err) {
+  // meta.options.fieldType is our convention for annotating models.
+  let meta = metaForField(content, fieldName, 'fieldType');
+  if (!meta) {
     return;
   }
 
-  // meta.options.fieldType is our convention for annotating
-  // models. meta.type is the name of the transform that ember-data
-  // is using, which we keep as a fallback.
   let type = meta.options && meta.options.fieldType;
-
+  // meta.type is the name of the transform that ember-data
+  // is using, which we keep as a fallback.
   if (!type && meta.type) {
-    // lift the default ember-data transform names into our core
-    // types
+    // lift the default ember-data transform names into our core types
     type = `@cardstack/core-types::${meta.type}`;
   }
 
@@ -25,16 +21,6 @@ export function fieldType(content, fieldName) {
     type = stripNamespace(type);
   }
   return type;
-}
-
-function stripNamespace(type) {
-  // Right now the actual field editor components get flattened down
-  // out of their namespaces, so we throw away everything but the
-  // last bit of their names here. This problem is easier to solve
-  // once I can integrate a module-unification resolver, so I'm
-  // leaving it like this for now.
-  let parts = type.split(/[/:]/g);
-  return parts[parts.length - 1];
 }
 
 export default Ember.Helper.helper(fieldType);

--- a/packages/rendering/addon/helpers/cs-placeholder.js
+++ b/packages/rendering/addon/helpers/cs-placeholder.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 import { humanize } from './cs-humanize';
 
-export default Ember.Helper.helper(function(params, { fieldConfig, value, active, fieldName }) {
+export default Ember.Helper.helper(function(params, options={}) {
+  let { fieldConfig, fieldCaption, value, active, fieldName } = options;
+
   if (!active) {
     return value;
   }
@@ -14,7 +16,7 @@ export default Ember.Helper.helper(function(params, { fieldConfig, value, active
     if (fieldConfig && fieldConfig.placeholder) {
       return fieldConfig.placeholder(humanize(fieldName));
     } else {
-      return `Enter ${humanize(fieldName)}`;
+      return `Enter ${fieldCaption}`;
     }
   } else {
     return value;

--- a/packages/rendering/addon/helpers/cs-silly-hash.js
+++ b/packages/rendering/addon/helpers/cs-silly-hash.js
@@ -1,6 +1,9 @@
-import Ember from 'ember';
+import { helper } from 'ember-helper';
 
 export function csSillyHash(unused, hash) {
+  // Implements a limited version of the (missing) handlebars splat operator
+  // Input:  { key0=readingTimeValue value0=5 key1=readingTimeUnits value1='minutes', ...}
+  // Output: { readingTimeValue: 5, readingTimeUnits: 'minutes', ... }
   let output = {};
   Object.keys(hash).forEach(key => {
     let m = /^key(\d+)/.exec(key);
@@ -11,4 +14,4 @@ export function csSillyHash(unused, hash) {
   return output;
 }
 
-export default Ember.Helper.helper(csSillyHash);
+export default helper(csSillyHash);

--- a/packages/rendering/addon/templates/components/cs-field.hbs
+++ b/packages/rendering/addon/templates/components/cs-field.hbs
@@ -1,5 +1,11 @@
 {{#mark-overlay id=id model=fieldInfo group="cardstack-fields" ~}}
-  {{#with (cs-placeholder value=(get content fieldName) fieldName=fieldName fieldConfig=fieldConfig active=tools.requestedEditing) as |value| ~}}
+  {{#with
+      (cs-placeholder
+        value=(get content fieldName)
+        fieldName=fieldName
+        fieldCaption=fieldInfo.caption
+        fieldConfig=fieldConfig
+        active=tools.requestedEditing) as |value| ~}}
   {{#if hasBlock ~}}
     {{yield value ~}}
   {{else ~}}

--- a/packages/rendering/app/helpers/cs-field-caption.js
+++ b/packages/rendering/app/helpers/cs-field-caption.js
@@ -1,0 +1,1 @@
+export { default, fieldCaption } from '@cardstack/rendering/helpers/cs-field-caption';

--- a/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
+++ b/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
@@ -27,8 +27,10 @@
       <div class="cs-field-editor-section">
       {{#if fieldMark.model.grouped}}
         {{#each fieldMark.model.grouped as |fieldName|}}
-          <label>{{cs-humanize fieldName}}</label>
-          {{cs-field-editor content=fieldMark.model.content field=fieldName enabled=editingEnabled}}
+          {{#with fieldMark.model.content as |content|}}
+            <label>{{cs-field-caption content fieldName}}</label>
+            {{cs-field-editor content=content field=fieldName enabled=editingEnabled}}
+          {{/with}}
         {{/each}}
       {{else}}
         {{cs-field-editor content=fieldMark.model.content field=fieldMark.model.name enabled=editingEnabled}}

--- a/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
+++ b/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
@@ -17,7 +17,7 @@
 
   {{#each fields key="id" as |fieldMark|}}
     {{#cs-collapsible-section class="cs-toolbox-section"
-                              title=(cs-humanize fieldMark.model.name)
+                              title=fieldMark.model.caption
                               opened=(eq fieldMark.id openedFieldId)
                               open=(action openField fieldMark)
                               close=(action openField null)

--- a/packages/tools/addon/templates/components/cs-field-overlays.hbs
+++ b/packages/tools/addon/templates/components/cs-field-overlays.hbs
@@ -1,6 +1,6 @@
 {{#overlay-marks group="cardstack-fields" as |mark|}}
   {{#create-overlay at=mark
-                   label=(cs-humanize mark.model.name)
+                   label=mark.model.caption
                    highlighted=(eq mark.id tools.highlightedFieldId)
                    hoverable=tools.editing
                    class="cs-field-overlay"

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@cardstack/ephemeral": "^0.2.11",
     "@cardstack/jsonapi": "^0.2.11",
+    "@cardstack/models": "^0.2.11",
     "@cardstack/test-support": "^0.2.11",
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "^2.12.0",

--- a/packages/tools/tests/dummy/app/components/field-editors/date-editor.js
+++ b/packages/tools/tests/dummy/app/components/field-editors/date-editor.js
@@ -1,0 +1,2 @@
+import StringEditor from '@cardstack/core-types/components/field-editors/string-editor';
+export default StringEditor;

--- a/packages/tools/tests/dummy/app/models/post.js
+++ b/packages/tools/tests/dummy/app/models/post.js
@@ -1,5 +1,0 @@
-import DS from 'ember-data';
-
-export default DS.Model.extend({
-  title: DS.attr('string')
-});

--- a/packages/tools/tests/dummy/app/templates/components/cardstack/post-page.hbs
+++ b/packages/tools/tests/dummy/app/templates/components/cardstack/post-page.hbs
@@ -6,4 +6,9 @@
   <p>
     {{cs-field content 'publishedAt'}}
   </p>
+  <p>
+    {{#cs-field-group content name="reading-time" fields="readingTimeValue,readingTimeUnits" as |rt|}}
+      <div>{{rt.readingTimeValue}} {{rt.readingTimeUnits}}</div>
+    {{/cs-field-group}}
+  </p>
 </div>

--- a/packages/tools/tests/dummy/app/templates/components/cardstack/post-page.hbs
+++ b/packages/tools/tests/dummy/app/templates/components/cardstack/post-page.hbs
@@ -1,4 +1,9 @@
 <div class="post-page">
   <div>{{#link-to "posts"}}Back to posts{{/link-to}}</div>
-  <h1>{{content.title}}</h1>
+  <h1>
+    {{cs-field content 'title'}}
+  </h1>
+  <p>
+    {{cs-field content 'publishedAt'}}
+  </p>
 </div>

--- a/packages/tools/tests/dummy/app/templates/components/cardstack/post-page.hbs
+++ b/packages/tools/tests/dummy/app/templates/components/cardstack/post-page.hbs
@@ -7,7 +7,7 @@
     {{cs-field content 'publishedAt'}}
   </p>
   <p>
-    {{#cs-field-group content name="reading-time" fields="readingTimeValue,readingTimeUnits" as |rt|}}
+    {{#cs-field-group content name="reading-time" caption="Underestimated Read Time" fields="readingTimeValue,readingTimeUnits" as |rt|}}
       <div>{{rt.readingTimeValue}} {{rt.readingTimeUnits}}</div>
     {{/cs-field-group}}
   </p>

--- a/packages/tools/tests/dummy/cardstack/seeds/development/activate-models.js
+++ b/packages/tools/tests/dummy/cardstack/seeds/development/activate-models.js
@@ -1,0 +1,8 @@
+/* eslint-env node */
+
+module.exports = [
+  {
+    type: 'plugin-configs',
+    id: '@cardstack/models'
+  }
+];

--- a/packages/tools/tests/dummy/cardstack/seeds/development/dev.js
+++ b/packages/tools/tests/dummy/cardstack/seeds/development/dev.js
@@ -9,15 +9,31 @@ function initialModels() {
     .withRelated('fields', [
       initial.addResource('fields', 'title').withAttributes({
         fieldType: '@cardstack/core-types::string'
-      })
+      }),
+      initial.addResource('fields', 'published-at').withAttributes({
+        caption: 'Publish Date',
+        fieldType: '@cardstack/core-types::date'
+      }),
+      initial.addResource('fields', 'reading-time-value').withAttributes({
+        fieldType: '@cardstack/core-types::integer'
+      }),
+      initial.addResource('fields', 'reading-time-units').withAttributes({
+        fieldType: '@cardstack/core-types::string'
+      }),
     ]);
   initial.addResource('posts', '1')
     .withAttributes({
-      title: 'hello world'
+      title: 'hello world',
+      publishedAt: new Date(2017, 3, 24),
+      readingTimeValue: 8,
+      readingTimeUnits: 'minutes',
     });
   initial.addResource('posts', '2')
     .withAttributes({
-      title: 'second'
+      title: 'second',
+      publishedAt: new Date(2017, 9, 20),
+      readingTimeValue: 2,
+      readingTimeUnits: 'hours',
     });
   return initial.getModels();
 }

--- a/packages/tools/tests/dummy/cardstack/seeds/development/dev.js
+++ b/packages/tools/tests/dummy/cardstack/seeds/development/dev.js
@@ -15,9 +15,11 @@ function initialModels() {
         fieldType: '@cardstack/core-types::date'
       }),
       initial.addResource('fields', 'reading-time-value').withAttributes({
+        caption: 'Value',
         fieldType: '@cardstack/core-types::integer'
       }),
       initial.addResource('fields', 'reading-time-units').withAttributes({
+        caption: 'Units',
         fieldType: '@cardstack/core-types::string'
       }),
     ]);

--- a/packages/tools/tests/dummy/cardstack/seeds/test/activate-models.js
+++ b/packages/tools/tests/dummy/cardstack/seeds/test/activate-models.js
@@ -1,0 +1,8 @@
+/* eslint-env node */
+
+module.exports = [
+  {
+    type: 'plugin-configs',
+    id: '@cardstack/models'
+  }
+];


### PR DESCRIPTION
What's left is:

* [x] To make it work for the labels of grouped fields, too, and possibly having a common API for the `fieldInfo` CP of cs-field.js and cs-field-group.js.
* [x] To also use the caption in the placeholder text, more precisely in https://github.com/cardstack/cardstack/blob/master/packages/rendering/addon/helpers/cs-placeholder.js. It still uses the humanized fieldName for now.
* [x] The blue label on the overlay (cs-field-overlay.js component)
* [x]  Collapsible section label for grouped fields
