### PR TITLE
fix calculation of realm intersections

### DIFF
--- a/packages/hub/schema/realms.js
+++ b/packages/hub/schema/realms.js
@@ -182,7 +182,7 @@ function mayReadLessThanAllFields(grant) {
 function realmIntersections(choiceRealms, singleRealms) {
   let nextChoices = choiceRealms[0];
   if (!nextChoices) {
-    return [singleRealms];
+    return singleRealms.length > 0 ? [singleRealms] : [];
   }
   let rest = realmIntersections(choiceRealms.slice(1), singleRealms);
   return nextChoices.map(choice => rest.concat([choice]));


### PR DESCRIPTION
…by not returning an empty nested array. Without this change, `realmIntersections` might return something like this:

```js
[[[], ['dotbc-users/admin-user'], [[], 'dotbc-users/test-user']]];
```

which ultimately would get converted to this set of realms:

```js
['/dotbc-users/admin-user', '/dotbc-users/test-user']
```

which never matches anything due to the leading slash.

Of course this should have tests but it's needed to unblock cardstack/dotbc#241 and I don't have the time to add the tests right now 😞 