### PR TITLE
use hints when they are available for more efficient updateContent

### DIFF
--- a/packages/hub/indexing/branch-update.js
+++ b/packages/hub/indexing/branch-update.js
@@ -64,7 +64,7 @@ class BranchUpdate {
 
   async _updateContent(hints) {
     let schema = await this.schema();
-    let types = hints ? hints.map(hint => hint.type).filter(type => Boolean(type)) : [];
+    let types = hints && Array.isArray(hints) ? hints.map(hint => hint.type).filter(type => Boolean(type)) : [];
     let updaters = Object.entries(this.updaters);
 
     let dataSourceIds = types.map(type => {

--- a/packages/hub/indexing/branch-update.js
+++ b/packages/hub/indexing/branch-update.js
@@ -63,7 +63,23 @@ class BranchUpdate {
   }
 
   async _updateContent(hints) {
-    for (let [sourceId, updater] of Object.entries(this.updaters)) {
+    let schema = await this.schema();
+    let types = (hints || []).map(hint => hint.type).filter(type => Boolean(type));
+    let updaters = Object.entries(this.updaters);
+
+    let dataSourceIds = types.map(type => {
+      let contentType = schema.types.get(type);
+      if (!contentType) { return; }
+      let dataSource = contentType.dataSource;
+      if (!dataSource) { return; }
+      return dataSource.id;
+    }).filter(item => Boolean(item));
+
+    if (dataSourceIds.length) {
+      updaters = updaters.filter(([ sourceId ]) => dataSourceIds.includes(sourceId));
+    }
+
+    for (let [sourceId, updater] of updaters) {
       let meta = await this._loadMeta(updater);
       let publicOps = Operations.create(this, sourceId);
       let newMeta = await updater.updateContent(meta, hints, publicOps);

--- a/packages/hub/indexing/branch-update.js
+++ b/packages/hub/indexing/branch-update.js
@@ -64,7 +64,7 @@ class BranchUpdate {
 
   async _updateContent(hints) {
     let schema = await this.schema();
-    let types = (hints || []).map(hint => hint.type).filter(type => Boolean(type));
+    let types = hints ? hints.map(hint => hint.type).filter(type => Boolean(type)) : [];
     let updaters = Object.entries(this.updaters);
 
     let dataSourceIds = types.map(type => {


### PR DESCRIPTION
@ef4 it looks like I didn't even need to use `owningDataSource` as `this.updaters` already had everything that I needed.