### PR TITLE
699 header section for fields

### DIFF
--- a/packages/tools/addon/components/cs-field-editor.js
+++ b/packages/tools/addon/components/cs-field-editor.js
@@ -5,6 +5,7 @@ import layout from '../templates/components/cs-field-editor';
 export default Component.extend({
   layout,
   classNames: ['cs-field-editor'],
+  attributeBindings: ['field:data-test-cs-field-editor'],
 
   // @args
   content: null,
@@ -19,7 +20,7 @@ export default Component.extend({
     this._super(...arguments);
     if (!this.permissions) {
       let permissions = await this.fetchPermissions();
-      // this.set('permissions', permissions); //TODO figure out why this throws...
+      this.set('permissions', permissions);
     }
   },
 

--- a/packages/tools/addon/components/cs-field-editor.js
+++ b/packages/tools/addon/components/cs-field-editor.js
@@ -19,7 +19,7 @@ export default Component.extend({
     this._super(...arguments);
     if (!this.permissions) {
       let permissions = await this.fetchPermissions();
-      this.set('permissions', permissions);
+      // this.set('permissions', permissions); //TODO figure out why this throws...
     }
   },
 

--- a/packages/tools/addon/services/cardstack-tools.js
+++ b/packages/tools/addon/services/cardstack-tools.js
@@ -11,6 +11,7 @@ import injectOptional from 'ember-inject-optional';
 import { defaultBranch } from '@cardstack/plugin-utils/environment';
 import { guidFor } from '@ember/object/internals';
 import { get, set } from '@ember/object';
+import { sortBy } from 'lodash';
 
 export default Service.extend({
   overlays: service('ember-overlays'),
@@ -27,6 +28,22 @@ export default Service.extend({
       let { grouped, name } = fieldMark.model;
       return fieldNames.concat(grouped ? grouped : name);
     }, []);
+  }),
+
+  headerSectionFields: computed('activeContentItem.model', function() {
+    let model = this.get('activeContentItem.model');
+    if (!model) { return []; }
+
+    let fields = [];
+    model.eachAttribute((attribute, meta) => {
+      if (meta.name !== 'selfLink' && get(meta, 'options.editorOptions.headerSection')) {
+        let fieldInfo = meta;
+        set(fieldInfo, 'id', guidFor(fieldInfo));
+        set(fieldInfo, 'model', model);
+        fields.push(fieldInfo);
+      }
+    });
+    return sortBy(fields, ['options.editorOptions.sortOrder']);
   }),
 
   modelFields: computed('_renderedFieldNames', 'activeContentItem.model', function() {

--- a/packages/tools/addon/styles/cardstack-right-edge.css
+++ b/packages/tools/addon/styles/cardstack-right-edge.css
@@ -13,6 +13,10 @@
 
 .cardstack-right-edge {
   --right-edge-width: 22rem;
+  display: flex;
+  align-content: flex-start;
+  flex-wrap: wrap;
+  flex-direction: column;
 
   position: relative;
   width: var(--right-edge-width);

--- a/packages/tools/addon/styles/cs-active-composition-panel.css
+++ b/packages/tools/addon/styles/cs-active-composition-panel.css
@@ -1,25 +1,42 @@
 .cs-active-composition-panel {
-    --tools-panel-height: 34rem;
-
     box-sizing: border-box;
     width: 100%;
-    height: var(--tools-panel-height);
     background-color: var(--normal-background);
     color: var(--bright-foreground);
     border: 1px solid var(--light05);
     border-radius: 20px;
     box-shadow: 0 2px 15px 0 var(--dark50);
+    margin-bottom: 65px;
+
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: column;
+    flex-grow: 2;
+}
+.cs-active-composition-panel--flex-slot {
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: column;
+    flex-grow: 1;
+}
+.cs-active-composition-panel--scroll-wrapper {
+    flex-grow: 1;
+    width: 100%;
+    overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right :0;
 }
 
-.cs-active-composition-panel--main.header-expanded {
-  --tools-scrollable-panel-height: 17rem;
-}
-.cs-active-composition-panel--main.header-collapsed {
-  --tools-scrollable-panel-height: 23rem;
-}
-.cs-active-composition-panel--main {
-    height: var(--tools-scrollable-panel-height);
-    overflow-y: scroll;
+.cs-active-composition-panel--main:after {
+    content: ' ';
+    display: block;
+    width: 100%;
+    height: 20px;
 }
 
 .cs-content-info {
@@ -69,7 +86,7 @@
 }
 
 .cs-toolbox-section:last-of-type {
-    border-bottom: 1px solid var(--light25);
+    border-bottom: none;
 }
 
 .cs-toolbox-section.opened {

--- a/packages/tools/addon/styles/cs-branch-control.css
+++ b/packages/tools/addon/styles/cs-branch-control.css
@@ -1,5 +1,6 @@
 .cs-branch-control {
   margin-bottom: 22px;
+  width: 100%;
 }
 
 .cs-branch-control .ember-power-select-trigger {

--- a/packages/tools/addon/styles/cs-composition-panel-header.css
+++ b/packages/tools/addon/styles/cs-composition-panel-header.css
@@ -1,5 +1,6 @@
 .cs-composition-panel-header {
     position: relative;
+    width: 100%;
     padding: 1em;
     color: var(--bright-foreground);
     border-top-left-radius: 20px;

--- a/packages/tools/addon/styles/cs-editor-switch.css
+++ b/packages/tools/addon/styles/cs-editor-switch.css
@@ -1,6 +1,7 @@
 .cs-editor-switch {
     position: absolute;
     right: 15px;
+    top: 80px;
     margin: -2px -2px 0 0;
     padding: 0;
     width: 50px;

--- a/packages/tools/addon/styles/cs-field-editor.css
+++ b/packages/tools/addon/styles/cs-field-editor.css
@@ -2,6 +2,10 @@
     padding-bottom: 0.5rem;
 }
 
+.cs-field-editor-section--title {
+    font-size: .75rem;
+}
+
 .cs-field-editor input,
 .cs-field-editor select,
 .cs-field-editor button {

--- a/packages/tools/addon/styles/cs-version-control.css
+++ b/packages/tools/addon/styles/cs-version-control.css
@@ -1,3 +1,25 @@
+.cs-version-control-header-fields .cs-field-editor-section {
+    padding: 0;
+}
+
+.cs-version-control-header-fields .cs-field-editor {
+    padding-bottom: 0;
+}
+
+.cs-version-control-header-fields--top-fields {
+    margin-top: .5rem;
+}
+
+.cs-version-control-header-fields .cs-field-editor > .field-editor > input[type="number"] {
+    width: 100%;
+}
+
+.cs-version-control-header-fields .cs-field-editor > .field-editor > input {
+    margin-bottom: .5rem;
+    padding-left: .5rem;
+    padding-right: .5rem;
+}
+
 .cs-version-control-dropdown {
     position: relative;
     display: flex;

--- a/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
+++ b/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
@@ -1,100 +1,104 @@
 {{cs-composition-panel-header
   model=model
+  headerSectionFields=headerSectionFields
   afterModelSaved=(action afterModelSaved)
   editingEnabled=editingEnabled
 }}
 
-{{!- this one scrolls }}
-<div class="cs-active-composition-panel--main {{if editingEnabled "header-expanded" "header-collapsed"}}">
-  {{#each renderedFields key="id" as |fieldMark|}}
-    {{! template-lint-disable attribute-indentation }}
-    {{#let
-      fieldMark.model
-      (eq fieldMark.model.content model)
-      (cs-field-editor-options-for fieldMark.model.content fieldMark.model.name)
-    as |fieldModel isPageModelField editorOptions|}}
-      {{#unless editorOptions.hideFromEditor}}
-        {{#cs-collapsible-section
-          class=(concat "cs-toolbox-section " (cs-error-class validationErrors fieldModel "invalid"))
-          title=(cs-card-meta-caption fieldModel.content fieldModel.caption isPageModelField)
-          opened=(eq fieldMark.id openedFieldId)
-          open=(action openField fieldMark)
-          close=(action openField null)
-          hovered=(perform highlightAndScrollToField fieldMark)
-          unhovered=(perform highlightAndScrollToField null)
-          data-test-field-name=fieldModel.name
-        }}
-          <div class="cs-field-editor-section">
-            {{#let
-              fieldModel.content
-              (get permissions (cs-uid fieldModel.content))
-            as |content fieldModelPermissions|}}
-              {{#if fieldModel.grouped}}
-                {{#each fieldModel.grouped as |fieldName|}}
-                  <label class="cs-field-editor-section--label">
-                    {{cs-field-caption content fieldName}}
-                  </label>
-                  {{cs-field-editor
-                    content=content
-                    field=fieldName
-                    editorOptions=editorOptions
-                    enabled=editingEnabled
-                    permissions=fieldModelPermissions
-                    onchange=(action "validate")
-                    errors=(get validationErrors fieldName)
-                  }}
-                {{/each}}
-              {{else}}
+<div class="cs-active-composition-panel--flex-slot">
+  <div class="cs-active-composition-panel--scroll-wrapper">
+    <div class="cs-active-composition-panel--main {{if editingEnabled "header-expanded" "header-collapsed"}}">
+      {{#each renderedFields key="id" as |fieldMark|}}
+        {{! template-lint-disable attribute-indentation }}
+        {{#let
+          fieldMark.model
+          (eq fieldMark.model.content model)
+          (cs-field-editor-options-for fieldMark.model.content fieldMark.model.name)
+        as |fieldModel isPageModelField editorOptions|}}
+          {{#unless (or editorOptions.hideFromEditor editorOptions.headerSection)}}
+            {{#cs-collapsible-section
+              class=(concat "cs-toolbox-section " (cs-error-class validationErrors fieldModel "invalid"))
+              title=(cs-card-meta-caption fieldModel.content fieldModel.caption isPageModelField)
+              opened=(eq fieldMark.id openedFieldId)
+              open=(action openField fieldMark)
+              close=(action openField null)
+              hovered=(perform highlightAndScrollToField fieldMark)
+              unhovered=(perform highlightAndScrollToField null)
+              data-test-field-name=fieldModel.name
+            }}
+              <div class="cs-field-editor-section">
+                {{#let
+                  fieldModel.content
+                  (get permissions (cs-uid fieldModel.content))
+                as |content fieldModelPermissions|}}
+                  {{#if fieldModel.grouped}}
+                    {{#each fieldModel.grouped as |fieldName|}}
+                      <label class="cs-field-editor-section--label">
+                        {{cs-field-caption content fieldName}}
+                      </label>
+                      {{cs-field-editor
+                        content=content
+                        field=fieldName
+                        editorOptions=editorOptions
+                        enabled=editingEnabled
+                        permissions=fieldModelPermissions
+                        onchange=(action "validate")
+                        errors=(get validationErrors fieldName)
+                      }}
+                    {{/each}}
+                  {{else}}
+                    {{cs-field-editor
+                      content=content
+                      field=fieldModel.name
+                      editorOptions=editorOptions
+                      enabled=editingEnabled
+                      permissions=fieldModelPermissions
+                      onchange=(action "validate")
+                      errors=(get validationErrors fieldModel.name)
+                    }}
+                  {{/if}}
+                {{/let}}
+              </div>
+            {{/cs-collapsible-section}}
+          {{/unless}}
+        {{/let}}
+      {{/each}}
+
+      {{!--
+        These are the fields that exist on the model (or in owned relationships)
+        but are not rendered
+      --}}
+      {{#each modelFields as |field|}}
+        {{#let
+          (get permissions (cs-uid field.model))
+          (eq field.model model)
+          (cs-field-editor-options-for field.model field.name)
+        as |fieldModelPermissions isPageModelField editorOptions|}}
+          {{#unless (or editorOptions.hideFromEditor editorOptions.headerSection)}}
+            {{#cs-collapsible-section
+              class=(concat "cs-toolbox-section " (cs-error-class validationErrors field.model "invalid"))
+              title=(cs-card-meta-caption field.model field.options.caption isPageModelField)
+              opened=(eq field.id openedFieldId)
+              open=(action openField field)
+              close=(action openField null)
+              data-test-field-name=field.name
+            }}
+              <div class="cs-field-editor-section">
                 {{cs-field-editor
-                  content=content
-                  field=fieldModel.name
+                  content=field.model
+                  field=field.name
                   editorOptions=editorOptions
                   enabled=editingEnabled
                   permissions=fieldModelPermissions
+                  fetchPermissions=(perform fetchPermissionsFor field.model)
                   onchange=(action "validate")
-                  errors=(get validationErrors fieldModel.name)
+                  errors=(get validationErrors field.name)
                 }}
-              {{/if}}
-            {{/let}}
-          </div>
-        {{/cs-collapsible-section}}
-      {{/unless}}
-    {{/let}}
-  {{/each}}
-
-  {{!--
-     These are the fields that exist on the model (or in owned relationships)
-     but are not rendered
-  --}}
-  {{#each modelFields as |field|}}
-    {{#let
-      (get permissions (cs-uid field.model))
-      (eq field.model model)
-      (cs-field-editor-options-for field.model field.name)
-    as |fieldModelPermissions isPageModelField editorOptions|}}
-      {{#unless editorOptions.hideFromEditor}}
-        {{#cs-collapsible-section
-          class=(concat "cs-toolbox-section " (cs-error-class validationErrors field.model "invalid"))
-          title=(cs-card-meta-caption field.model field.options.caption isPageModelField)
-          opened=(eq field.id openedFieldId)
-          open=(action openField field)
-          close=(action openField null)
-          data-test-field-name=field.name
-        }}
-          <div class="cs-field-editor-section">
-            {{cs-field-editor
-              content=field.model
-              field=field.name
-              editorOptions=editorOptions
-              enabled=editingEnabled
-              permissions=fieldModelPermissions
-              fetchPermissions=(perform fetchPermissionsFor field.model)
-              onchange=(action "validate")
-              errors=(get validationErrors field.name)
-            }}
-          </div>
-        {{/cs-collapsible-section}}
-      {{/unless}}
-    {{/let}}
-  {{/each}}
+              </div>
+            {{/cs-collapsible-section}}
+          {{/unless}}
+        {{/let}}
+      {{/each}}
+    </div>
+  </div>
 </div>

--- a/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
+++ b/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
@@ -1,104 +1,108 @@
-{{cs-composition-panel-header
-  model=model
-  headerSectionFields=headerSectionFields
-  afterModelSaved=(action afterModelSaved)
-  editingEnabled=editingEnabled
-}}
+{{#if (or (not model.id) permissions)}}
+  {{cs-composition-panel-header
+    model=model
+    permissions=permissions
+    headerSectionFields=headerSectionFields
+    afterModelSaved=(action afterModelSaved)
+    editingEnabled=editingEnabled
+  }}
 
-<div class="cs-active-composition-panel--flex-slot">
-  <div class="cs-active-composition-panel--scroll-wrapper">
-    <div class="cs-active-composition-panel--main {{if editingEnabled "header-expanded" "header-collapsed"}}">
-      {{#each renderedFields key="id" as |fieldMark|}}
-        {{! template-lint-disable attribute-indentation }}
-        {{#let
-          fieldMark.model
-          (eq fieldMark.model.content model)
-          (cs-field-editor-options-for fieldMark.model.content fieldMark.model.name)
-        as |fieldModel isPageModelField editorOptions|}}
-          {{#unless (or editorOptions.hideFromEditor editorOptions.headerSection)}}
-            {{#cs-collapsible-section
-              class=(concat "cs-toolbox-section " (cs-error-class validationErrors fieldModel "invalid"))
-              title=(cs-card-meta-caption fieldModel.content fieldModel.caption isPageModelField)
-              opened=(eq fieldMark.id openedFieldId)
-              open=(action openField fieldMark)
-              close=(action openField null)
-              hovered=(perform highlightAndScrollToField fieldMark)
-              unhovered=(perform highlightAndScrollToField null)
-              data-test-field-name=fieldModel.name
-            }}
-              <div class="cs-field-editor-section">
-                {{#let
-                  fieldModel.content
-                  (get permissions (cs-uid fieldModel.content))
-                as |content fieldModelPermissions|}}
-                  {{#if fieldModel.grouped}}
-                    {{#each fieldModel.grouped as |fieldName|}}
-                      <label class="cs-field-editor-section--label">
-                        {{cs-field-caption content fieldName}}
-                      </label>
+  <div class="cs-active-composition-panel--flex-slot">
+    <div class="cs-active-composition-panel--scroll-wrapper">
+      <div class="cs-active-composition-panel--main {{if editingEnabled "header-expanded" "header-collapsed"}}">
+        {{#each renderedFields key="id" as |fieldMark|}}
+          {{! template-lint-disable attribute-indentation }}
+          {{#let
+            fieldMark.model
+            (eq fieldMark.model.content model)
+            (cs-field-editor-options-for fieldMark.model.content fieldMark.model.name)
+          as |fieldModel isPageModelField editorOptions|}}
+            {{#unless (or editorOptions.hideFromEditor editorOptions.headerSection)}}
+              {{#cs-collapsible-section
+                class=(concat "cs-toolbox-section " (cs-error-class validationErrors fieldModel "invalid"))
+                title=(cs-card-meta-caption fieldModel.content fieldModel.caption isPageModelField)
+                opened=(eq fieldMark.id openedFieldId)
+                open=(action openField fieldMark)
+                close=(action openField null)
+                hovered=(perform highlightAndScrollToField fieldMark)
+                unhovered=(perform highlightAndScrollToField null)
+                data-test-field-name=fieldModel.name
+              }}
+                <div class="cs-field-editor-section">
+                  {{#let
+                    fieldModel.content
+                    (get permissions (cs-uid fieldModel.content))
+                  as |content fieldModelPermissions|}}
+                    {{#if fieldModel.grouped}}
+                      {{#each fieldModel.grouped as |fieldName|}}
+                        <label class="cs-field-editor-section--label">
+                          {{cs-field-caption content fieldName}}
+                        </label>
+                        {{cs-field-editor
+                          content=content
+                          field=fieldName
+                          editorOptions=editorOptions
+                          enabled=editingEnabled
+                          permissions=fieldModelPermissions
+                          onchange=(action "validate")
+                          errors=(get validationErrors fieldName)
+                        }}
+                      {{/each}}
+                    {{else}}
                       {{cs-field-editor
                         content=content
-                        field=fieldName
+                        field=fieldModel.name
                         editorOptions=editorOptions
                         enabled=editingEnabled
                         permissions=fieldModelPermissions
                         onchange=(action "validate")
-                        errors=(get validationErrors fieldName)
+                        errors=(get validationErrors fieldModel.name)
                       }}
-                    {{/each}}
-                  {{else}}
-                    {{cs-field-editor
-                      content=content
-                      field=fieldModel.name
-                      editorOptions=editorOptions
-                      enabled=editingEnabled
-                      permissions=fieldModelPermissions
-                      onchange=(action "validate")
-                      errors=(get validationErrors fieldModel.name)
-                    }}
-                  {{/if}}
-                {{/let}}
-              </div>
-            {{/cs-collapsible-section}}
-          {{/unless}}
-        {{/let}}
-      {{/each}}
+                    {{/if}}
+                  {{/let}}
+                </div>
+              {{/cs-collapsible-section}}
+            {{/unless}}
+          {{/let}}
+        {{/each}}
 
-      {{!--
-        These are the fields that exist on the model (or in owned relationships)
-        but are not rendered
-      --}}
-      {{#each modelFields as |field|}}
-        {{#let
-          (get permissions (cs-uid field.model))
-          (eq field.model model)
-          (cs-field-editor-options-for field.model field.name)
-        as |fieldModelPermissions isPageModelField editorOptions|}}
-          {{#unless (or editorOptions.hideFromEditor editorOptions.headerSection)}}
-            {{#cs-collapsible-section
-              class=(concat "cs-toolbox-section " (cs-error-class validationErrors field.model "invalid"))
-              title=(cs-card-meta-caption field.model field.options.caption isPageModelField)
-              opened=(eq field.id openedFieldId)
-              open=(action openField field)
-              close=(action openField null)
-              data-test-field-name=field.name
-            }}
-              <div class="cs-field-editor-section">
-                {{cs-field-editor
-                  content=field.model
-                  field=field.name
-                  editorOptions=editorOptions
-                  enabled=editingEnabled
-                  permissions=fieldModelPermissions
-                  fetchPermissions=(perform fetchPermissionsFor field.model)
-                  onchange=(action "validate")
-                  errors=(get validationErrors field.name)
-                }}
-              </div>
-            {{/cs-collapsible-section}}
-          {{/unless}}
-        {{/let}}
-      {{/each}}
+        {{!--
+          These are the fields that exist on the model (or in owned relationships)
+          but are not rendered
+        --}}
+        {{#each modelFields as |field|}}
+          {{#let
+            (get permissions (cs-uid field.model))
+            (eq field.model model)
+            (cs-field-editor-options-for field.model field.name)
+          as |fieldModelPermissions isPageModelField editorOptions|}}
+            {{#unless (or editorOptions.hideFromEditor editorOptions.headerSection)}}
+              {{#cs-collapsible-section
+                class=(concat "cs-toolbox-section " (cs-error-class validationErrors field.model "invalid"))
+                title=(cs-card-meta-caption field.model field.options.caption isPageModelField)
+                opened=(eq field.id openedFieldId)
+                open=(action openField field)
+                close=(action openField null)
+                data-test-field-name=field.name
+              }}
+                <div class="cs-field-editor-section">
+                  {{cs-field-editor
+                    content=field.model
+                    field=field.name
+                    editorOptions=editorOptions
+                    enabled=editingEnabled
+                    permissions=fieldModelPermissions
+                    onchange=(action "validate")
+                    errors=(get validationErrors field.name)
+                  }}
+                </div>
+              {{/cs-collapsible-section}}
+            {{/unless}}
+          {{/let}}
+        {{/each}}
+      </div>
     </div>
   </div>
-</div>
+{{else}}
+  {{!-- TODO show a busy indicator while we load the permissions --}}
+{{/if}}

--- a/packages/tools/addon/templates/components/cs-composition-panel-header.hbs
+++ b/packages/tools/addon/templates/components/cs-composition-panel-header.hbs
@@ -20,6 +20,7 @@
 {{cs-version-control
   model=model
   enabled=editingEnabled
+  headerSectionFields=headerSectionFields
   afterModelSaved=afterModelSaved
   on-error=(action (mut validationErrors))
 }}

--- a/packages/tools/addon/templates/components/cs-composition-panel-header.hbs
+++ b/packages/tools/addon/templates/components/cs-composition-panel-header.hbs
@@ -19,6 +19,7 @@
 
 {{cs-version-control
   model=model
+  permissions=permissions
   enabled=editingEnabled
   headerSectionFields=headerSectionFields
   afterModelSaved=afterModelSaved

--- a/packages/tools/addon/templates/components/cs-composition-panel.hbs
+++ b/packages/tools/addon/templates/components/cs-composition-panel.hbs
@@ -7,6 +7,7 @@
   {{else}}
     {{cs-active-composition-panel
       model=tools.activeContentItem.model
+      headerSectionFields=tools.headerSectionFields
       renderedFields=tools.activeFields
       modelFields=tools.modelFields
       openedFieldId=tools.openedFieldId

--- a/packages/tools/addon/templates/components/cs-version-control.hbs
+++ b/packages/tools/addon/templates/components/cs-version-control.hbs
@@ -12,50 +12,105 @@
   </button>
 </div>
 
-{{#liquid-if
-  enabled
-  rules=animationRules
-  growDuration=250
-  growPixelsPerSecond=1
-}}
-  <div class="cs-version-control-footer">
-    <div class="cs-version-control-footer--button-area">
-      {{#if update.isRunning}}
-        <span
-          class="cs-version-control--loading"
-          aria-label="Loading"
-          data-test-cs-version-control-loading
-        ></span>
-      {{/if}}
+<div class="cs-version-control-header-fields">
+  <div class="cs-version-control-header-fields--top-fields">
+    {{#each fieldsAboveFooter key="id" as |field|}}
+      {{#let
+        (get permissions (cs-uid field.model))
+        (eq field.model model)
+        (cs-field-editor-options-for field.model field.name)
+      as |fieldModelPermissions isPageModelField editorOptions|}}
+        <div class="cs-field-editor-section">
+          <div class="cs-field-editor-section--title">
+            {{cs-card-meta-caption field.model field.options.caption isPageModelField}}
+          </div>
+          {{cs-field-editor
+            content=field.model
+            field=field.name
+            editorOptions=editorOptions
+            enabled=editingEnabled
+            permissions=fieldModelPermissions
+            fetchPermissions=(perform fetchPermissionsFor field.model)
+            onchange=(action "validate")
+            errors=(get validationErrors field.name)
+          }}
+        </div>
+      {{/let}}
+    {{/each}}
+  </div>
+
+  {{#liquid-if
+    enabled
+    rules=animationRules
+    growDuration=250
+    growPixelsPerSecond=1
+  }}
+    <div class="cs-version-control-footer">
+      <div class="cs-version-control-footer--button-area">
+        {{#if update.isRunning}}
+          <span
+            class="cs-version-control--loading"
+            aria-label="Loading"
+            data-test-cs-version-control-loading
+          ></span>
+        {{/if}}
+
+        <button
+          class="cs-version-control--button cs-version-control--button-save {{if disabled "disabled" "enabled"}}"
+          disabled={{disabled}}
+          {{action (perform update)}}
+          data-test-cs-version-control-button-save="{{disabled}}"
+        >
+          Save
+        </button>
+        <button
+          class="cs-version-control--button cs-version-control--button-cancel"
+          {{action (perform cancel)}}
+          data-test-cs-version-control-button-cancel
+        >
+          Cancel
+        </button>
+      </div>
+      {{#with (concat modelType "-action-buttons") as |buttonsComponent|}}
+        {{#if (is-component buttonsComponent)}}
+          {{component buttonsComponent model=model modificationState=modificationState}}
+        {{/if}}
+      {{/with}}
 
       <button
-        class="cs-version-control--button cs-version-control--button-save {{if disabled "disabled" "enabled"}}"
-        disabled={{disabled}}
-        {{action (perform update)}}
-        data-test-cs-version-control-button-save="{{disabled}}"
+        class="cs-version-control--delete-button"
+        {{action (perform delete)}}
+        data-test-cs-version-control-delete-button
       >
-        Save
-      </button>
-      <button
-        class="cs-version-control--button cs-version-control--button-cancel"
-        {{action (perform cancel)}}
-        data-test-cs-version-control-button-cancel
-      >
-        Cancel
+        Delete
       </button>
     </div>
-    {{#with (concat modelType "-action-buttons") as |buttonsComponent|}}
-      {{#if (is-component buttonsComponent)}}
-        {{component buttonsComponent model=model modificationState=modificationState}}
-      {{/if}}
-    {{/with}}
+  {{/liquid-if}}
 
-    <button
-      class="cs-version-control--delete-button"
-      {{action (perform delete)}}
-      data-test-cs-version-control-delete-button
-    >
-      Delete
-    </button>
+  <div class="cs-version-control-header-fields--bottom-fields">
+    {{#each fieldsBelowFooter key="id" as |field|}}
+      {{#let
+        (get permissions (cs-uid field.model))
+        (eq field.model model)
+        (cs-field-editor-options-for field.model field.name)
+      as |fieldModelPermissions isPageModelField editorOptions|}}
+        <div class="cs-field-editor-section">
+          <div class="cs-field-editor-section--title">
+            {{cs-card-meta-caption field.model field.options.caption isPageModelField}}
+          </div>
+          {{cs-field-editor
+            content=field.model
+            field=field.name
+            editorOptions=editorOptions
+            enabled=editingEnabled
+            permissions=fieldModelPermissions
+            fetchPermissions=(perform fetchPermissionsFor field.model)
+            onchange=(action "validate")
+            errors=(get validationErrors field.name)
+          }}
+        </div>
+      {{/let}}
+    {{/each}}
+
   </div>
-{{/liquid-if}}
+</div>

--- a/packages/tools/addon/templates/components/cs-version-control.hbs
+++ b/packages/tools/addon/templates/components/cs-version-control.hbs
@@ -21,16 +21,17 @@
         (cs-field-editor-options-for field.model field.name)
       as |fieldModelPermissions isPageModelField editorOptions|}}
         <div class="cs-field-editor-section">
-          <div class="cs-field-editor-section--title">
-            {{cs-card-meta-caption field.model field.options.caption isPageModelField}}
-          </div>
+          {{#unless editorOptions.hideTitle}}
+            <div class="cs-field-editor-section--title">
+              {{cs-card-meta-caption field.model field.options.caption isPageModelField}}
+            </div>
+          {{/unless}}
           {{cs-field-editor
             content=field.model
             field=field.name
             editorOptions=editorOptions
-            enabled=editingEnabled
+            enabled=enabled
             permissions=fieldModelPermissions
-            fetchPermissions=(perform fetchPermissionsFor field.model)
             onchange=(action "validate")
             errors=(get validationErrors field.name)
           }}
@@ -95,16 +96,17 @@
         (cs-field-editor-options-for field.model field.name)
       as |fieldModelPermissions isPageModelField editorOptions|}}
         <div class="cs-field-editor-section">
-          <div class="cs-field-editor-section--title">
-            {{cs-card-meta-caption field.model field.options.caption isPageModelField}}
-          </div>
+          {{#unless editorOptions.hideTitle}}
+            <div class="cs-field-editor-section--title">
+              {{cs-card-meta-caption field.model field.options.caption isPageModelField}}
+            </div>
+          {{/unless}}
           {{cs-field-editor
             content=field.model
             field=field.name
             editorOptions=editorOptions
-            enabled=editingEnabled
+            enabled=enabled
             permissions=fieldModelPermissions
-            fetchPermissions=(perform fetchPermissionsFor field.model)
             onchange=(action "validate")
             errors=(get validationErrors field.name)
           }}

--- a/packages/tools/tests/acceptance/tools-test.js
+++ b/packages/tools/tests/acceptance/tools-test.js
@@ -57,7 +57,7 @@ module('Acceptance | tools', function(hooks) {
     await visit('/hub/posts/1');
     await login();
     await click('.cardstack-tools-launcher');
-    await waitFor('.cs-active-composition-panel');
+    await waitFor('.cs-active-composition-panel--main');
 
     let element = findTriggerElementWithLabel.call(this, /Title/);
     await click(element);
@@ -79,6 +79,7 @@ module('Acceptance | tools', function(hooks) {
     await visit('/hub/posts/1');
     await login();
     await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
 
     assert.dom('[data-test=reading-time]').containsText('8 minutes');
     assert.dom('[data-test=karma-0]').containsText('10 Good');
@@ -89,6 +90,7 @@ module('Acceptance | tools', function(hooks) {
     await visit('/hub/posts/1');
     await login();
     await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
 
     let element = findTriggerElementWithLabel.call(this, /Title/);
     await click(element);
@@ -112,6 +114,7 @@ module('Acceptance | tools', function(hooks) {
     await visit('/hub/posts/1');
     await login();
     await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
 
     let archivedSection = findTriggerElementWithLabel.call(this, /Archived/);
     assert.ok(archivedSection, "Unrendered field appears in editor");
@@ -120,18 +123,60 @@ module('Acceptance | tools', function(hooks) {
     assert.equal(titleSections.length, 1, "Rendered fields only appear once");
   });
 
-  test('it shows fields in the header section', async function(assert) {
+  test('it shows fields in the header section before the save button when sort order is less than 100', async function(assert) {
     await visit('/hub/posts/1');
     await login();
     await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
 
-    debugger;
+    assert.dom('.cs-version-control-header-fields--top-fields [data-test-cs-field-editor="keywords"]').exists();
+    assert.dom('.cs-version-control-header-fields--top-fields [data-test-cs-field-editor="rating"]').exists();
+    assert.dom('.cs-version-control-header-fields--top-fields [data-test-cs-field-editor="createdAt"]').doesNotExist();
+  });
+
+  test('it shows fields in the header section after the save button when sort order is greater than 100', async function(assert) {
+    await visit('/hub/posts/1');
+    await login();
+    await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
+
+    assert.dom('.cs-version-control-header-fields--bottom-fields [data-test-cs-field-editor="keywords"]').doesNotExist();
+    assert.dom('.cs-version-control-header-fields--bottom-fields [data-test-cs-field-editor="rating"]').doesNotExist();
+    assert.dom('.cs-version-control-header-fields--bottom-fields [data-test-cs-field-editor="createdAt"]').exists();
+  });
+
+  test('it can hide the title of fields in the header section', async function(assert) {
+    await visit('/hub/posts/1');
+    await login();
+    await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
+
+    let ratingSection = document.querySelector('[data-test-cs-field-editor="rating"]').closest('.cs-field-editor-section');
+    assert.notOk(ratingSection.querySelector('.cs-field-editor-section--title'));
+    let keywordsSection = document.querySelector('[data-test-cs-field-editor="keywords"]').closest('.cs-field-editor-section');
+    assert.ok(keywordsSection.querySelector('.cs-field-editor-section--title'));
+  });
+
+  test('fields shown in the header section are not shown in the non-header section (main section)', async function(assert) {
+    await visit('/hub/posts/1');
+    await login();
+    await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
+
+    let ratingFields = document.querySelectorAll('[data-test-cs-field-editor="rating"]');
+    let keywordsFields = document.querySelectorAll('[data-test-cs-field-editor="keywords"]');
+    let createdAtFields = document.querySelectorAll('[data-test-cs-field-editor="createdAt"]');
+
+    assert.equal(ratingFields.length, 1);
+    assert.equal(keywordsFields.length, 1);
+    assert.equal(createdAtFields.length, 1);
   });
 
   test('it does not collapse sections for right edge input fields that are not rendered in the template when you type in the field', async function(assert) {
     await visit('/hub/posts/1');
     await login();
     await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
 
     let slugLabel = findTriggerElementWithLabel.call(this, /Slug/);
     await click(slugLabel);
@@ -148,6 +193,7 @@ module('Acceptance | tools', function(hooks) {
     await visit('/hub/posts/1');
     await login();
     await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
 
     assert.ok(findTriggerElementWithLabel.call(this, /Comment #1: Review Status/));
     assert.ok(findTriggerElementWithLabel.call(this, /Comment #2: Review Status/));
@@ -158,6 +204,7 @@ module('Acceptance | tools', function(hooks) {
     await visit('/hub/posts/1');
     await login();
     await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
 
     assert.ok(findTriggerElementWithLabel.call(this, /Comment #1: Body/));
     assert.ok(findTriggerElementWithLabel.call(this, /Comment #1: Karma/));
@@ -169,6 +216,7 @@ module('Acceptance | tools', function(hooks) {
     await visit('/hub/posts/1');
     await login();
     await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
 
     let authorNameSectionTrigger = findTriggerElementWithLabel.call(this, /Author Name/);
     await click(authorNameSectionTrigger);
@@ -181,6 +229,7 @@ module('Acceptance | tools', function(hooks) {
     await visit('/hub/posts/1');
     await login();
     await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
     await waitFor('.cs-editor-switch')
     await click('.cs-editor-switch');
 
@@ -201,6 +250,7 @@ module('Acceptance | tools', function(hooks) {
     await visit('/hub/posts/1');
     await login();
     await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
     await waitFor('.cs-editor-switch')
     await click('.cs-editor-switch');
 
@@ -221,6 +271,7 @@ module('Acceptance | tools', function(hooks) {
     await visit('/hub/posts/1');
     await login();
     await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
     await waitFor('.cs-editor-switch')
     await click('.cs-editor-switch');
 
@@ -238,6 +289,7 @@ module('Acceptance | tools', function(hooks) {
     await visit('/hub/posts/1');
     await login();
     await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
     await waitFor('.cs-editor-switch')
     await click('.cs-editor-switch');
 
@@ -250,6 +302,7 @@ module('Acceptance | tools', function(hooks) {
     await visit('/hub/posts/1');
     await login();
     await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
     await waitFor('.cs-editor-switch')
     await click('.cs-editor-switch');
 
@@ -268,6 +321,7 @@ module('Acceptance | tools', function(hooks) {
     await visit('/hub/posts/1');
     await login();
     await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
     await waitFor('.cs-editor-switch')
     await click('.cs-editor-switch');
 

--- a/packages/tools/tests/acceptance/tools-test.js
+++ b/packages/tools/tests/acceptance/tools-test.js
@@ -120,6 +120,14 @@ module('Acceptance | tools', function(hooks) {
     assert.equal(titleSections.length, 1, "Rendered fields only appear once");
   });
 
+  test('it shows fields in the header section', async function(assert) {
+    await visit('/hub/posts/1');
+    await login();
+    await click('.cardstack-tools-launcher');
+
+    debugger;
+  });
+
   test('it does not collapse sections for right edge input fields that are not rendered in the template when you type in the field', async function(assert) {
     await visit('/hub/posts/1');
     await login();

--- a/packages/tools/tests/dummy/cardstack/seeds/ephemeral.js
+++ b/packages/tools/tests/dummy/cardstack/seeds/ephemeral.js
@@ -130,6 +130,18 @@ function initialModels() {
       initial.addResource('fields', 'title').withAttributes({
         fieldType: '@cardstack/core-types::string'
       }),
+      initial.addResource('fields', 'keywords').withAttributes({
+        editorOptions: { headerSection: true, sortOrder: 10 },
+        fieldType: '@cardstack/core-types::string'
+      }),
+      initial.addResource('fields', 'rating').withAttributes({
+        editorOptions: { headerSection: true, sortOrder: 20 },
+        fieldType: '@cardstack/core-types::integer'
+      }),
+      initial.addResource('fields', 'created-at').withAttributes({
+        editorOptions: { headerSection: true, sortOrder: 101 },
+        fieldType: '@cardstack/core-types::date'
+      }),
       initial.addResource('fields', 'published-at').withAttributes({
         caption: 'Publish Date',
         fieldType: '@cardstack/core-types::date'
@@ -265,6 +277,9 @@ function initialModels() {
     .withAttributes({
       title: '10 steps to becoming a fearsome pirate',
       publishedAt: new Date(2017, 3, 24),
+      createdAt: new Date(2017, 1, 24),
+      keywords: 'pirates, matey, bacardi',
+      rating: 2,
       archived: false,
       readingTimeValue: 8,
       hiddenFieldFromEditor: 'This field is hidden from the editor'
@@ -278,6 +293,9 @@ function initialModels() {
     .withAttributes({
       title: 'second',
       publishedAt: new Date(2017, 9, 20),
+      createdAt: new Date(2017, 1, 24),
+      keywords: 'dos, ni, futatsu',
+      rating: 5,
       archived: true,
       readingTimeValue: 2
     })

--- a/packages/tools/tests/dummy/cardstack/seeds/ephemeral.js
+++ b/packages/tools/tests/dummy/cardstack/seeds/ephemeral.js
@@ -34,7 +34,10 @@ function initialModels() {
       { type: 'content-types', id: 'comments' },
       { type: 'content-types', id: 'karma-types' },
       { type: 'content-types', id: 'posts' },
-      { type: 'content-types', id: 'time-units' }
+      { type: 'content-types', id: 'time-units' },
+      { type: 'content-types', id: 'created-at' },
+      { type: 'content-types', id: 'keywords' },
+      { type: 'content-types', id: 'rating' }
     ])
     .withAttributes({
       'may-create-resource': true,
@@ -135,7 +138,7 @@ function initialModels() {
         fieldType: '@cardstack/core-types::string'
       }),
       initial.addResource('fields', 'rating').withAttributes({
-        editorOptions: { headerSection: true, sortOrder: 20 },
+        editorOptions: { headerSection: true, sortOrder: 20, hideTitle: true },
         fieldType: '@cardstack/core-types::integer'
       }),
       initial.addResource('fields', 'created-at').withAttributes({


### PR DESCRIPTION
Fixes #699 

This adds a "header" section for fields, such that card authors can choose to render important fields in a special section that does not collapse. The the field attribute `editorOptions.headerSection = true` will render a field in the header section. `editorOptions.sortOrder` < 100 will render the field above the Save button.  `editorOptions.sortOrder` >= 100 will render the field below the Save button. 

This update also updates the CSS to allow the field editors to stretch the entire vertical space allowed, with a scrollable section for the fields below the header section.

Also, I've updated the fields to not render until the permissions are loaded.

<img width="770" alt="Screen Shot 2019-03-10 at 8 00 34 PM" src="https://user-images.githubusercontent.com/61075/54098676-e69bdc00-438b-11e9-82a4-43c9b14705f6.png">

