### PR TITLE
[WIP] Add activator blueprint for the ephemeral package

### DIFF
--- a/packages/ephemeral/blueprints/cardstack-ephemeral-seeds/files/cardstack/seeds/development/activate-ephemeral.js
+++ b/packages/ephemeral/blueprints/cardstack-ephemeral-seeds/files/cardstack/seeds/development/activate-ephemeral.js
@@ -1,0 +1,8 @@
+/* eslint-env node */
+
+module.exports = [
+  {
+    type: 'plugin-configs',
+    id: '@cardstack/ephemeral'
+  }
+];

--- a/packages/ephemeral/blueprints/cardstack-ephemeral-seeds/index.js
+++ b/packages/ephemeral/blueprints/cardstack-ephemeral-seeds/index.js
@@ -1,0 +1,10 @@
+/* eslint-env node */
+module.exports = {
+  normalizeEntityName: function() {
+    // this prevents an error when the entityName is
+    // not specified (since that doesn't actually matter
+    // to us
+  },
+
+  description: 'Generate initial seed model to activate @cardstack/ephemeral.'
+};

--- a/packages/ephemeral/package.json
+++ b/packages/ephemeral/package.json
@@ -7,6 +7,9 @@
   "cardstack-plugin": {
     "api-version": 1
   },
+  "ember-addon": {
+    "defaultBlueprint": "cardstack-ephemeral-seeds",
+  },
   "dependencies": {
     "@cardstack/di": "^0.3.2",
     "@cardstack/plugin-utils": "^0.3.2"


### PR DESCRIPTION
This seems fine (I copied it from the jsonapi one) but the `cardstack-ephemeral-seeds` generator doesn't seem to be added to a project to which I linked this.

Can it be because `ephemeral` is purely a server-side cardstack plugin?