### PR TITLE
image: Move `cardstack-modal` styles to `edges` package

### DIFF
--- a/packages/edges/addon/styles/addon.css
+++ b/packages/edges/addon/styles/addon.css
@@ -1,0 +1,25 @@
+.cardstack-modal-backdrop {
+    position: fixed;
+    top: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: black;
+    opacity: 0.8;
+    z-index: 999;
+}
+.cardstack-modal-container {
+    position: fixed;
+    top: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.cardstack-modal-dialog {
+    background-color: white;
+    border-radius: 4px;
+    max-height: 100vh;
+    overflow-y: auto;
+}

--- a/packages/image/addon/styles/addon.css
+++ b/packages/image/addon/styles/addon.css
@@ -1,32 +1,3 @@
-/* general styles */
-.cardstack-modal-backdrop {
-    position: fixed;
-    top: 0;
-    width: 100vw;
-    height: 100vh;
-    background-color: black;
-    opacity: 0.8;
-    z-index: 999;
-}
-.cardstack-modal-container {
-    position: fixed;
-    top: 0;
-    width: 100vw;
-    height: 100vh;
-    z-index: 1000;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-.cardstack-modal-dialog {
-    background-color: white;
-    border-radius: 4px;
-    max-height: 100vh;
-    overflow-y: auto;
-}
-
-/* Image specific styles */
-
 .cardstack-image-placeholder {
   width: 100%;
   height: 300px;


### PR DESCRIPTION
As part of https://github.com/cardstack/dotbc/pull/283 we wanted to make use of the pre-existing modal implementation but as we're not using the image addon (yet) the correct styles are not being included for `cardstack-modal`