### PR TITLE
Bind log.info to logger

### DIFF
--- a/packages/git/writer.js
+++ b/packages/git/writer.js
@@ -36,7 +36,7 @@ module.exports = class Writer {
 
     if (hyperledger) {
       let config = Object.assign({}, hyperledger);
-      config.logger = log.info;
+      config.logger = log.info.bind(log); // TODO fix logger so we don't have to bind
       this.hyperledgerConfig = config;
     }
 


### PR DESCRIPTION
this is necessary because of https://github.com/cardstack/logger/blob/master/src/logger.js#L73