### PR TITLE
New modules

### DIFF
--- a/packages/authentication/addon/authorizers/cardstack.js
+++ b/packages/authentication/addon/authorizers/cardstack.js
@@ -1,11 +1,10 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { isEmpty } from '@ember/utils';
 import Authorizer from 'ember-simple-auth/authorizers/base';
-
-const { isEmpty } = Ember;
 
 export default Authorizer.extend({
   authorize(rawSession, block) {
-    const accessToken = Ember.get(rawSession, 'data.meta.token');
+    const accessToken = get(rawSession, 'data.meta.token');
 
     if (!isEmpty(accessToken)) {
       block('Authorization', `Bearer ${accessToken}`);

--- a/packages/authentication/addon/cardstack-authenticator.js
+++ b/packages/authentication/addon/cardstack-authenticator.js
@@ -1,11 +1,12 @@
-import Ember from 'ember';
+import { warn } from '@ember/debug';
+import { inject as service } from '@ember/service';
 import Base from 'ember-simple-auth/authenticators/base';
 import RSVP from 'rsvp';
 import { hubURL } from '@cardstack/plugin-utils/environment';
 
 export default Base.extend({
-  cardstackSession: Ember.inject.service(),
-  session: Ember.inject.service(),
+  cardstackSession: service(),
+  session: service(),
 
   restore(rawSession) {
     return new RSVP.Promise((resolve, reject) => {
@@ -49,7 +50,7 @@ export default Base.extend({
          response.headers.get("content-type").toLowerCase().indexOf("application/json") >= 0) {
         return response.json()
       } else {
-        Ember.warn(`Got a non-json response from ${hubURL}/auth/${authenticationSource}`, false, { id: 'cardstack-authentication-nonjson-response' });
+        warn(`Got a non-json response from ${hubURL}/auth/${authenticationSource}`, false, { id: 'cardstack-authentication-nonjson-response' });
         return {};
       }
     });

--- a/packages/authentication/addon/components/cardstack-session.js
+++ b/packages/authentication/addon/components/cardstack-session.js
@@ -1,11 +1,12 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
 import layout from '../templates/components/cardstack-session';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   tagName: "",
-  session: Ember.inject.service(),
-  cardstackSession: Ember.inject.service(),
+  session: service(),
+  cardstackSession: service(),
 
   actions: {
     logout() {

--- a/packages/authentication/addon/services/cardstack-session.js
+++ b/packages/authentication/addon/services/cardstack-session.js
@@ -1,30 +1,33 @@
 // Builds on ember-simple-auth's session service by deriving a user
 // model from the session state. Also handle partially authenticated sessions
 
-import Ember from 'ember';
+import { alias } from '@ember/object/computed';
+
+import { computed } from '@ember/object';
+import Service, { inject as service } from '@ember/service';
 import { singularize } from 'ember-inflector';
 
-export default Ember.Service.extend({
-  session: Ember.inject.service(),
-  store: Ember.inject.service(),
+export default Service.extend({
+  session: service(),
+  store: service(),
 
-  isAuthenticated: Ember.computed('session.isAuthenticated', 'isPartiallyAuthenticated', function() {
+  isAuthenticated: computed('session.isAuthenticated', 'isPartiallyAuthenticated', function() {
     return this.get('session.isAuthenticated') && !this.get('isPartiallyAuthenticated');
   }),
 
-  isPartiallyAuthenticated: Ember.computed.alias('_rawSession.meta.partial-session'),
+  isPartiallyAuthenticated: alias('_rawSession.meta.partial-session'),
 
-  partialSession: Ember.computed('isPartiallyAuthenticated', '_rawSession', function() {
+  partialSession: computed('isPartiallyAuthenticated', '_rawSession', function() {
     if (this.get('isPartiallyAuthenticated')) {
       return this.get('_rawSession');
     }
   }),
 
-  partialAuthenticationMessage: Ember.computed.alias('partialSession.data.attributes.message'),
+  partialAuthenticationMessage: alias('partialSession.data.attributes.message'),
 
-  _rawSession: Ember.computed.alias('session.data.authenticated'),
+  _rawSession: alias('session.data.authenticated'),
 
-  user: Ember.computed('isAuthenticated', '_rawSession', function() {
+  user: computed('isAuthenticated', '_rawSession', function() {
     if (this.get('isAuthenticated')) {
       let rawSession = this.get('_rawSession');
       if (rawSession) {

--- a/packages/core-types/addon/components/cs-one-way-input.js
+++ b/packages/core-types/addon/components/cs-one-way-input.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-one-way-input';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   tagName: '',
   type: 'text',

--- a/packages/core-types/addon/components/field-editors/integer-editor.js
+++ b/packages/core-types/addon/components/field-editors/integer-editor.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../../templates/components/field-editors/integer-editor';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   invalid: false,
   refresh: 1,

--- a/packages/core-types/addon/components/field-editors/string-editor.js
+++ b/packages/core-types/addon/components/field-editors/string-editor.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
+import { not } from '@ember/object/computed';
+import Component from '@ember/component';
 import layout from '../../templates/components/field-editors/string-editor';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
-  disabled: Ember.computed.not('enabled')
+  disabled: not('enabled')
 });

--- a/packages/core-types/addon/helpers/cs-to-string.js
+++ b/packages/core-types/addon/helpers/cs-to-string.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import { helper as buildHelper } from '@ember/component/helper';
 
-export default Ember.Helper.helper(function([a]) {
+export default buildHelper(function([a]) {
   return a ? String(a) : a;
 });

--- a/packages/drupal-auth/addon/components/drupal-login.js
+++ b/packages/drupal-auth/addon/components/drupal-login.js
@@ -1,14 +1,15 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
+import { getOwner } from '@ember/application';
 import layout from '../templates/components/drupal-login';
 import { configure, getConfiguration } from 'torii/configuration';
 import { task } from 'ember-concurrency';
-const { getOwner } = Ember;
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   tagName: '',
-  session: Ember.inject.service(),
-  torii: Ember.inject.service(),
+  session: service(),
+  torii: service(),
 
   // This is the id of the authentication-sources model on the
   // server. Ours uses 'drupal' by default. It would theoretically be

--- a/packages/drupal-auth/app/torii-providers/drupal-oauth2-code.js
+++ b/packages/drupal-auth/app/torii-providers/drupal-oauth2-code.js
@@ -1,12 +1,11 @@
-import Ember from 'ember';
 import Provider from 'torii/providers/oauth2-code';
-import {configurable} from 'torii/configuration';
+import { configurable } from 'torii/configuration';
 import { computed } from '@ember/object';
 
 export default Provider.extend({
   name: 'drupal-oauth2-code',
   drupalUrl: configurable('drupalUrl'),
-  baseUrl: Ember.computed('drupalUrl', function() {
+  baseUrl: computed('drupalUrl', function() {
     return `${this.get('drupalUrl')}/oauth/authorize`;
   }),
   responseParams: computed(function() { return ['code', 'state']; })

--- a/packages/email-auth/addon/components/email-login.js
+++ b/packages/email-auth/addon/components/email-login.js
@@ -1,8 +1,8 @@
-import Ember from 'ember';
+import { getOwner } from '@ember/application';
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 import layout from '../templates/components/email-login';
 import { task } from 'ember-concurrency';
-
-const { getOwner, Component, inject: { service } } = Ember;
 
 export default Component.extend({
   layout,

--- a/packages/eslint-config/browser.js
+++ b/packages/eslint-config/browser.js
@@ -14,7 +14,6 @@ module.exports = {
     es6: true
   },
   rules: {
-    'ember/closure-actions': 'off',
     'no-restricted-globals': [2, 'find']
   },
   overrides: [

--- a/packages/eslint-config/browser.js
+++ b/packages/eslint-config/browser.js
@@ -14,10 +14,7 @@ module.exports = {
     es6: true
   },
   rules: {
-    // TODO: turn these on
-    'ember/new-module-imports': 'off',
     'ember/closure-actions': 'off',
-    'ember/no-old-shims': 'off',
     'no-restricted-globals': [2, 'find']
   },
   overrides: [

--- a/packages/github-auth/addon/components/github-login.js
+++ b/packages/github-auth/addon/components/github-login.js
@@ -1,14 +1,15 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
+import { getOwner } from '@ember/application';
 import layout from '../templates/components/github-login';
 import { configure, getConfiguration } from 'torii/configuration';
 import { task } from 'ember-concurrency';
-const { getOwner } = Ember;
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   tagName: '',
-  session: Ember.inject.service(),
-  torii: Ember.inject.service(),
+  session: service(),
+  torii: service(),
 
   // This is the id of the authentication-sources model on the
   // server. Ours uses 'github' by default. It would theoretically be

--- a/packages/image/addon/components/field-editors/image-editor.js
+++ b/packages/image/addon/components/field-editors/image-editor.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import { not } from '@ember/object/computed';
+import Component from '@ember/component';
 import layout from '../../templates/components/field-editors/image-editor';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
 
-  disabled: Ember.computed.not('enabled'),
+  disabled: not('enabled'),
 
   actions: {
     updateImage(dataURL) {

--- a/packages/image/addon/components/field-editors/image-upload-modal.js
+++ b/packages/image/addon/components/field-editors/image-upload-modal.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../../templates/components/field-editors/image-upload-modal';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['cardstack-image-upload-modal'],
   layout,
 

--- a/packages/image/addon/components/field-editors/image-upload-modal.js
+++ b/packages/image/addon/components/field-editors/image-upload-modal.js
@@ -17,7 +17,7 @@ export default Component.extend({
     },
 
     updateImage() {
-      this.sendAction('updateImage', this.get('dataURL'));
+      this.get('updateImage')(this.get('dataURL'));
     }
   }
 });

--- a/packages/image/addon/components/field-renderers/image-renderer.js
+++ b/packages/image/addon/components/field-renderers/image-renderer.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../../templates/components/field-renderers/image-renderer';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout
 });

--- a/packages/live-queries/addon/live-query.js
+++ b/packages/live-queries/addon/live-query.js
@@ -1,12 +1,12 @@
 import Ember from "ember";
 import { getOwner } from '@ember/application';
-import { getProperties } from '@ember/object';
+import { getProperties, computed } from '@ember/object';
 
 export function liveQuery(...args) {
   let query;
   let fn = args.pop();
   let deps = args;
-  return Ember.computed(...deps, function() {
+  return computed(...deps, function() {
     if (!this.isComponent) {
       Ember.Logger.warn(`Live-query should only be used inside a component due to the lifecycle operations that a component uses. If used outside of a component then you must manually cleanup the live query subscription.`);
     }

--- a/packages/mobiledoc/addon/components/cs-mobiledoc-editor.js
+++ b/packages/mobiledoc/addon/components/cs-mobiledoc-editor.js
@@ -1,8 +1,9 @@
-import Ember from 'ember';
+import { computed } from '@ember/object';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-mobiledoc-editor';
 import { task, timeout } from 'ember-concurrency';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
 
   // We are deliberately only reading `mobiledoc` once and not
@@ -10,7 +11,7 @@ export default Ember.Component.extend({
   // property as a way to explicitly invalidate the document if
   // needed. This guards against data loops that would otherwise lose
   // cursor position.
-  innerMobiledoc: Ember.computed('docKey', function() {
+  innerMobiledoc: computed('docKey', function() {
     return this.get('mobiledoc');
   }),
 

--- a/packages/mobiledoc/addon/components/cs-mobiledoc-editor.js
+++ b/packages/mobiledoc/addon/components/cs-mobiledoc-editor.js
@@ -21,7 +21,10 @@ export default Component.extend({
     yield timeout(500); // this debounces changes so that we're not
                         // propagating things up to the model on every
                         // keystroke, which can cause laggy typing.
-    this.sendAction('on-change', doc);
+    let handler = this.get('on-change');
+    if (handler) {
+      handler(doc);
+    }
     this._nextDoc = null;
   }).restartable(),
 
@@ -30,7 +33,10 @@ export default Component.extend({
       // If there were changes pending in the debouncer, hurry them
       // out before we're destroyed.
       this.get('onChange').cancelAll();
-      this.sendAction('on-change', this._nextDoc);
+      let handler = this.get('on-change');
+      if (handler) {
+        handler(this._nextDoc);
+      }
     }
     this._super();
   },

--- a/packages/mobiledoc/addon/components/cs-mobiledoc-overview.js
+++ b/packages/mobiledoc/addon/components/cs-mobiledoc-overview.js
@@ -1,11 +1,12 @@
-import Ember from 'ember';
+import { computed } from '@ember/object';
+import Component from '@ember/component';
+import { capitalize } from '@ember/string';
 import layout from '../templates/components/cs-mobiledoc-overview';
-const { capitalize } = Ember.String;
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   classNames: ['cs-mobiledoc-overview'],
-  sections: Ember.computed('mobiledoc', function() {
+  sections: computed('mobiledoc', function() {
     let doc = this.get('mobiledoc');
     if (!doc) {
       return [];

--- a/packages/mobiledoc/addon/components/field-editors/mobiledoc-editor.js
+++ b/packages/mobiledoc/addon/components/field-editors/mobiledoc-editor.js
@@ -1,11 +1,12 @@
-import Ember from 'ember';
+import { computed } from '@ember/object';
+import Component from '@ember/component';
+import { capitalize } from '@ember/string';
 import layout from '../../templates/components/field-editors/mobiledoc-editor';
-const { capitalize } = Ember.String;
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   classNames: ['mobiledoc-overview'],
-  sections: Ember.computed('mobiledoc', function() {
+  sections: computed('mobiledoc', function() {
     let doc = this.get('mobiledoc');
     if (!doc) {
       return [];

--- a/packages/mobiledoc/addon/components/field-renderers/mobiledoc-renderer.js
+++ b/packages/mobiledoc/addon/components/field-renderers/mobiledoc-renderer.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../../templates/components/field-renderers/mobiledoc-renderer';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout
 });

--- a/packages/mobiledoc/addon/components/inline-field-editors/mobiledoc-editor.js
+++ b/packages/mobiledoc/addon/components/inline-field-editors/mobiledoc-editor.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../../templates/components/inline-field-editors/mobiledoc-editor';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout
 });

--- a/packages/mock-auth/addon/components/mock-login.js
+++ b/packages/mock-auth/addon/components/mock-login.js
@@ -1,8 +1,9 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
 import layout from '../templates/components/mock-login';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   tagName: '',
-  mockLogin: Ember.inject.service()
+  mockLogin: service()
 });

--- a/packages/mock-auth/addon/services/mock-login.js
+++ b/packages/mock-auth/addon/services/mock-login.js
@@ -1,8 +1,8 @@
-import Ember from 'ember';
+import Service, { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 
-export default Ember.Service.extend({
-  session: Ember.inject.service(),
+export default Service.extend({
+  session: service(),
 
   source: 'mock-auth',
 

--- a/packages/models/addon/adapter.js
+++ b/packages/models/addon/adapter.js
@@ -1,10 +1,9 @@
+import { assign } from '@ember/polyfills';
+import { get } from '@ember/object';
 import DS from 'ember-data';
 import AdapterMixin from 'ember-resource-metadata/adapter-mixin';
-import Ember from 'ember';
 import { hubURL } from '@cardstack/plugin-utils/environment';
 import injectOptional from 'ember-inject-optional';
-
-const { get } = Ember;
 
 export default DS.JSONAPIAdapter.extend(AdapterMixin, {
   host: hubURL,
@@ -15,7 +14,7 @@ export default DS.JSONAPIAdapter.extend(AdapterMixin, {
   // queryRecord can use the hub's page.size control to just do a
   // query of with a limit of 1.
   async queryRecord(store, type, query) {
-    let upstreamQuery = Ember.assign({}, query);
+    let upstreamQuery = assign({}, query);
     upstreamQuery.page = { size: 1 };
     let response = await this._super(store, type, upstreamQuery);
     if (!response.data || !Array.isArray(response.data) || response.data.length < 1) {

--- a/packages/models/tests/dummy/app/routes/show-post.js
+++ b/packages/models/tests/dummy/app/routes/show-post.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   async model({ id }) {
     return this.store.findRecord('post', id);
   }

--- a/packages/rendering/addon/components/cardstack-content.js
+++ b/packages/rendering/addon/components/cardstack-content.js
@@ -1,15 +1,17 @@
-import Ember from 'ember';
+import { guidFor } from '@ember/object/internals';
+import { computed } from '@ember/object';
+import Component from '@ember/component';
 import layout from '../templates/components/cardstack-content';
 import { modelType } from '@cardstack/rendering/helpers/cs-model-type';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   format: 'card',
   tagName: '',
-  id: Ember.computed('content', 'format', function() {
-    return `${Ember.guidFor(this.get('content'))}/${this.get('format')}`;
+  id: computed('content', 'format', function() {
+    return `${guidFor(this.get('content'))}/${this.get('format')}`;
   }),
-  specificComponent: Ember.computed('content', 'format', function() {
+  specificComponent: computed('content', 'format', function() {
     let format = this.get('format');
     if (this.get('content.isCardstackPlaceholder')) {
       return `cardstack/cardstack-placeholder-${format}`;

--- a/packages/rendering/addon/components/cs-field.js
+++ b/packages/rendering/addon/components/cs-field.js
@@ -1,11 +1,13 @@
-import Ember from 'ember';
+import { getOwner } from '@ember/application';
+import { computed } from '@ember/object';
+import Component from '@ember/component';
+import { guidFor } from '@ember/object/internals';
 import layout from '../templates/components/cs-field';
-const { guidFor } = Ember;
 import { fieldType } from '../helpers/cs-field-type';
 import { fieldCaption } from '../helpers/cs-field-caption';
 import injectOptional from 'ember-inject-optional';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   tagName: '',
 
@@ -14,30 +16,30 @@ export default Ember.Component.extend({
   // present.
   tools: injectOptional.service('cardstack-tools'),
 
-  fieldType: Ember.computed('content', 'fieldName', function() {
+  fieldType: computed('content', 'fieldName', function() {
     return fieldType(this.get('content'), this.get('fieldName'));
   }),
 
-  fieldCaption: Ember.computed('content', 'fieldName', function() {
+  fieldCaption: computed('content', 'fieldName', function() {
     return fieldCaption(this.get('content'), this.get('fieldName'));
   }),
 
-  fieldConfig: Ember.computed('fieldType', function() {
+  fieldConfig: computed('fieldType', function() {
     let type = this.get('fieldType');
     if (type) {
-      return Ember.getOwner(this).resolveRegistration(`field-type:${type}`);
+      return getOwner(this).resolveRegistration(`field-type:${type}`);
     }
   }),
 
-  id: Ember.computed('content', 'fieldName', function() {
+  id: computed('content', 'fieldName', function() {
     return `${guidFor(this.get('content'))}/cs-field/${this.get('fieldName')}`;
   }),
 
-  defaultRenderer: Ember.computed('fieldType', function() {
+  defaultRenderer: computed('fieldType', function() {
     return `field-renderers/${this.get('fieldType')}-renderer`;
   }),
 
-  fieldInfo: Ember.computed('content', 'fieldName', 'fieldCaption', function() {
+  fieldInfo: computed('content', 'fieldName', 'fieldCaption', function() {
     return {
       name: this.get('fieldName'),
       content: this.get('content'),

--- a/packages/rendering/addon/helpers/cs-assert.js
+++ b/packages/rendering/addon/helpers/cs-assert.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
-const { htmlSafe } = Ember.String;
+import { getOwner } from '@ember/application';
+import Helper from '@ember/component/helper';
+import { htmlSafe } from '@ember/string';
 
-export default Ember.Helper.extend({
+export default Helper.extend({
   init() {
     this._super.apply(this, arguments);
-    this.environment = Ember.getOwner(this).resolveRegistration('config:environment').environment;
+    this.environment = getOwner(this).resolveRegistration('config:environment').environment;
   },
   compute(messages) {
     if (this.environment === 'production') {

--- a/packages/rendering/addon/helpers/cs-field-type.js
+++ b/packages/rendering/addon/helpers/cs-field-type.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { helper as buildHelper } from '@ember/component/helper';
 import metaForField from '../-private/meta-for-field';
 import stripNamespace from '../-private/strip-namespace';
 
@@ -25,4 +25,4 @@ export function fieldType(content, fieldName) {
   return type;
 }
 
-export default Ember.Helper.helper(fieldType);
+export default buildHelper(fieldType);

--- a/packages/rendering/addon/helpers/cs-humanize.js
+++ b/packages/rendering/addon/helpers/cs-humanize.js
@@ -1,5 +1,5 @@
-import { helper } from 'ember-helper';
-import { capitalize } from 'ember-string';
+import { helper } from '@ember/component/helper';
+import { capitalize } from '@ember/string';
 
 export default helper(function([a]) {
   if (a) {

--- a/packages/rendering/addon/helpers/cs-model-type.js
+++ b/packages/rendering/addon/helpers/cs-model-type.js
@@ -1,11 +1,12 @@
-import Ember from 'ember';
+import { helper as buildHelper } from '@ember/component/helper';
+import { get } from '@ember/object';
 
 export function modelType(model) {
   if (model) {
-    return Ember.get(model, 'type') || model.constructor.modelName;
+    return get(model, 'type') || model.constructor.modelName;
   }
 }
 
-export default Ember.Helper.helper(function([model]){
+export default buildHelper(function([model]){
   return modelType(model);
 });

--- a/packages/rendering/addon/helpers/cs-placeholder.js
+++ b/packages/rendering/addon/helpers/cs-placeholder.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import { helper as buildHelper } from '@ember/component/helper';
 import { humanize } from './cs-humanize';
 
-export default Ember.Helper.helper(function(params, options={}) {
+export default buildHelper(function(params, options={}) {
   let { fieldConfig, fieldCaption, value, active, fieldName } = options;
 
   if (!active) {

--- a/packages/rendering/tests/dummy/app/components/cardstack/beverage-card.js
+++ b/packages/rendering/tests/dummy/app/components/cardstack/beverage-card.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../../templates/components/cardstack/beverage-card';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout
 });

--- a/packages/rendering/tests/dummy/app/components/cardstack/beverage-page.js
+++ b/packages/rendering/tests/dummy/app/components/cardstack/beverage-page.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../../templates/components/cardstack/beverage-page';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout
 });

--- a/packages/rendering/tests/dummy/app/routes/card.js
+++ b/packages/rendering/tests/dummy/app/routes/card.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     return this.store.createRecord('beverage', {
       flavor: 'tea',

--- a/packages/rendering/tests/dummy/app/routes/index.js
+++ b/packages/rendering/tests/dummy/app/routes/index.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     return this.store.createRecord('beverage', {
       flavor: 'cola',

--- a/packages/routing/addon/components/cardstack/cardstack-placeholder-page.js
+++ b/packages/routing/addon/components/cardstack/cardstack-placeholder-page.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../../templates/components/cardstack/cardstack-placeholder-page';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout
 });

--- a/packages/routing/addon/helpers/cardstack-url.js
+++ b/packages/routing/addon/helpers/cardstack-url.js
@@ -1,4 +1,6 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Helper from '@ember/component/helper';
+import { get } from '@ember/object';
 import { modelType } from '@cardstack/rendering/helpers/cs-model-type';
 import { defaultBranch } from '@cardstack/plugin-utils/environment';
 import { pluralize } from 'ember-inflector';
@@ -9,9 +11,9 @@ export function urlForModel(context, model, { branch } = {}) {
     let type = pluralize(modelType(model));
     let routingId;
     if (model.constructor.routingField) {
-      routingId = Ember.get(model, model.constructor.routingField);
+      routingId = get(model, model.constructor.routingField);
     } else {
-      routingId = Ember.get(model, 'id');
+      routingId = get(model, 'id');
     }
     return urlForParams(context, type, routingId, { branch });
   }
@@ -22,12 +24,12 @@ export function urlForParams(context, type, routingId, { branch } = {}) {
     return;
   }
   type = pluralize(type);
-  let { name, params, queryParams } = Ember.get(context, 'cardstackRouting').routeFor(type, routingId, branch || defaultBranch);
+  let { name, params, queryParams } = get(context, 'cardstackRouting').routeFor(type, routingId, branch || defaultBranch);
   return hrefTo(context, name, ...params.map(p => p[1]), { isQueryParams: true, values: queryParams });
 }
 
-export default Ember.Helper.extend({
-  cardstackRouting: Ember.inject.service(),
+export default Helper.extend({
+  cardstackRouting: service(),
   compute(args, hash) {
     if (args.length === 2) {
       let [ type, routingId ] = args;

--- a/packages/routing/addon/routes/cardstack.js
+++ b/packages/routing/addon/routes/cardstack.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 import { defaultBranch } from '@cardstack/plugin-utils/environment';
 
-export default Ember.Route.extend({
+export default Route.extend({
   queryParams: {
     branch: {
       refreshModel: true

--- a/packages/routing/addon/routes/cardstack/common.js
+++ b/packages/routing/addon/routes/cardstack/common.js
@@ -1,8 +1,10 @@
-import Ember from 'ember';
+import { getOwner } from '@ember/application';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
 
-  service: Ember.inject.service('cardstack-routing'),
+  service: service('cardstack-routing'),
 
   _commonModelHook(type, slug) {
     let { branch } = this.modelFor('cardstack');
@@ -16,7 +18,7 @@ export default Ember.Route.extend({
       this.replaceWith(name, ...params.map(p => p[1]), { queryParams });
     }
 
-    let modelClass = Ember.getOwner(this).resolveRegistration(`model:${mType}`);
+    let modelClass = getOwner(this).resolveRegistration(`model:${mType}`);
     if (!modelClass) {
       throw new Error(`@cardstack/routing tried to use model ${mType} but it does not exist`);
     }

--- a/packages/routing/addon/routes/cardstack/new-content.js
+++ b/packages/routing/addon/routes/cardstack/new-content.js
@@ -1,7 +1,9 @@
-import Ember from 'ember';
+import { getOwner } from '@ember/application';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
-  service: Ember.inject.service('cardstack-routing'),
+export default Route.extend({
+  service: service('cardstack-routing'),
   queryParams: {
     // optionally prefill the routingId for the new record
     routingId: {
@@ -19,7 +21,7 @@ export default Ember.Route.extend({
     }
 
     let initialProperties = Object.create(null);
-    let modelClass = Ember.getOwner(this).resolveRegistration(`model:${modelType}`);
+    let modelClass = getOwner(this).resolveRegistration(`model:${modelType}`);
     if (!modelClass) {
       throw new Error(`@cardstack/routing tried to use model ${modelType} but it does not exist`);
     }

--- a/packages/routing/addon/services/routing.js
+++ b/packages/routing/addon/services/routing.js
@@ -1,8 +1,8 @@
-import Ember from 'ember';
+import Service from '@ember/service';
 import { pluralize, singularize } from 'ember-inflector';
 import { defaultBranch } from '@cardstack/plugin-utils/environment';
 
-export default Ember.Service.extend({
+export default Service.extend({
   defaultContentType: 'pages',
 
   routeFor(type, routingId, branch) {

--- a/packages/routing/tests/dummy/app/adapters/application.js
+++ b/packages/routing/tests/dummy/app/adapters/application.js
@@ -1,5 +1,5 @@
+import { assign } from '@ember/polyfills';
 import DS from 'ember-data';
-import Ember from 'ember';
 import { hubURL } from '@cardstack/plugin-utils/environment';
 
 export default DS.JSONAPIAdapter.extend({
@@ -7,7 +7,7 @@ export default DS.JSONAPIAdapter.extend({
   namespace: 'api',
 
   async queryRecord(store, type, query) {
-    let upstreamQuery = Ember.assign({}, query);
+    let upstreamQuery = assign({}, query);
     upstreamQuery.page = { size: 1 };
     let response = await this._super(store, type, upstreamQuery);
     if (!response.data || !Array.isArray(response.data) || response.data.length < 1) {

--- a/packages/routing/tests/dummy/app/routes/links.js
+++ b/packages/routing/tests/dummy/app/routes/links.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     return {
       myPost: this.store.createRecord('post', { id: '123 45' }),

--- a/packages/search/addon/components/cardstack-query-editor.js
+++ b/packages/search/addon/components/cardstack-query-editor.js
@@ -10,7 +10,7 @@ export default Component.extend({
   }),
   actions: {
     update() {
-      this.sendAction("update", assign({}, this.get("internalQuery")));
+      this.get("update")(assign({}, this.get("internalQuery")));
     }
   }
 });

--- a/packages/search/addon/components/cardstack-query-editor.js
+++ b/packages/search/addon/components/cardstack-query-editor.js
@@ -1,14 +1,16 @@
-import Ember from 'ember';
+import { assign } from '@ember/polyfills';
+import { computed } from '@ember/object';
+import Component from '@ember/component';
 import layout from '../templates/components/cardstack-query-editor';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
-  internalQuery: Ember.computed('query', function() {
+  internalQuery: computed('query', function() {
     return this.get('query') || {};
   }),
   actions: {
     update() {
-      this.sendAction("update", Ember.assign({}, this.get("internalQuery")));
+      this.sendAction("update", assign({}, this.get("internalQuery")));
     }
   }
 });

--- a/packages/search/addon/components/cardstack-search.js
+++ b/packages/search/addon/components/cardstack-search.js
@@ -1,13 +1,16 @@
-import Ember from 'ember';
+import { observer, computed } from '@ember/object';
+import { warn } from '@ember/debug';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
 import layout from '../templates/components/cardstack-search';
 import { task } from 'ember-concurrency';
 import { singularize } from 'ember-inflector';
 import { timeout } from 'ember-concurrency';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   tagName: '',
-  store: Ember.inject.service(),
+  store: service(),
 
   search: task(function * (cursor, debounce) {
     if (debounce) {
@@ -20,7 +23,7 @@ export default Ember.Component.extend({
       return;
     }
     if (!query.type) {
-      Ember.warn("cardstack-search queries must have a `type`", false, { id: 'cardstack-search-needs-type' });
+      warn("cardstack-search queries must have a `type`", false, { id: 'cardstack-search-needs-type' });
       this.set('items', []);
       this.set('links', null);
     } else {
@@ -40,11 +43,11 @@ export default Ember.Component.extend({
     }
   }).on('init').restartable(),
 
-  research: Ember.observer('query', function() {
+  research: observer('query', function() {
     this.get('search').perform(null, true);
   }),
 
-  cursor: Ember.computed('links', function() {
+  cursor: computed('links', function() {
     let nextUrl = this.get('links.next');
     if (nextUrl) {
       return new URL(nextUrl).searchParams.get('page[cursor]');

--- a/packages/search/addon/templates/components/cardstack-query-editor.hbs
+++ b/packages/search/addon/templates/components/cardstack-query-editor.hbs
@@ -1,3 +1,3 @@
 <label>
-  Search terms: {{input value=internalQuery.queryString key-up="update" }}
+  Search terms: {{input value=internalQuery.queryString key-up=(action "update") }}
 </label>

--- a/packages/search/tests/dummy/app/adapters/pokemon.js
+++ b/packages/search/tests/dummy/app/adapters/pokemon.js
@@ -1,5 +1,5 @@
+import { assign } from '@ember/polyfills';
 import JSONAPIAdapter from 'ember-data/adapters/json-api';
-import Ember from 'ember';
 import RSVP from 'rsvp';
 
 const delay = 500;
@@ -23,7 +23,7 @@ export default JSONAPIAdapter.extend({
       }
       return true;
     }).map(p => {
-      let attributes = Ember.assign({}, p);
+      let attributes = assign({}, p);
       delete attributes.id;
       return {
         type: 'pokemons',

--- a/packages/search/tests/dummy/app/helpers/pretty-json.js
+++ b/packages/search/tests/dummy/app/helpers/pretty-json.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import { helper as buildHelper } from '@ember/component/helper';
 
 export function prettyJson([value]) {
   return JSON.stringify(value, null, 2);
 }
 
-export default Ember.Helper.helper(prettyJson);
+export default buildHelper(prettyJson);

--- a/packages/tools/addon/components/cardstack-header.js
+++ b/packages/tools/addon/components/cardstack-header.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../templates/components/cardstack-header';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   classNames: ['cardstack-header', 'cardstack-tools']
 });

--- a/packages/tools/addon/components/cardstack-modal-target.js
+++ b/packages/tools/addon/components/cardstack-modal-target.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../templates/components/cardstack-modal-target';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   classNames: ['cardstack-modal']
 });

--- a/packages/tools/addon/components/cardstack-toolbox.js
+++ b/packages/tools/addon/components/cardstack-toolbox.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
 import layout from '../templates/components/cardstack-toolbox';
 import injectOptional from 'ember-inject-optional';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   classNames: ['cardstack-toolbox', 'cardstack-tools', 'cardstack-toolbox-width'],
   cardstackRouting: injectOptional.service('cardstack-routing'),
-  tools: Ember.inject.service('cardstack-tools')
+  tools: service('cardstack-tools')
 });

--- a/packages/tools/addon/components/cardstack-tools-launcher.js
+++ b/packages/tools/addon/components/cardstack-tools-launcher.js
@@ -1,11 +1,13 @@
-import Ember from 'ember';
+import { alias } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
 import layout from '../templates/components/cardstack-tools-launcher';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
-  tools: Ember.inject.service('cardstack-tools'),
-  toolsAvailable: Ember.computed.alias('tools.available'),
-  active: Ember.computed.alias('tools.active'),
+  tools: service('cardstack-tools'),
+  toolsAvailable: alias('tools.available'),
+  active: alias('tools.active'),
   tagName: '',
   actions: {
     setActive(isActive) {

--- a/packages/tools/addon/components/cardstack-tools.js
+++ b/packages/tools/addon/components/cardstack-tools.js
@@ -1,8 +1,9 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
 import layout from '../templates/components/cardstack-tools';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   tagName: "",
-  tools: Ember.inject.service('cardstack-tools')
+  tools: service('cardstack-tools')
 });

--- a/packages/tools/addon/components/cs-account-icon.js
+++ b/packages/tools/addon/components/cs-account-icon.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-account-icon';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   tagName: ''
 });

--- a/packages/tools/addon/components/cs-active-composition-panel.js
+++ b/packages/tools/addon/components/cs-active-composition-panel.js
@@ -1,9 +1,9 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-active-composition-panel';
 import { task, timeout } from 'ember-concurrency';
 import scrollToBounds from '../scroll-to-bounds';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   classNames: ['cs-active-composition-panel'],
 

--- a/packages/tools/addon/components/cs-admin-launcher.js
+++ b/packages/tools/addon/components/cs-admin-launcher.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-admin-launcher';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   classNames: ['cs-admin-launcher'],
   menuOpen: false,

--- a/packages/tools/addon/components/cs-branch-control.js
+++ b/packages/tools/addon/components/cs-branch-control.js
@@ -1,18 +1,20 @@
-import Ember from 'ember';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-branch-control';
 import { defaultBranch } from '@cardstack/plugin-utils/environment';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   classNames: ['cs-branch-control'],
   classNameBindings: ['enabled'],
-  tools: Ember.inject.service('cardstack-tools'),
+  tools: service('cardstack-tools'),
 
-  enabled: Ember.computed('tools.branch', function() {
+  enabled: computed('tools.branch', function() {
     return !!this.get('tools.branch');
   }),
 
-  previewing: Ember.computed('enabled', 'tools.branch', function() {
+  previewing: computed('enabled', 'tools.branch', function() {
     return this.get('enabled') && defaultBranch !== this.get('tools.branch');
   }),
 

--- a/packages/tools/addon/components/cs-collapsible-section.js
+++ b/packages/tools/addon/components/cs-collapsible-section.js
@@ -8,10 +8,16 @@ export default Component.extend({
   animationRules,
 
   mouseEnter(event) {
-    this.sendAction('hovered', event);
+    let hovered = this.get('hovered');
+    if (hovered) {
+      hovered(event);
+    }
   },
   mouseLeave(event) {
-    this.sendAction('unhovered', event);
+    let unhovered = this.get('unhovered');
+    if (unhovered) {
+      unhovered(event);
+    }
   },
 
   actions: {

--- a/packages/tools/addon/components/cs-collapsible-section.js
+++ b/packages/tools/addon/components/cs-collapsible-section.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-collapsible-section';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   tagName: 'section',
   classNameBindings: ['opened:opened:closed'],

--- a/packages/tools/addon/components/cs-composition-panel.js
+++ b/packages/tools/addon/components/cs-composition-panel.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-composition-panel';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   tagName: '',
   actions: {

--- a/packages/tools/addon/components/cs-create-button.js
+++ b/packages/tools/addon/components/cs-create-button.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-create-button';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   tagName: '',
-  tools: Ember.inject.service('cardstack-tools'),
+  tools: service('cardstack-tools'),
   actions: {
     create() {
       this.get('tools').setActivePanel('cs-create-menu');

--- a/packages/tools/addon/components/cs-create-menu.js
+++ b/packages/tools/addon/components/cs-create-menu.js
@@ -1,17 +1,20 @@
-import Ember from 'ember';
+import { getOwner } from '@ember/application';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-create-menu';
 import { transitionTo } from '../private-api';
 import { task } from 'ember-concurrency';
 import injectOptional from 'ember-inject-optional';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   classNames: ['cs-create-menu'],
-  tools: Ember.inject.service('cardstack-tools'),
-  store: Ember.inject.service(),
+  tools: service('cardstack-tools'),
+  store: service(),
   cardstackRouting: injectOptional.service(),
 
-  availableTypes: Ember.computed(function() { return []; }),
+  availableTypes: computed(function() { return []; }),
 
   loadAvailableTypes: task(function * () {
     let types = yield this.get('store').query('content-type', { filter: { not: { 'is-built-in' : true } } });
@@ -21,7 +24,7 @@ export default Ember.Component.extend({
   actions: {
     create(which) {
       let { name, params, queryParams } = this.get('cardstackRouting').routeForNew(which.id, this.get('tools.branch'));
-      transitionTo(Ember.getOwner(this), name, params.map(p => p[1]), queryParams);
+      transitionTo(getOwner(this), name, params.map(p => p[1]), queryParams);
       this.get('tools').setActivePanel('cs-composition-panel');
       this.get('tools').setEditing(true);
     }

--- a/packages/tools/addon/components/cs-editor-switch.js
+++ b/packages/tools/addon/components/cs-editor-switch.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-editor-switch';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   classNames: ['cs-editor-switch'],
-  tools: Ember.inject.service('cardstack-tools'),
+  tools: service('cardstack-tools'),
   actions: {
     setEditing(value) {
       this.get('tools').setEditing(value);

--- a/packages/tools/addon/components/cs-field-editor.js
+++ b/packages/tools/addon/components/cs-field-editor.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-field-editor';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   tagName: ''
 });

--- a/packages/tools/addon/components/cs-field-overlays.js
+++ b/packages/tools/addon/components/cs-field-overlays.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-field-overlays';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   classNames: ['cardstack-tools'],
-  tools: Ember.inject.service('cardstack-tools'),
+  tools: service('cardstack-tools'),
   actions: {
     openField(which) {
       this.get('tools').openField(which);

--- a/packages/tools/addon/components/cs-mode-button.js
+++ b/packages/tools/addon/components/cs-mode-button.js
@@ -1,12 +1,13 @@
-import Ember from 'ember';
+import { not, alias } from '@ember/object/computed';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-mode-button';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   classNames: ['cs-mode-button'],
   classNameBindings: ['active', 'iconOnly'],
-  iconOnly: Ember.computed.not('mode.description'),
-  active: Ember.computed.alias('mode.active'),
+  iconOnly: not('mode.description'),
+  active: alias('mode.active'),
   click() {
     this.get('mode.makeActive')();
   }

--- a/packages/tools/addon/components/cs-mode-choices.js
+++ b/packages/tools/addon/components/cs-mode-choices.js
@@ -1,18 +1,21 @@
-import Ember from 'ember';
+import { capitalize } from '@ember/string';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-mode-choices';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   tagName: '',
-  tools: Ember.inject.service('cardstack-tools'),
+  tools: service('cardstack-tools'),
 
-  optionsKey: Ember.computed('for', function() {
+  optionsKey: computed('for', function() {
     return this.get('for') + 'Choices';
   }),
 
   actions: {
     activate(modeId) {
-      this.get('tools')[`set${Ember.String.capitalize(this.get('for'))}`](modeId);
+      this.get('tools')[`set${capitalize(this.get('for'))}`](modeId);
     }
   }
 

--- a/packages/tools/addon/components/cs-placeholder-composition-panel.js
+++ b/packages/tools/addon/components/cs-placeholder-composition-panel.js
@@ -1,17 +1,19 @@
-import Ember from 'ember';
+import { getOwner } from '@ember/application';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-placeholder-composition-panel';
 import injectOptional from 'ember-inject-optional';
 import { transitionTo } from '../private-api';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   cardstackRouting: injectOptional.service('cardstack-routing'),
-  tools: Ember.inject.service('cardstack-tools'),
+  tools: service('cardstack-tools'),
   actions: {
     create() {
       let { name, params, queryParams } = this.get('cardstackRouting').routeForNew(this.get('model.type'), this.get('tools.branch'));
       queryParams.routingId = this.get('model.slug');
-      transitionTo(Ember.getOwner(this), name, params.map(p => p[1]), queryParams);
+      transitionTo(getOwner(this), name, params.map(p => p[1]), queryParams);
       this.get('tools').setActivePanel('cs-composition-panel');
       this.get('tools').setEditing(true);
     }

--- a/packages/tools/addon/components/cs-toggle-switch.js
+++ b/packages/tools/addon/components/cs-toggle-switch.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-toggle-switch';
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   classNames: ['cs-toggle-switch'],
   classNameBindings: ['enabled::disabled'],

--- a/packages/tools/addon/components/cs-version-control.js
+++ b/packages/tools/addon/components/cs-version-control.js
@@ -1,4 +1,6 @@
-import Ember from 'ember';
+import { getOwner } from '@ember/application';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
 import layout from '../templates/components/cs-version-control';
 import { task } from 'ember-concurrency';
 import { transitionTo } from '../private-api';
@@ -6,13 +8,13 @@ import { modelType } from '@cardstack/rendering/helpers/cs-model-type';
 import { defaultBranch } from '@cardstack/plugin-utils/environment';
 import { computed } from "@ember/object";
 
-export default Ember.Component.extend({
+export default Component.extend({
   layout,
   tagName: '',
   opened: true,
   animationRules,
-  resourceMetadata: Ember.inject.service(),
-  store: Ember.inject.service(),
+  resourceMetadata: service(),
+  store: service(),
 
   modelMeta: computed('model', function() {
     return this.get('resourceMetadata').read(this.get('model'));
@@ -146,7 +148,7 @@ export default Ember.Component.extend({
     let model = this.get('model');
     let placeholder = { isCardstackPlaceholder: true, type: modelType(model), slug: model.get('slug') };
     if (model.get('isNew')) {
-      transitionTo(Ember.getOwner(this), 'cardstack.new-content', [placeholder]);
+      transitionTo(getOwner(this), 'cardstack.new-content', [placeholder]);
       return;
     }
     let branch = this.get('modelMeta.branch');
@@ -154,7 +156,7 @@ export default Ember.Component.extend({
     let route = this.get('cardstackRouting').routeFor(modelType(model), model.get('slug'), branch);
     yield this.get('model').destroyRecord();
     if (route) {
-      transitionTo(Ember.getOwner(this), route.name, [placeholder], route.queryParams);
+      transitionTo(getOwner(this), route.name, [placeholder], route.queryParams);
     }
   }),
 

--- a/packages/tools/addon/helpers/cs-exact-target.js
+++ b/packages/tools/addon/helpers/cs-exact-target.js
@@ -1,4 +1,4 @@
-import { helper } from 'ember-helper';
+import { helper } from '@ember/component/helper';
 import $ from 'jquery';
 
 export default helper(function([selector, handler]) {

--- a/packages/tools/addon/helpers/cs-model-title.js
+++ b/packages/tools/addon/helpers/cs-model-title.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { helper as buildHelper } from '@ember/component/helper';
 
 let defaults = [
   'title',
@@ -17,4 +17,4 @@ export function csModelTitle([model]) {
   }
 }
 
-export default Ember.Helper.helper(csModelTitle);
+export default buildHelper(csModelTitle);

--- a/packages/tools/addon/helpers/cs-svg.js
+++ b/packages/tools/addon/helpers/cs-svg.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
-const { htmlSafe } = Ember.String
+import { helper as buildHelper } from '@ember/component/helper';
+import { htmlSafe } from '@ember/string';
 
 function formatAttrs(attrs) {
   return Object.keys(attrs)
@@ -12,4 +12,4 @@ export function csSvg([name], hash) {
   return htmlSafe(`<svg ${formatAttrs(hash)}><use xlink:href="${'#' + name}"></use></svg>`);
 }
 
-export default Ember.Helper.helper(csSvg);
+export default buildHelper(csSvg);

--- a/packages/tools/addon/services/cardstack-tools.js
+++ b/packages/tools/addon/services/cardstack-tools.js
@@ -1,36 +1,39 @@
-import Ember from 'ember';
+import { getOwner } from '@ember/application';
+import { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
+import Service, { inject as service } from '@ember/service';
 import { transitionTo } from '../private-api';
 import { modelType } from '@cardstack/rendering/helpers/cs-model-type';
 import injectOptional from 'ember-inject-optional';
 import { defaultBranch } from '@cardstack/plugin-utils/environment';
 
-export default Ember.Service.extend({
-  overlays: Ember.inject.service('ember-overlays'),
-  resourceMetadata: Ember.inject.service(),
-  marks: Ember.computed.alias('overlays.marks'),
+export default Service.extend({
+  overlays: service('ember-overlays'),
+  resourceMetadata: service(),
+  marks: alias('overlays.marks'),
 
-  fields: Ember.computed('marks', function() {
+  fields: computed('marks', function() {
     return this.get('marks').filter(m => m.group === 'cardstack-fields');
   }),
 
-  contentPages: Ember.computed('marks', function() {
+  contentPages: computed('marks', function() {
     return this.get('marks').filter(m => m.group === 'cardstack-pages');
   }),
 
-  activeContentItem: Ember.computed('contentPages', function() {
+  activeContentItem: computed('contentPages', function() {
     return this.get('contentPages')[0];
   }),
 
-  _activeItemMeta: Ember.computed('activeContentItem', function() {
+  _activeItemMeta: computed('activeContentItem', function() {
     let model = this.get('activeContentItem.model')
     if (model) {
       return this.get('resourceMetadata').read(model);
     }
   }),
 
-  branch: Ember.computed.alias('_activeItemMeta.branch'),
+  branch: alias('_activeItemMeta.branch'),
 
-  activeFields: Ember.computed('activeContentItem', 'fields', function() {
+  activeFields: computed('activeContentItem', 'fields', function() {
     let item = this.get('activeContentItem');
     if (item) {
       return this.get('fields').filter(f => f.model.content === item.model);
@@ -41,7 +44,7 @@ export default Ember.Service.extend({
 
   // Can tools be enabled at all? This affects whether we will offer a
   // launcher button
-  available: Ember.computed('sessionService.session.isAuthenticated', function() {
+  available: computed('sessionService.session.isAuthenticated', function() {
     // If cardstack-session service is available, tools are only
     // available when the session is authenticated. Otherwise we
     // default to always available.
@@ -56,7 +59,7 @@ export default Ember.Service.extend({
 
   // Which tab are we showing in the toolbox?
   activePanel: 'cs-composition-panel',
-  activePanelChoices: Ember.computed(function() {
+  activePanelChoices: computed(function() {
     return [
       {
         id: 'cs-composition-panel',
@@ -72,7 +75,7 @@ export default Ember.Service.extend({
   // Are we viewing the current URL as a normal page in its own right,
   // or in one of its other forms (like a preview card)?
   previewFormat: 'page',
-  previewFormatChoices: Ember.computed(function() {
+  previewFormatChoices: computed(function() {
     return [
       {
         id: 'page',
@@ -98,8 +101,8 @@ export default Ember.Service.extend({
   requestedEditing: false,
 
   // This is a placeholder until I integrate the auth system here.
-  mayEditLive: Ember.computed(function() {
-    let { cardstack } = Ember.getOwner(this).resolveRegistration('config:environment');
+  mayEditLive: computed(function() {
+    let { cardstack } = getOwner(this).resolveRegistration('config:environment');
     if (cardstack && typeof cardstack.mayEditLive === 'boolean') {
       return cardstack.mayEditLive;
     } else {
@@ -107,7 +110,7 @@ export default Ember.Service.extend({
     }
   }),
 
-  editing: Ember.computed('requestedEditing', 'branch', function() {
+  editing: computed('requestedEditing', 'branch', function() {
     return this.get('requestedEditing') &&
       (this.get('mayEditLive') ||
        this.get('branch') !== defaultBranch);
@@ -177,7 +180,7 @@ export default Ember.Service.extend({
         args,
         queryParams
       } = this.get('cardstackRouting').routeFor(modelType(model), model.get('slug'), which);
-      transitionTo(Ember.getOwner(this), name, args, queryParams);
+      transitionTo(getOwner(this), name, args, queryParams);
     }
   },
 

--- a/packages/tools/tests/dummy/app/routes/application.js
+++ b/packages/tools/tests/dummy/app/routes/application.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
 });

--- a/packages/tools/tests/dummy/app/routes/posts/index.js
+++ b/packages/tools/tests/dummy/app/routes/posts/index.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     return this.store.findAll('post');
   }

--- a/packages/tools/tests/dummy/app/routes/posts/show.js
+++ b/packages/tools/tests/dummy/app/routes/posts/show.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model({ id }) {
     return this.store.findRecord('post', id);
   }

--- a/packages/tools/tests/integration/components/cardstack-tools-launcher-test.js
+++ b/packages/tools/tests/integration/components/cardstack-tools-launcher-test.js
@@ -1,14 +1,15 @@
+import { run } from '@ember/runloop';
+import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
 
 module('Integration | Component | cardstack tools launcher', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
-    this.owner.register('service:cardstack-tools', Ember.Service.extend({
+    this.owner.register('service:cardstack-tools', Service.extend({
       available: true,
       active: false,
       setActive(value) {
@@ -45,7 +46,7 @@ module('Integration | Component | cardstack tools launcher', function(hooks) {
 
   test('clicking icon toggles tools', async function(assert) {
     await render(hbs`{{cardstack-tools-launcher}}`);
-    Ember.run(() => {
+    run(() => {
       this.$('svg').click();
     });
     assert.equal(this.$('svg.active').length, 1, "found active icon");

--- a/packages/tools/tests/integration/components/cs-branch-control-test.js
+++ b/packages/tools/tests/integration/components/cs-branch-control-test.js
@@ -1,14 +1,15 @@
+import { run } from '@ember/runloop';
+import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
 
 module('Integration | Component | cs branch control', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
-    this.owner.register('service:cardstack-tools', Ember.Service.extend({
+    this.owner.register('service:cardstack-tools', Service.extend({
       branch: 'master',
       init() {
         this._super();
@@ -35,7 +36,7 @@ module('Integration | Component | cs branch control', function(hooks) {
 
   test('it enters preview', async function(assert) {
     await render(hbs`{{cs-branch-control}}`);
-    Ember.run(() => {
+    run(() => {
       this.$('button:contains(Preview)').click();
     });
     assert.deepEqual(this.get('tools.branchSets'), ['draft']);
@@ -45,7 +46,7 @@ module('Integration | Component | cs branch control', function(hooks) {
   test('it enters live', async function(assert) {
     this.get('tools').set('branch', 'b');
     await render(hbs`{{cs-branch-control}}`);
-    Ember.run(() => {
+    run(() => {
       this.$('button:contains(Live)').click();
     });
     assert.deepEqual(this.get('tools.branchSets'), ['master']);

--- a/packages/tools/tests/integration/components/cs-field-editor-test.js
+++ b/packages/tools/tests/integration/components/cs-field-editor-test.js
@@ -1,9 +1,9 @@
+import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import DS from 'ember-data';
-import Ember from 'ember';
 
 module('Integration | Component | cs field editor', function(hooks) {
   setupRenderingTest(hooks);
@@ -27,7 +27,7 @@ module('Integration | Component | cs field editor', function(hooks) {
   });
 
   test('it renders correct field editor based on attr transform type', async function(assert) {
-    Ember.run(() => {
+    run(() => {
       this.set('model', this.get('store').createRecord('example'));
     });
     await render(hbs`{{cs-field-editor content=model field="title" }}`);
@@ -35,7 +35,7 @@ module('Integration | Component | cs field editor', function(hooks) {
   });
 
   test('it renders correct field editor based on custom fieldType annotation', async function(assert) {
-    Ember.run(() => {
+    run(() => {
       this.set('model', this.get('store').createRecord('example'));
     });
     await render(hbs`{{cs-field-editor content=model field="score" }}`);
@@ -43,7 +43,7 @@ module('Integration | Component | cs field editor', function(hooks) {
   });
 
   test('it passes content and field name to editor', async function(assert) {
-    Ember.run(() => {
+    run(() => {
       this.set('model', this.get('store').createRecord('example', { echo: 'woohoo' }));
     });
     await render(hbs`{{cs-field-editor content=model field="echo" }}`);
@@ -51,7 +51,7 @@ module('Integration | Component | cs field editor', function(hooks) {
   });
 
   test('it passes enabled state to editor', async function(assert) {
-    Ember.run(() => {
+    run(() => {
       this.set('model', this.get('store').createRecord('example', { echo: 'woohoo' }));
     });
     this.set('enabled', true);

--- a/packages/tools/tests/integration/components/cs-mode-choices-test.js
+++ b/packages/tools/tests/integration/components/cs-mode-choices-test.js
@@ -1,19 +1,21 @@
+import { run } from '@ember/runloop';
+import { computed } from '@ember/object';
+import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
 
 module('Integration | Component | cs mode choices', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
-    this.owner.register('service:cardstack-tools', Ember.Service.extend({
+    this.owner.register('service:cardstack-tools', Service.extend({
 
       // This is the basic protocol required by cs-mode-choices: a
       // property to control, choices, and a setter function:
       favoriteColor: 'blue',
-      favoriteColorChoices: Ember.computed(function() {
+      favoriteColorChoices: computed(function() {
         return [
           { id: 'blue', description: 'Blue' },
           { id: 'red', description: 'Red' }
@@ -47,7 +49,7 @@ module('Integration | Component | cs mode choices', function(hooks) {
         </section>
       {{/cs-mode-choices}}
     `);
-    Ember.run(() => this.$('.cs-mode-button:contains(Red)').click());
+    run(() => this.$('.cs-mode-button:contains(Red)').click());
     assert.equal(this.get('tools.favoriteColor'), 'red');
   });
 });

--- a/packages/tools/tests/integration/components/cs-version-control-test.js
+++ b/packages/tools/tests/integration/components/cs-version-control-test.js
@@ -1,8 +1,9 @@
+import { run } from '@ember/runloop';
+import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
 import DS from 'ember-data';
 
 let model;
@@ -15,7 +16,7 @@ module('Integration | Component | cs version control', function(hooks) {
     // looking for its metadata, and ember-resource-metadata works
     // through ember-data's identity map.
     this.owner.register('model:thing', DS.Model.extend());
-    model = Ember.Object.create({
+    model = EmberObject.create({
       id: 1,
       type: 'thing'
     });
@@ -50,7 +51,7 @@ module('Integration | Component | cs version control', function(hooks) {
     model.set('hasDirtyFields', true);
     model.set('isNew', false);
     await render(hbs`{{cs-version-control model=model enabled=true}}`);
-    Ember.run(() => {
+    run(() => {
       this.$('.cs-version-control-footer button').click();
     });
   });
@@ -63,7 +64,7 @@ module('Integration | Component | cs version control', function(hooks) {
     model.set('hasDirtyFields', false);
     model.set('isNew', false);
     await render(hbs`{{cs-version-control model=model enabled=true}}`);
-    Ember.run(() => {
+    run(() => {
       this.$('.cs-version-control-footer button').click();
     });
   });

--- a/packages/workflow/addon/components/cardstack-workflow-launcher.js
+++ b/packages/workflow/addon/components/cardstack-workflow-launcher.js
@@ -1,13 +1,13 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import { readOnly } from '@ember/object/computed';
+import Component from '@ember/component';
 import layout from '../templates/components/cardstack-workflow-launcher';
-
-const { Component, inject, computed } = Ember;
 
 export default Component.extend({
   layout,
   tagName: "",
   classNames: ['cardstack-workflow-launcher'],
-  workflow: inject.service('cardstack-workflow'),
-  notificationCount: computed.readOnly('workflow.notificationCount'),
+  workflow: service('cardstack-workflow'),
+  notificationCount: readOnly('workflow.notificationCount'),
 
 });

--- a/packages/workflow/addon/helpers/workflow-group-id.js
+++ b/packages/workflow/addon/helpers/workflow-group-id.js
@@ -1,8 +1,8 @@
-import Ember from 'ember';
+import { helper as buildHelper } from '@ember/component/helper';
 
 export function workflowGroupId(params) {
   let [priority, tag] = params;
   return `${priority}::${tag}`;
 }
 
-export default Ember.Helper.helper(workflowGroupId);
+export default buildHelper(workflowGroupId);

--- a/packages/workflow/addon/models/thread.js
+++ b/packages/workflow/addon/models/thread.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { A } from '@ember/array';
 import Thread from '@cardstack/models/generated/thread';
 import { task } from 'ember-concurrency';
 import { computed } from "@ember/object"
@@ -17,7 +17,7 @@ export default Thread.extend({
   tags: computed('_syncedMessages.[]', {
     get() {
       this.get('loadTags').perform();
-      return Ember.A();
+      return A();
     },
     set(k, v) {
       return v;
@@ -62,7 +62,7 @@ export default Thread.extend({
   _syncedMessages: computed({
     get() {
       this.get('_loadMessages').perform();
-      return Ember.A();
+      return A();
     },
     set(k,v) {
       return v;

--- a/packages/workflow/tests/dummy/app/routes/index.js
+++ b/packages/workflow/tests/dummy/app/routes/index.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
 });

--- a/packages/workflow/tests/integration/components/cardstack-workflow-launcher-test.js
+++ b/packages/workflow/tests/integration/components/cardstack-workflow-launcher-test.js
@@ -1,8 +1,8 @@
+import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
 
 module('Integration | Component | cardstack-workflow-launcher', function(hooks) {
   setupRenderingTest(hooks);
@@ -13,7 +13,7 @@ module('Integration | Component | cardstack-workflow-launcher', function(hooks) 
   });
 
   hooks.beforeEach(function() {
-    this.owner.register('service:cardstack-workflow', Ember.Service.extend({
+    this.owner.register('service:cardstack-workflow', Service.extend({
       notificationCount: 3
     }));
     this.workflow = this.owner.lookup('service:cardstack-workflow');


### PR DESCRIPTION
This turns on the last two new eslint rules that are part of ember-cli's defaults. I skipped them earlier to keep the size of PRs more manageable. Most of these changes were automated by ember-modules-codemod.