### PR TITLE
Add hub as a dependency in routing

### DIFF
--- a/packages/routing/package.json
+++ b/packages/routing/package.json
@@ -18,6 +18,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
+    "@cardstack/hub": "^0.3.1",
     "@cardstack/rendering": "0.3.0",
     "ember-cli-babel": "^6.8.2",
     "ember-cli-htmlbars": "^2.0.1",


### PR DESCRIPTION
Routing imports `environment` from the hub package [here](https://github.com/cardstack/cardstack/blob/master/packages/routing/addon/routes/cardstack.js#L2) and yet it doesn't have it listed as a dependency.