### PR TITLE
[CONCEPT] Mailer route

### DIFF
--- a/packages/email/middleware.js
+++ b/packages/email/middleware.js
@@ -1,0 +1,44 @@
+const { declareInjections } = require('@cardstack/di');
+const route = require('koa-better-route');
+
+module.exports = declareInjections({
+  messengers: 'hub:messengers'
+},
+
+class CodeGenMiddleware {
+  constructor() {
+    this.before = 'authentication';
+  }
+
+  middleware() {
+    //TODO: Get these from config
+    let messageSinkId = 'the-sink';
+    let defaultMailTo = 'contact@cardstack.com';
+
+    return route.post('/email/send', async (ctxt) => {
+      let { req } = ctxt;
+      let body = '';
+      req.on('data', chunk => {
+        body += chunk.toString();
+      });
+      req.on('end', () => {
+        console.log(body);
+        res.end('ok');
+      });
+      
+      await this.messengers.send(messageSinkId, {
+        to: defaultMailTo,
+        subject: 'Hello from cardstack',
+        from: 'jorge.lainfiesta@cardstack.com',
+        text: 'Hello my friend',
+        html: '<h1>Hello my friend</h1>'
+      });
+
+      ctxt.body = `console.log('Hello world: ${messageSinkId}')`;
+      ctxt.response.set('Access-Control-Allow-Origin', '*');
+      ctxt.response.set('Content-Type', 'application/javascript');
+      ctxt.status = 200;
+    });
+  }
+
+});

--- a/packages/email/middleware.js
+++ b/packages/email/middleware.js
@@ -2,6 +2,7 @@ const { declareInjections } = require('@cardstack/di');
 const route = require('koa-better-route');
 const koaJSONBody = require('koa-json-body');
 
+
 module.exports = declareInjections({
   messengers: 'hub:messengers'
 },
@@ -18,9 +19,15 @@ class CodeGenMiddleware {
 
     let body = koaJSONBody({ limit: '16mb' });
 
-    return route.post('/email/send', body, async (ctxt) => {
+    return route.post('/email/send', async (ctxt) => {
 
-      console.log(ctx.request.body)
+      if (!ctxt.state.bodyAlreadyParsed) {
+        await body(ctxt, err => {
+          if (err) {
+            throw err;
+          }
+        });
+      }
       
       await this.messengers.send(messageSinkId, {
         to: defaultMailTo,

--- a/packages/email/middleware.js
+++ b/packages/email/middleware.js
@@ -1,5 +1,6 @@
 const { declareInjections } = require('@cardstack/di');
 const route = require('koa-better-route');
+const koaJSONBody = require('koa-json-body');
 
 module.exports = declareInjections({
   messengers: 'hub:messengers'
@@ -15,16 +16,11 @@ class CodeGenMiddleware {
     let messageSinkId = 'the-sink';
     let defaultMailTo = 'contact@cardstack.com';
 
-    return route.post('/email/send', async (ctxt) => {
-      let { req } = ctxt;
-      let body = '';
-      req.on('data', chunk => {
-        body += chunk.toString();
-      });
-      req.on('end', () => {
-        console.log(body);
-        res.end('ok');
-      });
+    let body = koaJSONBody({ limit: '16mb' });
+
+    return route.post('/email/send', body, async (ctxt) => {
+
+      console.log(ctx.request.body)
       
       await this.messengers.send(messageSinkId, {
         to: defaultMailTo,

--- a/packages/email/middleware.js
+++ b/packages/email/middleware.js
@@ -41,19 +41,32 @@ class EmailMiddleware {
           }
         });
       }
+
+      let { from, subject, text, html } = ctxt.request.body.data.attributes;
       
       await this.messengers.send(messageSinkId, {
         to: defaultMailTo,
-        subject: 'Hello from cardstack',
-        from: 'jorge.lainfiesta@cardstack.com',
-        text: 'Hello my friend',
-        html: '<h1>Hello my friend</h1>'
+        subject,
+        from,
+        text,
+        html
       });
 
-      ctxt.body = `console.log('Hello world: ${messageSinkId}')`;
+      ctxt.body = {
+        data: {
+          type: 'email',
+          id: '?',
+          attributes: {
+            subject,
+            from,
+            text,
+            html
+          }
+        }
+      };
+      ctxt.response.set('Content-Type', 'application/vnd.api+json');
       ctxt.response.set('Access-Control-Allow-Origin', '*');
-      ctxt.response.set('Content-Type', 'application/javascript');
-      ctxt.status = 200;
+      ctxt.status = 201;
     });
   }
 

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -11,8 +11,10 @@
   },
   "description": "Email sending plugin for Cardstack",
   "dependencies": {
+    "@cardstack/di": "0.8.0",
     "@cardstack/logger": "^0.1.0",
     "@cardstack/plugin-utils": "0.10.1",
+    "koa-better-route": "^0.1.0",
     "nodemailer": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
For the "Contact Us" card, it was agreed that we would use the email plugin to send an email every time a person completed the form. However, `@cardstack/email` is a low-level interface, consumed mainly by `email-auth` through a `messenger`. 

This PR implements a simple middleware that exposes a new route on the server which sends an email using a `messenger`. It relies on `plugins-configs` to be set for `@cardstack/email` and a JSON-API payload.

Open Questions:

- [ ] Is this a correct implementation of the intended feature or is it quite hacky? 
- [ ] Is a generic email middleware appropriate to use for the contact us form, or should a more specific plugin be implemented? 
- [ ] Ed was mentioning we could implement this as a data-source. For the writing part: I assume we send an email everytime we get a write operation. But what would reading this data-source mean? 