### PR TITLE
Add support for relationship tracking & saving

### DIFF
--- a/packages/hub/schema/field.js
+++ b/packages/hub/schema/field.js
@@ -23,6 +23,8 @@ module.exports = class Field {
     this.editorComponent = model.attributes['editor-component'];
     this.inlineEditorComponent = model.attributes['inline-editor-component'];
     this.searchable = model.attributes.searchable == null ? true : model.attributes.searchable;
+    let owned = model.attributes.owned;
+    this.owned = typeof owned === 'undefined' ? false : owned;
 
     // Default values are modeled as relationships to separate models
     // so that we can distinguish a default value of null from not

--- a/packages/models/addon/model.js
+++ b/packages/models/addon/model.js
@@ -8,12 +8,12 @@ import { capitalize } from '@ember/string';
 export default DS.Model.extend(RelationshipTracker, {
   resourceMetadata: service(),
 
-  relationshipTrackerVersionKey: 'version',
+  relationshipTrackerVersionKey: 'relationshipTrackerVersion',
 
   init() {
     this._super();
     let dirtyTrackingProperties = [];
-    this._relationshipsByName.forEach((relation) => {
+    this._relationshipsByName().forEach((relation) => {
       let { kind, meta } = relation;
       let { owned } = meta.options;
       if (owned) {
@@ -26,7 +26,7 @@ export default DS.Model.extend(RelationshipTracker, {
     }
   },
 
-  version: computed(function() {
+  relationshipTrackerVersion: computed(function() {
     let meta = this.get('resourceMetadata').read(this);
     return meta && meta.version;
   }),
@@ -44,7 +44,7 @@ export default DS.Model.extend(RelationshipTracker, {
     // and then recurse down to save their `hasDirtyFields` owned relations
     // Save children first.
     let relatedSaves = this.dirtyRelationships.map(field => {
-      let { kind } = this._relationshipsByName.get(field);
+      let { kind } = this._relationshipsByName().get(field);
       let relatedRecords = kind === 'hasMany' ? this[field] : [ this.field ];
       let dirtyRecords = relatedRecords.filter(record => record.hasDirtyFields);
       return dirtyRecords.invoke('save');

--- a/packages/models/addon/model.js
+++ b/packages/models/addon/model.js
@@ -1,3 +1,29 @@
 import DS from 'ember-data';
 import RelationshipTracker from "ember-data-relationship-tracker";
-export default DS.Model.extend(RelationshipTracker);
+
+export default DS.Model.extend(RelationshipTracker, {
+  async save() {
+    // this._super is not safe to use asynchronously
+    // see https://github.com/ember-cli/ember-cli/issues/6282
+    let modelSave = this._super.bind(this);
+    await this.saveRelated();
+    await modelSave();
+  },
+
+  async saveRelated() {
+    let relationshipsByName = this.constructor.relationshipsByName;
+    let relatedSaves = this.dirtyRelationships.map(field => {
+      let { kind } = relationshipsByName.get(field);
+      let relatedRecords = kind === 'hasMany' ? this[field] : [ this.field ];
+      let dirtyRecords = relatedRecords.filter(record => record.hasDirtyFields);
+      return dirtyRecords.invoke('save');
+    });
+    return Promise.all(flatten(relatedSaves));
+  },
+});
+
+function flatten(arrays) {
+  return arrays.reduce((flattened, array) => {
+    return flattened.concat(array);
+  }, []);
+}

--- a/packages/models/addon/model.js
+++ b/packages/models/addon/model.js
@@ -1,7 +1,16 @@
 import DS from 'ember-data';
 import RelationshipTracker from "ember-data-relationship-tracker";
+import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
 
 export default DS.Model.extend(RelationshipTracker, {
+  resourceMetadata: service(),
+
+  version: computed(function() {
+    let meta = this.get('resourceMetadata').read(this);
+    return meta && meta.version;
+  }),
+
   async save() {
     // this._super is not safe to use asynchronously
     // see https://github.com/ember-cli/ember-cli/issues/6282

--- a/packages/models/addon/model.js
+++ b/packages/models/addon/model.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 import { computed, defineProperty, get } from '@ember/object';
 import { readOnly, or } from '@ember/object/computed';
 import { capitalize } from '@ember/string';
+import { run } from '@ember/runloop';
 
 export default DS.Model.extend(RelationshipTracker, {
   resourceMetadata: service(),
@@ -36,7 +37,9 @@ export default DS.Model.extend(RelationshipTracker, {
     // this._super is not safe to use asynchronously
     // see https://github.com/ember-cli/ember-cli/issues/6282
     let modelSave = this._super.bind(this);
-    await this.saveRelated();
+    run(async () => {
+      await this.saveRelated();
+    });
     await modelSave();
   },
 

--- a/packages/models/addon/model.js
+++ b/packages/models/addon/model.js
@@ -57,7 +57,7 @@ function createHasDirtyForRelationship(model, name, kind) {
       return model.get(name).toArray().some((related) => related.hasDirtyAttributes);
     }));
   } else {
-    defineProperty(model, propertyName, or(`${name}.hasDirtyAttributes`));
+    defineProperty(model, propertyName, readOnly(`${name}.hasDirtyAttributes`));
   }
   return propertyName;
 }

--- a/packages/models/addon/model.js
+++ b/packages/models/addon/model.js
@@ -1,12 +1,14 @@
 import DS from 'ember-data';
 import RelationshipTracker from "ember-data-relationship-tracker";
 import { inject as service } from '@ember/service';
-import { computed, defineProperty } from '@ember/object';
+import { computed, defineProperty, get } from '@ember/object';
 import { readOnly, or } from '@ember/object/computed';
 import { capitalize } from '@ember/string';
 
 export default DS.Model.extend(RelationshipTracker, {
   resourceMetadata: service(),
+
+  relationshipTrackerVersionKey: 'version',
 
   init() {
     this._super();
@@ -39,7 +41,10 @@ export default DS.Model.extend(RelationshipTracker, {
   },
 
   async saveRelated() {
-    let relationshipsByName = this.constructor.relationshipsByName;
+    let relationshipsByName = get(this.constructor, 'relationshipsByName');
+    //TODO: Go through owned relationships and save the ones which `hasDirtyFields`
+    // and then recurse down to save their `hasDirtyFields` owned relations
+    // Save children first.
     let relatedSaves = this.dirtyRelationships.map(field => {
       let { kind } = relationshipsByName.get(field);
       let relatedRecords = kind === 'hasMany' ? this[field] : [ this.field ];

--- a/packages/models/cardstack/code-generator.js
+++ b/packages/models/cardstack/code-generator.js
@@ -54,13 +54,6 @@ define('@cardstack/models/generated/{{modelName}}', ['exports', '@cardstack/mode
         }),
        {{/if}}
      {{/each}}
-
-     resourceMetadata: Ember.inject.service(),
-
-     version: Ember.computed(function() {
-       let meta = this.get('resourceMetadata').read(this);
-       return meta && meta.version;
-     })
    }){{#if routingField}}.reopenClass({ routingField: "{{routingField}}" }){{/if}};
 });
 `);

--- a/packages/models/cardstack/code-generator.js
+++ b/packages/models/cardstack/code-generator.js
@@ -54,6 +54,13 @@ define('@cardstack/models/generated/{{modelName}}', ['exports', '@cardstack/mode
         }),
        {{/if}}
      {{/each}}
+
+     resourceMetadata: Ember.inject.service(),
+
+     version: Ember.computed(function() {
+       let meta = this.get('resourceMetadata').read(this);
+       return meta && meta.version;
+     })
    }){{#if routingField}}.reopenClass({ routingField: "{{routingField}}" }){{/if}};
 });
 `);

--- a/packages/models/cardstack/code-generator.js
+++ b/packages/models/cardstack/code-generator.js
@@ -42,7 +42,8 @@ define('@cardstack/models/generated/{{modelName}}', ['exports', '@cardstack/mode
              inverse: null,
              caption: "{{field.caption}}",
              editorComponent: "{{field.editorComponent}}",
-             inlineEditorComponent: "{{field.inlineEditorComponent}}"
+             inlineEditorComponent: "{{field.inlineEditorComponent}}",
+             owned: {{field.owned}}
             }),
          {{/with}}
        {{else}}

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -28,9 +28,9 @@
     "@cardstack/di": "0.8.0",
     "@cardstack/plugin-utils": "0.10.1",
     "ember-cli-babel": "^6.8.2",
-    "ember-data-relationship-tracker": "^0.2.1",
+    "ember-data-relationship-tracker": "^0.3.0",
     "ember-inject-optional": "^0.1.0",
-    "ember-resource-metadata": "^0.2.0",
+    "ember-resource-metadata": "^0.3.0",
     "handlebars": "^4.0.6",
     "inflection": "^1.12.0"
   },

--- a/packages/tools/addon/components/cs-version-control.js
+++ b/packages/tools/addon/components/cs-version-control.js
@@ -7,6 +7,7 @@ import { transitionTo } from '../private-api';
 import { modelType } from '@cardstack/rendering/helpers/cs-model-type';
 import { defaultBranch } from '@cardstack/plugin-utils/environment';
 import { computed } from "@ember/object";
+import { or } from '@ember/object/computed';
 
 export default Component.extend({
   layout,
@@ -128,17 +129,12 @@ export default Component.extend({
     }
   }),
 
-  anythingDirty: computed('model.{hasDirtyFields,hasDirtyAttributes,hasDirtyOwned}', function() {
-    // hasDirtyFields comes from the ember-data-relationship-tracker
-    // addon, if it's available. It's fine if it's not since the value
-    // will default to false, you just don't get relationship dirty
-    // tracking
-    return this.get('model.hasDirtyFields') || this.get('model.hasDirtyAttributes') || this.get('model.hasDirtyOwned');
-  }),
+  // hasDirtyFields comes from the ember-data-relationship-tracker
+  // addon, if it's available. It's fine if it's not since the value
+  // will default to false, you just don't get relationship dirty tracking
+  anythingDirty: or('model.{hasDirtyFields,hasDirtyAttributes,hasDirtyOwned}'),
 
-  anythingPending: computed('model.isNew', 'anythingDirty', function() {
-    return this.get('model.isNew') || this.get('anythingDirty');
-  }),
+  anythingPending: or('model.isNew', 'anythingDirty'),
 
   update: task(function * () {
     yield this.get('model').save();

--- a/packages/tools/addon/components/cs-version-control.js
+++ b/packages/tools/addon/components/cs-version-control.js
@@ -128,12 +128,12 @@ export default Component.extend({
     }
   }),
 
-  anythingDirty: computed('model.{hasDirtyFields,hasDirtyAttributes}', function() {
+  anythingDirty: computed('model.{hasDirtyFields,hasDirtyAttributes,hasDirtyOwned}', function() {
     // hasDirtyFields comes from the ember-data-relationship-tracker
     // addon, if it's available. It's fine if it's not since the value
     // will default to false, you just don't get relationship dirty
     // tracking
-    return this.get('model.hasDirtyFields') || this.get('model.hasDirtyAttributes');
+    return this.get('model.hasDirtyFields') || this.get('model.hasDirtyAttributes') || this.get('model.hasDirtyOwned');
   }),
 
   anythingPending: computed('model.isNew', 'anythingDirty', function() {

--- a/packages/tools/addon/components/cs-version-control.js
+++ b/packages/tools/addon/components/cs-version-control.js
@@ -132,7 +132,7 @@ export default Component.extend({
   // hasDirtyFields comes from the ember-data-relationship-tracker
   // addon, if it's available. It's fine if it's not since the value
   // will default to false, you just don't get relationship dirty tracking
-  anythingDirty: or('model.{hasDirtyFields,hasDirtyAttributes,hasDirtyOwned}'),
+  anythingDirty: or('model.{hasDirtyFields,hasDirtyOwned}'),
 
   anythingPending: or('model.isNew', 'anythingDirty'),
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -32,7 +32,7 @@
     "ember-elsewhere": "^1.0.3",
     "ember-inject-optional": "^0.1.0",
     "ember-moment": "^7.3.0",
-    "ember-resource-metadata": "^0.2.0",
+    "ember-resource-metadata": "^0.3.0",
     "ember-truth-helpers": "^2.0.0",
     "liquid-fire": "^0.29.0",
     "postcss-cssnext": "^2.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,6 +77,20 @@
   version "0.25.1"
   resolved "https://registry.yarnpkg.com/@std/esm/-/esm-0.25.1.tgz#90ce810e48bf3eda8f3533dabc5d4e31046d8228"
 
+"@types/acorn@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/acorn/-/acorn-4.0.3.tgz#d1f3e738dde52536f9aad3d3380d14e448820afd"
+  dependencies:
+    "@types/estree" "*"
+
+"@types/estree@*":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+
+"@types/estree@0.0.38":
+  version "0.0.38"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.38.tgz#c1be40aa933723c608820a99a373a16d215a1ca2"
+
 "@types/events@*":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
@@ -84,6 +98,10 @@
 "@types/node@*":
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.0.tgz#d3480ee666df9784b1001a1872a2f6ccefb6c2d7"
+
+"@types/node@^9.6.0":
+  version "9.6.30"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.30.tgz#1ecf83eaf7ac2d0dada7a9d61a1e4e7a6183ac06"
 
 "@types/pg-types@*":
   version "1.11.4"
@@ -99,6 +117,10 @@
     "@types/node" "*"
     "@types/pg-types" "*"
 
+"@xg-wang/whatwg-fetch@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@xg-wang/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#f7b222c012a238e7d6e89ed3d72a1e0edb58453d"
+
 JSONStream@^1.0.4:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
@@ -109,6 +131,10 @@ JSONStream@^1.0.4:
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+
+abortcontroller-polyfill@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.1.9.tgz#9fefe359fda2e9e0932dc85e6106453ac393b2da"
 
 accepts@1.3.3:
   version "1.3.3"
@@ -124,6 +150,12 @@ accepts@^1.2.2, accepts@~1.3.4:
     mime-types "~2.1.16"
     negotiator "0.6.1"
 
+acorn-dynamic-import@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
+  dependencies:
+    acorn "^5.0.0"
+
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
@@ -133,6 +165,10 @@ acorn-jsx@^3.0.0:
 acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+
+acorn@^5.0.0, acorn@^5.5.3:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.2.tgz#91fa871883485d06708800318404e72bfb26dcc5"
 
 acorn@^5.2.1:
   version "5.2.1"
@@ -205,7 +241,7 @@ amd-name-resolver@1.0.0:
   dependencies:
     ensure-posix-path "^1.0.1"
 
-amd-name-resolver@1.2.0:
+amd-name-resolver@1.2.0, amd-name-resolver@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz#fc41b3848824b557313897d71f8d5a0184fbe679"
   dependencies:
@@ -576,6 +612,30 @@ babel-core@^6.14.0, babel-core@^6.24.1, babel-core@^6.26.0:
     private "^0.1.7"
     slash "^1.0.0"
     source-map "^0.5.6"
+
+babel-core@^6.26.3:
+  version "6.26.3"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-generator "^6.26.0"
+    babel-helpers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-register "^6.26.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    convert-source-map "^1.5.1"
+    debug "^2.6.9"
+    json5 "^0.5.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    path-is-absolute "^1.0.1"
+    private "^0.1.8"
+    slash "^1.0.0"
+    source-map "^0.5.7"
 
 babel-generator@^6.26.0:
   version "6.26.0"
@@ -1661,6 +1721,13 @@ broccoli-merge-trees@^1.0.0:
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
 
+broccoli-merge-trees@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-3.0.1.tgz#545dfe9f695cec43372b3ee7e63c7203713ea554"
+  dependencies:
+    broccoli-plugin "^1.3.0"
+    merge-trees "^2.0.0"
+
 broccoli-middleware@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-middleware/-/broccoli-middleware-1.0.0.tgz#92f4e1fb9a791ea986245a7077f35cc648dab097"
@@ -1765,6 +1832,22 @@ broccoli-rollup@^1.2.0:
     symlink-or-copy "^1.1.8"
     walk-sync "^0.3.1"
 
+broccoli-rollup@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/broccoli-rollup/-/broccoli-rollup-2.1.1.tgz#0b77dc4b7560a53e998ea85f3b56772612d4988d"
+  dependencies:
+    "@types/node" "^9.6.0"
+    amd-name-resolver "^1.2.0"
+    broccoli-plugin "^1.2.1"
+    fs-tree-diff "^0.5.2"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    magic-string "^0.24.0"
+    node-modules-path "^1.0.1"
+    rollup "^0.57.1"
+    symlink-or-copy "^1.1.8"
+    walk-sync "^0.3.1"
+
 broccoli-slow-trees@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/broccoli-slow-trees/-/broccoli-slow-trees-3.0.1.tgz#9bf2a9e2f8eb3ed3a3f2abdde988da437ccdc9b4"
@@ -1804,6 +1887,25 @@ broccoli-stew@^1.2.0, broccoli-stew@^1.3.3, broccoli-stew@^1.4.0, broccoli-stew@
     symlink-or-copy "^1.1.8"
     walk-sync "^0.3.0"
 
+broccoli-stew@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-2.0.0.tgz#68f3d94f13b4a79aa15d582703574fb4c3215e50"
+  dependencies:
+    broccoli-debug "^0.6.1"
+    broccoli-funnel "^2.0.0"
+    broccoli-merge-trees "^3.0.0"
+    broccoli-persistent-filter "^1.1.6"
+    broccoli-plugin "^1.3.0"
+    chalk "^2.4.1"
+    debug "^3.1.0"
+    ensure-posix-path "^1.0.1"
+    fs-extra "^6.0.1"
+    minimatch "^3.0.4"
+    resolve "^1.8.1"
+    rsvp "^4.8.3"
+    symlink-or-copy "^1.2.0"
+    walk-sync "^0.3.0"
+
 broccoli-string-replace@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/broccoli-string-replace/-/broccoli-string-replace-0.1.2.tgz#1ed92f85680af8d503023925e754e4e33676b91f"
@@ -1818,6 +1920,17 @@ broccoli-templater@^1.0.0:
     broccoli-filter "^0.1.11"
     broccoli-stew "^1.2.0"
     lodash.template "^3.3.2"
+
+broccoli-templater@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/broccoli-templater/-/broccoli-templater-2.0.1.tgz#2e001e45aeba7fa2eb9b19a54c9c61b741935799"
+  dependencies:
+    broccoli-persistent-filter "^1.4.3"
+    broccoli-plugin "^1.3.0"
+    fs-tree-diff "^0.5.7"
+    lodash.template "^4.4.0"
+    rimraf "^2.6.2"
+    walk-sync "^0.3.2"
 
 broccoli-uglify-sourcemap@^2.0.0:
   version "2.0.1"
@@ -2154,6 +2267,14 @@ chalk@^2.3.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 charm@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/charm/-/charm-1.0.2.tgz#8add367153a6d9a581331052c4090991da995e35"
@@ -2221,6 +2342,10 @@ clean-css@^3.4.5:
   dependencies:
     commander "2.8.x"
     source-map "0.4.x"
+
+clean-up-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clean-up-path/-/clean-up-path-1.0.0.tgz#de9e8196519912e749c9eaf67c13d64fac72a3e5"
 
 cli-cursor@^1.0.1:
   version "1.0.2"
@@ -2699,7 +2824,7 @@ conventional-recommended-bump@^1.0.0:
     meow "^3.3.0"
     object-assign "^4.0.1"
 
-convert-source-map@^1.1.0, convert-source-map@^1.5.0:
+convert-source-map@^1.1.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
@@ -2877,6 +3002,12 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-time@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/date-time/-/date-time-2.1.0.tgz#0286d1b4c769633b3ca13e1e62558d2dbdc2eba2"
+  dependencies:
+    time-zone "^1.0.0"
+
 dateformat@^1.0.11, dateformat@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-1.0.12.tgz#9f124b67594c937ff706932e4a642cca8dbbfee9"
@@ -2896,7 +3027,7 @@ debug@2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.4.0, debug@^2.6.8, debug@~2.6.4, debug@~2.6.6, debug@~2.6.7, debug@~2.6.9:
+debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.4.0, debug@^2.6.8, debug@^2.6.9, debug@~2.6.4, debug@~2.6.6, debug@~2.6.7, debug@~2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -3801,9 +3932,9 @@ ember-css-url@0.2.0:
   dependencies:
     ember-cli-babel "^6.6.0"
 
-ember-data-relationship-tracker@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/ember-data-relationship-tracker/-/ember-data-relationship-tracker-0.2.1.tgz#72d25ceba1ee2a2fda7b1c7eae9c65aa9ed2cf03"
+ember-data-relationship-tracker@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-data-relationship-tracker/-/ember-data-relationship-tracker-0.3.0.tgz#87199e34187070184b477d080ac20ab1b5207e17"
   dependencies:
     ember-cli-babel "^6.8.2"
     ember-lodash "^4.17.2"
@@ -3901,17 +4032,6 @@ ember-factory-for-polyfill@^1.1.0, ember-factory-for-polyfill@^1.3.1:
   dependencies:
     ember-cli-version-checker "^2.1.0"
 
-ember-fetch@^1.4.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-1.6.0.tgz#cf93d3f7049c593f14d11b6f0924b746303b7812"
-  dependencies:
-    broccoli-funnel "^1.2.0"
-    broccoli-stew "^1.4.2"
-    broccoli-templater "^1.0.0"
-    ember-cli-babel "^6.0.0"
-    node-fetch "^2.0.0-alpha.3"
-    whatwg-fetch "^2.0.3"
-
 "ember-fetch@^2.1.0 || ^3.0.0":
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-3.4.3.tgz#fb8ba73148bb2399a82b037e4fdf9a953cd496ba"
@@ -3922,6 +4042,23 @@ ember-fetch@^1.4.0:
     ember-cli-babel "^6.8.1"
     node-fetch "^2.0.0-alpha.9"
     whatwg-fetch "^2.0.3"
+
+ember-fetch@^5.1.1:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-5.1.3.tgz#f649c60d523bf1949125a4c497751df3b0c9f587"
+  dependencies:
+    "@xg-wang/whatwg-fetch" "^3.0.0"
+    abortcontroller-polyfill "^1.1.9"
+    babel-core "^6.26.3"
+    babel-preset-env "^1.7.0"
+    broccoli-concat "^3.2.2"
+    broccoli-merge-trees "^3.0.0"
+    broccoli-rollup "^2.1.1"
+    broccoli-stew "^2.0.0"
+    broccoli-templater "^2.0.1"
+    ember-cli-babel "^6.8.2"
+    node-fetch "^2.0.0-alpha.9"
+    rollup-plugin-babel "^3.0.7"
 
 ember-getowner-polyfill@^1.1.0, ember-getowner-polyfill@^1.2.2:
   version "1.2.5"
@@ -4087,9 +4224,9 @@ ember-resolver@^4.0.0:
     ember-cli-version-checker "^2.0.0"
     resolve "^1.3.3"
 
-ember-resource-metadata@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/ember-resource-metadata/-/ember-resource-metadata-0.2.0.tgz#28a6a4b0874d1c53ecb667004d5f7967b905db65"
+ember-resource-metadata@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-resource-metadata/-/ember-resource-metadata-0.3.0.tgz#b3e2316fb0b1e19d8dda49ad15ddd813c383ec89"
   dependencies:
     ember-cli-babel "^6.8.2"
     ember-inflector "^2.1.0"
@@ -4629,6 +4766,14 @@ esrecurse@^4.1.0:
 estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
+
+estree-walker@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e"
+
+estree-walker@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.2.tgz#d3850be7529c9580d815600b53126515e146dd39"
 
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
@@ -5219,6 +5364,14 @@ fs-extra@^4.0.3:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@~0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.27.0.tgz#66d4c25d1d2c6a8dafed7718cfcffe930f13b2c0"
@@ -5250,6 +5403,25 @@ fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5
     object-assign "^4.1.0"
     path-posix "^1.0.0"
     symlink-or-copy "^1.1.8"
+
+fs-tree-diff@^0.5.7:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz#a4ec6182c2f5bd80b9b83c8e23e4522e6f5fd946"
+  dependencies:
+    heimdalljs-logger "^0.1.7"
+    object-assign "^4.1.0"
+    path-posix "^1.0.0"
+    symlink-or-copy "^1.1.8"
+
+fs-updater@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/fs-updater/-/fs-updater-1.0.4.tgz#2329980f99ae9176e9a0e84f7637538a182ce63b"
+  dependencies:
+    can-symlink "^1.0.0"
+    clean-up-path "^1.0.0"
+    heimdalljs "^0.2.5"
+    heimdalljs-logger "^0.1.9"
+    rimraf "^2.6.2"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -5750,6 +5922,12 @@ heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3:
   dependencies:
     rsvp "~3.2.1"
 
+heimdalljs@^0.2.5:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.2.6.tgz#b0eebabc412813aeb9542f9cc622cb58dbdcd9fe"
+  dependencies:
+    rsvp "~3.2.1"
+
 heimdalljs@^0.3.0:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.3.3.tgz#e92d2c6f77fd46d5bf50b610d28ad31755054d0b"
@@ -6236,6 +6414,12 @@ is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
+is-reference@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.1.0.tgz#50e6ef3f64c361e2c53c0416cdc9420037f2685b"
+  dependencies:
+    "@types/estree" "0.0.38"
+
 is-resolvable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
@@ -6709,6 +6893,10 @@ loader.js@^4.2.3:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/loader.js/-/loader.js-4.6.0.tgz#b965663ddbe2d80da482454cb865efe496e93e22"
 
+locate-character@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/locate-character/-/locate-character-2.0.5.tgz#f2d2614d49820ecb3c92d80d193b8db755f74c0f"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -7049,7 +7237,7 @@ lodash.template@^3.3.2:
     lodash.restparam "^3.0.0"
     lodash.templatesettings "^3.0.0"
 
-lodash.template@^4.0.2, lodash.template@^4.2.4, lodash.template@^4.2.5:
+lodash.template@^4.0.2, lodash.template@^4.2.4, lodash.template@^4.2.5, lodash.template@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0"
   dependencies:
@@ -7155,6 +7343,12 @@ lru-cache@^4.0.1:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+magic-string@^0.24.0:
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.24.1.tgz#7e38e5f126cae9f15e71f0cf8e450818ca7d5a8f"
+  dependencies:
+    sourcemap-codec "^1.4.1"
 
 make-dir@^1.0.0:
   version "1.0.0"
@@ -7293,6 +7487,13 @@ merge-trees@^1.0.1:
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
 
+merge-trees@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-trees/-/merge-trees-2.0.0.tgz#a560d796e566c5d9b2c40472a2967cca48d85161"
+  dependencies:
+    fs-updater "^1.0.4"
+    heimdalljs "^0.2.5"
+
 merge@1.2.0, merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
@@ -7301,7 +7502,7 @@ methods@1.x, methods@^1.1.1, methods@~1.1.0, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
-micromatch@^2.1.5:
+micromatch@^2.1.5, micromatch@^2.3.11:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
   dependencies:
@@ -7635,7 +7836,7 @@ node-fetch@^1.3.3:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@^2.0.0-alpha.3, node-fetch@^2.0.0-alpha.9:
+node-fetch@^2.0.0-alpha.9:
   version "2.0.0-alpha.9"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.0.0-alpha.9.tgz#990c0634f510f76449a0d6f6eaec96b22f273628"
 
@@ -8036,6 +8237,10 @@ parse-json@^2.2.0:
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
   dependencies:
     error-ex "^1.2.0"
+
+parse-ms@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-1.0.1.tgz#56346d4749d78f23430ca0c713850aef91aa361d"
 
 parse-passwd@^1.0.0:
   version "1.0.0"
@@ -8586,11 +8791,17 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+pretty-ms@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-3.2.0.tgz#87a8feaf27fc18414d75441467d411d6e6098a25"
+  dependencies:
+    parse-ms "^1.0.0"
+
 printf@^0.2.3:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/printf/-/printf-0.2.5.tgz#c438ca2ca33e3927671db4ab69c0e52f936a4f0f"
 
-private@^0.1.6, private@^0.1.7, private@~0.1.5:
+private@^0.1.6, private@^0.1.7, private@^0.1.8, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
@@ -9099,6 +9310,10 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+require-relative@^0.8.7:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
+
 require-uncached@^1.0.2, require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
@@ -9128,6 +9343,12 @@ resolve-url@^0.2.1:
 resolve@1.5.0, resolve@^1.1.2, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  dependencies:
+    path-parse "^1.0.5"
+
+resolve@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
     path-parse "^1.0.5"
 
@@ -9169,7 +9390,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.5.3, rimraf@^2.5.4:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -9192,11 +9413,47 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^2.0.0"
     inherits "^2.0.1"
 
+rollup-plugin-babel@^3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-3.0.7.tgz#5b13611f1ab8922497e9d15197ae5d8a23fe3b1e"
+  dependencies:
+    rollup-pluginutils "^1.5.0"
+
+rollup-pluginutils@^1.5.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
+  dependencies:
+    estree-walker "^0.2.1"
+    minimatch "^3.0.2"
+
+rollup-pluginutils@^2.0.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.1.tgz#760d185ccc237dedc12d7ae48c6bcd127b4892d0"
+  dependencies:
+    estree-walker "^0.5.2"
+    micromatch "^2.3.11"
+
 rollup@^0.41.4:
   version "0.41.6"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.41.6.tgz#e0d05497877a398c104d816d2733a718a7a94e2a"
   dependencies:
     source-map-support "^0.4.0"
+
+rollup@^0.57.1:
+  version "0.57.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.57.1.tgz#0bb28be6151d253f67cf4a00fea48fb823c74027"
+  dependencies:
+    "@types/acorn" "^4.0.3"
+    acorn "^5.5.3"
+    acorn-dynamic-import "^3.0.0"
+    date-time "^2.1.0"
+    is-reference "^1.1.0"
+    locate-character "^2.0.5"
+    pretty-ms "^3.1.0"
+    require-relative "^0.8.7"
+    rollup-pluginutils "^2.0.1"
+    signal-exit "^3.0.2"
+    sourcemap-codec "^1.4.1"
 
 rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.5.0:
   version "3.6.2"
@@ -9206,7 +9463,7 @@ rsvp@^4.6.1, rsvp@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.7.0.tgz#dc1b0b1a536f7dec9d2be45e0a12ad4197c9fd96"
 
-rsvp@^4.8.2:
+rsvp@^4.8.2, rsvp@^4.8.3:
   version "4.8.3"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.3.tgz#25d4b9fdd0f95e216eb5884d9b3767d3fbfbe2cd"
 
@@ -9689,7 +9946,7 @@ source-map@0.4.x, source-map@^0.4.2, source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.0:
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -9706,6 +9963,10 @@ source-map@~0.1.x:
 source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+
+sourcemap-codec@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.1.tgz#c8fd92d91889e902a07aee392bdd2c5863958ba2"
 
 sourcemap-validator@^1.0.5:
   version "1.0.6"
@@ -10033,6 +10294,10 @@ symlink-or-copy@^1.0.0, symlink-or-copy@^1.0.1, symlink-or-copy@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/symlink-or-copy/-/symlink-or-copy-1.1.8.tgz#cabe61e0010c1c023c173b25ee5108b37f4b4aa3"
 
+symlink-or-copy@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz#5d49108e2ab824a34069b68974486c290020b393"
+
 table@^3.7.8:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
@@ -10208,6 +10473,10 @@ through2@^2.0.0, through2@^2.0.2:
 through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+
+time-zone@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/time-zone/-/time-zone-1.0.0.tgz#99c5bf55958966af6d06d83bdf3800dc82faec5d"
 
 timed-out@^4.0.0, timed-out@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Where relationship tracking is provided by the ember-data-relationship-tracker add-on

* [x] The update for a related record fails with a 400, `missing required field "meta.version"`, as the meta data is not sent in the payload
* [x] Related records are saved when they are added or deleted but not when only changing one of their attributes (update the title of a document-chapter)