### PR TITLE
Dropdown search editor enhancements

### DIFF
--- a/packages/core-types/addon/components/field-editors/dropdown-search-editor.js
+++ b/packages/core-types/addon/components/field-editors/dropdown-search-editor.js
@@ -1,17 +1,22 @@
 import Component from '@ember/component';
 import { dasherize } from '@ember/string';
 import { inject as service } from '@ember/service';
+import { task, timeout } from 'ember-concurrency';
 import layout from '../../templates/components/field-editors/dropdown-search-editor';
 import { get, getWithDefault, set, computed } from '@ember/object';
 // @TODO: expose public api
 import metaForField from '@cardstack/rendering/-private/meta-for-field';
 
+const { readOnly } = computed;
 
 export default Component.extend({
   layout,
   tagName: '',
   store: service(),
   cardstackEdges: service(),
+
+  matchBy: readOnly('editorOptions.matchBy'),
+
   init() {
     this._super();
 
@@ -23,6 +28,36 @@ export default Component.extend({
     return getWithDefault(this, 'editorOptions.displayFieldName', 'title');
   }),
 
+  searchFields: task(function * (value) {
+    yield timeout(300);
+
+    let store = get(this, 'store');
+    let content = get(this, 'content');
+    let field = get(this, 'field');
+    let meta = metaForField(content, field);
+    let contentType = (meta && meta.type) ? meta.type : dasherize(field);
+
+    let query = {
+      filter: {}
+    }
+
+    let displayFieldName = get(this, 'displayFieldName');
+
+    switch(get(this, 'matchBy')) {
+      case 'exact':
+        query.filter[displayFieldName] = { exact: value };
+        break;
+      case 'prefix':
+        query.filter[displayFieldName] = { prefix: value };
+        break;
+      case 'words':
+      default:
+        query.filter[displayFieldName] = value;
+    }
+
+    return store.query(contentType, query);
+  }),
+
   actions: {
     makeSelection(option) {
       let field = get(this, 'field');
@@ -31,22 +66,6 @@ export default Component.extend({
       content.watchRelationship(field, () => {
         set(content, field, option);
       })
-    },
-
-    searchFields(value) {
-      let store = get(this, 'store');
-      let content = get(this, 'content');
-      let field = get(this, 'field');
-      let meta = metaForField(content, field);
-      let contentType = (meta && meta.type) ? meta.type : dasherize(field);
-
-      let query = {
-        filter: {}
-      }
-
-      query.filter[this.get('displayFieldName')] = value;
-
-      return store.query(contentType, query);
     }
   }
 });

--- a/packages/core-types/addon/templates/components/field-editors/dropdown-search-editor.hbs
+++ b/packages/core-types/addon/templates/components/field-editors/dropdown-search-editor.hbs
@@ -6,7 +6,7 @@
     {{#power-select
       disabled=disabled
       selected=(get content field)
-      search=(action 'searchFields')
+      search=(perform searchFields)
       searchField=displayFieldName
       onchange=(action "makeSelection")
     as |option|}}

--- a/packages/core-types/tests/integration/components/field-editors/dropdown-search-editor-test.js
+++ b/packages/core-types/tests/integration/components/field-editors/dropdown-search-editor-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | field editors/dropdown search editor', async f
     this.set('model', model);
   });
 
-  test('can search', async function(assert) {
+  test('can search by words (default)', async function(assert) {
     await render(hbs`{{field-editors/dropdown-search-editor content=model field="bestTrack"}}`);
 
     assert.dom('.ember-power-select-selected-item').hasText('Electrodrome');
@@ -29,8 +29,65 @@ module('Integration | Component | field editors/dropdown search editor', async f
     assert.dom('.ember-power-select-option').exists({ count: 1 });
     assert.dom('.ember-power-select-option').hasText('Type to search', 'user prompted to search');
 
+    await typeInSearch('mar');
+    assert.dom('.ember-power-select-option').exists({ count: 1 });
+    assert.dom('.ember-power-select-option').hasText('No results found', 'no search results for partial word');
+
     await typeInSearch('mario');
     assert.dom('.ember-power-select-option').exists({ count: 2 }, 'dropdown is rendered with search results');
+
+    await selectChoose('.best-track-selector', 'Mario Circuit');
+
+    assert.dom('.ember-power-select-selected-item').hasText('Mario Circuit');
+  });
+
+  test('can search by prefix', async function(assert) {
+    this.set('editorOptions', { matchBy: 'prefix' });
+    await render(hbs`{{field-editors/dropdown-search-editor content=model field="bestTrack" editorOptions=editorOptions}}`);
+
+    assert.dom('.ember-power-select-selected-item').hasText('Electrodrome');
+
+    await clickTrigger();
+    assert.dom('.ember-power-select-option').exists({ count: 1 });
+    assert.dom('.ember-power-select-option').hasText('Type to search', 'user prompted to search');
+
+    await typeInSearch('mar');
+    assert.dom('.ember-power-select-option').exists({ count: 2 }, 'dropdown is rendered with search results');
+
+    await selectChoose('.best-track-selector', 'Mario Circuit');
+
+    assert.dom('.ember-power-select-selected-item').hasText('Mario Circuit');
+  });
+
+  test('can search by exact match', async function(assert) {
+    this.set('editorOptions', { matchBy: 'exact' });
+    await render(hbs`{{field-editors/dropdown-search-editor content=model field="bestTrack" editorOptions=editorOptions}}`);
+
+    assert.dom('.ember-power-select-selected-item').hasText('Electrodrome');
+
+    await clickTrigger();
+    assert.dom('.ember-power-select-option').exists({ count: 1 });
+    assert.dom('.ember-power-select-option').hasText('Type to search', 'user prompted to search');
+
+    await typeInSearch('mar');
+    assert.dom('.ember-power-select-option').exists({ count: 1 });
+    assert.dom('.ember-power-select-option').hasText('No results found', 'no search results for partial word');
+
+    await typeInSearch('mario');
+    assert.dom('.ember-power-select-option').exists({ count: 1 });
+    assert.dom('.ember-power-select-option').hasText('No results found', 'no search results for single word');
+
+    await typeInSearch('Mario');
+    assert.dom('.ember-power-select-option').exists({ count: 1 });
+    assert.dom('.ember-power-select-option').hasText('No results found', 'no search results for single capitalized word');
+
+    await typeInSearch('mario circuit');
+    assert.dom('.ember-power-select-option').exists({ count: 1 });
+    assert.dom('.ember-power-select-option').hasText('No results found', 'no results, exact match is case-sensitive');
+
+    await typeInSearch('Mario Circuit');
+    assert.dom('.ember-power-select-option').exists({ count: 1 }, 'dropdown is rendered with search results');
+    assert.dom('.ember-power-select-option').hasText('Mario Circuit', 'one result, matches exactly');
 
     await selectChoose('.best-track-selector', 'Mario Circuit');
 


### PR DESCRIPTION
* Use `ember-concurrency` task to debounce search (currently set to 300ms)
* Add ability to set filter match type via `editorOptions.matchBy`. Current options are:
  * `"words"` *(default)* - match only by whole words/terms, case-insensitive (i.e. `cat` will match `Cat food` but not `catsup`)
  * `"exact"`  - match *entire* field value exactly, case-sensitive (i.e. `Cat food` will match `Cat food`, but `Cat`, `cat food` and `food` will not)
  * `"prefix"` - match the beginning of any term in the field, (i.e. `cat` will match `Cat food`, `catsup`, `library catalog`, etc) 