### PR TITLE
change github auth user pemrissions to represent permissions as strings instead of objects for easier group construction

### DIFF
--- a/packages/github-auth/cardstack/searcher.js
+++ b/packages/github-auth/cardstack/searcher.js
@@ -100,7 +100,7 @@ module.exports = class GitHubSearcher {
 
       for (let repoPermission of repos[repo]) {
         if (userExpandedPermissions.includes(repoPermission.permission)) {
-          permissions.push(repoPermission);
+          permissions.push(`${repoPermission.repo}:${repoPermission.permission}`);
         }
       }
     }

--- a/packages/github-auth/cardstack/static-model.js
+++ b/packages/github-auth/cardstack/static-model.js
@@ -50,7 +50,7 @@ module.exports = function({ dataSource, provideUserSchema }) {
       type: 'fields',
       id: 'permissions',
       attributes: {
-        'field-type': '@cardstack/core-types::object'
+        'field-type': '@cardstack/core-types::string-array'
       }
     },
   ];

--- a/packages/github-auth/node-tests/authenticator-test.js
+++ b/packages/github-auth/node-tests/authenticator-test.js
@@ -86,7 +86,7 @@ describe('github-auth/authenticator', function() {
       "name": "Hassan Abdel-Rahman",
       "email": "hassan@cardstack.com",
       "avatar-url": "https://avatars2.githubusercontent.com/u/61075?v=4",
-      "permissions": [{ "repo": "cardstack/repo1", "permission": "read" }]
+      "permissions": ["cardstack/repo1:read"]
     });
     expect(response.body.data.meta.token).is.ok;
     expect(response.body.data.meta.validUntil).is.ok;

--- a/packages/github-auth/node-tests/searcher-test.js
+++ b/packages/github-auth/node-tests/searcher-test.js
@@ -137,17 +137,17 @@ describe('github-auth/searcher', function() {
 
       let user = await searchers.get(env.session, 'master', 'github-users', id);
 
-      expect(user.data.attributes.permissions).to.include({ repo: 'cardstack/repo1', permission: 'read' });
-      expect(user.data.attributes.permissions).to.not.include({ repo: 'cardstack/repo1', permission: 'write' });
-      expect(user.data.attributes.permissions).to.not.include({ repo: 'cardstack/repo1', permission: 'admin' });
+      expect(user.data.attributes.permissions).to.include('cardstack/repo1:read');
+      expect(user.data.attributes.permissions).to.not.include('cardstack/repo1:write');
+      expect(user.data.attributes.permissions).to.not.include('cardstack/repo1:admin');
 
-      expect(user.data.attributes.permissions).to.include({ repo: 'cardstack/repo2', permission: 'read' });
-      expect(user.data.attributes.permissions).to.not.include({ repo: 'cardstack/repo2', permission: 'write' });
-      expect(user.data.attributes.permissions).to.not.include({ repo: 'cardstack/repo2', permission: 'admin' });
+      expect(user.data.attributes.permissions).to.include('cardstack/repo2:read');
+      expect(user.data.attributes.permissions).to.not.include('cardstack/repo2:write');
+      expect(user.data.attributes.permissions).to.not.include('cardstack/repo2:admin');
 
-      expect(user.data.attributes.permissions).to.not.include({ repo: 'cardstack/repo3', permission: 'read' });
-      expect(user.data.attributes.permissions).to.not.include({ repo: 'cardstack/repo3', permission: 'write' });
-      expect(user.data.attributes.permissions).to.not.include({ repo: 'cardstack/repo3', permission: 'admin' });
+      expect(user.data.attributes.permissions).to.not.include('cardstack/repo3:read');
+      expect(user.data.attributes.permissions).to.not.include('cardstack/repo3:write');
+      expect(user.data.attributes.permissions).to.not.include('cardstack/repo3:admin');
     });
 
     it('can set permissions for user with write access on repo', async function() {
@@ -173,17 +173,17 @@ describe('github-auth/searcher', function() {
 
       let user = await searchers.get(env.session, 'master', 'github-users', id);
 
-      expect(user.data.attributes.permissions).to.include({ repo: 'cardstack/repo1', permission: 'read' });
-      expect(user.data.attributes.permissions).to.include({ repo: 'cardstack/repo1', permission: 'write' });
-      expect(user.data.attributes.permissions).to.not.include({ repo: 'cardstack/repo1', permission: 'admin' });
+      expect(user.data.attributes.permissions).to.include('cardstack/repo1:read');
+      expect(user.data.attributes.permissions).to.include('cardstack/repo1:write');
+      expect(user.data.attributes.permissions).to.not.include('cardstack/repo1:admin');
 
-      expect(user.data.attributes.permissions).to.include({ repo: 'cardstack/repo2', permission: 'read' });
-      expect(user.data.attributes.permissions).to.not.include({ repo: 'cardstack/repo2', permission: 'write' });
-      expect(user.data.attributes.permissions).to.not.include({ repo: 'cardstack/repo2', permission: 'admin' });
+      expect(user.data.attributes.permissions).to.include('cardstack/repo2:read');
+      expect(user.data.attributes.permissions).to.not.include('cardstack/repo2:write');
+      expect(user.data.attributes.permissions).to.not.include('cardstack/repo2:admin');
 
-      expect(user.data.attributes.permissions).to.not.include({ repo: 'cardstack/repo3', permission: 'read' });
-      expect(user.data.attributes.permissions).to.include({ repo: 'cardstack/repo3', permission: 'write' });
-      expect(user.data.attributes.permissions).to.not.include({ repo: 'cardstack/repo3', permission: 'admin' });
+      expect(user.data.attributes.permissions).to.not.include('cardstack/repo3:read');
+      expect(user.data.attributes.permissions).to.include('cardstack/repo3:write');
+      expect(user.data.attributes.permissions).to.not.include('cardstack/repo3:admin');
     });
 
     it('can set permissions for user with admin access on repo', async function() {
@@ -209,17 +209,17 @@ describe('github-auth/searcher', function() {
 
       let user = await searchers.get(env.session, 'master', 'github-users', id);
 
-      expect(user.data.attributes.permissions).to.include({ repo: 'cardstack/repo1', permission: 'read' });
-      expect(user.data.attributes.permissions).to.include({ repo: 'cardstack/repo1', permission: 'write' });
-      expect(user.data.attributes.permissions).to.include({ repo: 'cardstack/repo1', permission: 'admin' });
+      expect(user.data.attributes.permissions).to.include('cardstack/repo1:read');
+      expect(user.data.attributes.permissions).to.include('cardstack/repo1:write');
+      expect(user.data.attributes.permissions).to.include('cardstack/repo1:admin');
 
-      expect(user.data.attributes.permissions).to.include({ repo: 'cardstack/repo2', permission: 'read' });
-      expect(user.data.attributes.permissions).to.not.include({ repo: 'cardstack/repo2', permission: 'write' });
-      expect(user.data.attributes.permissions).to.not.include({ repo: 'cardstack/repo2', permission: 'admin' });
+      expect(user.data.attributes.permissions).to.include('cardstack/repo2:read');
+      expect(user.data.attributes.permissions).to.not.include('cardstack/repo2:write');
+      expect(user.data.attributes.permissions).to.not.include('cardstack/repo2:admin');
 
-      expect(user.data.attributes.permissions).to.not.include({ repo: 'cardstack/repo3', permission: 'read' });
-      expect(user.data.attributes.permissions).to.include({ repo: 'cardstack/repo3', permission: 'write' });
-      expect(user.data.attributes.permissions).to.not.include({ repo: 'cardstack/repo3', permission: 'admin' });
+      expect(user.data.attributes.permissions).to.not.include('cardstack/repo3:read');
+      expect(user.data.attributes.permissions).to.include('cardstack/repo3:write');
+      expect(user.data.attributes.permissions).to.not.include('cardstack/repo3:admin');
     });
   });
 


### PR DESCRIPTION
Permissions associated with users would change from this:
```js
 [
  { repo: 'cardstack/repo1', permission: 'read' },
  { repo: 'cardstack/repo1', permission: 'write' },
  { repo: 'cardstack/repo1', permission: 'admin' },
]
```
to this:
```js
[ 'cardstack/repo1:read', 'cardstack/repo1:write', 'cardstack/repo1:admin']
```

so that it is easier to define search queries for group construction.