### PR TITLE
pass on options when saving owned relationships

### DIFF
--- a/packages/models/addon/model.js
+++ b/packages/models/addon/model.js
@@ -39,7 +39,7 @@ export default DS.Model.extend(RelationshipTracker, {
     let modelSave = this._super.bind(this);
 
     if (Object.keys(this.ownedRelationships).length > 0) {
-      await this.saveRelated();
+      await this.saveRelated(...arguments);
     }
 
     await modelSave(...arguments);
@@ -51,7 +51,7 @@ export default DS.Model.extend(RelationshipTracker, {
       if (isRelationDirty) {
         let relatedRecords = relatedRecordsFor(this, relationName);
         let dirtyRecords = relatedRecords.filter(record => record.hasDirtyFields);
-        return Promise.all(dirtyRecords.map(record => record.save()));
+        return Promise.all(dirtyRecords.map(record => record.save(...arguments)));
       }
     });
     return Promise.all(flatten(relatedSaves));


### PR DESCRIPTION
Cardstack models save their owned relationships automatically but they don't pass on the options they receive themselves when saving to the `save` calls on the owned relationships. That can result in the parent and owned records to be stored on different branches when the `branch` parameter is passed when the parent's `save` is invoked but not passed on to the `save` invocations of the owned records.

see cardstack/dotbc#509