### PR TITLE
Fix sinon fake to return a promise like the method it replaces

### DIFF
--- a/packages/git/node-tests/writer-test.js
+++ b/packages/git/node-tests/writer-test.js
@@ -848,8 +848,8 @@ describe('git/writer/hyperledger', function() {
     await destroyDefaultEnvironment(env);
   });
 
-  it('writes to hyperledger if configured when writing', async function () {
-    let fakePush = fake();
+  it('writes to hyperledger if configured when writing', async function () { let
+  fakePush = fake.returns(new Promise(resolve => resolve()));
 
     replace(gitChain, 'push', fakePush);
 


### PR DESCRIPTION
This was causing an error in tests that whilst not causing the tests to fail,
was annoying.