### PR TITLE
Separate hub process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "7"
+  - "8"
 
 sudo: required
 services:

--- a/packages/hub/bin/cardstack-hub.js
+++ b/packages/hub/bin/cardstack-hub.js
@@ -51,8 +51,16 @@ function commandLineOptions() {
     process.exit(-1);
   }
 
+  commander.emberConfigEnv = loadAppConfig();
+
   return commander;
 }
+
+function loadAppConfig() {
+  let env = process.env.EMBER_ENV || 'development';
+  return require(path.join(process.cwd(), 'config', 'environment'))(env);
+}
+
 
 function loadSeedModels(options) {
   try {

--- a/packages/hub/bin/generate-key.js
+++ b/packages/hub/bin/generate-key.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const crypto = require('crypto');
 let key = crypto.randomBytes(32);
-process.stdout.write(`CARDSTACK_SESSIONS_KEY=${key.toString('base64')}\n`);
+process.stdout.write(`export CARDSTACK_SESSIONS_KEY=${key.toString('base64')}\n`);

--- a/packages/hub/commands/start-native.js
+++ b/packages/hub/commands/start-native.js
@@ -1,0 +1,38 @@
+const { spawn } = require('child_process');
+const { waitForExit } = require('../util/process');
+const path = require('path');
+
+module.exports = {
+  name: 'hub:start',
+  description: "Starts the Cardstack hub",
+
+  works: 'insideProject',
+
+  availableOptions: [
+    {
+      name: 'environment',
+      aliases: ['e', { 'dev': 'development' }, { 'prod': 'production' }],
+      description: 'Possible values are "development", "production", and "test".',
+      type: String,
+      default: 'development'
+    }
+  ],
+
+  async run(args) {
+    if (!process.env.CARDSTACK_SESSIONS_KEY) {
+      const crypto = require('crypto');
+      let key = crypto.randomBytes(32);
+      process.env.CARDSTACK_SESSIONS_KEY = key.toString('base64');
+    }
+    if (!process.env.DEBUG) {
+      process.env.DEBUG = 'cardstack/*';
+    }
+    if (!process.env.DEBUG_COLORS) {
+      process.env.DEBUG_COLORS='yes';
+    }
+    let proc = spawn('npx', ['cardstack-hub', path.join(this.project.root, 'cardstack', 'seeds', args.environment)]);
+    proc.stdout.pipe(this.ui.outputStream, {end: false});
+    proc.stderr.pipe(this.ui.errorStream, {end: false});
+    await waitForExit(proc);
+  }
+};

--- a/packages/hub/main.js
+++ b/packages/hub/main.js
@@ -38,11 +38,6 @@ async function wireItUp(projectDir, encryptionKeys, seedModels, opts = {}) {
   return container;
 }
 
-function loadAppConfig(projectDir) {
-  let env = process.env.EMBER_ENV || 'development';
-  return require(path.join(projectDir, 'config', 'environment'))(env);
-}
-
 async function makeServer(projectDir, encryptionKeys, seedModels, opts = {}) {
   let readyResolver;
   if (opts.containerized) {
@@ -63,8 +58,6 @@ async function makeServer(projectDir, encryptionKeys, seedModels, opts = {}) {
       ready: readyPromise,
       heartbeat: opts.heartbeat
     });
-
-    opts.emberConfigEnv = loadAppConfig(projectDir);
 
     await orchestrator.ready;
   }

--- a/packages/hub/main.js
+++ b/packages/hub/main.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const Koa = require('koa');
 const { Registry, Container } = require('@cardstack/di');
 // lazy load only in container mode, since they uses node 8 features

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -2,7 +2,8 @@
   "name": "@cardstack/hub",
   "version": "0.3.0",
   "bin": {
-    "cardstack-hub": "./bin/cardstack-hub.js"
+    "cardstack-hub": "./bin/cardstack-hub.js",
+    "cardstack-generate-key": "./bin/generate-key.js"
   },
   "keywords": [
     "cardstack-plugin",


### PR DESCRIPTION
This standardizes on running the hub separately from ember-cli in development.

So now you must do `ember hub:start` before `ember s`. 

This makes it much easier to start either side independently, and it makes their respective output easier to understand.