### PR TITLE
Simplify `@cardstack/test-support` import paths

### DIFF
--- a/packages/hub/node-tests/computed-field-test.js
+++ b/packages/hub/node-tests/computed-field-test.js
@@ -1,9 +1,9 @@
-const JSONAPIFactory = require('../../../tests/sample-computed-fields/node_modules/@cardstack/test-support/jsonapi-factory');
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
 
 const {
   createDefaultEnvironment,
   destroyDefaultEnvironment
-} = require('../../../tests/sample-computed-fields/node_modules/@cardstack/test-support/env');
+} = require('@cardstack/test-support/env');
 
 describe('hub/computed-fields', function() {
   let env, apple, banana, chocolate;

--- a/packages/hub/node-tests/group-test.js
+++ b/packages/hub/node-tests/group-test.js
@@ -1,8 +1,8 @@
-const JSONAPIFactory = require('../../../tests/stub-project/node_modules/@cardstack/test-support/jsonapi-factory');
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
 const {
   createDefaultEnvironment,
   destroyDefaultEnvironment
-} = require('../../../tests/stub-project/node_modules/@cardstack/test-support/env');
+} = require('@cardstack/test-support/env');
 
 describe('schema/group', function() {
   let env, hassan, ed, vanGogh, schema;

--- a/packages/hub/node-tests/indexers-test.js
+++ b/packages/hub/node-tests/indexers-test.js
@@ -1,10 +1,10 @@
-const JSONAPIFactory = require('../../../tests/stub-project/node_modules/@cardstack/test-support/jsonapi-factory');
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
 const Session = require('@cardstack/plugin-utils/session');
 const {
   createDefaultEnvironment,
   destroyDefaultEnvironment,
   defaultDataSourceId
-} = require('../../../tests/stub-project/node_modules/@cardstack/test-support/env');
+} = require('@cardstack/test-support/env');
 
 describe('hub/indexers', function() {
   let env;

--- a/packages/hub/node-tests/messengers-test.js
+++ b/packages/hub/node-tests/messengers-test.js
@@ -1,10 +1,10 @@
 const {
   createDefaultEnvironment,
   destroyDefaultEnvironment
-} = require('../../../tests/stub-project/node_modules/@cardstack/test-support/env');
+} = require('@cardstack/test-support/env');
 
-const JSONAPIFactory = require('../../../tests/stub-project/node_modules/@cardstack/test-support/jsonapi-factory');
-const TestMessenger = require('../../../tests/stub-project/node_modules/@cardstack/test-support-messenger/messenger');
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
+const TestMessenger = require('@cardstack/test-support-messenger/messenger');
 
 describe('hub/messengers', function() {
   let env, messengers;

--- a/packages/hub/node-tests/middleware-stack-test.js
+++ b/packages/hub/node-tests/middleware-stack-test.js
@@ -1,10 +1,10 @@
-const JSONAPIFactory = require('../../../tests/stub-middleware/node_modules/@cardstack/test-support/jsonapi-factory');
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
 const supertest = require('supertest');
 const Koa = require('koa');
 const {
   createDefaultEnvironment,
   destroyDefaultEnvironment
-} = require('../../../tests/stub-middleware/node_modules/@cardstack/test-support/env');
+} = require('@cardstack/test-support/env');
 
 
 let SecondMiddleware = require('../../../tests/stub-middleware/middleware/second.js');

--- a/packages/hub/node-tests/plugin-loader-test.js
+++ b/packages/hub/node-tests/plugin-loader-test.js
@@ -1,5 +1,5 @@
 const { Registry, Container } = require('@cardstack/di');
-const JSONAPIFactory = require('../../../tests/stub-project/node_modules/@cardstack/test-support/jsonapi-factory');
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
 
 describe('hub/plugin-loader', function() {
   let pluginLoader, configuredPlugins;

--- a/packages/hub/node-tests/schema-auth-test.js
+++ b/packages/hub/node-tests/schema-auth-test.js
@@ -1,9 +1,9 @@
-const JSONAPIFactory = require('../../../tests/stub-project/node_modules/@cardstack/test-support/jsonapi-factory');
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
 const PendingChange = require('@cardstack/plugin-utils/pending-change');
 const {
   createDefaultEnvironment,
   destroyDefaultEnvironment
-} = require('../../../tests/stub-project/node_modules/@cardstack/test-support/env');
+} = require('@cardstack/test-support/env');
 const bootstrapSchema = require('../bootstrap-schema');
 const Session = require('@cardstack/plugin-utils/session');
 

--- a/packages/hub/node-tests/schema-read-auth-test.js
+++ b/packages/hub/node-tests/schema-read-auth-test.js
@@ -1,9 +1,9 @@
 const Session = require('@cardstack/plugin-utils/session');
-const JSONAPIFactory = require('../../../tests/stub-project/node_modules/@cardstack/test-support/jsonapi-factory');
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
 const {
   createDefaultEnvironment,
   destroyDefaultEnvironment
-} = require('../../../tests/stub-searcher/node_modules/@cardstack/test-support/env');
+} = require('@cardstack/test-support/env');
 
 let env, baseSchema, searchers, writers;
 

--- a/packages/hub/node-tests/schema-validation-test.js
+++ b/packages/hub/node-tests/schema-validation-test.js
@@ -1,10 +1,10 @@
-const JSONAPIFactory = require('../../../tests/stub-project/node_modules/@cardstack/test-support/jsonapi-factory');
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
 const PendingChange = require('@cardstack/plugin-utils/pending-change');
 const bootstrapSchema = require('../bootstrap-schema');
 const {
   createDefaultEnvironment,
   destroyDefaultEnvironment
-} = require('../../../tests/stub-project/node_modules/@cardstack/test-support/env');
+} = require('@cardstack/test-support/env');
 
 describe('schema/validation', function() {
 

--- a/packages/hub/node-tests/searchers-auth-test.js
+++ b/packages/hub/node-tests/searchers-auth-test.js
@@ -1,8 +1,8 @@
-const JSONAPIFactory = require('../../../tests/stub-searcher/node_modules/@cardstack/test-support/jsonapi-factory');
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
 const {
   createDefaultEnvironment,
   destroyDefaultEnvironment
-} = require('../../../tests/stub-searcher/node_modules/@cardstack/test-support/env');
+} = require('@cardstack/test-support/env');
 const Session = require('@cardstack/plugin-utils/session');
 const everyone = { type: 'groups', id: 'everyone' };
 

--- a/packages/hub/node-tests/searchers-test.js
+++ b/packages/hub/node-tests/searchers-test.js
@@ -1,8 +1,8 @@
-const JSONAPIFactory = require('../../../tests/stub-searcher/node_modules/@cardstack/test-support/jsonapi-factory');
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
 const {
   createDefaultEnvironment,
   destroyDefaultEnvironment
-} = require('../../../tests/stub-searcher/node_modules/@cardstack/test-support/env');
+} = require('@cardstack/test-support/env');
 
 describe('hub/searchers/basics', function() {
   let env, chocolate, source;

--- a/packages/hub/node-tests/static-indexer-test.js
+++ b/packages/hub/node-tests/static-indexer-test.js
@@ -1,8 +1,8 @@
-const JSONAPIFactory = require('../../../tests/stub-static-models/node_modules/@cardstack/test-support/jsonapi-factory');
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
 const {
   createDefaultEnvironment,
   destroyDefaultEnvironment
-} = require('../../../tests/stub-static-models/node_modules/@cardstack/test-support/env');
+} = require('@cardstack/test-support/env');
 const project = __dirname + '/../../../tests/stub-static-models';
 
 describe('static-indexer', function() {


### PR DESCRIPTION
There is no reason for us to use relative paths to reach into the `node_modules` of a different folder when we can import from `@cardstack/test-support` directly.