### PR TITLE
navigate to isolated card on click of overlay

### DIFF
--- a/packages/tools/addon/components/cs-field-overlays.js
+++ b/packages/tools/addon/components/cs-field-overlays.js
@@ -1,14 +1,36 @@
 import { inject as service } from '@ember/service';
+import { defaultBranch } from '@cardstack/plugin-utils/environment';
+import { modelType } from '@cardstack/rendering/helpers/cs-model-type';
+import { pluralize } from 'ember-inflector';
+import { get } from '@ember/object';
 import Component from '@ember/component';
 import layout from '../templates/components/cs-field-overlays';
 
 export default Component.extend({
   layout,
   classNames: ['cardstack-tools'],
+
   tools: service('cardstack-tools'),
+  cardstackRouting: service(),
+  router: service(),
+
   actions: {
     openField(which) {
       this.get('tools').openField(which);
+    },
+    navigateToCard(model) {
+      let routingId;
+      let type = pluralize(modelType(model));
+      if (model.constructor.routingField) {
+        routingId = get(model, model.constructor.routingField);
+      } else {
+        routingId = get(model, 'id');
+      }
+
+      // TODO: I don't know why the defaultBranch is not working here
+      let { name, params, queryParams } = this.get('cardstackRouting').routeFor(type, routingId, defaultBranch || 'master');
+
+      this.get('router').transitionTo(name, ...params.map(p => p[1]), { queryParams });
     }
   }
 });

--- a/packages/tools/addon/templates/components/cs-field-overlays.hbs
+++ b/packages/tools/addon/templates/components/cs-field-overlays.hbs
@@ -24,5 +24,6 @@
                    highlighted=false
                    hoverable=tools.editing
                    class="cs-content-overlay"
+                   onclick=(action 'navigateToCard' mark.model)
                    }}
 {{/overlay-marks}}

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -23,6 +23,7 @@
     "@cardstack/edges": "0.10.0",
     "@cardstack/plugin-utils": "0.10.1",
     "@cardstack/rendering": "0.8.0",
+    "@cardstack/routing": "^0.10.10",
     "ember-cli-babel": "^6.8.2",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-is-component": "^0.5.0",


### PR DESCRIPTION
This was part of #303 but I am splitting it out to make it easier to get merged.

This is a bit of an interim implementation that allows us to navigate to the isolated version of an embedded card for editing.