### PR TITLE
Making sure static models exist on all branches

### DIFF
--- a/packages/hub/indexing/branch-update.js
+++ b/packages/hub/indexing/branch-update.js
@@ -36,9 +36,11 @@ class BranchUpdate {
   }
 
   addStaticModels(schemaModels, allModels) {
-    if (!this.updaters['static-models']) { return; } // static models updaters only run on the master branch
-
+    // static models must be added to all branches
     this.schemaModels = this.schemaModels.concat(schemaModels);
+
+    // we only keep track of the static-models updater on master
+    if (!this.updaters['static-models']) { return; }
     this.updaters['static-models'].staticModels = allModels;
   }
 


### PR DESCRIPTION
Fixes https://github.com/cardstack/dotbc/issues/163

This is a relatively small fix for something that was creating a relatively large issue. If you had defined your schema in static-models then no branch other than the controlling branch (master) would get indexed correctly. This is because the schema models were not available during the indexing process on other branches and any document contexts that were generated for other branches would return empty search documents.