### PR TITLE
Incorporate document-context into searchers

### DIFF
--- a/packages/hub/indexers.js
+++ b/packages/hub/indexers.js
@@ -135,10 +135,10 @@ class Indexers extends EventEmitter {
           // Compare each branch, so we don't invalidate the schemas
           // unnecessarily
           for (let [branch, newSchema] of Object.entries(schemas)) {
-            let oldSchema = priorCache[branch];
+            let oldSchema = (await priorCache)[branch];
             if (!newSchema.equalTo(oldSchema)) {
               log.info('schema for branch %s was changed', branch);
-              priorCache[branch] = newSchema;
+              (await priorCache)[branch] = newSchema;
               if (oldSchema) {
                 await oldSchema.teardown();
               }

--- a/packages/hub/indexers.js
+++ b/packages/hub/indexers.js
@@ -72,7 +72,8 @@ class Indexers extends EventEmitter {
         }
       })();
     }
-    return (await this._schemaCache)[branch];
+    let schema = (await this._schemaCache)[branch];
+    return schema;
   }
 
   async invalidateSchemaCache() {

--- a/packages/hub/indexers.js
+++ b/packages/hub/indexers.js
@@ -72,8 +72,7 @@ class Indexers extends EventEmitter {
         }
       })();
     }
-    let schema = (await this._schemaCache)[branch];
-    return schema;
+    return (await this._schemaCache)[branch];
   }
 
   async invalidateSchemaCache() {

--- a/packages/hub/indexing/document-context.js
+++ b/packages/hub/indexing/document-context.js
@@ -15,6 +15,7 @@ module.exports = class DocumentContext {
     this.upstreamDoc = upstreamDoc;
     this.additionalIncludes = additionalIncludes;
     this._read = read;
+    this.isCollection = upstreamDoc && upstreamDoc.data && Array.isArray(upstreamDoc.data);
 
     // included resources that we actually found
     this.pristineIncludes = [];
@@ -33,6 +34,8 @@ module.exports = class DocumentContext {
   }
 
   async searchDoc() {
+    if (this.isCollection) { return; }
+
     let searchDoc = await this._getCachedSearchDoc();
     if (!searchDoc) { return; }
 
@@ -49,12 +52,17 @@ module.exports = class DocumentContext {
     if (!searchDoc) { return; }
 
     let pristine = searchDoc.cardstack_pristine;
-    pristine.data.meta.source = this.sourceId;
+
+    if (!this.isCollection) {
+      pristine.data.meta.source = this.sourceId;
+    }
 
     return pristine;
   }
 
   async realms() {
+    if (this.isCollection) { return; }
+
     let searchDoc = await this._getCachedSearchDoc();
     if (!searchDoc) { return; }
 
@@ -62,24 +70,31 @@ module.exports = class DocumentContext {
   }
 
   async references() {
+    if (this.isCollection) { return; }
+
     await this._getCachedSearchDoc(); // side effect builds up the references
     return this._references;
   }
 
   async read(type, id) {
     this._references.push(`${type}/${id}`);
+    //TODO implement some kind of caching here a'la jsonapi middleware's _loadAllIncluded()
     return this._read(type, id);
   }
 
 
   // TODO come up with a better way to cache (use Model)
   async _getCachedSearchDoc() {
-    let contentType = this.schema.types.get(this.type);
-    if (!contentType) {
-      return;
+    let searchTree;
+    if (!this.isCollection) {
+      let contentType = this.schema.types.get(this.type);
+      if (!contentType) { return; }
+
+      searchTree = contentType.includesTree;
     }
+
     if (!this._searchDoc) {
-      this._searchDoc = await this._build(this.type, this.id, this.upstreamDoc, contentType.includesTree, 0);
+      this._searchDoc = await this._build(this.type, this.id, this.upstreamDoc, searchTree, 0);
     }
     if (this._searchDoc) {
       return Object.assign({}, this._searchDoc);
@@ -126,12 +141,12 @@ module.exports = class DocumentContext {
       return;
     }
     let related;
-    if (value.data && (searchTree && searchTree[field.id] || this.additionalIncludes.includes(field.id))) {
+    if (value.data && searchTree[field.id]) {
       if (Array.isArray(value.data)) {
         related = await Promise.all(value.data.map(async ({ type, id }) => {
           let resource = await this.read(type, id);
           if (resource) {
-            return this._build(type, id, resource, searchTree && searchTree[field.id], depth + 1);
+            return this._build(type, id, resource, searchTree[field.id], depth + 1);
           }
         }));
         related = related.filter(Boolean);
@@ -139,7 +154,7 @@ module.exports = class DocumentContext {
       } else {
         let resource = await this.read(value.data.type, value.data.id);
         if (resource) {
-          related = await this._build(resource.type, resource.id, resource, searchTree && searchTree[field.id], depth + 1);
+          related = await this._build(resource.type, resource.id, resource, searchTree[field.id], depth + 1);
         }
         let data = related ? { type: related.type, id: related.id } : null;
         ensure(pristineDocOut, 'relationships')[field.id] = Object.assign({}, value, { data });
@@ -151,66 +166,111 @@ module.exports = class DocumentContext {
     searchDocOut[field.id] = related;
   }
 
-  async _build(type, id, jsonapiDoc, searchTree, depth) {
-    let contentType = this.schema.types.get(type);
-    if (!contentType) {
-      log.warn("ignoring unknown document type=%s id=%s", type, id);
-      return;
-    }
+  _buildSearchTree(searchTree, contentType, segments) {
+    if (!segments.length) { return contentType; }
+    if (searchTree[segments[0]]) { return; }
 
+    let field = contentType.realAndComputedFields.get(segments[0]);
+    if (!field || !field.relatedTypes) { return contentType; }
+
+    let relatedTypes = Object.keys(field.relatedTypes);
+    if (!relatedTypes.length) { return contentType; }
+
+    //TODO how to decide which related type to use?
+    searchTree[segments[0]] = this._buildSearchTree(Object.assign({}, searchTree), this.schema.types.get(relatedTypes[0]), segments.slice(1));
+
+    return searchTree;
+  }
+
+  async _build(type, id, jsonapiDoc, searchTree, depth) {
+    let isCollection = this.isCollection && depth === 0;
     // we store the id as a regular field in elasticsearch here, because
     // we use elasticsearch's own built-in _id for our own composite key
     // that takes into account branches.
     //
     // we don't store the type as a regular field in elasticsearch,
     // because we're keeping it in the built in _type field.
-    let searchDoc = { ['id']: id };
+    let searchDoc = isCollection ? {} : { ['id']: id };
 
     // this is the copy of the document we will return to anybody who
     // retrieves it. It's supposed to already be a correct jsonapi
     // response, as opposed to the searchDoc itself which is mangled
     // for searchability.
-    let pristine = {
-      data: { id, type }
-    };
+    let pristine = isCollection ? { data: [] } : { data: { id, type } };
+    let rootItems = [];
 
-    // we are going inside a parent document's includes, so we need
-    // our own type here.
-    if (depth > 0) {
-      searchDoc['type'] = type;
+    if (isCollection) {
+      for (let [index, resource] of jsonapiDoc.data.entries()) {
+        let contentType = this.schema.types.get(resource.type);
+        if (!contentType) { continue; }
+
+        let additionalIncludes = {};
+        for (let segments of this.additionalIncludes) {
+          this._buildSearchTree(additionalIncludes, contentType, segments);
+        }
+
+        let pristineItem = await this._build(resource.type, resource.id, resource, Object.assign(additionalIncludes, contentType.includesTree), depth + 1);
+        assignMeta(pristineItem, jsonapiDoc.data[index]);
+
+        pristine.data.push(pristineItem);
+        rootItems.push(`${resource.type}/${resource.id}`);
+      }
+      assignMeta(pristine, jsonapiDoc);
+    } else {
+      let contentType = this.schema.types.get(type);
+      if (!contentType) {
+        log.warn("ignoring unknown document type=%s id=%s", type, id);
+        return;
+      }
+      // we are going inside a parent document's includes, so we need
+      // our own type here.
+      if (depth > 0) {
+        searchDoc['type'] = type;
+      }
+      let userModel = new Model(contentType, jsonapiDoc, this.schema, this.read.bind(this));
+      await this._buildAttributes(contentType, jsonapiDoc, userModel, pristine, searchDoc);
+      await this._buildRelationships(contentType, jsonapiDoc, userModel, pristine, searchDoc, searchTree, depth);
+
+      assignMeta(pristine.data, jsonapiDoc);
     }
 
-    let userModel = new Model(contentType, jsonapiDoc, this.schema, this.read.bind(this));
-    await this._buildAttributes(contentType, jsonapiDoc, userModel, pristine, searchDoc);
-    await this._buildRelationships(contentType, jsonapiDoc, userModel, pristine, searchDoc, searchTree, depth);
+    if (depth === 0) {
+      this.pristineIncludes = this.pristineIncludes.filter(r => !rootItems.includes(`${r.type}/${r.id}`));
+    }
 
     // top level document embeds all the other pristine includes
     if (this.pristineIncludes.length > 0 && depth === 0) {
       pristine.included = uniqBy([pristine].concat(this.pristineIncludes), r => `${r.type}/${r.id}`).slice(1);
     }
 
-    // The next fields in the searchDoc get a "cardstack_" prefix so
-    // they aren't likely to collide with the user's attribute or
-    // relationship.
-
-    if (jsonapiDoc.meta) {
-      pristine.data.meta = Object.assign({}, jsonapiDoc.meta);
-    } else {
-      pristine.data.meta = {};
-    }
-
     if (depth > 0) {
       this.pristineIncludes.push(pristine.data);
     } else {
+      // The next fields in the searchDoc get a "cardstack_" prefix so
+      // they aren't likely to collide with the user's attribute or
+      // relationship.
       searchDoc.cardstack_pristine = pristine;
-      searchDoc.cardstack_references = this._references;
-      searchDoc.cardstack_realms = this.schema.authorizedReadRealms(type, jsonapiDoc);
-      authLog.trace("setting resource_realms for %s %s: %j", type, id, searchDoc.cardstack_realms);
+      if (!isCollection) {
+        searchDoc.cardstack_references = this._references;
+        searchDoc.cardstack_realms = this.schema.authorizedReadRealms(type, jsonapiDoc);
+        authLog.trace("setting resource_realms for %s %s: %j", type, id, searchDoc.cardstack_realms);
+      }
+    }
+    if (this.isCollection && depth === 1) {
+      return pristine.data;
     }
     return searchDoc;
   }
 
 };
+
+function assignMeta(pristine, resource) {
+  if (resource.meta) {
+    pristine.meta = Object.assign({}, resource.meta);
+  } else {
+    pristine.meta = {};
+  }
+}
 
 function ensure(obj, section) {
   if (!obj.data[section]) {

--- a/packages/hub/searchers.js
+++ b/packages/hub/searchers.js
@@ -2,6 +2,8 @@ const { declareInjections } = require('@cardstack/di');
 const log = require('@cardstack/logger')('cardstack/searchers');
 const Error = require('@cardstack/plugin-utils/error');
 const Session = require('@cardstack/plugin-utils/session');
+const DocumentContext = require('./indexing/document-context');
+const { uniqBy } = require('lodash');
 
 module.exports = declareInjections({
   controllingBranch: 'hub:controlling-branch',
@@ -72,7 +74,7 @@ class Searchers {
     return this.get(session, this.controllingBranch.name, type, id);
   }
 
-  async search(session, branch, query) {
+  async search(session, branch, query, additionalIncludes) {
     if (arguments.length < 3) {
       throw new Error(`session is now a required argument to searchers.search`);
     }
@@ -99,6 +101,35 @@ class Searchers {
     let result = await next();
     if (result) {
       let schema = await schemaPromise;
+      let pristineResult = [];
+      let included = [];
+      let rootItems = [];
+
+      for (let doc of result.data) {
+        let pristine = await (new DocumentContext({
+          branch,
+          schema,
+          id: doc.id,
+          type: doc.type,
+          sourceId: doc.meta.source,
+          upstreamDoc: doc,
+          additionalIncludes,
+          read: this._read(branch)
+        }).pristineDoc());
+
+        rootItems.push(`${doc.type}/${doc.id}`);
+        if (pristine.included) {
+          included = included.concat(pristine.included);
+          delete pristine.included;
+        }
+        pristineResult.push(pristine);
+      }
+
+      included = included.filter(r => !rootItems.includes(`${r.type}/${r.id}`));
+      if (included.length) {
+        result.included = uniqBy(included, r => `${r.type}/${r.id}`);
+      }
+
       let authorizedResult = await schema.applyReadAuthorization(result, { session });
       if (authorizedResult.data.length !== result.data.length) {
         // We can eventually make this more of just a warning, but for
@@ -118,5 +149,19 @@ class Searchers {
     return this.search(session, this.controllingBranch.name, query);
   }
 
+  _read(branch) {
+    return async (type, id) => {
+      let result;
+      try {
+        result = await this.get(Session.INTERNAL_PRIVILEGED, branch, type, id);
+      } catch (err) {
+        if (err.status !== 404) { throw err; }
+      }
+
+      if (result && result.data) {
+        return result.data;
+      }
+    };
+  }
 
 });

--- a/packages/hub/searchers.js
+++ b/packages/hub/searchers.js
@@ -36,7 +36,7 @@ class Searchers {
     let sources = await this._lookupSources();
     let index = 0;
     let sessionOrEveryone = session || Session.EVERYONE;
-    // let schemaPromise = this.currentSchema.forBranch(branch);
+    let schemaPromise = this.currentSchema.forBranch(branch);
     let next = async () => {
       let source = sources[index++];
       if (source) {
@@ -55,8 +55,7 @@ class Searchers {
     let result = await next();
     let authorizedResult;
     if (result && result.data) {
-      // let schema = await schemaPromise;
-      let schema = await this.currentSchema.forBranch(branch);
+      let schema = await schemaPromise;
       let pristineResult = await (new DocumentContext({
         id,
         type,

--- a/packages/hub/searchers.js
+++ b/packages/hub/searchers.js
@@ -100,13 +100,12 @@ class Searchers {
     let result = await next();
     if (result) {
       let schema = await schemaPromise;
-      let include = get(query, 'queryString.include');
-      let additionalIncludes = include ? include.split(',').map(part => part.split('.')) : [];
+      let additionalIncludes = (get(query, 'queryString.include') || '').split(',');
       let pristineResult = await (new DocumentContext({
         branch,
         schema,
-        upstreamDoc: result,
         additionalIncludes,
+        upstreamDoc: result,
         read: this._read(branch)
       }).pristineDoc());
 

--- a/packages/jsonapi/middleware.js
+++ b/packages/jsonapi/middleware.js
@@ -1,34 +1,33 @@
 const Error = require('@cardstack/plugin-utils/error');
 const qs = require('qs');
-const { merge, flatten, uniq } = require('lodash');
+const { merge } = require('lodash');
 const koaJSONBody = require('koa-json-body');
 const log = require('@cardstack/logger')('cardstack/jsonapi');
 const { declareInjections } = require('@cardstack/di');
 const { URL } = require('url');
-const defaultIncludes = {};
 const { withJsonErrorHandling } = Error;
 
 module.exports = declareInjections({
   searcher: 'hub:searchers',
   writers: 'hub:writers',
   indexers: 'hub:indexers',
-  schema: 'hub:current-schema'
+  controllingBranch: 'hub:controlling-branch',
 }, {
-  create({ searcher, writers, indexers }) {
+  create({ searcher, writers, indexers, controllingBranch }) {
     return {
       category: 'api',
       after: 'authentication',
       middleware() {
-        return jsonapiMiddleware(searcher, writers, indexers);
+        return jsonapiMiddleware(searcher, writers, indexers, controllingBranch.name);
       }
     };
   }
 });
 
-function jsonapiMiddleware(searcher, writers, indexers) {
+function jsonapiMiddleware(searcher, writers, indexers, defaultBranch) {
   // TODO move into config
   let options = {
-    defaultBranch: 'master',
+    defaultBranch,
     prefix: 'api'
   };
 
@@ -84,26 +83,10 @@ class Handler {
     this.query = qs.parse(this.ctxt.request.querystring, { plainObjects: true });
     this.branch = this.query.branch || options.defaultBranch;
     this.prefix = options.prefix || '';
-    this._includes = null;
   }
 
   get session() {
     return this.ctxt.state.cardstackSession;
-  }
-
-  get includes() {
-    if (!this._includes) {
-      if (this.query.include != null) {
-        if (this.query.include) {
-          this._includes = this.query.include.split(',').map(part => part.split('.'));
-        } else {
-          this._includes = [];
-        }
-      } else {
-        this._includes = defaultIncludes;
-      }
-    }
-    return this._includes;
   }
 
   filterExpression(type, id) {
@@ -206,36 +189,6 @@ class Handler {
     this.ctxt.set('location', origin + this.ctxt.request.path + '/' + record.data.id);
   }
 
-  async _lookupRecord(type, id) {
-    let record = await this.searcher.get(this.session, this.branch, type, id);
-    return record;
-  }
-
-  async _cachedLookupRecord(type, id, cache) {
-    let key = `${type}/${id}`;
-    {
-      let cached = cache[key];
-      if (cached) {
-        return cached;
-      }
-    }
-    let resource = await this._lookupRecord(type, id);
-    if (resource) {
-      if (!cache[key]) {
-        cache[key] = resource.data;
-      }
-      if (resource.included) {
-        for (let inner of resource.included) {
-          let innerKey = `${inner.type}/${inner.id}`;
-          if (!cache[innerKey]) {
-            cache[innerKey] = inner;
-          }
-        }
-      }
-      return cache[key];
-    }
-  }
-
   _mandatoryBodyData() {
     let data;
     if (!this.ctxt.request.body || !(data = this.ctxt.request.body.data)) {
@@ -255,73 +208,5 @@ class Handler {
     let u = new URL(origin + (this.ctxt.req.originalUrl || this.ctxt.req.url));
     u.search = "?" + qs.stringify(p, { encode: false });
     return u.href;
-  }
-
-  async _loadAllIncluded(root) {
-    // this is a map from each requested include path to a promise
-    // that resolves with the list of resources in that set
-    let sets = Object.create(null);
-
-    // this is a map from type/id strings to each of the resources we
-    // have already loaded.
-    let cache = Object.create(null);
-    for (let resource of root) {
-      cache[`${resource.type}/${resource.id}`] = resource;
-    }
-
-    // some included models may have already come along with the
-    // document we got out of the searcher
-    if (this.ctxt.body.included) {
-      for (let resource of this.ctxt.body.included) {
-        cache[`${resource.type}/${resource.id}`] = resource;
-      }
-    }
-
-    this.includes.forEach(segments => this._loadIncluded(root, segments, cache, sets));
-
-    // this uniq works because our cache works as an identity map
-    let included = uniq(root.concat(flatten(await Promise.all(Object.values(sets)))));
-
-    if (included.length > root.length) {
-      this.ctxt.body.included = included.slice(root.length);
-    } else {
-      delete this.ctxt.body.included;
-    }
-  }
-
-  async _loadIncluded(root, segments, cache, sets) {
-    let name = segments.join('.');
-    if (sets[name]) {
-      return sets[name];
-    }
-
-    return sets[name] = (async () => {
-      let tail = segments[segments.length - 1];
-      let sourceSet;
-      if (segments.length === 1) {
-        sourceSet = root;
-      } else {
-        sourceSet = await this._loadIncluded(root, segments.slice(0, -1), cache, sets);
-      }
-
-      // TODO: we could correlate all the things that need to be
-      // fetched at this level into a single query, or at least a
-      // single query per type.
-      let lists = await Promise.all(sourceSet.map(async record => {
-        if (!record.relationships || !record.relationships[tail]) {
-          return [];
-        }
-        let data = record.relationships[tail].data;
-        if (Array.isArray(data)) {
-          return Promise.all(data.map(ref => this._cachedLookupRecord(ref.type, ref.id, cache)));
-        } else if (data) {
-          let resource = await this._cachedLookupRecord(data.type, data.id, cache);
-          return [resource];
-        } else {
-          return [];
-        }
-      }));
-      return flatten(lists);
-    })();
   }
 }

--- a/packages/jsonapi/middleware.js
+++ b/packages/jsonapi/middleware.js
@@ -182,9 +182,8 @@ class Handler {
       filter: this.filterExpression(type),
       sort: this.query.sort,
       page: this.query.page,
-      queryString: this.query.q
-      // TODO: I feel like we can do better here....
-    }, flatten(this.includes || []));
+      queryString: this.query
+    });
     let body = { data: models, meta: { total: page.total } };
     if (page.cursor) {
       body.links = {

--- a/packages/jsonapi/middleware.js
+++ b/packages/jsonapi/middleware.js
@@ -143,14 +143,12 @@ class Handler {
   }
 
   async handleIndividualGET(type, id) {
-    let body = await this._lookupRecord(type, id);
-    this.ctxt.body = body;
-    if (this.includes === defaultIncludes) {
-      // leave alone whatever includes were already on the document we
-      // got out of the search index.
-      return;
+    let include = (this.query.include || '').split(',');
+    let body = await this.searcher.get(this.session, this.branch, type, id, include);
+    if (this.query.include === '') {
+      delete body.included;
     }
-    await this._loadAllIncluded([body.data]);
+    this.ctxt.body = body;
   }
 
   async handleIndividualPATCH(type, id) {


### PR DESCRIPTION
@ef4 I wanted to do a checkpoint with you to make sure I'm going down the right path here. I overhauled the `handleCollectionGET()` to use pristineDoc's from document-context that already have the included's.

Some questions:
- In the tracking issue, we talk about making sure that we are not doing wasted work when processing the doc in the document-context that we get from the searcher. Does that mean the building of the relationships? Like if the document-context sees that the relationship already exists in the doc it is processing--just use what is already there? (same for attrs)?
- how should we signal to the document-context which additional fields we'd like to have in `included`? I just flattened the the `this.includes` from the `Handler`, but that feels not right as I'm destroying the path information that was specified by the client in the `include` query param.
- I'm not using the `searchTree` in the document-context for the additional included fields. I feel wrong about that, but I don't really understand how to leverage the searchTree mechanism for additional included fields specified by the client. Guidance here would be helpful.

This addresses items in https://github.com/cardstack/cardstack/issues/237