### PR TITLE
asserting that DB state is clean in test setup to deal with unruly tests

### DIFF
--- a/packages/test-support/addon/fixtures.js
+++ b/packages/test-support/addon/fixtures.js
@@ -10,7 +10,10 @@ export default class Fixtures {
   }
 
   setupTest(hooks) {
-    hooks.beforeEach(async () => await this.setup());
+    hooks.beforeEach(async () => {
+      await this.teardown();
+      await this.setup();
+    });
     hooks.afterEach(async () => await this.teardown());
   }
 


### PR DESCRIPTION
i ran into the situation where some broken tests left state in the DB that effected the next test run. asserting that DB state is clean in test setup to deal with unruly tests