### PR TITLE
Use exact search for content-type by default

### DIFF
--- a/packages/jsonapi/middleware.js
+++ b/packages/jsonapi/middleware.js
@@ -112,7 +112,7 @@ class Handler {
     return this.prefix === 'api-validate';
   }
 
-  filterExpression(type, id) {
+  typeFilterExpression(type, id) {
     let filter = this.query.filter;
     if (!filter) {
       filter = {};
@@ -121,7 +121,9 @@ class Handler {
       // This overwrites any additional type filter the user tried to
       // provide in their query, which is reasonable (the endpoint
       // name itself is taking precedence).
-      filter.type = type;
+      filter.type = {
+        exact: type
+      };
     }
     if (id != null) {
       filter.id = id;
@@ -235,7 +237,7 @@ class Handler {
 
   async handleCollectionGET(type) {
     let { data: models, meta: { page }, included } = await this.searcher.search(this.session, this.branch, {
-      filter: this.filterExpression(type),
+      filter: this.typeFilterExpression(type),
       sort: this.query.sort,
       page: this.query.page,
       include: this.query.include,

--- a/packages/jsonapi/node-tests/middleware-test.js
+++ b/packages/jsonapi/node-tests/middleware-test.js
@@ -15,9 +15,8 @@ describe('jsonapi/middleware', function() {
 
   async function sharedSetup() {
     let factory = new JSONAPIFactory();
-    let articleType = factory.addResource('content-types', 'articles');
 
-    articleType.withRelated('fields', [
+    factory.addResource('content-types', 'articles').withRelated('fields', [
       factory.addResource('fields', 'title')
         .withAttributes({ fieldType: '@cardstack/core-types::string' }),
       factory.addResource('fields', 'body')
@@ -27,7 +26,15 @@ describe('jsonapi/middleware', function() {
         .withRelated('related-types', [{ type: 'content-types', id: 'authors' }]),
       factory.addResource('fields', 'editor')
         .withAttributes({ fieldType: '@cardstack/core-types::belongs-to' })
-        .withRelated('related-types', [{ type: 'content-types', id: 'authors' }])
+        .withRelated('related-types', [{ type: 'content-types', id: 'authors' }]),
+      factory.addResource('fields', 'article-links').withAttributes({
+        fieldType: '@cardstack/core-types::has-many'
+      }).withRelated('related-types', [
+        factory.addResource('content-types', 'article-links')
+        .withRelated('fields', [
+          factory.addResource('fields', 'url').withAttributes({ fieldType: '@cardstack/core-types::string' })
+        ])
+      ]),
     ]);
 
     factory.addResource('constraints')
@@ -92,7 +99,17 @@ describe('jsonapi/middleware', function() {
             })
           ]
         )
-      );
+        ).withRelated(
+          'article-links',
+          [
+            factory.addResource('article-links', 'link-1').withAttributes({
+              url: 'http://cardstack.com/cards/articles/1'
+            }),
+            factory.addResource('article-links', 'link-2').withAttributes({
+              url: 'http://cardstack.com/cards/articles/3'
+            })
+          ]
+        );
 
     factory.addResource('articles', 3)
       .withAttributes({

--- a/packages/pgsearch/searcher.js
+++ b/packages/pgsearch/searcher.js
@@ -68,7 +68,7 @@ module.exports = declareInjections({
     query = [...query, "limit", param(size + 1) ];
 
     let sql = queryToSQL(query);
-    log.trace("search %s %j", sql.text, sql.values);
+    log.trace("search: %s trace: %j", sql.text, sql.values);
     let response = await this.client.query(sql);
     let totalResponse = await totalResponsePromise;
 


### PR DESCRIPTION
You can pass in a `fuzzy` query param if you want to use fuzzy content-type search, i.e. `/api/articles?fuzzy=true`

Fixes #302 