### PR TITLE
Fix missing repository urls (for Ember Observer)

### DIFF
--- a/packages/edges/package.json
+++ b/packages/edges/package.json
@@ -11,7 +11,7 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
+  "repository": "https://github.com/cardstack/cardstack",
   "scripts": {
     "build": "ember build",
     "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",

--- a/packages/email-auth/package.json
+++ b/packages/email-auth/package.json
@@ -12,7 +12,7 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
+  "repository": "https://github.com/cardstack/cardstack",
   "scripts": {
     "build": "ember build",
     "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -16,7 +16,7 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
+  "repository": "https://github.com/cardstack/cardstack",
   "scripts": {
     "build": "ember build",
     "lint:js": "eslint .",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -15,7 +15,7 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
+  "repository": "https://github.com/cardstack/cardstack",
   "scripts": {
     "build": "ember build",
     "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",


### PR DESCRIPTION
Noticed a few @Cardstock/[name] repos missing their repository URLs on Ember Observer, this should fix that.

- models
- email-auth
- search
- edges

see: https://emberobserver.com/lists/invalid-repo-url