### PR TITLE
Add eslint rule for keyword spacing for Ember code

### DIFF
--- a/packages/authentication/addon/cardstack-authenticator.js
+++ b/packages/authentication/addon/cardstack-authenticator.js
@@ -89,7 +89,7 @@ export default Base.extend({
 
       localStorage.setItem('cardstack-authentication-source', authenticationSource);
 
-      if(response.headers.get("content-type") &&
+      if (response.headers.get("content-type") &&
          response.headers.get("content-type").toLowerCase().indexOf("application/json") >= 0) {
         return response.json()
       } else {

--- a/packages/authentication/node-tests/ip-test.js
+++ b/packages/authentication/node-tests/ip-test.js
@@ -15,7 +15,7 @@ describe('authentication/middleware/ip', function() {
     let factory = new JSONAPIFactory();
 
 
-    if(callback) {
+    if (callback) {
       await callback(factory);
     }
 

--- a/packages/core-types/addon/components/field-editors/dropdown-base-editor.js
+++ b/packages/core-types/addon/components/field-editors/dropdown-base-editor.js
@@ -35,7 +35,7 @@ export default Component.extend({
     let options;
     try {
       options = yield store.findAll(contentType);
-    } catch(e) {
+    } catch (e) {
       set(this, 'missingContentType', true);
     }
 
@@ -57,7 +57,7 @@ export default Component.extend({
 
     let displayFieldName = get(this, 'displayFieldName');
 
-    switch(get(this, 'matchBy')) {
+    switch (get(this, 'matchBy')) {
       case 'exact':
         query.filter[displayFieldName] = { exact: value };
         break;

--- a/packages/eslint-config/browser.js
+++ b/packages/eslint-config/browser.js
@@ -14,7 +14,8 @@ module.exports = {
     es6: true
   },
   rules: {
-    'no-restricted-globals': [2, 'find']
+    'no-restricted-globals': [2, 'find'],
+    'keyword-spacing': [2],
   },
   overrides: [
     // This loads our node rules

--- a/packages/mobiledoc/addon/components/paragraph-options.js
+++ b/packages/mobiledoc/addon/components/paragraph-options.js
@@ -45,7 +45,7 @@ export default Component.extend({
   },
 
   currentIcon: computed('cursor', function () {
-    switch(this.get('_lastActiveSection.tagName')) {
+    switch (this.get('_lastActiveSection.tagName')) {
     case 'blockquote':
       return 'EditorQuote';
     case 'p':

--- a/packages/mock-auth/addon/services/mock-login.js
+++ b/packages/mock-auth/addon/services/mock-login.js
@@ -18,7 +18,7 @@ export default Service.extend({
 
       try {
         yield this.get('session').authenticate('authenticator:cardstack', this.get('source'), { authorizationCode: mockUserId });
-      } catch(err) {
+      } catch (err) {
         message = err.message;
       }
 

--- a/packages/tools/addon/components/cs-version-control.js
+++ b/packages/tools/addon/components/cs-version-control.js
@@ -136,13 +136,13 @@ export default Component.extend({
   }),
 
   title: computed('modificationState', 'upstreamState', function() {
-    switch(this.get('modificationState')) {
+    switch (this.get('modificationState')) {
     case 'new':
       return 'Drafted'
     case 'changed':
       return 'Changed';
     case 'saved':
-      switch(this.get('upstreamState')) {
+      switch (this.get('upstreamState')) {
       case 'pending':
         return '...';
       case 'self':


### PR DESCRIPTION
This is a simple enough addition to the eslint rules that enforces spacing around keywords. e.g.: 

wrong: 
```js
if(status === 'thing') {
  // somestuff
}
```

right: 
```js
if (status === 'thing') {
  // somestuff
}
```