### PR TITLE
add getters for id and type to model

### DIFF
--- a/packages/hub/model.js
+++ b/packages/hub/model.js
@@ -8,6 +8,14 @@ module.exports = class Model {
     priv.set(this, { contentType, jsonapiDoc, read, schema });
   }
 
+  get id() {
+    return priv.get(this).jsonapiDoc.id;
+  }
+
+  get type() {
+    return priv.get(this).jsonapiDoc.type;
+  }
+
   getContentType() {
     return priv.get(this).contentType;
   }


### PR DESCRIPTION
This adds getters for `type` and `id` so that these can be synchronously accessed as simple attributes as opposed to having to go through the asynchronous method `getField`.