### PR TITLE
Pass branch query param through adapterOptions to the adapter

### DIFF
--- a/packages/data/addon/services/cardstack-data.js
+++ b/packages/data/addon/services/cardstack-data.js
@@ -31,7 +31,7 @@ export default Service.extend({
     let branch = opts.branch || defaultBranch;
     let contentType = await this._getContentType(type);
     let fieldset = contentType.get(`fieldsets.${format}`);
-    let _opts = Object.assign({ branch }, opts);
+    let _opts = Object.assign({ adapterOptions: { branch } }, opts);
 
     if (!fieldset) {
       return await store.findRecord(singularize(type), id, _opts);
@@ -50,9 +50,9 @@ export default Service.extend({
     let store = this.get('store');
     let branch = opts.branch || defaultBranch;
     let type = opts.type || 'cardstack-card';
-    let _opts = Object.assign({ branch, modelName: type }, opts);
+    let _opts = Object.assign({ modelName: type }, opts);
 
-    let result = await store.query(type, _opts);
+    let result = await store.query(type, _opts, { adapterOptions: { branch }});
 
     let recordLoadPromises = [];
     for (let record of result.toArray()) {
@@ -237,7 +237,7 @@ export default Service.extend({
     // we need to specify `reload` in order to allow the included resources to be added to the store.
     // otherwise, if the primary resource is already in the store, ember data is skipping adding the
     // included resources into the store.
-    this._loadedRecordsCache[cacheKey] = store.findRecord(type, id, { include, reload: true, branch });
+    this._loadedRecordsCache[cacheKey] = store.findRecord(type, id, { include, reload: true, adapterOptions: { branch } });
 
     return await this._loadedRecordsCache[cacheKey];
   }

--- a/packages/models/addon/adapter.js
+++ b/packages/models/addon/adapter.js
@@ -40,9 +40,12 @@ export default DS.JSONAPIAdapter.extend(AdapterMixin, {
   buildURL(modelName, id, snapshot, requestType, query) {
     let actualModelName = snapshot && snapshot.modelName || query && query.modelName;
     let url = this._super(actualModelName || modelName, id, snapshot, requestType, query);
+    let branchFromSnapshot = snapshot && get(snapshot, 'adapterOptions.branch');
+    let branchFromQuery = query && get(query, 'adapterOptions.branch');
+    let branch = branchFromSnapshot || branchFromQuery;
 
-    if(snapshot && snapshot.adapterOptions && snapshot.adapterOptions.branch) {
-      url += `?branch=${snapshot.adapterOptions.branch}`;
+    if (branch) {
+      url += `?branch=${branch}`;
     }
 
     return url;


### PR DESCRIPTION
Closes https://github.com/cardstack/dotbc/issues/426

Paired with https://github.com/cardstack/dotbc/pull/444

In order for the adapter to consistently receive the branch query param, we should be passing it 
through `adapterOptions`.  (see [DS.Store docs](https://emberjs.com/api/ember-data/3.8/classes/DS.Store/methods/query?anchor=query)). This PR does that for `store.query` and `store.findRecord` in the cardstack-data service.

This is a quick fix until we improve the way branches are handled