### PR TITLE
Reuse cloned repo in the git datasource

### DIFF
--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -20,6 +20,7 @@
     "mkdirp": "^0.5.1",
     "moment-timezone": "^0.5.11",
     "nodegit": "^0.23.0",
+    "rimraf": "^2.6.2",
     "temp": "^0.8.3"
   },
   "devDependencies": {

--- a/packages/git/service.js
+++ b/packages/git/service.js
@@ -37,15 +37,11 @@ class GitLocalCache {
     let cacheDirectory = remote.cacheDir;
 
     if (!cacheDirectory) {
-      if(!this.cacheDirectory) {
-        this.cacheDirectory = join(tmpdir(), 'cardstack-git-local-cache');
-      }
+      cacheDirectory = join(tmpdir(), 'cardstack-git-local-cache');
 
-      if(!existsSync(this.cacheDirectory)) {
-        await mkdirp(this.cacheDirectory);
+      if(!existsSync(cacheDirectory)) {
+        await mkdirp(cacheDirectory);
       }
-
-      cacheDirectory = this.cacheDirectory;
     }
 
     let repoPath = join(cacheDirectory, filenamifyUrl(remote.url));


### PR DESCRIPTION
Fixes https://github.com/cardstack/cardstack/issues/455

This fixes the case where starting the hub clones a remote repo and then when you restart the hub it refuses to clone it again because the folder "already exists and is not empty". 

I have opted **not** to attempt any pulling semantics on initialisation because we don't actually know what the target branch is at this stage. Any conflicts will be handled by the git datasource writer accordingly and the indexer will pull its target branch on every index cycle anyway 👍 