### PR TITLE
Sort record attributes deterministically before save #692

### DIFF
--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -18,6 +18,7 @@
     "@cardstack/plugin-utils": "0.13.70",
     "delay": "^4.1.0",
     "filenamify-url": "^1.0.0",
+    "json-stable-stringify-without-jsonify": "^1.0.1",
     "mkdirp": "^0.5.1",
     "moment-timezone": "^0.5.11",
     "nodegit": "^0.23.0",

--- a/packages/git/writer.js
+++ b/packages/git/writer.js
@@ -14,6 +14,7 @@ const { promisify } = require('util');
 const temp = require('temp').track();
 const Gitchain = require('@cardstack/gitchain');
 const log = require('@cardstack/logger')('cardstack/git');
+const stringify = require('json-stable-stringify-without-jsonify');
 
 const mkdir = promisify(temp.mkdir);
 
@@ -256,7 +257,9 @@ async function finalizer(pendingChange) {
   return withErrorHandling(id, type, async () => {
     if (file) {
       if (pendingChange.finalDocument) {
-        file.setContent(JSON.stringify({
+        // use stringify library instead of JSON.stringify, since JSON's method
+        // is non-deterministic and could produce unnecessary diffs
+        file.setContent(stringify({
           attributes: pendingChange.finalDocument.attributes,
           relationships: pendingChange.finalDocument.relationships
         }, null, 2));

--- a/yarn.lock
+++ b/yarn.lock
@@ -9514,6 +9514,7 @@ json-schema@0.2.3:
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
 json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR has an effect on previously persisted data.

Before, when you saved a record with the git writer, the resulting stringified JSON could have a meaningless diff, where the attributes drifted around. This is because `JSON.stringify` is not deterministic. This PR uses a library to deterministically sort keys before saving the JSON. This change will result in a major diff the first time past data is modified, but smaller, meaningful diffs afterwards.

We should consider doing a one-time sorting migration for existing apps, depending on the use patterns.

Closes #692