### PR TITLE
cleanse problematic chars in auth response

### DIFF
--- a/packages/authentication/index.js
+++ b/packages/authentication/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const Handlebars = require('handlebars');
 const log = require('@cardstack/logger')('cardstack/auth');
+const he = require('he');
 
 module.exports = {
   name: '@cardstack/authentication',
@@ -21,6 +22,9 @@ module.exports = {
     } else {
       let compiled = Handlebars.compile(userTemplate);
       let stringRewritten = compiled(externalUser);
+      // replace double quote HTML entities first with escaped quotes
+      // so we dont end up escaping legit JSON quotes
+      stringRewritten = he.decode(stringRewritten.replace(/&quot;/g, '\\"')).replace(/\s/g, ' ');
       try {
         rewritten = JSON.parse(stringRewritten);
       } catch (err) {

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -35,6 +35,7 @@
     "ember-inflector": "^2.1.0",
     "ember-simple-auth": "^1.2.2",
     "handlebars": "^4.0.6",
+    "he": "^1.1.1",
     "koa-better-route": "^0.1.0",
     "koa-compose": "^3.2.1",
     "koa-json-body": "^5.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5576,7 +5576,7 @@ hawk@~6.0.2:
     hoek "4.x.x"
     sntp "2.x.x"
 
-he@1.1.1:
+he@1.1.1, he@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 


### PR DESCRIPTION
This prevents `JSON.parse` errors when rewriting users from the auth response