### PR TITLE
Make @cardstack/search a cardstack plugin

### DIFF
--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -3,8 +3,12 @@
   "version": "0.4.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
-    "ember-addon"
+    "ember-addon",
+    "cardstack-plugin"
   ],
+  "cardstack-plugin": {
+    "api-version": 1
+  },
   "license": "MIT",
   "author": "",
   "directories": {


### PR DESCRIPTION
The `search` packages is not defined as a cardstack plugin and thus, when installed in a client app, throws the following error:

    Error: Unable to check whether plugin @cardstack/search is enabled: got exception Not Found from http://localhost:3000/api/plugins/%40cardstack%2Fsearch

@ef4 Some other packages also don't have the `cardstack-plugin` keyword and the related `api-version` definition (`di` and `bundler` possibly more) but I think that's because those are pure server-side packages that don't need this?