### PR TITLE
Query based relationships

### DIFF
--- a/packages/core-types/cardstack/field-types/belongs-to.js
+++ b/packages/core-types/cardstack/field-types/belongs-to.js
@@ -1,12 +1,12 @@
 module.exports = {
   valid(value, { relatedTypes }) {
-    if (!value.hasOwnProperty('data')) {
-      return 'has no "data" property';
+    if (!value.hasOwnProperty('data') && !value.hasOwnProperty('links')) {
+      return 'requires either a "data" or "links" property';
     }
-    if (Array.isArray(value.data)) {
+    if (value.data && Array.isArray(value.data)) {
       return 'accepts only a single resource, not a list of resources';
     }
-    if (relatedTypes && value.data && !relatedTypes[value.data.type] ) {
+    if (relatedTypes && value.data && !relatedTypes[value.data.type]) {
       return `refers to disallowed type "${value.data.type}"`;
     }
     return true;

--- a/packages/core-types/cardstack/field-types/has-many.js
+++ b/packages/core-types/cardstack/field-types/has-many.js
@@ -1,12 +1,12 @@
 module.exports = {
   valid(value, { relatedTypes }) {
-    if (!value.hasOwnProperty('data')) {
-      return 'has no "data" property';
+    if (!value.hasOwnProperty('data') && !value.hasOwnProperty('links')) {
+      return 'requires either a "data" or "links" property';
     }
-    if (!Array.isArray(value.data)) {
+    if (value.hasOwnProperty('data') && !Array.isArray(value.data)) {
       return 'accepts only a list of resources, not a single resource';
     }
-    if (relatedTypes) {
+    if (relatedTypes && value.data) {
       let disallowed = value.data.filter(ref => !relatedTypes[ref.type]);
       if (disallowed.length > 0) {
         return `refers to disallowed type(s) ${disallowed.map(d => `"${d.type}"`).join(', ')}`;

--- a/packages/hub/indexing/document-context.js
+++ b/packages/hub/indexing/document-context.js
@@ -144,15 +144,6 @@ module.exports = class DocumentContext {
 
     this._references.push(`${key}`);
 
-    // if (get(this, 'upstreamDoc.data.id') === id && get(this, 'upstreamDoc.data.type') === type) {
-    //   return this.upstreamDoc.data;
-    // }
-
-    // let includedResource = this.suppliedIncluded ? this.suppliedIncluded.find(i => key === `${i.type}/${i.id}`) : null;
-    // if (includedResource) {
-    //   return includedResource;
-    // }
-
     let cached = this.cache[key];
     if (cached) {
       log.debug(`document with key ${key} is in cache, fetching...`);

--- a/packages/hub/model.js
+++ b/packages/hub/model.js
@@ -1,11 +1,24 @@
 // This implements the public interface that allows user-provided code
 // (like computed fields) to access models.
-
 const priv = new WeakMap();
+const qs = require('qs');
+const log = require('@cardstack/logger')('cardstack/hub/model');
 
-module.exports = class Model {
-  constructor(contentType, jsonapiDoc, schema, read) {
-    priv.set(this, { contentType, jsonapiDoc, read, schema });
+exports.privateModels = priv;
+
+function isRelationshipObject(obj) {
+  // json:api spec says you're also a valid relationship object if you have
+  // only a "meta" property, but we don't really use that case, so we're not
+  // including it here.
+  return obj && (
+    obj.hasOwnProperty('links') ||
+    obj.hasOwnProperty('data')
+  );
+}
+
+exports.Model = class Model {
+  constructor(contentType, jsonapiDoc, schema, read, search) {
+    priv.set(this, { contentType, jsonapiDoc, schema, read, search });
   }
 
   get id() {
@@ -35,13 +48,15 @@ module.exports = class Model {
     }
     let computedField = contentType.computedFields.get(field.id);
     if (computedField) {
-      return computedField.compute(this);
+      let userValue = await computedField.compute(this);
+      if (field.isRelationship && !isRelationshipObject(userValue)) {
+        log.warn('computed relationship returned not a relationship object');
+        userValue = { data: userValue };
+      }
+      return userValue;
     } else if (field.isRelationship) {
       if (jsonapiDoc.relationships) {
-        let relObj = jsonapiDoc.relationships[field.id];
-        if (relObj) {
-          return relObj.data;
-        }
+        return jsonapiDoc.relationships[field.id];
       }
     } else if (field.id === 'id' || field.id === 'type') {
       return jsonapiDoc[field.id];
@@ -51,16 +66,39 @@ module.exports = class Model {
   }
 
   async getRelated(fieldName) {
-    let refs = await this.getField(fieldName);
-    if (Array.isArray(refs)) {
-      return Promise.all(refs.map(ref => this.getModel(ref.type, ref.id)));
-    } else if (refs) {
-      return this.getModel(refs.type, refs.id);
+    let relObj = await this.getField(fieldName);
+    let { contentType } = priv.get(this);
+    let field = contentType.realAndComputedFields.get(fieldName);
+    let isCollection = field.fieldType === '@cardstack/core-types::has-many';
+
+    if (relObj && relObj.hasOwnProperty('links') && relObj.links.related) {
+      let models = await this.getModels(qs.parse(relObj.links.related.split('/api?')[1]));
+      if (isCollection) {
+        return models;
+      } else {
+        return models[0];
+      }
     }
+
+    if (relObj && relObj.data) {
+      let refs = relObj.data;
+      if (Array.isArray(refs)) {
+        return (await Promise.all(refs.map(ref => this.getModel(ref.type, ref.id)))).filter(Boolean);
+      } else {
+        return this.getModel(refs.type, refs.id);
+      }
+    }
+
+    if (isCollection) {
+      return [];
+    } else {
+      return null;
+    }
+
   }
 
   async getModel(type, id) {
-    let { schema, read, jsonapiDoc } = priv.get(this);
+    let { schema, read, search, jsonapiDoc } = priv.get(this);
     let contentType = schema.types.get(type);
     if (!contentType) {
       throw new Error(`${jsonapiDoc.type} ${jsonapiDoc.id} tried to getModel nonexistent type ${type} `);
@@ -68,7 +106,15 @@ module.exports = class Model {
     let model = await read(type, id);
     if (!model) { return; }
 
-    return new Model(contentType, model, schema, read);
+    return new Model(contentType, model, schema, read, search);
   }
 
+  async getModels(query) {
+    let { schema, search, read } = priv.get(this);
+
+    let models = await search(query);
+    if (!models) { return; }
+
+    return models.data.map(model => new Model(schema.types.get(model.type), model, schema, read, search));
+  }
 };

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -42,6 +42,7 @@
     "lodash": "^4.17.11",
     "nssocket": "^0.6.0",
     "path-is-inside": "^1.0.2",
+    "qs": "^6.6.0",
     "quick-temp": "^0.1.8",
     "resolve": "^1.3.3",
     "superagent": "^3.8.1",

--- a/packages/test-support/addon/jsonapi-factory.js
+++ b/packages/test-support/addon/jsonapi-factory.js
@@ -31,11 +31,15 @@ export default class JSONAPIFactory {
       let dependsOn = [];
       if (model.relationships) {
         Object.keys(model.relationships).forEach(rel => {
-          let data = model.relationships[rel].data;
-          if (Array.isArray(data)) {
-            dependsOn = dependsOn.concat(data.map(ref => `${ref.type}/${ref.id}`));
-          } else {
-            dependsOn.push(`${data.type}/${data.id}`);
+          let { data/*, links*/ } = model.relationships[rel];
+
+
+          if (data) {
+            if (Array.isArray(data)) {
+              dependsOn = dependsOn.concat(data.map(ref => `${ref.type}/${ref.id}`));
+            } else {
+              dependsOn.push(`${data.type}/${data.id}`);
+            }
           }
         });
       }
@@ -89,15 +93,28 @@ class ResourceFactory {
       throw new Error(`No value for ${fieldName}`);
     }
     if (!this.data.relationships) {
-        this.data.relationships = {};
+      this.data.relationships = {};
     }
     let data;
     if (Array.isArray(value)) {
-      data = value.map(entry => ({ type: entry.type, id: entry.id}));
+      data = value.map(entry => ({ type: entry.type, id: entry.id }));
     } else {
-      data ={ type: value.type, id: value.id};
+      data = { type: value.type, id: value.id };
     }
     this.data.relationships[dasherize(fieldName)] = { data };
+    return this;
+  }
+  withRelatedLink(fieldName, link) {
+    if (!link) {
+      throw new Error(`No link for ${fieldName}`);
+    }
+    if (typeof link !== 'string') {
+      throw new Error(`Link must be a string: link is ${JSON.stringify(link, null, 2)}`);
+    }
+    if (!this.data.relationships) {
+      this.data.relationships = {};
+    }
+    this.data.relationships[dasherize(fieldName)] = { links: { related: link } };
     return this;
   }
   asDocument() {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -78,6 +78,7 @@
     "eslint-plugin-mocha": "^5.2.0",
     "eslint-plugin-node": "^7.0.1",
     "loader.js": "^4.7.0",
+    "qs": "^6.6.0",
     "qunit-dom": "^0.8.0",
     "squishable-container": "^0.1.0"
   },

--- a/packages/tools/tests/acceptance/tools-test.js
+++ b/packages/tools/tests/acceptance/tools-test.js
@@ -335,6 +335,46 @@ module('Acceptance | tools', function(hooks) {
     assert.dom('.field-editor > input').isNotDisabled();
   });
 
+  test('adding new record updates the query-based relationship', async function(assert) {
+    await visit('/hub/catalogs/1');
+
+    assert.dom('.popular-posts .post-embedded').exists({ count: 1 });
+    assert.dom('.popular-posts .post-embedded:nth-of-type(1)').hasText('Second Post');
+    assert.dom('.top-post .post-embedded').exists({ count: 1 });
+    assert.dom('.top-post .post-embedded').hasText('Second Post');
+
+    await login();
+    await click('.cardstack-tools-launcher');
+    await waitFor('.cs-active-composition-panel--main');
+    await waitFor('.cs-editor-switch')
+    await click('.cs-editor-switch');
+
+    await click('.cs-create-button');
+
+    let newPostButton = findAddNewButtonWithLabel.call(this, /Posts/);
+    await click(newPostButton);
+
+    let titleSectionTrigger = findTriggerElementWithLabel.call(this, /Title/);
+    await click(titleSectionTrigger);
+
+    let titleSection = titleSectionTrigger.closest('section');
+    let titleInput = titleSection.querySelector('input');
+    await fillIn(titleInput, 'Adventures in Pirating');
+
+    let ratingInput = document.querySelector('[data-test-cs-field-editor="rating"] input');
+    await fillIn(ratingInput, 5);
+
+    await click('[data-test-cs-version-control-button-save="false"]');
+    await waitFor('[data-test-cs-version-control-button-save="true"]');
+    await visit('/hub/catalogs/1');
+
+    assert.dom('.popular-posts .post-embedded').exists({ count: 2 });
+    assert.dom('.popular-posts .post-embedded:nth-of-type(1)').hasText('Adventures in Pirating');
+    assert.dom('.popular-posts .post-embedded:nth-of-type(2)').hasText('Second Post');
+    assert.dom('.top-post .post-embedded').exists({ count: 1 });
+    assert.dom('.top-post .post-embedded').hasText('Adventures in Pirating');
+  });
+
   test('saving a new document changes the URL to the canonical path of the saved document', async function(assert) {
     await visit('/hub/posts/1');
     await login();

--- a/packages/tools/tests/dummy/app/templates/components/cardstack/catalog-isolated.hbs
+++ b/packages/tools/tests/dummy/app/templates/components/cardstack/catalog-isolated.hbs
@@ -1,0 +1,15 @@
+<div class="catalog-page">
+  <h1>
+    {{cs-field content "title"}}
+  </h1>
+  <h2>Popular Posts</h2>
+  <ul class="popular-posts">
+    {{#each content.popularPosts as |post i|}}
+      {{cardstack-content content=post format="embedded"}}
+    {{/each}}
+  </ul>
+  <h2>Top-rated Post</h2>
+  <div class="top-post">
+    {{cardstack-content content=content.topPost format="embedded"}}
+  </div>
+</div>

--- a/tests/sample-computed-fields/computed-field-types/same-color-foods.js
+++ b/tests/sample-computed-fields/computed-field-types/same-color-foods.js
@@ -1,0 +1,16 @@
+exports.type = '@cardstack/core-types::has-many';
+
+exports.compute = async function(model) {
+  let color = await model.getField('color');
+  let groceryList = await model.getRelated('grocery-list');
+  if (!groceryList) { return []; }
+
+  let sameColor = [];
+  for (let otherModel of groceryList) {
+    let otherColor = await otherModel.getField('color');
+    if (otherColor === color && otherModel.id !== model.id) {
+      sameColor.push({ type: otherModel.type, id: otherModel.id });
+    }
+  }
+  return sameColor.sort((a, b) => (a.id > b.id) ? 1 : -1);
+};


### PR DESCRIPTION
This is the "first pass" at implementing query-based relationships. It allows you to have query based relationships in seed data, using the `withRelatedLink` factory function.

Example:
```javascript
// create the schema
factory.addResource('content-types', 'boards')
  .withAttributes({
    defaultIncludes: [
      'published-articles'
    ],
    fieldsets: {
      isolated: [
        { field: 'published-articles', format: 'embedded' },
      ],
    }
  })
  .withRelated('fields', [
    { type: 'fields', id: 'title'},
    factory.addResource('fields', 'published-articles').withAttributes({
      fieldType: '@cardstack/core-types::has-many'
    })
  ]);

factory.addResource('content-types', 'articles')
  .withAttributes({
    ...
  }) // etc.

// add the query relationship
factory.addResource('boards', 'community').withAttributes({
  title: 'Community'
}).withRelatedLink('published-articles', `/api?${qs.stringify({
  filter: {
    type: { exact: 'articles' }
  },
  sort: '-published-date'
})}`);
```

which, in our index, will create a `board` that looks something like:
```javascript
{
  "data": {
    "id": "community",
    "type": "boards",
    "attributes": {
      "title": "Community"
    },
    "relationships": {
      "published-articles": {
        "data": [],
        "links": {
          "related": "/api?filter%5Btype%5D%5Bexact%5D=articles&sort=-published-date"
        }
      }
    }
  }
}
```

When you `GET` the `board` via API, the `relationships.published-articles.data` will be populated with `articles` based on the query.