### PR TITLE
Watch image relationship setting

### DIFF
--- a/packages/image/addon/components/field-editors/cardstack-image-editor.js
+++ b/packages/image/addon/components/field-editors/cardstack-image-editor.js
@@ -13,7 +13,19 @@ export default Component.extend({
   updateImage: task(function * (file) {
     let image = this.get('store').createRecord('cardstack-image', { file });
     yield image.save();
-    this.set(`content.${this.get('field')}`, image);
+    let field = this.field;
+    this.content.watchRelationship(field, () => {
+      this.set(`content.${field}`, image);
+    });
     this.set('showUploader', false);
-  }).restartable()
+  }).restartable(),
+
+  actions: {
+    removeImage() {
+      let field = this.field;
+      this.content.watchRelationship(field, () => {
+        this.set(`content.${field}`, null);
+      });
+    }
+  }
 });

--- a/packages/image/addon/templates/components/field-editors/cardstack-image-editor.hbs
+++ b/packages/image/addon/templates/components/field-editors/cardstack-image-editor.hbs
@@ -7,7 +7,7 @@
     {{/if}}
   </button>
   {{#if (get content field "base64")}}
-    <button {{action (mut (get content field)) null}} disabled={{disabled}}>
+    <button onclick={{action "removeImage"}} disabled={{disabled}}>
       Remove image
     </button>
   {{/if}}


### PR DESCRIPTION
Setting image fields were not done in a "dirty tracking compatible" way.

This PR aims to remedy that.