### PR TITLE
Eslint improvement

### DIFF
--- a/packages/eslint-config/-node.js
+++ b/packages/eslint-config/-node.js
@@ -1,0 +1,24 @@
+module.exports = {
+  parserOptions: {
+    ecmaVersion: 8
+  },
+  env: {
+    'node': true,
+    'browser': false,
+    'es6': true
+  },
+  // I'm doing this instead of `extends` so that this config module
+  // can be used within override blocks of other config modules.
+  rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
+    'no-constant-condition': ["error", { checkLoops: false }],
+    'require-yield': 0,
+    'no-var': "error",
+    semi: ["error", "always"],
+    'node/no-extraneous-require': ['error', {
+      'allowModules': []
+    }],
+    'node/no-missing-require': ['error'],
+    'no-undef': 'error'
+  }),
+  plugins: ['node']
+};

--- a/packages/eslint-config/browser.js
+++ b/packages/eslint-config/browser.js
@@ -22,7 +22,7 @@ module.exports = {
   },
   overrides: [
     // This loads our node rules
-    Object.assign({}, require('./index'), {
+    Object.assign({}, require('./-node'), {
       // And applies them to all the paths that are node paths in a
       // standard ember-addon
       files: [

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -17,7 +17,8 @@ module.exports = {
     'node/no-extraneous-require': ['error', {
       'allowModules': []
     }],
-    'node/no-missing-require': ['error']
+    'node/no-missing-require': ['error'],
+    'no-undef': 'error'
   }),
   plugins: ['node']
 };

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,24 +1,12 @@
-module.exports = {
-  parserOptions: {
-    ecmaVersion: 8
-  },
-  env: {
-    'node': true,
-    'browser': false,
-    'es6': true
-  },
-  // I'm doing this instead of `extends` so that this config module
-  // can be used within override blocks of other config modules.
-  rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
-    'no-constant-condition': ["error", { checkLoops: false }],
-    'require-yield': 0,
-    'no-var': "error",
-    semi: ["error", "always"],
-    'node/no-extraneous-require': ['error', {
-      'allowModules': []
-    }],
-    'node/no-missing-require': ['error'],
-    'no-undef': 'error'
-  }),
-  plugins: ['node']
-};
+let node = require('./-node');
+let test = require('./test');
+
+module.exports = Object.assign({}, node, {
+  overrides: [
+    Object.assign({}, test, {
+      files: [
+        'node-tests/**/*.js'
+      ]
+    })
+  ]
+});

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -24,5 +24,8 @@
     "eslint": ">= 4",
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^5.2.1"
+  },
+  "engines": {
+    "node": ">= 8"
   }
 }

--- a/packages/eslint-config/test.js
+++ b/packages/eslint-config/test.js
@@ -1,4 +1,4 @@
-module.exports = Object.assign({}, require('./index'), {
+module.exports = Object.assign({}, require('./-node'), {
   globals: {
     describe: false,
     it: false,

--- a/packages/handlebars/.eslintrc.js
+++ b/packages/handlebars/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  "extends": '@cardstack/eslint-config'
+};


### PR DESCRIPTION
 - our no-undef rule was accidentally disabled by a recent refactor. This turns it back on.
 - we were also failing to apply test-specific rules to node-tests directories that happen to live inside node-specific packages (that is, packages whose eslint config inherits from `@cardstack/eslint-config` , not `@cardstack/eslint-config/browser`).