### PR TITLE
hub/writers: Simplify `_getSchemaDetailsForType()` function

### DIFF
--- a/packages/hub/writers.js
+++ b/packages/hub/writers.js
@@ -184,9 +184,12 @@ class Writers {
 
   _getSchemaDetailsForType(schema, type) {
     let contentType = schema.types.get(type);
-    let writer;
-    if (!contentType || !contentType.dataSource || !(writer = contentType.dataSource.writer)) {
-      log.debug('non-writeable type %s: exists=%s hasDataSource=%s hasWriter=%s', type, !!contentType, !!(contentType && contentType.dataSource), !!writer);
+    if (!contentType || !contentType.dataSource || !contentType.dataSource.writer) {
+      log.debug('non-writeable type %s: exists=%s hasDataSource=%s hasWriter=%s',
+        type,
+        Boolean(contentType),
+        Boolean(contentType && contentType.dataSource),
+        Boolean(contentType && contentType.dataSource && contentType.dataSource.writer));
 
       throw new Error(`"${type}" is not a writable type`, {
         status: 403,
@@ -194,6 +197,7 @@ class Writers {
       });
     }
 
+    let writer = contentType.dataSource.writer;
     let sourceId = contentType.dataSource.id;
     return { writer, sourceId };
   }


### PR DESCRIPTION
Assignments should not be part of conditions as they make the code hard to follow and the same logic can often be expressed in a simpler way.

This code path was discovered during the work on #466.