### PR TITLE
Error in calculating modelFields

### DIFF
--- a/packages/tools/addon/services/cardstack-tools.js
+++ b/packages/tools/addon/services/cardstack-tools.js
@@ -31,7 +31,7 @@ export default Service.extend({
     let model = this.get('activeContentItem.model');
     if (!model) { return []; }
 
-    let records = [model, ...model.relatedOwnedRecords()];
+    let records = [model, ...ownedRelatedRecords([model])];
     let modelFields = records.map((record) => {
       let fields = [];
       record.eachAttribute((attribute, meta) => {


### PR DESCRIPTION
@ef4 @balinterdi  I came across this error when running the "deck" with the yarn-linked `restyling-right-edge` branch: `Uncaught TypeError: model.relatedOwnedRecords(...) is not a function or its return value is not iterable`. Below change seems to work... If not, feel free to take over.