### PR TITLE
use field type for indexed mappings based on ABI

### DIFF
--- a/packages/ethereum/cardstack/indexer.js
+++ b/packages/ethereum/cardstack/indexer.js
@@ -169,15 +169,19 @@ class Updater {
       if (!branch || !type || !id || !contract || isContractType) { continue; }
 
       let contractAddress = this.contracts[contract].addresses[branch];
-      let data = await this.ethereumService.getContractInfoFromHint({ id, type, branch, contract });
+      let { data, methodName } = await this.ethereumService.getContractInfoFromHint({ id, type, branch, contract });
+      let methodAbiEntry = this.contracts[contract]["abi"].find(item => item.type === 'function' &&
+                                                                        item.constant &&
+                                                                        item.name === methodName);
+      let fieldName = this._fieldTypeFor(contract, methodAbiEntry);
       let model = {
         type,
         attributes: {
-          'ethereum-address': id, // preserve the case of the ID here to faithfully represent EIP-55 encoding
-          'mapping-number-value': data,
+          'ethereum-address': id // preserve the case of the ID here to faithfully represent EIP-55 encoding
         },
         relationships: {}
       };
+      model.attributes[fieldName] = data;
       model.relationships[`${contract}-contract`] = {
         data: { id: contractAddress, type: pluralize(contract) }
       };

--- a/packages/ethereum/cardstack/service.js
+++ b/packages/ethereum/cardstack/service.js
@@ -181,20 +181,20 @@ class EthereumService {
     }
 
     let aContract = this._contracts[branch][contract];
-    let contractMethod;
+    let methodName;
     if (typeof aContract.methods[method] === 'function') {
-      contractMethod = aContract.methods[method];
+      methodName = method;
     } else if (typeof aContract.methods[singularize(method)] === 'function') {
-      contractMethod = aContract.methods[singularize(method)];
+      methodName = singularize(method);
     } else if (typeof aContract.methods[capitalize(method)] === 'function') {
-      contractMethod = aContract.methods[capitalize(method)];
+      methodName = capitalize(method);
     } else if (typeof aContract.methods[singularize(capitalize(method))] === 'function') {
-      contractMethod = aContract.methods[singularize(capitalize(method))];
+      methodName = singularize(capitalize(method));
     }
 
-    let contractInfo = await contractMethod(id).call();
-    log.debug(`retrieved contract data for contract ${contract}.${method}(${id || ''}): ${contractInfo}`);
-    return contractInfo;
+    let data = await aContract.methods[methodName](id).call();
+    log.debug(`retrieved contract data for contract ${contract}.${methodName}(${id || ''}): ${data}`);
+    return { data, methodName };
   }
 
   async getPastEventsAsHints() {

--- a/packages/ethereum/contracts/SampleToken.sol
+++ b/packages/ethereum/contracts/SampleToken.sol
@@ -10,6 +10,78 @@ import "./zeppelin/MintableToken.sol";
 contract SampleToken is MintableToken {
   string public name = "SampleToken";
   string public symbol = "TOK";
+  uint256 public balanceLimit;
+
+  mapping (address => uint256) public customBuyerLimit;
+  mapping (address => bool) public approvedBuyer;
+
+  mapping (address => uint256) vestingStartDate;
+  mapping (address => uint256) vestingCliffDate;
+  mapping (address => uint256) vestingDurationSec;
+  mapping (address => uint256) vestingFullyVestedAmount;
+  mapping (address => uint256) vestingRevokeDate;
+  mapping (address => bool) vestingIsRevocable;
+
+  event WhiteList(address indexed buyer, uint256 holdCap);
+  event VestedTokenGrant(address indexed beneficiary, uint256 startDate, uint256 cliffSec, uint256 durationSec, uint256 fullyVestedAmount, uint256 revokeDate, bool isRevocable);
 
   function fund() payable public { }
+
+  function setBalanceLimit(uint256 _balanceLimit) onlyOwner public returns (bool) {
+    balanceLimit = _balanceLimit;
+  }
+
+  function setCustomBuyer(address buyer, uint256 _balanceLimit) onlyOwner public returns (bool) {
+    customBuyerLimit[buyer] = _balanceLimit;
+    addBuyer(buyer);
+
+    return true;
+  }
+
+  function addBuyer(address buyer) onlyOwner public returns (bool) {
+    approvedBuyer[buyer] = true;
+
+    uint256 _balanceLimit = customBuyerLimit[buyer];
+    if (_balanceLimit == 0) {
+      _balanceLimit = balanceLimit;
+    }
+
+    WhiteList(buyer, _balanceLimit);
+
+    return true;
+  }
+
+  function grantVestedTokens(address beneficiary,
+                             uint256 fullyVestedAmount,
+                             uint256 startDate,
+                             uint256 cliffSec,
+                             uint256 durationSec,
+                             uint256 revokeDate,
+                             bool isRevocable) onlyOwner public returns(bool) {
+    vestingStartDate[beneficiary] = startDate;
+    vestingCliffDate[beneficiary] = cliffSec;
+    vestingDurationSec[beneficiary] = durationSec;
+    vestingFullyVestedAmount[beneficiary] = fullyVestedAmount;
+    vestingRevokeDate[beneficiary] = revokeDate;
+    vestingIsRevocable[beneficiary] = isRevocable;
+
+    VestedTokenGrant(beneficiary, startDate, cliffSec, durationSec, fullyVestedAmount, revokeDate, isRevocable);
+
+    return true;
+  }
+
+  function vestingSchedule(address beneficiary) public
+                                                view returns (uint256 startDate,
+                                                              uint256 cliffDate,
+                                                              uint256 durationSec,
+                                                              uint256 fullyVestedAmount,
+                                                              uint256 revokeDate,
+                                                              bool isRevocable) {
+    startDate = vestingStartDate[beneficiary];
+    cliffDate = vestingCliffDate[beneficiary];
+    durationSec = vestingDurationSec[beneficiary];
+    fullyVestedAmount = vestingFullyVestedAmount[beneficiary];
+    revokeDate = vestingRevokeDate[beneficiary];
+    isRevocable = vestingIsRevocable[beneficiary];
+  }
 }

--- a/packages/hub/util/bin-utils.js
+++ b/packages/hub/util/bin-utils.js
@@ -3,7 +3,6 @@
 const commander = require('commander');
 const path = require('path');
 const fs = require('fs');
-const crypto = require('crypto');
 
 const testingToken = require('crypto').randomBytes(32).toString('base64').replace(/\W+/g, '');
 const seedsFolder = 'seeds';


### PR DESCRIPTION
Fixes #162
When indexing a mapping entry for a contract, use the field type for the mapping based on the ABI for the contract method instead of hard coded number field type.