### PR TITLE
add login lifecycle actions to support doing things after successful login

### DIFF
--- a/packages/mock-auth/addon/components/mock-login.js
+++ b/packages/mock-auth/addon/components/mock-login.js
@@ -1,9 +1,29 @@
 import { inject as service } from '@ember/service';
+import { get, set } from '@ember/object';
 import Component from '@ember/component';
 import layout from '../templates/components/mock-login';
 
 export default Component.extend({
   layout,
   tagName: '',
-  mockLogin: service()
+  mockLogin: service(),
+
+  init() {
+    this._super();
+
+    let service = get(this, 'mockLogin');
+    let onAuthentication = get(this, 'onAuthenticationSuccess');
+    let onPartialAuthentication = get(this, 'onPartialAuthenticationSuccess');
+    let onAuthenticationFailed = get(this, 'onAuthenticationFailed');
+
+    if (typeof onAuthentication === 'function') {
+      set(service, 'authenticationHandler', onAuthentication.bind(this));
+    }
+    if (typeof onPartialAuthentication === 'function') {
+      set(service, 'partialAuthenticationHandler', onPartialAuthentication.bind(this));
+    }
+    if (typeof onAuthenticationFailed === 'function') {
+      set(service, 'authenticationFailedHandler', onAuthenticationFailed.bind(this));
+    }
+  },
 });

--- a/packages/mock-auth/addon/services/mock-login.js
+++ b/packages/mock-auth/addon/services/mock-login.js
@@ -1,15 +1,37 @@
 import Service, { inject as service } from '@ember/service';
+import { get } from '@ember/object';
 import { task } from 'ember-concurrency';
 
 export default Service.extend({
   session: service(),
+  cardstackSession: service(),
 
   source: 'mock-auth',
+  authenticationHandler: null,
+  partialAuthenticationHandler: null,
+  authenticationFailedHandler: null,
 
   login: task(function * (mockUserId) {
     mockUserId = this.get('mockUserId') || mockUserId;
     if (mockUserId ) {
       yield this.get('session').authenticate('authenticator:cardstack', this.get('source'), { authorizationCode: mockUserId });
+
+      let session = get(this, 'cardstackSession');
+      let onAuthenticationHandler = get(this, 'authenticationHandler');
+      let onPartialAuthenticationHandler = get(this, 'partialAuthenticationHandler');
+      let onAuthenticationFailedHandler = get(this, 'authenticationFailedHandler');
+
+      if (get(session, 'isAuthenticated') &&
+        typeof onAuthenticationHandler === 'function') {
+        onAuthenticationHandler(session);
+      } else if (get(session, 'isPartiallyAuthenticated') && typeof
+        onPartialAuthenticationHandler === 'function') {
+        onPartialAuthenticationHandler(session);
+      } else if (!get(session, 'isAuthenticated') &&
+        !get(session, 'isPartiallyAuthenticated') &&
+        onAuthenticationFailedHandler === 'function') {
+        onAuthenticationFailedHandler();
+      }
     }
   }).drop()
 });

--- a/packages/mock-auth/tests/acceptance/login-test.js
+++ b/packages/mock-auth/tests/acceptance/login-test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { waitFor, click, visit } from '@ember/test-helpers';
+
+module('Acceptance | login', function(hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(async function() {
+    await this.owner.lookup('service:cardstack-codegen').refreshCode();
+  });
+
+  test('can login', async function(assert) {
+    await visit('/');
+
+    await click('#login-button');
+
+    await waitFor('#logout-button');
+
+    assert.equal(this.element.querySelector('#auth-message').textContent.trim(), 'Has authenticated session: true');
+    assert.equal(this.element.querySelector('#test-message').textContent.trim(), 'Did you login? yes');
+  });
+});

--- a/packages/mock-auth/tests/dummy/app/controllers/application.js
+++ b/packages/mock-auth/tests/dummy/app/controllers/application.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  actions: {
+    onLogin() {
+      this.set('didLogin', 'yes');
+    }
+  }
+});

--- a/packages/mock-auth/tests/dummy/app/templates/application.hbs
+++ b/packages/mock-auth/tests/dummy/app/templates/application.hbs
@@ -1,13 +1,15 @@
 {{#cardstack-session as |session|}}
-  <div>Has authenticated session: {{session.isAuthenticated}}</div>
+  <div id="auth-message">Has authenticated session: {{session.isAuthenticated}}</div>
   {{#if session.isAuthenticated }}
     <div>{{#link-to 'user' session.user.id}}Profile{{/link-to}}</div>
-    <button {{action session.logout}}>Logout {{session.user.name}}</button>
+      <button id="logout-button"> {{action session.logout}}>Logout {{session.user.name}}</button>
   {{else}}
-    {{#mock-login as |login|}}
-      <button {{action login "user1"}}>Login</button>
+    {{#mock-login onAuthenticationSuccess=(action 'onLogin') as |login|}}
+      <button id="login-button" {{action login "user1"}}>Login</button>
     {{/mock-login}}
   {{/if}}
 {{/cardstack-session}}
+
+<div id="test-message">Did you login? {{didLogin}}</div>
 
 {{outlet}}

--- a/packages/mock-auth/tests/dummy/cardstack/seeds/ephemeral.js
+++ b/packages/mock-auth/tests/dummy/cardstack/seeds/ephemeral.js
@@ -17,6 +17,12 @@ function initialModels() {
         }
       }
     });
+
+  factory.addResource('grants')
+    .withRelated('who', { type: 'groups', id: 'everyone' })
+    .withAttributes({
+      mayLogin: true
+    });
   return factory.getModels();
 }
 


### PR DESCRIPTION
this can support our needs around redirecting to different routes in the consuming app after authentication and authorization of the cardstack session.