### PR TITLE
refactored ethereum indexing to buffer through elastic search for large indexing jobs

### DIFF
--- a/packages/ethereum/cardstack/abi-utils.js
+++ b/packages/ethereum/cardstack/abi-utils.js
@@ -1,0 +1,56 @@
+const Ember = require('ember-source/dist/ember.debug');
+const { dasherize } = Ember.String;
+
+function fieldTypeFor(contractName, abiItem) {
+  if (!abiItem.outputs || !abiItem.outputs.length) { return; }
+
+  if (!abiItem.inputs.length) {
+    // We are not handling multiple return types for non-mapping functions
+    // unclear what that would actually look like in the schema...
+    switch(abiItem.outputs[0].type) {
+      // Using strings to represent uint256, as the max int
+      // int in js is 2^53, vs 2^256 in solidity
+      case 'uint256':
+      case 'bytes32':
+      case 'string':
+      case 'address':
+        return { fields: [{ type: '@cardstack/core-types::string' }]};
+      case 'bool':
+        return { fields: [{ type: '@cardstack/core-types::boolean' }]};
+    }
+  // deal with just mappings that use address as a key for now
+  } else if (abiItem.inputs.length === 1 && abiItem.inputs[0].type === "address") {
+    return {
+      isMapping: true,
+      fields: abiItem.outputs.map(output => {
+        let name, type, isNamedField;
+        if (output.name && abiItem.outputs.length > 1) {
+          name = `${dasherize(abiItem.name)}-${dasherize(output.name)}`;
+          isNamedField = true;
+        }
+        switch(output.type) {
+          case 'uint256':
+            name = name || `mapping-number-value`;
+            type = 'number';
+            break;
+          case 'bool':
+            name = name || `mapping-boolean-value`;
+            type = 'boolean';
+            break;
+          case 'bytes32':
+          case 'string':
+          case 'address':
+          default:
+            name = name || `mapping-string-value`;
+            type = 'string';
+        }
+
+        return { name, type, isNamedField };
+      })
+    };
+  }
+}
+
+module.exports = {
+  fieldTypeFor
+};

--- a/packages/ethereum/cardstack/buffer.js
+++ b/packages/ethereum/cardstack/buffer.js
@@ -1,0 +1,216 @@
+const ElasticAssert = require('@cardstack/elasticsearch/test-support');
+const Client = require('@cardstack/elasticsearch/client');
+const Ember = require('ember-source/dist/ember.debug');
+const { dasherize } = Ember.String;
+const { pluralize } = require('inflection');
+const { get, groupBy, orderBy } = require('lodash');
+const { declareInjections } = require('@cardstack/di');
+const log = require('@cardstack/logger')('cardstack/ethereum/buffer');
+const { fieldTypeFor } = require('./abi-utils');
+
+const indexPrefix = 'ethereum_buffer';
+
+function attachMeta(model, meta) {
+  model.meta = Object.assign(model.meta || {}, meta);
+  return model;
+}
+
+function collapseBufferedHints(hints) {
+  let groupedHints = groupBy(hints, ({ id, type }) => type + '_' + id); // not taking branch into consideration, as address collisions across networks is astronomically remote
+  return Object.keys(groupedHints).map(key => {
+    let hintsForAddress = orderBy(groupedHints[key], ['blockheight'], ['desc']);
+    return hintsForAddress[0];
+  });
+}
+
+module.exports = declareInjections({
+  indexer: 'hub:indexers',
+},
+
+class EthereumBuffer {
+
+  static create(...args) {
+    return new this(...args);
+  }
+
+  constructor({ indexer }) {
+    this.branches = null;
+    this.ethereumService = null;
+    this.indexer = indexer;
+    this.client = null;
+    this.contractDefinitions = {};
+    this.contractName = null;
+    this._bufferedLoadPromise = null; // expose this promise to the tests
+    this._setupPromise = this._ensureClient();
+    this._processingHints = [];
+    this.bulkOps = null;
+  }
+
+  async start({ name, contract, branches, ethereumService }) {
+    await this._setupPromise;
+
+    this.contractDefinitions[name] = contract;
+    this.branches = branches;
+    this.ethereumService = ethereumService;
+
+    await this.ethereumService.start({ name, contract, buffer: this });
+  }
+
+  loadModels(contractName, blockHeights, hints) {
+    // we are intentionally not returning this promise, but rather save it for our tests to use
+    this._bufferedLoadPromise = Promise.resolve(this._bufferedLoadPromise)
+      .then(() => this._processHints({contractName, blockHeights, hints }));
+  }
+
+  async readModels(contractName, blockHeights, hints) {
+    let bufferedModels = [];
+    let unbufferedHints = [];
+
+    if (!hints) {
+      this.loadModels(contractName, blockHeights, null);
+      return [];
+    }
+
+    for (let hint of hints) {
+      let { id, type } = hint;
+      let bufferedModel;
+      try {
+        bufferedModel = await this.client.es.get({
+          index: this.index,
+          type,
+          id
+        }).then(resp => resp._source);
+      } catch (err) {
+        // not found is ok, that just means we need to trigger the load of the model
+        if (err.status !== 404) { throw err; }
+      }
+
+      let modelBranch = get(bufferedModel, 'meta.branch');
+      let modelBlockheight = get(bufferedModel, 'meta.blockheight');
+      if (modelBranch &&
+          modelBlockheight &&
+          (!blockHeights[modelBranch] ||
+           modelBlockheight >= blockHeights[modelBranch])) {
+        bufferedModels.push(bufferedModel);
+      } else if (this._processingHints && !this._processingHints.find(h => h.id === id && h.type === type)) {
+        unbufferedHints.push(hint);
+      }
+    }
+
+    if (unbufferedHints.length) {
+      this.loadModels(contractName, blockHeights, unbufferedHints);
+    }
+
+    return bufferedModels;
+  }
+
+  async _ensureClient() {
+    if (!this.client) {
+      this.client = await Client.create();
+    }
+
+    await this._ensureIndex();
+  }
+
+  async _ensureIndex() {
+    let ea = new ElasticAssert();
+    let indices = await ea.indices();
+    let index = indices.find(i => i.indexOf(`${Client.branchPrefix}_${indexPrefix}_`) > -1);
+
+    if (!index) {
+      index = `${Client.branchPrefix}_${indexPrefix}_` + require('crypto').randomBytes(16).toString('base64').replace(/\W+/g, '').toLowerCase();
+      await this.client.es.indices.create({ index });
+    }
+
+    this.index = index;
+  }
+
+  async _bufferRecord(record) {
+    log.debug(`indexing model in elasticsearch buffer ${JSON.stringify(record, null, 2)}`);
+    await this.bulkOps.add({
+      index: {
+        _index: this.index,
+        _type: record.type,
+        _id: record.id
+      }
+    }, record);
+
+    return {
+      type: record.type,
+      id: record.id,
+      branch: record.meta.branch
+    };
+  }
+
+  async _processHints({ contractName, blockHeights, hints }) {
+    log.debug(`processing hints for ethereum with last indexed blockheights ${JSON.stringify(blockHeights)}, ${JSON.stringify(hints, null, 2)}`);
+    this.bulkOps = this.client.bulkOps({});
+    this._processingHints = hints;
+    let contractDefinition = this.contractDefinitions[contractName];
+    if (!contractDefinition) { return; }
+    let bufferedHints = [];
+
+    let contractHints = hints && hints.length ? hints.filter(hint => hint.isContractType) : [];
+    if (!contractHints.length) {
+      for (let branch of Object.keys(contractDefinition.addresses)) {
+        let blockheight = await this.ethereumService.getBlockHeight(branch);
+        bufferedHints.push(await this._bufferRecord(attachMeta(await this.ethereumService.getContractInfo({ branch, contract: contractName }), { blockheight, branch, contractName })));
+      }
+    } else {
+      for (let { branch, type } of contractHints) {
+        let blockheight = await this.ethereumService.getBlockHeight(branch);
+        bufferedHints.push(await this._bufferRecord(attachMeta(await this.ethereumService.getContractInfo({ branch, type }), { blockheight, branch, contractName })));
+      }
+    }
+
+    if (!hints || !hints.length) {
+      hints = await this.ethereumService.getPastEventsAsHints(blockHeights);
+    }
+
+    for (let { id, branch, type, isContractType } of hints) {
+      if (!branch || !type || !id || isContractType) { continue; }
+
+      let contractAddress = contractDefinition.addresses[branch];
+      let blockheight = await this.ethereumService.getBlockHeight(branch);
+      let { data, methodName } = await this.ethereumService.getContractInfoFromHint({ id, type, branch, contractName });
+      let methodAbiEntry = contractDefinition["abi"].find(item => item.type === 'function' &&
+        item.constant &&
+        item.name === methodName);
+      let { isMapping, fields } = fieldTypeFor(contractName, methodAbiEntry);
+      if (!isMapping || !fields.length) { continue; }
+
+      let model = {
+        id: id.toLowerCase(),
+        type,
+        attributes: {
+          'ethereum-address': id // preserve the case of the ID here to faithfully represent EIP-55 encoding
+        },
+        relationships: {}
+      };
+
+      if (typeof data === "object") {
+        for (let returnName of Object.keys(data)) {
+          let fieldName = `${dasherize(methodName)}-${dasherize(returnName)}`;
+          if (!fields.find(field => field.name === fieldName)) { continue; }
+          model.attributes[fieldName] = data[returnName];
+        }
+      } else {
+        model.attributes[fields[0].name] = data;
+      }
+
+      model.relationships[`${contractName}-contract`] = {
+        data: { id: contractAddress, type: pluralize(contractName) }
+      };
+
+      bufferedHints.push(await this._bufferRecord(attachMeta(model, { blockheight, branch, contractName })));
+    }
+
+    await this.bulkOps.finalize();
+
+    await this.indexer.update({
+      hints: collapseBufferedHints(bufferedHints)
+    });
+
+    this._processingHints = [];
+  }
+});

--- a/packages/ethereum/package.json
+++ b/packages/ethereum/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@cardstack/di": "0.6.14",
+    "@cardstack/elasticsearch": "0.6.14",
     "@cardstack/logger": "^0.1.0",
     "@cardstack/plugin-utils": "0.6.14",
     "ember-source": "~2.18.2",


### PR DESCRIPTION
Because of this approach, we were able to remove a lot of the quirky async from the ethereum service, and all the "special" async needs for the ethereum event handling can be dealt with in the `buffer.loadModels()` that we we reviewing today. The result is that there is one overall promise that is available to the tests that we can `await` for all things ethereum related. Also, I removed all the logic around using hints to decide if ethereum models have been buffered or not, and we rather we use buffer's ES index and the last indexed blockheight vs the buffered model's blockheight to determine if we need to reload the model from ethereum.

I've also tested it against our contract in rinkeby, and the hub starts up and is listening on port 3000 almost instantly 👌 

Also, this introduces `blockheight` as `{ meta }` for ethereum models, which is think is a pretty good  idea, as it give more context in terms of when the data was obtained.