### PR TITLE
Cardstack authenticator throws with error message on 401

### DIFF
--- a/packages/authentication/addon/cardstack-authenticator.js
+++ b/packages/authentication/addon/cardstack-authenticator.js
@@ -58,6 +58,11 @@ export default Base.extend({
       },
       body: JSON.stringify(payload)
     }).then(response => {
+      if (response.status === 401) {
+        return response.json().then(body => {
+          throw new Error(body.errors[0].detail);
+        })
+      }
       if (response.status !== 200) {
         throw new Error("Authentication attempt failed");
       }

--- a/packages/mock-auth/addon/services/mock-login.js
+++ b/packages/mock-auth/addon/services/mock-login.js
@@ -14,7 +14,13 @@ export default Service.extend({
   login: task(function * (mockUserId) {
     mockUserId = this.get('mockUserId') || mockUserId;
     if (mockUserId ) {
-      yield this.get('session').authenticate('authenticator:cardstack', this.get('source'), { authorizationCode: mockUserId });
+      let message;
+
+      try {
+        yield this.get('session').authenticate('authenticator:cardstack', this.get('source'), { authorizationCode: mockUserId });
+      } catch(err) {
+        message = err.message;
+      }
 
       let session = get(this, 'cardstackSession');
       let onAuthenticationHandler = get(this, 'authenticationHandler');
@@ -28,9 +34,9 @@ export default Service.extend({
         onPartialAuthenticationHandler === 'function') {
         onPartialAuthenticationHandler(session);
       } else if (!get(session, 'isAuthenticated') &&
-        !get(session, 'isPartiallyAuthenticated') &&
+        !get(session, 'isPartiallyAuthenticated') && typeof
         onAuthenticationFailedHandler === 'function') {
-        onAuthenticationFailedHandler();
+        onAuthenticationFailedHandler(message);
       }
     }
   }).drop()


### PR DESCRIPTION
Also has `mock-auth` catching the error message and passing it to `onAuthenticationFailedHandler`. There is a corresponding change to [cardstack/cardstack-auth0](https://github.com/cardstack/cardstack-auth0/pull/30) that does the same.

No automated tests, only manual.