### PR TITLE
use default pgboss polling (1 sec)

### DIFF
--- a/packages/hub/bin/cardstack-hub.js
+++ b/packages/hub/bin/cardstack-hub.js
@@ -42,7 +42,6 @@ if (process.env.PGHOST && process.env.PGPORT && process.env.PGUSER) {
     database: 'postgres'
 	};
 }
-config.newJobCheckInterval = 100; // set to minimum to speed up tests
 
 async function runServer(options, dataSources) {
   let {


### PR DESCRIPTION
we already assert faster check interval in test-support.createDefaultEnvironment, no need for it here.