### PR TITLE
making it easier to operationalize the production hub server

### DIFF
--- a/packages/hub/commands/start-native.js
+++ b/packages/hub/commands/start-native.js
@@ -1,11 +1,9 @@
-const {
-  spawnHub,
-  prepareSpawnHub
-} = require('../main');
+const path = require('path');
+const { spawn } = require('child_process');
 
 module.exports = {
   name: 'hub:start',
-  description: "Starts the Cardstack hub",
+  description: "Start the Cardstack hub for local development and testing",
   works: 'insideProject',
 
   availableOptions: [
@@ -40,15 +38,66 @@ module.exports = {
 
   async run(args) {
     if (args.print) {
-      let { setEnvVars, bin, args: shellArgs } = await prepareSpawnHub(this.project.pkg.name, this.project.configPath(), args.environment, args.port, args.url);
+      let { setEnvVars, bin, args: shellArgs } = await this.prepareSpawnHub(this.project.pkg.name, this.project.configPath(), args.environment, args.port, args.url);
       for (let [key, value] of Object.entries(setEnvVars)) {
-        process.stdout.write(`${key}=${value}\n`);
+        process.stdout.write(`export ${key}=${value}\n`);
       }
       process.stdout.write(`${bin} ${shellArgs.join(' ')}\n`);
     } else {
-      await spawnHub(this.project.pkg.name, this.project.configPath(), args.environment, args.port, args.url);
+      await this.spawnHub(this.project.pkg.name, this.project.configPath(), args.environment, args.port, args.url);
     }
     await new Promise(() => {});
-  }
+  },
 
+  prepareSpawnHub(packageName, configPath, environment, port, explicitURL) {
+    let setEnvVars = Object.create(null);
+    if (!process.env.CARDSTACK_SESSIONS_KEY) {
+      const crypto = require('crypto');
+      let key = crypto.randomBytes(32);
+      setEnvVars.CARDSTACK_SESSIONS_KEY = key.toString('base64');
+    }
+
+    if (!process.env.ELASTICSEARCH_PREFIX) {
+      setEnvVars.ELASTICSEARCH_PREFIX = packageName.replace(/^[^a-zA-Z]*/, '').replace(/[^a-zA-Z0-9]/g, '_') + '_' + environment;
+    }
+
+    if (!process.env.SEED_DIR) {
+      setEnvVars.SEED_DIR = path.join(path.dirname(configPath),
+                                      '..', 'cardstack', 'seeds', environment);
+
+    }
+
+    if (explicitURL) {
+      setEnvVars.HUB_URL = explicitURL;
+    }
+
+    setEnvVars.PORT = port;
+
+    let bin = path.resolve(path.join(__dirname, '..', 'bin', 'cardstack-hub.js'));
+
+    return { setEnvVars, bin, args: [] };
+  },
+
+  async spawnHub(packageName, configPath, environment, port, url) {
+    let { setEnvVars, bin, args } = this.prepareSpawnHub(packageName, configPath, environment, port, url);
+
+    for (let [key, value] of Object.entries(setEnvVars)) {
+      process.env[key] = value;
+    }
+
+    let proc = spawn(process.execPath, [bin, ...args], { stdio: [0, 1, 2, 'ipc']  });
+    await new Promise((resolve, reject) => {
+      // by convention the hub will send a hello message if it sees we
+      // are supervising it over IPC. If we get an error or exit before
+      // that, it's a failure to spawn the hub.
+      proc.on('message', message => {
+        if (message === 'hub hello') {
+          resolve();
+        }
+      });
+      proc.on('error', reject);
+      proc.on('exit', reject);
+    });
+    return `http://localhost:${port}`;
+  }
 };

--- a/packages/hub/index.js
+++ b/packages/hub/index.js
@@ -74,8 +74,8 @@ let addon = {
       // we wait until here to require this because in the
       // containerized case, "main" and its recursive dependencies
       // never need to load on the host environment.
-      let { spawnHub } = require('./main');
-      return spawnHub(this.project.pkg.name, this.project.configPath(), this._env, process.env.HUB_PORT || 3000);
+      let StartNative = require('./commands/start-native');
+      return StartNative.spawnHub(this.project.pkg.name, this.project.configPath(), this._env, process.env.HUB_PORT || 3000);
     }
   },
 


### PR DESCRIPTION
Mostly by moving things from command line arguments to environment variables.

Warning to @bagby and @habdelra: this changes the Hub's invocation slightly again, so if you're using custom start scripts still it will troll you again. (You probably shouldn't need them anymore, I think everything is customizable through env vars now.)