### PR TITLE
size the placeholder image appropriately

### DIFF
--- a/packages/image/addon/styles/addon.css
+++ b/packages/image/addon/styles/addon.css
@@ -4,6 +4,7 @@
   background-image: url(/@cardstack/image/placeholder.png);
   background-repeat: no-repeat;
   background-position: center;
+  background-size: contain;
 }
 
 .cardstack-image-editor {


### PR DESCRIPTION
my OCD started kicking in

Before:
<img width="570" alt="screen shot 2019-03-08 at 11 22 43 am" src="https://user-images.githubusercontent.com/61075/54041015-a7f00100-4194-11e9-9926-3ef67db8cfe0.png">

After:
<img width="569" alt="screen shot 2019-03-08 at 11 22 48 am" src="https://user-images.githubusercontent.com/61075/54041028-af170f00-4194-11e9-9e37-6e0bd4eb6ec9.png">
