### PR TITLE
searcher caching

### DIFF
--- a/packages/hub/node-tests/searchers-test.js
+++ b/packages/hub/node-tests/searchers-test.js
@@ -25,6 +25,9 @@ describe('hub/searchers/basics', function() {
       }),
       factory.addResource('fields', 'topping').withAttributes({
         fieldType: '@cardstack/core-types::case-insensitive'
+      }),
+      factory.addResource('fields', 'example-counter').withAttributes({
+        fieldType: '@cardstack/core-types::integer'
       })
     ]);
 
@@ -37,72 +40,133 @@ describe('hub/searchers/basics', function() {
     env = await createDefaultEnvironment(`${__dirname}/../../../tests/stub-searcher`, factory.getModels());
   }
 
-  afterEach(async function() {
+  async function teardown() {
     if (env) {
       await destroyDefaultEnvironment(env);
     }
+  }
+
+  describe('empty', function() {
+    before(async function(){ await setup({}); });
+    after(teardown);
+
+    it("throws when no searcher#get has it", async function() {
+      try {
+        await env.lookup('hub:searchers').get(env.session, 'master', 'examples', 'nonexistent');
+        throw new Error("should not get here");
+      } catch (err) {
+        expect(err.message).to.match(/No such resource master\/examples\/nonexist/);
+      }
+    });
+
+    it("searchers#get finds record via internal searcher", async function() {
+      let response = await env.lookup('hub:searchers').get(env.session, 'master', 'examples', chocolate.id);
+      expect(response.data.attributes['example-flavor']).to.equal('chocolate');
+    });
+
+    it("searchers#search finds record via internal searcher", async function() {
+      let response = await env.lookup('hub:searchers').search(env.session, 'master', { filter: { 'example-flavor': { exact: 'chocolate' } } });
+      expect(response.data).length(1);
+      expect(response.data[0].attributes['example-flavor']).to.equal('chocolate');
+    });
+
+    it("searchers#search finds record via internal searcher with custom analyzer", async function() {
+      let response = await env.lookup('hub:searchers').search(env.session, 'master', { filter: { 'topping': { exact: 'SPriNkLeS' } } });
+      expect(response.data).length(1);
+      expect(response.data[0].attributes['topping']).to.equal('sprinkles');
+    });
   });
 
+  describe('injectFirst', function() {
+    before(async function(){ await setup({ injectFirst: 'vanilla' }); });
+    after(teardown);
 
-  it("throws when no searcher#get has it", async function() {
-    await setup({});
-    try {
-      await env.lookup('hub:searchers').get(env.session, 'master', 'examples', 'nonexistent');
-      throw new Error("should not get here");
-    } catch (err) {
-      expect(err.message).to.match(/No such resource master\/examples\/nonexist/);
+    it("a plugin's searcher#get can run before the internal searcher", async function() {
+      let response = await env.lookup('hub:searchers').get(env.session, 'master', 'examples', chocolate.id);
+      expect(response.data.attributes['example-flavor']).to.equal('vanilla');
+    });
+
+    it("a plugin's searchers#search can run before the internal searcher", async function() {
+      let response = await env.lookup('hub:searchers').search(env.session, 'master', { filter: { 'example-flavor': { exact: 'chocolate' } } });
+      expect(response.data).length(1);
+      expect(response.data[0].attributes['example-flavor']).to.equal('vanilla');
+    });
+
+    it("adds source id to model when using searcher#get", async function() {
+      let response = await env.lookup('hub:searchers').get(env.session, 'master', 'examples', 'anything');
+      expect(response.data).has.deep.property('meta.source', source.id);
+    });
+
+    it("adds source id to model when using searcher#search", async function() {
+      let response = await env.lookup('hub:searchers').search(env.session, 'master', {});
+      expect(response.data[0]).has.deep.property('meta.source', source.id);
+    });
+
+  });
+
+  describe('injectSecond', function() {
+    before(async function(){ await setup({ injectSecond: 'vanilla' }); });
+    after(teardown);
+
+    it("a plugin's searcher#get can run after the internal searcher", async function() {
+      let response = await env.lookup('hub:searchers').get(env.session, 'master', 'examples', '10000');
+      expect(response.data.attributes['example-flavor']).to.equal('vanilla');
+    });
+  });
+
+  describe('caching', function() {
+    beforeEach(async function(){
+      await setup({
+        injectSecond: 'vanilla',
+        metaFor: {
+          'examples/1000': {
+            'cardstack-cache-control': { 'max-age': 300 }
+          }
+        }
+       });
+    });
+    afterEach(teardown);
+
+    // I'm manually reaching in here rather than try to wait or use a negative
+    // maxAge, because the only bulletproof thing we could do is wait around
+    // for expiration, and I don't want to wait around, so instead we'll do
+    // something fast that will fail loudly if the implementation changes out
+    // from under us.
+   async function alterExpiration(branch, type, id, interval) {
+      let client = env.lookup(`plugin-client:${require.resolve('@cardstack/pgsearch/client')}`);
+      let result = await client.query('update documents set expires = expires + $1 where branch=$2 and type=$3 and id=$4', [interval, branch, type, id]);
+      if (result.rowCount !== 1) {
+        throw new Error(`test was unable to alter expiration`);
+      }
     }
-  });
 
-  it("searchers#get finds record via internal searcher", async function() {
-    await setup({});
-    let response = await env.lookup('hub:searchers').get(env.session, 'master', 'examples', chocolate.id);
-    expect(response.data.attributes['example-flavor']).to.equal('chocolate');
-  });
+    it("can cache searcher#get responses", async function() {
+      let response = await env.lookup('hub:searchers').get(env.session, 'master', 'examples', '1000');
+      expect(response).has.deep.property('data.attributes.example-counter');
+      let firstCounter = response.data.attributes['example-counter'];
+      response = await env.lookup('hub:searchers').get(env.session, 'master', 'examples', '1000');
+      let secondCounter = response.data.attributes['example-counter'];
+      expect(firstCounter).to.equal(secondCounter);
+    });
 
-  it("a plugin's searcher#get can run before the internal searcher", async function() {
-    await setup({ injectFirst: 'vanilla' });
-    let response = await env.lookup('hub:searchers').get(env.session, 'master', 'examples', chocolate.id);
-    expect(response.data.attributes['example-flavor']).to.equal('vanilla');
-  });
+    it("does not return expired searcher#get responses", async function() {
+      let response = await env.lookup('hub:searchers').get(env.session, 'master', 'examples', '1000');
+      expect(response).has.deep.property('data.attributes.example-counter');
+      let firstCounter = response.data.attributes['example-counter'];
 
-  it("a plugin's searcher#get can run after the internal searcher", async function() {
-    await setup({ injectSecond: 'vanilla' });
-    let response = await env.lookup('hub:searchers').get(env.session, 'master', 'examples', '10000');
-    expect(response.data.attributes['example-flavor']).to.equal('vanilla');
-  });
+      await alterExpiration('master', 'examples', '1000', '-301 seconds');
 
-  it("searchers#search finds record via internal searcher", async function() {
-    await setup({});
-    let response = await env.lookup('hub:searchers').search(env.session, 'master', { filter: { 'example-flavor': { exact: 'chocolate' } } });
-    expect(response.data).length(1);
-    expect(response.data[0].attributes['example-flavor']).to.equal('chocolate');
-  });
+      response = await env.lookup('hub:searchers').get(env.session, 'master', 'examples', '1000');
+      let secondCounter = response.data.attributes['example-counter'];
+      expect(firstCounter).to.not.equal(secondCounter);
+    });
 
-  it("searchers#search finds record via internal searcher with custom analyzer", async function() {
-    await setup({});
-    let response = await env.lookup('hub:searchers').search(env.session, 'master', { filter: { 'topping': { exact: 'SPriNkLeS' } } });
-    expect(response.data).length(1);
-    expect(response.data[0].attributes['topping']).to.equal('sprinkles');
-  });
-
-  it("a plugin's searchers#search can run before the internal searcher", async function() {
-    await setup({ injectFirst: 'vanilla' });
-    let response = await env.lookup('hub:searchers').search(env.session, 'master', { filter: { 'example-flavor': { exact: 'chocolate' } } });
-    expect(response.data).length(1);
-    expect(response.data[0].attributes['example-flavor']).to.equal('vanilla');
-  });
-
-  it("adds source id to model when using searcher#get", async function() {
-    await setup({ injectFirst: 'vanilla' });
-    let response = await env.lookup('hub:searchers').get(env.session, 'master', 'examples', 'anything');
-    expect(response.data).has.deep.property('meta.source', source.id);
-  });
-
-  it("adds source id to model when using searcher#search", async function() {
-    await setup({ injectFirst: 'vanilla' });
-    let response = await env.lookup('hub:searchers').search(env.session, 'master', {});
-    expect(response.data[0]).has.deep.property('meta.source', source.id);
+    it("does not return expired documents in searcher#search", async function() {
+      await env.lookup('hub:searchers').get(env.session, 'master', 'examples', '1000');
+      await alterExpiration('master', 'examples', '1000', '-301 seconds');
+      let response = await env.lookup('hub:searchers').search(env.session, 'master', { filter: { type: 'examples', id: '1000' }});
+      expect(response.data).length(0);
+    });
   });
 
 });

--- a/packages/pgsearch/migrations/1535043960627_add-expires.js
+++ b/packages/pgsearch/migrations/1535043960627_add-expires.js
@@ -1,0 +1,8 @@
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.addColumns("documents", {
+    expires: { type: "timestamp with time zone" }
+  });
+};
+

--- a/packages/pgsearch/util.js
+++ b/packages/pgsearch/util.js
@@ -1,0 +1,93 @@
+function addExplicitParens(expression){
+  if (expression.length === 0) {
+    return expression;
+  } else {
+    return ['(', ...expression, ')'];
+  }
+}
+
+function separatedByCommas(expressions) {
+  return expressions.reduce((accum, expression) => {
+    if (accum.length > 0){
+      accum.push(',');
+    }
+    return accum.concat(expression);
+  }, []);
+}
+
+function param(value) {
+  return { param: value };
+}
+
+function every(expressions){
+  if (expressions.length === 0){
+    return ['true'];
+  }
+  return expressions.map(addExplicitParens).reduce((accum, expression) => [...accum, 'AND', ...expression]);
+}
+
+function any(expressions){
+  if (expressions.length === 0){
+    return ['false'];
+  }
+  return expressions.map(addExplicitParens).reduce((accum, expression) => [...accum, 'OR', ...expression]);
+}
+
+function queryToSQL(query){
+  let values = [];
+  let text = query.map(element =>{
+    if (element.hasOwnProperty('param')) {
+      values.push(element.param);
+      return `$${values.length}`;
+    } else {
+      return element;
+    }
+  }).join(' ');
+  return {
+    text,
+    values
+  };
+}
+
+function safeName(name) {
+  if (!/^[a-zA-Z0-9_]+$/.test(name)) {
+    throw new Error(`potentially unsafe name in SQL: ${name}`);
+  }
+  return name;
+}
+
+// takes a pojo with column name keys and expression values
+function upsert(table, constraint, values) {
+  let names = Object.keys(values).map(safeName);
+  let nameExpressions = names.map(name => [name]);
+  let valueExpressions = Object.keys(values).map(k => {
+    let v = values[k];
+    if (!Array.isArray(v) && !v.hasOwnProperty('param')) {
+      throw new Error(`values passed to upsert helper must already be expressions. You passed ${v} for ${k}`);
+    }
+    return v;
+  });
+  return ['insert into', safeName(table),
+    ...addExplicitParens(separatedByCommas(nameExpressions)),
+    'values',
+    ...addExplicitParens(separatedByCommas(valueExpressions)),
+    'on conflict on constraint', safeName(constraint),
+    'do UPDATE SET',
+                                           // this interpolation is safe because
+                                           // of safeName() above. In general
+                                           // don't add any more interpolations
+                                           // unless you've really thought hard
+                                           // about the security implications.
+    ...separatedByCommas(names.map(name => `${name}=EXCLUDED.${name}`))
+  ];
+}
+
+module.exports = {
+  addExplicitParens,
+  separatedByCommas,
+  param,
+  every,
+  any,
+  queryToSQL,
+  upsert
+};

--- a/tests/stub-searcher/searcher.js
+++ b/tests/stub-searcher/searcher.js
@@ -8,6 +8,7 @@ module.exports = class StubSearcher {
 
   constructor(params) {
     this.params = params;
+    this.counter = 0;
   }
 
   async get(session, branch, type, id, next) {
@@ -16,7 +17,7 @@ module.exports = class StubSearcher {
     }
 
     if (this.params.injectFirst) {
-      return { data: makeModel(type, id, this.params.injectFirst) };
+      return { data: this.makeModel(type, id, this.params.injectFirst), meta: this.makeMeta(type, id) };
     }
 
     let result = await next();
@@ -24,14 +25,14 @@ module.exports = class StubSearcher {
       return result;
     }
     if (this.params.injectSecond) {
-      return { data: makeModel(type, id, this.params.injectSecond) };
+      return { data: this.makeModel(type, id, this.params.injectSecond), meta: this.makeMeta(type, id) };
     }
   }
 
   async search(session, branch, query, next) {
     if (this.params.injectFirst) {
       return {
-        data: [ makeModel('examples', '2', this.params.injectFirst) ],
+        data: [ this.makeModel('examples', '2', this.params.injectFirst) ],
         meta: {
           page: {}
         }
@@ -39,14 +40,25 @@ module.exports = class StubSearcher {
     }
     return next();
   }
+
+  makeModel(type, id, flavor) {
+    return {
+      type,
+      id,
+      attributes: {
+        'example-flavor': flavor,
+        'example-counter': this.counter++
+      }
+    };
+  }
+
+  makeMeta(type, id) {
+    if (this.params.metaFor) {
+      return this.params.metaFor[`${type}/${id}`];
+    }
+    return {};
+  }
+
 };
 
-function makeModel(type, id, flavor) {
-  return {
-    type,
-    id,
-    attributes: {
-      'example-flavor': flavor
-    }
-  };
-}
+


### PR DESCRIPTION
This allows any custom searcher to opt-in to lettings its results go into the search index for a given expiration period.

It works for `get`, not `search`. The searcher uses `meta.cardstack-cache-control.max-age`, which has the same meaning as in the HTTP CacheControl header.

I also reorganized the search basic tests to make them run much faster by sharing the setup between tests that have the same setup.