### PR TITLE
Switch indexers.update() from realTime to forceRefresh

### DIFF
--- a/packages/authentication/node-tests/authentication-test.js
+++ b/packages/authentication/node-tests/authentication-test.js
@@ -377,7 +377,7 @@ describe('authentication/middleware', function() {
         expect(response.body).has.deep.property('data.meta.token');
         expect(response.body).has.deep.property('data.attributes.email', 'quint@example.com');
 
-        await env.lookup('hub:indexers').update({ realTime: true });
+        await env.lookup('hub:indexers').update({ forceRefresh: true });
 
         response = await request.get('/').set('authorization', `Bearer ${response.body.data.meta.token}`);
         expect(response).hasStatus(200);
@@ -489,7 +489,7 @@ describe('authentication/middleware', function() {
         expect(response.body).has.deep.property('data.meta.token');
         expect(response.body).has.deep.property('data.attributes.email', 'updated.email@this-changed.com');
 
-        await env.lookup('hub:indexers').update({ realTime: true });
+        await env.lookup('hub:indexers').update({ forceRefresh: true });
 
         response = await request.get('/').set('authorization', `Bearer ${response.body.data.meta.token}`);
         expect(response).hasStatus(200);
@@ -521,7 +521,7 @@ describe('authentication/middleware', function() {
         expect(response.body).has.deep.property('data.attributes.favorite-toy', 'squeaky snake');
         expect(response.body).not.has.deep.property('data.attributes.secret-rating');
 
-        await env.lookup('hub:indexers').update({ realTime: true });
+        await env.lookup('hub:indexers').update({ forceRefresh: true });
 
         response = await request.get('/').set('authorization', `Bearer ${response.body.data.meta.token}`);
         expect(response).hasStatus(200);
@@ -547,7 +547,7 @@ describe('authentication/middleware', function() {
         expect(response).hasStatus(200);
         expect(response.body).has.deep.property('data.meta.token');
 
-        await env.lookup('hub:indexers').update({ realTime: true });
+        await env.lookup('hub:indexers').update({ forceRefresh: true });
 
         response = await request.get('/').set('authorization', `Bearer ${response.body.data.meta.token}`);
         expect(response).hasStatus(200);
@@ -571,7 +571,7 @@ describe('authentication/middleware', function() {
         expect(response.body).has.deep.property('data.meta.token');
         let autoId = response.body.data.id;
 
-        await env.lookup('hub:indexers').update({ realTime: true });
+        await env.lookup('hub:indexers').update({ forceRefresh: true });
 
         response = await request.get('/').set('authorization', `Bearer ${response.body.data.meta.token}`);
         expect(response).hasStatus(200);
@@ -605,7 +605,7 @@ describe('authentication/middleware', function() {
         expect(response.body).has.deep.property('data.attributes.favorite-toy', null);
         expect(response.body).not.has.deep.property('data.attributes.secret-rating');
 
-        await env.lookup('hub:indexers').update({ realTime: true });
+        await env.lookup('hub:indexers').update({ forceRefresh: true });
 
         response = await request.get('/').set('authorization', `Bearer ${response.body.data.meta.token}`);
         expect(response).hasStatus(200);

--- a/packages/elasticsearch/client.js
+++ b/packages/elasticsearch/client.js
@@ -78,8 +78,8 @@ module.exports = class SearchClient {
     this._mappings = null;
   }
 
-  bulkOps({ realTime, batchSize }) {
-    return new BulkOps(this.es, { realTime, batchSize });
+  bulkOps({ forceRefresh, batchSize }) {
+    return new BulkOps(this.es, { forceRefresh, batchSize });
   }
 
   async accomodateSchema(branch, schema) {

--- a/packages/elasticsearch/node-tests/indexer-test.js
+++ b/packages/elasticsearch/node-tests/indexer-test.js
@@ -62,7 +62,7 @@ describe('elasticsearch/indexer', function() {
       }
     });
     expect(article).has.deep.property('id');
-    await indexer.update({ realTime: true });
+    await indexer.update({ forceRefresh: true });
     let found = await searcher.get(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
@@ -86,7 +86,7 @@ describe('elasticsearch/indexer', function() {
       }
     });
     expect(article).has.deep.property('id');
-    await indexer.update({ realTime: true });
+    await indexer.update({ forceRefresh: true });
     let found = await searcher.get(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
@@ -114,11 +114,11 @@ describe('elasticsearch/indexer', function() {
       }
     });
     expect(article).has.deep.property('id');
-    await indexer.update({ realTime: true });
+    await indexer.update({ forceRefresh: true });
 
     person.attributes.name = 'Edward V';
     await writer.update('master', env.session, 'people', person.id, person);
-    await indexer.update({ realTime: true });
+    await indexer.update({ forceRefresh: true });
 
     let found = await searcher.get(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
@@ -147,13 +147,13 @@ describe('elasticsearch/indexer', function() {
       }
     });
     expect(article).has.deep.property('id');
-    await indexer.update({ realTime: true });
+    await indexer.update({ forceRefresh: true });
 
     person.attributes.name = 'Edward V';
     article.attributes.title = 'A Better Title';
     await writer.update('master', env.session, 'people', person.id, person);
     await writer.update('master', env.session, 'articles', article.id, article);
-    await indexer.update({ realTime: true });
+    await indexer.update({ forceRefresh: true });
 
     let found = await searcher.get(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
@@ -175,7 +175,7 @@ describe('elasticsearch/indexer', function() {
       }
     });
     expect(article).has.deep.property('id');
-    await indexer.update({ realTime: true });
+    await indexer.update({ forceRefresh: true });
     let found = await searcher.get(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.relationships.author.data', null);
@@ -200,7 +200,7 @@ describe('elasticsearch/indexer', function() {
       }
     });
     expect(article).has.deep.property('id');
-    await indexer.update({ realTime: true });
+    await indexer.update({ forceRefresh: true });
     let found = await searcher.get(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.relationships.reviewers.data');
@@ -220,7 +220,7 @@ describe('elasticsearch/indexer', function() {
       }
     });
     expect(article).has.deep.property('id');
-    await indexer.update({ realTime: true });
+    await indexer.update({ forceRefresh: true });
 
     let found = await searcher.get(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
@@ -235,7 +235,7 @@ describe('elasticsearch/indexer', function() {
       }
     });
 
-    await indexer.update({ realTime: true });
+    await indexer.update({ forceRefresh: true });
 
     found = await searcher.get(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;

--- a/packages/email-auth/node-tests/email-auth-test.js
+++ b/packages/email-auth/node-tests/email-auth-test.js
@@ -80,7 +80,7 @@ describe('email-auth', function() {
     expect(response.body).has.deep.property('data.id');
     expect(response.body).has.deep.property('data.meta.token');
 
-    await env.lookup('hub:indexers').update({ realTime: true });
+    await env.lookup('hub:indexers').update({ forceRefresh: true });
 
     response = await request.get('/').set('authorization', `Bearer ${response.body.data.meta.token}`);
     expect(response).hasStatus(200);

--- a/packages/ephemeral/service.js
+++ b/packages/ephemeral/service.js
@@ -241,7 +241,7 @@ class EphemeralStorage {
 
 
 
-    await this.indexers.update({ realTime: true });
+    await this.indexers.update({ forceRefresh: true });
     log.debug(`restored checkpoint ${id}`);
     return generationCounter;
   }

--- a/packages/ethereum/cardstack/service.js
+++ b/packages/ethereum/cardstack/service.js
@@ -193,7 +193,7 @@ class EthereumService {
       let hints = uniqWith(queue, isEqual);
 
       log.debug("processing index queue ", hints);
-      this._indexerPromise = this._indexer.update({ realTime: true, hints });
+      this._indexerPromise = this._indexer.update({ forceRefresh: true, hints });
 
       Promise.resolve(this._indexerPromise)
         .then(() => {
@@ -238,4 +238,3 @@ function  getEventDefinitions(contractName, contractDefinitions) {
   }
   return events;
 }
-

--- a/packages/git/node-tests/indexer-test.js
+++ b/packages/git/node-tests/indexer-test.js
@@ -317,8 +317,8 @@ describe('git/indexer', function() {
 
     await logger.expectWarn(/Unable to load previously indexed commit/, async () => {
       // TODO: should only take one cycle
-      await indexer.update({ realTime: true });
-      await indexer.update({ realTime: true });
+      await indexer.update({ forceRefresh: true });
+      await indexer.update({ forceRefresh: true });
     });
 
 

--- a/packages/hub/indexing/branch-update.js
+++ b/packages/hub/indexing/branch-update.js
@@ -55,8 +55,8 @@ class BranchUpdate {
     }
   }
 
-  async update(realTime, hints) {
-    this.bulkOps = this.client.bulkOps({ realTime });
+  async update(forceRefresh, hints) {
+    this.bulkOps = this.client.bulkOps({ forceRefresh });
     await this.client.accomodateSchema(this.branch, await this.schema());
     await this._updateContent(hints);
   }

--- a/packages/hub/indexing/running-indexers.js
+++ b/packages/hub/indexing/running-indexers.js
@@ -67,9 +67,9 @@ module.exports = class RunningIndexers {
     return flatten(newSchemaModels);
   }
 
-  async update(realTime, hints) {
+  async update(forceRefresh, hints) {
     await this._loadSchemaModels();
-    await Promise.all(Object.values(this.branches).map(branch => branch.update(realTime, hints)));
+    await Promise.all(Object.values(this.branches).map(branch => branch.update(forceRefresh, hints)));
     return await this._schemas();
   }
 

--- a/packages/hub/node-tests/indexers-test.js
+++ b/packages/hub/node-tests/indexers-test.js
@@ -72,7 +72,7 @@ describe('hub/indexers', function() {
       let source = [...activeSources.values()].find(s => s.sourceType === '@cardstack/ephemeral');
       let storage = await source.writer.storage;
       storage.store(config.type, config.id, config, false, null);
-      await env.lookup('hub:indexers').update({ realTime: true });
+      await env.lookup('hub:indexers').update({ forceRefresh: true });
       doc = await env.lookup('hub:searchers').get(env.session, 'master', 'plugins', 'sample-plugin-one');
       expect(doc).has.deep.property('data.attributes.enabled', false);
     });

--- a/packages/hub/node-tests/middleware-stack-test.js
+++ b/packages/hub/node-tests/middleware-stack-test.js
@@ -79,7 +79,7 @@ describe('middleware-stack', function() {
       let config = await env.lookup('hub:searchers').get(env.session, 'master', 'plugin-configs', 'stub-middleware-extra');
       config.data.attributes.enabled = true;
       await env.lookup('hub:writers').update('master', env.session, config.data.type, config.data.id, config.data);
-      await env.lookup('hub:indexers').update({ realTime: true });
+      await env.lookup('hub:indexers').update({ forceRefresh: true });
       let response = await request.get('/extra');
       expect(response).hasStatus(200);
       expect(response.body).has.property('message', 'Extra middleware plugin');
@@ -93,7 +93,7 @@ describe('middleware-stack', function() {
           enabled: false
         }
       });
-      await env.lookup('hub:indexers').update({ realTime: true });
+      await env.lookup('hub:indexers').update({ forceRefresh: true });
       let response = await request.get('/first');
       expect(response).hasStatus(404);
     });

--- a/packages/jsonapi/middleware.js
+++ b/packages/jsonapi/middleware.js
@@ -158,7 +158,7 @@ class Handler {
     this.ctxt.body = { data: record };
     this.ctxt.status = 200;
     if (this.query.nowait == null) {
-      await this.indexers.update({ realTime: true, hints: [{ branch: this.branch, id, type }] });
+      await this.indexers.update({ forceRefresh: true, hints: [{ branch: this.branch, id, type }] });
     }
   }
 
@@ -168,7 +168,7 @@ class Handler {
       await this.writers.delete(this.branch, this.session, version, type, id);
       this.ctxt.status = 204;
       if (this.query.nowait == null) {
-        await this.indexers.update({ realTime: true, hints: [{ branch: this.branch, id, type }] });
+        await this.indexers.update({ forceRefresh: true, hints: [{ branch: this.branch, id, type }] });
       }
     } catch (err) {
       // By convention, the writer always refers to the version as
@@ -223,7 +223,7 @@ class Handler {
     }
     this.ctxt.set('location', origin + this.ctxt.request.path + '/' + record.id);
     if (this.query.nowait == null) {
-      await this.indexers.update({ realTime: true, hints: [{ branch: this.branch, id: record.id, type }] });
+      await this.indexers.update({ forceRefresh: true, hints: [{ branch: this.branch, id: record.id, type }] });
     }
   }
 

--- a/packages/postgresql/node-tests/indexer-test.js
+++ b/packages/postgresql/node-tests/indexer-test.js
@@ -56,7 +56,7 @@ describe('postgresql/indexer', function() {
 
     env = await createDefaultEnvironment(`${__dirname}/..`, factory.getModels());
 
-    await env.lookup('hub:indexers').update({ realTime: true });
+    await env.lookup('hub:indexers').update({ forceRefresh: true });
   }
 
   async function teardown() {
@@ -157,7 +157,7 @@ describe('postgresql/indexer', function() {
 
     it('discovers new records', async function() {
       await client.query('insert into articles values ($1, $2)', ['2', 'second article']);
-      await env.lookup('hub:indexers').update({ realTime: true });
+      await env.lookup('hub:indexers').update({ forceRefresh: true });
       let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'articles', '2');
       expect(doc).is.ok;
       let model = doc.data;
@@ -168,7 +168,7 @@ describe('postgresql/indexer', function() {
 
     it('updates records', async function() {
       await client.query('update articles set title=$1 where id=$2', ['I was updated', '0']);
-      await env.lookup('hub:indexers').update({ realTime: true });
+      await env.lookup('hub:indexers').update({ forceRefresh: true });
       let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'articles', '0');
       expect(doc).is.ok;
       let model = doc.data;
@@ -178,7 +178,7 @@ describe('postgresql/indexer', function() {
 
     it('deletes records', async function() {
       await client.query('delete from articles where id=$1', ['0']);
-      await env.lookup('hub:indexers').update({ realTime: true });
+      await env.lookup('hub:indexers').update({ forceRefresh: true });
       try {
         await env.lookup('hub:searchers').get(env.session, 'master', 'articles', '0');
         throw new Error("should not get here");
@@ -189,7 +189,7 @@ describe('postgresql/indexer', function() {
 
     it('discovers newly added content type', async function() {
       await client.query('create table humans (id varchar primary key, name varchar)');
-      await env.lookup('hub:indexers').update({ realTime: true });
+      await env.lookup('hub:indexers').update({ forceRefresh: true });
       let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'humans');
       expect(doc).is.ok;
       let model = doc.data;
@@ -200,7 +200,7 @@ describe('postgresql/indexer', function() {
 
     it('removes deleted content type', async function() {
       await client.query('drop table articles');
-      await env.lookup('hub:indexers').update({ realTime: true });
+      await env.lookup('hub:indexers').update({ forceRefresh: true });
       try {
         await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'articles');
         throw new Error("should not get here");
@@ -212,7 +212,7 @@ describe('postgresql/indexer', function() {
     it('discovers newly added column', async function() {
       await client.query('alter table articles add column author varchar');
       await client.query('update articles set author=$1 where id=$2', ['Arthur', '0']);
-      await env.lookup('hub:indexers').update({ realTime: true });
+      await env.lookup('hub:indexers').update({ forceRefresh: true });
       let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'articles');
       expect(doc).is.ok;
       let model = doc.data;

--- a/packages/postgresql/node-tests/writer-test.js
+++ b/packages/postgresql/node-tests/writer-test.js
@@ -75,7 +75,7 @@ describe('postgresql/writer', function() {
 
 
     env = await createDefaultEnvironment(`${__dirname}/..`, factory.getModels());
-    await env.lookup('hub:indexers').update({ realTime: true });
+    await env.lookup('hub:indexers').update({ forceRefresh: true });
     writer = env.lookup('hub:writers');
   });
 

--- a/packages/test-support/env.js
+++ b/packages/test-support/env.js
@@ -93,7 +93,7 @@ exports.createDefaultEnvironment = async function(projectDir, initialModels = []
       await writers.create('master', session, model.type, model);
     }
 
-    await container.lookup('hub:indexers').update({ realTime: true });
+    await container.lookup('hub:indexers').update({ forceRefresh: true });
 
     Object.assign(container, {
       session,


### PR DESCRIPTION
This makes us _always_ wait for content to be visible before resolving the update() promise. That is basically always what you want (if you don't care about it, you can still just not await the promise).

Before, we would choose between forcing an immediate hard refresh before resolving, or we would just resolve immediately without waiting for content to be visible in the search index.

Now, we either wait for the next scheduled refresh to happen, or we force a refresh to happen, but in either case when `update()` resolves you can be confident that your content is visible in the search index.