### PR TITLE
added node eslint rules in cardstack folders

### DIFF
--- a/packages/authentication/cardstack/.eslintrc.js
+++ b/packages/authentication/cardstack/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  "extends": '@cardstack/eslint-config'
+};

--- a/packages/codegen/cardstack/.eslintrc.js
+++ b/packages/codegen/cardstack/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  "extends": '@cardstack/eslint-config'
+};

--- a/packages/drupal-auth/cardstack/.eslintrc.js
+++ b/packages/drupal-auth/cardstack/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  "extends": '@cardstack/eslint-config'
+};

--- a/packages/email-auth/cardstack/.eslintrc.js
+++ b/packages/email-auth/cardstack/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  "extends": '@cardstack/eslint-config'
+};


### PR DESCRIPTION
My editor is getting upset that there aren't node eslint rules in the cardstack folders after the recent eslint updates.