### PR TITLE
Fix adding logged-in user details to git commits

### DIFF
--- a/packages/git/writer.js
+++ b/packages/git/writer.js
@@ -135,9 +135,16 @@ module.exports = class Writer {
 
   async _commitOptions(operation, type, id, session) {
     let user = session && await session.loadUser();
+    let userAttributes = {};
+    try {
+      userAttributes = user.data.attributes;
+    } catch (e) {
+      // do nothing
+    }
+
     return {
-      authorName: (user && user.attributes && user.attributes['full-name']) || 'Anonymous Coward',
-      authorEmail: (user && user.attributes && user.attributes.email) || 'anon@example.com',
+      authorName: userAttributes['full-name'] || userAttributes.name || 'Anonymous Coward',
+      authorEmail: userAttributes.email || 'anon@example.com',
       committerName: this.myName,
       committerEmail: this.myEmail,
       message: `${operation} ${type} ${String(id).slice(12)}`

--- a/packages/git/writer.js
+++ b/packages/git/writer.js
@@ -135,12 +135,7 @@ module.exports = class Writer {
 
   async _commitOptions(operation, type, id, session) {
     let user = session && await session.loadUser();
-    let userAttributes = {};
-    try {
-      userAttributes = user.data.attributes;
-    } catch (e) {
-      // do nothing
-    }
+    let userAttributes = (user && user.data && user.data.attributes) || {};
 
     return {
       authorName: userAttributes['full-name'] || userAttributes.name || 'Anonymous Coward',


### PR DESCRIPTION
<img width="509" alt="screenshot 2018-12-13 at 11 00 24" src="https://user-images.githubusercontent.com/594890/49934664-e3956a80-fec6-11e8-89ea-dd78e5f5be5d.png">


This implementation was already there, it just was accessing the wrong location of the session user (`user.attributes` instead of `user.data.attributes`).

