### PR TITLE
Lint for extraneous requires

### DIFF
--- a/packages/authentication/node-tests/stub-authenticators/package.json
+++ b/packages/authentication/node-tests/stub-authenticators/package.json
@@ -8,6 +8,7 @@
     ]
   },
   "devDependencies": {
-    "@cardstack/test-support": "*"
+    "@cardstack/test-support": "*",
+    "@cardstack/plugin-utils": "*"
   }
 }

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -56,6 +56,7 @@
     "ember-toolbars": "^0.4.1",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "koa": "2",
     "loader.js": "^4.2.3",
     "supertest": "^2.0.1"

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -32,6 +32,7 @@
     "ember-simple-auth": "^1.2.2",
     "handlebars": "^4.0.6",
     "koa-better-route": "^0.1.0",
+    "koa-compose": "^3.2.1",
     "koa-json-body": "^5.3.0"
   },
   "devDependencies": {

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@cardstack/eslint-config": "^0.3.4",
     "eslint": "4.9.0",
-    "eslint-plugin-ember": "^4.6.1"
+    "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1"
   }
 }

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -48,6 +48,7 @@
     "ember-source": "~2.17.0-beta.1",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/packages/core-types/package.json
+++ b/packages/core-types/package.json
@@ -49,6 +49,7 @@
     "ember-source": "~2.17.0-beta.1",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/packages/di/package.json
+++ b/packages/di/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@cardstack/eslint-config": "^0.3.4",
     "eslint": "4.9.0",
-    "eslint-plugin-ember": "^4.6.1"
+    "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1"
   }
 }

--- a/packages/drupal-auth/package.json
+++ b/packages/drupal-auth/package.json
@@ -50,6 +50,7 @@
     "ember-source": "~2.17.0-beta.1",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/packages/drupal/package.json
+++ b/packages/drupal/package.json
@@ -13,7 +13,8 @@
     "@cardstack/eslint-config": "^0.3.4",
     "@cardstack/test-support": "^0.4.1",
     "eslint": "4.9.0",
-    "eslint-plugin-ember": "^4.6.1"
+    "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1"
   },
   "keywords": [
     "cardstack-plugin"

--- a/packages/elasticsearch/package.json
+++ b/packages/elasticsearch/package.json
@@ -18,6 +18,7 @@
     "@cardstack/eslint-config": "^0.3.4",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "lodash": "^4.17.4"
   },
   "scripts": {

--- a/packages/email-auth/package.json
+++ b/packages/email-auth/package.json
@@ -46,6 +46,7 @@
     "ember-source": "~2.17.0-beta.1",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "koa": "2",
     "loader.js": "^4.2.3",
     "supertest": "^2.0.1"

--- a/packages/email-auth/package.json
+++ b/packages/email-auth/package.json
@@ -47,6 +47,7 @@
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
     "eslint-plugin-node": "^5.2.1",
+    "handlebars": "^4.0.6",
     "koa": "2",
     "loader.js": "^4.2.3",
     "supertest": "^2.0.1"

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@cardstack/eslint-config": "^0.3.4",
     "eslint": "4.9.0",
-    "eslint-plugin-ember": "^4.6.1"
+    "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1"
   }
 }

--- a/packages/ephemeral/package.json
+++ b/packages/ephemeral/package.json
@@ -16,6 +16,7 @@
     "@cardstack/eslint-config": "^0.3.4",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "koa": "2",
     "supertest": "^2.0.1"
   },

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -10,8 +10,12 @@ module.exports = {
     'no-constant-condition': ["error", { checkLoops: false }],
     'require-yield': 0,
     'no-var': "error",
-    semi: ["error", "always"]
+    semi: ["error", "always"],
+    'node/no-extraneous-require': ['error', {
+      'allowModules': []
+    }]
   },
+  plugins: ['node'],
   globals: {
     Promise: false,
     Map: false,

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/cardstack/cardstack#readme",
   "peerDependencies": {
     "eslint": ">= 4",
-    "eslint-plugin-ember": "^4.6.1"
+    "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1"
   }
 }

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -14,7 +14,8 @@
     "@cardstack/eslint-config": "^0.3.4",
     "@cardstack/test-support": "^0.4.1",
     "eslint": "4.9.0",
-    "eslint-plugin-ember": "^4.6.1"
+    "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1"
   },
   "dependencies": {
     "@cardstack/nodegit": "0.19.0-cardstack.0",

--- a/packages/github-auth/package.json
+++ b/packages/github-auth/package.json
@@ -54,6 +54,7 @@
     "ember-source": "~2.17.0-beta.1",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/packages/handlebars/package.json
+++ b/packages/handlebars/package.json
@@ -19,7 +19,8 @@
   "devDependencies": {
     "@cardstack/eslint-config": "^0.3.4",
     "eslint": "4.9.0",
-    "eslint-plugin-ember": "^4.6.1"
+    "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"

--- a/packages/hub/node-tests/stub-middleware-extra/package.json
+++ b/packages/hub/node-tests/stub-middleware-extra/package.json
@@ -2,5 +2,8 @@
   "keywords": ["cardstack-plugin"],
   "cardstack-plugin": {
     "api-version": 1
+  },
+  "dependencies": {
+    "koa-better-route": "*"
   }
 }

--- a/packages/hub/node-tests/test-authenticator/package.json
+++ b/packages/hub/node-tests/test-authenticator/package.json
@@ -4,5 +4,9 @@
   ],
   "cardstack-plugin": {
     "api-version": 1
+  },
+  "dependencies": {
+    "@cardstack/di": "*",
+    "@cardstack/plugin-utils": "*"
   }
 }

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -47,6 +47,7 @@
     "@cardstack/eslint-config": "^0.3.4",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "koa-better-route": "^0.1.0",
     "supertest": "^2.0.1"
   },

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -23,6 +23,7 @@
     "@cardstack/handlebars": "^0.3.4",
     "@cardstack/plugin-utils": "^0.4.1",
     "broccoli-concat": "^3.2.2",
+    "broccoli-plugin": "^1.3.0",
     "broccoli-source": "^1.1.0",
     "chalk": "^2.3.0",
     "commander": "^2.9.0",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -45,6 +45,7 @@
     "ember-source": "~2.17.0-beta.1",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/packages/jsonapi/package.json
+++ b/packages/jsonapi/package.json
@@ -14,6 +14,7 @@
     "@cardstack/test-support-authenticator": "^0.4.1",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "koa": "2",
     "supertest": "^2.0.1"
   },

--- a/packages/mobiledoc/package.json
+++ b/packages/mobiledoc/package.json
@@ -49,6 +49,7 @@
     "ember-source": "~2.17.0-beta.1",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/packages/mock-auth/package.json
+++ b/packages/mock-auth/package.json
@@ -55,6 +55,7 @@
     "ember-source": "~2.17.0-beta.1",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -56,6 +56,7 @@
     "ember-source": "~2.17.0-beta.1",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/packages/plugin-utils/package.json
+++ b/packages/plugin-utils/package.json
@@ -12,6 +12,7 @@
     "denodeify": "^1.2.1",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "fixturify": "^0.3.4",
     "fs-extra": "^4.0.2",
     "walk-sync": "^0.3.2"

--- a/packages/plugin-utils/when-enabled.js
+++ b/packages/plugin-utils/when-enabled.js
@@ -3,7 +3,7 @@
   whether the addon is enabled in cardstack hub.
 */
 const ConditionalInclude = require('./conditional-include');
-const locateHub = require('@cardstack/plugin-utils/locate-hub');
+const locateHub = require('./locate-hub');
 const request = require('superagent');
 
 const treeMethods = [

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -12,7 +12,8 @@
     "@cardstack/eslint-config": "^0.3.4",
     "@cardstack/test-support": "^0.4.1",
     "eslint": "4.9.0",
-    "eslint-plugin-ember": "^4.6.1"
+    "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1"
   },
   "dependencies": {
     "@cardstack/plugin-utils": "^0.4.1",

--- a/packages/rendering/package.json
+++ b/packages/rendering/package.json
@@ -48,6 +48,7 @@
     "ember-source": "~2.17.0-beta.1",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/packages/routing/package.json
+++ b/packages/routing/package.json
@@ -48,6 +48,7 @@
     "ember-source": "~2.17.0-beta.1",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -46,6 +46,7 @@
     "ember-source": "~2.17.0-beta.1",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/packages/test-support-authenticator/package.json
+++ b/packages/test-support-authenticator/package.json
@@ -14,7 +14,8 @@
   "devDependencies": {
     "@cardstack/eslint-config": "^0.3.4",
     "eslint": "4.9.0",
-    "eslint-plugin-ember": "^4.6.1"
+    "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1"
   },
   "author": "Edward Faulkner <edward@eaf4.com>",
   "license": "MIT",

--- a/packages/test-support-messenger/package.json
+++ b/packages/test-support-messenger/package.json
@@ -13,7 +13,8 @@
   "devDependencies": {
     "@cardstack/eslint-config": "^0.3.4",
     "eslint": "4.9.0",
-    "eslint-plugin-ember": "^4.6.1"
+    "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1"
   },
   "author": "Edward Faulkner <edward@eaf4.com>",
   "license": "MIT",

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -41,7 +41,8 @@
   "devDependencies": {
     "@cardstack/eslint-config": "^0.3.4",
     "eslint": "4.9.0",
-    "eslint-plugin-ember": "^4.6.1"
+    "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1"
   },
   "author": "Edward Faulkner <edward@eaf4.com>",
   "license": "MIT",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -62,6 +62,7 @@
     "ember-source": "~2.17.0-beta.1",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3",
     "squishable-container": "^0.1.0"
   },

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -54,6 +54,7 @@
     "ember-truth-helpers": "^1.3.0",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^4.6.1",
+    "eslint-plugin-node": "^5.2.1",
     "liquid-fire": "^0.29.0",
     "loader.js": "4.2.3",
     "moment-timezone": "^0.5.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3654,6 +3654,15 @@ eslint-plugin-ember@^4.6.1:
     require-folder-tree "^1.4.5"
     snake-case "^2.1.0"
 
+eslint-plugin-node@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz#80df3253c4d7901045ec87fa660a284e32bdca29"
+  dependencies:
+    ignore "^3.3.6"
+    minimatch "^3.0.4"
+    resolve "^1.3.3"
+    semver "5.3.0"
+
 eslint-scope@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
@@ -4822,7 +4831,7 @@ iferr@^0.1.5, iferr@~0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
 
-ignore@^3.2.0, ignore@^3.3.3:
+ignore@^3.2.0, ignore@^3.3.3, ignore@^3.3.6:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
@@ -8162,6 +8171,10 @@ semver@4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.2.tgz#c7a07158a80bedd052355b770d82d6640f803be7"
 
+semver@5.3.0, semver@~5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
 semver@^4.3.1:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
@@ -8169,10 +8182,6 @@ semver@^4.3.1:
 semver@~5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.1.1.tgz#a3292a373e6f3e0798da0b20641b9a9c5bc47e19"
-
-semver@~5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
 send@0.16.1:
   version "0.16.1"


### PR DESCRIPTION
Fixes #93.

This is split into two commits, one adding the linting infrastructure, the other fixing the resulting lint errors.