### PR TITLE
[wip] Initial queue plugin implementation

### DIFF
--- a/packages/hub/main.js
+++ b/packages/hub/main.js
@@ -17,6 +17,12 @@ async function wireItUp(projectDir, encryptionKeys, dataSources, opts = {}) {
   registry.register('config:encryption-key', encryptionKeys);
   registry.register('config:public-url', { url: opts.url });
   registry.register('config:ci-session', { id: opts.ciSessionId });
+  registry.register('config:pg-boss', opts.pgBossConfig || {
+    database: process.env.PG_BOSS_DATABASE,
+    host:     process.env.PG_BOSS_HOST,
+    user:     process.env.PG_BOSS_USER,
+    port:     process.env.PG_BOSS_PORT
+  });
 
   if (typeof opts.seeds === 'function') {
     registry.register('config:initial-models', opts.seeds);

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -24,6 +24,7 @@
     "@cardstack/handlebars": "0.8.0",
     "@cardstack/logger": "^0.1.0",
     "@cardstack/plugin-utils": "0.8.0",
+    "@cardstack/queue": "^0.8.1",
     "broccoli-concat": "^3.2.2",
     "broccoli-plugin": "^1.3.0",
     "broccoli-source": "^1.1.0",

--- a/packages/hub/plugin-loader.js
+++ b/packages/hub/plugin-loader.js
@@ -24,8 +24,7 @@ const featureTypes = [
   'authenticators',
   'middleware',
   'messengers',
-  'code-generators',
-  'queues'
+  'code-generators'
 ];
 const javascriptPattern = /(.*)\.js$/;
 

--- a/packages/hub/plugin-loader.js
+++ b/packages/hub/plugin-loader.js
@@ -24,7 +24,8 @@ const featureTypes = [
   'authenticators',
   'middleware',
   'messengers',
-  'code-generators'
+  'code-generators',
+  'queues'
 ];
 const javascriptPattern = /(.*)\.js$/;
 

--- a/packages/hub/queues.js
+++ b/packages/hub/queues.js
@@ -1,0 +1,7 @@
+const Queue = require('@cardstack/queue');
+
+module.exports = class Queues {
+  static create() {
+    return new Queue();
+  }
+};

--- a/packages/hub/queues.js
+++ b/packages/hub/queues.js
@@ -1,7 +1,15 @@
 const Queue = require('@cardstack/queue');
+const { declareInjections } = require('@cardstack/di');
 
-module.exports = class Queues {
-  static create() {
-    return new Queue();
+module.exports = declareInjections({
+  config: 'config:pg-boss'
+},
+class Queues {
+  static create({config}) {
+    return new Queue(config);
   }
-};
+
+  static async teardown(instance) {
+    await instance.stop();
+  }
+});

--- a/packages/queue/.eslintrc.js
+++ b/packages/queue/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  "extends": require.resolve('@cardstack/eslint-config')
+};

--- a/packages/queue/.npmignore
+++ b/packages/queue/.npmignore
@@ -1,0 +1,1 @@
+/node-tests

--- a/packages/queue/README.md
+++ b/packages/queue/README.md
@@ -1,0 +1,56 @@
+# Job queuing plugin for Cardstack
+
+This plugin is for queueing jobs with cardstack hub. It uses [pg-boss](https://github.com/timgit/pg-boss) and
+by extension, postgresql, to manage queued jobs,
+
+# Required database configuration
+
+The test suite is configured to talk to a PostgreSQL docker container. You can start it like:
+
+    docker run --name cardstack-postgres -d --rm -p 5444:5432 cardstack/pg-test
+
+And stop it like:
+
+    docker stop cardstack-postgres
+
+
+# API
+
+Assuming you've looked up the queues feature from DI etc, e.g.
+
+```js
+let queue = env.lookup('hub:queues');
+```
+
+You can subscribe to a job by passing in a handler:
+
+```js
+queue.subscribe('my-job', handler, options);
+```
+
+Options are passed directly to pg boss.
+
+Handlers can be sync or async:
+
+```js
+queue.subscribe('my-job', () => console.log("sync handler") );
+
+queue.subscribe('my-job', () => { return new Promise() } );
+
+queue.subscribe('my-job', async () => { await stuff(); console.log('done') });
+```
+
+You can then publish jobs to the named queues.
+
+To publish without waiting for the job to complete, use the `publish` method:
+
+```js
+  let jobId = await queue.publish('my-job', {someDataForJob: 123}, options);
+  // this line executes after the job gets to the db, but before it is executed
+```
+To publish and wait for the job to complete, use the `publishAndWait` method:
+
+```js
+  let jobResult = await queue.publishAndWait('my-job', {someDataForJob: 123}, options);
+  // this line executes after the job is completed
+```

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -1,0 +1,103 @@
+const PgBoss = require('pg-boss');
+const log = require('@cardstack/logger')('cardstack/queue');
+
+module.exports = class Queue {
+  constructor() {
+    this.boss = null;
+    this.promiseResolveCallbacks = {};
+    this.promiseRejectCallbacks = {};
+    this.callbackedQueues = [];
+    this.jobErrors = {};
+  }
+
+  async _ensureBoss() {
+    if (!this.boss) {
+      this.boss = new PgBoss({ database: 'postgres', host: 'localhost', user: 'postgres', port: 5444 });
+      await this.boss.start();
+      log.debug("Boss started");
+    }
+  }
+
+  async stop() {
+    if (this.boss) {
+      await this.boss.stop();
+      log.debug("Boss stopped");
+      this.boss = null;
+    }
+  }
+
+  async publish(jobName, ...options) {
+    await this._ensureBoss();
+    let jobId = await this.boss.publish(jobName, ...options);
+    log.debug(`Published new job ${jobId} to queue ${jobName}`);
+    return jobId;
+  }
+
+  async publishAndWait(jobName, ...options) {
+    let jobId = await this.publish(jobName, ...options);
+
+    this._setupCallbacks(jobName);
+
+    return new Promise((resolve, reject) => {
+      this.promiseResolveCallbacks[jobId] = resolve;
+      this.promiseRejectCallbacks[jobId] = reject;
+    });
+  }
+
+  async subscribe(jobName, handler, options={}) {
+    log.debug(`Subscribing to queue ${jobName}`);
+
+    await this._ensureBoss();
+
+    // handlers in boss use a callback style. Wrapping allows a promise style
+    // in handlers instead of having to deal with an old-style done callback
+    let wrappedHander = async (job, done) => {
+      log.debug(`Processing job ${job.id} from queue ${jobName}`);
+      let result;
+
+      try {
+        result = await handler(job);
+      } catch (e) {
+        log.debug(`Error occurred during proccesing of job ${job.id}: ${e.message}`);
+        this.jobErrors[job.id] = e;
+        done(e);
+        return;
+      }
+      log.debug(`Processing complete of ${job.id} from queue ${jobName}`);
+      done(null, result);
+    };
+
+    // boss uses a different argument order and options is optional, this
+    // is weird, as why would you ever subscribe without a handler?
+
+    // I'm switching the argument order to simplify things
+    return await this.boss.subscribe(jobName, options, wrappedHander);
+  }
+
+
+  _setupCallbacks(jobName) {
+    if (this.callbackedQueues.includes(jobName)) {
+      return;
+    }
+
+    this.boss.onComplete(jobName, job => {
+      let promiseResolve = this.promiseResolveCallbacks[job.data.request.id];
+      this._cleanupJob(job.data.request.id);
+      promiseResolve(job);
+    });
+    this.boss.onFail(jobName, job => {
+      let promiseReject = this.promiseRejectCallbacks[job.data.request.id];
+      let error = this.jobErrors[job.data.request.id];
+      this._cleanupJob(job.data.request.id);
+      promiseReject(error);
+    });
+
+    this.callbackedQueues.push(jobName);
+  }
+
+  _cleanupJob(jobId) {
+    delete this.jobErrors[jobId];
+    delete this.promiseResolveCallbacks[jobId];
+    delete this.promiseRejectCallbacks[jobId];
+  }
+};

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -2,17 +2,18 @@ const PgBoss = require('pg-boss');
 const log = require('@cardstack/logger')('cardstack/queue');
 
 module.exports = class Queue {
-  constructor() {
+  constructor(config) {
     this.boss = null;
     this.promiseResolveCallbacks = {};
     this.promiseRejectCallbacks = {};
     this.callbackedQueues = [];
     this.jobErrors = {};
+    this.config = config;
   }
 
   async _ensureBoss() {
     if (!this.boss) {
-      this.boss = new PgBoss({ database: 'postgres', host: 'localhost', user: 'postgres', port: 5444 });
+      this.boss = new PgBoss(this.config);
       await this.boss.start();
       log.debug("Boss started");
     }

--- a/packages/queue/node-tests/queue-test.js
+++ b/packages/queue/node-tests/queue-test.js
@@ -1,0 +1,202 @@
+const {
+  createDefaultEnvironment,
+  destroyDefaultEnvironment
+} = require('@cardstack/test-support/env');
+
+const delay = require('delay');
+
+
+describe('@cardstack/queue', function() {
+  let env, queue;
+
+  async function setup() {
+    env = await createDefaultEnvironment(`${__dirname}/..`);
+
+    queue = env.lookup('hub:queues');
+
+    await env.lookup('hub:indexers').update({ forceRefresh: true });
+  }
+
+  async function teardown() {
+    await destroyDefaultEnvironment(env);
+    await queue.stop();
+  }
+
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('can publish a job ', async function() {
+    await queue.publish('test-job');
+  });
+
+  it('can subscribe to a job', async function() {
+    await queue.publish('test-job');
+    await new Promise((resolve) =>
+      queue.subscribe('test-job', resolve)
+    );
+  });
+
+  it('can return a promise that resolves after a job is complete', async function() {
+    let isDoneWithoutWait = false, isDoneWithWait = false;
+
+    let noWaitWorker = () => {
+      isDoneWithoutWait = true;
+    };
+    await queue.subscribe('long-job-without-wait', noWaitWorker);
+
+    expect(isDoneWithoutWait).to.not.be.ok;
+
+    await queue.publish('long-job-without-wait');
+
+    expect(isDoneWithoutWait).to.not.be.ok;
+
+    let waitWorker = () => {
+      isDoneWithWait = true;
+    };
+
+    await queue.subscribe('long-job-with-wait', waitWorker);
+    expect(isDoneWithWait).to.not.be.ok;
+
+    let result = await queue.publishAndWait('long-job-with-wait');
+    expect(isDoneWithWait).to.be.ok;
+    expect(result.name).to.equal("long-job-with-wait__state__complete");
+
+  }).timeout(4000);
+
+
+  it('completes immediately if workers do not return a promise', function(done) {
+    (async () => {
+      let isDone = false;
+
+      let worker = () => {
+        setTimeout(() => {
+          isDone = true;
+          done();
+        }, 1000);
+      };
+
+      await queue.subscribe('timeout-job', worker);
+
+      await queue.publishAndWait('timeout-job');
+
+      expect(isDone).to.be.falsy;
+      // it didn't wait, because the worker didn't return a promise
+    })();
+  }).timeout(4000);
+
+  it('waits for promises in workers', async function() {
+    let isDone = false;
+
+    let worker = () => {
+      return new Promise(resolve => {
+        setTimeout(() => {
+          isDone = true;
+          resolve();
+        }, 1000);
+      });
+    };
+
+    await queue.subscribe('promise-job', worker);
+
+    await queue.publishAndWait('promise-job');
+    expect(isDone).to.be.ok;
+  }).timeout(4000);
+
+  it('waits for async workers', async function() {
+    let isDone = false;
+
+    let worker = async () => {
+      await delay(1000);
+      isDone = true;
+    };
+
+    await queue.subscribe('async-job', worker);
+
+    await queue.publishAndWait('async-job');
+    expect(isDone).to.be.ok;
+  }).timeout(4000);
+
+  it('the result of the job is returned to the waiter', async function() {
+
+    let worker = async () => {
+      await delay(10);
+      return {outcome: "it worked!"};
+    };
+
+    await queue.subscribe('async-job', worker);
+
+    let result = await queue.publishAndWait('async-job');
+    expect(result.data.response.outcome).to.equal("it worked!");
+  }).timeout(4000);
+
+  it('handles sync errors', async function() {
+    let worker = () => {
+      throw new Error("sync error");
+    };
+
+    await queue.subscribe('sync-error-job', worker);
+    try {
+      await queue.publishAndWait('sync-error-job');
+      expect(false).to.be.ok("should not get here");
+    } catch (e) {
+      expect(e.message).to.equal("sync error");
+    }
+  }).timeout(4000);
+
+  it('handles async errors', async function() {
+    let worker = async () => {
+      await delay(100);
+      throw new Error("async error");
+    };
+
+    await queue.subscribe('async-error-job', worker);
+    try {
+      await queue.publishAndWait('async-error-job');
+      expect(false).to.be.ok("should not get here");
+    } catch (e) {
+      expect(e.message).to.equal("async error");
+    }
+  }).timeout(4000);
+
+  it('cleans up state', async function() {
+    let worker = () => {
+      throw new Error("sync error");
+    };
+
+    await queue.subscribe('cleanup-job', worker);
+    try {
+      await queue.publishAndWait('cleanup-job');
+      expect(false).to.be.ok("should not get here");
+    } catch (e) {
+      expect(e.message).to.equal("sync error");
+    }
+
+    expect(Object.keys(queue.jobErrors).length).to.equal(0);
+    expect(Object.keys(queue.promiseResolveCallbacks).length).to.equal(0);
+    expect(Object.keys(queue.promiseRejectCallbacks).length).to.equal(0);
+  }).timeout(4000);
+
+  it('works with multiple publishes', async function() {
+    let workCount = 0;
+    let worker = () => {
+      workCount += 1;
+    };
+
+    await queue.subscribe('test-multiple-job', worker);
+
+    await queue.publishAndWait('test-multiple-job');
+    await queue.publishAndWait('test-multiple-job');
+
+    expect(workCount).to.equal(2);
+  }).timeout(8000);
+
+  it('sends data to the job', async function() {
+    let worker = ({data}) => {
+      expect(data.foo).to.equal(123);
+    };
+    await queue.subscribe('test-job', worker);
+    await queue.publishAndWait('test-job', {foo: 123});
+  }).timeout(4000);
+
+
+});

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@cardstack/queue",
+  "version": "0.8.1",
+  "description": "Job queueing plugin for @cardstack/hub.",
+  "repository": "https://github.com/cardstack/cardstack",
+  "author": "Alex Speller <alex@alexspeller.com>",
+  "license": "MIT",
+  "engines": {
+    "node": ">= 7.7"
+  },
+  "devDependencies": {
+    "@cardstack/eslint-config": "0.8.0",
+    "@cardstack/test-support": "0.8.0",
+    "delay": "2.0.0",
+    "eslint": "4.9.0",
+    "eslint-plugin-ember": "^5.0.0",
+    "eslint-plugin-node": "^5.2.1"
+  },
+  "dependencies": {
+    "@cardstack/di": "0.8.0",
+    "@cardstack/logger": "^0.1.0",
+    "@cardstack/plugin-utils": "0.8.0",
+    "pg-boss": "^2.5.1"
+  },
+  "keywords": [
+    "cardstack-plugin"
+  ],
+  "cardstack-plugin": {
+    "api-version": 1
+  },
+  "scripts": {
+    "test": "mocha ../test-support/bin/run.js"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3037,6 +3037,12 @@ del@^2.0.2:
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
 
+delay@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/delay/-/delay-2.0.0.tgz#9112eadc03e4ec7e00297337896f273bbd91fae5"
+  dependencies:
+    p-defer "^1.0.0"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -8172,6 +8178,10 @@ p-cancelable@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.4.0.tgz#bcb41d35bf6097fc4367a065b6eb84b9b124eff0"
 
+p-defer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
@@ -8358,6 +8368,13 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
+pg-boss@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/pg-boss/-/pg-boss-2.5.1.tgz#c8228a47c417052d194ca3c5164c549867631e2f"
+  dependencies:
+    pg "^7.4.1"
+    uuid "^3.2.1"
+
 pg-connection-string@0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-0.1.3.tgz#da1847b20940e42ee1492beaf65d49d91b245df7"
@@ -8381,6 +8398,18 @@ pg@^7.0.3:
   dependencies:
     buffer-writer "1.0.1"
     js-string-escape "1.0.1"
+    packet-reader "0.3.1"
+    pg-connection-string "0.1.3"
+    pg-pool "~2.0.3"
+    pg-types "~1.12.1"
+    pgpass "1.x"
+    semver "4.3.2"
+
+pg@^7.4.1:
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-7.4.3.tgz#f7b6f93f5340ecc2596afbb94a13e3d6b609834b"
+  dependencies:
+    buffer-writer "1.0.1"
     packet-reader "0.3.1"
     pg-connection-string "0.1.3"
     pg-pool "~2.0.3"
@@ -10894,6 +10923,10 @@ uuid@^2.0.1:
 uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
+uuid@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
 uws@~0.14.4:
   version "0.14.5"


### PR DESCRIPTION
There is one unresolved question here, which is how to configure pg-boss.

I was planning to do it using env variables; so first off, check if `PG_BOSS_DB_URL` is present, then check for `PG_BOSS_DB_HOST`, `PG_BOSS_DB_NAME` etc, then just default to nothing which will try to connect to localhost as is the default behaviour for the pg module.

However, if I do that, I'm not quite sure how I'd override that for testing - I guess I could just do `process.env.PG_BOSS_DB_URL = whatever` in the test setup but that seems a bit unidiomatic?