### PR TITLE
making cancelled jobs visible in pgboss and leveraging in ethereum index builder

### DIFF
--- a/packages/ethereum/scripts/build-index.js
+++ b/packages/ethereum/scripts/build-index.js
@@ -61,6 +61,7 @@ try {
       ],{
         env: {
           HUB_ENVIRONMENT: process.env.HUB_ENVIRONMENT || 'production',
+          LOG_LEVELS: process.env.LOG_LEVELS,
           PGHOST: process.env.PGHOST,
           PGPORT: process.env.PGPORT,
           PGUSER: process.env.PGUSER,

--- a/packages/queue/index.js
+++ b/packages/queue/index.js
@@ -52,6 +52,11 @@ module.exports = class Queue {
   async publishAndWait(jobName, ...options) {
     let jobId = await this.publish(jobName, ...options);
 
+    // When pg-boss wants to cancel a job because you are using singletonKey to ensure
+    // job uniqueness or throttling, it will return a null jobId. This guard at least
+    // prevents promises from never resolving when pg-boss tries to cancel a job.
+    if (!jobId) { return { jobCancelled: true }; }
+
     this._setupCallbacks(jobName);
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
pgboss will actually cancel jobs due to using a job uniqueness indicator (`singletonKey`) and/or as the result of pgboss throttling jobs. When pgboss cancels a job, it will return a `null` `jobId`. Our current queue `publishAndWait()` cannot handle cancelled jobs, as we are using the `jobId` to correlate the jobs that the client is waiting for. In the case the pg-boss decides to cancel a job, we'll resolve the promise and pass an object that indicates that the job was cancelled. 

I'm leveraging this in the ethereum transaction index build process, which is actually run on many independent node processes as part of running the DB migration. If a node process sees that pg-boss has cancelled the db migrate job, that means that it is running that job on behalf of another node process. It would be great if we could actually resolve the job publish promise when the job is completed by another node process, but I think that is beyond the current capability of pg-boss.