### PR TITLE
Branch update refactor

### DIFF
--- a/packages/core-types/cardstack/computed-field-types/alias.js
+++ b/packages/core-types/cardstack/computed-field-types/alias.js
@@ -1,0 +1,28 @@
+async function resolvePath(model, pathSegments) {
+  if (!model) { return; }
+
+  if (!pathSegments.length) { return model; }
+
+  if (pathSegments.length === 1) {
+    let field = pathSegments[0];
+    let contentType = model.getContentType();
+    let isRelationship = contentType.realAndComputedFields.get(field).isRelationship;
+    return isRelationship ? await model.getRelated(field) : await model.getField(field);
+  }
+
+  return await resolvePath(await model.getRelated(pathSegments[0]), pathSegments.slice(1));
+}
+
+exports.type = function(typeOf, { aliasPath }) {
+  let pathSegments = aliasPath.split('.');
+  return typeOf(pathSegments[pathSegments.length - 1]);
+};
+
+exports.compute = async function(model, { aliasPath, defaultValue }) {
+  let value = await resolvePath(model, aliasPath.split('.'));
+  if (value !== undefined) {
+    return value;
+  } else if (defaultValue !== undefined) {
+    return defaultValue;
+  }
+};

--- a/packages/drupal/indexer.js
+++ b/packages/drupal/indexer.js
@@ -115,10 +115,6 @@ class Updater {
     };
   }
 
-  async read() {
-    throw new Error("Drupal indexer doesn't implement resource embedding yet");
-  }
-
   _makeField(propName, propDef, fields) {
     let canonicalName = drupalToCardstackField(propName);
     if (!fields[canonicalName]) {

--- a/packages/ephemeral/indexer.js
+++ b/packages/ephemeral/indexer.js
@@ -63,8 +63,4 @@ class Updater {
       identity: this.storage.identity
     };
   }
-
-  async read(type, id /*, isSchema */) {
-    return this.storage.lookup(type, id);
-  }
 }

--- a/packages/ethereum/cardstack/indexer.js
+++ b/packages/ethereum/cardstack/indexer.js
@@ -178,14 +178,6 @@ class Updater {
     };
   }
 
-  async read(type, id, isSchema) {
-    if (isSchema) {
-      return (await this.schema()).find(model => model.type === type && model.id === model.id);
-    }
-
-    return await this.buffer.readModel({ type, id });
-  }
-
   _namedFieldFor(fieldName, type) {
     let fieldType;
     switch(type) {

--- a/packages/git/indexer.js
+++ b/packages/git/indexer.js
@@ -189,21 +189,6 @@ class GitUpdater {
     };
   }
 
-  async read(type, id, isSchema) {
-    await this._loadCommit();
-    let entry;
-    try {
-      entry = await this.rootTree.getEntry(`${ isSchema ? 'schema' : 'contents' }/${type}/${id}.json`);
-    } catch(err) {
-      // unfortunately nodegit doesn't seem to have a non-throwing way
-      // to test for the existence of a complete path
-    }
-    if (entry) {
-      let doc = await this._entryToDoc(type, id, entry);
-      return doc;
-    }
-  }
-
   async _loadCommit() {
     if (!this.commit) {
       this.commit = await this._commitAtBranch(this.branch);

--- a/packages/hub/bootstrap-schema.js
+++ b/packages/hub/bootstrap-schema.js
@@ -122,7 +122,8 @@ const models = [
       fields: {
         data: [
           { type: 'fields', id: 'features' },
-          { type: 'fields', id: 'enabled' }
+          { type: 'fields', id: 'config' },
+          { type: 'computed-fields', id: 'plugin-enabled' }
         ]
       },
       'data-source': {
@@ -611,6 +612,24 @@ const models = [
     id: 'enabled',
     attributes: {
       'field-type': '@cardstack/core-types::boolean'
+    }
+  },
+  {
+    type: 'computed-fields',
+    id: 'plugin-enabled',
+    attributes: {
+      'computed-field-type': '@cardstack/core-types::alias',
+      params: {
+        'aliasPath': 'config.enabled',
+        'defaultValue': true
+      }
+    }
+  },
+  {
+    type: 'fields',
+    id: 'config',
+    attributes: {
+      'field-type': '@cardstack/core-types::belongs-to'
     }
   },
   {

--- a/packages/hub/indexers/static-models.js
+++ b/packages/hub/indexers/static-models.js
@@ -64,9 +64,4 @@ class Updater {
     await ops.finishReplaceAll();
     return { models };
   }
-
-  async read(type, id /*, isSchema */) {
-    let matches = m => m.type === type && m.id === id;
-    return this.models.find(matches) || this.staticModels.find(matches);
-  }
 }

--- a/packages/hub/model.js
+++ b/packages/hub/model.js
@@ -8,6 +8,10 @@ module.exports = class Model {
     priv.set(this, { contentType, jsonapiDoc, read, schema });
   }
 
+  getContentType() {
+    return priv.get(this).contentType;
+  }
+
   async getField(fieldName) {
     let { contentType, jsonapiDoc } = priv.get(this);
     let field = contentType.realAndComputedFields.get(fieldName);
@@ -47,8 +51,9 @@ module.exports = class Model {
       throw new Error(`${jsonapiDoc.type} ${jsonapiDoc.id} tried to getModel nonexistent type ${type} `);
     }
     let model = await read(type, id);
+    if (!model) { return; }
+
     return new Model(contentType, model, schema, read);
   }
-
 
 };

--- a/packages/hub/node-tests/indexers-test.js
+++ b/packages/hub/node-tests/indexers-test.js
@@ -70,7 +70,7 @@ describe('hub/indexers', function() {
       // backend instead of going through hub:writers. That ensures
       // we aren't relying on side-effects from the writers.
       let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'plugins', 'sample-plugin-one');
-      expect(doc).has.deep.property('data.attributes.enabled', true);
+      expect(doc).has.deep.property('data.attributes.plugin-enabled', true);
       let config = {
         id: 'sample-plugin-one',
         type: 'plugin-configs',
@@ -84,7 +84,7 @@ describe('hub/indexers', function() {
       storage.store(config.type, config.id, config, false, null);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
       doc = await env.lookup('hub:searchers').get(env.session, 'master', 'plugins', 'sample-plugin-one');
-      expect(doc).has.deep.property('data.attributes.enabled', false);
+      expect(doc).has.deep.property('data.attributes.plugin-enabled', false);
     });
   });
 

--- a/packages/hub/plugin-loader.js
+++ b/packages/hub/plugin-loader.js
@@ -73,6 +73,9 @@ class PluginLoader {
         plugin.relationships = {
           features: {
             data: features.map(({ type, id }) => ({ type, id }))
+          },
+          config: {
+            data: { type: 'plugin-configs', id: plugin.id }
           }
         };
         allFeatures = allFeatures.concat(features);

--- a/packages/mock-auth/cardstack/indexer.js
+++ b/packages/mock-auth/cardstack/indexer.js
@@ -108,10 +108,4 @@ class Updater {
       lastSchema: schema
     };
   }
-
-  async read(type, id, isSchema) {
-    if (isSchema) {
-      return (await this.schema()).find(model => model.type === type && model.id === model.id);
-    }
-  }
 }

--- a/packages/pgsearch/client.js
+++ b/packages/pgsearch/client.js
@@ -363,7 +363,7 @@ class Batch {
         sourceId,
         generation,
         schema,
-        read: (type, id) => read(type, id),
+        read,
         upstreamDoc: {
           type: 'user-realms',
           id: userRealmsId,

--- a/packages/postgresql/indexer.js
+++ b/packages/postgresql/indexer.js
@@ -119,18 +119,6 @@ class Updater {
     return this._schema;
   }
 
-  async read(type, id, isSchema) {
-    if (isSchema) {
-      let schema = await this.schema();
-      return schema.find(model => model.type === type && model.id === id);
-    }
-    let { schema, table } = this.mapper.tableForType(type);
-    let result = await this.query(`select * from ${schema}.${table} where id=$1`, [id]);
-    if (result.rows.length > 0) {
-      return await this._toDocument(type, result.rows[0]);
-    }
-  }
-
   async _loadSchema() {
     // This is an inner join, so it will "miss" any table that has no
     // columns. But that's a silly case I don't want to support


### PR DESCRIPTION
I'm collapsing PR https://github.com/cardstack/cardstack/pull/253 into this PR (each with separate commits). 

This addresses issue #237 And removes the need to read from the index as part of indexing plugins via the use of server-side computed properties

For the 1st commit where we refactor plugins to use a computed to access plugin-config:
> Removes the need to read from the index as part of indexing plugins via the use of server-side computed properties
> Also, I’m seeing that you cannot have a computed property be named the same as a real field, as these share a common namespace in the ContentType.realAndComputedFields map. this is problematic if we want a computed called enabled that aliases to a real field called enabled. so i’m naming the computed plugin-enabled, my thinking was that it was better to rename the computed than the real field, as i'td be a bummer for the computed to squat on a really commonly named field like enabled.

For the second commit I'm removing the uncachedRead from BranchUpdate which then allows us to remove the `read()` hook from all the indexers.