### PR TITLE
[CONCEPT] cs-field-alternatives

### DIFF
--- a/packages/rendering/addon/components/cs-field-alternatives.js
+++ b/packages/rendering/addon/components/cs-field-alternatives.js
@@ -1,7 +1,7 @@
 import layout from '../templates/components/cs-field-alternatives';
 import { humanize } from '../helpers/cs-humanize';
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { computed, get } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { A } from '@ember/array';
 
@@ -24,6 +24,28 @@ export default Component.extend({
       content: this.get('content'),
       alternatives: this.get('alternativesList'),
       caption: this.get('groupCaption')
+    };
+  }),
+
+  alternativesStatus: computed('content', 'alternativesList.[]', function() {
+    // One alternative should be marked as enabled at all times
+    //Check which alternative has data
+    let content = this.get('content');
+    let alternativesList = this.get('alternativesList');
+    
+    let alternativesWithData = alternativesList
+      .filter((alternative) => {
+        let hasData = get(alternative, 'fieldNames')
+          .map((fieldName) => get(content, fieldName))
+          .filter((data) => !!data);
+        return get(hasData, 'length') > 0;
+      });
+    let firstWithData = (alternativesWithData.length > 0) ? alternativesWithData[0] : null;
+
+    // Select first with data or first in list
+    let activeName = (firstWithData) ? get(firstWithData, 'name') : get(alternativesList, 'firstObject.name');
+    return {
+      [activeName]: true
     };
   }),
 

--- a/packages/rendering/addon/components/cs-field-alternatives.js
+++ b/packages/rendering/addon/components/cs-field-alternatives.js
@@ -1,0 +1,38 @@
+import layout from '../templates/components/cs-field-alternatives';
+import { humanize } from '../helpers/cs-humanize';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import { A } from '@ember/array';
+
+export default Component.extend({
+  layout,
+  tagName: '',
+  alternativesList: A(),
+
+  id: computed('content', 'name', function() {
+    return `${guidFor(this.get('content'))}/cs-field-alternatives/${this.get('name')}`;
+  }),
+
+  groupCaption: computed('caption', 'name', function() {
+    return this.get('caption') || humanize(this.get('name'));
+  }),
+
+  fieldInfo: computed('content', 'fieldName', function() {
+    return {
+      name: this.get('name'),
+      content: this.get('content'),
+      alternatives: this.get('alternativesList'),
+      caption: this.get('groupCaption')
+    };
+  }),
+
+  actions: {
+    registerAlternative(alternative) {
+      this.get('alternativesList').pushObject(alternative);
+    }
+  }
+
+}).reopenClass({
+  positionalParams: ['content']
+});

--- a/packages/rendering/addon/components/cs-field-alternatives/alternative.js
+++ b/packages/rendering/addon/components/cs-field-alternatives/alternative.js
@@ -1,0 +1,34 @@
+import layout from '../../templates/components/cs-field-alternatives/alternative';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { assert } from '@ember/debug';
+
+const LIMIT = 7;
+
+export default Component.extend({
+  layout,
+  tagName: '',
+
+  fieldNames: computed('fields', function() {
+    let fields = this.get('fields');
+    if (!Array.isArray(fields)) {
+      fields = fields.split(/\s*,\s*/g);
+    }
+    if (fields.length > LIMIT) {
+      throw new Error(`can't handle more than ${LIMIT} fields in a group at the moment, see cs-field-group's template`);
+    }
+    return fields;
+  }),
+
+  init() {
+    this._super(...arguments);
+    assert('Alternative name must be provided', !!this.get('name'));
+    assert('Alternative fieldNames must be provided', !!this.get('fieldNames'));
+
+    this.get('registerAlternative')({
+      name: this.get('name'),
+      fieldNames: this.get('fieldNames')
+    });
+  }
+
+});

--- a/packages/rendering/addon/components/cs-field-alternatives/alternative.js
+++ b/packages/rendering/addon/components/cs-field-alternatives/alternative.js
@@ -20,7 +20,11 @@ export default Component.extend({
     return fields;
   }),
 
-  init() {
+  active: computed('alternativesStatus', 'name', function() {
+    return this.get('alternativesStatus')[this.get('name')];
+  }),
+
+  didInsertElement() {
     this._super(...arguments);
     assert('Alternative name must be provided', !!this.get('name'));
     assert('Alternative fieldNames must be provided', !!this.get('fieldNames'));

--- a/packages/rendering/addon/templates/components/cs-field-alternatives.hbs
+++ b/packages/rendering/addon/templates/components/cs-field-alternatives.hbs
@@ -1,0 +1,10 @@
+{{#mark-overlay id=id model=fieldInfo group="cardstack-fields" ~}}
+  {{yield
+    (hash 
+      alternative=(component 'cs-field-alternatives/alternative'
+        content=content
+        registerAlternative=(action 'registerAlternative')
+      )
+    )
+  ~}}
+{{/mark-overlay ~}}

--- a/packages/rendering/addon/templates/components/cs-field-alternatives.hbs
+++ b/packages/rendering/addon/templates/components/cs-field-alternatives.hbs
@@ -4,6 +4,7 @@
       alternative=(component 'cs-field-alternatives/alternative'
         content=content
         registerAlternative=(action 'registerAlternative')
+        alternativesStatus=alternativesStatus
       )
     )
   ~}}

--- a/packages/rendering/addon/templates/components/cs-field-alternatives/alternative.hbs
+++ b/packages/rendering/addon/templates/components/cs-field-alternatives/alternative.hbs
@@ -1,18 +1,20 @@
-{{yield
-  (cs-silly-hash
-    key0=(get fieldNames "0")
-    value0=(get content (get fieldNames "0"))
-    key1=(get fieldNames "1")
-    value1=(get content (get fieldNames "1"))
-    key2=(get fieldNames "2")
-    value2=(get content (get fieldNames "2"))
-    key3=(get fieldNames "3")
-    value3=(get content (get fieldNames "3"))
-    key4=(get fieldNames "4")
-    value4=(get content (get fieldNames "4"))
-    key5=(get fieldNames "5")
-    value5=(get content (get fieldNames "5"))
-    key6=(get fieldNames "6")
-    value6=(get content (get fieldNames "6"))
-  )
-~}}
+{{#if active}}
+  {{yield
+    (cs-silly-hash
+      key0=(get fieldNames "0")
+      value0=(get content (get fieldNames "0"))
+      key1=(get fieldNames "1")
+      value1=(get content (get fieldNames "1"))
+      key2=(get fieldNames "2")
+      value2=(get content (get fieldNames "2"))
+      key3=(get fieldNames "3")
+      value3=(get content (get fieldNames "3"))
+      key4=(get fieldNames "4")
+      value4=(get content (get fieldNames "4"))
+      key5=(get fieldNames "5")
+      value5=(get content (get fieldNames "5"))
+      key6=(get fieldNames "6")
+      value6=(get content (get fieldNames "6"))
+    )
+  ~}}
+{{/if}}

--- a/packages/rendering/addon/templates/components/cs-field-alternatives/alternative.hbs
+++ b/packages/rendering/addon/templates/components/cs-field-alternatives/alternative.hbs
@@ -1,0 +1,18 @@
+{{yield
+  (cs-silly-hash
+    key0=(get fieldNames "0")
+    value0=(get content (get fieldNames "0"))
+    key1=(get fieldNames "1")
+    value1=(get content (get fieldNames "1"))
+    key2=(get fieldNames "2")
+    value2=(get content (get fieldNames "2"))
+    key3=(get fieldNames "3")
+    value3=(get content (get fieldNames "3"))
+    key4=(get fieldNames "4")
+    value4=(get content (get fieldNames "4"))
+    key5=(get fieldNames "5")
+    value5=(get content (get fieldNames "5"))
+    key6=(get fieldNames "6")
+    value6=(get content (get fieldNames "6"))
+  )
+~}}

--- a/packages/rendering/app/components/cs-field-alternatives.js
+++ b/packages/rendering/app/components/cs-field-alternatives.js
@@ -1,0 +1,1 @@
+export { default } from '@cardstack/rendering/components/cs-field-alternatives';

--- a/packages/rendering/app/components/cs-field-alternatives/alternative.js
+++ b/packages/rendering/app/components/cs-field-alternatives/alternative.js
@@ -1,0 +1,1 @@
+export { default } from '@cardstack/rendering/components/cs-field-alternatives/alternative';

--- a/packages/rendering/tests/dummy/app/models/beverage.js
+++ b/packages/rendering/tests/dummy/app/models/beverage.js
@@ -3,5 +3,8 @@ import DS from 'ember-data';
 export default DS.Model.extend({
   flavor: DS.attr('string'),
   size: DS.attr('number'),
-  sizeUnits: DS.attr('string')
+  sizeUnits: DS.attr('string'),
+  serialCode: DS.attr('string'),
+  price: DS.attr('string'),
+  expirationDate: DS.attr('string')
 });

--- a/packages/rendering/tests/dummy/app/routes/index.js
+++ b/packages/rendering/tests/dummy/app/routes/index.js
@@ -5,7 +5,8 @@ export default Route.extend({
     return this.store.createRecord('beverage', {
       flavor: 'cola',
       size: 16,
-      sizeUnits: 'oz'
+      sizeUnits: 'oz',
+      serialCode: '9789929-591332'
     });
   }
 });

--- a/packages/rendering/tests/dummy/app/templates/components/cardstack/beverage-page.hbs
+++ b/packages/rendering/tests/dummy/app/templates/components/cardstack/beverage-page.hbs
@@ -1,4 +1,18 @@
 <div class="page-flavor">{{cs-field content "flavor"}}</div>
-{{#cs-field-group content name="size" fields="size,sizeUnits" as |s|}}
+{{!-- {{#cs-field-group content name="size" fields="size,sizeUnits" as |s|}}
   <div class="page-size">{{s.size}} {{s.sizeUnits}}</div>
-{{/cs-field-group}}
+{{/cs-field-group}} --}}
+
+
+{{!-- {{#cs-field-alternatives content name="size" caption="Beverage size"}}
+
+{{/cs-field-alternatives}} --}}
+
+{{#cs-field-alternatives content name="size" caption="Beverage size" as |rt|}}
+  {{#rt.alternative name='size-measurement' fields="size" as |alt1|}}
+    <div>{{alt1.size}}</div>
+  {{/rt.alternative}}
+  {{#rt.alternative name='size-label' fields="sizeUnits" as |alt1|}}
+    <div>{{alt1.sizeUnits}}</div>
+  {{/rt.alternative}}
+{{/cs-field-alternatives}}

--- a/packages/rendering/tests/dummy/app/templates/components/cardstack/beverage-page.hbs
+++ b/packages/rendering/tests/dummy/app/templates/components/cardstack/beverage-page.hbs
@@ -1,18 +1,19 @@
 <div class="page-flavor">{{cs-field content "flavor"}}</div>
-{{!-- {{#cs-field-group content name="size" fields="size,sizeUnits" as |s|}}
+
+{{#cs-field-group content name="size" fields="size,sizeUnits" as |s|}}
   <div class="page-size">{{s.size}} {{s.sizeUnits}}</div>
-{{/cs-field-group}} --}}
+{{/cs-field-group}}
 
-
-{{!-- {{#cs-field-alternatives content name="size" caption="Beverage size"}}
-
-{{/cs-field-alternatives}} --}}
-
-{{#cs-field-alternatives content name="size" caption="Beverage size" as |rt|}}
-  {{#rt.alternative name='size-measurement' fields="size" as |alt1|}}
-    <div>{{alt1.size}}</div>
+{{#cs-field-alternatives content name="extra-info" caption="Extra information" as |rt|}}
+  {{#rt.alternative name='serial-code' fields="serialCode" as |info|}}
+    <div>
+      <strong>Serial code:</strong> {{info.serialCode}}
+    </div>
   {{/rt.alternative}}
-  {{#rt.alternative name='size-label' fields="sizeUnits" as |alt1|}}
-    <div>{{alt1.sizeUnits}}</div>
+  {{#rt.alternative name='details' fields="price,expirationDate" as |info|}}
+    <div>
+      <strong>Price:</strong> {{info.price}} <br>
+      <strong>Expiration Date:</strong>{{info.expirationDate}}
+    </div>
   {{/rt.alternative}}
 {{/cs-field-alternatives}}

--- a/packages/tools/addon/components/cs-alternatives-editor.js
+++ b/packages/tools/addon/components/cs-alternatives-editor.js
@@ -1,0 +1,6 @@
+import Component from '@ember/component';
+import layout from '../templates/components/cs-alternatives-editor';
+
+export default Component.extend({
+  layout
+});

--- a/packages/tools/addon/components/cs-alternatives-editor.js
+++ b/packages/tools/addon/components/cs-alternatives-editor.js
@@ -1,6 +1,19 @@
 import Component from '@ember/component';
+import { get, set } from '@ember/object';
 import layout from '../templates/components/cs-alternatives-editor';
 
 export default Component.extend({
-  layout
+  layout,
+  actions: {
+    switchAlternative(current, target, transitionToTab) {
+      // Clear current alternative's fields
+      let currentAlternative = this.get('alternatives').findBy('name', current);
+      let content = this.get('content');
+      get(currentAlternative, 'fieldNames').forEach((fieldName) => {
+        set(content, fieldName, '');
+      });
+
+      transitionToTab(target);
+    }
+  }
 });

--- a/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
+++ b/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
@@ -34,14 +34,7 @@
         {{/each}}
       {{else}}
         {{#if fieldMark.model.alternatives}}
-          {{#each fieldMark.model.alternatives as |alternative|}}
-            {{#each alternative.fieldNames as |fieldName|}}
-              {{#with fieldMark.model.content as |content|}}
-                <label>{{cs-field-caption content fieldName}}</label>
-                {{cs-field-editor content=content field=fieldName enabled=editingEnabled}}
-              {{/with}}
-            {{/each}}
-          {{/each}}
+          {{cs-alternatives-editor content=fieldMark.model.content alternatives=fieldMark.model.alternatives enabled=editingEnabled}}
         {{else}}
           {{cs-field-editor content=fieldMark.model.content field=fieldMark.model.name enabled=editingEnabled}}
         {{/if}}

--- a/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
+++ b/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
@@ -33,7 +33,18 @@
           {{/with}}
         {{/each}}
       {{else}}
-        {{cs-field-editor content=fieldMark.model.content field=fieldMark.model.name enabled=editingEnabled}}
+        {{#if fieldMark.model.alternatives}}
+          {{#each fieldMark.model.alternatives as |alternative|}}
+            {{#each alternative.fieldNames as |fieldName|}}
+              {{#with fieldMark.model.content as |content|}}
+                <label>{{cs-field-caption content fieldName}}</label>
+                {{cs-field-editor content=content field=fieldName enabled=editingEnabled}}
+              {{/with}}
+            {{/each}}
+          {{/each}}
+        {{else}}
+          {{cs-field-editor content=fieldMark.model.content field=fieldMark.model.name enabled=editingEnabled}}
+        {{/if}}
       {{/if}}
       </div>
     {{/cs-collapsible-section}}

--- a/packages/tools/addon/templates/components/cs-alternatives-editor.hbs
+++ b/packages/tools/addon/templates/components/cs-alternatives-editor.hbs
@@ -4,13 +4,15 @@
       onclick={{action "switchAlternative" w.currentStep alternative.name w.transition-to}}
       aria-pressed={{eq w.currentStep alternative.name}}
     >
-      {{alternative.name}}
+      {{cs-humanize alternative.name}}
     </button>
   {{/each}}
 
   {{#each alternatives as |alternative|}}
     {{#w.step name=alternative.name}}
-      <h3>{{alternative.name}}</h3>
+      <h3>
+        {{cs-humanize alternative.name}}
+      </h3>
       {{#each alternative.fieldNames as |fieldName|}}
         <label>{{cs-field-caption content fieldName}}</label>
         {{cs-field-editor content=content field=fieldName enabled=enabled}}

--- a/packages/tools/addon/templates/components/cs-alternatives-editor.hbs
+++ b/packages/tools/addon/templates/components/cs-alternatives-editor.hbs
@@ -1,0 +1,20 @@
+{{#step-manager as |w|}}
+  {{#each alternatives as |alternative|}}
+    <button
+      onclick={{action w.transition-to alternative.name}}
+      aria-pressed={{eq w.currentStep alternative.name}}
+    >
+      {{alternative.name}}
+    </button>
+  {{/each}}
+
+  {{#each alternatives as |alternative|}}
+    {{#w.step name=alternative.name}}
+      <h3>{{alternative.name}}</h3>
+      {{#each alternative.fieldNames as |fieldName|}}
+        <label>{{cs-field-caption content fieldName}}</label>
+        {{cs-field-editor content=content field=fieldName enabled=enabled}}
+      {{/each}}
+    {{/w.step}}
+  {{/each}}
+{{/step-manager}}

--- a/packages/tools/addon/templates/components/cs-alternatives-editor.hbs
+++ b/packages/tools/addon/templates/components/cs-alternatives-editor.hbs
@@ -1,7 +1,7 @@
 {{#step-manager as |w|}}
   {{#each alternatives as |alternative|}}
     <button
-      onclick={{action w.transition-to alternative.name}}
+      onclick={{action "switchAlternative" w.currentStep alternative.name w.transition-to}}
       aria-pressed={{eq w.currentStep alternative.name}}
     >
       {{alternative.name}}

--- a/packages/tools/app/components/cs-alternatives-editor.js
+++ b/packages/tools/app/components/cs-alternatives-editor.js
@@ -1,0 +1,1 @@
+export { default } from '@cardstack/tools/components/cs-alternatives-editor';

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -63,6 +63,7 @@
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.0.0",
     "ember-source-channel-url": "^1.0.1",
+    "ember-steps": "^6.0.2",
     "ember-try": "^0.2.23",
     "eslint": "4.9.0",
     "eslint-plugin-ember": "^5.0.0",

--- a/packages/tools/tests/dummy/app/templates/components/cardstack/post-page.hbs
+++ b/packages/tools/tests/dummy/app/templates/components/cardstack/post-page.hbs
@@ -6,9 +6,19 @@
   <p>
     {{cs-field content 'publishedAt'}}
   </p>
-  <p>
+  {{!-- <p>
     {{#cs-field-group content name="reading-time" caption="Underestimated Read Time" fields="readingTimeValue,readingTimeUnits" as |rt|}}
       <div>{{rt.readingTimeValue}} {{rt.readingTimeUnits}}</div>
     {{/cs-field-group}}
+  </p> --}}
+  <p>
+    {{#cs-field-alternatives content name="reading-time" caption="Underestimated Read Time" as |rt|}}
+      {{#rt.alternative name='first-alt' fields="readingTimeValue" as |alt1|}}
+        <div>{{alt1.readingTimeValue}}</div>
+      {{/rt.alternative}}
+      {{#rt.alternative name='second-alt' fields="readingTimeUnits" as |alt1|}}
+        <div>{{alt1.readingTimeUnits}}</div>
+      {{/rt.alternative}}
+    {{/cs-field-alternatives}}
   </p>
 </div>


### PR DESCRIPTION
This PR proposes an implementation for mutually exclusive alternatives field described in https://github.com/cardstack/deck/issues/80

At the moment, the restriction imposed by `cs-field-alternatives` is purely at the UI level. This means that when the user edits these fields, they can choose which group of fields to edit. When they choose an alternative, the other alternative's fields are cleared. 

The purpose of this PR is to show a concept of how a field like this could be implemented. We also want to evaluate if it's desirable to have this field option.

Pending issues:

- Implement a way to show a `placeholder` for `cs-field-alternatives`
- Implement a test for `renderign` and `tools` components that affect this feature.
- Revisit UI styles for the `tools` component.
- Fix mark overlay that renders in a different location.

Considerations:

- Taking this to the schema level could bring a better user experience and ensure that the fields are in fact mutually exclusive. However, it could be relatively complex because we would have to define a mechanism to logically group fields in the schema. 
