### PR TITLE
read inter-doc dependencies from pgsearch

### DIFF
--- a/packages/pgsearch/TODO
+++ b/packages/pgsearch/TODO
@@ -1,9 +1,10 @@
 # Implementation notes for pgsearch refactor
 
 3. Refactord cardstack_pristine, cardstack_references, etc, out of searchDoc.
-4. When we invalidate documents, we're feeding post-processed ones back into the indexing process. We will need to strip off computed properties, etc, there. For now it's possible they would persist.
-4.5 The `read` method in branch update should get smarter.
 5. verify cursor behavior in docsThatReference (either manually or write a test)
 6. Improve DI system to remove hack where we do require.resolve during injections.
 8. Switch filter default from non-exact to exact.
 9. Drop implicit "any" array support inside operators like 'exact'
+10. readOtherIndexers can become a full searcher, but that involves more sophisticated invalidation queries
+uncachedRead should go away (this is easier to do if we replace readOtherIndexers with a full searcher)
+custom search representations not implemented (example: mobiledoc, which still has leftover mobiledoc-text-renderer dep), tests passing by accident

--- a/tests/pgsearch-test-app/node_modules/fake-indexer/indexer.js
+++ b/tests/pgsearch-test-app/node_modules/fake-indexer/indexer.js
@@ -1,0 +1,34 @@
+module.exports = class FakeIndexer {
+    static create(params) {
+        let obj = new this();
+        Object.assign(obj, params);
+        return obj;
+    }
+
+    async branches() {
+        return ['master'];
+    }
+
+    async beginUpdate(/* branch */) {
+        return new Updater(this.changedModels);
+    }
+};
+
+class Updater {
+    constructor(changedModels) {
+        this.changedModels = changedModels;
+    }
+    async schema() {
+        return [];
+    }
+
+    async updateContent(meta, hints, ops) {
+        for (let { model, type, id } of this.changedModels) {
+            if (model) {
+                await ops.save(type, id, model);
+            } else {
+                await ops.delete(type, id);
+            }
+        }
+    }
+}

--- a/tests/pgsearch-test-app/node_modules/fake-indexer/package.json
+++ b/tests/pgsearch-test-app/node_modules/fake-indexer/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "fake-indexer",
+    "keywords": ["cardstack-plugin"],
+    "cardstack-plugin": {
+      "api-version": 1
+    }
+  }

--- a/tests/pgsearch-test-app/package.json
+++ b/tests/pgsearch-test-app/package.json
@@ -4,7 +4,8 @@
   },
   "devDependencies": {
     "@cardstack/mobiledoc": "*",
-    "@cardstack/test-support": "*"
+    "@cardstack/test-support": "*",
+    "fake-indexer": "*"
   },
   "engines": {
     "node": ">= 8"


### PR DESCRIPTION
During indexing we used to always read inter-document dependencies from their upstream data sources. Now we can read them from the pgsearch cache.

I'm keeping the uncached-read around for now because we were exposing it to plugins and they need to be refactored to work differently. They can't use the cached read because we can't necessarily track the dependencies from what they read to what they emit.