### PR TITLE
Mark model dirty when belongs-to relationship changes

### DIFF
--- a/packages/core-types/addon/components/field-editors/dropdown-choices-editor.js
+++ b/packages/core-types/addon/components/field-editors/dropdown-choices-editor.js
@@ -38,7 +38,9 @@ export default Component.extend({
       let field = get(this, 'field');
       let content = get(this, 'content');
 
-      set(content, field, option);
+      content.watchRelationship(field, () => {
+        set(content, field, option);
+      })
     }
   }
 });

--- a/packages/core-types/tests/integration/components/field-editors/dropdown-choices-test.js
+++ b/packages/core-types/tests/integration/components/field-editors/dropdown-choices-test.js
@@ -4,11 +4,17 @@ import { render } from '@ember/test-helpers';
 import { clickTrigger, selectChoose } from 'ember-power-select/test-support/helpers';
 import hbs from 'htmlbars-inline-precompile';
 
+const modelStub = {
+  watchRelationship: (field, fn) => {
+    fn.call(this);
+  }
+};
+
 module('Integration | Component | field editors/dropdown choices editor', async function(hooks) {
   setupRenderingTest(hooks);
 
   test('can select an option from the dropdown', async function(assert) {
-    this.set('model', {});
+    this.set('model', modelStub);
     await render(hbs`{{field-editors/dropdown-choices-editor content=model field="feeling" enabled=true}}`);
 
     await clickTrigger();
@@ -20,7 +26,7 @@ module('Integration | Component | field editors/dropdown choices editor', async 
   });
 
   test('can specify a different field to use for option', async function(assert) {
-    this.set('model', {});
+    this.set('model', modelStub);
     this.set('editorOptions', { displayFieldName: 'name' });
     await render(hbs`{{field-editors/dropdown-choices-editor content=model field="vehicle" editorOptions=editorOptions enabled=true}}`);
 


### PR DESCRIPTION
This sets the model as `dirty` when selecting a different option in the `dropdown-choices-editor`, so that the "Update" button is enabled in the Editor. (it's marked as clean if you save or revert back to original value before save)