### PR TITLE
explicitely instruct postgres to build english tsvectors

### DIFF
--- a/packages/pgsearch/client.js
+++ b/packages/pgsearch/client.js
@@ -211,7 +211,7 @@ class Batch {
       type: param(type),
       id: param(id),
       search_doc: param(searchDoc),
-      q: ['to_tsvector(', param(searchDoc), ')'],
+      q: [`to_tsvector('english',`, param(searchDoc), ')'],
       pristine_doc: param(pristineDoc),
       upstream_doc: param(upstreamDoc),
       source: param(sourceId),


### PR DESCRIPTION
It looks like postgres in AWS is not configured to build English tsvectors by default. So we need to be explicit about this.