### PR TITLE
Reload models from API on route transitions

### DIFF
--- a/packages/routing/addon/routes/cardstack/common.js
+++ b/packages/routing/addon/routes/cardstack/common.js
@@ -29,7 +29,7 @@ export default Route.extend({
         branch
       });
     } else {
-      promise = this.store.findRecord(mType, slug, { branch });
+      promise = this.store.findRecord(mType, slug, { branch, reload: true });
     }
 
     return promise.catch(err => {

--- a/packages/routing/tests/acceptance/content-test.js
+++ b/packages/routing/tests/acceptance/content-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { visit, currentURL } from '@ember/test-helpers';
+import { visit, currentURL, click } from '@ember/test-helpers';
 
 module('Acceptance | content', function(hooks) {
   setupApplicationTest(hooks);
@@ -32,5 +32,12 @@ module('Acceptance | content', function(hooks) {
     await visit('/c/posts/bogus');
     assert.equal(currentURL(), '/c/posts/bogus');
     assert.equal(this.element.querySelector('h1').textContent.trim(), 'Not Found');
+  });
+
+  test('reloads models on route transitions', async function(assert) {
+    await visit('/c/categories/category-1');
+    await click('[data-test-post="1"]')
+
+    assert.equal(currentURL(), '/c/posts/1');
   });
 });

--- a/packages/routing/tests/dummy/app/models/category.js
+++ b/packages/routing/tests/dummy/app/models/category.js
@@ -2,5 +2,5 @@ import DS from 'ember-data';
 
 export default DS.Model.extend({
   title: DS.attr('string'),
-  page: DS.belongsTo({ async: false })
+  posts: DS.hasMany({ async: false })
 });

--- a/packages/routing/tests/dummy/app/templates/components/cardstack/category-page.hbs
+++ b/packages/routing/tests/dummy/app/templates/components/cardstack/category-page.hbs
@@ -1,0 +1,7 @@
+<div class="title">{{content.title}}</div>
+
+{{#each content.posts as |post|}}
+  <a href={{cardstack-url post}} data-test-post={{post.id}}>
+    {{post.title}}
+  </a>
+{{/each}}

--- a/packages/routing/tests/dummy/app/templates/components/cardstack/post-page.hbs
+++ b/packages/routing/tests/dummy/app/templates/components/cardstack/post-page.hbs
@@ -1,1 +1,2 @@
 <div class="title">{{content.title}}</div>
+<div class="page">belongs to page <em>"{{content.page.blurb}}"</em></div>

--- a/packages/routing/tests/dummy/cardstack/seeds/ephemeral.js
+++ b/packages/routing/tests/dummy/cardstack/seeds/ephemeral.js
@@ -5,23 +5,8 @@ const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
 function initialModels() {
   let initial = new JSONAPIFactory();
 
-  initial.addResource('content-types', 'posts')
-    .withRelated('fields', [
-      initial.addResource('fields', 'title').withAttributes({
-        fieldType: '@cardstack/core-types::string'
-      })
-    ]);
-  initial.addResource('posts', '1')
-    .withAttributes({
-      title: 'hello world'
-    });
-  initial.addResource('posts', '2')
-    .withAttributes({
-      title: 'second post'
-    });
-
   initial.addResource('content-types', 'pages')
-    .withRelated('fields', [
+  .withRelated('fields', [
       initial.addResource('fields', 'blurb').withAttributes({
         fieldType: '@cardstack/core-types::string'
       }),
@@ -29,16 +14,60 @@ function initialModels() {
         fieldType: '@cardstack/core-types::string'
       })
     ]);
-  initial.addResource('pages')
+  initial.addResource('pages', 'page-homepage')
     .withAttributes({
       blurb: 'this is the homepage',
       permalink: ' '
     });
-  initial.addResource('pages')
+  initial.addResource('pages', 'page-second')
     .withAttributes({
       blurb: 'I am the second page',
       permalink: 'second'
     });
+
+  initial.addResource('content-types', 'posts')
+    .withAttributes({
+      defaultIncludes: ['page']
+    })
+    .withRelated('fields', [
+      initial.addResource('fields', 'title').withAttributes({
+        fieldType: '@cardstack/core-types::string'
+      }),
+      initial.addResource('fields', 'page').withAttributes({
+        fieldType: '@cardstack/core-types::belongs-to'
+      }),
+    ]);
+  initial.addResource('posts', '1')
+    .withAttributes({
+      title: 'hello world'
+    })
+    .withRelated('page', { type: 'pages', id: 'page-second' });
+  initial.addResource('posts', '2')
+    .withAttributes({
+      title: 'second post'
+    })
+    .withRelated('page', { type: 'pages', id: 'page-second' });
+
+  initial.addResource('content-types', 'categories')
+    .withAttributes({
+      defaultIncludes: ['posts']
+    })
+    .withRelated('fields', [
+      initial.addResource('fields', 'title').withAttributes({
+        fieldType: '@cardstack/core-types::string'
+      }),
+      initial.addResource('fields', 'posts').withAttributes({
+        fieldType: '@cardstack/core-types::has-many'
+      })
+    ]);
+  initial.addResource('categories', 'category-1')
+    .withAttributes({
+      title: 'test category'
+    })
+    .withRelated('posts', [
+      { type: 'posts', id: '1' },
+      { type: 'posts', id: '2' }
+    ]);
 
   return initial.getModels();
 }


### PR DESCRIPTION
This fixes a problem with models being reused from Ember Data's in-memory store on route transitions. [Ember Data's `findRecord`](https://emberjs.com/api/ember-data/3.3/classes/DS.Store/methods/findRecord?anchor=findRecord) will returns records from its in-memory store if they are present already and not wait for the API request to finish. If these records have synchronous relationships though, it cannot be known for sure whether all of these relationships have been loaded already, potentially leading to the dreaded _"Uncaught Error: Assertion Failed: You looked up the 'xyz' relationship on a 'abc' with id 1 but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.belongsTo({ async: true })`)"_ error.

This opts out of that behavior (`reload: true`) and always waits until the API request finished and the complete record has been loaded from the API.

closes cardstack/deck#58