### PR TITLE
Allow editing un-rendered fields in owned resources

### DIFF
--- a/packages/data/addon/services/cardstack-data.js
+++ b/packages/data/addon/services/cardstack-data.js
@@ -143,6 +143,9 @@ export default Service.extend({
       return [`${humanType} `, card.id]
         .join('#');
     }
+    if (attribute === 'uid') {
+      return `${getType(card)}/${card.id}`;
+    }
     return '';
   },
 

--- a/packages/tools/addon/helpers/cs-uid.js
+++ b/packages/tools/addon/helpers/cs-uid.js
@@ -1,0 +1,11 @@
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+
+export default Helper.extend({
+  data: service('cardstack-data'),
+
+  compute([ model ]) {
+    return this.get('data').getCardMeta(model, 'uid');
+  }
+});
+

--- a/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
+++ b/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
@@ -37,7 +37,10 @@
         unhovered=(perform highlightAndScrollToField null)
       }}
         <div class="cs-field-editor-section">
-          {{#let fieldModel.content as |content|}}
+          {{#let
+            fieldModel.content
+            (get permissions (cs-uid fieldModel.content))
+          as |content fieldModelPermissions|}}
             {{#if fieldModel.grouped}}
               {{#each fieldModel.grouped as |fieldName|}}
                 <label>{{cs-field-caption content fieldName}}</label>
@@ -48,11 +51,9 @@
                   content=content
                   field=fieldName
                   enabled=editingEnabled
-                  canUpdate=(or
-                    (not isPageModelField)
-                    (and
-                      permissions.mayUpdateResource
-                      (contains fieldName permissions.writableFields))
+                  canUpdate=(and
+                    fieldModelPermissions.mayUpdateResource
+                    (contains fieldName fieldModelPermissions.writableFields)
                   )
                   onchange=(action "validate")
                   errors=(get validationErrors fieldName)
@@ -66,11 +67,9 @@
                 content=content
                 field=fieldModel.name
                 enabled=editingEnabled
-                canUpdate=(or
-                  (not isPageModelField)
-                  (and
-                    permissions.mayUpdateResource
-                    (contains fieldModel.name permissions.writableFields))
+                canUpdate=(and
+                  fieldModelPermissions.mayUpdateResource
+                  (contains fieldModel.name fieldModelPermissions.writableFields)
                 )
                 onchange=(action "validate")
                 errors=(get validationErrors fieldModel.name)
@@ -83,7 +82,10 @@
   {{/each}}
 
   {{#each modelFields as |field|}}
-    {{#let (eq field.model model) as |isPageModelField|}}
+    {{#let
+      (get permissions (cs-uid field.model))
+      (eq field.model model)
+    as |fieldModelPermissions isPageModelField|}}
       {{#cs-collapsible-section
         class=(concat "cs-toolbox-section "
           (if
@@ -100,8 +102,8 @@
             field=field.name
             enabled=editingEnabled
             canUpdate=(and
-              permissions.mayUpdateResource
-              (contains field.name permissions.writableFields)
+              fieldModelPermissions.mayUpdateResource
+              (contains field.name fieldModelPermissions.writableFields)
             )
             onchange=(action "validate")
             errors=(get validationErrors field.name)

--- a/packages/tools/app/helpers/cs-uid.js
+++ b/packages/tools/app/helpers/cs-uid.js
@@ -1,0 +1,1 @@
+export { default } from '@cardstack/tools/helpers/cs-uid';

--- a/packages/tools/tests/acceptance/tools-test.js
+++ b/packages/tools/tests/acceptance/tools-test.js
@@ -116,4 +116,23 @@ module('Acceptance | tools', function(hooks) {
     let nameInput = findInputWithValue.call(this, 'LeChuck');
     assert.dom(nameInput).isDisabled('Computed field is disabled');
   });
+
+  test('allow editing fields for related, owned records', async function(assert) {
+    await visit('/1');
+    await login();
+    await click('.cardstack-tools-launcher');
+    await click('.cs-toggle-switch');
+
+    let reviewStatusActionTrigger = findTriggerElementWithLabel.call(this, /Comment #1: Review Status/);
+    await click(reviewStatusActionTrigger);
+
+    let reviewStatusInput = findInputWithValue.call(this, 'approved');
+    assert.dom(reviewStatusInput).isNotDisabled();
+
+    reviewStatusActionTrigger = findTriggerElementWithLabel.call(this, /Comment #2: Review Status/);
+    await click(reviewStatusActionTrigger);
+
+    reviewStatusInput = findInputWithValue.call(this, 'pending');
+    assert.dom(reviewStatusInput).isNotDisabled();
+  });
 });


### PR DESCRIPTION
This is done by fetching –and correctly setting– permissions for owned resources.

Todos:

* [x] Write test