### PR TITLE
Update test-support-authenticator to handle newer session semantics

### DIFF
--- a/packages/test-support-authenticator/middleware.js
+++ b/packages/test-support-authenticator/middleware.js
@@ -8,6 +8,7 @@ module.exports = declareInjections({
 class TestAuthenticator {
   constructor() {
     this.userId = 'the-default-test-user';
+    this.type = 'test-users';
   }
   get category() {
     return 'authentication';
@@ -16,7 +17,7 @@ class TestAuthenticator {
     let self = this;
     return async (ctxt, next) => {
       if (self.userId != null) {
-        ctxt.state.cardstackSession = this.sessions.create('test-users', self.userId);
+        ctxt.state.cardstackSession = this.sessions.create(self.type, self.userId);
       }
       await next();
     };

--- a/packages/test-support/env.js
+++ b/packages/test-support/env.js
@@ -74,6 +74,13 @@ exports.createDefaultEnvironment = async function(projectDir, initialModels = []
         let plugins = await this.lookup('hub:plugins').active();
         let m = plugins.lookupFeatureAndAssert('middleware', '@cardstack/test-support-authenticator');
         m.userId = id;
+        m.type = 'test-users';
+      },
+      async setUser(type, id) {
+        let plugins = await this.lookup('hub:plugins').active();
+        let m = plugins.lookupFeatureAndAssert('middleware', '@cardstack/test-support-authenticator');
+        m.userId = id;
+        m.type = type;
       }
     });
     return container;


### PR DESCRIPTION
You really need to set the `type` and not just the `id`, because now the auth system fully vets types.