### PR TITLE
hub/data-source: Remove duplicate `_writer` assignment

### DIFF
--- a/packages/hub/schema/data-source.js
+++ b/packages/hub/schema/data-source.js
@@ -7,7 +7,6 @@ module.exports = class DataSource {
   constructor(model, plugins, projectPath) {
     this.id = model.id;
     this.sourceType = model.attributes['source-type'];
-    this._writer = null;
     this._params = Object.assign({ dataSource: this }, model.attributes.params);
     this._Writer = plugins.lookupFeatureFactory('writers', this.sourceType);
     this._writer = null;


### PR DESCRIPTION
The same property is already being assigned three lines later.

This code path was discovered during the work on #466.