### PR TITLE
new static-models feature

### DIFF
--- a/packages/hub/indexers.js
+++ b/packages/hub/indexers.js
@@ -64,7 +64,7 @@ class Indexers extends EventEmitter {
   async schemaForBranch(branch) {
     if (!this._schemaCache) {
       this._schemaCache = (async () => {
-        let running = new RunningIndexers(await this._seedSchema(), await this._client(), this.emit.bind(this));
+        let running = new RunningIndexers(await this._seedSchema(), await this._client(), this.emit.bind(this), this.schemaLoader.ownTypes());
         try {
           return await running.schemas();
         } finally {
@@ -174,7 +174,7 @@ class Indexers extends EventEmitter {
   async _doUpdate(forceRefresh, hints) {
     log.debug('begin update, forceRefresh=%s', forceRefresh);
     let priorCache = this._schemaCache;
-    let running = new RunningIndexers(await this._seedSchema(), await this._client(), this.emit.bind(this));
+    let running = new RunningIndexers(await this._seedSchema(), await this._client(), this.emit.bind(this), this.schemaLoader.ownTypes());
     try {
       let schemas = await running.update(forceRefresh, hints);
       if (this._schemaCache === priorCache) {

--- a/packages/hub/indexing/branch-update.js
+++ b/packages/hub/indexing/branch-update.js
@@ -21,17 +21,25 @@ class BranchUpdate {
     this.read = this.read.bind(this);
   }
 
-  async addIndexer(indexer) {
+  async addDataSource(dataSource) {
     if (this._schema) {
       throw new Error("Bug in hub indexing. Something tried to add an indexer after we had already established the schema");
     }
+    let indexer = dataSource.indexer;
+    if (!indexer) {
+      return [];
+    }
     let updater = await indexer.beginUpdate(this.branch);
-    let dataSource = owningDataSource.get(indexer);
     owningDataSource.set(updater, dataSource);
     let newModels = await updater.schema();
     this.schemaModels.push(newModels);
     this.updaters[dataSource.id] = updater;
     return newModels;
+  }
+
+  addStaticModels(schemaModels, allModels) {
+    this.schemaModels = this.schemaModels.concat(schemaModels);
+    this.updaters['static-models'].staticModels = allModels;
   }
 
   async schema() {
@@ -258,4 +266,3 @@ class BranchUpdate {
 }
 
 exports.BranchUpdate = BranchUpdate;
-exports.owningDataSource = owningDataSource;

--- a/packages/hub/node-tests/static-indexer-test.js
+++ b/packages/hub/node-tests/static-indexer-test.js
@@ -1,0 +1,41 @@
+const JSONAPIFactory = require('../../../tests/stub-static-models/node_modules/@cardstack/test-support/jsonapi-factory');
+const {
+  createDefaultEnvironment,
+  destroyDefaultEnvironment
+} = require('../../../tests/stub-static-models/node_modules/@cardstack/test-support/env');
+const project = __dirname + '/../../../tests/stub-static-models';
+
+describe('static-indexer', function() {
+  let factory, env;
+
+  beforeEach(async function() {
+    factory = new JSONAPIFactory();
+    factory.addResource('data-sources').withAttributes({
+      'source-type': 'data-source-with-static',
+      params: {
+        otherThing2Title: 'chocolate cake'
+      }
+    });
+  });
+
+  afterEach(async function() {
+    await destroyDefaultEnvironment(env);
+  });
+
+  it('can rely on schema from static content', async function() {
+    factory.addResource('my-things', '1');
+    env = await createDefaultEnvironment(project, factory.getModels());
+  });
+
+  it('can rely on static content', async function() {
+    env = await createDefaultEnvironment(project, factory.getModels());
+    await env.lookup('hub:searchers').get(env.session, 'master', 'other-things', '2');
+  });
+
+  it('has access to data source params', async function() {
+    env = await createDefaultEnvironment(project, factory.getModels());
+    let thing = await env.lookup('hub:searchers').get(env.session, 'master', 'other-things', '2');
+    expect(thing).has.deep.property('data.attributes.title', 'chocolate cake');
+  });
+
+});

--- a/packages/hub/plugin-loader.js
+++ b/packages/hub/plugin-loader.js
@@ -20,6 +20,7 @@ const featureTypes = [
   'writers',
   'searchers',
   'indexers',
+  'static-models',
   'authenticators',
   'middleware',
   'messengers',

--- a/packages/hub/schema/data-source.js
+++ b/packages/hub/schema/data-source.js
@@ -14,7 +14,9 @@ module.exports = class DataSource {
     this._searcher = null;
     this._Authenticator = plugins.lookupFeatureFactory('authenticators', this.sourceType);
     this._authenticator = null;
-    if (!this._Writer && !this._Indexer && !this._Searcher && !this._Authenticator) {
+    this._StaticModels = plugins.lookupFeatureFactory('static-models', this.sourceType);
+    this._staticModels = null;
+    if (!this._Writer && !this._Indexer && !this._Searcher && !this._Authenticator && !this._StaticModels) {
       throw new Error(`${this.sourceType} is either missing or does not appear to be a valid data source plugin`);
     }
     this.mayCreateUser = !!model.attributes['may-create-user'];
@@ -46,6 +48,16 @@ module.exports = class DataSource {
       this._authenticator = this._Authenticator.create(this._params);
     }
     return this._authenticator;
+  }
+  get staticModels() {
+    if (!this._staticModels) {
+      if (this._StaticModels) {
+        this._staticModels = this._StaticModels.class.call(null, this._params);
+      } else {
+        this._staticModels = [];
+      }
+    }
+    return this._staticModels;
   }
   async teardown() {
     if (this._writer && typeof this._writer.teardown === 'function') {

--- a/tests/stub-static-models/node_modules/@cardstack/test-support
+++ b/tests/stub-static-models/node_modules/@cardstack/test-support
@@ -1,0 +1,1 @@
+../../../../packages/test-support

--- a/tests/stub-static-models/node_modules/data-source-with-static/package.json
+++ b/tests/stub-static-models/node_modules/data-source-with-static/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "data-source-with-static",
+  "keywords": ["cardstack-plugin"],
+  "cardstack-plugin": {
+    "api-version": 1
+  }
+}

--- a/tests/stub-static-models/node_modules/data-source-with-static/static-model.js
+++ b/tests/stub-static-models/node_modules/data-source-with-static/static-model.js
@@ -1,0 +1,36 @@
+module.exports = function(params) {
+  return [
+    {
+      type: 'content-types',
+      id: 'my-things',
+      relationships: {
+        fields: {
+          data: []
+        }
+      }
+    },
+    {
+      type: 'content-types',
+      id: 'other-things',
+      relationships: {
+        fields: {
+          data: [{ type: 'fields', id: 'title-of-thing'}]
+        }
+      }
+    },
+    {
+      type: 'fields',
+      id: 'title-of-thing',
+      attributes: {
+        'field-type': '@cardstack/core-types::string'
+      }
+    },
+    {
+      type: 'other-things',
+      id: '2',
+      attributes: {
+        title: params.otherThing2Title
+      }
+    }
+  ];
+};

--- a/tests/stub-static-models/package.json
+++ b/tests/stub-static-models/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "stub-static-models",
+  "keywords": ["cardstack-plugin"],
+  "cardstack-plugin": {
+    "api-version": 1
+  },
+  "dependencies": {
+    "data-source-with-static" : "*"
+  },
+  "devDependencies": {
+    "@cardstack/test-support": "*"
+  },
+  "engines": {
+    "node": ">= 8"
+  }
+}


### PR DESCRIPTION
Data sources often need to add some models (typically new content-types and fields) for their own use. For example, the github-auth data source can provide a github-users content type and its fields, so that you can have a working setup out of the box.

Up until now, it was possible to do this by implementing an Indexer, but that has two downsides:

 - it has quite a lot of boilerplate to index what is effectively static content that won't change during the lifetime of a configured data source
 - I'm about to begin locking down more precisely which content-types are assigned to which data sources, and I'd prefer not to assign the `content-types` content-type to every data source that just happens to want to introduce a little bit of schema for itself.

Here I address these issues by creating a new plugin feature named static-models. This lets a data source declaratively add any content it needs to, based solely on the data source's configuration. The models that it exports are owned by the hub's built-in static-models data source, which allows the plugin to focus instead on indexer its own actual content, not its "meta" content.