### PR TITLE
clarify bearer token api

### DIFF
--- a/packages/authentication/addon/services/cardstack-session.js
+++ b/packages/authentication/addon/services/cardstack-session.js
@@ -38,6 +38,10 @@ export default Service.extend({
         return this.get('store').peekRecord(singularize(rawSession.data.type), rawSession.data.id);
       }
     }
-  })
+  }),
+
+  token: computed('_rawSession', function() {
+    return this.get('_rawSession.data.meta.token');
+  }),
 
 });

--- a/packages/data/addon/services/cardstack-data.js
+++ b/packages/data/addon/services/cardstack-data.js
@@ -18,7 +18,7 @@ function getType(record) {
 
 export default Service.extend({
   store: inject(),
-  session: injectOptional.service(),
+  cardstackSession: injectOptional.service(),
 
   init() {
     this._super();
@@ -144,15 +144,11 @@ export default Service.extend({
     let headers = {
       'Content-Type': 'application/vnd.api+json',
     };
-    let token = this._sessionToken();
+    let token = this.get('cardstackSession.token');
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
     }
     return headers;
-  },
-
-  _sessionToken() {
-    return this.get('session.data.authenticated.data.meta.token');
   },
 
   _errorsByField(body) {

--- a/packages/models/addon/adapter.js
+++ b/packages/models/addon/adapter.js
@@ -84,14 +84,9 @@ export default DS.JSONAPIAdapter.extend(AdapterMixin, {
 
   ajaxOptions() {
     let hash = this._super(...arguments);
-
-    if (this.get('cardstackSession')) {
-      // @cardstack/authentication is available. If it has a valid
-      // session, apply the token to our request
-
+    let token = this.get('cardstackSession.token');
+    if (token) {
       let { beforeSend } = hash;
-      let token = this.get('session.data.authenticated.data.meta.token');
-
       hash.beforeSend = (xhr) => {
         xhr.setRequestHeader('Authorization', `Bearer ${token}`);
         if (beforeSend) {


### PR DESCRIPTION
Anyone who needs the current session's bearer token should go through cardstackSession service (not the underlying ember-simple-auth session service).

This change also fixes the frequent source of "ignoring invalid token" log spew, because we were incorrectly setting an Authorization header even when the token was undefined sometimes.