### PR TITLE
Add datetime field editor

### DIFF
--- a/packages/core-types/addon/components/field-editors/datetime-editor.js
+++ b/packages/core-types/addon/components/field-editors/datetime-editor.js
@@ -1,0 +1,8 @@
+import { not } from '@ember/object/computed';
+import Component from '@ember/component';
+import layout from '../../templates/components/field-editors/datetime-editor';
+
+export default Component.extend({
+  layout,
+  disabled: not('enabled')
+});

--- a/packages/core-types/addon/templates/components/field-editors/datetime-editor.hbs
+++ b/packages/core-types/addon/templates/components/field-editors/datetime-editor.hbs
@@ -1,0 +1,1 @@
+{{input type="datetime-local" value=(get content field) disabled=disabled}}

--- a/packages/core-types/app/components/field-editors/datetime-editor.js
+++ b/packages/core-types/app/components/field-editors/datetime-editor.js
@@ -1,0 +1,1 @@
+export { default } from '@cardstack/core-types/components/field-editors/datetime-editor';

--- a/packages/core-types/tests/integration/components/field-editors/datetime-editor-test.js
+++ b/packages/core-types/tests/integration/components/field-editors/datetime-editor-test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | field editors/datetime editor', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('model', {
+      expiration: '2030-01-01T10:00:00'
+    });
+    await render(hbs`{{field-editors/datetime-editor content=model field="expiration" enabled=true}}`);
+
+    assert.dom('input[type=datetime-local]').hasValue('2030-01-01T10:00:00', 'datetime input has correct value');
+    assert.dom('input').isNotDisabled('datetime field is not disabled');
+  });
+
+  test('it renders with invalid datetime', async function(assert) {
+    this.set('model', {
+      expiration: 'pizza'
+    });
+    await render(hbs`{{field-editors/datetime-editor content=model field="expiration" enabled=true}}`);
+    assert.dom('input[type=datetime-local]').hasNoValue('datetime input has no value');
+    assert.dom('input').isNotDisabled('datetime field is not disabled');
+  });
+
+  test('it can be disabled', async function(assert) {
+    this.set('model', {
+      expiration: '2030-01-01T10:00:00'
+    });
+    await render(hbs`{{field-editors/datetime-editor content=model field="expiration" enabled=false}}`);
+    assert.dom('input').isDisabled('datetime field is disabled');
+  });
+});


### PR DESCRIPTION
This adds a datetime editor, similar to the existing date editor but also allowing to specify the time part of the datetime. This uses the `datetime-local` input type which currently is not supported by quite some browsers (see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local). We can write our own date/time picking UI in a follow-up issues though.

The issue originally said this:

> The editor should accept an option that allows specifying the default time to set (e.g. 00:00) if no time is selected by the user.

but I'm not actually sure it's a good idea. The behavior of the `datetime-local` input time (in Chrome at least) is that the field does not have a value at all `.value` is `null` until a time has been selected which is probably much better as that'd behavior forces the user to select a time which is probably better than applying an arbitrary default.

closes #362