### PR TITLE
card-picker: Improve styling

### DIFF
--- a/packages/card-picker/addon/styles/cardstack-cards-editor.css
+++ b/packages/card-picker/addon/styles/cardstack-cards-editor.css
@@ -9,6 +9,8 @@
 }
 .cards-editor--input-row > span {
   flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .cards-editor--input-row > .text-button {
   display: inline-block;

--- a/packages/card-picker/addon/styles/cardstack-cards-editor.css
+++ b/packages/card-picker/addon/styles/cardstack-cards-editor.css
@@ -3,11 +3,11 @@
   margin-bottom: 1rem;
   flex: 1 1 300px;
 }
- .cards-editor--input-row > .drag-handle {
+.cards-editor--input-row > .drag-handle {
   margin-right: 0.25rem;
   cursor: pointer;
 }
- .cards-editor--input-row > .text-button {
+.cards-editor--input-row > .text-button {
   display: inline-block;
   border: 0;
   margin-top: .4em;
@@ -20,7 +20,7 @@
   text-decoration: underline;
   color: var(--rising-foreground);
 }
- .cards-editor--button-panel > button {
+.cards-editor--button-panel > button {
   background-color: var(--tools-highlight);
   border: 1px solid var(--deep-tools-highlight);
   color: var(--bright-foreground);

--- a/packages/card-picker/addon/styles/cardstack-cards-editor.css
+++ b/packages/card-picker/addon/styles/cardstack-cards-editor.css
@@ -1,11 +1,14 @@
 .cards-editor--input-row {
   display: flex;
+  align-items: flex-start;
   margin-bottom: 1rem;
 }
 .cards-editor--input-row > .drag-handle {
   margin-right: 0.25rem;
+  margin-top: -3px;
   cursor: pointer;
   flex: 0 0 auto;
+  align-self: center;
 }
 .cards-editor--input-row > span {
   flex-grow: 1;

--- a/packages/card-picker/addon/styles/cardstack-cards-editor.css
+++ b/packages/card-picker/addon/styles/cardstack-cards-editor.css
@@ -1,11 +1,14 @@
 .cards-editor--input-row {
   display: flex;
   margin-bottom: 1rem;
-  flex: 1 1 300px;
 }
 .cards-editor--input-row > .drag-handle {
   margin-right: 0.25rem;
   cursor: pointer;
+  flex: 0 0 auto;
+}
+.cards-editor--input-row > span {
+  flex-grow: 1;
 }
 .cards-editor--input-row > .text-button {
   display: inline-block;
@@ -19,6 +22,7 @@
   user-select: none;
   text-decoration: underline;
   color: var(--rising-foreground);
+  flex: 0 0 auto;
 }
 .cards-editor--button-panel > button {
   background-color: var(--tools-highlight);


### PR DESCRIPTION
This PR resolves a few flexbox-related issues and resolves #419 by using `text-overflow: ellipsis` on the card titles.

#### Before
![bildschirmfoto 2018-11-12 um 11 45 31](https://user-images.githubusercontent.com/141300/48342693-aee88600-e670-11e8-906f-96754556d642.png)

#### After
![bildschirmfoto 2018-11-12 um 11 54 08](https://user-images.githubusercontent.com/141300/48343094-bc524000-e671-11e8-8a49-2bd0b4b615b7.png)

