### PR TITLE
dont block on boot-time indexing and dont update index on session authentication

### DIFF
--- a/packages/authentication/cardstack/middleware.js
+++ b/packages/authentication/cardstack/middleware.js
@@ -300,19 +300,12 @@ class Authentication {
       }
     }
 
-    let madeIndexUpdate = false;
     if (!have && source.mayCreateUser) {
       have = await this.writer.create(this.controllingBranch.name, Session.INTERNAL_PRIVILEGED, user.data.type, user);
-      madeIndexUpdate = true;
     }
     if (have && source.mayUpdateUser) {
       user.data.meta = have.data.meta;
       have = await this.writer.update(this.controllingBranch.name, Session.INTERNAL_PRIVILEGED, user.data.type, have.data.id, user);
-      madeIndexUpdate = true;
-    }
-
-    if (madeIndexUpdate) {
-      await this.indexers.update({ hints: [{ type: have.data.type, id: have.data.id, branch: this.controllingBranch.name }] });
     }
 
     return have;

--- a/packages/hub/main.js
+++ b/packages/hub/main.js
@@ -35,7 +35,10 @@ async function wireItUp(projectDir, encryptionKeys, dataSources, opts = {}) {
   // in the test suite we want more deterministic control of when
   // indexing happens
   if (!opts.disableAutomaticIndexing) {
-    await container.lookup('hub:indexers').update();
+    await container.lookup(`plugin-client:${require.resolve('@cardstack/pgsearch/client')}`).ensureDatabaseSetup();
+
+    // some datasources are dependent upon a sync at boot for index of pristine system
+    container.lookup('hub:indexers').update(); // dont await boot-time indexing, invalidation logic has our back
     setInterval(() => container.lookup('hub:indexers').update(), 600000);
   }
 


### PR DESCRIPTION
I opted not to remove the boot time indexing altogether, as some data sources rely upon that to populate a pristine system -- like the ethereum plugin. Rather I just stopped awaiting on it, as the index invalidation logic should have our back. The reprecussion of this is that we need to make sure the pgsearch DB is setup, as awaiting the boot-time index had the side effect of running the pgsearch DB migration at boot time.