### PR TITLE
rewrite external user when dealing with authentication result that is a partial session + mock user partial session support

### DIFF
--- a/packages/authentication/addon/cardstack-authenticator.js
+++ b/packages/authentication/addon/cardstack-authenticator.js
@@ -15,8 +15,8 @@ export default Base.extend({
         rawSession.data.meta.validUntil > Date.now() / 1000;
 
       let partialSession =
-        rawSession.data &&
-        rawSession.data.type === 'partial-sessions';
+        rawSession.meta &&
+        rawSession.meta['partial-session'];
 
       let secret             = localStorage.getItem('cardstack-secret-token'),
         authenticationSource = localStorage.getItem('cardstack-authentication-source');

--- a/packages/authentication/addon/services/cardstack-session.js
+++ b/packages/authentication/addon/services/cardstack-session.js
@@ -12,9 +12,13 @@ export default Ember.Service.extend({
     return this.get('session.isAuthenticated') && !this.get('isPartiallyAuthenticated');
   }),
 
-  isPartiallyAuthenticated: Ember.computed.equal('_rawSession.data.type', 'partial-sessions'),
+  isPartiallyAuthenticated: Ember.computed.alias('_rawSession.meta.partial-session'),
 
-  message: Ember.computed.reads('_rawSession.data.attributes.message'),
+  partialSession: Ember.computed('isPartiallyAuthenticated', '_rawSession', function() {
+    if (this.get('isPartiallyAuthenticated')) {
+      return this.get('_rawSession');
+    }
+  }),
 
   _rawSession: Ember.computed.alias('session.data.authenticated'),
 

--- a/packages/authentication/cardstack/middleware.js
+++ b/packages/authentication/cardstack/middleware.js
@@ -128,19 +128,7 @@ class Authentication {
       user = await this._processExternalUser(result, source);
     }
 
-    if (result && result.meta && result.meta.partialSession) {
-      if (!user) {
-        // top-level meta is not passed through (it was for
-        // communicating from plugin to us). Plugins could use
-        // resource-level metadata instead if they want to.
-        delete result.meta;
-        user = result;
-      }
-
-      if (user.data.type !== 'partial-sessions') {
-        user.data.type = 'partial-sessions';
-      }
-
+    if (user && user.data && user.data.type === 'partial-sessions') {
       ctxt.body = user;
       ctxt.status = 200;
       return;
@@ -171,6 +159,10 @@ class Authentication {
   async _processExternalUser(externalUser, source) {
     let user = rewriteExternalUser(externalUser, source);
     if (!user.data || !user.data.type) { return; }
+
+    if (user.data.type === 'partial-sessions') {
+      return user;
+    }
 
     let have;
 

--- a/packages/authentication/node-tests/authentication-test.js
+++ b/packages/authentication/node-tests/authentication-test.js
@@ -393,11 +393,14 @@ describe('authentication/middleware', function() {
       it('can return a partial session', async function() {
         let response = await request.post(`/auth/echo`).send({
           data: {
-            type: 'partial-sessions',
+            type: 'users',
             attributes: {
               state: 'i-am-partial',
               message: "you're not done yet"
             }
+          },
+          meta: {
+            'partial-session': true
           }
         });
         expect(response).hasStatus(200);

--- a/packages/authentication/node-tests/authentication-test.js
+++ b/packages/authentication/node-tests/authentication-test.js
@@ -406,11 +406,14 @@ describe('authentication/middleware', function() {
         expect(response).hasStatus(200);
         expect(response.body).not.has.deep.property('meta.token');
         expect(response.body.data).deep.equals({
-          type: 'partial-sessions',
+          type: 'users',
           attributes: {
             state: 'i-am-partial',
             message: "you're not done yet"
           }
+        });
+        expect(response.body.meta).deep.equals({
+          'partial-session': true
         });
       });
 

--- a/packages/authentication/node-tests/authentication-test.js
+++ b/packages/authentication/node-tests/authentication-test.js
@@ -393,13 +393,11 @@ describe('authentication/middleware', function() {
       it('can return a partial session', async function() {
         let response = await request.post(`/auth/echo`).send({
           data: {
+            type: 'partial-sessions',
             attributes: {
               state: 'i-am-partial',
               message: "you're not done yet"
             }
-          },
-          meta: {
-            partialSession: true
           }
         });
         expect(response).hasStatus(200);

--- a/packages/email-auth/cardstack/authenticator.js
+++ b/packages/email-auth/cardstack/authenticator.js
@@ -50,13 +50,11 @@ class {
         });
         return {
           data: {
+            type: 'partial-sessions',
             attributes: {
               message: 'Check your email',
               state: 'pending-email'
             }
-          },
-          meta: {
-            partialSession: true
           }
         };
       } else {

--- a/packages/email-auth/cardstack/authenticator.js
+++ b/packages/email-auth/cardstack/authenticator.js
@@ -50,11 +50,14 @@ class {
         });
         return {
           data: {
-            type: 'partial-sessions',
+            type: 'users',
             attributes: {
               message: 'Check your email',
               state: 'pending-email'
             }
+          },
+          meta: {
+            'partial-session': true
           }
         };
       } else {

--- a/packages/email-auth/node-tests/email-auth-test.js
+++ b/packages/email-auth/node-tests/email-auth-test.js
@@ -96,11 +96,14 @@ describe('email-auth', function() {
     expect(response).hasStatus(200);
     expect(response.body).not.has.deep.property('meta.token');
     expect(response.body.data).deep.equals({
-      type: 'partial-sessions',
+      type: 'users',
       attributes: {
         message: 'Check your email',
         state: 'pending-email'
       }
+    });
+    expect(response.body.meta).deep.equals({
+      'partial-session': true
     });
     let sentMessages = await TestMessenger.sentMessages(env);
     expect(sentMessages).has.length(1, 'sent messages has the wrong length');

--- a/packages/mock-auth/addon/components/mock-login.js
+++ b/packages/mock-auth/addon/components/mock-login.js
@@ -9,8 +9,19 @@ export default Ember.Component.extend({
 
   source: 'mock-auth',
 
+  init() {
+    this._super();
+
+    if (window && window.location && window.location.search) {
+      let urlParams = new URLSearchParams(window.location.search);
+      let mockUserId = urlParams.get("mock-user");
+      this.set('mockUserId', mockUserId);
+    }
+  },
+
   login: task(function * (mockUserId) {
-    if (mockUserId) {
+    mockUserId = mockUserId || this.get('mockUserId');
+    if (mockUserId ) {
       yield this.get('session').authenticate('authenticator:cardstack', this.get('source'), { authorizationCode: mockUserId });
     }
   }).drop()

--- a/packages/mock-auth/cardstack/authenticator.js
+++ b/packages/mock-auth/cardstack/authenticator.js
@@ -7,7 +7,7 @@ module.exports = class {
   constructor(params) {
     this.users = params["users"];
 
-    this.defaultUserTemplate =  `{ "data": { "id": "{{id}}", "type": "mock-users", "attributes": { "name": "{{name}}", "email":"{{email}}", "avatar-url":"{{{picture}}}", "email-verified":{{verified}}{{#unless verified}}, "message": { "state": "verifiy-email", "id": "{{id}}"} {{/unless}} }}}`;
+    this.defaultUserTemplate =  `{ "data": { "id": "{{id}}", "type": {{#if verified}}"mock-users"{{else}}"partial-sessions"{{/if}}, "attributes": { "name": "{{name}}", "email":"{{email}}", "avatar-url":"{{{picture}}}", "email-verified":{{verified}}{{#unless verified}}, "message": { "state": "verifiy-email", "id": "{{id}}"} {{/unless}} }}}`;
   }
 
   async authenticate(payload /*, userSearcher */) {
@@ -21,9 +21,6 @@ module.exports = class {
     if (mockUser) {
       mockUser.id = payload.authorizationCode;
 
-      if (!mockUser.verified) {
-        mockUser.meta = { partialSession: true };
-      }
       return mockUser;
     }
 

--- a/packages/mock-auth/cardstack/authenticator.js
+++ b/packages/mock-auth/cardstack/authenticator.js
@@ -7,7 +7,7 @@ module.exports = class {
   constructor(params) {
     this.users = params["users"];
 
-    this.defaultUserTemplate =  `{ "data": { "id": "{{id}}", "type": "mock-users", "attributes": { "name": "{{name}}", "email":"{{email}}", "avatar-url":"{{{picture}}}" }}}`;
+    this.defaultUserTemplate =  `{ "data": { "id": "{{id}}", "type": "mock-users", "attributes": { "name": "{{name}}", "email":"{{email}}", "avatar-url":"{{{picture}}}", "email-verified":{{verified}}{{#unless verified}}, "message": { "state": "verifiy-email", "id": "{{id}}"} {{/unless}} }}}`;
   }
 
   async authenticate(payload /*, userSearcher */) {
@@ -18,9 +18,12 @@ module.exports = class {
     }
 
     let mockUser = this.users[payload.authorizationCode];
-    mockUser.id = payload.authorizationCode;
-
     if (mockUser) {
+      mockUser.id = payload.authorizationCode;
+
+      if (!mockUser.verified) {
+        mockUser.meta = { partialSession: true };
+      }
       return mockUser;
     }
 

--- a/packages/mock-auth/cardstack/authenticator.js
+++ b/packages/mock-auth/cardstack/authenticator.js
@@ -7,7 +7,7 @@ module.exports = class {
   constructor(params) {
     this.users = params["users"];
 
-    this.defaultUserTemplate =  `{ "data": { "id": "{{id}}", "type": {{#if verified}}"mock-users"{{else}}"partial-sessions"{{/if}}, "attributes": { "name": "{{name}}", "email":"{{email}}", "avatar-url":"{{{picture}}}", "email-verified":{{verified}}{{#unless verified}}, "message": { "state": "verifiy-email", "id": "{{id}}"} {{/unless}} }}}`;
+    this.defaultUserTemplate =  `{ "data": { "id": "{{id}}", "type": "mock-users", "attributes": { "name": "{{name}}", "email":"{{email}}", "avatar-url":"{{{picture}}}", "email-verified":{{verified}}{{#unless verified}}, "message": { "state": "verifiy-email", "id": "{{id}}"} {{/unless}} }} {{#unless verified}}, "meta": { "partial-session": true } {{/unless}} }`;
   }
 
   async authenticate(payload /*, userSearcher */) {


### PR DESCRIPTION
I think partial sessions have enjoyed the fact that the email auth is intrinsically JSON API. I believe we need to convert the auth response using the user template before we start checking for the `type` as this blows up when it deals with an auth response that is not JSON API (like Auth0).