### PR TITLE
Add the concept of a session meta, and store the request IP in it in the

### DIFF
--- a/packages/authentication/node-tests/ip-test.js
+++ b/packages/authentication/node-tests/ip-test.js
@@ -1,0 +1,77 @@
+const supertest = require('supertest');
+const Koa = require('koa');
+const {
+  createDefaultEnvironment,
+  destroyDefaultEnvironment
+} = require('@cardstack/test-support/env');
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
+
+describe('authentication/middleware/ip', function() {
+
+  let request, env, auth;
+  let ciSessionId = '1234567890';
+
+  async function setup(callback) {
+    let factory = new JSONAPIFactory();
+
+
+    if(callback) {
+      await callback(factory);
+    }
+
+
+    env = await createDefaultEnvironment(`${__dirname}/stub-authenticators`, factory.getModels(), { ciSessionId });
+    let app = new Koa();
+    app.use(env.lookup('hub:middleware-stack').middleware());
+    app.use(async function(ctxt) {
+      ctxt.set('Content-Type', 'application/json');
+      ctxt.body = ctxt.state.cardstackSession && ctxt.state.cardstackSession.meta;
+    });
+    request = supertest(app.callback());
+    auth = env.lookup('plugin-middleware:' + require.resolve('../cardstack/middleware'));
+  }
+
+  async function teardown() {
+    await destroyDefaultEnvironment(env);
+  }
+
+  after(teardown);
+
+  it('there is no session meta if there is no session', async function() {
+    await setup();
+    let response = await request.get('/');
+    expect(response.body).deep.equals({});
+  });
+
+  it('has the ip in the session meta', async function() {
+    await setup();
+    let { token } = await auth.createToken({ id: env.user.data.id, type: 'test-users' }, 30);
+    let response = await request.get('/').set('authorization', `Bearer ${token}`);
+    expect(response.body).has.property('ip', "::ffff:127.0.0.1");
+  });
+
+  it('ignores the X-Forwarded-For header over the request ip if it is present and allow-x-forwarded-for is not configured', async function() {
+    await setup();
+    let { token } = await auth.createToken({ id: env.user.data.id, type: 'test-users' }, 30);
+    let response = await request.get('/').set('authorization', `Bearer ${token}`).set('X-Forwarded-For', '8.8.8.8');
+
+    expect(response.body).has.property('ip', "::ffff:127.0.0.1");
+  });
+
+  it('uses the X-Forwarded-For header over the request ip if it is present and allow-x-forwarded-for is configured to be allowed', async function() {
+    await setup((factory) => {
+      factory.addResource('plugin-configs', '@cardstack/authentication')
+        .withAttributes({
+          'plugin-config': {
+            'allow-x-forwarded-for': true
+          }
+        });
+    });
+
+    let { token } = await auth.createToken({ id: env.user.data.id, type: 'test-users' }, 30);
+
+    let response = await request.get('/').set('authorization', `Bearer ${token}`).set('X-Forwarded-For', '8.8.8.8');
+    expect(response.body).has.property('ip', "8.8.8.8");
+  });
+
+});

--- a/packages/hub/bootstrap-schema.js
+++ b/packages/hub/bootstrap-schema.js
@@ -121,7 +121,8 @@ const models = [
     relationships: {
       fields: {
         data: [
-          { type: 'fields', id: 'enabled' }
+          { type: 'fields', id: 'enabled' },
+          { type: 'fields', id: 'plugin-config' }
         ]
       }
     }
@@ -578,6 +579,13 @@ const models = [
     id: 'enabled',
     attributes: {
       'field-type': '@cardstack/core-types::boolean'
+    }
+  },
+  {
+    type: 'fields',
+    id: 'plugin-config',
+    attributes: {
+      'field-type': '@cardstack/core-types::object'
     }
   },
   {

--- a/packages/hub/sessions.js
+++ b/packages/hub/sessions.js
@@ -26,7 +26,7 @@ class Sessions {
     return this._userSearcher;
   }
 
-  create(type, id) {
-    return new Session({ type, id }, this.userSearcher);
+  create(type, id, meta) {
+    return new Session({ type, id }, this.userSearcher, null, null, meta);
   }
 });

--- a/packages/plugin-utils/session.js
+++ b/packages/plugin-utils/session.js
@@ -5,11 +5,12 @@ class Session {
   //
   // optionalUser can be a jsonapi document representing that user (a
   // full document, including the top-level `data` property)
-  constructor(payload, userSearcher, optionalUser, optionalRealms) {
+  constructor(payload, userSearcher, optionalUser, optionalRealms, meta) {
     this.payload = payload;
     this.userSearcher = userSearcher;
     this._user = optionalUser;
     this._realms = optionalRealms;
+    this.meta = meta;
   }
   get id() {
     return this.payload.id;


### PR DESCRIPTION
authentication middleware.

A plugin config can be added to allow respecting the X-Forwarded-For header if
the app is hosted behind a reverse proxy.