### PR TITLE
deal with duelling sessions 

### DIFF
--- a/packages/authentication/cardstack/middleware.js
+++ b/packages/authentication/cardstack/middleware.js
@@ -140,6 +140,11 @@ class Authentication {
           if (!user) { throw new Error(`cant find user type ${session.type} id ${session.id}`); }
 
           await this._generateSession(ctxt, user);
+
+          let m = bearerTokenPattern.exec(ctxt.header['authorization']);
+          if (m) {
+            ctxt.body.data.meta['prevToken'] = m[1];
+          }
         });
       }
     ]));


### PR DESCRIPTION
Handle dueling sessions by telling the client the token it used when checking the token status. 

The fundamental issue is that Ember Simple Auth coordinates the session across multiple tabs of a browser, which is actually a pretty neat feature; however, the act of checking the status of a hub's session will generate a new session. ESA's coordination of sessions across tabs will trigger each tab to check the status of the session, and thereby change the session in an alternating manner over and over again. To prevent this from happening, each client will generate a random ID for itself, and when it receives a session token it will save in local storage the token received, the ID of the client that first requested the token, and the time the token was received. When ESA invokes the `restore` hook of the authenticator as a result of a change to local storage, the client can then check if the newly received session from the server has a previous token that matches its client ID, if it doesnt (and if that was requested within a "grace period"), then the client can resolve the `restore` hook with the session it just received instead of trying to double check it with the server again (and thus not triggering the endless loop).

The end result of this fix is actually pretty cool and aligns with the session coordination that ESA is trying to do for you: when you have multiple tabs open and log into one tab, you will automatically be logged into all the other tabs you have open. And vice versa, when you log out of one tab, you are automatically logged out of all the other tabs that you have open.