### PR TITLE
Fixes #162 use mapping field type based on ABI of contract & Fixes #163 handle multiple return values

### DIFF
--- a/packages/ethereum/cardstack/indexer.js
+++ b/packages/ethereum/cardstack/indexer.js
@@ -169,15 +169,19 @@ class Updater {
       if (!branch || !type || !id || !contract || isContractType) { continue; }
 
       let contractAddress = this.contracts[contract].addresses[branch];
-      let data = await this.ethereumService.getContractInfoFromHint({ id, type, branch, contract });
+      let { data, methodName } = await this.ethereumService.getContractInfoFromHint({ id, type, branch, contract });
+      let methodAbiEntry = this.contracts[contract]["abi"].find(item => item.type === 'function' &&
+                                                                        item.constant &&
+                                                                        item.name === methodName);
+      let fieldName = this._fieldTypeFor(contract, methodAbiEntry);
       let model = {
         type,
         attributes: {
-          'ethereum-address': id, // preserve the case of the ID here to faithfully represent EIP-55 encoding
-          'mapping-number-value': data,
+          'ethereum-address': id // preserve the case of the ID here to faithfully represent EIP-55 encoding
         },
         relationships: {}
       };
+      model.attributes[fieldName] = data;
       model.relationships[`${contract}-contract`] = {
         data: { id: contractAddress, type: pluralize(contract) }
       };

--- a/packages/ethereum/cardstack/indexer.js
+++ b/packages/ethereum/cardstack/indexer.js
@@ -173,7 +173,9 @@ class Updater {
       let methodAbiEntry = this.contracts[contract]["abi"].find(item => item.type === 'function' &&
                                                                         item.constant &&
                                                                         item.name === methodName);
-      let fieldName = this._fieldTypeFor(contract, methodAbiEntry);
+      let { isMapping, fields } = this._fieldTypeFor(contract, methodAbiEntry);
+      if (!isMapping || !fields.length) { continue; }
+
       let model = {
         type,
         attributes: {
@@ -181,7 +183,17 @@ class Updater {
         },
         relationships: {}
       };
-      model.attributes[fieldName] = data;
+
+      if (typeof data === "object") {
+        for (let returnName of Object.keys(data)) {
+          let fieldName = `${dasherize(methodName)}-${dasherize(returnName)}`;
+          if (!fields.find(field => field.name === fieldName)) { continue; }
+          model.attributes[fieldName] = data[returnName];
+        }
+      } else {
+        model.attributes[fields[0].name] = data;
+      }
+
       model.relationships[`${contract}-contract`] = {
         data: { id: contractAddress, type: pluralize(contract) }
       };
@@ -201,6 +213,28 @@ class Updater {
     }
   }
 
+  _namedFieldFor(fieldName, type) {
+    let fieldType;
+    switch(type) {
+      // Using strings to represent uint256, as the max int
+      // int in js is 2^53, vs 2^256 in solidity
+      case 'boolean':
+        fieldType = '@cardstack/core-types::boolean';
+        break;
+      case 'number':
+      case 'string':
+      default:
+        fieldType = '@cardstack/core-types::string';
+    }
+    return {
+      type: 'fields',
+      id: fieldName,
+      attributes: {
+        "field-type": fieldType
+      }
+    };
+  }
+
   _belongsToFieldFor(contractName) {
     return {
       type: 'fields',
@@ -218,7 +252,7 @@ class Updater {
     };
   }
 
-  _mappingFieldFor(contractName, fieldName, valueType) {
+  _mappingFieldFor(contractName, fieldName, fields) {
     return {
       type: "content-types",
       id: pluralize(`${contractName}-${dasherize(fieldName)}`),
@@ -226,9 +260,10 @@ class Updater {
         fields: {
           data: [
             { type: "fields", id: "ethereum-address" },
-            { type: "fields", id: valueType },
             { type: "fields", id: contractName + "-contract" }
-          ]
+          ].concat(fields.map(field => {
+            return { type: "fields", id: field.name };
+          }))
         },
         'data-source': {
           data: { type: 'data-sources', id: this.dataSourceId.toString() }
@@ -263,25 +298,32 @@ class Updater {
     let customTypes = [];
     abi.forEach(item => {
       if (item.type === "function" && item.constant) {
-        let type = this._fieldTypeFor(contractName, item);
-        if (!type) { return; }
+        let fieldInfo = this._fieldTypeFor(contractName, item);
+        if (!fieldInfo) { return; }
+        let { isMapping, fields:nestedFields } = fieldInfo;
 
         let field = {
           type: "fields",
           id: `${contractName}-${dasherize(item.name)}`,
         };
 
-        if (type.indexOf("@") > -1) {
-          field.attributes = { "field-type": type };
+        if (!isMapping && nestedFields.length === 1) {
+          field.attributes = { "field-type": nestedFields[0]["type"] };
           fields.push(field);
         }
 
-        if (type.indexOf('mapping') > -1) {
+        if (isMapping) {
+          for (let mappingField of nestedFields) {
+            if (!mappingField.isNamedField) { continue; }
+            customTypes.push(this._namedFieldFor(mappingField.name, mappingField.type));
+          }
+
           let relatedField = this._belongsToFieldFor(contractName);
           if (!customTypes.find(field => field.id === relatedField.id)) {
             customTypes.push(relatedField);
           }
-          let mappingField = this._mappingFieldFor(contractName, item.name, type);
+
+          let mappingField = this._mappingFieldFor(contractName, item.name, nestedFields);
           if (!customTypes.find(field => field.id === mappingField.id)) {
             customTypes.push(mappingField);
             customTypes.push(this._openGrantForContentType(`${contractName}-${dasherize(item.name)}`));
@@ -296,32 +338,50 @@ class Updater {
   _fieldTypeFor(contractName, abiItem) {
     if (!abiItem.outputs || !abiItem.outputs.length) { return; }
 
-
     if (!abiItem.inputs.length) {
+      // We are not handling multiple return types for non-mapping functions
+      // unclear what that would actually look like in the schema...
       switch(abiItem.outputs[0].type) {
-          // Using strings to represent uint256, as the max int
-          // int in js is 2^53, vs 2^256 in solidity
+        // Using strings to represent uint256, as the max int
+        // int in js is 2^53, vs 2^256 in solidity
         case 'uint256':
         case 'bytes32':
         case 'string':
         case 'address':
-          return '@cardstack/core-types::string';
+          return { fields: [{ type: '@cardstack/core-types::string' }]};
         case 'bool':
-          return '@cardstack/core-types::boolean';
+          return { fields: [{ type: '@cardstack/core-types::boolean' }]};
       }
     // deal with just mappings that use address as a key for now
     } else if (abiItem.inputs.length === 1 && abiItem.inputs[0].type === "address") {
-      switch(abiItem.outputs[0].type) {
-        case 'uint256':
-          return `mapping-number-value`;
-        case 'bool':
-          return `mapping-boolean-value`;
-        case 'bytes32':
-        case 'string':
-        case 'address':
-        default:
-          return `mapping-string-value`;
-      }
+      return {
+        isMapping: true,
+        fields: abiItem.outputs.map(output => {
+          let name, type, isNamedField;
+          if (output.name && abiItem.outputs.length > 1) {
+            name = `${dasherize(abiItem.name)}-${dasherize(output.name)}`;
+            isNamedField = true;
+          }
+          switch(output.type) {
+            case 'uint256':
+              name = name || `mapping-number-value`;
+              type = 'number';
+              break;
+            case 'bool':
+              name = name || `mapping-boolean-value`;
+              type = 'boolean';
+              break;
+            case 'bytes32':
+            case 'string':
+            case 'address':
+            default:
+              name = name || `mapping-string-value`;
+              type = 'string';
+          }
+
+          return { name, type, isNamedField };
+        })
+      };
     }
   }
 

--- a/packages/ethereum/cardstack/service.js
+++ b/packages/ethereum/cardstack/service.js
@@ -181,20 +181,20 @@ class EthereumService {
     }
 
     let aContract = this._contracts[branch][contract];
-    let contractMethod;
+    let methodName;
     if (typeof aContract.methods[method] === 'function') {
-      contractMethod = aContract.methods[method];
+      methodName = method;
     } else if (typeof aContract.methods[singularize(method)] === 'function') {
-      contractMethod = aContract.methods[singularize(method)];
+      methodName = singularize(method);
     } else if (typeof aContract.methods[capitalize(method)] === 'function') {
-      contractMethod = aContract.methods[capitalize(method)];
+      methodName = capitalize(method);
     } else if (typeof aContract.methods[singularize(capitalize(method))] === 'function') {
-      contractMethod = aContract.methods[singularize(capitalize(method))];
+      methodName = singularize(capitalize(method));
     }
 
-    let contractInfo = await contractMethod(id).call();
-    log.debug(`retrieved contract data for contract ${contract}.${method}(${id || ''}): ${contractInfo}`);
-    return contractInfo;
+    let data = await aContract.methods[methodName](id).call();
+    log.debug(`retrieved contract data for contract ${contract}.${methodName}(${id || ''}): ${data}`);
+    return { data, methodName };
   }
 
   async getPastEventsAsHints() {

--- a/packages/ethereum/contracts/SampleToken.sol
+++ b/packages/ethereum/contracts/SampleToken.sol
@@ -10,6 +10,78 @@ import "./zeppelin/MintableToken.sol";
 contract SampleToken is MintableToken {
   string public name = "SampleToken";
   string public symbol = "TOK";
+  uint256 public balanceLimit;
+
+  mapping (address => uint256) public customBuyerLimit;
+  mapping (address => bool) public approvedBuyer;
+
+  mapping (address => uint256) vestingStartDate;
+  mapping (address => uint256) vestingCliffDate;
+  mapping (address => uint256) vestingDurationSec;
+  mapping (address => uint256) vestingFullyVestedAmount;
+  mapping (address => uint256) vestingRevokeDate;
+  mapping (address => bool) vestingIsRevocable;
+
+  event WhiteList(address indexed buyer, uint256 holdCap);
+  event VestedTokenGrant(address indexed beneficiary, uint256 startDate, uint256 cliffSec, uint256 durationSec, uint256 fullyVestedAmount, uint256 revokeDate, bool isRevocable);
 
   function fund() payable public { }
+
+  function setBalanceLimit(uint256 _balanceLimit) onlyOwner public returns (bool) {
+    balanceLimit = _balanceLimit;
+  }
+
+  function setCustomBuyer(address buyer, uint256 _balanceLimit) onlyOwner public returns (bool) {
+    customBuyerLimit[buyer] = _balanceLimit;
+    addBuyer(buyer);
+
+    return true;
+  }
+
+  function addBuyer(address buyer) onlyOwner public returns (bool) {
+    approvedBuyer[buyer] = true;
+
+    uint256 _balanceLimit = customBuyerLimit[buyer];
+    if (_balanceLimit == 0) {
+      _balanceLimit = balanceLimit;
+    }
+
+    WhiteList(buyer, _balanceLimit);
+
+    return true;
+  }
+
+  function grantVestedTokens(address beneficiary,
+                             uint256 fullyVestedAmount,
+                             uint256 startDate,
+                             uint256 cliffSec,
+                             uint256 durationSec,
+                             uint256 revokeDate,
+                             bool isRevocable) onlyOwner public returns(bool) {
+    vestingStartDate[beneficiary] = startDate;
+    vestingCliffDate[beneficiary] = cliffSec;
+    vestingDurationSec[beneficiary] = durationSec;
+    vestingFullyVestedAmount[beneficiary] = fullyVestedAmount;
+    vestingRevokeDate[beneficiary] = revokeDate;
+    vestingIsRevocable[beneficiary] = isRevocable;
+
+    VestedTokenGrant(beneficiary, startDate, cliffSec, durationSec, fullyVestedAmount, revokeDate, isRevocable);
+
+    return true;
+  }
+
+  function vestingSchedule(address beneficiary) public
+                                                view returns (uint256 startDate,
+                                                              uint256 cliffDate,
+                                                              uint256 durationSec,
+                                                              uint256 fullyVestedAmount,
+                                                              uint256 revokeDate,
+                                                              bool isRevocable) {
+    startDate = vestingStartDate[beneficiary];
+    cliffDate = vestingCliffDate[beneficiary];
+    durationSec = vestingDurationSec[beneficiary];
+    fullyVestedAmount = vestingFullyVestedAmount[beneficiary];
+    revokeDate = vestingRevokeDate[beneficiary];
+    isRevocable = vestingIsRevocable[beneficiary];
+  }
 }

--- a/packages/ethereum/truffle-tests/ethereum-indexer-test.js
+++ b/packages/ethereum/truffle-tests/ethereum-indexer-test.js
@@ -79,7 +79,8 @@ contract('SampleToken', function(accounts) {
                 eventContentTriggers: {
                   Transfer: [ "sample-token-balance-ofs" ],
                   Mint: [ "sample-token-balance-ofs" ],
-                  WhiteList: [ "sample-token-approved-buyers", "sample-token-custom-buyer-limits" ]
+                  WhiteList: [ "sample-token-approved-buyers", "sample-token-custom-buyer-limits" ],
+                  VestedTokenGrant: [ "sample-token-vesting-schedules" ]
                 }
               }
             }
@@ -195,11 +196,11 @@ contract('SampleToken', function(accounts) {
                 },
                 {
                   "type": "fields",
-                  "id": "mapping-number-value"
+                  "id": "sample-token-contract"
                 },
                 {
                   "type": "fields",
-                  "id": "sample-token-contract"
+                  "id": "mapping-number-value"
                 }
               ]
             },
@@ -228,11 +229,11 @@ contract('SampleToken', function(accounts) {
                 },
                 {
                   "type": "fields",
-                  "id": "mapping-number-value"
+                  "id": "sample-token-contract"
                 },
                 {
                   "type": "fields",
-                  "id": "sample-token-contract"
+                  "id": "mapping-number-value"
                 }
               ]
             },
@@ -241,6 +242,152 @@ contract('SampleToken', function(accounts) {
                 "type": "data-sources",
                 "id": dataSource.id
               }
+            }
+          }
+        }
+      });
+
+      schema = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'sample-token-vesting-schedules');
+      expect(schema).to.deep.equal({
+        "data": {
+          "type": "content-types",
+          "id": "sample-token-vesting-schedules",
+          "relationships": {
+            "fields": {
+              "data": [
+                {
+                  "type": "fields",
+                  "id": "ethereum-address"
+                },
+                {
+                  "type": "fields",
+                  "id": "sample-token-contract"
+                },
+                {
+                  "type": "fields",
+                  "id": "vesting-schedule-start-date"
+                },
+                {
+                  "type": "fields",
+                  "id": "vesting-schedule-cliff-date"
+                },
+                {
+                  "type": "fields",
+                  "id": "vesting-schedule-duration-sec"
+                },
+                {
+                  "type": "fields",
+                  "id": "vesting-schedule-fully-vested-amount"
+                },
+                {
+                  "type": "fields",
+                  "id": "vesting-schedule-revoke-date"
+                },
+                {
+                  "type": "fields",
+                  "id": "vesting-schedule-is-revocable"
+                }
+              ]
+            },
+            "data-source": {
+              "data": {
+                "type": "data-sources",
+                "id": dataSource.id
+              }
+            }
+          }
+        }
+      });
+
+      schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vesting-schedule-start-date');
+      expect(schema).to.deep.equal({
+        "data": {
+          "type": "fields",
+          "id": "vesting-schedule-start-date",
+          "attributes": {
+            "field-type": "@cardstack/core-types::string"
+          }
+        }
+      });
+
+      schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vesting-schedule-cliff-date');
+      expect(schema).to.deep.equal({
+        "data": {
+          "type": "fields",
+          "id": "vesting-schedule-cliff-date",
+          "attributes": {
+            "field-type": "@cardstack/core-types::string"
+          }
+        }
+      });
+
+      schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vesting-schedule-duration-sec');
+      expect(schema).to.deep.equal({
+        "data": {
+          "type": "fields",
+          "id": "vesting-schedule-duration-sec",
+          "attributes": {
+            "field-type": "@cardstack/core-types::string"
+          }
+        }
+      });
+
+      schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vesting-schedule-fully-vested-amount');
+      expect(schema).to.deep.equal({
+        "data": {
+          "type": "fields",
+          "id": "vesting-schedule-fully-vested-amount",
+          "attributes": {
+            "field-type": "@cardstack/core-types::string"
+          }
+        }
+      });
+
+      schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vesting-schedule-revoke-date');
+      expect(schema).to.deep.equal({
+        "data": {
+          "type": "fields",
+          "id": "vesting-schedule-revoke-date",
+          "attributes": {
+            "field-type": "@cardstack/core-types::string"
+          }
+        }
+      });
+
+      schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vesting-schedule-is-revocable');
+      expect(schema).to.deep.equal({
+        "data": {
+          "type": "fields",
+          "id": "vesting-schedule-is-revocable",
+          "attributes": {
+            "field-type": "@cardstack/core-types::boolean"
+          }
+        }
+      });
+
+      schema = await env.lookup('hub:searchers').get(env.session, 'master', 'grants', 'sample-token-vesting-schedule-grant');
+      expect(schema).to.deep.equal({
+        "data": {
+          "type": "grants",
+          "id": "sample-token-vesting-schedule-grant",
+          "attributes": {
+            "may-read-fields": true,
+            "may-read-resource": true
+          },
+          "relationships": {
+            "who": {
+              "data": {
+                "id": "everyone",
+                "type": "groups"
+              }
+            },
+            "types": {
+              "data": [
+                {
+                  "id": "sample-token-vesting-schedules",
+                  "type": "content-types"
+                }
+              ]
             }
           }
         }
@@ -260,11 +407,11 @@ contract('SampleToken', function(accounts) {
                 },
                 {
                   "type": "fields",
-                  "id": "mapping-boolean-value"
+                  "id": "sample-token-contract"
                 },
                 {
                   "type": "fields",
-                  "id": "sample-token-contract"
+                  "id": "mapping-boolean-value"
                 }
               ]
             },
@@ -404,6 +551,45 @@ contract('SampleToken', function(accounts) {
       });
     });
 
+    it("indexes mapping entry that contains multiple return values", async function() {
+      await token.grantVestedTokens(accountOne,
+                                    100,
+                                    1000000000,
+                                    1000500000,
+                                    500000,
+                                    1000600000,
+                                    true);
+      await waitForEthereumEvents(ethereumService);
+
+      let vestingSchedule = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-vesting-schedules', accountOne);
+
+      expect(vestingSchedule.data.attributes["ethereum-address"]).to.not.equal(vestingSchedule.data.id, 'the case between the addresses is different');
+      vestingSchedule.data.attributes["ethereum-address"] = vestingSchedule.data.attributes["ethereum-address"].toLowerCase();
+      expect(vestingSchedule).to.deep.equal({
+        "data": {
+          "id": accountOne,
+          "type": "sample-token-vesting-schedules",
+          "attributes": {
+            "ethereum-address": accountOne,
+            "vesting-schedule-fully-vested-amount": "100",
+            "vesting-schedule-start-date": "1000000000",
+            "vesting-schedule-cliff-date": "1000500000",
+            "vesting-schedule-duration-sec": "500000",
+            "vesting-schedule-revoke-date": "1000600000",
+            "vesting-schedule-is-revocable": true
+          },
+          "relationships": {
+            "sample-token-contract": {
+              "data": {
+                "id": token.address,
+                "type": "sample-tokens"
+              }
+            }
+          }
+        }
+      });
+    });
+
     it("indexes mapping entry content types when a contract fires an ethereum event", async function() {
       try {
         await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-balance-ofs', accountOne);
@@ -532,7 +718,6 @@ contract('SampleToken', function(accounts) {
       let accountTwoCustomBuyerLimit = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-custom-buyer-limits', accountTwo);
       expect(accountTwoCustomBuyerLimit.data.attributes["mapping-number-value"]).to.equal("10", "the mapping-number-value is correct");
     });
-
   });
 
   describe('ethereum-indexer event triggers', function() {

--- a/packages/hub/util/bin-utils.js
+++ b/packages/hub/util/bin-utils.js
@@ -3,7 +3,6 @@
 const commander = require('commander');
 const path = require('path');
 const fs = require('fs');
-const crypto = require('crypto');
 
 const testingToken = require('crypto').randomBytes(32).toString('base64').replace(/\W+/g, '');
 const seedsFolder = 'seeds';


### PR DESCRIPTION
Fixes #162 When indexing a mapping entry for a contract, use the field type for the mapping based on the ABI for the contract method instead of hard coded number field type.

Fixes #163 handles mapping function that have multiple return values