### PR TITLE
Show all fields in sidebar, not just rendered ones

### DIFF
--- a/packages/core-types/addon/styles/addon.css
+++ b/packages/core-types/addon/styles/addon.css
@@ -7,7 +7,6 @@
   color: var(--error-color);
   background-color: var(--error-background);
   font-size: 0.8rem;
-  width: 100%;
   padding: 0.25rem;
 }
 

--- a/packages/tools/addon/helpers/cs-has-errors.js
+++ b/packages/tools/addon/helpers/cs-has-errors.js
@@ -1,10 +1,10 @@
 import { helper } from '@ember/component/helper';
 
-export function csHasErrors([errors, fieldModel]) {
+export function csHasErrors([errors, model, options]) {
   if (!errors) { return false; }
-  let { grouped, content } = fieldModel;
-  let fields = grouped ? grouped : [fieldModel.name];
-  return hasErrorForAnyField(errors, content, fields);
+  let { name: fieldName, grouped } = options;
+  let fields = grouped ? grouped : [fieldName];
+  return hasErrorForAnyField(errors, model, fields);
 }
 
 export default helper(csHasErrors);

--- a/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
+++ b/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
@@ -17,44 +17,69 @@
     on-error=(action (mut validationErrors))
   }}
 
-  {{#each fields key="id" as |fieldMark|}}
+  {{#each modelFields as |field|}}
     {{#cs-collapsible-section
       class=(concat "cs-toolbox-section "
         (if
-          (cs-has-errors validationErrors fieldMark.model)
+          (cs-has-errors validationErrors field.model (hash name=field.name))
           "invalid"))
-      title=fieldMark.model.caption
-      opened=(eq fieldMark.id openedFieldId)
-      open=(action openField fieldMark)
+      title=field.options.caption
+      opened=(eq field.id openedFieldId)
+      open=(action openField field)
       close=(action openField null)
-      hovered=(perform highlightAndScrollToField fieldMark)
-      unhovered=(perform highlightAndScrollToField null)
     }}
       <div class="cs-field-editor-section">
-      {{#if fieldMark.model.grouped}}
-        {{#each fieldMark.model.grouped as |fieldName|}}
-          {{#with fieldMark.model.content as |content|}}
-            <label>{{cs-field-caption content fieldName}}</label>
-            {{cs-field-editor
-              content=content
-              field=fieldName
-              enabled=editingEnabled
-              onchange=(action "validate")
-              errors=(get validationErrors fieldName)
-            }}
-          {{/with}}
-        {{/each}}
-      {{else}}
         {{cs-field-editor
-          content=fieldMark.model.content
-          field=fieldMark.model.name
+          content=field.model
+          field=field.name
           enabled=editingEnabled
           onchange=(action "validate")
-          errors=(get validationErrors fieldMark.model.name)
+          errors=(get validationErrors field.name)
         }}
-      {{/if}}
       </div>
     {{/cs-collapsible-section}}
+  {{/each}}
+
+  {{#each renderedFields key="id" as |fieldMark|}}
+    {{#let fieldMark.model as |model|}}
+      {{#cs-collapsible-section
+        class=(concat "cs-toolbox-section "
+          (if
+            (cs-has-errors validationErrors model (hash name=model.name grouped=model.grouped))
+            "invalid"))
+        title=model.caption
+        opened=(eq fieldMark.id openedFieldId)
+        open=(action openField fieldMark)
+        close=(action openField null)
+        hovered=(perform highlightAndScrollToField fieldMark)
+        unhovered=(perform highlightAndScrollToField null)
+      }}
+        <div class="cs-field-editor-section">
+        {{#if model.grouped}}
+          {{#each model.grouped as |fieldName|}}
+            {{#with model.content as |content|}}
+              <label>{{cs-field-caption content fieldName}}</label>
+              {{cs-field-editor
+                content=content
+                field=fieldName
+                enabled=editingEnabled
+                onchange=(action "validate")
+                errors=(get validationErrors fieldName)
+              }}
+            {{/with}}
+          {{/each}}
+        {{else}}
+          {{cs-field-editor
+            content=model.content
+            field=model.name
+            enabled=editingEnabled
+            onchange=(action "validate")
+            errors=(get validationErrors model.name)
+          }}
+        {{/if}}
+        </div>
+      {{/cs-collapsible-section}}
+    {{/let}}
   {{/each}}
 
 </div>

--- a/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
+++ b/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
@@ -17,29 +17,6 @@
     on-error=(action (mut validationErrors))
   }}
 
-  {{#each modelFields as |field|}}
-    {{#cs-collapsible-section
-      class=(concat "cs-toolbox-section "
-        (if
-          (cs-has-errors validationErrors field.model (hash name=field.name))
-          "invalid"))
-      title=field.options.caption
-      opened=(eq field.id openedFieldId)
-      open=(action openField field)
-      close=(action openField null)
-    }}
-      <div class="cs-field-editor-section">
-        {{cs-field-editor
-          content=field.model
-          field=field.name
-          enabled=editingEnabled
-          onchange=(action "validate")
-          errors=(get validationErrors field.name)
-        }}
-      </div>
-    {{/cs-collapsible-section}}
-  {{/each}}
-
   {{#each renderedFields key="id" as |fieldMark|}}
     {{#let fieldMark.model as |model|}}
       {{#cs-collapsible-section
@@ -81,5 +58,29 @@
       {{/cs-collapsible-section}}
     {{/let}}
   {{/each}}
+
+  {{#each modelFields as |field|}}
+    {{#cs-collapsible-section
+      class=(concat "cs-toolbox-section "
+        (if
+          (cs-has-errors validationErrors field.model (hash name=field.name))
+          "invalid"))
+      title=field.options.caption
+      opened=(eq field.id openedFieldId)
+      open=(action openField field)
+      close=(action openField null)
+    }}
+      <div class="cs-field-editor-section">
+        {{cs-field-editor
+          content=field.model
+          field=field.name
+          enabled=editingEnabled
+          onchange=(action "validate")
+          errors=(get validationErrors field.name)
+        }}
+      </div>
+    {{/cs-collapsible-section}}
+  {{/each}}
+
 
 </div>

--- a/packages/tools/addon/templates/components/cs-composition-panel.hbs
+++ b/packages/tools/addon/templates/components/cs-composition-panel.hbs
@@ -6,7 +6,8 @@
   {{else}}
     {{cs-active-composition-panel
       model=tools.activeContentItem.model
-      fields=tools.activeFields
+      renderedFields=tools.activeFields
+      modelFields=tools.modelFields
       openedFieldId=tools.openedFieldId
       highlightedFieldId=tool.highlightedFieldId
       openField=(action "openField")

--- a/packages/tools/tests/acceptance/tools-test.js
+++ b/packages/tools/tests/acceptance/tools-test.js
@@ -6,6 +6,10 @@ function findTriggerElementWithLabel(labelRegex) {
   return [...this.element.querySelectorAll('.cs-toolbox-section label')].find(element => labelRegex.test(element.textContent));
 }
 
+function findSectionLabels(label) {
+  return [...this.element.querySelectorAll('.cs-toolbox-section label')].filter(element => label === element.textContent);
+}
+
 function findInputWithValue(value) {
   return Array.from(this.element.querySelectorAll('input'))
     .find(element => element.value === value);
@@ -64,5 +68,16 @@ module('Acceptance | tools', function(hooks) {
     await triggerEvent(commentBodyEditor, 'blur');
     await waitFor('.field-editor--error-message');
     assert.dom('.field-editor--error-message').hasText('body must not be empty');
+  });
+
+  test('show all fields, not just those rendered from template', async function(assert) {
+    await visit('/1');
+    await click('.cardstack-tools-launcher');
+
+    let archivedSection = findTriggerElementWithLabel.call(this, /Archived/);
+    assert.ok(archivedSection, "Unrendered field appears in editor");
+
+    let titleSections = findSectionLabels.call(this, "Title");
+    assert.equal(titleSections.length, 1, "Rendered fields only appear once");
   });
 });

--- a/packages/tools/tests/dummy/app/templates/components/cardstack/post-isolated.hbs
+++ b/packages/tools/tests/dummy/app/templates/components/cardstack/post-isolated.hbs
@@ -10,9 +10,6 @@
     Category: {{cs-field content 'category'}}
   </p>
   <p>
-    Archived: {{cs-field content 'archived'}}
-  </p>
-  <p>
     {{#cs-field-group content name="reading-time" caption="Underestimated Read Time" fields="readingTimeValue,readingTimeUnit" as |rt|}}
       <div>{{rt.readingTimeValue}} {{rt.readingTimeUnit}}</div>
     {{/cs-field-group}}


### PR DESCRIPTION
See #300 

Todos:

* [x] ~~Consider DRYing the rendering of `renderedFields` and `modelFields`~~