### PR TITLE
better port control

### DIFF
--- a/packages/hub/bin/cardstack-hub.js
+++ b/packages/hub/bin/cardstack-hub.js
@@ -35,6 +35,7 @@ function commandLineOptions() {
   commander
     .usage('[options] <seed-config-directory>')
     .option('-p --port <port>', 'Server listen port', 3000)
+    .option('-u --url <url>', "Server's public base URL. Defaults to http://localhost:$PORT.")
     .option('-c --containerized', 'Run the hub in container mode (temporary feature flag)')
     .option('-l --leave-services-running', 'Leave dockerized services running, to improve future startup time')
     .option('--heartbeat', 'Shut down after not receiving a heartbeat from ember-cli')

--- a/packages/hub/commands/start-native.js
+++ b/packages/hub/commands/start-native.js
@@ -17,9 +17,22 @@ module.exports = {
       default: 'development'
     },
     {
+      name: 'port',
+      aliases: ['p'],
+      description: 'Port to listen on',
+      type: Number,
+      default: 3000
+    },
+    {
+      name: 'url',
+      aliases: ['d'],
+      description: 'Public URL at which clients will be able to talk to the Hub. For production use you will almost always need to set this. For local development, you can leave it unset and it will default to localhost on the configured listen port.',
+      type: String
+    },
+    {
       name: 'print',
       description: 'Instead of starting the hub, print the startup command(s) we would run.',
-      aliases: ['p'],
+      aliases: ['r'],
       type: Boolean,
       default: false
     }
@@ -27,13 +40,13 @@ module.exports = {
 
   async run(args) {
     if (args.print) {
-      let { setEnvVars, bin, args: shellArgs } = await prepareSpawnHub(this.project.pkg.name, this.project.configPath(), args.environment);
+      let { setEnvVars, bin, args: shellArgs } = await prepareSpawnHub(this.project.pkg.name, this.project.configPath(), args.environment, args.port, args.url);
       for (let [key, value] of Object.entries(setEnvVars)) {
         process.stdout.write(`${key}=${value}\n`);
       }
       process.stdout.write(`${bin} ${shellArgs.join(' ')}\n`);
     } else {
-      await spawnHub(this.project.pkg.name, this.project.configPath(), args.environment);
+      await spawnHub(this.project.pkg.name, this.project.configPath(), args.environment, args.port, args.url);
     }
     await new Promise(() => {});
   }

--- a/packages/hub/index.js
+++ b/packages/hub/index.js
@@ -75,7 +75,7 @@ let addon = {
       // containerized case, "main" and its recursive dependencies
       // never need to load on the host environment.
       let { spawnHub } = require('./main');
-      return spawnHub(this.project.pkg.name, this.project.configPath(), this._env);
+      return spawnHub(this.project.pkg.name, this.project.configPath(), this._env, process.env.HUB_PORT || 3000);
     }
   },
 

--- a/packages/plugin-utils/code-generators/environment.js
+++ b/packages/plugin-utils/code-generators/environment.js
@@ -1,4 +1,6 @@
 const Handlebars = require('handlebars');
+const { declareInjections } = require('@cardstack/di');
+
 const template = Handlebars.compile(`
 define("@cardstack/plugin-utils/environment", ["exports"], function (exports) {
   "use strict";
@@ -11,10 +13,11 @@ define("@cardstack/plugin-utils/environment", ["exports"], function (exports) {
 });
 `);
 
-module.exports = class {
-  static create() {
-    return new this();
-  }
+module.exports = declareInjections({
+  publicURL: 'config:public-url'
+},
+
+class {
   async generateCode(appModulePrefix, branch) {
     let env = Object.assign(this._content(), { appModulePrefix, branch });
     return template({ properties: Object.entries(env).map(([name, value]) => ({ name, value })) });
@@ -22,8 +25,8 @@ module.exports = class {
   _content() {
     return {
       defaultBranch: 'master',
-      hubURL: 'http://localhost:3000',
+      hubURL: this.publicURL.url,
       compiledAt: new Date().toISOString()
     };
   }
-};
+});

--- a/packages/plugin-utils/package.json
+++ b/packages/plugin-utils/package.json
@@ -18,6 +18,7 @@
     "walk-sync": "^0.3.2"
   },
   "dependencies": {
+    "@cardstack/di": "^0.5.0",
     "broccoli-plugin": "^1.3.0",
     "ember-cli-babel": "^6.8.2",
     "handlebars": "^4.0.6",


### PR DESCRIPTION
This adds `--port` and `--url` options to `ember hub:start`. It needs `--url` in production so that the ember app's it helps build via codegen will know where to find it.

I also added an optional way to alter the chosen port if you are letting the hub start automatically via `ember s` or `ember test`: set the `HUB_PORT` environment variable.