### PR TITLE
remove --allow-dev-dependencies flag

### DIFF
--- a/packages/git/node-tests/indexer-test.js
+++ b/packages/git/node-tests/indexer-test.js
@@ -36,8 +36,7 @@ describe('git/indexer', function() {
     let registry = new Registry();
     registry.register('config:seed-models', factory.getModels());
     registry.register('config:project', {
-      path: `${__dirname}/..`,
-      allowDevDependencies: true
+      path: `${__dirname}/..`
     });
     indexer = new Container(registry).lookup('hub:indexers');
   });
@@ -431,8 +430,7 @@ describe('git/indexer failures', function() {
     let registry = new Registry();
     registry.register('config:seed-models', factory.getModels());
     registry.register('config:project', {
-      path: `${__dirname}/..`,
-      allowDevDependencies: true
+      path: `${__dirname}/..`
     });
     indexer = new Container(registry).lookup('hub:indexers');
   });

--- a/packages/hub/bin/cardstack-hub.js
+++ b/packages/hub/bin/cardstack-hub.js
@@ -24,7 +24,6 @@ function commandLineOptions() {
   commander
     .usage('[options] <seed-config-directory>')
     .option('-p --port <port>', 'Server listen port', 3000)
-    .option('-d --allow-dev-dependencies', 'Allow the hub to load devDependencies')
     .option('-c --containerized', 'Run the hub in container mode (temporary feature flag)')
     .option('-l --leave-services-running', 'Leave dockerized services running, to improve future startup time')
     .option('--heartbeat', 'Shut down after not receiving a heartbeat from ember-cli')

--- a/packages/hub/main.js
+++ b/packages/hub/main.js
@@ -13,8 +13,7 @@ const { spawn } = require('child_process');
 async function wireItUp(projectDir, encryptionKeys, seedModels, opts = {}) {
   let registry = new Registry();
   registry.register('config:project', {
-    path: projectDir,
-    allowDevDependencies: opts.allowDevDependencies
+    path: projectDir
   });
   registry.register('config:seed-models', seedModels);
   registry.register('config:encryption-key', encryptionKeys);
@@ -93,18 +92,10 @@ async function spawnHub(packageName, configPath, environment) {
     process.env.ELASTICSEARCH_PREFIX = packageName.replace(/^[^a-zA-Z]*/, '').replace(/[^a-zA-Z0-9]/g, '_') + '_' + environment;
   }
 
-  // I think this flag needs to get refactored away, it's always the
-  // right behavior to have it turned on, there's no time that your
-  // app will be installed without the devDeps present. So the
-  // distinction really only matters for addons. And even when
-  // inside an addon running the dummy app, devDeps should always be
-  // included.
-  let flags = ['--allow-dev-dependencies'];
-
   let seedDir = path.join(path.dirname(configPath),
                           '..', 'cardstack', 'seeds', environment);
 
-  let proc = spawn(path.join(__dirname, 'bin', 'cardstack-hub.js'), [...flags, seedDir], { stdio: [0, 1, 2, 'ipc']  });
+  let proc = spawn(path.join(__dirname, 'bin', 'cardstack-hub.js'), [seedDir], { stdio: [0, 1, 2, 'ipc']  });
   await new Promise((resolve, reject) => {
     // by convention the hub will send a hello message if it sees we
     // are supervising it over IPC. If we get an error or exit before

--- a/packages/hub/node-tests/plugin-loader-test.js
+++ b/packages/hub/node-tests/plugin-loader-test.js
@@ -7,8 +7,7 @@ describe('hub/plugin-loader', function() {
   before(async function() {
     let registry = new Registry();
     registry.register('config:project', {
-      path: __dirname + '/../../../tests/stub-project',
-      allowDevDependencies: true
+      path: __dirname + '/../../../tests/stub-project'
     }, { instantiate: false });
     pluginLoader = new Container(registry).lookup('hub:plugin-loader');
 

--- a/packages/hub/node-tests/schema-auth-test.js
+++ b/packages/hub/node-tests/schema-auth-test.js
@@ -38,7 +38,7 @@ describe('schema/auth', function() {
         factory.getResource('fields', 'title')
       ]);
     let registry = new Registry();
-    registry.register('config:project', { path: `${__dirname}/../../../tests/stub-project`, allowDevDependencies: true });
+    registry.register('config:project', { path: `${__dirname}/../../../tests/stub-project` });
     loader = new Container(registry).lookup('hub:schema-loader');
   });
 

--- a/packages/hub/node-tests/schema-validation-test.js
+++ b/packages/hub/node-tests/schema-validation-test.js
@@ -106,7 +106,7 @@ describe('schema/validation', function() {
     grantAllPermissions(factory);
 
     let registry = new Registry();
-    registry.register('config:project', { path: `${__dirname}/../../../tests/stub-project`, allowDevDependencies: true });
+    registry.register('config:project', { path: `${__dirname}/../../../tests/stub-project` });
     let container = new Container(registry);
     let loader = container.lookup('hub:schema-loader');
     schema = await loader.loadFrom(factory.getModels());

--- a/packages/test-support/env.js
+++ b/packages/test-support/env.js
@@ -71,7 +71,6 @@ exports.createDefaultEnvironment = async function(projectDir, initialModels = []
       }).withRelated('who', factory.addResource('groups', user.data.id));
 
     container = await wireItUp(projectDir, crypto.randomBytes(32), factory.getModels(), {
-      allowDevDependencies: true,
       disableAutomaticIndexing: true
     });
 


### PR DESCRIPTION
Because it should always be true. There's no realistic time when an app won't have its dev dependencies.

 - if we stick to ember conventions for the ember stuff, many things you need to run builds are devDeps. But we want to be able to run builds even on deployed servers.

 - people can still `yarn install --prod` if they really want to, but that's playing on hard mode for not a lot of benefit. It's really easy to introduce bugs that only strike in production.