### PR TITLE
expose branches on the API

### DIFF
--- a/packages/data/addon/services/cardstack-data.js
+++ b/packages/data/addon/services/cardstack-data.js
@@ -138,6 +138,20 @@ export default Service.extend({
     }
   },
 
+  async branches() {
+    let url = `${hubURL}/api/branches`;
+    let response = await fetch(url, {
+      headers: this._headers()
+    });
+    let { data } = await response.json();
+    let { attributes, relationships } = data;
+    return {
+      mayUpdateResource: attributes['may-update-resource'],
+      writableFields: relationships['writable-fields'].data
+        .map((field) => camelize(field.id))
+    }
+  },
+
   getCardMeta(card, attribute) {
     if (attribute === 'human-id') {
       let humanType = getType(card)

--- a/packages/jsonapi/middleware.js
+++ b/packages/jsonapi/middleware.js
@@ -250,6 +250,13 @@ class Handler {
   }
 
   async handleCollectionGET(type) {
+    if(type === 'branches') {
+      let branches = await this.indexers.branches();
+
+      this.ctxt.body = { data: branches.map(branch => ({id: branch, type: 'branches', attributes: {}}))};
+      return;
+    }
+
     let { data: models, meta: { page }, included } = await this.searcher.search(this.session, this.branch, {
       filter: this.filterExpression(type),
       sort: this.query.sort,


### PR DESCRIPTION
This is a bit of a rudimentary implementation (that does actually work) designed to spark some conversation about the right way to achieve this same thing.

Currently, with these changes active I am able to make this request: 

```
curl 'http://localhost:3000/api/branches'
```

and get this response: 

```json
{
  "data": [{
    "id": "master",
    "type": "branches",
    "attributes": {}
  }, {
    "id": "face",
    "type": "branches",
    "attributes": {}
  }, {
    "id": "master-update",
    "type": "branches",
    "attributes": {}
  }, {
    "id": "sandbox-master",
    "type": "branches",
    "attributes": {}
  }]
}
```

Which corresponds to the branches on my local git repo: 

```bash
➜  application-data git:(face) git branch | cat
* face
  master
  master-update
  sandbox-master
```
