### PR TITLE
Move environment codegen into plugin-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "lerna": "^2.0.0-rc.5",
-    "mocha": "^3.2.0"
+    "mocha": "^4.0.1"
   },
   "scripts": {
     "test": "npm run node-tests && npm run ember-tests",

--- a/packages/authentication/addon/cardstack-authenticator.js
+++ b/packages/authentication/addon/cardstack-authenticator.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import Base from 'ember-simple-auth/authenticators/base';
 import RSVP from 'rsvp';
-import { hubURL } from '@cardstack/hub/environment';
+import { hubURL } from '@cardstack/plugin-utils/environment';
 
 export default Base.extend({
   cardstackSession: Ember.inject.service(),

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@cardstack/di": "^0.4.4",
     "@cardstack/logger": "^0.1.0",
+    "@cardstack/plugin-utils": "^0.4.4",
     "ember-cli-babel": "^6.8.2",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-fetch": "^1.4.0",
@@ -38,7 +39,6 @@
   },
   "devDependencies": {
     "@cardstack/eslint-config": "^0.4.4",
-    "@cardstack/plugin-utils": "^0.4.4",
     "@cardstack/test-support": "^0.4.4",
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "https://github.com/ember-cli/ember-cli#a4734540b3889c7f6ef304fe6a81dd356f77bfe4",

--- a/packages/codegen/addon/index.js
+++ b/packages/codegen/addon/index.js
@@ -1,4 +1,4 @@
-import { hubURL, defaultBranch } from '@cardstack/hub/environment';
+import { hubURL, defaultBranch } from '@cardstack/plugin-utils/environment';
 import fetch from 'fetch';
 import Service from '@ember/service';
 import { computed } from '@ember/object';

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@cardstack/eslint-config": "^0.4.4",
+    "@cardstack/jsonapi": "^0.4.4",
     "@cardstack/test-support": "^0.4.4",
     "ember-cli": "https://github.com/ember-cli/ember-cli#a4734540b3889c7f6ef304fe6a81dd356f77bfe4",
     "ember-cli-dependency-checker": "^2.1.0",

--- a/packages/codegen/tests/integration/codegen-test.js
+++ b/packages/codegen/tests/integration/codegen-test.js
@@ -5,15 +5,15 @@ module('Integration | CodeGen', function(hooks) {
   setupTest(hooks);
 
   test('finds hub-generated environment', function(assert) {
-    let env = window.require('@cardstack/hub/environment');
+    let env = window.require('@cardstack/plugin-utils/environment');
     assert.ok(!!env, 'found hub environment');
   });
 
   test('can refresh hub-generated environment', async function(assert) {
-    let env = window.require('@cardstack/hub/environment');
+    let env = window.require('@cardstack/plugin-utils/environment');
     env.seenInCodeGenTest = true;
     await this.owner.lookup('service:cardstack-codegen').refreshCode();
-    let env2 = window.require('@cardstack/hub/environment');
+    let env2 = window.require('@cardstack/plugin-utils/environment');
     assert.ok(!env2.seenInCodeGenTest, 'should have a refresh version of the module');
   });
 

--- a/packages/models/addon/adapter.js
+++ b/packages/models/addon/adapter.js
@@ -1,7 +1,7 @@
 import DS from 'ember-data';
 import AdapterMixin from 'ember-resource-metadata/adapter-mixin';
 import Ember from 'ember';
-import { hubURL } from '@cardstack/hub/environment';
+import { hubURL } from '@cardstack/plugin-utils/environment';
 
 export default DS.JSONAPIAdapter.extend(AdapterMixin, {
   host: hubURL,

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@cardstack/codegen": "^0.4.4",
     "@cardstack/di": "^0.4.4",
+    "@cardstack/plugin-utils": "^0.4.4",
     "@cardstack/tools": "^0.4.4",
     "ember-cli-babel": "^6.8.2",
     "ember-resource-metadata": "^0.1.0",

--- a/packages/plugin-utils/addon/.eslintrc.js
+++ b/packages/plugin-utils/addon/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  "extends": require.resolve('@cardstack/eslint-config/browser')
+};

--- a/packages/plugin-utils/addon/environment.js
+++ b/packages/plugin-utils/addon/environment.js
@@ -1,0 +1,16 @@
+// This file only gets included in the app if no hub is running.  If a
+// hub is running, we instead rely on it's code-generators support to
+// generate this file (and populate it with more meaningful, dynamic
+// data).
+//
+// The default values here are useful for situations like within
+// plugin's own test suites.
+//
+// If you find yourself wanting to customize the values in this file,
+// you should really just configure the hub and add some seed models
+// so it runs.
+export const defaultBrach = 'master';
+export const hubURL = 'http://localhost:3000';
+export const compiledAt = null;
+export const appModulePrefix = 'dummy';
+export const branch = 'master';

--- a/packages/plugin-utils/code-generators/environment.js
+++ b/packages/plugin-utils/code-generators/environment.js
@@ -1,6 +1,6 @@
 const Handlebars = require('handlebars');
 const template = Handlebars.compile(`
-define("@cardstack/hub/environment", ["exports"], function (exports) {
+define("@cardstack/plugin-utils/environment", ["exports"], function (exports) {
   "use strict";
   Object.defineProperty(exports, "__esModule", {
     value: true
@@ -20,7 +20,6 @@ module.exports = class {
     return template({ properties: Object.entries(env).map(([name, value]) => ({ name, value })) });
   }
   _content() {
-    // TODO: make these dynamic
     return {
       defaultBranch: 'master',
       hubURL: 'http://localhost:3000',

--- a/packages/plugin-utils/index.js
+++ b/packages/plugin-utils/index.js
@@ -1,0 +1,19 @@
+const locateHub = require('./locate-hub');
+const ConditionalInclude = require('./conditional-include');
+
+module.exports = {
+  name: '@cardstack/plugin-utils',
+
+  treeForAddon() {
+    let tree = this._super.apply(this, arguments);
+    async function hubNotRunning() {
+      let hub = await locateHub();
+      if (!hub) {
+        return true;
+      }
+      return !(await hub.url());
+    }
+    return new ConditionalInclude(tree, { name: 'default cardstack env', predicate: hubNotRunning });
+  }
+
+};

--- a/packages/plugin-utils/package.json
+++ b/packages/plugin-utils/package.json
@@ -18,14 +18,19 @@
     "walk-sync": "^0.3.2"
   },
   "dependencies": {
-    "@cardstack/jsonapi": "^0.4.4",
     "broccoli-plugin": "^1.3.0",
+    "ember-cli-babel": "^6.8.2",
+    "handlebars": "^4.0.6",
     "ms": "2.0.0",
     "superagent": "^3.8.1",
     "symlink-or-copy": "^1.1.8"
   },
+  "peerDependencies": {
+    "@cardstack/jsonapi": "^0.4.4"
+  },
   "keywords": [
-    "cardstack-plugin"
+    "cardstack-plugin",
+    "ember-addon"
   ],
   "cardstack-plugin": {
     "api-version": 1

--- a/packages/routing/addon/helpers/cardstack-url.js
+++ b/packages/routing/addon/helpers/cardstack-url.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { modelType } from '@cardstack/rendering/helpers/cs-model-type';
-import { defaultBranch } from '@cardstack/hub/environment';
+import { defaultBranch } from '@cardstack/plugin-utils/environment';
 import { pluralize } from 'ember-inflector';
 import { hrefTo } from 'ember-href-to/helpers/href-to';
 

--- a/packages/routing/addon/routes/cardstack.js
+++ b/packages/routing/addon/routes/cardstack.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { defaultBranch } from '@cardstack/hub/environment';
+import { defaultBranch } from '@cardstack/plugin-utils/environment';
 
 export default Ember.Route.extend({
   queryParams: {

--- a/packages/routing/addon/services/routing.js
+++ b/packages/routing/addon/services/routing.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { pluralize, singularize } from 'ember-inflector';
-import { defaultBranch } from '@cardstack/hub/environment';
+import { defaultBranch } from '@cardstack/plugin-utils/environment';
 
 export default Ember.Service.extend({
   defaultContentType: 'pages',

--- a/packages/routing/tests/dummy/app/adapters/application.js
+++ b/packages/routing/tests/dummy/app/adapters/application.js
@@ -1,6 +1,6 @@
 import DS from 'ember-data';
 import Ember from 'ember';
-import { hubURL } from '@cardstack/hub/environment';
+import { hubURL } from '@cardstack/plugin-utils/environment';
 
 export default DS.JSONAPIAdapter.extend({
   host: hubURL,

--- a/packages/test-support/addon/fixtures.js
+++ b/packages/test-support/addon/fixtures.js
@@ -1,5 +1,5 @@
 import Factory from './jsonapi-factory';
-import { hubURL } from '@cardstack/hub/environment';
+import { hubURL } from '@cardstack/plugin-utils/environment';
 
 export default class Fixtures {
   constructor(fn) {

--- a/packages/tools/addon/components/cs-branch-control.js
+++ b/packages/tools/addon/components/cs-branch-control.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/cs-branch-control';
-import { defaultBranch } from '@cardstack/hub/environment';
+import { defaultBranch } from '@cardstack/plugin-utils/environment';
 
 export default Ember.Component.extend({
   layout,

--- a/packages/tools/addon/components/cs-version-control.js
+++ b/packages/tools/addon/components/cs-version-control.js
@@ -3,7 +3,7 @@ import layout from '../templates/components/cs-version-control';
 import { task } from 'ember-concurrency';
 import { transitionTo } from '../private-api';
 import { modelType } from '@cardstack/rendering/helpers/cs-model-type';
-import { defaultBranch } from '@cardstack/hub/environment';
+import { defaultBranch } from '@cardstack/plugin-utils/environment';
 import { computed } from "@ember/object";
 
 export default Ember.Component.extend({

--- a/packages/tools/addon/services/cardstack-tools.js
+++ b/packages/tools/addon/services/cardstack-tools.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { transitionTo } from '../private-api';
 import { modelType } from '@cardstack/rendering/helpers/cs-model-type';
 import injectOptional from 'ember-inject-optional';
-import { defaultBranch } from '@cardstack/hub/environment';
+import { defaultBranch } from '@cardstack/plugin-utils/environment';
 
 export default Ember.Service.extend({
   overlays: Ember.inject.service('ember-overlays'),

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@cardstack/rendering": "^0.4.4",
+    "@cardstack/plugin-utils": "^0.4.4",
     "ember-cli-babel": "^6.8.2",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-is-component": "^0.5.0",

--- a/packages/tools/tests/dummy/app/adapters/post.js
+++ b/packages/tools/tests/dummy/app/adapters/post.js
@@ -1,6 +1,6 @@
 import AdapterMixin from 'ember-resource-metadata/adapter-mixin';
 import DS from 'ember-data';
-import { hubURL } from '@cardstack/hub/environment';
+import { hubURL } from '@cardstack/plugin-utils/environment';
 
 export default DS.JSONAPIAdapter.extend(AdapterMixin, {
   host: hubURL,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2552,12 +2552,6 @@ debug@2.3.3:
   dependencies:
     ms "0.7.2"
 
-debug@2.6.8:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
-  dependencies:
-    ms "2.0.0"
-
 debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.0, debug@^2.6.8, debug@~2.6.7:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -2692,10 +2686,6 @@ dezalgo@^1.0.0, dezalgo@^1.0.1, dezalgo@^1.0.2, dezalgo@~1.0.3:
   dependencies:
     asap "^2.0.0"
     wrappy "1"
-
-diff@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
 diff@3.3.1:
   version "3.3.1"
@@ -4598,10 +4588,6 @@ growl@1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
 
-growl@1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
-
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -5633,10 +5619,6 @@ lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
 
-lodash._basecreate@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
-
 lodash._basecreate@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-2.3.0.tgz#9b88a86a4dcff7b7f3c61d83a2fcfc0671ec9de0"
@@ -5836,14 +5818,6 @@ lodash.clonedeep@~3.0.2:
   dependencies:
     lodash._baseclone "^3.0.0"
     lodash._bindcallback "^3.0.0"
-
-lodash.create@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
-  dependencies:
-    lodash._baseassign "^3.0.0"
-    lodash._basecreate "^3.0.0"
-    lodash._isiterateecall "^3.0.0"
 
 lodash.debounce@^3.1.1:
   version "3.1.1"
@@ -6370,23 +6344,6 @@ mocha-eslint@^3.0.1:
     eslint "^3.0.0"
     glob-all "^3.0.1"
     replaceall "^0.1.6"
-
-mocha@^3.2.0:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
-  dependencies:
-    browser-stdout "1.3.0"
-    commander "2.9.0"
-    debug "2.6.8"
-    diff "3.2.0"
-    escape-string-regexp "1.0.5"
-    glob "7.1.1"
-    growl "1.9.2"
-    he "1.1.1"
-    json3 "3.3.2"
-    lodash.create "3.1.1"
-    mkdirp "0.5.1"
-    supports-color "3.1.2"
 
 mocha@^4.0.1:
   version "4.0.1"
@@ -8705,12 +8662,6 @@ supertest@^2.0.1:
   dependencies:
     methods "1.x"
     superagent "^2.0.0"
-
-supports-color@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
-  dependencies:
-    has-flag "^1.0.0"
 
 supports-color@4.4.0:
   version "4.4.0"


### PR DESCRIPTION
Any addon that wants to discover the basic hub environment configuration should do it by importing `@cardstack/plugin-utils/environment`. This replaces `@cardstack/hub/environment`, because plugins aren't supposed to directly depend on the hub package, which made the previous naming confusing.

I've also added a fallback so that if no hub is configured plugins can still import (default) configuration without throwing errors.