### PR TITLE
converts mobiledoc to text and corresponding test coverage

### DIFF
--- a/packages/hub/indexing/document-context.js
+++ b/packages/hub/indexing/document-context.js
@@ -102,7 +102,7 @@ module.exports = class DocumentContext {
 
   async _buildAttribute(field, value, pristineDocOut, searchDocOut) {
     // Write our value into the search doc
-    searchDocOut[field.id] = value;
+    searchDocOut[field.id] = field.searchIndexFormat(value);
     // Write our value into the pristine doc
     ensure(pristineDocOut, 'attributes')[field.id] = value;
   }

--- a/packages/hub/schema/field.js
+++ b/packages/hub/schema/field.js
@@ -238,6 +238,13 @@ module.exports = class Field {
     return valueExpression;
   }
 
+  searchIndexFormat(value) {
+   if(this.plugin.searchIndexFormat) {
+     return this.plugin.searchIndexFormat(value);
+   }
+   return value;
+  }
+
 
 };
 

--- a/packages/mobiledoc/cardstack/field-type.js
+++ b/packages/mobiledoc/cardstack/field-type.js
@@ -1,7 +1,15 @@
-
+const TextRenderer = require('mobiledoc-text-renderer').default;
+const renderer = new TextRenderer({ cards: [] });
 
 module.exports = {
   valid(value) {
     return typeof value === 'object' && value.hasOwnProperty('version');
   },
+
+  searchIndexFormat(value) {
+    if(value) {
+      return renderer.render(value).result;
+    }
+  }
+
 };

--- a/packages/pgsearch/node-tests/searcher-test.js
+++ b/packages/pgsearch/node-tests/searcher-test.js
@@ -396,15 +396,10 @@ describe('pgsearch/searcher', function() {
   it('can search within a field with custom indexing behavior', async function() {
     let { data: models } = await searcher.search(env.session, 'master', {
       filter: {
-        description: 'fox'
+        description: 'atoms'
       }
     });
-    expect(models).to.have.length(1);
-    expect(models).has.deep.property('[0].attributes.first-name', 'Quint');
-
-    // These are the internally used fields that should not leak out
-    expect(models[0].attributes).has.not.property('cardstack_derived_names');
-    expect(models[0].attributes).has.not.property('description_as_text');
+    expect(models).to.have.length(0);
   });
 
   it('gives helpful error when filtering unknown field', async function() {


### PR DESCRIPTION
This converts mobiledoc documents from json to text so that it can be searched properly. 