### PR TITLE
Guard against data leakage from unreadable fields

### DIFF
--- a/packages/hub/node-tests/schema-auth-test.js
+++ b/packages/hub/node-tests/schema-auth-test.js
@@ -49,7 +49,22 @@ describe('schema/auth/write', function() {
     await ea.deleteContentIndices();
   });
 
+  it("attempting to create a thing you can't read results in Not Found", async function() {
+    let schema = await loader.loadFrom(factory.getModels());
+    let action = create({
+      type: 'articles',
+      id: '1'
+    });
+    let errors = await schema.validationErrors(action);
+    expect(errors).collectionContains({
+      status: 404,
+      detail: 'Not found'
+    });
+  });
+
+
   it("forbids creation", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
       type: 'articles',
@@ -63,6 +78,7 @@ describe('schema/auth/write', function() {
   });
 
   it("everyone grant allows creation when there's no session", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayCreateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
@@ -73,6 +89,7 @@ describe('schema/auth/write', function() {
   });
 
   it("everyone grant allows creation when there's some session", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayCreateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
@@ -84,6 +101,7 @@ describe('schema/auth/write', function() {
   });
 
   it("user-provided id denied without a grant", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayCreateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
@@ -98,7 +116,7 @@ describe('schema/auth/write', function() {
   });
 
   it("user-provided id approved with a grant", async function() {
-    factory.addResource('grants').withAttributes({ mayCreateResource: true }).withRelated('who', everyone);
+    factory.addResource('grants').withAttributes({ mayCreateResource: true, mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayWriteFields: true }).withRelated('who', everyone)
       .withRelated('fields', [
         factory.getResource('fields', 'id')
@@ -114,6 +132,7 @@ describe('schema/auth/write', function() {
   });
 
   it("user-specific grant allows creation", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayCreateResource: true })
       .withRelated('who', { type: 'groups', id: '0' });
     let schema = await loader.loadFrom(factory.getModels());
@@ -126,6 +145,7 @@ describe('schema/auth/write', function() {
   });
 
   it("id-dependent grant allows creation", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayCreateResource: true, mayWriteFields: true })
       .withRelated('who', { type: 'fields', id: 'id' });
     let schema = await loader.loadFrom(factory.getModels());
@@ -139,6 +159,7 @@ describe('schema/auth/write', function() {
   });
 
   it("id-dependent grant rejects creation", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayCreateResource: true, mayWriteFields: true })
       .withRelated('who', { type: 'fields', id: 'id' });
     let schema = await loader.loadFrom(factory.getModels());
@@ -155,6 +176,7 @@ describe('schema/auth/write', function() {
   });
 
   it("attribute-dependent grant allows creation", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayCreateResource: true, mayWriteFields: true })
       .withRelated('who', { type: 'fields', id: 'title' });
     let schema = await loader.loadFrom(factory.getModels());
@@ -170,6 +192,7 @@ describe('schema/auth/write', function() {
   });
 
   it("attribute-dependent grant rejects creation", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayCreateResource: true, mayWriteFields: true })
       .withRelated('who', { type: 'fields', id: 'title' });
     let schema = await loader.loadFrom(factory.getModels());
@@ -190,6 +213,7 @@ describe('schema/auth/write', function() {
 
 
   it("user-specific grant doesn't match missing user", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayCreateResource: true })
       .withRelated('who', { type: 'groups', id: '0' });
     let schema = await loader.loadFrom(factory.getModels());
@@ -205,6 +229,7 @@ describe('schema/auth/write', function() {
   });
 
   it("user-specific grant doesn't match wrong user", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayCreateResource: true })
       .withRelated('who', { type: 'groups', id: '0' });
     let schema = await loader.loadFrom(factory.getModels());
@@ -220,6 +245,7 @@ describe('schema/auth/write', function() {
   });
 
   it("allows by type", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayCreateResource: true })
       .withRelated('who', everyone)
       .withRelated('types', [factory.getResource('content-types', 'articles')]);
@@ -232,6 +258,7 @@ describe('schema/auth/write', function() {
   });
 
   it("forbids by type", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayCreateResource: true })
       .withRelated('who', everyone)
       .withRelated('types', [factory.getResource('content-types', 'articles')]);
@@ -261,6 +288,7 @@ describe('schema/auth/write', function() {
   });
 
   it("forbids update", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = update({
       type: 'articles',
@@ -283,6 +311,8 @@ describe('schema/auth/write', function() {
   });
 
   it("forbids update when attribute-dependent grant does not match initial state", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true })
+      .withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayWriteFields: true })
       .withRelated('who', { type: 'fields', id: 'title' });
     let schema = await loader.loadFrom(factory.getModels());
@@ -308,6 +338,8 @@ describe('schema/auth/write', function() {
   });
 
   it("allows update when attribute-dependent grant matches initial state", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true })
+      .withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayWriteFields: true })
       .withRelated('who', { type: 'fields', id: 'title' });
     let schema = await loader.loadFrom(factory.getModels());
@@ -368,6 +400,7 @@ describe('schema/auth/write', function() {
 
 
   it("approves field write at creation via grant", async function () {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayCreateResource: true, mayWriteFields: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
@@ -382,6 +415,7 @@ describe('schema/auth/write', function() {
   });
 
   it("approves null field write at creation when no default is set", async function () {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayCreateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
@@ -395,6 +429,7 @@ describe('schema/auth/write', function() {
   });
 
   it("rejects null field write at creation when default is set", async function () {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayCreateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
@@ -413,6 +448,7 @@ describe('schema/auth/write', function() {
 
 
   it("approves field write at creation when it matches default value", async function () {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayCreateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
@@ -427,6 +463,7 @@ describe('schema/auth/write', function() {
 
 
   it("rejects field write at creation", async function () {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
     factory.addResource('grants').withAttributes({ mayCreateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
@@ -444,7 +481,7 @@ describe('schema/auth/write', function() {
   });
 
   it("approves field write at update via grant", async function () {
-    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayWriteFields: true }).withRelated('who', everyone);
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayWriteFields: true, mayReadResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = update({
       type: 'articles',
@@ -464,7 +501,7 @@ describe('schema/auth/write', function() {
   });
 
   it("approves via a field-specific grant", async function () {
-    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayWriteFields: true })
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayWriteFields: true, mayReadResource: true })
       .withRelated('who', everyone)
       .withRelated('fields', [
         factory.getResource('fields', 'coolness')
@@ -488,7 +525,7 @@ describe('schema/auth/write', function() {
   });
 
   it("rejects a non-matching field-specific grant", async function () {
-    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayWriteFields: true })
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayWriteFields: true, mayReadResource: true })
       .withRelated('who', everyone)
       .withRelated('fields', [
         factory.getResource('fields', 'coolness')
@@ -513,7 +550,7 @@ describe('schema/auth/write', function() {
 
 
   it("approves field write at update via unchanged value", async function () {
-    factory.addResource('grants').withAttributes({ mayUpdateResource: true }).withRelated('who', everyone);
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayReadResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = update({
       type: 'articles',
@@ -533,7 +570,7 @@ describe('schema/auth/write', function() {
   });
 
   it("approves field write at update when it matches default", async function () {
-    factory.addResource('grants').withAttributes({ mayUpdateResource: true }).withRelated('who', everyone);
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayReadResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = update({
       type: 'articles',
@@ -553,7 +590,7 @@ describe('schema/auth/write', function() {
   });
 
   it("allows inclusion of non-changed field updateDefault will change it", async function () {
-    factory.addResource('grants').withAttributes({ mayUpdateResource: true }).withRelated('who', everyone);
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayReadResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = update({
       type: 'articles',
@@ -574,7 +611,7 @@ describe('schema/auth/write', function() {
   });
 
   it("rejects write of field that differs from updateDefault", async function () {
-    factory.addResource('grants').withAttributes({ mayUpdateResource: true }).withRelated('who', everyone);
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayReadResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = update({
       type: 'articles',
@@ -597,7 +634,7 @@ describe('schema/auth/write', function() {
   });
 
   it("rejects field write at update", async function () {
-    factory.addResource('grants').withAttributes({ mayUpdateResource: true }).withRelated('who', everyone);
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayReadResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = update({
       type: 'articles',
@@ -636,7 +673,7 @@ describe('schema/auth/write', function() {
     let errors = await schema.validationErrors(action);
     expect(errors).collectionContains({
       status: 404,
-      detail: '"articles" is not a valid type'
+      detail: 'Not found'
     });
   });
 
@@ -663,7 +700,7 @@ describe('schema/auth/write', function() {
     let errors = await schema.validationErrors(action);
     expect(errors).collectionContains({
       status: 404,
-      detail: '"articles" is not a valid type'
+      detail: 'Not found'
     });
   });
 

--- a/packages/hub/node-tests/schema-auth-test.js
+++ b/packages/hub/node-tests/schema-auth-test.js
@@ -619,6 +619,62 @@ describe('schema/auth/write', function() {
     });
   });
 
+  it("forbids creation of a resource that you're not authorized to read", async function() {
+    // As a policy, we require you to have resource-level read auth on
+    // things you are creating or updating. This is because we're
+    // going to echo the results back to you, and we don't want there
+    // to be any ambiguity that would allow secrets to leak.
+    factory.addResource('grants').withAttributes({ mayCreateResource: true }).withRelated('who', everyone);
+    let schema = await loader.loadFrom(factory.getModels());
+    let action = create({
+      type: 'articles',
+      id: '1',
+      attributes: {
+        coolness: 6
+      }
+    });
+    let errors = await schema.validationErrors(action);
+    expect(errors).collectionContains({
+      status: 404,
+      detail: '"articles" is not a valid type'
+    });
+  });
+
+  it("forbids update of a resource that you're not authorized to read", async function() {
+    // As a policy, we require you to have resource-level read auth on
+    // things you are creating or updating . This is because we're
+    // going to echo the results back to you, and we don't want there
+    // to be any ambiguity that would allow secrets to leak.
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true }).withRelated('who', everyone);
+    let schema = await loader.loadFrom(factory.getModels());
+    let action = update({
+      type: 'articles',
+      id: '1',
+      attributes: {
+        coolness: 6
+      }
+    },{
+      type: 'articles',
+      id: '1',
+      attributes: {
+        coolness: 6
+      }
+    });
+    let errors = await schema.validationErrors(action);
+    expect(errors).collectionContains({
+      status: 404,
+      detail: '"articles" is not a valid type'
+    });
+  });
+
+  it("forbids inclusion of fields you're not authorized to read, even if they are unchanged, during create", async function() {
+    throw new Error("implement me");
+  });
+
+  it("forbids inclusion of fields you're not authorized to read, even if they are unchanged, during update", async function() {
+    throw new Error("implement me");
+  });
+
 });
 
 function create(document) {

--- a/packages/hub/node-tests/schema-auth-test.js
+++ b/packages/hub/node-tests/schema-auth-test.js
@@ -49,6 +49,13 @@ describe('schema/auth/write', function() {
     await ea.deleteContentIndices();
   });
 
+  function allReadable() {
+    factory.addResource('grants').withAttributes({
+      mayReadResource: true,
+      mayReadFields: true
+    }).withRelated('who', everyone);
+  }
+
   it("attempting to create a thing you can't read results in Not Found", async function() {
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
@@ -64,7 +71,7 @@ describe('schema/auth/write', function() {
 
 
   it("forbids creation", async function() {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
       type: 'articles',
@@ -78,7 +85,7 @@ describe('schema/auth/write', function() {
   });
 
   it("everyone grant allows creation when there's no session", async function() {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     factory.addResource('grants').withAttributes({ mayCreateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
@@ -89,7 +96,7 @@ describe('schema/auth/write', function() {
   });
 
   it("everyone grant allows creation when there's some session", async function() {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     factory.addResource('grants').withAttributes({ mayCreateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
@@ -101,7 +108,7 @@ describe('schema/auth/write', function() {
   });
 
   it("user-provided id denied without a grant", async function() {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     factory.addResource('grants').withAttributes({ mayCreateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
@@ -132,7 +139,7 @@ describe('schema/auth/write', function() {
   });
 
   it("user-specific grant allows creation", async function() {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     factory.addResource('grants').withAttributes({ mayCreateResource: true })
       .withRelated('who', { type: 'groups', id: '0' });
     let schema = await loader.loadFrom(factory.getModels());
@@ -145,7 +152,7 @@ describe('schema/auth/write', function() {
   });
 
   it("id-dependent grant allows creation", async function() {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     factory.addResource('grants').withAttributes({ mayCreateResource: true, mayWriteFields: true })
       .withRelated('who', { type: 'fields', id: 'id' });
     let schema = await loader.loadFrom(factory.getModels());
@@ -159,7 +166,7 @@ describe('schema/auth/write', function() {
   });
 
   it("id-dependent grant rejects creation", async function() {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     factory.addResource('grants').withAttributes({ mayCreateResource: true, mayWriteFields: true })
       .withRelated('who', { type: 'fields', id: 'id' });
     let schema = await loader.loadFrom(factory.getModels());
@@ -176,7 +183,7 @@ describe('schema/auth/write', function() {
   });
 
   it("attribute-dependent grant allows creation", async function() {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     factory.addResource('grants').withAttributes({ mayCreateResource: true, mayWriteFields: true })
       .withRelated('who', { type: 'fields', id: 'title' });
     let schema = await loader.loadFrom(factory.getModels());
@@ -192,7 +199,7 @@ describe('schema/auth/write', function() {
   });
 
   it("attribute-dependent grant rejects creation", async function() {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     factory.addResource('grants').withAttributes({ mayCreateResource: true, mayWriteFields: true })
       .withRelated('who', { type: 'fields', id: 'title' });
     let schema = await loader.loadFrom(factory.getModels());
@@ -213,7 +220,7 @@ describe('schema/auth/write', function() {
 
 
   it("user-specific grant doesn't match missing user", async function() {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     factory.addResource('grants').withAttributes({ mayCreateResource: true })
       .withRelated('who', { type: 'groups', id: '0' });
     let schema = await loader.loadFrom(factory.getModels());
@@ -229,7 +236,7 @@ describe('schema/auth/write', function() {
   });
 
   it("user-specific grant doesn't match wrong user", async function() {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     factory.addResource('grants').withAttributes({ mayCreateResource: true })
       .withRelated('who', { type: 'groups', id: '0' });
     let schema = await loader.loadFrom(factory.getModels());
@@ -245,7 +252,7 @@ describe('schema/auth/write', function() {
   });
 
   it("allows by type", async function() {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     factory.addResource('grants').withAttributes({ mayCreateResource: true })
       .withRelated('who', everyone)
       .withRelated('types', [factory.getResource('content-types', 'articles')]);
@@ -258,7 +265,7 @@ describe('schema/auth/write', function() {
   });
 
   it("forbids by type", async function() {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     factory.addResource('grants').withAttributes({ mayCreateResource: true })
       .withRelated('who', everyone)
       .withRelated('types', [factory.getResource('content-types', 'articles')]);
@@ -288,7 +295,7 @@ describe('schema/auth/write', function() {
   });
 
   it("forbids update", async function() {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     let schema = await loader.loadFrom(factory.getModels());
     let action = update({
       type: 'articles',
@@ -400,7 +407,7 @@ describe('schema/auth/write', function() {
 
 
   it("approves field write at creation via grant", async function () {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     factory.addResource('grants').withAttributes({ mayCreateResource: true, mayWriteFields: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
@@ -415,7 +422,7 @@ describe('schema/auth/write', function() {
   });
 
   it("approves null field write at creation when no default is set", async function () {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     factory.addResource('grants').withAttributes({ mayCreateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
@@ -429,7 +436,7 @@ describe('schema/auth/write', function() {
   });
 
   it("rejects null field write at creation when default is set", async function () {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     factory.addResource('grants').withAttributes({ mayCreateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
@@ -448,7 +455,7 @@ describe('schema/auth/write', function() {
 
 
   it("approves field write at creation when it matches default value", async function () {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     factory.addResource('grants').withAttributes({ mayCreateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
@@ -463,7 +470,7 @@ describe('schema/auth/write', function() {
 
 
   it("rejects field write at creation", async function () {
-    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
     factory.addResource('grants').withAttributes({ mayCreateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = create({
@@ -481,7 +488,8 @@ describe('schema/auth/write', function() {
   });
 
   it("approves field write at update via grant", async function () {
-    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayWriteFields: true, mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayWriteFields: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = update({
       type: 'articles',
@@ -501,7 +509,8 @@ describe('schema/auth/write', function() {
   });
 
   it("approves via a field-specific grant", async function () {
-    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayWriteFields: true, mayReadResource: true })
+    allReadable();
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayWriteFields: true })
       .withRelated('who', everyone)
       .withRelated('fields', [
         factory.getResource('fields', 'coolness')
@@ -525,7 +534,8 @@ describe('schema/auth/write', function() {
   });
 
   it("rejects a non-matching field-specific grant", async function () {
-    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayWriteFields: true, mayReadResource: true })
+    allReadable();
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayWriteFields: true })
       .withRelated('who', everyone)
       .withRelated('fields', [
         factory.getResource('fields', 'coolness')
@@ -550,7 +560,8 @@ describe('schema/auth/write', function() {
 
 
   it("approves field write at update via unchanged value", async function () {
-    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = update({
       type: 'articles',
@@ -570,7 +581,8 @@ describe('schema/auth/write', function() {
   });
 
   it("approves field write at update when it matches default", async function () {
-    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = update({
       type: 'articles',
@@ -590,7 +602,8 @@ describe('schema/auth/write', function() {
   });
 
   it("allows inclusion of non-changed field updateDefault will change it", async function () {
-    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = update({
       type: 'articles',
@@ -611,7 +624,8 @@ describe('schema/auth/write', function() {
   });
 
   it("rejects write of field that differs from updateDefault", async function () {
-    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = update({
       type: 'articles',
@@ -634,7 +648,8 @@ describe('schema/auth/write', function() {
   });
 
   it("rejects field write at update", async function () {
-    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayReadResource: true }).withRelated('who', everyone);
+    allReadable();
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true }).withRelated('who', everyone);
     let schema = await loader.loadFrom(factory.getModels());
     let action = update({
       type: 'articles',
@@ -704,12 +719,99 @@ describe('schema/auth/write', function() {
     });
   });
 
-  it("forbids inclusion of fields you're not authorized to read, even if they are unchanged, during create", async function() {
-    throw new Error("implement me");
+  it("does not leak existence of fields you're not authorized to read, even if they are unchanged, during create", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    factory.addResource('grants').withAttributes({ mayCreateResource: true, mayWriteFields: true }).withRelated('who', everyone);
+    let schema = await loader.loadFrom(factory.getModels());
+    let action = create({
+      type: 'articles',
+      attributes: {
+        title: null,
+        coolness: 0
+      }
+    });
+    let errors = await schema.validationErrors(action);
+    expect(errors).collectionContains({
+      status: 400,
+      title: 'Validation error',
+      detail: 'type "articles" has no field named "title"'
+    });
+    expect(errors).collectionContains({
+      status: 400,
+      title: 'Validation error',
+      detail: 'type "articles" has no field named "coolness"'
+    });
+    expect(errors).has.length(2);
   });
 
+  it("does not leak existence of fields you're not authorized to read during create", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    factory.addResource('grants').withAttributes({ mayCreateResource: true, mayWriteFields: true }).withRelated('who', everyone);
+    let schema = await loader.loadFrom(factory.getModels());
+    let action = create({
+      type: 'articles',
+      attributes: {
+        title: "my title",
+        coolness: 1
+      }
+    });
+    let errors = await schema.validationErrors(action);
+    expect(errors).collectionContains({
+      status: 400,
+      title: 'Validation error',
+      detail: 'type "articles" has no field named "title"'
+    });
+    expect(errors).collectionContains({
+      status: 400,
+      title: 'Validation error',
+      detail: 'type "articles" has no field named "coolness"'
+    });
+    expect(errors).has.length(2);
+  });
+
+  it("does not leak other errors for fields you're not authorized to read, during create", async function() {
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    factory.addResource('grants').withAttributes({ mayCreateResource: true, mayWriteFields: true }).withRelated('who', everyone);
+    let schema = await loader.loadFrom(factory.getModels());
+    let action = create({
+      type: 'articles',
+      attributes: {
+        // This is a format error
+        coolness: "purple"
+      }
+    });
+    let errors = await schema.validationErrors(action);
+    expect(errors).collectionContains({
+      status: 400,
+      title: 'Validation error',
+      detail: 'type "articles" has no field named "coolness"'
+    });
+    expect(errors).has.length(1);
+  });
+
+
   it("forbids inclusion of fields you're not authorized to read, even if they are unchanged, during update", async function() {
-    throw new Error("implement me");
+    factory.addResource('grants').withAttributes({ mayReadResource: true }).withRelated('who', everyone);
+    factory.addResource('grants').withAttributes({ mayUpdateResource: true, mayWriteFields: true }).withRelated('who', everyone);
+    let schema = await loader.loadFrom(factory.getModels());
+    let action = update({
+      type: 'articles',
+      attributes: {
+        title: 'a'
+      }
+    }, {
+      type: 'articles',
+      attributes: {
+        title: 'a'
+      }
+    });
+    let errors = await schema.validationErrors(action);
+    expect(errors).collectionContains({
+      status: 400,
+      title: 'Validation error',
+      detail: 'type "articles" has no field named "title"'
+    });
+    expect(errors).has.length(1);
   });
 
 });

--- a/packages/hub/schema/index.js
+++ b/packages/hub/schema/index.js
@@ -214,6 +214,15 @@ class Schema {
     return userType.hasLoginAuthorization(userRealms);
   }
 
+  // This takes an arbitrary JSON:API document and makes it safe to
+  // show within the given context. If it can't be shown at all
+  // (because the primary resource is not readable), we return
+  // undefined.
+  //
+  // Otherwise, we go through each included resource and field to
+  // ensure there are valid grants for them. We return a new sanitized
+  // document that strips out any included resources or fields that
+  // were lacking grants.
   async applyReadAuthorization(document, context={}) {
     if (!document.data) {
       return;

--- a/packages/jsonapi/node-tests/middleware-test.js
+++ b/packages/jsonapi/node-tests/middleware-test.js
@@ -666,7 +666,7 @@ describe('jsonapi/middleware', function() {
           }
         }
       });
-      expect(response.status).to.equal(401);
+      expect(response.status).to.equal(404);
     });
 
     it('applies authorization during update', async function() {
@@ -682,7 +682,7 @@ describe('jsonapi/middleware', function() {
           meta: { version }
         }
       });
-      expect(response).hasStatus(401);
+      expect(response).hasStatus(404);
     });
 
     it('applies authorization during delete', async function() {

--- a/packages/postgresql/node-tests/writer-test.js
+++ b/packages/postgresql/node-tests/writer-test.js
@@ -61,7 +61,9 @@ describe('postgresql/writer', function() {
         mayCreateResource: false,
         mayUpdateResource: true,
         mayDeleteResource: false,
-        mayWriteFields: true
+        mayWriteFields: true,
+        mayReadResource: true,
+        mayReadFields: true
       }).withRelated('who', factory.addResource('groups', 'update-only'));
 
     factory.addResource('grants')
@@ -69,7 +71,9 @@ describe('postgresql/writer', function() {
         mayCreateResource: true,
         mayUpdateResource: false,
         mayDeleteResource: false,
-        mayWriteFields: true
+        mayWriteFields: true,
+        mayReadResource: true,
+        mayReadFields: true
       }).withRelated('who', factory.addResource('groups', 'create-only'));
 
     factory.addResource('grants')
@@ -77,7 +81,9 @@ describe('postgresql/writer', function() {
         mayCreateResource: false,
         mayUpdateResource: false,
         mayDeleteResource: true,
-        mayWriteFields: true
+        mayWriteFields: true,
+        mayReadResource: true,
+        mayReadFields: true
       }).withRelated('who', factory.addResource('groups', 'delete-only'));
 
 


### PR DESCRIPTION
This PR finishes implementing the remainder of the grant rules as described at the top of grant.js.

They ensure that you can't accidentally leak non-readable resources or fields as a side effect of write requests.

For example, if you try to PATCH a resource that you have permission to read but not write, you should see a permission denied error. But if you try to PATCH a resource where you have neither read nor write, you should see Not Found, so that we won't leak the existence of the resource you're not supposed to be able to see.

A similar arguable applies to non-readable fields. We don't want to let people infer the existence of non-readable fields by giving different error messages by trying to include them in a POST or PATCH. And even worse, we don't want to make it possible to infer the value of a hidden field by taking advantage of the (otherwise sensible) rule where we silently tolerate the inclusion of non-writable fields as long as you aren't trying to change their values.

This PR closes those gaps, and explicitly requires that you have may-read-resource and may-read-fields grants for anything you're including in a POST or PATCH request.




