### PR TITLE
Fixes #250. Refactor to more efficiently buffer the ethereum indexing using pgsearch

### DIFF
--- a/packages/ethereum/cardstack/service.js
+++ b/packages/ethereum/cardstack/service.js
@@ -141,11 +141,11 @@ module.exports = class EthereumService {
           }
         } else {
           log.trace(`contract event received for ${name}: ${JSON.stringify(event, null, 2)}`);
-          let hints = this._generateHintsFromEvent({ branch, contract: name, event });
-          log.debug("addings hints to queue", JSON.stringify(hints, null, 2));
+          let identifiers = this._generateHintsFromEvent({ branch, contract: name, event });
+          log.debug("calling index for identifers", JSON.stringify(identifiers, null, 2));
 
           if (buffer) {
-            buffer.loadModels(name, null, hints);
+            buffer.indexModels(name, null, identifiers);
           }
         }
       });

--- a/packages/ethereum/package.json
+++ b/packages/ethereum/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@cardstack/di": "0.8.0",
-    "@cardstack/elasticsearch": "0.9.0",
+    "@cardstack/hub": "0.9.13",
     "@cardstack/logger": "^0.1.0",
     "@cardstack/pgsearch": "0.9.13",
     "@cardstack/plugin-utils": "0.8.0",

--- a/packages/ethereum/truffle-tests/ethereum-indexer-test.js
+++ b/packages/ethereum/truffle-tests/ethereum-indexer-test.js
@@ -848,7 +848,7 @@ contract('SampleToken', function(accounts) {
   });
 
   describe('ethereum-indexer for past events', function() {
-    let pastToken, token, indexers, contract;
+    let pastToken, token, pgclient, indexers, contract;
 
     async function setup() {
       let factory = new JSONAPIFactory();
@@ -879,6 +879,7 @@ contract('SampleToken', function(accounts) {
       contract = dataSource.data.attributes.params.contract,
       env = await createDefaultEnvironment(`${__dirname}/..`, factory.getModels());
       indexers = await env.lookup('hub:indexers');
+      pgclient = await env.lookup(`plugin-client:${require.resolve('@cardstack/pgsearch/client')}`);
 
       buffer = env.lookup(`plugin-services:${require.resolve('../cardstack/buffer')}`);
       ethereumService = buffer.ethereumService;
@@ -894,7 +895,7 @@ contract('SampleToken', function(accounts) {
 
       let addCount = 0;
 
-      indexers.on('add', ({ type }) => {
+      pgclient.on('add', ({ type }) => {
         if (!['sample-tokens', 'sample-token-balance-ofs'].includes(type)) { return; }
         addCount++;
       });
@@ -929,7 +930,7 @@ contract('SampleToken', function(accounts) {
 
       let addCount = 0;
 
-      indexers.on('add', ({ type }) => {
+      pgclient.on('add', ({ type }) => {
         if (!['sample-tokens', 'sample-token-balance-ofs'].includes(type)) { return; }
         addCount++;
       });

--- a/packages/hub/indexers.js
+++ b/packages/hub/indexers.js
@@ -98,7 +98,7 @@ class Indexers extends EventEmitter {
     // also we dont want to use singletoneNextSlot, since all the indexing calls are important (as they can have different hints, and we dont want to collapse jobs)
     await this.jobQueue.publishAndWait('hub/indexers/update',
       { forceRefresh, hints },
-      {  expireIn: '2 hours' }
+      { singletonKey: 'hub/indexers/update', singletonNextSlot: true, expireIn: '2 hours' }
     );
   }
 


### PR DESCRIPTION
This removes the need for ES in ethereum buffer, and writes the documents directly into the pgsearch index, as well as negates the need to pass hints to the hub:indexers.update(). Additionally this restores serially processing indexer.update() jobs.