### PR TITLE
Fixes #690 set URL to document`s path after it is saved

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -74,6 +74,7 @@
               "CARDSTACK_SESSIONS_KEY":"OQUQi8NH0asrYgeoE10ijOFBhd/P1BU8HZP/rNqO5nw=",
               "PGSEARCH_NAMESPACE":"cardstack_data_development",
               "INITIAL_DATA_DIR":"${workspaceFolder}/packages/tools/tests/dummy/cardstack",
+              "HUB_ENVIRONMENT":"test",
               "PORT":"3000"
           },
           "args": [

--- a/packages/models/addon/serializer.js
+++ b/packages/models/addon/serializer.js
@@ -13,6 +13,24 @@ export default DS.JSONAPISerializer.extend(SerializerMixin, {
     return this._super.apply(this, arguments);
   },
 
+  _normalizeSave(store, primaryModelClass, payload) {
+    let selfLink;
+    if ((selfLink = get(payload, 'data.links.self'))) {
+      payload.data.attributes = payload.data.attributes || {};
+      payload.data.attributes['self-link'] = selfLink;
+    }
+  },
+
+  normalizeCreateRecordResponse (store, primaryModelClass, payload) {
+    this._normalizeSave(store, primaryModelClass, payload);
+    return this._super.apply(this, arguments);
+  },
+
+  normalizeSaveResponse (store, primaryModelClass, payload) {
+    this._normalizeSave(store, primaryModelClass, payload);
+    return this._super.apply(this, arguments);
+  },
+
   serialize() {
     let json = this._super(...arguments);
     if (get(json, 'data.attributes')) {

--- a/packages/models/addon/serializer.js
+++ b/packages/models/addon/serializer.js
@@ -13,21 +13,12 @@ export default DS.JSONAPISerializer.extend(SerializerMixin, {
     return this._super.apply(this, arguments);
   },
 
-  _normalizeSave(store, primaryModelClass, payload) {
+  normalizeCreateRecordResponse(store, primaryModelClass, payload) {
     let selfLink;
     if ((selfLink = get(payload, 'data.links.self'))) {
       payload.data.attributes = payload.data.attributes || {};
       payload.data.attributes['self-link'] = selfLink;
     }
-  },
-
-  normalizeCreateRecordResponse(store, primaryModelClass, payload) {
-    this._normalizeSave(store, primaryModelClass, payload);
-    return this._super.apply(this, arguments);
-  },
-
-  normalizeUpdateRecordResponse(store, primaryModelClass, payload) {
-    this._normalizeSave(store, primaryModelClass, payload);
     return this._super.apply(this, arguments);
   },
 

--- a/packages/models/addon/serializer.js
+++ b/packages/models/addon/serializer.js
@@ -21,12 +21,12 @@ export default DS.JSONAPISerializer.extend(SerializerMixin, {
     }
   },
 
-  normalizeCreateRecordResponse (store, primaryModelClass, payload) {
+  normalizeCreateRecordResponse(store, primaryModelClass, payload) {
     this._normalizeSave(store, primaryModelClass, payload);
     return this._super.apply(this, arguments);
   },
 
-  normalizeSaveResponse (store, primaryModelClass, payload) {
+  normalizeUpdateRecordResponse(store, primaryModelClass, payload) {
     this._normalizeSave(store, primaryModelClass, payload);
     return this._super.apply(this, arguments);
   },

--- a/packages/tools/addon/components/cs-active-composition-panel.js
+++ b/packages/tools/addon/components/cs-active-composition-panel.js
@@ -4,6 +4,7 @@ import { task, timeout } from 'ember-concurrency';
 import scrollToBounds from '../scroll-to-bounds';
 import { inject as service } from '@ember/service';
 import { camelize } from '@ember/string';
+import { urlForModel } from '@cardstack/routing/helpers/cardstack-url';
 
 export default Component.extend({
   layout,
@@ -13,6 +14,7 @@ export default Component.extend({
   permissions: null,
 
   data: service('cardstack-data'),
+  router: service(),
 
   didReceiveAttrs() {
     this._super(...arguments);
@@ -66,6 +68,12 @@ export default Component.extend({
       scrollToBounds(field.bounds());
     }
   }).restartable(),
+
+  afterModelSaved(model, branch) {
+    let location = this.get('router.location');
+    let url = urlForModel(this, model, { branch });
+    location.setURL(url);
+  },
 
   actions: {
     validate() {

--- a/packages/tools/addon/components/cs-active-composition-panel.js
+++ b/packages/tools/addon/components/cs-active-composition-panel.js
@@ -15,6 +15,7 @@ export default Component.extend({
 
   data: service('cardstack-data'),
   router: service(),
+  cardstackRouting: service(), // this is used in the `urlForModel` helper (since it has no container)
 
   didReceiveAttrs() {
     this._super(...arguments);

--- a/packages/tools/addon/components/cs-version-control.js
+++ b/packages/tools/addon/components/cs-version-control.js
@@ -152,11 +152,17 @@ export default Component.extend({
 
   update: task(function * () {
     let model = this.get('model');
+    let afterModelSaved = this.get('afterModelSaved');
     let errors = yield this.get('data').validate(model);
     if (Object.keys(errors).length > 0) {
       return this['on-error'](errors);
     }
     yield model.save();
+
+    if (typeof afterModelSaved === 'function') {
+      let branch = this.get('modelMeta').branch || defaultBranch;
+      afterModelSaved(model, branch);
+    }
   }).keepLatest(),
 
   cancel: task(function * () {

--- a/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
+++ b/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
@@ -1,5 +1,6 @@
 {{cs-composition-panel-header
   model=model
+  afterModelSaved=(action afterModelSaved)
   editingEnabled=editingEnabled
 }}
 

--- a/packages/tools/addon/templates/components/cs-composition-panel-header.hbs
+++ b/packages/tools/addon/templates/components/cs-composition-panel-header.hbs
@@ -20,5 +20,6 @@
 {{cs-version-control
   model=model
   enabled=editingEnabled
+  afterModelSaved=afterModelSaved
   on-error=(action (mut validationErrors))
 }}


### PR DESCRIPTION
This handles the situation where after a new document is saved, the URL is set to the canonical URL for the newly saved document. This also handles the situation where the URL for a document is updated if one of the document's fields that effect the URL (like a `slug` field) is changed.