### PR TITLE
Boolean field editor

### DIFF
--- a/packages/core-types/addon/components/field-editors/boolean-editor.js
+++ b/packages/core-types/addon/components/field-editors/boolean-editor.js
@@ -1,0 +1,16 @@
+import { get, set } from '@ember/object';
+import Component from '@ember/component';
+import layout from '../../templates/components/field-editors/boolean-editor';
+
+export default Component.extend({
+  layout,
+
+  actions: {
+    toggleValue(value) {
+      let content = get(this, 'content');
+      let field = get(this, 'field');
+
+      set(content, field, value);
+    }
+  }
+});

--- a/packages/core-types/addon/templates/components/field-editors/boolean-editor.hbs
+++ b/packages/core-types/addon/templates/components/field-editors/boolean-editor.hbs
@@ -1,0 +1,5 @@
+{{#cs-toggle-switch value=(get content field) change=(action "toggleValue") enabled=enabled}}
+  On
+{{else}}
+  Off
+{{/cs-toggle-switch}}

--- a/packages/core-types/app/components/field-editors/boolean-editor.js
+++ b/packages/core-types/app/components/field-editors/boolean-editor.js
@@ -1,0 +1,1 @@
+export { default } from '@cardstack/core-types/components/field-editors/boolean-editor';

--- a/packages/core-types/tests/acceptance/editor-test.js
+++ b/packages/core-types/tests/acceptance/editor-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { visit, currentURL, fillIn } from '@ember/test-helpers';
+import { visit, currentURL, fillIn, click } from '@ember/test-helpers';
 import { selectChoose } from 'ember-power-select/test-support/helpers';
 import RSVP from 'rsvp';
 
@@ -25,12 +25,14 @@ module('Acceptance | field editors', async function(hooks) {
 
     assert.equal(model.get('name'), 'Metal Mario', 'driver name is correct');
     assert.equal(model.get('dob'), '1999-01-01', 'driver dob is correct');
+    assert.equal(model.get('isGoodGuy'), true, 'driver is a good guy');
     assert.equal(feeling, 'Happy', 'driver is feeling happy');
     assert.equal(vehicle, 'Sport Bike', 'driver is using a sport bike');
     assert.equal(alternateVehicle, 'Standard Kart', 'drivers alternate vehicle is a standard kart');
 
     await fillIn('.ember-text-field:nth-of-type(1)', 'METAL Mario');
     await fillIn('.ember-text-field:nth-of-type(2)', '1998-01-01');
+    await click('.cs-toggle-switch');
     await selectChoose('.feeling-selector', 'Sad');
     await selectChoose('.vehicle-selector', 'Honeycoupe');
     await selectChoose('.alternate-vehicle-selector', 'Wild Wiggler');
@@ -45,6 +47,7 @@ module('Acceptance | field editors', async function(hooks) {
 
     assert.equal(model.get('name'), 'METAL Mario', 'metal mario is more metal');
     assert.equal(model.get('dob'), '1998-01-01', 'metal mario was born earlier');
+    assert.equal(model.get('isGoodGuy'), false, 'metal mario is a bad guy');
     assert.equal(feeling, 'Sad', 'metal mario is sad');
     assert.equal(vehicle, 'Honeycoupe', 'metal mario is driving a honeycoupe');
     assert.equal(alternateVehicle, 'Wild Wiggler', 'metal marios alternate vehicle is a wild wiggler');

--- a/packages/core-types/tests/dummy/app/templates/editor.hbs
+++ b/packages/core-types/tests/dummy/app/templates/editor.hbs
@@ -2,6 +2,8 @@ Name: {{cs-field-editor content=model field="name" enabled=true}}
 <br/>
 DOB: {{cs-field-editor content=model field="dob" enabled=true}}
 <br/>
+Is Good Guy? {{cs-field-editor content=model field="isGoodGuy" enabled=true}}
+<br/>
 Feeling: {{cs-field-editor content=model field="feeling" enabled=true}}
 <br/>
 Vehicle: {{cs-field-editor content=model field="vehicle" enabled=true}}

--- a/packages/core-types/tests/dummy/cardstack/seeds/ephemeral.js
+++ b/packages/core-types/tests/dummy/cardstack/seeds/ephemeral.js
@@ -20,6 +20,9 @@ function initialModels() {
     initial.addResource('fields', 'dob').withAttributes({
       fieldType: '@cardstack/core-types::date'
     }),
+    initial.addResource('fields', 'is-good-guy').withAttributes({
+      fieldType: '@cardstack/core-types::boolean'
+    }),
     initial.addResource('fields', 'feeling').withAttributes({
       fieldType: '@cardstack/core-types::belongs-to',
       editorComponent: 'field-editors/dropdown-choices-editor'
@@ -60,32 +63,36 @@ function initialModels() {
   initial.addResource('drivers', 'kingboo')
     .withAttributes({
       name: 'King Boo',
-      dob: '1998-01-21'
+      dob: '1998-01-21',
+      isGoodGuy: false
     })
     .withRelated('feeling', exuberantFeeling)
     .withRelated('vehicle', standardKartVehicle);
 
-  initial.addResource('drivers', 'metalmario')
+    initial.addResource('drivers', 'metalmario')
     .withAttributes({
       name: 'Metal Mario',
-      dob: '1999-01-01'
+      dob: '1999-01-01',
+      isGoodGuy: true
     })
     .withRelated('feeling', happyFeeling)
     .withRelated('vehicle', sportBikeVehicle)
     .withRelated('alternate-vehicle', standardKartVehicle);
 
-  initial.addResource('drivers', 'link')
+    initial.addResource('drivers', 'link')
     .withAttributes({
       name: 'Link',
-      dob: '2003-01-01'
+      dob: '2003-01-01',
+      isGoodGuy: true
     })
     .withRelated('feeling', happyFeeling)
     .withRelated('vehicle', sportBikeVehicle);
 
-  initial.addResource('drivers', 'shyguy')
+    initial.addResource('drivers', 'shyguy')
     .withAttributes({
       name: 'Shy Guy',
-      dob: '2001-01-01'
+      dob: '2001-01-01',
+      isGoodGuy: false
     })
     .withRelated('feeling', sadFeeling)
     .withRelated('vehicle', sportBikeVehicle);

--- a/packages/core-types/tests/integration/components/field-editors/boolean-editor-test.js
+++ b/packages/core-types/tests/integration/components/field-editors/boolean-editor-test.js
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | field editors/boolean editor', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('model', {
+      addKetchup: false
+    });
+    await render(hbs`{{field-editors/boolean-editor content=model field="addKetchup" enabled=true}}`);
+    assert.dom('.cs-toggle-switch').hasText('Off', 'slider has correct value');
+    assert.dom('.cs-toggle-switch.disabled').doesNotExist('slider is not disabled');
+
+    await click('.cs-toggle-switch');
+    assert.dom('.cs-toggle-switch').hasText('On', 'slider has correct value');
+  });
+
+  test('it can be disabled', async function(assert) {
+    this.set('model', {
+      addKetchup: false
+    });
+    await render(hbs`{{field-editors/boolean-editor content=model field="addKetchup" enabled=false}}`);
+    assert.dom('.cs-toggle-switch.disabled').exists('slider is disabled');
+  });
+});


### PR DESCRIPTION
Uses a `{{cs-toggle-switch}}` (same as the Editor switch). Future enhancements could include options for the switch text ("on/off", "yes/no", "true/false", etc), different UI (checkbox, switch, button, radio, etc).