### PR TITLE
Better fixtures

### DIFF
--- a/packages/test-support/addon/fixtures.js
+++ b/packages/test-support/addon/fixtures.js
@@ -63,10 +63,8 @@ export default class Fixtures {
       destructionList = destructionList.concat(createdModels.reverse());
     }
 
-    for (let [index, item] of destructionList.entries()) {
+    for (let item of destructionList) {
       if (!item.type) { continue; }
-
-      let isLast = index === destructionList.length - 1;
 
       if (item.id) {
         let response = await fetch(`${hubURL}/api/${encodeURIComponent(item.type)}/${encodeURIComponent(item.id)}`, {
@@ -80,7 +78,7 @@ export default class Fixtures {
         if (response.status !== 200) { continue; }
 
         let { data:model } = await response.json();
-        await this._deleteModel(model, isLast);
+        await this._deleteModel(model);
       } else {
         let response = await fetch(`${hubURL}/api/${encodeURIComponent(item.type)}`, {
           method: 'GET',
@@ -94,7 +92,7 @@ export default class Fixtures {
 
         let { data:models } = await response.json();
         for (let model of models) {
-          await this._deleteModel(model, isLast);
+          await this._deleteModel(model);
         }
       }
     }

--- a/packages/test-support/addon/fixtures.js
+++ b/packages/test-support/addon/fixtures.js
@@ -10,10 +10,7 @@ export default class Fixtures {
   }
 
   setupTest(hooks) {
-    hooks.beforeEach(async () => {
-      await this.teardown();
-      await this.setup();
-    });
+    hooks.beforeEach(async () => await this.setup());
     hooks.afterEach(async () => await this.teardown());
   }
 
@@ -28,26 +25,34 @@ export default class Fixtures {
     let models = this._factory.getModels();
 
     for (let [, model] of models.entries()) {
-      let url = `${hubURL}/api/${encodeURIComponent(model.type)}`;
-      let response = await fetch(url, {
-        method: 'POST',
-        headers: {
-          authorization: `Bearer ${ciSessionId}`,
-          "content-type": 'application/vnd.api+json'
-        },
-        body: JSON.stringify({
-          data: {
-            id: model.id,
-            type: model.type,
-            attributes: model.attributes,
-            relationships: model.relationships
-          }
-        })
-      });
+      let response = await this._createModel(model);
+      if (response.status === 409) {
+        await this._fetchAndDelete(model);
+        response = await this._createModel(model);
+      }
       if (response.status !== 201) {
         throw new Error(`Unexpected response ${response.status} while trying to define fixtures: ${await response.text()}`);
       }
     }
+  }
+
+  async _createModel(model) {
+    let url = `${hubURL}/api/${encodeURIComponent(model.type)}`;
+    return await fetch(url, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${ciSessionId}`,
+        "content-type": 'application/vnd.api+json'
+      },
+      body: JSON.stringify({
+        data: {
+          id: model.id,
+          type: model.type,
+          attributes: model.attributes,
+          relationships: model.relationships
+        }
+      })
+    });
   }
 
   async teardown() {
@@ -67,18 +72,7 @@ export default class Fixtures {
       if (!item.type) { continue; }
 
       if (item.id) {
-        let response = await fetch(`${hubURL}/api/${encodeURIComponent(item.type)}/${encodeURIComponent(item.id)}`, {
-          method: 'GET',
-          headers: {
-            authorization: `Bearer ${ciSessionId}`,
-            accept: 'application/vnd.api+json'
-          }
-        });
-
-        if (response.status !== 200) { continue; }
-
-        let { data:model } = await response.json();
-        await this._deleteModel(model);
+        await this._fetchAndDelete(item);
       } else {
         let response = await fetch(`${hubURL}/api/${encodeURIComponent(item.type)}`, {
           method: 'GET',
@@ -95,6 +89,21 @@ export default class Fixtures {
           await this._deleteModel(model);
         }
       }
+    }
+  }
+
+  async _fetchAndDelete(item) {
+    let response = await fetch(`${hubURL}/api/${encodeURIComponent(item.type)}/${encodeURIComponent(item.id)}`, {
+      method: 'GET',
+      headers: {
+        authorization: `Bearer ${ciSessionId}`,
+        accept: 'application/vnd.api+json'
+      }
+    });
+
+    if (response.status === 200) {
+      let { data:model } = await response.json();
+      await this._deleteModel(model);
     }
   }
 


### PR DESCRIPTION
Automatically handle 409s on demand, instead of preemptively trying to run teardowns at the start of each suite. Should be both more robust and faster.