### PR TITLE
Pass logger function to Gitchain

### DIFF
--- a/packages/git/writer.js
+++ b/packages/git/writer.js
@@ -36,7 +36,7 @@ module.exports = class Writer {
 
     if (hyperledger) {
       let config = Object.assign({}, hyperledger);
-      config.logger = log;
+      config.logger = log.info;
       this.hyperledgerConfig = config;
     }
 


### PR DESCRIPTION
Gitchain expects a logger function, not the logger itself.