### PR TITLE
filtering by bool is dicey since filters are coerced to strings, using `exists` instead

### DIFF
--- a/packages/tools/addon/components/cs-create-menu.js
+++ b/packages/tools/addon/components/cs-create-menu.js
@@ -17,7 +17,7 @@ export default Component.extend({
   availableTypes: computed(function() { return []; }),
 
   loadAvailableTypes: task(function * () {
-    let types = yield this.get('store').query('content-type', { filter: { not: { 'is-built-in' : true } } });
+    let types = yield this.get('store').query('content-type', { filter: { 'is-built-in' : { exists: false } } });
     this.set('availableTypes', types);
   }).on('init'),
 


### PR DESCRIPTION
I think this relied on elastic search specific semantics, as content types that are not built-in won't even have a `built-in` field. (where ES considered not having the field the same as the field build set to `false`.)