### PR TITLE
Make data service's type argument optional

### DIFF
--- a/packages/data/addon/services/cardstack-data.js
+++ b/packages/data/addon/services/cardstack-data.js
@@ -45,9 +45,10 @@ export default Service.extend({
     return record;
   },
 
-  async query(type, format, opts={}) {
+  async query(format, opts={}) {
     let store = this.get('store');
     let branch = opts.branch || defaultBranch;
+    let type = opts.type || 'cardstack-card';
     let _opts = Object.assign({ branch, modelName: type }, opts);
 
     let result = await store.query(type, _opts);
@@ -62,9 +63,9 @@ export default Service.extend({
     return result;
   },
 
-  async queryCard(type, format, opts={}) {
+  async queryCard(format, opts={}) {
     let card;
-    let result = await this.query(type, format, opts);
+    let result = await this.query(format, opts);
     if (result && (card = result.toArray()) && card) {
       return card[0];
     }

--- a/packages/data/tests/integration/query-test.js
+++ b/packages/data/tests/integration/query-test.js
@@ -48,7 +48,7 @@ module('Integration | @cardstack/data service query()', function (hooks) {
 
     test("it can load relationships for a query in a particular format", async function (assert) {
       let dataService = this.owner.lookup('service:cardstackData');
-      let pages = await run(() => dataService.query('page', 'isolated', { filter: { title: 'Homepage' } }));
+      let pages = await run(() => dataService.query('isolated', { filter: { title: 'Homepage' }, type: 'page' }));
 
       let homepage = pages.get('firstObject')
       let articles = homepage.get('articles').toArray().map(i => i.toJSON());
@@ -93,7 +93,7 @@ module('Integration | @cardstack/data service query()', function (hooks) {
 
     test("it can load relationships for a queryCard in a particular format", async function (assert) {
       let dataService = this.owner.lookup('service:cardstackData');
-      let homepage = await run(() => dataService.queryCard('page', 'isolated', { filter: { title: 'Homepage' } }));
+      let homepage = await run(() => dataService.queryCard('isolated', { filter: { title: 'Homepage' }, type: 'page' }));
 
       let articles = homepage.get('articles').toArray().map(i => i.toJSON());
       let author = homepage.get('articles.firstObject.author');
@@ -135,6 +135,16 @@ module('Integration | @cardstack/data service query()', function (hooks) {
       });
     });
 
+    test("it can load cards without a type", async function (assert) {
+      let dataService = this.owner.lookup('service:cardstackData');
+      let pages = await run(() => dataService.query('isolated', { filter: { title: 'Homepage' } }));
+
+      assert.equal(1, pages.length);
+
+      let homepage = pages.get('firstObject');
+
+      assert.ok(homepage);
+    });
   });
 
   module('with defaultIncludes', function (hooks) {
@@ -160,7 +170,7 @@ module('Integration | @cardstack/data service query()', function (hooks) {
 
     test("it loads the defaultIncludes when a format is requested that is not in the fieldset", async function(assert) {
       let dataService = this.owner.lookup('service:cardstackData');
-      let pages = await run(() => dataService.query('page', 'isolated', { filter: { title: 'Homepage' } }));
+      let pages = await run(() => dataService.query('isolated', { filter: { title: 'Homepage' }, type: 'page' }));
 
       let homepage = pages.get('firstObject')
       let articles = homepage.get('articles').toArray().map(i => i.toJSON());
@@ -236,7 +246,7 @@ module('Integration | @cardstack/data service query()', function (hooks) {
     // So ultimately we should also assert that the relationship field does not exist as part of this test.
     test("it does not load a relationship that is not in a request format's fieldset but is defaultIncluded", async function (assert) {
       let dataService = this.owner.lookup('service:cardstackData');
-      let pages = await run(() => dataService.query('page', 'isolated', { filter: { title: 'Homepage' } }));
+      let pages = await run(() => dataService.query('isolated', { filter: { title: 'Homepage' }, type: 'page' }));
 
       let homepage = pages.get('firstObject')
       let articles = homepage.get('articles').toArray().map(i => i.toJSON());
@@ -267,6 +277,16 @@ module('Integration | @cardstack/data service query()', function (hooks) {
       }]);
     });
 
+    test("it can load cards without a type", async function (assert) {
+      let dataService = this.owner.lookup('service:cardstackData');
+      let pages = await run(() => dataService.query('isolated', { filter: { title: 'Homepage' } }));
+
+      assert.equal(1, pages.length);
+
+      let homepage = pages.get('firstObject');
+
+      assert.ok(homepage);
+    });
   });
 
   // Ember runloop.

--- a/packages/models/addon/adapter.js
+++ b/packages/models/addon/adapter.js
@@ -11,6 +11,14 @@ export default DS.JSONAPIAdapter.extend(AdapterMixin, {
   cardstackSession: injectOptional.service(),
   session: injectOptional.service(),
 
+  pathForType(modelName) {
+    if (modelName === 'cardstack-card') {
+      return '';
+    } else {
+      return this._super(...arguments);
+    }
+  },
+
   // queryRecord can use the hub's page.size control to just do a
   // query of with a limit of 1.
   async queryRecord(store, type, query) {

--- a/packages/models/cardstack/code-generator.js
+++ b/packages/models/cardstack/code-generator.js
@@ -110,6 +110,12 @@ class CodeGenerator {
         reexportTemplate({ target: `${appModulePrefix}/serializers/${modelName}`, source: `@cardstack/models/serializer` })
       );
     }
+
+    // define an adapter for the cardstack-card base type as well to allow for polymorphic queries
+    modules.push(
+      reexportTemplate({ target: `${appModulePrefix}/adapters/cardstack-card`, source: `@cardstack/models/adapter` })
+    );
+
     return modules.join("");
   }
   _generatedModel(modelName, type) {

--- a/packages/models/tests/integration/models-test.js
+++ b/packages/models/tests/integration/models-test.js
@@ -119,6 +119,14 @@ module('Integration | Models', function(hooks) {
     assert.equal(models.objectAt(0).get('id'), '1')
   });
 
+  test('it can query for the base type', async function(assert) {
+    let models = await run(
+      () => this.store.query('cardstack-card', { filter: { title: 'world' } })
+    );
+    assert.equal(models.get('length'), 1);
+    assert.equal(models.objectAt(0).get('id'), '1')
+  });
+
   test('it can queryRecord', async function(assert) {
     let model = await run(
       () => this.store.queryRecord('post', { filter: { title: 'world' } })


### PR DESCRIPTION
This makes the `type` argument optional for the data service's `query` and `queryCard` methods so that we can run heterogeneous queries.

closes #375 