### PR TITLE
Fix module path for cs-field-type

### DIFF
--- a/packages/rendering/app/helpers/cs-field-type.js
+++ b/packages/rendering/app/helpers/cs-field-type.js
@@ -1,1 +1,1 @@
-export { default, fieldType } from '@cardstack/tools/helpers/cs-field-type';
+export { default, fieldType } from '@cardstack/rendering/helpers/cs-field-type';


### PR DESCRIPTION
I don't even understand how this worked as the `@cardstack/tools/helpers/cs-field-type` doesn't exist. Unless, because `rendering` is a dependency of `tools`, the helper path get copied from `rendering` to `tools`, in the app directory of the addon.

At any rate, the fix is definitely needed.