### PR TITLE
refactor plugins to use a computed to access plugin-config `enabled` property

### DIFF
--- a/packages/core-types/cardstack/computed-field-types/alias.js
+++ b/packages/core-types/cardstack/computed-field-types/alias.js
@@ -1,0 +1,28 @@
+async function resolvePath(model, pathSegments) {
+  if (!model) { return; }
+
+  if (!pathSegments.length) { return model; }
+
+  if (pathSegments.length === 1) {
+    let field = pathSegments[0];
+    let contentType = model.getContentType();
+    let isRelationship = contentType.realAndComputedFields.get(field).isRelationship;
+    return isRelationship ? await model.getRelated(field) : await model.getField(field);
+  }
+
+  return await resolvePath(await model.getRelated(pathSegments[0]), pathSegments.slice(1));
+}
+
+exports.type = function(typeOf, { aliasPath }) {
+  let pathSegments = aliasPath.split('.');
+  return typeOf(pathSegments[pathSegments.length - 1]);
+};
+
+exports.compute = async function(model, { aliasPath, defaultValue }) {
+  let value = await resolvePath(model, aliasPath.split('.'));
+  if (value !== undefined) {
+    return value;
+  } else if (defaultValue !== undefined) {
+    return defaultValue;
+  }
+};

--- a/packages/hub/bootstrap-schema.js
+++ b/packages/hub/bootstrap-schema.js
@@ -122,7 +122,8 @@ const models = [
       fields: {
         data: [
           { type: 'fields', id: 'features' },
-          { type: 'fields', id: 'enabled' }
+          { type: 'fields', id: 'config' },
+          { type: 'computed-fields', id: 'plugin-enabled' }
         ]
       },
       'data-source': {
@@ -611,6 +612,24 @@ const models = [
     id: 'enabled',
     attributes: {
       'field-type': '@cardstack/core-types::boolean'
+    }
+  },
+  {
+    type: 'computed-fields',
+    id: 'plugin-enabled',
+    attributes: {
+      'computed-field-type': '@cardstack/core-types::alias',
+      params: {
+        'aliasPath': 'config.enabled',
+        'defaultValue': true
+      }
+    }
+  },
+  {
+    type: 'fields',
+    id: 'config',
+    attributes: {
+      'field-type': '@cardstack/core-types::belongs-to'
     }
   },
   {

--- a/packages/hub/model.js
+++ b/packages/hub/model.js
@@ -8,6 +8,10 @@ module.exports = class Model {
     priv.set(this, { contentType, jsonapiDoc, read, schema });
   }
 
+  getContentType() {
+    return priv.get(this).contentType;
+  }
+
   async getField(fieldName) {
     let { contentType, jsonapiDoc } = priv.get(this);
     let field = contentType.realAndComputedFields.get(fieldName);
@@ -47,8 +51,9 @@ module.exports = class Model {
       throw new Error(`${jsonapiDoc.type} ${jsonapiDoc.id} tried to getModel nonexistent type ${type} `);
     }
     let model = await read(type, id);
+    if (!model) { return; }
+
     return new Model(contentType, model, schema, read);
   }
-
 
 };

--- a/packages/hub/node-tests/indexers-test.js
+++ b/packages/hub/node-tests/indexers-test.js
@@ -70,7 +70,7 @@ describe('hub/indexers', function() {
       // backend instead of going through hub:writers. That ensures
       // we aren't relying on side-effects from the writers.
       let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'plugins', 'sample-plugin-one');
-      expect(doc).has.deep.property('data.attributes.enabled', true);
+      expect(doc).has.deep.property('data.attributes.plugin-enabled', true);
       let config = {
         id: 'sample-plugin-one',
         type: 'plugin-configs',
@@ -84,7 +84,7 @@ describe('hub/indexers', function() {
       storage.store(config.type, config.id, config, false, null);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
       doc = await env.lookup('hub:searchers').get(env.session, 'master', 'plugins', 'sample-plugin-one');
-      expect(doc).has.deep.property('data.attributes.enabled', false);
+      expect(doc).has.deep.property('data.attributes.plugin-enabled', false);
     });
   });
 

--- a/packages/hub/plugin-loader.js
+++ b/packages/hub/plugin-loader.js
@@ -73,6 +73,9 @@ class PluginLoader {
         plugin.relationships = {
           features: {
             data: features.map(({ type, id }) => ({ type, id }))
+          },
+          config: {
+            data: { type: 'plugin-configs', id: plugin.id }
           }
         };
         allFeatures = allFeatures.concat(features);


### PR DESCRIPTION
This addresses issue https://github.com/cardstack/cardstack/issues/237 And removes the need to read from the index as part of indexing plugins via the use of server-side computed properties

Also, I’m seeing that you cannot have a computed property be named the same as a real field, as these share a common namespace in the `ContentType.realAndComputedFields` map. this is problematic if we want a computed called `enabled` that aliases to a real field called `enabled`. so i’m naming the computed `plugin-enabled`, my thinking was that it was better to rename the computed than the real field, as i'td be a bummer for the computed to squat on a really commonly named field like `enabled`.