### PR TITLE
prevent client from trying to explicitly delete a user-realm when tearing down

### DIFF
--- a/packages/test-support/addon/fixtures.js
+++ b/packages/test-support/addon/fixtures.js
@@ -25,7 +25,7 @@ export default class Fixtures {
     let models = this._factory.getModels();
 
     for (let [, model] of models.entries()) {
-      let url = `${hubURL}/api/${model.type}`;
+      let url = `${hubURL}/api/${encodeURIComponent(model.type)}`;
       let response = await fetch(url, {
         method: 'POST',
         headers: {
@@ -65,7 +65,7 @@ export default class Fixtures {
       let isLast = index === destructionList.length - 1;
 
       if (item.id) {
-        let response = await fetch(`${hubURL}/api/${item.type}/${item.id}`, {
+        let response = await fetch(`${hubURL}/api/${encodeURIComponent(item.type)}/${encodeURIComponent(item.id)}`, {
           method: 'GET',
           headers: { authorization: `Bearer ${ciSessionId}` }
         });
@@ -75,7 +75,7 @@ export default class Fixtures {
         let { data:model } = await response.json();
         await this._deleteModel(model, isLast);
       } else {
-        let response = await fetch(`${hubURL}/api/${item.type}`, {
+        let response = await fetch(`${hubURL}/api/${encodeURIComponent(item.type)}`, {
           method: 'GET',
           headers: { authorization: `Bearer ${ciSessionId}` }
         });
@@ -91,12 +91,14 @@ export default class Fixtures {
   }
 
   async _deleteModel(model) {
+    if (model.type === 'user-realms') { return; }
+
     let version = model.meta && model.meta.version;
     let headers = { authorization: `Bearer ${ciSessionId}` };
     if (version) {
       headers["If-Match"] = version;
     }
-    let url = `${hubURL}/api/${model.type}/${model.id}`;
+    let url = `${hubURL}/api/${encodeURIComponent(model.type)}/${encodeURIComponent(model.id)}`;
     await fetch(url, {
       method: 'DELETE',
       headers


### PR DESCRIPTION
When the client tries to explicitly delete a user-realm during test teardown, the DB gets quite upset: 

```
cardstack/writers deleting type=user-realms id=users/billwagby

  error: relation "public.user_realms" does not exist
      at Connection.parseE (/Users/hassan/codez/cardstack/node_modules/pg/lib/connection.js:546:11)
      at Connection.parseMessage (/Users/hassan/codez/cardstack/node_modules/pg/lib/connection.js:371:19)
      at Socket.<anonymous> (/Users/hassan/codez/cardstack/node_modules/pg/lib/connection.js:114:22)
      at emitOne (events.js:115:13)
      at Socket.emit (events.js:210:7)
      at addChunk (_stream_readable.js:263:12)
      at readableAddChunk (_stream_readable.js:250:11)
      at Socket.Readable.push (_stream_readable.js:208:10)
      at TCP.onread (net.js:597:20)
```

updating fixtures to skip over user-realms when tearing down, as invalidation should take care of this when deleting a user. also URL encoding the type and id's