### PR TITLE
hub/schema: Use `realFields` in `withOnlyRealFields()`

### DIFF
--- a/packages/hub/schema/index.js
+++ b/packages/hub/schema/index.js
@@ -69,7 +69,7 @@ class Schema {
         continue;
       }
       for (let fieldName of Object.keys(doc[section])) {
-        if (this.computedFields.has(fieldName)) {
+        if (!this.realFields.has(fieldName)) {
           if (activeDoc === doc) {
             activeDoc = Object.assign({}, doc);
           }


### PR DESCRIPTION
From what I understand `realFields` is not the opposite of `computedFields` because unknown fields are neither of those two. Since the function is called `withOnlyRealFields()` we should only include the `realFields`, or rename the function to `withoutComputedFields()`.

This code path was discovered during the work on #466.