### PR TITLE
Adding Node 10 to Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: node_js
 node_js:
   - "8"
+  - "10"
 
 sudo: required
 services:


### PR DESCRIPTION
Thanks to https://github.com/cardstack/cardstack/pull/402 we should now be able to use Node 10 for cardstack 🎉 

This is just a PR to kick off Travis and to open the discussion.

## To Do
- [x] Update ember-cli-postcss See https://github.com/cardstack/cardstack/pull/413
- [x] Figure out why the truffle tests are failing