### PR TITLE
fixed bugs in ethereum transaction indexer

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -130,7 +130,7 @@
             "console": "integratedTerminal",
             "args": [
                 "test",
-                "${workspaceRoot}/packages/ethereum/truffle-tests/*-test.js"
+                "${workspaceRoot}/packages/ethereum/truffle-tests/addresses-test.js"
             ]
         }
     ]

--- a/packages/ethereum/package.json
+++ b/packages/ethereum/package.json
@@ -35,6 +35,7 @@
     "inflection": "^1.12.0",
     "jsonpatch": "^3.0.1",
     "lodash": "^4.17.11",
+    "semver": "^5.6.0",
     "web3": "^1.0.0-beta.37"
   },
   "devDependencies": {


### PR DESCRIPTION
Found and fixed a bunch of bugs in the Ethereum TransactionIndxeer after beginning to use the etheruem address indexing.

1. The way we were using transaction nonces as a means to version the addresses had some fundamental problems. In Ethereum transaction nonces are assigned based on the _sending_ address. Since we are indexing both sides of the transactions, this is problematic when the nonce is used as a means to version an address that is on the receiving end of a transaction. Instead I've switched to using the block position of the transaction, which is a sequential number assigned to each transaction as part of mining the block. The address versions work in a semver-like way, where they are assigned as `<block-number>.<transaction-index>`, e.g. `5008932.231` so that each transaction that is indexed will increase the version number of the `ethereum-addresses` hub resource.
2. We were not taking the price of gas into consideration when using our heuristic to find the first block to start start indexing an address. I added new errors that are thrown when it becomes clear that our heuristic is not being processed correctly (negative balances, or reaching the genesis block and not coming to a successful end state with our heuristic).
3. Our testing transactions in the ganache private blockchain were being polluted with transactions that are used to setup the initial address balances, which contributed to hiding the problems above. I've updated our tests to use random ethereum addresses that are not tainted with setup transactions.
4. The way we were comparing against `0` was incorrect for the `web3.BigNumber` classes. Which compounded all the the issues above.
5. I've added a `discoveredAtBlock` to the meta in our indexed ethereum addresses to make it more clear how far back the hub went in terms of indexing the address. (This is similar to BlockTrails "first encountered" field). This field is set to the block height that you first expressed a desire in indexing the address, or the farthest back the hub could detect activity against the address--whichever has the lowest block height.
