### PR TITLE
postgres: allow a typeHint to change a relationship to an attribute

### DIFF
--- a/packages/hub/indexing/branch-update.js
+++ b/packages/hub/indexing/branch-update.js
@@ -29,11 +29,10 @@ class BranchUpdate {
     if (!indexer) {
       return [];
     }
-    let updater = await indexer.beginUpdate(this.branch);
+    let updater = this.updaters[dataSource.id] = await indexer.beginUpdate(this.branch);
     owningDataSource.set(updater, dataSource);
     let newModels = await updater.schema();
     this.schemaModels.push(newModels);
-    this.updaters[dataSource.id] = updater;
     return newModels;
   }
 

--- a/packages/postgresql/indexer.js
+++ b/packages/postgresql/indexer.js
@@ -201,6 +201,12 @@ class Updater {
           AND KCU2.ORDINAL_POSITION = KCU1.ORDINAL_POSITION`);
 
     for (let {fk_table_name, fk_column_name, referenced_table_name, fk_constraint_schema} of relationshipColumns) {
+      let hint = get(this.typeHints, `${fk_table_name}.${fk_column_name}`);
+      if (hint && hint !== '@cardstack/core-types::belongs-to' && hint !== '@cardstack/core-types::has-many') {
+        // this column has been forced to be a non-relationship type, so we leave it alone here.
+        continue;
+      }
+
       let field = fields[this.mapper.fieldNameFor(fk_constraint_schema, fk_table_name, fk_column_name)];
       if (!field) {
         throw new Error(`There was a problem with the relationship field ${fk_column_name}, it could not be found to turn into a relationship`);

--- a/packages/postgresql/indexer.js
+++ b/packages/postgresql/indexer.js
@@ -148,6 +148,10 @@ class Updater {
       let contentTypeName = this.mapper.typeNameFor(table_schema, table_name);
       let fieldName = this.mapper.fieldNameFor(table_schema, table_name, column_name);
 
+      if (!types[contentTypeName]) {
+        types[contentTypeName] = this._initializeContentType(contentTypeName);
+      }
+
       // Every content type always has an ID field implicitly, it
       // doesn't need to be created.
       if (fieldName === 'id') {
@@ -169,9 +173,6 @@ class Updater {
         fields[fieldName] = this._initializeField(fieldName, fieldType);
       }
 
-      if (!types[contentTypeName]) {
-        types[contentTypeName] = this._initializeContentType(contentTypeName);
-      }
       types[contentTypeName].relationships.fields.data.push({ type: 'fields', id: fieldName });
     }
 


### PR DESCRIPTION
If a column has a foreign key constraint, we make a relationship out of it by default. But if you really just want the value as an attribute, you can use a typeHint to say it should really be a `@cardstack/core-types::string`, etc.

In the process of writing tests for this I found and fixed two other issues
 - failure to cleanup correctly if you get an exception from an updater's schema() method
 - failure of postgres indexer to discover a table that has only an id column (which is a valid way to create an enumeration).