### PR TITLE
Update node-pg-migrate

### DIFF
--- a/packages/postgresql/indexer.js
+++ b/packages/postgresql/indexer.js
@@ -7,7 +7,7 @@ const { apply_patch } = require('jsonpatch');
 const NameMapper = require('./name-mapper');
 const { declareInjections } = require('@cardstack/di');
 const path = require('path');
-const migrate = require('@cardstack/node-pg-migrate').default;
+const migrate = require('node-pg-migrate').default;
 
 // Yes, this is slightly bananas. But it's easier to just read the
 // output of the "test_decoding" plugin that ships with postgres than
@@ -85,7 +85,8 @@ module.exports = declareInjections({
         password: config.password,
         port: config.port
       },
-      dir
+      dir,
+      log: (...args) => log.debug(...args)
     });
   }
 });

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -21,7 +21,7 @@
     "@cardstack/di": "0.8.0",
     "@cardstack/elasticsearch": "0.8.0",
     "@cardstack/logger": "^0.1.0",
-    "@cardstack/node-pg-migrate": "3.0.0-rc2-cardstack.1",
+    "node-pg-migrate": "3.5.0",
     "@cardstack/plugin-utils": "0.8.0",
     "jsonpatch": "^3.0.1",
     "lodash": "^4.17.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,18 +8,6 @@
   dependencies:
     ms "2.0.0"
 
-"@cardstack/node-pg-migrate@3.0.0-rc2-cardstack.1":
-  version "3.0.0-rc2-cardstack.1"
-  resolved "https://registry.yarnpkg.com/@cardstack/node-pg-migrate/-/node-pg-migrate-3.0.0-rc2-cardstack.1.tgz#26dcb5d53cb097371118e0299a02da9857b9904f"
-  dependencies:
-    "@types/pg" "^7.4.5"
-    lodash "~4.17.0"
-    mkdirp "~0.5.1"
-    yargs "~11.0.0"
-  optionalDependencies:
-    config ">=1.0.0"
-    dotenv ">=1.0.0"
-
 "@cardstack/nodegit@^0.21.2-cardstack.1":
   version "0.21.2-cardstack.1"
   resolved "https://registry.yarnpkg.com/@cardstack/nodegit/-/nodegit-0.21.2-cardstack.1.tgz#551efebaca210d9f5bfcf8dc9537d3e5d4e9fe95"
@@ -7726,6 +7714,18 @@ node-notifier@^5.0.1:
     semver "^5.3.0"
     shellwords "^0.1.0"
     which "^1.2.12"
+
+node-pg-migrate@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/node-pg-migrate/-/node-pg-migrate-3.5.0.tgz#f39f20ca6003ac257dc13037bd08bc440b7143be"
+  dependencies:
+    "@types/pg" "^7.4.5"
+    lodash "~4.17.0"
+    mkdirp "~0.5.1"
+    yargs "~11.0.0"
+  optionalDependencies:
+    config ">=1.0.0"
+    dotenv ">=1.0.0"
 
 node-pre-gyp@^0.6.39, node-pre-gyp@~0.6.39:
   version "0.6.39"


### PR DESCRIPTION
node-pg-migrate has merged all our changes, and the newest version can quiet most of the noisy logs.