### PR TITLE
fixing eslint-config on mobiledoc package by using npmignore for node-tests

### DIFF
--- a/packages/mobiledoc/.eslintrc.js
+++ b/packages/mobiledoc/.eslintrc.js
@@ -1,12 +1,4 @@
 module.exports = {
   root: true,
-  extends: '@cardstack/eslint-config/browser',
-  overrides: [{
-    files: 'node-tests/**/*.js',
-    rules: {
-      'node/no-unpublished-require': ['error', {
-        'allowModules': ['@cardstack/test-support'],
-      }]
-    }
-  }]
+  extends: '@cardstack/eslint-config/browser'
 };

--- a/packages/mobiledoc/.npmignore
+++ b/packages/mobiledoc/.npmignore
@@ -2,6 +2,7 @@
 /config/ember-try.js
 /dist
 /tests
+/node-tests
 /tmp
 **/.gitkeep
 .bowerrc


### PR DESCRIPTION
This is just based on a comment on a previous PR that has been merged https://github.com/cardstack/cardstack/pull/292/files#r218638387