### PR TITLE
Refactor searchers get

### DIFF
--- a/packages/authentication/cardstack/middleware.js
+++ b/packages/authentication/cardstack/middleware.js
@@ -36,7 +36,7 @@ class Authentication {
   get userSearcher() {
     return {
       get: (type, userId) => {
-        return this.searcher.getCard(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, type, userId);
+        return this.searcher.getCard(Session.INTERNAL_PRIVILEGED, type, userId, { version: this.controllingBranch.name });
       },
       search: (params) => {
         return this.searcher.searchForCard(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, params);
@@ -166,7 +166,7 @@ class Authentication {
     let config, ip;
 
     try {
-       config = await this.searcher.getCurrentCard(Session.INTERNAL_PRIVILEGED, 'plugin-configs', '@cardstack/authentication');
+       config = await this.searcher.getCard(Session.INTERNAL_PRIVILEGED, 'plugin-configs', '@cardstack/authentication');
     } catch (e) {
       // no config for the authentication plugin, assume header should not be respected
     }

--- a/packages/authentication/cardstack/middleware.js
+++ b/packages/authentication/cardstack/middleware.js
@@ -36,7 +36,7 @@ class Authentication {
   get userSearcher() {
     return {
       get: (type, userId) => {
-        return this.searcher.get(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, type, userId);
+        return this.searcher.getCard(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, type, userId);
       },
       search: (params) => {
         return this.searcher.search(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, params);
@@ -166,7 +166,7 @@ class Authentication {
     let config, ip;
 
     try {
-       config = await this.searcher.getFromControllingBranch(Session.INTERNAL_PRIVILEGED, 'plugin-configs', '@cardstack/authentication');
+       config = await this.searcher.getCurrentCard(Session.INTERNAL_PRIVILEGED, 'plugin-configs', '@cardstack/authentication');
     } catch (e) {
       // no config for the authentication plugin, assume header should not be respected
     }

--- a/packages/authentication/cardstack/middleware.js
+++ b/packages/authentication/cardstack/middleware.js
@@ -39,7 +39,7 @@ class Authentication {
         return this.searcher.getCard(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, type, userId);
       },
       search: (params) => {
-        return this.searcher.search(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, params);
+        return this.searcher.searchForCard(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, params);
       }
     };
   }

--- a/packages/authentication/cardstack/middleware.js
+++ b/packages/authentication/cardstack/middleware.js
@@ -36,7 +36,7 @@ class Authentication {
   get userSearcher() {
     return {
       get: (type, userId) => {
-        return this.searcher.get(Session.INTERNAL_PRIVILEGED, type, userId);
+        return this.searcher.get(Session.INTERNAL_PRIVILEGED, 'local-hub', type, userId);
       },
       search: (params) => {
         return this.searcher.search(Session.INTERNAL_PRIVILEGED, params);
@@ -166,7 +166,7 @@ class Authentication {
     let config, ip;
 
     try {
-       config = await this.searcher.get(Session.INTERNAL_PRIVILEGED, 'plugin-configs', '@cardstack/authentication');
+       config = await this.searcher.get(Session.INTERNAL_PRIVILEGED, 'local-hub', 'plugin-configs', '@cardstack/authentication');
     } catch (e) {
       // no config for the authentication plugin, assume header should not be respected
     }

--- a/packages/authentication/cardstack/middleware.js
+++ b/packages/authentication/cardstack/middleware.js
@@ -36,10 +36,10 @@ class Authentication {
   get userSearcher() {
     return {
       get: (type, userId) => {
-        return this.searcher.getCard(Session.INTERNAL_PRIVILEGED, type, userId, { version: this.controllingBranch.name });
+        return this.searcher.get(Session.INTERNAL_PRIVILEGED, type, userId);
       },
       search: (params) => {
-        return this.searcher.searchForCard(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, params);
+        return this.searcher.search(Session.INTERNAL_PRIVILEGED, params);
       }
     };
   }
@@ -166,7 +166,7 @@ class Authentication {
     let config, ip;
 
     try {
-       config = await this.searcher.getCard(Session.INTERNAL_PRIVILEGED, 'plugin-configs', '@cardstack/authentication');
+       config = await this.searcher.get(Session.INTERNAL_PRIVILEGED, 'plugin-configs', '@cardstack/authentication');
     } catch (e) {
       // no config for the authentication plugin, assume header should not be respected
     }

--- a/packages/authentication/node-tests/authentication-test.js
+++ b/packages/authentication/node-tests/authentication-test.js
@@ -522,7 +522,7 @@ describe('authentication/middleware', function() {
 
       it('can return updated user info when getting token status', async function() {
         let { token } = await auth.createToken({ id: quint.id, type: 'test-users' }, 30);
-        let { data:updatedQuint } = await env.lookup('hub:searchers').get(env.session, 'test-users', quint.id);
+        let { data:updatedQuint } = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'test-users', quint.id);
         updatedQuint.attributes.email = 'updated@example.com';
 
         await env.lookup('hub:writers').update('master', env.session, 'test-users', quint.id, { data: updatedQuint });

--- a/packages/authentication/node-tests/authentication-test.js
+++ b/packages/authentication/node-tests/authentication-test.js
@@ -522,7 +522,7 @@ describe('authentication/middleware', function() {
 
       it('can return updated user info when getting token status', async function() {
         let { token } = await auth.createToken({ id: quint.id, type: 'test-users' }, 30);
-        let { data:updatedQuint } = await env.lookup('hub:searchers').getCard(env.session, 'master', 'test-users', quint.id);
+        let { data:updatedQuint } = await env.lookup('hub:searchers').getCard(env.session, 'test-users', quint.id);
         updatedQuint.attributes.email = 'updated@example.com';
 
         await env.lookup('hub:writers').update('master', env.session, 'test-users', quint.id, { data: updatedQuint });

--- a/packages/authentication/node-tests/authentication-test.js
+++ b/packages/authentication/node-tests/authentication-test.js
@@ -522,7 +522,7 @@ describe('authentication/middleware', function() {
 
       it('can return updated user info when getting token status', async function() {
         let { token } = await auth.createToken({ id: quint.id, type: 'test-users' }, 30);
-        let { data:updatedQuint } = await env.lookup('hub:searchers').get(env.session, 'master', 'test-users', quint.id);
+        let { data:updatedQuint } = await env.lookup('hub:searchers').getCard(env.session, 'master', 'test-users', quint.id);
         updatedQuint.attributes.email = 'updated@example.com';
 
         await env.lookup('hub:writers').update('master', env.session, 'test-users', quint.id, { data: updatedQuint });

--- a/packages/authentication/node-tests/authentication-test.js
+++ b/packages/authentication/node-tests/authentication-test.js
@@ -522,7 +522,7 @@ describe('authentication/middleware', function() {
 
       it('can return updated user info when getting token status', async function() {
         let { token } = await auth.createToken({ id: quint.id, type: 'test-users' }, 30);
-        let { data:updatedQuint } = await env.lookup('hub:searchers').getCard(env.session, 'test-users', quint.id);
+        let { data:updatedQuint } = await env.lookup('hub:searchers').get(env.session, 'test-users', quint.id);
         updatedQuint.attributes.email = 'updated@example.com';
 
         await env.lookup('hub:writers').update('master', env.session, 'test-users', quint.id, { data: updatedQuint });

--- a/packages/ethereum/cardstack/transaction-indexer.js
+++ b/packages/ethereum/cardstack/transaction-indexer.js
@@ -274,6 +274,7 @@ class TransactionIndexer {
     let batch = this.pgsearchClient.beginBatch(this.schema, this.searchers);
     for (let address of addresses) {
       let document = await this.searchers.get(Session.INTERNAL_PRIVILEGED,
+        'local-hub',
         'ethereum-addresses',
         address,
         ['transactions.from-address', 'transactions.to-address']);
@@ -313,7 +314,7 @@ class TransactionIndexer {
 
     let addressResource;
     try {
-      addressResource = await this.searchers.get(Session.INTERNAL_PRIVILEGED, 'ethereum-addresses', address.toLowerCase());
+      addressResource = await this.searchers.get(Session.INTERNAL_PRIVILEGED, 'local-hub', 'ethereum-addresses', address.toLowerCase());
     } catch (err) {
       if (err.status !== 404) { throw err; }
     }

--- a/packages/ethereum/cardstack/transaction-indexer.js
+++ b/packages/ethereum/cardstack/transaction-indexer.js
@@ -273,7 +273,7 @@ class TransactionIndexer {
 
     let batch = this.pgsearchClient.beginBatch(this.schema, this.searchers);
     for (let address of addresses) {
-      let document = await this.searchers.getFromControllingBranch(Session.INTERNAL_PRIVILEGED,
+      let document = await this.searchers.getCurrentCard(Session.INTERNAL_PRIVILEGED,
         'ethereum-addresses',
         address,
         ['transactions.from-address', 'transactions.to-address']);
@@ -313,7 +313,7 @@ class TransactionIndexer {
 
     let addressResource;
     try {
-      addressResource = await this.searchers.getFromControllingBranch(Session.INTERNAL_PRIVILEGED, 'ethereum-addresses', address.toLowerCase());
+      addressResource = await this.searchers.getCurrentCard(Session.INTERNAL_PRIVILEGED, 'ethereum-addresses', address.toLowerCase());
     } catch (err) {
       if (err.status !== 404) { throw err; }
     }

--- a/packages/ethereum/cardstack/transaction-indexer.js
+++ b/packages/ethereum/cardstack/transaction-indexer.js
@@ -95,7 +95,7 @@ class TransactionIndexer {
       page: { size }
     };
 
-    let { data:results } = await this.searchers.searchFromControllingBranch(Session.INTERNAL_PRIVILEGED, addressQuery);
+    let { data:results } = await this.searchers.searchForCurrentCard(Session.INTERNAL_PRIVILEGED, addressQuery);
     if (results.length === size) {
       throw new Error(`There are more tracked-ethereum-addresses than the system is configured to return (${size} addresses). Increase the max number of tracked addresses in 'params.addressIndexing.maxAddressesTracked' for data source configuration'.`);
     }
@@ -108,7 +108,7 @@ class TransactionIndexer {
 
   async _getIndexedAddresses() {
     let size = get(this, 'addressIndexing.maxAddressesTracked') || DEFAULT_MAX_ADDRESSES_TRACKED;
-    let { data: indexedAddresses } = await this.searchers.searchFromControllingBranch(Session.INTERNAL_PRIVILEGED, {
+    let { data: indexedAddresses } = await this.searchers.searchForCurrentCard(Session.INTERNAL_PRIVILEGED, {
       filter: { type: { exact: 'ethereum-addresses' } },
       page: { size }
     });
@@ -235,7 +235,7 @@ class TransactionIndexer {
 
     batch = this.pgsearchClient.beginBatch(this.schema, this.searchers);
     for (let address of trackedAddresses) {
-      let { data:newTransactions } = await this.searchers.searchFromControllingBranch(Session.INTERNAL_PRIVILEGED, {
+      let { data:newTransactions } = await this.searchers.searchForCurrentCard(Session.INTERNAL_PRIVILEGED, {
         filter: {
           or: [{
             type: { exact: 'ethereum-transactions' },

--- a/packages/ethereum/cardstack/transaction-indexer.js
+++ b/packages/ethereum/cardstack/transaction-indexer.js
@@ -95,7 +95,7 @@ class TransactionIndexer {
       page: { size }
     };
 
-    let { data:results } = await this.searchers.searchForCurrentCard(Session.INTERNAL_PRIVILEGED, addressQuery);
+    let { data:results } = await this.searchers.search(Session.INTERNAL_PRIVILEGED, addressQuery);
     if (results.length === size) {
       throw new Error(`There are more tracked-ethereum-addresses than the system is configured to return (${size} addresses). Increase the max number of tracked addresses in 'params.addressIndexing.maxAddressesTracked' for data source configuration'.`);
     }
@@ -108,7 +108,7 @@ class TransactionIndexer {
 
   async _getIndexedAddresses() {
     let size = get(this, 'addressIndexing.maxAddressesTracked') || DEFAULT_MAX_ADDRESSES_TRACKED;
-    let { data: indexedAddresses } = await this.searchers.searchForCurrentCard(Session.INTERNAL_PRIVILEGED, {
+    let { data: indexedAddresses } = await this.searchers.search(Session.INTERNAL_PRIVILEGED, {
       filter: { type: { exact: 'ethereum-addresses' } },
       page: { size }
     });
@@ -235,7 +235,7 @@ class TransactionIndexer {
 
     batch = this.pgsearchClient.beginBatch(this.schema, this.searchers);
     for (let address of trackedAddresses) {
-      let { data:newTransactions } = await this.searchers.searchForCurrentCard(Session.INTERNAL_PRIVILEGED, {
+      let { data:newTransactions } = await this.searchers.search(Session.INTERNAL_PRIVILEGED, {
         filter: {
           or: [{
             type: { exact: 'ethereum-transactions' },
@@ -273,7 +273,7 @@ class TransactionIndexer {
 
     let batch = this.pgsearchClient.beginBatch(this.schema, this.searchers);
     for (let address of addresses) {
-      let document = await this.searchers.getCard(Session.INTERNAL_PRIVILEGED,
+      let document = await this.searchers.get(Session.INTERNAL_PRIVILEGED,
         'ethereum-addresses',
         address,
         ['transactions.from-address', 'transactions.to-address']);
@@ -313,7 +313,7 @@ class TransactionIndexer {
 
     let addressResource;
     try {
-      addressResource = await this.searchers.getCard(Session.INTERNAL_PRIVILEGED, 'ethereum-addresses', address.toLowerCase());
+      addressResource = await this.searchers.get(Session.INTERNAL_PRIVILEGED, 'ethereum-addresses', address.toLowerCase());
     } catch (err) {
       if (err.status !== 404) { throw err; }
     }

--- a/packages/ethereum/cardstack/transaction-indexer.js
+++ b/packages/ethereum/cardstack/transaction-indexer.js
@@ -273,7 +273,7 @@ class TransactionIndexer {
 
     let batch = this.pgsearchClient.beginBatch(this.schema, this.searchers);
     for (let address of addresses) {
-      let document = await this.searchers.getCurrentCard(Session.INTERNAL_PRIVILEGED,
+      let document = await this.searchers.getCard(Session.INTERNAL_PRIVILEGED,
         'ethereum-addresses',
         address,
         ['transactions.from-address', 'transactions.to-address']);
@@ -313,7 +313,7 @@ class TransactionIndexer {
 
     let addressResource;
     try {
-      addressResource = await this.searchers.getCurrentCard(Session.INTERNAL_PRIVILEGED, 'ethereum-addresses', address.toLowerCase());
+      addressResource = await this.searchers.getCard(Session.INTERNAL_PRIVILEGED, 'ethereum-addresses', address.toLowerCase());
     } catch (err) {
       if (err.status !== 404) { throw err; }
     }

--- a/packages/ethereum/truffle-tests/addresses-test.js
+++ b/packages/ethereum/truffle-tests/addresses-test.js
@@ -166,7 +166,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let senderBalance = await getBalance(from);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: sender } = await searchers.get(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', from);
 
         expect(sender).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(from));
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
@@ -178,7 +178,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block.number);
         expect(sender).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: transaction } = await searchers.get(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -194,7 +194,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let recipientBalance = await getBalance(to);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: recipient } = await searchers.get(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', to);
 
         expect(recipient).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(to));
         expect(recipient).has.deep.property('attributes.balance', recipientBalance.toString());
@@ -203,7 +203,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipient).has.deep.property('meta.blockHeight', block.number);
         expect(recipient).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: transaction } = await searchers.get(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -224,7 +224,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let block = await getBlock(txn3.blockNumber);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: sender } = await searchers.get(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', from);
         expect(sender.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
           { type: 'ethereum-transactions', id: txn1.hash },
@@ -251,7 +251,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let block = await getBlock(txn3.blockNumber);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: recipient } = await searchers.get(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', to);
         expect(recipient.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: txn1.hash },
           { type: 'ethereum-transactions', id: txn2.hash },
@@ -283,7 +283,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await waitForEthereumEvents(transactionIndexer);
         await createTrackedEthereumAddress(sender);
 
-        let { data: senderDoc } = await searchers.get(env.session, 'ethereum-addresses', sender);
+        let { data: senderDoc } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', sender);
 
         expect(senderDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(sender));
         expect(senderDoc).has.deep.property('attributes.balance', senderBalance.toString());
@@ -297,17 +297,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: transaction1 } = await searchers.get(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction2 } = await searchers.get(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction3 } = await searchers.get(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
@@ -334,7 +334,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await waitForEthereumEvents(transactionIndexer);
         await createTrackedEthereumAddress(recipient);
 
-        let { data: recipientDoc } = await searchers.get(env.session, 'ethereum-addresses', recipient);
+        let { data: recipientDoc } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', recipient);
 
         expect(recipientDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(recipient));
         expect(recipientDoc).has.deep.property('attributes.balance', recipientBalance.toString());
@@ -347,17 +347,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: transaction1 } = await searchers.get(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction2 } = await searchers.get(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction3 } = await searchers.get(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
@@ -384,7 +384,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await waitForEthereumEvents(transactionIndexer);
         await createTrackedEthereumAddress(addressY);
 
-        let { data: recipientDoc } = await searchers.get(env.session, 'ethereum-addresses', addressY);
+        let { data: recipientDoc } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', addressY);
 
         expect(recipientDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(addressY));
         expect(recipientDoc).has.deep.property('attributes.balance', balance.toString());
@@ -398,17 +398,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: transaction1 } = await searchers.get(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: addressY });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: addressX });
 
-        let { data: transaction2 } = await searchers.get(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: addressX });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: addressY });
 
-        let { data: transaction3 } = await searchers.get(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: addressY });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: addressX });
@@ -425,13 +425,13 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let txn = await getTransaction(txnHash);
         await waitForEthereumEvents(transactionIndexer);
 
-        await searchers.get(env.session, 'ethereum-transactions', txn.hash);
+        await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn.hash);
         await env.lookup('hub:writers').delete('master', env.session, version, 'tracked-ethereum-addresses', sender);
         await waitForEthereumEvents(transactionIndexer);
 
         let error = null;
         try {
-          await searchers.get(env.session, 'ethereum-addresses', sender);
+          await searchers.get(env.session, 'local-hub', 'ethereum-addresses', sender);
         } catch (e) {
           error = e;
         }
@@ -489,7 +489,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         // 2 events for update of the 2 addresses
         expect(addressIndexingCount).to.equal(2);
 
-        let { data: sender } = await searchers.get(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', from);
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
         expect(sender.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
@@ -501,7 +501,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block3.number);
         expect(sender).has.deep.property('meta.version', `${block3.number}.0`);
 
-        let { data: recipient } = await searchers.get(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', to);
         expect(recipient).has.deep.property('attributes.balance', recipientBalance.toString());
         expect(recipient.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: txn1.hash },
@@ -512,17 +512,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipient).has.deep.property('meta.blockHeight', block3.number);
         expect(recipient).has.deep.property('meta.version', `${block3.number}.0`);
 
-        let { data: transaction1 } = await searchers.get(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
 
-        let { data: transaction2 } = await searchers.get(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
 
-        let { data: transaction3 } = await searchers.get(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -542,7 +542,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         // 2 events for update of the 2 addresses
         expect(addressIndexingCount).to.equal(4);
 
-        let { data: senderUpdated } = await searchers.get(env.session, 'ethereum-addresses', from);
+        let { data: senderUpdated } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', from);
         expect(senderUpdated).has.deep.property('attributes.balance', senderBalance.toString());
         expect(senderUpdated.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
@@ -555,7 +555,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(senderUpdated).has.deep.property('meta.blockHeight', block4.number);
         expect(senderUpdated).has.deep.property('meta.version', `${block4.number}.0`);
 
-        let { data: recipientUpdated } = await searchers.get(env.session, 'ethereum-addresses', to);
+        let { data: recipientUpdated } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', to);
         expect(recipientUpdated).has.deep.property('attributes.balance', recipientBalance.toString());
         expect(recipientUpdated.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: txn1.hash },
@@ -567,7 +567,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipientUpdated).has.deep.property('meta.blockHeight', block4.number);
         expect(recipientUpdated).has.deep.property('meta.version', `${block4.number}.0`);
 
-        let { data: transaction4 } = await searchers.get(env.session, 'ethereum-transactions', txn4.hash);
+        let { data: transaction4 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn4.hash);
         await assertTxnResourceMatchesEthTxn(transaction4, txn4, block4);
         expect(transaction4.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction4.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -601,7 +601,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
           let error;
           try {
-            await searchers.get(env.session, 'ethereum-addresses', id);
+            await searchers.get(env.session, 'local-hub', 'ethereum-addresses', id);
           } catch (e) {
             error = e;
           }
@@ -611,7 +611,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await env.lookup('hub:indexers').update({ forceRefresh: true });
         await waitForEthereumEvents(transactionIndexer);
 
-        let { data: sender } = await searchers.get(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', from);
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
         expect(sender.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
@@ -623,7 +623,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block3.number);
         expect(sender).has.deep.property('meta.version', `${block3.number}.0`);
 
-        let { data: recipient } = await searchers.get(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', to);
         expect(recipient).has.deep.property('attributes.balance', recipientBalance.toString());
         expect(recipient.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: txn1.hash },
@@ -634,17 +634,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipient).has.deep.property('meta.blockHeight', block3.number);
         expect(recipient).has.deep.property('meta.version', `${block3.number}.0`);
 
-        let { data: transaction1 } = await searchers.get(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
 
-        let { data: transaction2 } = await searchers.get(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
 
-        let { data: transaction3 } = await searchers.get(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -660,7 +660,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let senderBalance = await getBalance(from);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: sender } = await searchers.get(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', from);
 
         expect(sender).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(from));
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
@@ -672,7 +672,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block.number);
         expect(sender).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: transaction } = await searchers.get(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -692,7 +692,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         await createTrackedEthereumAddress(sender);
 
-        let { data: senderDoc } = await searchers.get(env.session, 'ethereum-addresses', sender);
+        let { data: senderDoc } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', sender);
 
         expect(senderDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(sender));
         expect(senderDoc).has.deep.property('attributes.balance', senderBalance.toString());
@@ -704,7 +704,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn.hash }
         ]);
 
-        let { data: transaction } = await searchers.get(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
@@ -716,7 +716,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         await createTrackedEthereumAddress(trackedAddress);
 
-        let { data: addressDoc } = await searchers.get(env.session, 'ethereum-addresses', trackedAddress);
+        let { data: addressDoc } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', trackedAddress);
 
         expect(addressDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(trackedAddress));
         expect(addressDoc).has.deep.property('attributes.balance', '0');
@@ -749,7 +749,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         await waitForEthereumEvents(transactionIndexer);
 
-        let { data: senderDoc } = await searchers.get(env.session, 'ethereum-addresses', sender);
+        let { data: senderDoc } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', sender);
         expect(senderDoc).has.deep.property('attributes.balance', senderBalance.toString());
         expect(senderDoc.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
@@ -826,7 +826,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let recipientBalance = await getBalance(to);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: sender } = await searchers.get(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', from);
 
         expect(sender).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(from));
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
@@ -838,7 +838,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block.number);
         expect(sender).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: recipient } = await searchers.get(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', to);
 
         expect(recipient).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(to));
         expect(recipient).has.deep.property('attributes.balance', recipientBalance.toString());
@@ -847,7 +847,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipient).has.deep.property('meta.blockHeight', block.number);
         expect(recipient).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: transaction } = await searchers.get(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -877,7 +877,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         await createTrackedEthereumAddresses([ sender, recipient ]);
 
-        let { data: senderDoc } = await searchers.get(env.session, 'ethereum-addresses', sender);
+        let { data: senderDoc } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', sender);
 
         expect(senderDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(sender));
         expect(senderDoc).has.deep.property('attributes.balance', senderBalance.toString());
@@ -891,7 +891,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: recipientDoc } = await searchers.get(env.session, 'ethereum-addresses', recipient);
+        let { data: recipientDoc } = await searchers.get(env.session, 'local-hub', 'ethereum-addresses', recipient);
 
         expect(recipientDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(recipient));
         expect(recipientDoc).has.deep.property('attributes.balance', recipientBalance.toString());
@@ -904,17 +904,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: transaction1 } = await searchers.get(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction2 } = await searchers.get(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction3 } = await searchers.get(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
@@ -936,7 +936,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         let error = null;
         try {
-          await searchers.get(env.session, 'ethereum-addresses', sender);
+          await searchers.get(env.session, 'local-hub', 'ethereum-addresses', sender);
         } catch (e) {
           error = e;
         }
@@ -944,7 +944,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         error = null;
         try {
-          await searchers.get(env.session, 'ethereum-addresses', recipient);
+          await searchers.get(env.session, 'local-hub', 'ethereum-addresses', recipient);
         } catch (e) {
           error = e;
         }
@@ -973,16 +973,16 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         let error = null;
         try {
-          await searchers.get(env.session, 'ethereum-addresses', sender);
+          await searchers.get(env.session, 'local-hub', 'ethereum-addresses', sender);
         } catch (e) {
           error = e;
         }
         expect(error.status).to.equal(404);
 
         // this should not error
-        await searchers.get(env.session, 'ethereum-addresses', recipient);
+        await searchers.get(env.session, 'local-hub', 'ethereum-addresses', recipient);
 
-        let { data: transaction } = await searchers.get(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.get(env.session, 'local-hub', 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });

--- a/packages/ethereum/truffle-tests/addresses-test.js
+++ b/packages/ethereum/truffle-tests/addresses-test.js
@@ -166,7 +166,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let senderBalance = await getBalance(from);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: sender } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.getCard(env.session, 'ethereum-addresses', from);
 
         expect(sender).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(from));
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
@@ -178,7 +178,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block.number);
         expect(sender).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: transaction } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.getCard(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -194,7 +194,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let recipientBalance = await getBalance(to);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: recipient } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.getCard(env.session, 'ethereum-addresses', to);
 
         expect(recipient).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(to));
         expect(recipient).has.deep.property('attributes.balance', recipientBalance.toString());
@@ -203,7 +203,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipient).has.deep.property('meta.blockHeight', block.number);
         expect(recipient).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: transaction } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.getCard(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -224,7 +224,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let block = await getBlock(txn3.blockNumber);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: sender } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.getCard(env.session, 'ethereum-addresses', from);
         expect(sender.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
           { type: 'ethereum-transactions', id: txn1.hash },
@@ -251,7 +251,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let block = await getBlock(txn3.blockNumber);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: recipient } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.getCard(env.session, 'ethereum-addresses', to);
         expect(recipient.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: txn1.hash },
           { type: 'ethereum-transactions', id: txn2.hash },
@@ -283,7 +283,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await waitForEthereumEvents(transactionIndexer);
         await createTrackedEthereumAddress(sender);
 
-        let { data: senderDoc } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', sender);
+        let { data: senderDoc } = await searchers.getCard(env.session, 'ethereum-addresses', sender);
 
         expect(senderDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(sender));
         expect(senderDoc).has.deep.property('attributes.balance', senderBalance.toString());
@@ -297,17 +297,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: transaction1 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.getCard(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction2 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.getCard(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction3 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.getCard(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
@@ -334,7 +334,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await waitForEthereumEvents(transactionIndexer);
         await createTrackedEthereumAddress(recipient);
 
-        let { data: recipientDoc } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', recipient);
+        let { data: recipientDoc } = await searchers.getCard(env.session, 'ethereum-addresses', recipient);
 
         expect(recipientDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(recipient));
         expect(recipientDoc).has.deep.property('attributes.balance', recipientBalance.toString());
@@ -347,17 +347,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: transaction1 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.getCard(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction2 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.getCard(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction3 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.getCard(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
@@ -384,7 +384,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await waitForEthereumEvents(transactionIndexer);
         await createTrackedEthereumAddress(addressY);
 
-        let { data: recipientDoc } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', addressY);
+        let { data: recipientDoc } = await searchers.getCard(env.session, 'ethereum-addresses', addressY);
 
         expect(recipientDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(addressY));
         expect(recipientDoc).has.deep.property('attributes.balance', balance.toString());
@@ -398,17 +398,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: transaction1 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.getCard(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: addressY });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: addressX });
 
-        let { data: transaction2 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.getCard(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: addressX });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: addressY });
 
-        let { data: transaction3 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.getCard(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: addressY });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: addressX });
@@ -425,13 +425,13 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let txn = await getTransaction(txnHash);
         await waitForEthereumEvents(transactionIndexer);
 
-        await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn.hash);
+        await searchers.getCard(env.session, 'ethereum-transactions', txn.hash);
         await env.lookup('hub:writers').delete('master', env.session, version, 'tracked-ethereum-addresses', sender);
         await waitForEthereumEvents(transactionIndexer);
 
         let error = null;
         try {
-          await searchers.getCurrentCard(env.session, 'ethereum-addresses', sender);
+          await searchers.getCard(env.session, 'ethereum-addresses', sender);
         } catch (e) {
           error = e;
         }
@@ -489,7 +489,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         // 2 events for update of the 2 addresses
         expect(addressIndexingCount).to.equal(2);
 
-        let { data: sender } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.getCard(env.session, 'ethereum-addresses', from);
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
         expect(sender.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
@@ -501,7 +501,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block3.number);
         expect(sender).has.deep.property('meta.version', `${block3.number}.0`);
 
-        let { data: recipient } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.getCard(env.session, 'ethereum-addresses', to);
         expect(recipient).has.deep.property('attributes.balance', recipientBalance.toString());
         expect(recipient.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: txn1.hash },
@@ -512,17 +512,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipient).has.deep.property('meta.blockHeight', block3.number);
         expect(recipient).has.deep.property('meta.version', `${block3.number}.0`);
 
-        let { data: transaction1 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.getCard(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
 
-        let { data: transaction2 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.getCard(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
 
-        let { data: transaction3 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.getCard(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -542,7 +542,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         // 2 events for update of the 2 addresses
         expect(addressIndexingCount).to.equal(4);
 
-        let { data: senderUpdated } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', from);
+        let { data: senderUpdated } = await searchers.getCard(env.session, 'ethereum-addresses', from);
         expect(senderUpdated).has.deep.property('attributes.balance', senderBalance.toString());
         expect(senderUpdated.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
@@ -555,7 +555,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(senderUpdated).has.deep.property('meta.blockHeight', block4.number);
         expect(senderUpdated).has.deep.property('meta.version', `${block4.number}.0`);
 
-        let { data: recipientUpdated } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', to);
+        let { data: recipientUpdated } = await searchers.getCard(env.session, 'ethereum-addresses', to);
         expect(recipientUpdated).has.deep.property('attributes.balance', recipientBalance.toString());
         expect(recipientUpdated.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: txn1.hash },
@@ -567,7 +567,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipientUpdated).has.deep.property('meta.blockHeight', block4.number);
         expect(recipientUpdated).has.deep.property('meta.version', `${block4.number}.0`);
 
-        let { data: transaction4 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn4.hash);
+        let { data: transaction4 } = await searchers.getCard(env.session, 'ethereum-transactions', txn4.hash);
         await assertTxnResourceMatchesEthTxn(transaction4, txn4, block4);
         expect(transaction4.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction4.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -601,7 +601,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
           let error;
           try {
-            await searchers.getCurrentCard(env.session, 'ethereum-addresses', id);
+            await searchers.getCard(env.session, 'ethereum-addresses', id);
           } catch (e) {
             error = e;
           }
@@ -611,7 +611,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await env.lookup('hub:indexers').update({ forceRefresh: true });
         await waitForEthereumEvents(transactionIndexer);
 
-        let { data: sender } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.getCard(env.session, 'ethereum-addresses', from);
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
         expect(sender.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
@@ -623,7 +623,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block3.number);
         expect(sender).has.deep.property('meta.version', `${block3.number}.0`);
 
-        let { data: recipient } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.getCard(env.session, 'ethereum-addresses', to);
         expect(recipient).has.deep.property('attributes.balance', recipientBalance.toString());
         expect(recipient.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: txn1.hash },
@@ -634,17 +634,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipient).has.deep.property('meta.blockHeight', block3.number);
         expect(recipient).has.deep.property('meta.version', `${block3.number}.0`);
 
-        let { data: transaction1 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.getCard(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
 
-        let { data: transaction2 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.getCard(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
 
-        let { data: transaction3 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.getCard(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -660,7 +660,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let senderBalance = await getBalance(from);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: sender } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.getCard(env.session, 'ethereum-addresses', from);
 
         expect(sender).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(from));
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
@@ -672,7 +672,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block.number);
         expect(sender).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: transaction } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.getCard(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -692,7 +692,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         await createTrackedEthereumAddress(sender);
 
-        let { data: senderDoc } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', sender);
+        let { data: senderDoc } = await searchers.getCard(env.session, 'ethereum-addresses', sender);
 
         expect(senderDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(sender));
         expect(senderDoc).has.deep.property('attributes.balance', senderBalance.toString());
@@ -704,7 +704,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn.hash }
         ]);
 
-        let { data: transaction } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.getCard(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
@@ -716,7 +716,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         await createTrackedEthereumAddress(trackedAddress);
 
-        let { data: addressDoc } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', trackedAddress);
+        let { data: addressDoc } = await searchers.getCard(env.session, 'ethereum-addresses', trackedAddress);
 
         expect(addressDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(trackedAddress));
         expect(addressDoc).has.deep.property('attributes.balance', '0');
@@ -749,7 +749,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         await waitForEthereumEvents(transactionIndexer);
 
-        let { data: senderDoc } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', sender);
+        let { data: senderDoc } = await searchers.getCard(env.session, 'ethereum-addresses', sender);
         expect(senderDoc).has.deep.property('attributes.balance', senderBalance.toString());
         expect(senderDoc.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
@@ -826,7 +826,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let recipientBalance = await getBalance(to);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: sender } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.getCard(env.session, 'ethereum-addresses', from);
 
         expect(sender).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(from));
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
@@ -838,7 +838,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block.number);
         expect(sender).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: recipient } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.getCard(env.session, 'ethereum-addresses', to);
 
         expect(recipient).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(to));
         expect(recipient).has.deep.property('attributes.balance', recipientBalance.toString());
@@ -847,7 +847,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipient).has.deep.property('meta.blockHeight', block.number);
         expect(recipient).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: transaction } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.getCard(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -877,7 +877,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         await createTrackedEthereumAddresses([ sender, recipient ]);
 
-        let { data: senderDoc } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', sender);
+        let { data: senderDoc } = await searchers.getCard(env.session, 'ethereum-addresses', sender);
 
         expect(senderDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(sender));
         expect(senderDoc).has.deep.property('attributes.balance', senderBalance.toString());
@@ -891,7 +891,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: recipientDoc } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', recipient);
+        let { data: recipientDoc } = await searchers.getCard(env.session, 'ethereum-addresses', recipient);
 
         expect(recipientDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(recipient));
         expect(recipientDoc).has.deep.property('attributes.balance', recipientBalance.toString());
@@ -904,17 +904,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: transaction1 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.getCard(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction2 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.getCard(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction3 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.getCard(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
@@ -936,7 +936,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         let error = null;
         try {
-          await searchers.getCurrentCard(env.session, 'ethereum-addresses', sender);
+          await searchers.getCard(env.session, 'ethereum-addresses', sender);
         } catch (e) {
           error = e;
         }
@@ -944,7 +944,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         error = null;
         try {
-          await searchers.getCurrentCard(env.session, 'ethereum-addresses', recipient);
+          await searchers.getCard(env.session, 'ethereum-addresses', recipient);
         } catch (e) {
           error = e;
         }
@@ -973,16 +973,16 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         let error = null;
         try {
-          await searchers.getCurrentCard(env.session, 'ethereum-addresses', sender);
+          await searchers.getCard(env.session, 'ethereum-addresses', sender);
         } catch (e) {
           error = e;
         }
         expect(error.status).to.equal(404);
 
         // this should not error
-        await searchers.getCurrentCard(env.session, 'ethereum-addresses', recipient);
+        await searchers.getCard(env.session, 'ethereum-addresses', recipient);
 
-        let { data: transaction } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.getCard(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });

--- a/packages/ethereum/truffle-tests/addresses-test.js
+++ b/packages/ethereum/truffle-tests/addresses-test.js
@@ -166,7 +166,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let senderBalance = await getBalance(from);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: sender } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', from);
 
         expect(sender).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(from));
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
@@ -178,7 +178,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block.number);
         expect(sender).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: transaction } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -194,7 +194,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let recipientBalance = await getBalance(to);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: recipient } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', to);
 
         expect(recipient).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(to));
         expect(recipient).has.deep.property('attributes.balance', recipientBalance.toString());
@@ -203,7 +203,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipient).has.deep.property('meta.blockHeight', block.number);
         expect(recipient).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: transaction } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -224,7 +224,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let block = await getBlock(txn3.blockNumber);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: sender } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', from);
         expect(sender.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
           { type: 'ethereum-transactions', id: txn1.hash },
@@ -251,7 +251,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let block = await getBlock(txn3.blockNumber);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: recipient } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', to);
         expect(recipient.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: txn1.hash },
           { type: 'ethereum-transactions', id: txn2.hash },
@@ -283,7 +283,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await waitForEthereumEvents(transactionIndexer);
         await createTrackedEthereumAddress(sender);
 
-        let { data: senderDoc } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', sender);
+        let { data: senderDoc } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', sender);
 
         expect(senderDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(sender));
         expect(senderDoc).has.deep.property('attributes.balance', senderBalance.toString());
@@ -297,17 +297,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: transaction1 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction2 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction3 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
@@ -334,7 +334,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await waitForEthereumEvents(transactionIndexer);
         await createTrackedEthereumAddress(recipient);
 
-        let { data: recipientDoc } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', recipient);
+        let { data: recipientDoc } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', recipient);
 
         expect(recipientDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(recipient));
         expect(recipientDoc).has.deep.property('attributes.balance', recipientBalance.toString());
@@ -347,17 +347,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: transaction1 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction2 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction3 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
@@ -384,7 +384,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await waitForEthereumEvents(transactionIndexer);
         await createTrackedEthereumAddress(addressY);
 
-        let { data: recipientDoc } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', addressY);
+        let { data: recipientDoc } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', addressY);
 
         expect(recipientDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(addressY));
         expect(recipientDoc).has.deep.property('attributes.balance', balance.toString());
@@ -398,17 +398,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: transaction1 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: addressY });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: addressX });
 
-        let { data: transaction2 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: addressX });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: addressY });
 
-        let { data: transaction3 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: addressY });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: addressX });
@@ -425,13 +425,13 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let txn = await getTransaction(txnHash);
         await waitForEthereumEvents(transactionIndexer);
 
-        await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn.hash);
+        await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn.hash);
         await env.lookup('hub:writers').delete('master', env.session, version, 'tracked-ethereum-addresses', sender);
         await waitForEthereumEvents(transactionIndexer);
 
         let error = null;
         try {
-          await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', sender);
+          await searchers.getCurrentCard(env.session, 'ethereum-addresses', sender);
         } catch (e) {
           error = e;
         }
@@ -489,7 +489,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         // 2 events for update of the 2 addresses
         expect(addressIndexingCount).to.equal(2);
 
-        let { data: sender } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', from);
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
         expect(sender.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
@@ -501,7 +501,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block3.number);
         expect(sender).has.deep.property('meta.version', `${block3.number}.0`);
 
-        let { data: recipient } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', to);
         expect(recipient).has.deep.property('attributes.balance', recipientBalance.toString());
         expect(recipient.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: txn1.hash },
@@ -512,17 +512,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipient).has.deep.property('meta.blockHeight', block3.number);
         expect(recipient).has.deep.property('meta.version', `${block3.number}.0`);
 
-        let { data: transaction1 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
 
-        let { data: transaction2 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
 
-        let { data: transaction3 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -542,7 +542,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         // 2 events for update of the 2 addresses
         expect(addressIndexingCount).to.equal(4);
 
-        let { data: senderUpdated } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', from);
+        let { data: senderUpdated } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', from);
         expect(senderUpdated).has.deep.property('attributes.balance', senderBalance.toString());
         expect(senderUpdated.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
@@ -555,7 +555,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(senderUpdated).has.deep.property('meta.blockHeight', block4.number);
         expect(senderUpdated).has.deep.property('meta.version', `${block4.number}.0`);
 
-        let { data: recipientUpdated } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', to);
+        let { data: recipientUpdated } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', to);
         expect(recipientUpdated).has.deep.property('attributes.balance', recipientBalance.toString());
         expect(recipientUpdated.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: txn1.hash },
@@ -567,7 +567,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipientUpdated).has.deep.property('meta.blockHeight', block4.number);
         expect(recipientUpdated).has.deep.property('meta.version', `${block4.number}.0`);
 
-        let { data: transaction4 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn4.hash);
+        let { data: transaction4 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn4.hash);
         await assertTxnResourceMatchesEthTxn(transaction4, txn4, block4);
         expect(transaction4.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction4.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -601,7 +601,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
           let error;
           try {
-            await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', id);
+            await searchers.getCurrentCard(env.session, 'ethereum-addresses', id);
           } catch (e) {
             error = e;
           }
@@ -611,7 +611,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await env.lookup('hub:indexers').update({ forceRefresh: true });
         await waitForEthereumEvents(transactionIndexer);
 
-        let { data: sender } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', from);
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
         expect(sender.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
@@ -623,7 +623,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block3.number);
         expect(sender).has.deep.property('meta.version', `${block3.number}.0`);
 
-        let { data: recipient } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', to);
         expect(recipient).has.deep.property('attributes.balance', recipientBalance.toString());
         expect(recipient.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: txn1.hash },
@@ -634,17 +634,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipient).has.deep.property('meta.blockHeight', block3.number);
         expect(recipient).has.deep.property('meta.version', `${block3.number}.0`);
 
-        let { data: transaction1 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
 
-        let { data: transaction2 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
 
-        let { data: transaction3 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -660,7 +660,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let senderBalance = await getBalance(from);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: sender } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', from);
 
         expect(sender).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(from));
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
@@ -672,7 +672,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block.number);
         expect(sender).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: transaction } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -692,7 +692,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         await createTrackedEthereumAddress(sender);
 
-        let { data: senderDoc } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', sender);
+        let { data: senderDoc } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', sender);
 
         expect(senderDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(sender));
         expect(senderDoc).has.deep.property('attributes.balance', senderBalance.toString());
@@ -704,7 +704,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn.hash }
         ]);
 
-        let { data: transaction } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
@@ -716,7 +716,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         await createTrackedEthereumAddress(trackedAddress);
 
-        let { data: addressDoc } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', trackedAddress);
+        let { data: addressDoc } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', trackedAddress);
 
         expect(addressDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(trackedAddress));
         expect(addressDoc).has.deep.property('attributes.balance', '0');
@@ -749,7 +749,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         await waitForEthereumEvents(transactionIndexer);
 
-        let { data: senderDoc } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', sender);
+        let { data: senderDoc } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', sender);
         expect(senderDoc).has.deep.property('attributes.balance', senderBalance.toString());
         expect(senderDoc.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
@@ -826,7 +826,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let recipientBalance = await getBalance(to);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: sender } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', from);
 
         expect(sender).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(from));
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
@@ -838,7 +838,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block.number);
         expect(sender).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: recipient } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', to);
 
         expect(recipient).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(to));
         expect(recipient).has.deep.property('attributes.balance', recipientBalance.toString());
@@ -847,7 +847,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipient).has.deep.property('meta.blockHeight', block.number);
         expect(recipient).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: transaction } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -877,7 +877,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         await createTrackedEthereumAddresses([ sender, recipient ]);
 
-        let { data: senderDoc } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', sender);
+        let { data: senderDoc } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', sender);
 
         expect(senderDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(sender));
         expect(senderDoc).has.deep.property('attributes.balance', senderBalance.toString());
@@ -891,7 +891,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: recipientDoc } = await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', recipient);
+        let { data: recipientDoc } = await searchers.getCurrentCard(env.session, 'ethereum-addresses', recipient);
 
         expect(recipientDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(recipient));
         expect(recipientDoc).has.deep.property('attributes.balance', recipientBalance.toString());
@@ -904,17 +904,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: transaction1 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction2 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction3 } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
@@ -936,7 +936,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         let error = null;
         try {
-          await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', sender);
+          await searchers.getCurrentCard(env.session, 'ethereum-addresses', sender);
         } catch (e) {
           error = e;
         }
@@ -944,7 +944,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         error = null;
         try {
-          await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', recipient);
+          await searchers.getCurrentCard(env.session, 'ethereum-addresses', recipient);
         } catch (e) {
           error = e;
         }
@@ -973,16 +973,16 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         let error = null;
         try {
-          await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', sender);
+          await searchers.getCurrentCard(env.session, 'ethereum-addresses', sender);
         } catch (e) {
           error = e;
         }
         expect(error.status).to.equal(404);
 
         // this should not error
-        await searchers.getFromControllingBranch(env.session, 'ethereum-addresses', recipient);
+        await searchers.getCurrentCard(env.session, 'ethereum-addresses', recipient);
 
-        let { data: transaction } = await searchers.getFromControllingBranch(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.getCurrentCard(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });

--- a/packages/ethereum/truffle-tests/addresses-test.js
+++ b/packages/ethereum/truffle-tests/addresses-test.js
@@ -800,10 +800,10 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await sendTransaction({ from, to, value, gasPrice });
         await waitForEthereumEvents(transactionIndexer);
 
-        let { data: indexedAddresses } = await searchers.searchFromControllingBranch(env.session, {
+        let { data: indexedAddresses } = await searchers.searchForCurrentCard(env.session, {
           filter: { type: { exact: 'ethereum-addresses' } }
         });
-        let { data: indexedTransactions } = await searchers.searchFromControllingBranch(env.session, {
+        let { data: indexedTransactions } = await searchers.searchForCurrentCard(env.session, {
           filter: { type: { exact: 'ethereum-transactions' } }
         });
 

--- a/packages/ethereum/truffle-tests/addresses-test.js
+++ b/packages/ethereum/truffle-tests/addresses-test.js
@@ -166,7 +166,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let senderBalance = await getBalance(from);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: sender } = await searchers.getCard(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.get(env.session, 'ethereum-addresses', from);
 
         expect(sender).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(from));
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
@@ -178,7 +178,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block.number);
         expect(sender).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: transaction } = await searchers.getCard(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.get(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -194,7 +194,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let recipientBalance = await getBalance(to);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: recipient } = await searchers.getCard(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.get(env.session, 'ethereum-addresses', to);
 
         expect(recipient).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(to));
         expect(recipient).has.deep.property('attributes.balance', recipientBalance.toString());
@@ -203,7 +203,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipient).has.deep.property('meta.blockHeight', block.number);
         expect(recipient).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: transaction } = await searchers.getCard(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.get(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -224,7 +224,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let block = await getBlock(txn3.blockNumber);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: sender } = await searchers.getCard(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.get(env.session, 'ethereum-addresses', from);
         expect(sender.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
           { type: 'ethereum-transactions', id: txn1.hash },
@@ -251,7 +251,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let block = await getBlock(txn3.blockNumber);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: recipient } = await searchers.getCard(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.get(env.session, 'ethereum-addresses', to);
         expect(recipient.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: txn1.hash },
           { type: 'ethereum-transactions', id: txn2.hash },
@@ -283,7 +283,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await waitForEthereumEvents(transactionIndexer);
         await createTrackedEthereumAddress(sender);
 
-        let { data: senderDoc } = await searchers.getCard(env.session, 'ethereum-addresses', sender);
+        let { data: senderDoc } = await searchers.get(env.session, 'ethereum-addresses', sender);
 
         expect(senderDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(sender));
         expect(senderDoc).has.deep.property('attributes.balance', senderBalance.toString());
@@ -297,17 +297,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: transaction1 } = await searchers.getCard(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.get(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction2 } = await searchers.getCard(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.get(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction3 } = await searchers.getCard(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.get(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
@@ -334,7 +334,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await waitForEthereumEvents(transactionIndexer);
         await createTrackedEthereumAddress(recipient);
 
-        let { data: recipientDoc } = await searchers.getCard(env.session, 'ethereum-addresses', recipient);
+        let { data: recipientDoc } = await searchers.get(env.session, 'ethereum-addresses', recipient);
 
         expect(recipientDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(recipient));
         expect(recipientDoc).has.deep.property('attributes.balance', recipientBalance.toString());
@@ -347,17 +347,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: transaction1 } = await searchers.getCard(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.get(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction2 } = await searchers.getCard(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.get(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction3 } = await searchers.getCard(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.get(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
@@ -384,7 +384,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await waitForEthereumEvents(transactionIndexer);
         await createTrackedEthereumAddress(addressY);
 
-        let { data: recipientDoc } = await searchers.getCard(env.session, 'ethereum-addresses', addressY);
+        let { data: recipientDoc } = await searchers.get(env.session, 'ethereum-addresses', addressY);
 
         expect(recipientDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(addressY));
         expect(recipientDoc).has.deep.property('attributes.balance', balance.toString());
@@ -398,17 +398,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: transaction1 } = await searchers.getCard(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.get(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: addressY });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: addressX });
 
-        let { data: transaction2 } = await searchers.getCard(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.get(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: addressX });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: addressY });
 
-        let { data: transaction3 } = await searchers.getCard(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.get(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: addressY });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: addressX });
@@ -425,13 +425,13 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let txn = await getTransaction(txnHash);
         await waitForEthereumEvents(transactionIndexer);
 
-        await searchers.getCard(env.session, 'ethereum-transactions', txn.hash);
+        await searchers.get(env.session, 'ethereum-transactions', txn.hash);
         await env.lookup('hub:writers').delete('master', env.session, version, 'tracked-ethereum-addresses', sender);
         await waitForEthereumEvents(transactionIndexer);
 
         let error = null;
         try {
-          await searchers.getCard(env.session, 'ethereum-addresses', sender);
+          await searchers.get(env.session, 'ethereum-addresses', sender);
         } catch (e) {
           error = e;
         }
@@ -489,7 +489,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         // 2 events for update of the 2 addresses
         expect(addressIndexingCount).to.equal(2);
 
-        let { data: sender } = await searchers.getCard(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.get(env.session, 'ethereum-addresses', from);
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
         expect(sender.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
@@ -501,7 +501,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block3.number);
         expect(sender).has.deep.property('meta.version', `${block3.number}.0`);
 
-        let { data: recipient } = await searchers.getCard(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.get(env.session, 'ethereum-addresses', to);
         expect(recipient).has.deep.property('attributes.balance', recipientBalance.toString());
         expect(recipient.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: txn1.hash },
@@ -512,17 +512,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipient).has.deep.property('meta.blockHeight', block3.number);
         expect(recipient).has.deep.property('meta.version', `${block3.number}.0`);
 
-        let { data: transaction1 } = await searchers.getCard(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.get(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
 
-        let { data: transaction2 } = await searchers.getCard(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.get(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
 
-        let { data: transaction3 } = await searchers.getCard(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.get(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -542,7 +542,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         // 2 events for update of the 2 addresses
         expect(addressIndexingCount).to.equal(4);
 
-        let { data: senderUpdated } = await searchers.getCard(env.session, 'ethereum-addresses', from);
+        let { data: senderUpdated } = await searchers.get(env.session, 'ethereum-addresses', from);
         expect(senderUpdated).has.deep.property('attributes.balance', senderBalance.toString());
         expect(senderUpdated.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
@@ -555,7 +555,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(senderUpdated).has.deep.property('meta.blockHeight', block4.number);
         expect(senderUpdated).has.deep.property('meta.version', `${block4.number}.0`);
 
-        let { data: recipientUpdated } = await searchers.getCard(env.session, 'ethereum-addresses', to);
+        let { data: recipientUpdated } = await searchers.get(env.session, 'ethereum-addresses', to);
         expect(recipientUpdated).has.deep.property('attributes.balance', recipientBalance.toString());
         expect(recipientUpdated.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: txn1.hash },
@@ -567,7 +567,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipientUpdated).has.deep.property('meta.blockHeight', block4.number);
         expect(recipientUpdated).has.deep.property('meta.version', `${block4.number}.0`);
 
-        let { data: transaction4 } = await searchers.getCard(env.session, 'ethereum-transactions', txn4.hash);
+        let { data: transaction4 } = await searchers.get(env.session, 'ethereum-transactions', txn4.hash);
         await assertTxnResourceMatchesEthTxn(transaction4, txn4, block4);
         expect(transaction4.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction4.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -601,7 +601,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
           let error;
           try {
-            await searchers.getCard(env.session, 'ethereum-addresses', id);
+            await searchers.get(env.session, 'ethereum-addresses', id);
           } catch (e) {
             error = e;
           }
@@ -611,7 +611,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await env.lookup('hub:indexers').update({ forceRefresh: true });
         await waitForEthereumEvents(transactionIndexer);
 
-        let { data: sender } = await searchers.getCard(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.get(env.session, 'ethereum-addresses', from);
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
         expect(sender.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
@@ -623,7 +623,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block3.number);
         expect(sender).has.deep.property('meta.version', `${block3.number}.0`);
 
-        let { data: recipient } = await searchers.getCard(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.get(env.session, 'ethereum-addresses', to);
         expect(recipient).has.deep.property('attributes.balance', recipientBalance.toString());
         expect(recipient.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: txn1.hash },
@@ -634,17 +634,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipient).has.deep.property('meta.blockHeight', block3.number);
         expect(recipient).has.deep.property('meta.version', `${block3.number}.0`);
 
-        let { data: transaction1 } = await searchers.getCard(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.get(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
 
-        let { data: transaction2 } = await searchers.getCard(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.get(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
 
-        let { data: transaction3 } = await searchers.getCard(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.get(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -660,7 +660,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let senderBalance = await getBalance(from);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: sender } = await searchers.getCard(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.get(env.session, 'ethereum-addresses', from);
 
         expect(sender).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(from));
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
@@ -672,7 +672,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block.number);
         expect(sender).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: transaction } = await searchers.getCard(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.get(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -692,7 +692,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         await createTrackedEthereumAddress(sender);
 
-        let { data: senderDoc } = await searchers.getCard(env.session, 'ethereum-addresses', sender);
+        let { data: senderDoc } = await searchers.get(env.session, 'ethereum-addresses', sender);
 
         expect(senderDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(sender));
         expect(senderDoc).has.deep.property('attributes.balance', senderBalance.toString());
@@ -704,7 +704,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn.hash }
         ]);
 
-        let { data: transaction } = await searchers.getCard(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.get(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
@@ -716,7 +716,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         await createTrackedEthereumAddress(trackedAddress);
 
-        let { data: addressDoc } = await searchers.getCard(env.session, 'ethereum-addresses', trackedAddress);
+        let { data: addressDoc } = await searchers.get(env.session, 'ethereum-addresses', trackedAddress);
 
         expect(addressDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(trackedAddress));
         expect(addressDoc).has.deep.property('attributes.balance', '0');
@@ -749,7 +749,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         await waitForEthereumEvents(transactionIndexer);
 
-        let { data: senderDoc } = await searchers.getCard(env.session, 'ethereum-addresses', sender);
+        let { data: senderDoc } = await searchers.get(env.session, 'ethereum-addresses', sender);
         expect(senderDoc).has.deep.property('attributes.balance', senderBalance.toString());
         expect(senderDoc.relationships.transactions.data).to.eql([
           { type: 'ethereum-transactions', id: setupTxn.hash },
@@ -800,10 +800,10 @@ contract('ethereum-addresses indexing', function (_accounts) {
         await sendTransaction({ from, to, value, gasPrice });
         await waitForEthereumEvents(transactionIndexer);
 
-        let { data: indexedAddresses } = await searchers.searchForCurrentCard(env.session, {
+        let { data: indexedAddresses } = await searchers.search(env.session, {
           filter: { type: { exact: 'ethereum-addresses' } }
         });
-        let { data: indexedTransactions } = await searchers.searchForCurrentCard(env.session, {
+        let { data: indexedTransactions } = await searchers.search(env.session, {
           filter: { type: { exact: 'ethereum-transactions' } }
         });
 
@@ -826,7 +826,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         let recipientBalance = await getBalance(to);
 
         await waitForEthereumEvents(transactionIndexer);
-        let { data: sender } = await searchers.getCard(env.session, 'ethereum-addresses', from);
+        let { data: sender } = await searchers.get(env.session, 'ethereum-addresses', from);
 
         expect(sender).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(from));
         expect(sender).has.deep.property('attributes.balance', senderBalance.toString());
@@ -838,7 +838,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(sender).has.deep.property('meta.blockHeight', block.number);
         expect(sender).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: recipient } = await searchers.getCard(env.session, 'ethereum-addresses', to);
+        let { data: recipient } = await searchers.get(env.session, 'ethereum-addresses', to);
 
         expect(recipient).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(to));
         expect(recipient).has.deep.property('attributes.balance', recipientBalance.toString());
@@ -847,7 +847,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
         expect(recipient).has.deep.property('meta.blockHeight', block.number);
         expect(recipient).has.deep.property('meta.version', `${block.number}.0`);
 
-        let { data: transaction } = await searchers.getCard(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.get(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: to });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: from });
@@ -877,7 +877,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         await createTrackedEthereumAddresses([ sender, recipient ]);
 
-        let { data: senderDoc } = await searchers.getCard(env.session, 'ethereum-addresses', sender);
+        let { data: senderDoc } = await searchers.get(env.session, 'ethereum-addresses', sender);
 
         expect(senderDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(sender));
         expect(senderDoc).has.deep.property('attributes.balance', senderBalance.toString());
@@ -891,7 +891,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: recipientDoc } = await searchers.getCard(env.session, 'ethereum-addresses', recipient);
+        let { data: recipientDoc } = await searchers.get(env.session, 'ethereum-addresses', recipient);
 
         expect(recipientDoc).has.deep.property('attributes.ethereum-address', web3.toChecksumAddress(recipient));
         expect(recipientDoc).has.deep.property('attributes.balance', recipientBalance.toString());
@@ -904,17 +904,17 @@ contract('ethereum-addresses indexing', function (_accounts) {
           { type: 'ethereum-transactions', id: txn3.hash }
         ]);
 
-        let { data: transaction1 } = await searchers.getCard(env.session, 'ethereum-transactions', txn1.hash);
+        let { data: transaction1 } = await searchers.get(env.session, 'ethereum-transactions', txn1.hash);
         await assertTxnResourceMatchesEthTxn(transaction1, txn1, block1);
         expect(transaction1.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction1.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction2 } = await searchers.getCard(env.session, 'ethereum-transactions', txn2.hash);
+        let { data: transaction2 } = await searchers.get(env.session, 'ethereum-transactions', txn2.hash);
         await assertTxnResourceMatchesEthTxn(transaction2, txn2, block2);
         expect(transaction2.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction2.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
 
-        let { data: transaction3 } = await searchers.getCard(env.session, 'ethereum-transactions', txn3.hash);
+        let { data: transaction3 } = await searchers.get(env.session, 'ethereum-transactions', txn3.hash);
         await assertTxnResourceMatchesEthTxn(transaction3, txn3, block3);
         expect(transaction3.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction3.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });
@@ -936,7 +936,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         let error = null;
         try {
-          await searchers.getCard(env.session, 'ethereum-addresses', sender);
+          await searchers.get(env.session, 'ethereum-addresses', sender);
         } catch (e) {
           error = e;
         }
@@ -944,7 +944,7 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         error = null;
         try {
-          await searchers.getCard(env.session, 'ethereum-addresses', recipient);
+          await searchers.get(env.session, 'ethereum-addresses', recipient);
         } catch (e) {
           error = e;
         }
@@ -973,16 +973,16 @@ contract('ethereum-addresses indexing', function (_accounts) {
 
         let error = null;
         try {
-          await searchers.getCard(env.session, 'ethereum-addresses', sender);
+          await searchers.get(env.session, 'ethereum-addresses', sender);
         } catch (e) {
           error = e;
         }
         expect(error.status).to.equal(404);
 
         // this should not error
-        await searchers.getCard(env.session, 'ethereum-addresses', recipient);
+        await searchers.get(env.session, 'ethereum-addresses', recipient);
 
-        let { data: transaction } = await searchers.getCard(env.session, 'ethereum-transactions', txn.hash);
+        let { data: transaction } = await searchers.get(env.session, 'ethereum-transactions', txn.hash);
         await assertTxnResourceMatchesEthTxn(transaction, txn, block);
         expect(transaction.relationships['to-address'].data).to.eql({ type: 'ethereum-addresses', id: recipient });
         expect(transaction.relationships['from-address'].data).to.eql({ type: 'ethereum-addresses', id: sender });

--- a/packages/ethereum/truffle-tests/contracts-test.js
+++ b/packages/ethereum/truffle-tests/contracts-test.js
@@ -104,7 +104,7 @@ contract('Token Indexing', function (accounts) {
       afterEach(teardown);
 
       it('can generate schema from ERC-20 contract`s ABI', async function () {
-        let schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-tokens');
+        let schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-tokens');
         expect(schema).to.deep.equal({
           "data": {
             "id": "sample-tokens",
@@ -171,7 +171,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'grants', 'sample-token-grant');
+        schema = await env.lookup('hub:searchers').get(env.session, 'grants', 'sample-token-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -203,7 +203,7 @@ contract('Token Indexing', function (accounts) {
         });
 
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-balance-ofs');
+        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-balance-ofs');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -247,7 +247,7 @@ contract('Token Indexing', function (accounts) {
         });
 
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-custom-buyer-limits');
+        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-custom-buyer-limits');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -286,7 +286,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-vesting-schedules');
+        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-vesting-schedules');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -345,7 +345,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vesting-schedule-start-date');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vesting-schedule-start-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -359,7 +359,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vesting-schedule-cliff-date');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vesting-schedule-cliff-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -373,7 +373,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vesting-schedule-duration-sec');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vesting-schedule-duration-sec');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -387,7 +387,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vesting-schedule-fully-vested-amount');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vesting-schedule-fully-vested-amount');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -401,7 +401,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vesting-schedule-revoke-date');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vesting-schedule-revoke-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -415,7 +415,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vesting-schedule-is-revocable');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vesting-schedule-is-revocable');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -429,7 +429,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'grants', 'sample-token-vesting-schedule-grant');
+        schema = await env.lookup('hub:searchers').get(env.session, 'grants', 'sample-token-vesting-schedule-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -460,7 +460,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-approved-buyers');
+        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-approved-buyers');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -499,7 +499,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'grants', 'sample-token-balance-of-grant');
+        schema = await env.lookup('hub:searchers').get(env.session, 'grants', 'sample-token-balance-of-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -530,7 +530,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-name');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-name');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -544,7 +544,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-minting-finished');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-minting-finished');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -558,7 +558,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-owner');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-owner');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -572,7 +572,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-symbol');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-symbol');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -586,7 +586,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-total-supply');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-total-supply');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -600,7 +600,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-contract');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-contract');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -624,7 +624,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-transfer-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-transfer-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -675,7 +675,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'grants', 'sample-token-transfer-events-grant');
+        schema = await env.lookup('hub:searchers').get(env.session, 'grants', 'sample-token-transfer-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -706,7 +706,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-transfer-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-transfer-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -720,7 +720,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'transfer-event-from');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'transfer-event-from');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -734,7 +734,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'transfer-event-to');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'transfer-event-to');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -748,7 +748,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'transfer-event-value');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'transfer-event-value');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -762,7 +762,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-token-frozen-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-token-frozen-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -805,7 +805,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'grants', 'sample-token-token-frozen-events-grant');
+        schema = await env.lookup('hub:searchers').get(env.session, 'grants', 'sample-token-token-frozen-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -836,7 +836,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-token-frozen-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-token-frozen-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -850,7 +850,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'token-frozen-event-is-frozen');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'token-frozen-event-is-frozen');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -864,7 +864,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-mint-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-mint-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -911,7 +911,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'grants', 'sample-token-mint-events-grant');
+        schema = await env.lookup('hub:searchers').get(env.session, 'grants', 'sample-token-mint-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -942,7 +942,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-mint-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-mint-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -956,7 +956,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'mint-event-to');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'mint-event-to');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -970,7 +970,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'mint-event-amount');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'mint-event-amount');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -984,7 +984,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-white-list-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-white-list-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -1031,7 +1031,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'grants', 'sample-token-white-list-events-grant');
+        schema = await env.lookup('hub:searchers').get(env.session, 'grants', 'sample-token-white-list-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -1062,7 +1062,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-white-list-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-white-list-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1076,7 +1076,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'white-list-event-buyer');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'white-list-event-buyer');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1090,7 +1090,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'white-list-event-hold-cap');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'white-list-event-hold-cap');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1104,7 +1104,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-vested-token-grant-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-vested-token-grant-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -1171,7 +1171,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'grants', 'sample-token-vested-token-grant-events-grant');
+        schema = await env.lookup('hub:searchers').get(env.session, 'grants', 'sample-token-vested-token-grant-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -1202,7 +1202,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-vested-token-grant-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-vested-token-grant-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1216,7 +1216,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vested-token-grant-event-beneficiary');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vested-token-grant-event-beneficiary');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1230,7 +1230,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vested-token-grant-event-start-date');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vested-token-grant-event-start-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1244,7 +1244,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vested-token-grant-event-cliff-sec');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vested-token-grant-event-cliff-sec');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1258,7 +1258,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vested-token-grant-event-duration-sec');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vested-token-grant-event-duration-sec');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1272,7 +1272,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vested-token-grant-event-fully-vested-amount');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vested-token-grant-event-fully-vested-amount');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1286,7 +1286,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vested-token-grant-event-revoke-date');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vested-token-grant-event-revoke-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1300,7 +1300,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vested-token-grant-event-is-revocable');
+        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vested-token-grant-event-is-revocable');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1316,7 +1316,7 @@ contract('Token Indexing', function (accounts) {
       });
 
       it("indexes a contract", async function () {
-        let contract = await env.lookup('hub:searchers').getCard(env.session, 'sample-tokens', token.address);
+        let contract = await env.lookup('hub:searchers').get(env.session, 'sample-tokens', token.address);
         contract.data.attributes["sample-token-owner"] = contract.data.attributes["sample-token-owner"].toLowerCase();
         delete contract.data.meta;
         expect(contract).to.deep.equal({
@@ -1351,7 +1351,7 @@ contract('Token Indexing', function (accounts) {
 
         await waitForEthereumEvents(eventIndexer);
 
-        let vestingSchedule = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-vesting-schedules', accountOne);
+        let vestingSchedule = await env.lookup('hub:searchers').get(env.session, 'sample-token-vesting-schedules', accountOne);
 
         expect(vestingSchedule.data.attributes["ethereum-address"]).to.not.equal(vestingSchedule.data.id, 'the case between the addresses is different');
         vestingSchedule.data.attributes["ethereum-address"] = vestingSchedule.data.attributes["ethereum-address"].toLowerCase();
@@ -1391,14 +1391,14 @@ contract('Token Indexing', function (accounts) {
 
       it("indexes mapping entry content types when a contract fires an ethereum event", async function () {
         try {
-          await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountOne);
+          await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountOne);
           throw new Error("balance-of record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-balance-ofs/${accountOne}`);
         }
 
         try {
-          await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountTwo);
+          await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountTwo);
           throw new Error("balance-of record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-balance-ofs/${accountTwo}`);
@@ -1412,7 +1412,7 @@ contract('Token Indexing', function (accounts) {
 
         await waitForEthereumEvents(eventIndexer);
 
-        let accountOneLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountOne);
+        let accountOneLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountOne);
         expect(accountOneLedgerEntry.data.attributes["ethereum-address"]).to.not.equal(accountOneLedgerEntry.data.id, 'the case between the addresses is different');
         accountOneLedgerEntry.data.attributes["ethereum-address"] = accountOneLedgerEntry.data.attributes["ethereum-address"].toLowerCase();
         delete accountOneLedgerEntry.data.meta;
@@ -1447,10 +1447,10 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        let accountTwoLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountTwo);
+        let accountTwoLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountTwo);
         expect(accountTwoLedgerEntry.data.attributes["mapping-number-value"]).to.equal("10", "the token balance is correct");
 
-        let transferEvent1 = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-transfer-events', transferEvent1Id);
+        let transferEvent1 = await env.lookup('hub:searchers').get(env.session, 'sample-token-transfer-events', transferEvent1Id);
         delete transferEvent1.data.meta;
         toLowercase(transferEvent1, 'data.attributes.transfer-event-from');
         toLowercase(transferEvent1, 'data.attributes.transfer-event-to');
@@ -1474,7 +1474,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        let transferEvent2 = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-transfer-events', transferEvent2Id);
+        let transferEvent2 = await env.lookup('hub:searchers').get(env.session, 'sample-token-transfer-events', transferEvent2Id);
         toLowercase(transferEvent2, 'data.attributes.transfer-event-from');
         toLowercase(transferEvent2, 'data.attributes.transfer-event-to');
         expect(transferEvent2.data.attributes["block-number"]).to.equal(transferEvents[0].blockNumber, 'the block number is correct');
@@ -1487,28 +1487,28 @@ contract('Token Indexing', function (accounts) {
 
       it("indexes mapping entry content with different field types for the same event", async function () {
         try {
-          await env.lookup('hub:searchers').getCard(env.session, 'sample-token-custom-buyer-limits', accountOne);
+          await env.lookup('hub:searchers').get(env.session, 'sample-token-custom-buyer-limits', accountOne);
           throw new Error("sample-token-custom-buyer-limits record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-custom-buyer-limits/${accountOne}`);
         }
 
         try {
-          await env.lookup('hub:searchers').getCard(env.session, 'sample-token-approved-buyers', accountOne);
+          await env.lookup('hub:searchers').get(env.session, 'sample-token-approved-buyers', accountOne);
           throw new Error("sample-token-approved-buyers record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-approved-buyers/${accountOne}`);
         }
 
         try {
-          await env.lookup('hub:searchers').getCard(env.session, 'sample-token-custom-buyer-limits', accountTwo);
+          await env.lookup('hub:searchers').get(env.session, 'sample-token-custom-buyer-limits', accountTwo);
           throw new Error("sample-token-custom-buyer-limits record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-custom-buyer-limits/${accountTwo}`);
         }
 
         try {
-          await env.lookup('hub:searchers').getCard(env.session, 'sample-token-approved-buyers', accountTwo);
+          await env.lookup('hub:searchers').get(env.session, 'sample-token-approved-buyers', accountTwo);
           throw new Error("sample-token-approved-buyers record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-approved-buyers/${accountTwo}`);
@@ -1522,7 +1522,7 @@ contract('Token Indexing', function (accounts) {
         await env.lookup('hub:indexers').update({ forceRefresh: true });
         await waitForEthereumEvents(eventIndexer);
 
-        let accountOneApprovedBuyer = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-approved-buyers', accountOne);
+        let accountOneApprovedBuyer = await env.lookup('hub:searchers').get(env.session, 'sample-token-approved-buyers', accountOne);
         accountOneApprovedBuyer.data.attributes["ethereum-address"] = accountOneApprovedBuyer.data.attributes["ethereum-address"].toLowerCase();
         delete accountOneApprovedBuyer.data.meta;
         expect(accountOneApprovedBuyer).to.deep.equal({
@@ -1552,7 +1552,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        let accountOneCustomBuyerLimit = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-custom-buyer-limits', accountOne);
+        let accountOneCustomBuyerLimit = await env.lookup('hub:searchers').get(env.session, 'sample-token-custom-buyer-limits', accountOne);
         accountOneCustomBuyerLimit.data.attributes["ethereum-address"] = accountOneCustomBuyerLimit.data.attributes["ethereum-address"].toLowerCase();
         delete accountOneCustomBuyerLimit.data.meta;
         expect(accountOneCustomBuyerLimit).to.deep.equal({
@@ -1582,10 +1582,10 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        let accountTwoApprovedBuyer = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-approved-buyers', accountTwo);
+        let accountTwoApprovedBuyer = await env.lookup('hub:searchers').get(env.session, 'sample-token-approved-buyers', accountTwo);
         expect(accountTwoApprovedBuyer.data.attributes["mapping-boolean-value"]).to.equal(true, "the mapping-boolean-value is correct");
 
-        let accountTwoCustomBuyerLimit = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-custom-buyer-limits', accountTwo);
+        let accountTwoCustomBuyerLimit = await env.lookup('hub:searchers').get(env.session, 'sample-token-custom-buyer-limits', accountTwo);
         expect(accountTwoCustomBuyerLimit.data.attributes["mapping-number-value"]).to.equal("10", "the mapping-number-value is correct");
       });
     });
@@ -1625,21 +1625,21 @@ contract('Token Indexing', function (accounts) {
       afterEach(teardown);
 
       it('can update contract document from event content trigger', async function () {
-        let contract = await env.lookup('hub:searchers').getCard(env.session, 'sample-tokens', token.address);
+        let contract = await env.lookup('hub:searchers').get(env.session, 'sample-tokens', token.address);
         expect(contract.data.attributes['sample-token-minting-finished']).to.equal(false, 'the minting-finished field is correct');
 
         let { logs: events } = await token.finishMinting();
         let eventId = `${events[0].transactionHash}_${events[0].logIndex}`;
         await waitForEthereumEvents(eventIndexer);
 
-        contract = await env.lookup('hub:searchers').getCard(env.session, 'sample-tokens', token.address);
+        contract = await env.lookup('hub:searchers').get(env.session, 'sample-tokens', token.address);
         expect(contract.data.attributes['sample-token-minting-finished']).to.equal(true, 'the minting-finished field is correct');
 
         expect(contract.data.relationships['sample-token-mint-finished-events']).to.deep.equal({
           "data": [{ type: "sample-token-mint-finished-events", id: eventId }]
         });
 
-        let event = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-mint-finished-events', eventId);
+        let event = await env.lookup('hub:searchers').get(env.session, 'sample-token-mint-finished-events', eventId);
         expect(event.data.attributes["block-number"]).to.equal(events[0].blockNumber, 'the block number is correct');
         expect(event.data.attributes["transaction-hash"]).to.equal(events[0].transactionHash, 'the transaction id is correct');
         expect(event.data.attributes["event-name"]).to.equal('MintFinished', 'the event name is correct');
@@ -1694,7 +1694,7 @@ contract('Token Indexing', function (accounts) {
         await indexers.update({ forceRefresh: true });
         await waitForEthereumEvents(eventIndexer);
 
-        let accountOneLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountOne);
+        let accountOneLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountOne);
 
         expect(accountOneLedgerEntry.data.relationships['sample-token-mint-events']).to.deep.equal({
           "data": [{ type: "sample-token-mint-events", id: mintEventId }]
@@ -1704,7 +1704,7 @@ contract('Token Indexing', function (accounts) {
           "data": [{ type: "sample-token-transfer-events", id: transferEventId }]
         });
 
-        let transferEvent = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-transfer-events', transferEventId);
+        let transferEvent = await env.lookup('hub:searchers').get(env.session, 'sample-token-transfer-events', transferEventId);
         toLowercase(transferEvent, 'data.attributes.transfer-event-from');
         toLowercase(transferEvent, 'data.attributes.transfer-event-to');
         expect(transferEvent.data.attributes["block-number"]).to.equal(mintEvents[1].blockNumber, 'the block number is correct');
@@ -1776,8 +1776,8 @@ contract('Token Indexing', function (accounts) {
         await waitForEthereumEvents(eventIndexer);
 
         expect(addCount).to.equal(5, 'the correct number of records were indexed');
-        let accountOneLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountOne);
-        let accountTwoLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountTwo);
+        let accountOneLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountOne);
+        let accountTwoLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountTwo);
 
         expect(accountOneLedgerEntry.data.attributes["mapping-number-value"]).to.equal("80", "the token balance is correct");
         expect(accountTwoLedgerEntry.data.attributes["mapping-number-value"]).to.equal("20", "the token balance is correct");
@@ -1851,8 +1851,8 @@ contract('Token Indexing', function (accounts) {
 
         await waitForEthereumEvents(eventIndexer);
 
-        let accountOneBalance = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountOne);
-        let accountThreeBalance = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountThree);
+        let accountOneBalance = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountOne);
+        let accountThreeBalance = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountThree);
 
         expect(accountOneBalance.data.attributes['utility-payment-amount']).to.equal(50, 'utility-payment-amount computed field is correct');
         expect(accountThreeBalance.data.attributes['utility-payment-amount']).to.equal(20, 'utility-payment-amount computed field is correct');
@@ -1903,11 +1903,11 @@ contract('Token Indexing', function (accounts) {
       afterEach(teardown);
 
       it("can index a large amount of past events on the contract", async function () {
-        let accountOneLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountOne.toLowerCase());
-        let accountTwoLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountTwo.toLowerCase());
-        let accountThreeLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountThree.toLowerCase());
-        let tokenRecord = await env.lookup('hub:searchers').getCard(env.session, 'sample-tokens', token.address);
-        let events = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { page: { size: 5000 }, filter: { type: 'sample-token-white-list-events' } });
+        let accountOneLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountOne.toLowerCase());
+        let accountTwoLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountTwo.toLowerCase());
+        let accountThreeLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountThree.toLowerCase());
+        let tokenRecord = await env.lookup('hub:searchers').get(env.session, 'sample-tokens', token.address);
+        let events = await env.lookup('hub:searchers').search(env.session, { page: { size: 5000 }, filter: { type: 'sample-token-white-list-events' } });
 
         expect(tokenRecord.data.attributes["sample-token-buyer-count"]).to.equal("1000", "the buyer count is correct");
         expect(accountOneLedgerEntry.data.attributes["mapping-number-value"]).to.equal("50", "the token balance is correct");
@@ -1916,7 +1916,7 @@ contract('Token Indexing', function (accounts) {
         expect(events.data.length).to.equal(addresses.length, 'the correct number of whitelist event documents were created');
 
         for (let address of addresses) {
-          let whitelistEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-approved-buyers', address.toLowerCase());
+          let whitelistEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-approved-buyers', address.toLowerCase());
           expect(whitelistEntry.data.attributes["mapping-boolean-value"]).to.equal(true);
         }
       });

--- a/packages/ethereum/truffle-tests/contracts-test.js
+++ b/packages/ethereum/truffle-tests/contracts-test.js
@@ -104,7 +104,7 @@ contract('Token Indexing', function (accounts) {
       afterEach(teardown);
 
       it('can generate schema from ERC-20 contract`s ABI', async function () {
-        let schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-tokens');
+        let schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'sample-tokens');
         expect(schema).to.deep.equal({
           "data": {
             "id": "sample-tokens",
@@ -171,7 +171,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'grants', 'sample-token-grant');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'grants', 'sample-token-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -203,7 +203,7 @@ contract('Token Indexing', function (accounts) {
         });
 
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-balance-ofs');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'sample-token-balance-ofs');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -247,7 +247,7 @@ contract('Token Indexing', function (accounts) {
         });
 
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-custom-buyer-limits');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'sample-token-custom-buyer-limits');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -286,7 +286,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-vesting-schedules');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'sample-token-vesting-schedules');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -345,7 +345,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vesting-schedule-start-date');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'vesting-schedule-start-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -359,7 +359,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vesting-schedule-cliff-date');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'vesting-schedule-cliff-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -373,7 +373,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vesting-schedule-duration-sec');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'vesting-schedule-duration-sec');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -387,7 +387,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vesting-schedule-fully-vested-amount');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'vesting-schedule-fully-vested-amount');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -401,7 +401,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vesting-schedule-revoke-date');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'vesting-schedule-revoke-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -415,7 +415,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vesting-schedule-is-revocable');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'vesting-schedule-is-revocable');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -429,7 +429,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'grants', 'sample-token-vesting-schedule-grant');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'grants', 'sample-token-vesting-schedule-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -460,7 +460,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-approved-buyers');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'sample-token-approved-buyers');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -499,7 +499,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'grants', 'sample-token-balance-of-grant');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'grants', 'sample-token-balance-of-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -530,7 +530,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-name');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'sample-token-name');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -544,7 +544,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-minting-finished');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'sample-token-minting-finished');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -558,7 +558,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-owner');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'sample-token-owner');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -572,7 +572,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-symbol');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'sample-token-symbol');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -586,7 +586,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-total-supply');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'sample-token-total-supply');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -600,7 +600,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-contract');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'sample-token-contract');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -624,7 +624,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-transfer-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'sample-token-transfer-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -675,7 +675,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'grants', 'sample-token-transfer-events-grant');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'grants', 'sample-token-transfer-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -706,7 +706,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-transfer-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'sample-token-transfer-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -720,7 +720,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'transfer-event-from');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'transfer-event-from');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -734,7 +734,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'transfer-event-to');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'transfer-event-to');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -748,7 +748,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'transfer-event-value');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'transfer-event-value');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -762,7 +762,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-token-frozen-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'sample-token-token-frozen-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -805,7 +805,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'grants', 'sample-token-token-frozen-events-grant');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'grants', 'sample-token-token-frozen-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -836,7 +836,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-token-frozen-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'sample-token-token-frozen-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -850,7 +850,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'token-frozen-event-is-frozen');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'token-frozen-event-is-frozen');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -864,7 +864,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-mint-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'sample-token-mint-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -911,7 +911,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'grants', 'sample-token-mint-events-grant');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'grants', 'sample-token-mint-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -942,7 +942,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-mint-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'sample-token-mint-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -956,7 +956,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'mint-event-to');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'mint-event-to');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -970,7 +970,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'mint-event-amount');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'mint-event-amount');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -984,7 +984,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-white-list-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'sample-token-white-list-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -1031,7 +1031,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'grants', 'sample-token-white-list-events-grant');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'grants', 'sample-token-white-list-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -1062,7 +1062,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-white-list-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'sample-token-white-list-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1076,7 +1076,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'white-list-event-buyer');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'white-list-event-buyer');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1090,7 +1090,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'white-list-event-hold-cap');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'white-list-event-hold-cap');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1104,7 +1104,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'content-types', 'sample-token-vested-token-grant-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'sample-token-vested-token-grant-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -1171,7 +1171,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'grants', 'sample-token-vested-token-grant-events-grant');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'grants', 'sample-token-vested-token-grant-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -1202,7 +1202,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'sample-token-vested-token-grant-events');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'sample-token-vested-token-grant-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1216,7 +1216,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vested-token-grant-event-beneficiary');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'vested-token-grant-event-beneficiary');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1230,7 +1230,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vested-token-grant-event-start-date');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'vested-token-grant-event-start-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1244,7 +1244,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vested-token-grant-event-cliff-sec');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'vested-token-grant-event-cliff-sec');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1258,7 +1258,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vested-token-grant-event-duration-sec');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'vested-token-grant-event-duration-sec');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1272,7 +1272,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vested-token-grant-event-fully-vested-amount');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'vested-token-grant-event-fully-vested-amount');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1286,7 +1286,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vested-token-grant-event-revoke-date');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'vested-token-grant-event-revoke-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1300,7 +1300,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'fields', 'vested-token-grant-event-is-revocable');
+        schema = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'fields', 'vested-token-grant-event-is-revocable');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1316,7 +1316,7 @@ contract('Token Indexing', function (accounts) {
       });
 
       it("indexes a contract", async function () {
-        let contract = await env.lookup('hub:searchers').get(env.session, 'sample-tokens', token.address);
+        let contract = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-tokens', token.address);
         contract.data.attributes["sample-token-owner"] = contract.data.attributes["sample-token-owner"].toLowerCase();
         delete contract.data.meta;
         expect(contract).to.deep.equal({
@@ -1351,7 +1351,7 @@ contract('Token Indexing', function (accounts) {
 
         await waitForEthereumEvents(eventIndexer);
 
-        let vestingSchedule = await env.lookup('hub:searchers').get(env.session, 'sample-token-vesting-schedules', accountOne);
+        let vestingSchedule = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-vesting-schedules', accountOne);
 
         expect(vestingSchedule.data.attributes["ethereum-address"]).to.not.equal(vestingSchedule.data.id, 'the case between the addresses is different');
         vestingSchedule.data.attributes["ethereum-address"] = vestingSchedule.data.attributes["ethereum-address"].toLowerCase();
@@ -1391,14 +1391,14 @@ contract('Token Indexing', function (accounts) {
 
       it("indexes mapping entry content types when a contract fires an ethereum event", async function () {
         try {
-          await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountOne);
+          await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-balance-ofs', accountOne);
           throw new Error("balance-of record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-balance-ofs/${accountOne}`);
         }
 
         try {
-          await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountTwo);
+          await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-balance-ofs', accountTwo);
           throw new Error("balance-of record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-balance-ofs/${accountTwo}`);
@@ -1412,7 +1412,7 @@ contract('Token Indexing', function (accounts) {
 
         await waitForEthereumEvents(eventIndexer);
 
-        let accountOneLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountOne);
+        let accountOneLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-balance-ofs', accountOne);
         expect(accountOneLedgerEntry.data.attributes["ethereum-address"]).to.not.equal(accountOneLedgerEntry.data.id, 'the case between the addresses is different');
         accountOneLedgerEntry.data.attributes["ethereum-address"] = accountOneLedgerEntry.data.attributes["ethereum-address"].toLowerCase();
         delete accountOneLedgerEntry.data.meta;
@@ -1447,10 +1447,10 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        let accountTwoLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountTwo);
+        let accountTwoLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-balance-ofs', accountTwo);
         expect(accountTwoLedgerEntry.data.attributes["mapping-number-value"]).to.equal("10", "the token balance is correct");
 
-        let transferEvent1 = await env.lookup('hub:searchers').get(env.session, 'sample-token-transfer-events', transferEvent1Id);
+        let transferEvent1 = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-transfer-events', transferEvent1Id);
         delete transferEvent1.data.meta;
         toLowercase(transferEvent1, 'data.attributes.transfer-event-from');
         toLowercase(transferEvent1, 'data.attributes.transfer-event-to');
@@ -1474,7 +1474,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        let transferEvent2 = await env.lookup('hub:searchers').get(env.session, 'sample-token-transfer-events', transferEvent2Id);
+        let transferEvent2 = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-transfer-events', transferEvent2Id);
         toLowercase(transferEvent2, 'data.attributes.transfer-event-from');
         toLowercase(transferEvent2, 'data.attributes.transfer-event-to');
         expect(transferEvent2.data.attributes["block-number"]).to.equal(transferEvents[0].blockNumber, 'the block number is correct');
@@ -1487,28 +1487,28 @@ contract('Token Indexing', function (accounts) {
 
       it("indexes mapping entry content with different field types for the same event", async function () {
         try {
-          await env.lookup('hub:searchers').get(env.session, 'sample-token-custom-buyer-limits', accountOne);
+          await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-custom-buyer-limits', accountOne);
           throw new Error("sample-token-custom-buyer-limits record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-custom-buyer-limits/${accountOne}`);
         }
 
         try {
-          await env.lookup('hub:searchers').get(env.session, 'sample-token-approved-buyers', accountOne);
+          await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-approved-buyers', accountOne);
           throw new Error("sample-token-approved-buyers record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-approved-buyers/${accountOne}`);
         }
 
         try {
-          await env.lookup('hub:searchers').get(env.session, 'sample-token-custom-buyer-limits', accountTwo);
+          await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-custom-buyer-limits', accountTwo);
           throw new Error("sample-token-custom-buyer-limits record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-custom-buyer-limits/${accountTwo}`);
         }
 
         try {
-          await env.lookup('hub:searchers').get(env.session, 'sample-token-approved-buyers', accountTwo);
+          await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-approved-buyers', accountTwo);
           throw new Error("sample-token-approved-buyers record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-approved-buyers/${accountTwo}`);
@@ -1522,7 +1522,7 @@ contract('Token Indexing', function (accounts) {
         await env.lookup('hub:indexers').update({ forceRefresh: true });
         await waitForEthereumEvents(eventIndexer);
 
-        let accountOneApprovedBuyer = await env.lookup('hub:searchers').get(env.session, 'sample-token-approved-buyers', accountOne);
+        let accountOneApprovedBuyer = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-approved-buyers', accountOne);
         accountOneApprovedBuyer.data.attributes["ethereum-address"] = accountOneApprovedBuyer.data.attributes["ethereum-address"].toLowerCase();
         delete accountOneApprovedBuyer.data.meta;
         expect(accountOneApprovedBuyer).to.deep.equal({
@@ -1552,7 +1552,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        let accountOneCustomBuyerLimit = await env.lookup('hub:searchers').get(env.session, 'sample-token-custom-buyer-limits', accountOne);
+        let accountOneCustomBuyerLimit = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-custom-buyer-limits', accountOne);
         accountOneCustomBuyerLimit.data.attributes["ethereum-address"] = accountOneCustomBuyerLimit.data.attributes["ethereum-address"].toLowerCase();
         delete accountOneCustomBuyerLimit.data.meta;
         expect(accountOneCustomBuyerLimit).to.deep.equal({
@@ -1582,10 +1582,10 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        let accountTwoApprovedBuyer = await env.lookup('hub:searchers').get(env.session, 'sample-token-approved-buyers', accountTwo);
+        let accountTwoApprovedBuyer = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-approved-buyers', accountTwo);
         expect(accountTwoApprovedBuyer.data.attributes["mapping-boolean-value"]).to.equal(true, "the mapping-boolean-value is correct");
 
-        let accountTwoCustomBuyerLimit = await env.lookup('hub:searchers').get(env.session, 'sample-token-custom-buyer-limits', accountTwo);
+        let accountTwoCustomBuyerLimit = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-custom-buyer-limits', accountTwo);
         expect(accountTwoCustomBuyerLimit.data.attributes["mapping-number-value"]).to.equal("10", "the mapping-number-value is correct");
       });
     });
@@ -1625,21 +1625,21 @@ contract('Token Indexing', function (accounts) {
       afterEach(teardown);
 
       it('can update contract document from event content trigger', async function () {
-        let contract = await env.lookup('hub:searchers').get(env.session, 'sample-tokens', token.address);
+        let contract = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-tokens', token.address);
         expect(contract.data.attributes['sample-token-minting-finished']).to.equal(false, 'the minting-finished field is correct');
 
         let { logs: events } = await token.finishMinting();
         let eventId = `${events[0].transactionHash}_${events[0].logIndex}`;
         await waitForEthereumEvents(eventIndexer);
 
-        contract = await env.lookup('hub:searchers').get(env.session, 'sample-tokens', token.address);
+        contract = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-tokens', token.address);
         expect(contract.data.attributes['sample-token-minting-finished']).to.equal(true, 'the minting-finished field is correct');
 
         expect(contract.data.relationships['sample-token-mint-finished-events']).to.deep.equal({
           "data": [{ type: "sample-token-mint-finished-events", id: eventId }]
         });
 
-        let event = await env.lookup('hub:searchers').get(env.session, 'sample-token-mint-finished-events', eventId);
+        let event = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-mint-finished-events', eventId);
         expect(event.data.attributes["block-number"]).to.equal(events[0].blockNumber, 'the block number is correct');
         expect(event.data.attributes["transaction-hash"]).to.equal(events[0].transactionHash, 'the transaction id is correct');
         expect(event.data.attributes["event-name"]).to.equal('MintFinished', 'the event name is correct');
@@ -1694,7 +1694,7 @@ contract('Token Indexing', function (accounts) {
         await indexers.update({ forceRefresh: true });
         await waitForEthereumEvents(eventIndexer);
 
-        let accountOneLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountOne);
+        let accountOneLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-balance-ofs', accountOne);
 
         expect(accountOneLedgerEntry.data.relationships['sample-token-mint-events']).to.deep.equal({
           "data": [{ type: "sample-token-mint-events", id: mintEventId }]
@@ -1704,7 +1704,7 @@ contract('Token Indexing', function (accounts) {
           "data": [{ type: "sample-token-transfer-events", id: transferEventId }]
         });
 
-        let transferEvent = await env.lookup('hub:searchers').get(env.session, 'sample-token-transfer-events', transferEventId);
+        let transferEvent = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-transfer-events', transferEventId);
         toLowercase(transferEvent, 'data.attributes.transfer-event-from');
         toLowercase(transferEvent, 'data.attributes.transfer-event-to');
         expect(transferEvent.data.attributes["block-number"]).to.equal(mintEvents[1].blockNumber, 'the block number is correct');
@@ -1776,8 +1776,8 @@ contract('Token Indexing', function (accounts) {
         await waitForEthereumEvents(eventIndexer);
 
         expect(addCount).to.equal(5, 'the correct number of records were indexed');
-        let accountOneLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountOne);
-        let accountTwoLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountTwo);
+        let accountOneLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-balance-ofs', accountOne);
+        let accountTwoLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-balance-ofs', accountTwo);
 
         expect(accountOneLedgerEntry.data.attributes["mapping-number-value"]).to.equal("80", "the token balance is correct");
         expect(accountTwoLedgerEntry.data.attributes["mapping-number-value"]).to.equal("20", "the token balance is correct");
@@ -1851,8 +1851,8 @@ contract('Token Indexing', function (accounts) {
 
         await waitForEthereumEvents(eventIndexer);
 
-        let accountOneBalance = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountOne);
-        let accountThreeBalance = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountThree);
+        let accountOneBalance = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-balance-ofs', accountOne);
+        let accountThreeBalance = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-balance-ofs', accountThree);
 
         expect(accountOneBalance.data.attributes['utility-payment-amount']).to.equal(50, 'utility-payment-amount computed field is correct');
         expect(accountThreeBalance.data.attributes['utility-payment-amount']).to.equal(20, 'utility-payment-amount computed field is correct');
@@ -1903,10 +1903,10 @@ contract('Token Indexing', function (accounts) {
       afterEach(teardown);
 
       it("can index a large amount of past events on the contract", async function () {
-        let accountOneLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountOne.toLowerCase());
-        let accountTwoLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountTwo.toLowerCase());
-        let accountThreeLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-balance-ofs', accountThree.toLowerCase());
-        let tokenRecord = await env.lookup('hub:searchers').get(env.session, 'sample-tokens', token.address);
+        let accountOneLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-balance-ofs', accountOne.toLowerCase());
+        let accountTwoLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-balance-ofs', accountTwo.toLowerCase());
+        let accountThreeLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-balance-ofs', accountThree.toLowerCase());
+        let tokenRecord = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-tokens', token.address);
         let events = await env.lookup('hub:searchers').search(env.session, { page: { size: 5000 }, filter: { type: 'sample-token-white-list-events' } });
 
         expect(tokenRecord.data.attributes["sample-token-buyer-count"]).to.equal("1000", "the buyer count is correct");
@@ -1916,7 +1916,7 @@ contract('Token Indexing', function (accounts) {
         expect(events.data.length).to.equal(addresses.length, 'the correct number of whitelist event documents were created');
 
         for (let address of addresses) {
-          let whitelistEntry = await env.lookup('hub:searchers').get(env.session, 'sample-token-approved-buyers', address.toLowerCase());
+          let whitelistEntry = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-token-approved-buyers', address.toLowerCase());
           expect(whitelistEntry.data.attributes["mapping-boolean-value"]).to.equal(true);
         }
       });

--- a/packages/ethereum/truffle-tests/contracts-test.js
+++ b/packages/ethereum/truffle-tests/contracts-test.js
@@ -1907,7 +1907,7 @@ contract('Token Indexing', function (accounts) {
         let accountTwoLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountTwo.toLowerCase());
         let accountThreeLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountThree.toLowerCase());
         let tokenRecord = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-tokens', token.address);
-        let events = await env.lookup('hub:searchers').search(env.session, 'master', { page: { size: 5000 }, filter: { type: 'sample-token-white-list-events' } });
+        let events = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { page: { size: 5000 }, filter: { type: 'sample-token-white-list-events' } });
 
         expect(tokenRecord.data.attributes["sample-token-buyer-count"]).to.equal("1000", "the buyer count is correct");
         expect(accountOneLedgerEntry.data.attributes["mapping-number-value"]).to.equal("50", "the token balance is correct");

--- a/packages/ethereum/truffle-tests/contracts-test.js
+++ b/packages/ethereum/truffle-tests/contracts-test.js
@@ -104,7 +104,7 @@ contract('Token Indexing', function (accounts) {
       afterEach(teardown);
 
       it('can generate schema from ERC-20 contract`s ABI', async function () {
-        let schema = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'sample-tokens');
+        let schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-tokens');
         expect(schema).to.deep.equal({
           "data": {
             "id": "sample-tokens",
@@ -171,7 +171,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'grants', 'sample-token-grant');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'grants', 'sample-token-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -203,7 +203,7 @@ contract('Token Indexing', function (accounts) {
         });
 
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'sample-token-balance-ofs');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-balance-ofs');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -247,7 +247,7 @@ contract('Token Indexing', function (accounts) {
         });
 
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'sample-token-custom-buyer-limits');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-custom-buyer-limits');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -286,7 +286,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'sample-token-vesting-schedules');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-vesting-schedules');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -345,7 +345,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vesting-schedule-start-date');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vesting-schedule-start-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -359,7 +359,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vesting-schedule-cliff-date');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vesting-schedule-cliff-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -373,7 +373,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vesting-schedule-duration-sec');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vesting-schedule-duration-sec');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -387,7 +387,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vesting-schedule-fully-vested-amount');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vesting-schedule-fully-vested-amount');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -401,7 +401,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vesting-schedule-revoke-date');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vesting-schedule-revoke-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -415,7 +415,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vesting-schedule-is-revocable');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vesting-schedule-is-revocable');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -429,7 +429,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'grants', 'sample-token-vesting-schedule-grant');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'grants', 'sample-token-vesting-schedule-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -460,7 +460,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'sample-token-approved-buyers');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-approved-buyers');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -499,7 +499,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'grants', 'sample-token-balance-of-grant');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'grants', 'sample-token-balance-of-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -530,7 +530,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'sample-token-name');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-name');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -544,7 +544,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'sample-token-minting-finished');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-minting-finished');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -558,7 +558,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'sample-token-owner');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-owner');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -572,7 +572,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'sample-token-symbol');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-symbol');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -586,7 +586,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'sample-token-total-supply');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-total-supply');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -600,7 +600,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'sample-token-contract');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-contract');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -624,7 +624,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'sample-token-transfer-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-transfer-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -675,7 +675,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'grants', 'sample-token-transfer-events-grant');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'grants', 'sample-token-transfer-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -706,7 +706,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'sample-token-transfer-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-transfer-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -720,7 +720,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'transfer-event-from');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'transfer-event-from');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -734,7 +734,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'transfer-event-to');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'transfer-event-to');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -748,7 +748,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'transfer-event-value');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'transfer-event-value');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -762,7 +762,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'sample-token-token-frozen-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-token-frozen-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -805,7 +805,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'grants', 'sample-token-token-frozen-events-grant');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'grants', 'sample-token-token-frozen-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -836,7 +836,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'sample-token-token-frozen-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-token-frozen-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -850,7 +850,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'token-frozen-event-is-frozen');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'token-frozen-event-is-frozen');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -864,7 +864,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'sample-token-mint-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-mint-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -911,7 +911,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'grants', 'sample-token-mint-events-grant');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'grants', 'sample-token-mint-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -942,7 +942,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'sample-token-mint-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-mint-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -956,7 +956,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'mint-event-to');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'mint-event-to');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -970,7 +970,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'mint-event-amount');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'mint-event-amount');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -984,7 +984,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'sample-token-white-list-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-white-list-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -1031,7 +1031,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'grants', 'sample-token-white-list-events-grant');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'grants', 'sample-token-white-list-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -1062,7 +1062,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'sample-token-white-list-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-white-list-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1076,7 +1076,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'white-list-event-buyer');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'white-list-event-buyer');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1090,7 +1090,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'white-list-event-hold-cap');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'white-list-event-hold-cap');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1104,7 +1104,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'sample-token-vested-token-grant-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-vested-token-grant-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -1171,7 +1171,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'grants', 'sample-token-vested-token-grant-events-grant');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'grants', 'sample-token-vested-token-grant-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -1202,7 +1202,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'sample-token-vested-token-grant-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-vested-token-grant-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1216,7 +1216,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vested-token-grant-event-beneficiary');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vested-token-grant-event-beneficiary');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1230,7 +1230,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vested-token-grant-event-start-date');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vested-token-grant-event-start-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1244,7 +1244,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vested-token-grant-event-cliff-sec');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vested-token-grant-event-cliff-sec');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1258,7 +1258,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vested-token-grant-event-duration-sec');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vested-token-grant-event-duration-sec');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1272,7 +1272,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vested-token-grant-event-fully-vested-amount');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vested-token-grant-event-fully-vested-amount');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1286,7 +1286,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vested-token-grant-event-revoke-date');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vested-token-grant-event-revoke-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1300,7 +1300,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').get(env.session, 'master', 'fields', 'vested-token-grant-event-is-revocable');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vested-token-grant-event-is-revocable');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1316,7 +1316,7 @@ contract('Token Indexing', function (accounts) {
       });
 
       it("indexes a contract", async function () {
-        let contract = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-tokens', token.address);
+        let contract = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-tokens', token.address);
         contract.data.attributes["sample-token-owner"] = contract.data.attributes["sample-token-owner"].toLowerCase();
         delete contract.data.meta;
         expect(contract).to.deep.equal({
@@ -1351,7 +1351,7 @@ contract('Token Indexing', function (accounts) {
 
         await waitForEthereumEvents(eventIndexer);
 
-        let vestingSchedule = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-vesting-schedules', accountOne);
+        let vestingSchedule = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-vesting-schedules', accountOne);
 
         expect(vestingSchedule.data.attributes["ethereum-address"]).to.not.equal(vestingSchedule.data.id, 'the case between the addresses is different');
         vestingSchedule.data.attributes["ethereum-address"] = vestingSchedule.data.attributes["ethereum-address"].toLowerCase();
@@ -1391,14 +1391,14 @@ contract('Token Indexing', function (accounts) {
 
       it("indexes mapping entry content types when a contract fires an ethereum event", async function () {
         try {
-          await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-balance-ofs', accountOne);
+          await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountOne);
           throw new Error("balance-of record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-balance-ofs/${accountOne}`);
         }
 
         try {
-          await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-balance-ofs', accountTwo);
+          await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountTwo);
           throw new Error("balance-of record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-balance-ofs/${accountTwo}`);
@@ -1412,7 +1412,7 @@ contract('Token Indexing', function (accounts) {
 
         await waitForEthereumEvents(eventIndexer);
 
-        let accountOneLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-balance-ofs', accountOne);
+        let accountOneLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountOne);
         expect(accountOneLedgerEntry.data.attributes["ethereum-address"]).to.not.equal(accountOneLedgerEntry.data.id, 'the case between the addresses is different');
         accountOneLedgerEntry.data.attributes["ethereum-address"] = accountOneLedgerEntry.data.attributes["ethereum-address"].toLowerCase();
         delete accountOneLedgerEntry.data.meta;
@@ -1447,10 +1447,10 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        let accountTwoLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-balance-ofs', accountTwo);
+        let accountTwoLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountTwo);
         expect(accountTwoLedgerEntry.data.attributes["mapping-number-value"]).to.equal("10", "the token balance is correct");
 
-        let transferEvent1 = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-transfer-events', transferEvent1Id);
+        let transferEvent1 = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-transfer-events', transferEvent1Id);
         delete transferEvent1.data.meta;
         toLowercase(transferEvent1, 'data.attributes.transfer-event-from');
         toLowercase(transferEvent1, 'data.attributes.transfer-event-to');
@@ -1474,7 +1474,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        let transferEvent2 = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-transfer-events', transferEvent2Id);
+        let transferEvent2 = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-transfer-events', transferEvent2Id);
         toLowercase(transferEvent2, 'data.attributes.transfer-event-from');
         toLowercase(transferEvent2, 'data.attributes.transfer-event-to');
         expect(transferEvent2.data.attributes["block-number"]).to.equal(transferEvents[0].blockNumber, 'the block number is correct');
@@ -1487,28 +1487,28 @@ contract('Token Indexing', function (accounts) {
 
       it("indexes mapping entry content with different field types for the same event", async function () {
         try {
-          await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-custom-buyer-limits', accountOne);
+          await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-custom-buyer-limits', accountOne);
           throw new Error("sample-token-custom-buyer-limits record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-custom-buyer-limits/${accountOne}`);
         }
 
         try {
-          await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-approved-buyers', accountOne);
+          await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-approved-buyers', accountOne);
           throw new Error("sample-token-approved-buyers record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-approved-buyers/${accountOne}`);
         }
 
         try {
-          await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-custom-buyer-limits', accountTwo);
+          await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-custom-buyer-limits', accountTwo);
           throw new Error("sample-token-custom-buyer-limits record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-custom-buyer-limits/${accountTwo}`);
         }
 
         try {
-          await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-approved-buyers', accountTwo);
+          await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-approved-buyers', accountTwo);
           throw new Error("sample-token-approved-buyers record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-approved-buyers/${accountTwo}`);
@@ -1522,7 +1522,7 @@ contract('Token Indexing', function (accounts) {
         await env.lookup('hub:indexers').update({ forceRefresh: true });
         await waitForEthereumEvents(eventIndexer);
 
-        let accountOneApprovedBuyer = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-approved-buyers', accountOne);
+        let accountOneApprovedBuyer = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-approved-buyers', accountOne);
         accountOneApprovedBuyer.data.attributes["ethereum-address"] = accountOneApprovedBuyer.data.attributes["ethereum-address"].toLowerCase();
         delete accountOneApprovedBuyer.data.meta;
         expect(accountOneApprovedBuyer).to.deep.equal({
@@ -1552,7 +1552,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        let accountOneCustomBuyerLimit = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-custom-buyer-limits', accountOne);
+        let accountOneCustomBuyerLimit = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-custom-buyer-limits', accountOne);
         accountOneCustomBuyerLimit.data.attributes["ethereum-address"] = accountOneCustomBuyerLimit.data.attributes["ethereum-address"].toLowerCase();
         delete accountOneCustomBuyerLimit.data.meta;
         expect(accountOneCustomBuyerLimit).to.deep.equal({
@@ -1582,10 +1582,10 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        let accountTwoApprovedBuyer = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-approved-buyers', accountTwo);
+        let accountTwoApprovedBuyer = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-approved-buyers', accountTwo);
         expect(accountTwoApprovedBuyer.data.attributes["mapping-boolean-value"]).to.equal(true, "the mapping-boolean-value is correct");
 
-        let accountTwoCustomBuyerLimit = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-custom-buyer-limits', accountTwo);
+        let accountTwoCustomBuyerLimit = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-custom-buyer-limits', accountTwo);
         expect(accountTwoCustomBuyerLimit.data.attributes["mapping-number-value"]).to.equal("10", "the mapping-number-value is correct");
       });
     });
@@ -1625,21 +1625,21 @@ contract('Token Indexing', function (accounts) {
       afterEach(teardown);
 
       it('can update contract document from event content trigger', async function () {
-        let contract = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-tokens', token.address);
+        let contract = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-tokens', token.address);
         expect(contract.data.attributes['sample-token-minting-finished']).to.equal(false, 'the minting-finished field is correct');
 
         let { logs: events } = await token.finishMinting();
         let eventId = `${events[0].transactionHash}_${events[0].logIndex}`;
         await waitForEthereumEvents(eventIndexer);
 
-        contract = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-tokens', token.address);
+        contract = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-tokens', token.address);
         expect(contract.data.attributes['sample-token-minting-finished']).to.equal(true, 'the minting-finished field is correct');
 
         expect(contract.data.relationships['sample-token-mint-finished-events']).to.deep.equal({
           "data": [{ type: "sample-token-mint-finished-events", id: eventId }]
         });
 
-        let event = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-mint-finished-events', eventId);
+        let event = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-mint-finished-events', eventId);
         expect(event.data.attributes["block-number"]).to.equal(events[0].blockNumber, 'the block number is correct');
         expect(event.data.attributes["transaction-hash"]).to.equal(events[0].transactionHash, 'the transaction id is correct');
         expect(event.data.attributes["event-name"]).to.equal('MintFinished', 'the event name is correct');
@@ -1694,7 +1694,7 @@ contract('Token Indexing', function (accounts) {
         await indexers.update({ forceRefresh: true });
         await waitForEthereumEvents(eventIndexer);
 
-        let accountOneLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-balance-ofs', accountOne);
+        let accountOneLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountOne);
 
         expect(accountOneLedgerEntry.data.relationships['sample-token-mint-events']).to.deep.equal({
           "data": [{ type: "sample-token-mint-events", id: mintEventId }]
@@ -1704,7 +1704,7 @@ contract('Token Indexing', function (accounts) {
           "data": [{ type: "sample-token-transfer-events", id: transferEventId }]
         });
 
-        let transferEvent = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-transfer-events', transferEventId);
+        let transferEvent = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-transfer-events', transferEventId);
         toLowercase(transferEvent, 'data.attributes.transfer-event-from');
         toLowercase(transferEvent, 'data.attributes.transfer-event-to');
         expect(transferEvent.data.attributes["block-number"]).to.equal(mintEvents[1].blockNumber, 'the block number is correct');
@@ -1776,8 +1776,8 @@ contract('Token Indexing', function (accounts) {
         await waitForEthereumEvents(eventIndexer);
 
         expect(addCount).to.equal(5, 'the correct number of records were indexed');
-        let accountOneLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-balance-ofs', accountOne);
-        let accountTwoLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-balance-ofs', accountTwo);
+        let accountOneLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountOne);
+        let accountTwoLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountTwo);
 
         expect(accountOneLedgerEntry.data.attributes["mapping-number-value"]).to.equal("80", "the token balance is correct");
         expect(accountTwoLedgerEntry.data.attributes["mapping-number-value"]).to.equal("20", "the token balance is correct");
@@ -1851,8 +1851,8 @@ contract('Token Indexing', function (accounts) {
 
         await waitForEthereumEvents(eventIndexer);
 
-        let accountOneBalance = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-balance-ofs', accountOne);
-        let accountThreeBalance = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-balance-ofs', accountThree);
+        let accountOneBalance = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountOne);
+        let accountThreeBalance = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountThree);
 
         expect(accountOneBalance.data.attributes['utility-payment-amount']).to.equal(50, 'utility-payment-amount computed field is correct');
         expect(accountThreeBalance.data.attributes['utility-payment-amount']).to.equal(20, 'utility-payment-amount computed field is correct');
@@ -1903,10 +1903,10 @@ contract('Token Indexing', function (accounts) {
       afterEach(teardown);
 
       it("can index a large amount of past events on the contract", async function () {
-        let accountOneLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-balance-ofs', accountOne.toLowerCase());
-        let accountTwoLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-balance-ofs', accountTwo.toLowerCase());
-        let accountThreeLedgerEntry = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-balance-ofs', accountThree.toLowerCase());
-        let tokenRecord = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-tokens', token.address);
+        let accountOneLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountOne.toLowerCase());
+        let accountTwoLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountTwo.toLowerCase());
+        let accountThreeLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountThree.toLowerCase());
+        let tokenRecord = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-tokens', token.address);
         let events = await env.lookup('hub:searchers').search(env.session, 'master', { page: { size: 5000 }, filter: { type: 'sample-token-white-list-events' } });
 
         expect(tokenRecord.data.attributes["sample-token-buyer-count"]).to.equal("1000", "the buyer count is correct");
@@ -1916,7 +1916,7 @@ contract('Token Indexing', function (accounts) {
         expect(events.data.length).to.equal(addresses.length, 'the correct number of whitelist event documents were created');
 
         for (let address of addresses) {
-          let whitelistEntry = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-token-approved-buyers', address.toLowerCase());
+          let whitelistEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-approved-buyers', address.toLowerCase());
           expect(whitelistEntry.data.attributes["mapping-boolean-value"]).to.equal(true);
         }
       });

--- a/packages/ethereum/truffle-tests/contracts-test.js
+++ b/packages/ethereum/truffle-tests/contracts-test.js
@@ -104,7 +104,7 @@ contract('Token Indexing', function (accounts) {
       afterEach(teardown);
 
       it('can generate schema from ERC-20 contract`s ABI', async function () {
-        let schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-tokens');
+        let schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-tokens');
         expect(schema).to.deep.equal({
           "data": {
             "id": "sample-tokens",
@@ -171,7 +171,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'grants', 'sample-token-grant');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'grants', 'sample-token-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -203,7 +203,7 @@ contract('Token Indexing', function (accounts) {
         });
 
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-balance-ofs');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-balance-ofs');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -247,7 +247,7 @@ contract('Token Indexing', function (accounts) {
         });
 
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-custom-buyer-limits');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-custom-buyer-limits');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -286,7 +286,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-vesting-schedules');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-vesting-schedules');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -345,7 +345,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vesting-schedule-start-date');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vesting-schedule-start-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -359,7 +359,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vesting-schedule-cliff-date');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vesting-schedule-cliff-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -373,7 +373,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vesting-schedule-duration-sec');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vesting-schedule-duration-sec');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -387,7 +387,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vesting-schedule-fully-vested-amount');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vesting-schedule-fully-vested-amount');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -401,7 +401,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vesting-schedule-revoke-date');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vesting-schedule-revoke-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -415,7 +415,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vesting-schedule-is-revocable');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vesting-schedule-is-revocable');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -429,7 +429,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'grants', 'sample-token-vesting-schedule-grant');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'grants', 'sample-token-vesting-schedule-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -460,7 +460,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-approved-buyers');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-approved-buyers');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -499,7 +499,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'grants', 'sample-token-balance-of-grant');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'grants', 'sample-token-balance-of-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -530,7 +530,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-name');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-name');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -544,7 +544,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-minting-finished');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-minting-finished');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -558,7 +558,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-owner');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-owner');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -572,7 +572,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-symbol');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-symbol');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -586,7 +586,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-total-supply');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-total-supply');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -600,7 +600,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-contract');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-contract');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -624,7 +624,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-transfer-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-transfer-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -675,7 +675,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'grants', 'sample-token-transfer-events-grant');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'grants', 'sample-token-transfer-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -706,7 +706,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-transfer-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-transfer-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -720,7 +720,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'transfer-event-from');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'transfer-event-from');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -734,7 +734,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'transfer-event-to');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'transfer-event-to');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -748,7 +748,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'transfer-event-value');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'transfer-event-value');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -762,7 +762,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-token-frozen-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-token-frozen-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -805,7 +805,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'grants', 'sample-token-token-frozen-events-grant');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'grants', 'sample-token-token-frozen-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -836,7 +836,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-token-frozen-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-token-frozen-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -850,7 +850,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'token-frozen-event-is-frozen');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'token-frozen-event-is-frozen');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -864,7 +864,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-mint-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-mint-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -911,7 +911,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'grants', 'sample-token-mint-events-grant');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'grants', 'sample-token-mint-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -942,7 +942,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-mint-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-mint-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -956,7 +956,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'mint-event-to');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'mint-event-to');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -970,7 +970,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'mint-event-amount');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'mint-event-amount');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -984,7 +984,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-white-list-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-white-list-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -1031,7 +1031,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'grants', 'sample-token-white-list-events-grant');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'grants', 'sample-token-white-list-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -1062,7 +1062,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-white-list-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-white-list-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1076,7 +1076,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'white-list-event-buyer');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'white-list-event-buyer');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1090,7 +1090,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'white-list-event-hold-cap');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'white-list-event-hold-cap');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1104,7 +1104,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'sample-token-vested-token-grant-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'sample-token-vested-token-grant-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "content-types",
@@ -1171,7 +1171,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'grants', 'sample-token-vested-token-grant-events-grant');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'grants', 'sample-token-vested-token-grant-events-grant');
         expect(schema).to.deep.equal({
           "data": {
             "type": "grants",
@@ -1202,7 +1202,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'sample-token-vested-token-grant-events');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'sample-token-vested-token-grant-events');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1216,7 +1216,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vested-token-grant-event-beneficiary');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vested-token-grant-event-beneficiary');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1230,7 +1230,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vested-token-grant-event-start-date');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vested-token-grant-event-start-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1244,7 +1244,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vested-token-grant-event-cliff-sec');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vested-token-grant-event-cliff-sec');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1258,7 +1258,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vested-token-grant-event-duration-sec');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vested-token-grant-event-duration-sec');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1272,7 +1272,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vested-token-grant-event-fully-vested-amount');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vested-token-grant-event-fully-vested-amount');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1286,7 +1286,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vested-token-grant-event-revoke-date');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vested-token-grant-event-revoke-date');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1300,7 +1300,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        schema = await env.lookup('hub:searchers').getCard(env.session, 'master', 'fields', 'vested-token-grant-event-is-revocable');
+        schema = await env.lookup('hub:searchers').getCard(env.session, 'fields', 'vested-token-grant-event-is-revocable');
         expect(schema).to.deep.equal({
           "data": {
             "type": "fields",
@@ -1316,7 +1316,7 @@ contract('Token Indexing', function (accounts) {
       });
 
       it("indexes a contract", async function () {
-        let contract = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-tokens', token.address);
+        let contract = await env.lookup('hub:searchers').getCard(env.session, 'sample-tokens', token.address);
         contract.data.attributes["sample-token-owner"] = contract.data.attributes["sample-token-owner"].toLowerCase();
         delete contract.data.meta;
         expect(contract).to.deep.equal({
@@ -1351,7 +1351,7 @@ contract('Token Indexing', function (accounts) {
 
         await waitForEthereumEvents(eventIndexer);
 
-        let vestingSchedule = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-vesting-schedules', accountOne);
+        let vestingSchedule = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-vesting-schedules', accountOne);
 
         expect(vestingSchedule.data.attributes["ethereum-address"]).to.not.equal(vestingSchedule.data.id, 'the case between the addresses is different');
         vestingSchedule.data.attributes["ethereum-address"] = vestingSchedule.data.attributes["ethereum-address"].toLowerCase();
@@ -1391,14 +1391,14 @@ contract('Token Indexing', function (accounts) {
 
       it("indexes mapping entry content types when a contract fires an ethereum event", async function () {
         try {
-          await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountOne);
+          await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountOne);
           throw new Error("balance-of record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-balance-ofs/${accountOne}`);
         }
 
         try {
-          await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountTwo);
+          await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountTwo);
           throw new Error("balance-of record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-balance-ofs/${accountTwo}`);
@@ -1412,7 +1412,7 @@ contract('Token Indexing', function (accounts) {
 
         await waitForEthereumEvents(eventIndexer);
 
-        let accountOneLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountOne);
+        let accountOneLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountOne);
         expect(accountOneLedgerEntry.data.attributes["ethereum-address"]).to.not.equal(accountOneLedgerEntry.data.id, 'the case between the addresses is different');
         accountOneLedgerEntry.data.attributes["ethereum-address"] = accountOneLedgerEntry.data.attributes["ethereum-address"].toLowerCase();
         delete accountOneLedgerEntry.data.meta;
@@ -1447,10 +1447,10 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        let accountTwoLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountTwo);
+        let accountTwoLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountTwo);
         expect(accountTwoLedgerEntry.data.attributes["mapping-number-value"]).to.equal("10", "the token balance is correct");
 
-        let transferEvent1 = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-transfer-events', transferEvent1Id);
+        let transferEvent1 = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-transfer-events', transferEvent1Id);
         delete transferEvent1.data.meta;
         toLowercase(transferEvent1, 'data.attributes.transfer-event-from');
         toLowercase(transferEvent1, 'data.attributes.transfer-event-to');
@@ -1474,7 +1474,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        let transferEvent2 = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-transfer-events', transferEvent2Id);
+        let transferEvent2 = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-transfer-events', transferEvent2Id);
         toLowercase(transferEvent2, 'data.attributes.transfer-event-from');
         toLowercase(transferEvent2, 'data.attributes.transfer-event-to');
         expect(transferEvent2.data.attributes["block-number"]).to.equal(transferEvents[0].blockNumber, 'the block number is correct');
@@ -1487,28 +1487,28 @@ contract('Token Indexing', function (accounts) {
 
       it("indexes mapping entry content with different field types for the same event", async function () {
         try {
-          await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-custom-buyer-limits', accountOne);
+          await env.lookup('hub:searchers').getCard(env.session, 'sample-token-custom-buyer-limits', accountOne);
           throw new Error("sample-token-custom-buyer-limits record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-custom-buyer-limits/${accountOne}`);
         }
 
         try {
-          await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-approved-buyers', accountOne);
+          await env.lookup('hub:searchers').getCard(env.session, 'sample-token-approved-buyers', accountOne);
           throw new Error("sample-token-approved-buyers record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-approved-buyers/${accountOne}`);
         }
 
         try {
-          await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-custom-buyer-limits', accountTwo);
+          await env.lookup('hub:searchers').getCard(env.session, 'sample-token-custom-buyer-limits', accountTwo);
           throw new Error("sample-token-custom-buyer-limits record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-custom-buyer-limits/${accountTwo}`);
         }
 
         try {
-          await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-approved-buyers', accountTwo);
+          await env.lookup('hub:searchers').getCard(env.session, 'sample-token-approved-buyers', accountTwo);
           throw new Error("sample-token-approved-buyers record should not exist for this address");
         } catch (err) {
           expect(err.message).to.equal(`No such resource master/sample-token-approved-buyers/${accountTwo}`);
@@ -1522,7 +1522,7 @@ contract('Token Indexing', function (accounts) {
         await env.lookup('hub:indexers').update({ forceRefresh: true });
         await waitForEthereumEvents(eventIndexer);
 
-        let accountOneApprovedBuyer = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-approved-buyers', accountOne);
+        let accountOneApprovedBuyer = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-approved-buyers', accountOne);
         accountOneApprovedBuyer.data.attributes["ethereum-address"] = accountOneApprovedBuyer.data.attributes["ethereum-address"].toLowerCase();
         delete accountOneApprovedBuyer.data.meta;
         expect(accountOneApprovedBuyer).to.deep.equal({
@@ -1552,7 +1552,7 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        let accountOneCustomBuyerLimit = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-custom-buyer-limits', accountOne);
+        let accountOneCustomBuyerLimit = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-custom-buyer-limits', accountOne);
         accountOneCustomBuyerLimit.data.attributes["ethereum-address"] = accountOneCustomBuyerLimit.data.attributes["ethereum-address"].toLowerCase();
         delete accountOneCustomBuyerLimit.data.meta;
         expect(accountOneCustomBuyerLimit).to.deep.equal({
@@ -1582,10 +1582,10 @@ contract('Token Indexing', function (accounts) {
           }
         });
 
-        let accountTwoApprovedBuyer = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-approved-buyers', accountTwo);
+        let accountTwoApprovedBuyer = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-approved-buyers', accountTwo);
         expect(accountTwoApprovedBuyer.data.attributes["mapping-boolean-value"]).to.equal(true, "the mapping-boolean-value is correct");
 
-        let accountTwoCustomBuyerLimit = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-custom-buyer-limits', accountTwo);
+        let accountTwoCustomBuyerLimit = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-custom-buyer-limits', accountTwo);
         expect(accountTwoCustomBuyerLimit.data.attributes["mapping-number-value"]).to.equal("10", "the mapping-number-value is correct");
       });
     });
@@ -1625,21 +1625,21 @@ contract('Token Indexing', function (accounts) {
       afterEach(teardown);
 
       it('can update contract document from event content trigger', async function () {
-        let contract = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-tokens', token.address);
+        let contract = await env.lookup('hub:searchers').getCard(env.session, 'sample-tokens', token.address);
         expect(contract.data.attributes['sample-token-minting-finished']).to.equal(false, 'the minting-finished field is correct');
 
         let { logs: events } = await token.finishMinting();
         let eventId = `${events[0].transactionHash}_${events[0].logIndex}`;
         await waitForEthereumEvents(eventIndexer);
 
-        contract = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-tokens', token.address);
+        contract = await env.lookup('hub:searchers').getCard(env.session, 'sample-tokens', token.address);
         expect(contract.data.attributes['sample-token-minting-finished']).to.equal(true, 'the minting-finished field is correct');
 
         expect(contract.data.relationships['sample-token-mint-finished-events']).to.deep.equal({
           "data": [{ type: "sample-token-mint-finished-events", id: eventId }]
         });
 
-        let event = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-mint-finished-events', eventId);
+        let event = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-mint-finished-events', eventId);
         expect(event.data.attributes["block-number"]).to.equal(events[0].blockNumber, 'the block number is correct');
         expect(event.data.attributes["transaction-hash"]).to.equal(events[0].transactionHash, 'the transaction id is correct');
         expect(event.data.attributes["event-name"]).to.equal('MintFinished', 'the event name is correct');
@@ -1694,7 +1694,7 @@ contract('Token Indexing', function (accounts) {
         await indexers.update({ forceRefresh: true });
         await waitForEthereumEvents(eventIndexer);
 
-        let accountOneLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountOne);
+        let accountOneLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountOne);
 
         expect(accountOneLedgerEntry.data.relationships['sample-token-mint-events']).to.deep.equal({
           "data": [{ type: "sample-token-mint-events", id: mintEventId }]
@@ -1704,7 +1704,7 @@ contract('Token Indexing', function (accounts) {
           "data": [{ type: "sample-token-transfer-events", id: transferEventId }]
         });
 
-        let transferEvent = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-transfer-events', transferEventId);
+        let transferEvent = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-transfer-events', transferEventId);
         toLowercase(transferEvent, 'data.attributes.transfer-event-from');
         toLowercase(transferEvent, 'data.attributes.transfer-event-to');
         expect(transferEvent.data.attributes["block-number"]).to.equal(mintEvents[1].blockNumber, 'the block number is correct');
@@ -1776,8 +1776,8 @@ contract('Token Indexing', function (accounts) {
         await waitForEthereumEvents(eventIndexer);
 
         expect(addCount).to.equal(5, 'the correct number of records were indexed');
-        let accountOneLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountOne);
-        let accountTwoLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountTwo);
+        let accountOneLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountOne);
+        let accountTwoLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountTwo);
 
         expect(accountOneLedgerEntry.data.attributes["mapping-number-value"]).to.equal("80", "the token balance is correct");
         expect(accountTwoLedgerEntry.data.attributes["mapping-number-value"]).to.equal("20", "the token balance is correct");
@@ -1851,8 +1851,8 @@ contract('Token Indexing', function (accounts) {
 
         await waitForEthereumEvents(eventIndexer);
 
-        let accountOneBalance = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountOne);
-        let accountThreeBalance = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountThree);
+        let accountOneBalance = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountOne);
+        let accountThreeBalance = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountThree);
 
         expect(accountOneBalance.data.attributes['utility-payment-amount']).to.equal(50, 'utility-payment-amount computed field is correct');
         expect(accountThreeBalance.data.attributes['utility-payment-amount']).to.equal(20, 'utility-payment-amount computed field is correct');
@@ -1903,10 +1903,10 @@ contract('Token Indexing', function (accounts) {
       afterEach(teardown);
 
       it("can index a large amount of past events on the contract", async function () {
-        let accountOneLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountOne.toLowerCase());
-        let accountTwoLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountTwo.toLowerCase());
-        let accountThreeLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-balance-ofs', accountThree.toLowerCase());
-        let tokenRecord = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-tokens', token.address);
+        let accountOneLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountOne.toLowerCase());
+        let accountTwoLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountTwo.toLowerCase());
+        let accountThreeLedgerEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-balance-ofs', accountThree.toLowerCase());
+        let tokenRecord = await env.lookup('hub:searchers').getCard(env.session, 'sample-tokens', token.address);
         let events = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { page: { size: 5000 }, filter: { type: 'sample-token-white-list-events' } });
 
         expect(tokenRecord.data.attributes["sample-token-buyer-count"]).to.equal("1000", "the buyer count is correct");
@@ -1916,7 +1916,7 @@ contract('Token Indexing', function (accounts) {
         expect(events.data.length).to.equal(addresses.length, 'the correct number of whitelist event documents were created');
 
         for (let address of addresses) {
-          let whitelistEntry = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-token-approved-buyers', address.toLowerCase());
+          let whitelistEntry = await env.lookup('hub:searchers').getCard(env.session, 'sample-token-approved-buyers', address.toLowerCase());
           expect(whitelistEntry.data.attributes["mapping-boolean-value"]).to.equal(true);
         }
       });

--- a/packages/git/node-tests/config-test.js
+++ b/packages/git/node-tests/config-test.js
@@ -88,7 +88,7 @@ describe('git/config', function() {
 
     env = await createDefaultEnvironment(`${__dirname}/..`, factory.getModels());
 
-    let response = await env.lookup('hub:searchers').search(env.session, 'master', { filter: { type: 'articles' } });
+    let response = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { filter: { type: 'articles' } });
     expect(response.data.map(m => m.id)).deep.equals(['2']);
   });
 
@@ -158,7 +158,7 @@ describe('git/config', function() {
 
     env = await createDefaultEnvironment(`${__dirname}/..`, factory.getModels());
 
-    let response = await env.lookup('hub:searchers').search(env.session, 'master', { filter: { type: 'articles' } });
+    let response = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { filter: { type: 'articles' } });
     expect(response.data.map(m => m.id)).deep.equals(['2']);
   });
 

--- a/packages/git/node-tests/config-test.js
+++ b/packages/git/node-tests/config-test.js
@@ -88,7 +88,7 @@ describe('git/config', function() {
 
     env = await createDefaultEnvironment(`${__dirname}/..`, factory.getModels());
 
-    let response = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { filter: { type: 'articles' } });
+    let response = await env.lookup('hub:searchers').search(env.session, { filter: { type: 'articles' } });
     expect(response.data.map(m => m.id)).deep.equals(['2']);
   });
 
@@ -158,7 +158,7 @@ describe('git/config', function() {
 
     env = await createDefaultEnvironment(`${__dirname}/..`, factory.getModels());
 
-    let response = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { filter: { type: 'articles' } });
+    let response = await env.lookup('hub:searchers').search(env.session, { filter: { type: 'articles' } });
     expect(response.data.map(m => m.id)).deep.equals(['2']);
   });
 

--- a/packages/git/node-tests/indexer-remote-test.js
+++ b/packages/git/node-tests/indexer-remote-test.js
@@ -201,7 +201,7 @@ describe('git/indexer cloning', function() {
     await start();
     await indexer.update();
 
-    let contents = await searcher.getCard(env.session, 'master', 'events', 'event-1');
+    let contents = await searcher.getCard(env.session, 'events', 'event-1');
     let jsonapi = toResource(contents);
     expect(jsonapi).has.deep.property('attributes.title', 'This is a test event');
   });

--- a/packages/git/node-tests/indexer-remote-test.js
+++ b/packages/git/node-tests/indexer-remote-test.js
@@ -201,7 +201,7 @@ describe('git/indexer cloning', function() {
     await start();
     await indexer.update();
 
-    let contents = await searcher.get(env.session, 'events', 'event-1');
+    let contents = await searcher.get(env.session, 'local-hub', 'events', 'event-1');
     let jsonapi = toResource(contents);
     expect(jsonapi).has.deep.property('attributes.title', 'This is a test event');
   });

--- a/packages/git/node-tests/indexer-remote-test.js
+++ b/packages/git/node-tests/indexer-remote-test.js
@@ -201,7 +201,7 @@ describe('git/indexer cloning', function() {
     await start();
     await indexer.update();
 
-    let contents = await searcher.getCard(env.session, 'events', 'event-1');
+    let contents = await searcher.get(env.session, 'events', 'event-1');
     let jsonapi = toResource(contents);
     expect(jsonapi).has.deep.property('attributes.title', 'This is a test event');
   });

--- a/packages/git/node-tests/indexer-remote-test.js
+++ b/packages/git/node-tests/indexer-remote-test.js
@@ -201,7 +201,7 @@ describe('git/indexer cloning', function() {
     await start();
     await indexer.update();
 
-    let contents = await searcher.get(env.session, 'master', 'events', 'event-1');
+    let contents = await searcher.getCard(env.session, 'master', 'events', 'event-1');
     let jsonapi = toResource(contents);
     expect(jsonapi).has.deep.property('attributes.title', 'This is a test event');
   });

--- a/packages/git/node-tests/indexer-test.js
+++ b/packages/git/node-tests/indexer-test.js
@@ -66,7 +66,7 @@ describe('git/indexer', function() {
 
     assertNoDocument = async function(version, type, id) {
       try {
-        await searcher.get(env.session, type, id, { version });
+        await searcher.get(env.session, 'local-hub', type, id, { version });
       } catch(err) {
         expect(err.status).to.equal(404);
         return;
@@ -104,7 +104,7 @@ describe('git/indexer', function() {
     let indexerState = await client.loadMeta({ branch: 'master', id: dataSource.id });
     expect(indexerState.commit).to.equal(head);
 
-    let contents = await searcher.get(env.session, 'articles', 'hello-world');
+    let contents = await searcher.get(env.session, 'local-hub', 'articles', 'hello-world');
     let jsonapi = toResource(contents);
     expect(jsonapi).has.deep.property('attributes.title', 'world');
   });
@@ -176,7 +176,7 @@ describe('git/indexer', function() {
     let indexerState = await client.loadMeta({ branch: 'master', id: dataSource.id });
     expect(indexerState.commit).to.equal(head);
 
-    let contents = await searcher.get(env.session, 'articles', 'hello-world');
+    let contents = await searcher.get(env.session, 'local-hub', 'articles', 'hello-world');
     expect(contents).to.have.deep.property('data.attributes.title', 'somebody else');
   });
 
@@ -244,13 +244,13 @@ describe('git/indexer', function() {
     await start();
 
     {
-      let both = toResource(await searcher.get(env.session, 'articles', 'both'));
+      let both = toResource(await searcher.get(env.session, 'local-hub', 'articles', 'both'));
       expect(both).has.deep.property('attributes.title', 'article from both repos, left version');
 
-      let left = toResource(await searcher.get(env.session, 'articles', 'left'));
+      let left = toResource(await searcher.get(env.session, 'local-hub', 'articles', 'left'));
       expect(left).has.deep.property('attributes.title', 'article from left repo');
 
-      let upstream = toResource(await searcher.get(env.session, 'articles', 'upstream'));
+      let upstream = toResource(await searcher.get(env.session, 'local-hub', 'articles', 'upstream'));
       expect(upstream).has.deep.property('attributes.title', 'article from upstream');
 
       await assertNoDocument('master', 'articles', 'right');
@@ -273,15 +273,15 @@ describe('git/indexer', function() {
 
     {
       // Update
-      let both = toResource(await searcher.get(env.session, 'articles', 'both'));
+      let both = toResource(await searcher.get(env.session, 'local-hub', 'articles', 'both'));
       expect(both).has.deep.property('attributes.title', 'article from both repos, right version');
 
       // Create
-      let right = toResource(await searcher.get(env.session, 'articles', 'right'));
+      let right = toResource(await searcher.get(env.session, 'local-hub', 'articles', 'right'));
       expect(right).has.deep.property('attributes.title', 'article from right repo');
 
       // Leave other data sources alone
-      let upstream = toResource(await searcher.get(env.session, 'articles', 'upstream'));
+      let upstream = toResource(await searcher.get(env.session, 'local-hub', 'articles', 'upstream'));
       expect(upstream).has.deep.property('attributes.title', 'article from upstream');
 
       // Delete
@@ -310,7 +310,7 @@ describe('git/indexer', function() {
 
     await start();
 
-    let contents = await searcher.get(env.session, 'articles', 'hello-world');
+    let contents = await searcher.get(env.session, 'local-hub', 'articles', 'hello-world');
     expect(contents).has.deep.property('included');
     expect(contents.included).has.length(1);
     expect(contents.included[0]).has.deep.property('attributes.name', 'Q');

--- a/packages/git/node-tests/indexer-test.js
+++ b/packages/git/node-tests/indexer-test.js
@@ -66,7 +66,7 @@ describe('git/indexer', function() {
 
     assertNoDocument = async function(branch, type, id) {
       try {
-        await searcher.get(env.session, branch, type, id);
+        await searcher.getCard(env.session, branch, type, id);
       } catch(err) {
         expect(err.status).to.equal(404);
         return;
@@ -104,7 +104,7 @@ describe('git/indexer', function() {
     let indexerState = await client.loadMeta({ branch: 'master', id: dataSource.id });
     expect(indexerState.commit).to.equal(head);
 
-    let contents = await searcher.get(env.session, 'master', 'articles', 'hello-world');
+    let contents = await searcher.getCard(env.session, 'master', 'articles', 'hello-world');
     let jsonapi = toResource(contents);
     expect(jsonapi).has.deep.property('attributes.title', 'world');
   });
@@ -176,7 +176,7 @@ describe('git/indexer', function() {
     let indexerState = await client.loadMeta({ branch: 'master', id: dataSource.id });
     expect(indexerState.commit).to.equal(head);
 
-    let contents = await searcher.get(env.session, 'master', 'articles', 'hello-world');
+    let contents = await searcher.getCard(env.session, 'master', 'articles', 'hello-world');
     expect(contents).to.have.deep.property('data.attributes.title', 'somebody else');
   });
 
@@ -244,13 +244,13 @@ describe('git/indexer', function() {
     await start();
 
     {
-      let both = toResource(await searcher.get(env.session, 'master', 'articles', 'both'));
+      let both = toResource(await searcher.getCard(env.session, 'master', 'articles', 'both'));
       expect(both).has.deep.property('attributes.title', 'article from both repos, left version');
 
-      let left = toResource(await searcher.get(env.session, 'master', 'articles', 'left'));
+      let left = toResource(await searcher.getCard(env.session, 'master', 'articles', 'left'));
       expect(left).has.deep.property('attributes.title', 'article from left repo');
 
-      let upstream = toResource(await searcher.get(env.session, 'master', 'articles', 'upstream'));
+      let upstream = toResource(await searcher.getCard(env.session, 'master', 'articles', 'upstream'));
       expect(upstream).has.deep.property('attributes.title', 'article from upstream');
 
       await assertNoDocument('master', 'articles', 'right');
@@ -273,15 +273,15 @@ describe('git/indexer', function() {
 
     {
       // Update
-      let both = toResource(await searcher.get(env.session, 'master', 'articles', 'both'));
+      let both = toResource(await searcher.getCard(env.session, 'master', 'articles', 'both'));
       expect(both).has.deep.property('attributes.title', 'article from both repos, right version');
 
       // Create
-      let right = toResource(await searcher.get(env.session, 'master', 'articles', 'right'));
+      let right = toResource(await searcher.getCard(env.session, 'master', 'articles', 'right'));
       expect(right).has.deep.property('attributes.title', 'article from right repo');
 
       // Leave other data sources alone
-      let upstream = toResource(await searcher.get(env.session, 'master', 'articles', 'upstream'));
+      let upstream = toResource(await searcher.getCard(env.session, 'master', 'articles', 'upstream'));
       expect(upstream).has.deep.property('attributes.title', 'article from upstream');
 
       // Delete
@@ -310,7 +310,7 @@ describe('git/indexer', function() {
 
     await start();
 
-    let contents = await searcher.get(env.session, 'master', 'articles', 'hello-world');
+    let contents = await searcher.getCard(env.session, 'master', 'articles', 'hello-world');
     expect(contents).has.deep.property('included');
     expect(contents.included).has.length(1);
     expect(contents.included[0]).has.deep.property('attributes.name', 'Q');

--- a/packages/git/node-tests/indexer-test.js
+++ b/packages/git/node-tests/indexer-test.js
@@ -64,14 +64,14 @@ describe('git/indexer', function() {
       client = env.lookup(`plugin-client:${require.resolve('@cardstack/pgsearch/client')}`);
     };
 
-    assertNoDocument = async function(branch, type, id) {
+    assertNoDocument = async function(version, type, id) {
       try {
-        await searcher.getCard(env.session, branch, type, id);
+        await searcher.getCard(env.session, type, id, { version });
       } catch(err) {
         expect(err.status).to.equal(404);
         return;
       }
-      throw new Error(`expected not to find document branch=${branch} type=${type} id=${id}`);
+      throw new Error(`expected not to find document version=${version} type=${type} id=${id}`);
     };
   });
 
@@ -104,7 +104,7 @@ describe('git/indexer', function() {
     let indexerState = await client.loadMeta({ branch: 'master', id: dataSource.id });
     expect(indexerState.commit).to.equal(head);
 
-    let contents = await searcher.getCard(env.session, 'master', 'articles', 'hello-world');
+    let contents = await searcher.getCard(env.session, 'articles', 'hello-world');
     let jsonapi = toResource(contents);
     expect(jsonapi).has.deep.property('attributes.title', 'world');
   });
@@ -176,7 +176,7 @@ describe('git/indexer', function() {
     let indexerState = await client.loadMeta({ branch: 'master', id: dataSource.id });
     expect(indexerState.commit).to.equal(head);
 
-    let contents = await searcher.getCard(env.session, 'master', 'articles', 'hello-world');
+    let contents = await searcher.getCard(env.session, 'articles', 'hello-world');
     expect(contents).to.have.deep.property('data.attributes.title', 'somebody else');
   });
 
@@ -244,13 +244,13 @@ describe('git/indexer', function() {
     await start();
 
     {
-      let both = toResource(await searcher.getCard(env.session, 'master', 'articles', 'both'));
+      let both = toResource(await searcher.getCard(env.session, 'articles', 'both'));
       expect(both).has.deep.property('attributes.title', 'article from both repos, left version');
 
-      let left = toResource(await searcher.getCard(env.session, 'master', 'articles', 'left'));
+      let left = toResource(await searcher.getCard(env.session, 'articles', 'left'));
       expect(left).has.deep.property('attributes.title', 'article from left repo');
 
-      let upstream = toResource(await searcher.getCard(env.session, 'master', 'articles', 'upstream'));
+      let upstream = toResource(await searcher.getCard(env.session, 'articles', 'upstream'));
       expect(upstream).has.deep.property('attributes.title', 'article from upstream');
 
       await assertNoDocument('master', 'articles', 'right');
@@ -273,15 +273,15 @@ describe('git/indexer', function() {
 
     {
       // Update
-      let both = toResource(await searcher.getCard(env.session, 'master', 'articles', 'both'));
+      let both = toResource(await searcher.getCard(env.session, 'articles', 'both'));
       expect(both).has.deep.property('attributes.title', 'article from both repos, right version');
 
       // Create
-      let right = toResource(await searcher.getCard(env.session, 'master', 'articles', 'right'));
+      let right = toResource(await searcher.getCard(env.session, 'articles', 'right'));
       expect(right).has.deep.property('attributes.title', 'article from right repo');
 
       // Leave other data sources alone
-      let upstream = toResource(await searcher.getCard(env.session, 'master', 'articles', 'upstream'));
+      let upstream = toResource(await searcher.getCard(env.session, 'articles', 'upstream'));
       expect(upstream).has.deep.property('attributes.title', 'article from upstream');
 
       // Delete
@@ -310,7 +310,7 @@ describe('git/indexer', function() {
 
     await start();
 
-    let contents = await searcher.getCard(env.session, 'master', 'articles', 'hello-world');
+    let contents = await searcher.getCard(env.session, 'articles', 'hello-world');
     expect(contents).has.deep.property('included');
     expect(contents.included).has.length(1);
     expect(contents.included[0]).has.deep.property('attributes.name', 'Q');

--- a/packages/git/node-tests/indexer-test.js
+++ b/packages/git/node-tests/indexer-test.js
@@ -66,7 +66,7 @@ describe('git/indexer', function() {
 
     assertNoDocument = async function(version, type, id) {
       try {
-        await searcher.getCard(env.session, type, id, { version });
+        await searcher.get(env.session, type, id, { version });
       } catch(err) {
         expect(err.status).to.equal(404);
         return;
@@ -104,7 +104,7 @@ describe('git/indexer', function() {
     let indexerState = await client.loadMeta({ branch: 'master', id: dataSource.id });
     expect(indexerState.commit).to.equal(head);
 
-    let contents = await searcher.getCard(env.session, 'articles', 'hello-world');
+    let contents = await searcher.get(env.session, 'articles', 'hello-world');
     let jsonapi = toResource(contents);
     expect(jsonapi).has.deep.property('attributes.title', 'world');
   });
@@ -176,7 +176,7 @@ describe('git/indexer', function() {
     let indexerState = await client.loadMeta({ branch: 'master', id: dataSource.id });
     expect(indexerState.commit).to.equal(head);
 
-    let contents = await searcher.getCard(env.session, 'articles', 'hello-world');
+    let contents = await searcher.get(env.session, 'articles', 'hello-world');
     expect(contents).to.have.deep.property('data.attributes.title', 'somebody else');
   });
 
@@ -244,13 +244,13 @@ describe('git/indexer', function() {
     await start();
 
     {
-      let both = toResource(await searcher.getCard(env.session, 'articles', 'both'));
+      let both = toResource(await searcher.get(env.session, 'articles', 'both'));
       expect(both).has.deep.property('attributes.title', 'article from both repos, left version');
 
-      let left = toResource(await searcher.getCard(env.session, 'articles', 'left'));
+      let left = toResource(await searcher.get(env.session, 'articles', 'left'));
       expect(left).has.deep.property('attributes.title', 'article from left repo');
 
-      let upstream = toResource(await searcher.getCard(env.session, 'articles', 'upstream'));
+      let upstream = toResource(await searcher.get(env.session, 'articles', 'upstream'));
       expect(upstream).has.deep.property('attributes.title', 'article from upstream');
 
       await assertNoDocument('master', 'articles', 'right');
@@ -273,15 +273,15 @@ describe('git/indexer', function() {
 
     {
       // Update
-      let both = toResource(await searcher.getCard(env.session, 'articles', 'both'));
+      let both = toResource(await searcher.get(env.session, 'articles', 'both'));
       expect(both).has.deep.property('attributes.title', 'article from both repos, right version');
 
       // Create
-      let right = toResource(await searcher.getCard(env.session, 'articles', 'right'));
+      let right = toResource(await searcher.get(env.session, 'articles', 'right'));
       expect(right).has.deep.property('attributes.title', 'article from right repo');
 
       // Leave other data sources alone
-      let upstream = toResource(await searcher.getCard(env.session, 'articles', 'upstream'));
+      let upstream = toResource(await searcher.get(env.session, 'articles', 'upstream'));
       expect(upstream).has.deep.property('attributes.title', 'article from upstream');
 
       // Delete
@@ -310,7 +310,7 @@ describe('git/indexer', function() {
 
     await start();
 
-    let contents = await searcher.getCard(env.session, 'articles', 'hello-world');
+    let contents = await searcher.get(env.session, 'articles', 'hello-world');
     expect(contents).has.deep.property('included');
     expect(contents.included).has.length(1);
     expect(contents.included[0]).has.deep.property('attributes.name', 'Q');

--- a/packages/github-auth/node-tests/searcher-test.js
+++ b/packages/github-auth/node-tests/searcher-test.js
@@ -55,7 +55,7 @@ describe('github-auth/searcher', function() {
         .get(`/users/${id}`)
         .reply(200, userMock);
 
-      let user = await searchers.get(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'local-hub', 'github-users', id);
       expect(user.data.attributes.permissions.length).to.equal(0);
     });
   });
@@ -110,7 +110,7 @@ describe('github-auth/searcher', function() {
         .get(`/repos/cardstack/repo3/collaborators/${id}/permission`)
         .reply(200, permissionMock);
 
-      let user = await searchers.get(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'local-hub', 'github-users', id);
       expect(user.data.attributes.permissions.length).to.equal(0);
     });
 
@@ -135,7 +135,7 @@ describe('github-auth/searcher', function() {
         .get(`/repos/cardstack/repo3/collaborators/${id}/permission`)
         .reply(200, permissionMock);
 
-      let user = await searchers.get(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'local-hub', 'github-users', id);
 
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:read');
       expect(user.data.attributes.permissions).to.not.include('cardstack/repo1:write');
@@ -171,7 +171,7 @@ describe('github-auth/searcher', function() {
         .get(`/repos/cardstack/repo3/collaborators/${id}/permission`)
         .reply(200, permissionMock);
 
-      let user = await searchers.get(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'local-hub', 'github-users', id);
 
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:read');
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:write');
@@ -207,7 +207,7 @@ describe('github-auth/searcher', function() {
         .get(`/repos/cardstack/repo3/collaborators/${id}/permission`)
         .reply(200, permissionMock);
 
-      let user = await searchers.get(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'local-hub', 'github-users', id);
 
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:read');
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:write');
@@ -255,7 +255,7 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      let user = await searchers.get(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'local-hub', 'github-users', id);
 
       expect(user).has.deep.property('data.id', id);
       expect(user).has.deep.property('data.type', 'github-users');
@@ -276,10 +276,10 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      await searchers.get(env.session, 'github-users', id);
+      await searchers.get(env.session, 'local-hub', 'github-users', id);
       mock.name = "Van Gogh";
 
-      let user = await searchers.get(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'local-hub', 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Hassan Abdel-Rahman");
     });
 
@@ -296,17 +296,17 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      await searchers.get(env.session, 'github-users', id);
+      await searchers.get(env.session, 'local-hub', 'github-users', id);
       mock.name = "Van Gogh";
 
       await alterExpiration('master', 'github-users', id, '-30 seconds');
 
-      let user = await searchers.get(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'local-hub', 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Hassan Abdel-Rahman");
 
       await alterExpiration('master', 'github-users', id, '-31 seconds');
 
-      user = await searchers.get(env.session, 'github-users', id);
+      user = await searchers.get(env.session, 'local-hub', 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Van Gogh");
     });
   });
@@ -345,16 +345,16 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      await searchers.get(env.session, 'github-users', id);
+      await searchers.get(env.session, 'local-hub', 'github-users', id);
       mock.name = "Van Gogh";
 
       await alterExpiration('master', 'github-users', id, '-61 seconds');
 
-      let user = await searchers.get(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'local-hub', 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Hassan Abdel-Rahman");
 
       await alterExpiration('master', 'github-users', id, '-240 seconds');
-      user = await searchers.get(env.session, 'github-users', id);
+      user = await searchers.get(env.session, 'local-hub', 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Van Gogh");
     });
   });
@@ -393,10 +393,10 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      await searchers.get(env.session, 'github-users', id);
+      await searchers.get(env.session, 'local-hub', 'github-users', id);
       mock.name = "Van Gogh";
 
-      let user = await searchers.get(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'local-hub', 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Van Gogh");
     });
   });

--- a/packages/github-auth/node-tests/searcher-test.js
+++ b/packages/github-auth/node-tests/searcher-test.js
@@ -55,7 +55,7 @@ describe('github-auth/searcher', function() {
         .get(`/users/${id}`)
         .reply(200, userMock);
 
-      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'github-users', id);
       expect(user.data.attributes.permissions.length).to.equal(0);
     });
   });
@@ -110,7 +110,7 @@ describe('github-auth/searcher', function() {
         .get(`/repos/cardstack/repo3/collaborators/${id}/permission`)
         .reply(200, permissionMock);
 
-      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'github-users', id);
       expect(user.data.attributes.permissions.length).to.equal(0);
     });
 
@@ -135,7 +135,7 @@ describe('github-auth/searcher', function() {
         .get(`/repos/cardstack/repo3/collaborators/${id}/permission`)
         .reply(200, permissionMock);
 
-      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'github-users', id);
 
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:read');
       expect(user.data.attributes.permissions).to.not.include('cardstack/repo1:write');
@@ -171,7 +171,7 @@ describe('github-auth/searcher', function() {
         .get(`/repos/cardstack/repo3/collaborators/${id}/permission`)
         .reply(200, permissionMock);
 
-      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'github-users', id);
 
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:read');
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:write');
@@ -207,7 +207,7 @@ describe('github-auth/searcher', function() {
         .get(`/repos/cardstack/repo3/collaborators/${id}/permission`)
         .reply(200, permissionMock);
 
-      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'github-users', id);
 
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:read');
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:write');
@@ -255,7 +255,7 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'github-users', id);
 
       expect(user).has.deep.property('data.id', id);
       expect(user).has.deep.property('data.type', 'github-users');
@@ -276,10 +276,10 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      await searchers.getCard(env.session, 'master', 'github-users', id);
+      await searchers.getCard(env.session, 'github-users', id);
       mock.name = "Van Gogh";
 
-      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Hassan Abdel-Rahman");
     });
 
@@ -296,17 +296,17 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      await searchers.getCard(env.session, 'master', 'github-users', id);
+      await searchers.getCard(env.session, 'github-users', id);
       mock.name = "Van Gogh";
 
       await alterExpiration('master', 'github-users', id, '-30 seconds');
 
-      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Hassan Abdel-Rahman");
 
       await alterExpiration('master', 'github-users', id, '-31 seconds');
 
-      user = await searchers.getCard(env.session, 'master', 'github-users', id);
+      user = await searchers.getCard(env.session, 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Van Gogh");
     });
   });
@@ -345,16 +345,16 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      await searchers.getCard(env.session, 'master', 'github-users', id);
+      await searchers.getCard(env.session, 'github-users', id);
       mock.name = "Van Gogh";
 
       await alterExpiration('master', 'github-users', id, '-61 seconds');
 
-      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Hassan Abdel-Rahman");
 
       await alterExpiration('master', 'github-users', id, '-240 seconds');
-      user = await searchers.getCard(env.session, 'master', 'github-users', id);
+      user = await searchers.getCard(env.session, 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Van Gogh");
     });
   });
@@ -393,10 +393,10 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      await searchers.getCard(env.session, 'master', 'github-users', id);
+      await searchers.getCard(env.session, 'github-users', id);
       mock.name = "Van Gogh";
 
-      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Van Gogh");
     });
   });

--- a/packages/github-auth/node-tests/searcher-test.js
+++ b/packages/github-auth/node-tests/searcher-test.js
@@ -55,7 +55,7 @@ describe('github-auth/searcher', function() {
         .get(`/users/${id}`)
         .reply(200, userMock);
 
-      let user = await searchers.get(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
       expect(user.data.attributes.permissions.length).to.equal(0);
     });
   });
@@ -110,7 +110,7 @@ describe('github-auth/searcher', function() {
         .get(`/repos/cardstack/repo3/collaborators/${id}/permission`)
         .reply(200, permissionMock);
 
-      let user = await searchers.get(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
       expect(user.data.attributes.permissions.length).to.equal(0);
     });
 
@@ -135,7 +135,7 @@ describe('github-auth/searcher', function() {
         .get(`/repos/cardstack/repo3/collaborators/${id}/permission`)
         .reply(200, permissionMock);
 
-      let user = await searchers.get(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
 
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:read');
       expect(user.data.attributes.permissions).to.not.include('cardstack/repo1:write');
@@ -171,7 +171,7 @@ describe('github-auth/searcher', function() {
         .get(`/repos/cardstack/repo3/collaborators/${id}/permission`)
         .reply(200, permissionMock);
 
-      let user = await searchers.get(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
 
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:read');
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:write');
@@ -207,7 +207,7 @@ describe('github-auth/searcher', function() {
         .get(`/repos/cardstack/repo3/collaborators/${id}/permission`)
         .reply(200, permissionMock);
 
-      let user = await searchers.get(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
 
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:read');
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:write');
@@ -255,7 +255,7 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      let user = await searchers.get(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
 
       expect(user).has.deep.property('data.id', id);
       expect(user).has.deep.property('data.type', 'github-users');
@@ -276,10 +276,10 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      await searchers.get(env.session, 'master', 'github-users', id);
+      await searchers.getCard(env.session, 'master', 'github-users', id);
       mock.name = "Van Gogh";
 
-      let user = await searchers.get(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Hassan Abdel-Rahman");
     });
 
@@ -296,17 +296,17 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      await searchers.get(env.session, 'master', 'github-users', id);
+      await searchers.getCard(env.session, 'master', 'github-users', id);
       mock.name = "Van Gogh";
 
       await alterExpiration('master', 'github-users', id, '-30 seconds');
 
-      let user = await searchers.get(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Hassan Abdel-Rahman");
 
       await alterExpiration('master', 'github-users', id, '-31 seconds');
 
-      user = await searchers.get(env.session, 'master', 'github-users', id);
+      user = await searchers.getCard(env.session, 'master', 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Van Gogh");
     });
   });
@@ -345,16 +345,16 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      await searchers.get(env.session, 'master', 'github-users', id);
+      await searchers.getCard(env.session, 'master', 'github-users', id);
       mock.name = "Van Gogh";
 
       await alterExpiration('master', 'github-users', id, '-61 seconds');
 
-      let user = await searchers.get(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Hassan Abdel-Rahman");
 
       await alterExpiration('master', 'github-users', id, '-240 seconds');
-      user = await searchers.get(env.session, 'master', 'github-users', id);
+      user = await searchers.getCard(env.session, 'master', 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Van Gogh");
     });
   });
@@ -393,10 +393,10 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      await searchers.get(env.session, 'master', 'github-users', id);
+      await searchers.getCard(env.session, 'master', 'github-users', id);
       mock.name = "Van Gogh";
 
-      let user = await searchers.get(env.session, 'master', 'github-users', id);
+      let user = await searchers.getCard(env.session, 'master', 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Van Gogh");
     });
   });

--- a/packages/github-auth/node-tests/searcher-test.js
+++ b/packages/github-auth/node-tests/searcher-test.js
@@ -55,7 +55,7 @@ describe('github-auth/searcher', function() {
         .get(`/users/${id}`)
         .reply(200, userMock);
 
-      let user = await searchers.getCard(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'github-users', id);
       expect(user.data.attributes.permissions.length).to.equal(0);
     });
   });
@@ -110,7 +110,7 @@ describe('github-auth/searcher', function() {
         .get(`/repos/cardstack/repo3/collaborators/${id}/permission`)
         .reply(200, permissionMock);
 
-      let user = await searchers.getCard(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'github-users', id);
       expect(user.data.attributes.permissions.length).to.equal(0);
     });
 
@@ -135,7 +135,7 @@ describe('github-auth/searcher', function() {
         .get(`/repos/cardstack/repo3/collaborators/${id}/permission`)
         .reply(200, permissionMock);
 
-      let user = await searchers.getCard(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'github-users', id);
 
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:read');
       expect(user.data.attributes.permissions).to.not.include('cardstack/repo1:write');
@@ -171,7 +171,7 @@ describe('github-auth/searcher', function() {
         .get(`/repos/cardstack/repo3/collaborators/${id}/permission`)
         .reply(200, permissionMock);
 
-      let user = await searchers.getCard(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'github-users', id);
 
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:read');
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:write');
@@ -207,7 +207,7 @@ describe('github-auth/searcher', function() {
         .get(`/repos/cardstack/repo3/collaborators/${id}/permission`)
         .reply(200, permissionMock);
 
-      let user = await searchers.getCard(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'github-users', id);
 
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:read');
       expect(user.data.attributes.permissions).to.include('cardstack/repo1:write');
@@ -255,7 +255,7 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      let user = await searchers.getCard(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'github-users', id);
 
       expect(user).has.deep.property('data.id', id);
       expect(user).has.deep.property('data.type', 'github-users');
@@ -276,10 +276,10 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      await searchers.getCard(env.session, 'github-users', id);
+      await searchers.get(env.session, 'github-users', id);
       mock.name = "Van Gogh";
 
-      let user = await searchers.getCard(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Hassan Abdel-Rahman");
     });
 
@@ -296,17 +296,17 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      await searchers.getCard(env.session, 'github-users', id);
+      await searchers.get(env.session, 'github-users', id);
       mock.name = "Van Gogh";
 
       await alterExpiration('master', 'github-users', id, '-30 seconds');
 
-      let user = await searchers.getCard(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Hassan Abdel-Rahman");
 
       await alterExpiration('master', 'github-users', id, '-31 seconds');
 
-      user = await searchers.getCard(env.session, 'github-users', id);
+      user = await searchers.get(env.session, 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Van Gogh");
     });
   });
@@ -345,16 +345,16 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      await searchers.getCard(env.session, 'github-users', id);
+      await searchers.get(env.session, 'github-users', id);
       mock.name = "Van Gogh";
 
       await alterExpiration('master', 'github-users', id, '-61 seconds');
 
-      let user = await searchers.getCard(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Hassan Abdel-Rahman");
 
       await alterExpiration('master', 'github-users', id, '-240 seconds');
-      user = await searchers.getCard(env.session, 'github-users', id);
+      user = await searchers.get(env.session, 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Van Gogh");
     });
   });
@@ -393,10 +393,10 @@ describe('github-auth/searcher', function() {
           }];
         });
 
-      await searchers.getCard(env.session, 'github-users', id);
+      await searchers.get(env.session, 'github-users', id);
       mock.name = "Van Gogh";
 
-      let user = await searchers.getCard(env.session, 'github-users', id);
+      let user = await searchers.get(env.session, 'github-users', id);
       expect(user).has.deep.property('data.attributes.name', "Van Gogh");
     });
   });

--- a/packages/hub/main.js
+++ b/packages/hub/main.js
@@ -71,7 +71,7 @@ async function startIndexing(environment, container) {
       await ephemeralStorage.validateModels(models, async (type, id) => {
         let result;
         try {
-          result = await searchers.getCurrentCard(Session.INTERNAL_PRIVILEGED, type, id);
+          result = await searchers.getCard(Session.INTERNAL_PRIVILEGED, type, id);
         } catch (err) {
           if (err.status !== 404) { throw err; }
         }

--- a/packages/hub/main.js
+++ b/packages/hub/main.js
@@ -71,7 +71,7 @@ async function startIndexing(environment, container) {
       await ephemeralStorage.validateModels(models, async (type, id) => {
         let result;
         try {
-          result = await searchers.getFromControllingBranch(Session.INTERNAL_PRIVILEGED, type, id);
+          result = await searchers.getCurrentCard(Session.INTERNAL_PRIVILEGED, type, id);
         } catch (err) {
           if (err.status !== 404) { throw err; }
         }

--- a/packages/hub/main.js
+++ b/packages/hub/main.js
@@ -71,7 +71,7 @@ async function startIndexing(environment, container) {
       await ephemeralStorage.validateModels(models, async (type, id) => {
         let result;
         try {
-          result = await searchers.get(Session.INTERNAL_PRIVILEGED, type, id);
+          result = await searchers.get(Session.INTERNAL_PRIVILEGED, 'local-hub', type, id);
         } catch (err) {
           if (err.status !== 404) { throw err; }
         }

--- a/packages/hub/main.js
+++ b/packages/hub/main.js
@@ -71,7 +71,7 @@ async function startIndexing(environment, container) {
       await ephemeralStorage.validateModels(models, async (type, id) => {
         let result;
         try {
-          result = await searchers.getCard(Session.INTERNAL_PRIVILEGED, type, id);
+          result = await searchers.get(Session.INTERNAL_PRIVILEGED, type, id);
         } catch (err) {
           if (err.status !== 404) { throw err; }
         }

--- a/packages/hub/messengers.js
+++ b/packages/hub/messengers.js
@@ -22,7 +22,7 @@ class Messengers {
     if (this.messengerCache[sinkId]) {
       return this.messengerCache[sinkId];
     } else {
-      let sink = await this.searchers.get(Session.INTERNAL_PRIVILEGED, 'message-sinks', sinkId);
+      let sink = await this.searchers.get(Session.INTERNAL_PRIVILEGED, 'local-hub', 'message-sinks', sinkId);
 
       if (!sink) {
         throw new Error(`Tried to send a message to message sink ${sinkId} but it does not exist`, { status: 500 });

--- a/packages/hub/messengers.js
+++ b/packages/hub/messengers.js
@@ -22,7 +22,7 @@ class Messengers {
     if (this.messengerCache[sinkId]) {
       return this.messengerCache[sinkId];
     } else {
-      let sink = await this.searchers.getFromControllingBranch(Session.INTERNAL_PRIVILEGED, 'message-sinks', sinkId);
+      let sink = await this.searchers.getCurrentCard(Session.INTERNAL_PRIVILEGED, 'message-sinks', sinkId);
 
       if (!sink) {
         throw new Error(`Tried to send a message to message sink ${sinkId} but it does not exist`, { status: 500 });

--- a/packages/hub/messengers.js
+++ b/packages/hub/messengers.js
@@ -22,7 +22,7 @@ class Messengers {
     if (this.messengerCache[sinkId]) {
       return this.messengerCache[sinkId];
     } else {
-      let sink = await this.searchers.getCurrentCard(Session.INTERNAL_PRIVILEGED, 'message-sinks', sinkId);
+      let sink = await this.searchers.getCard(Session.INTERNAL_PRIVILEGED, 'message-sinks', sinkId);
 
       if (!sink) {
         throw new Error(`Tried to send a message to message sink ${sinkId} but it does not exist`, { status: 500 });

--- a/packages/hub/messengers.js
+++ b/packages/hub/messengers.js
@@ -22,7 +22,7 @@ class Messengers {
     if (this.messengerCache[sinkId]) {
       return this.messengerCache[sinkId];
     } else {
-      let sink = await this.searchers.getCard(Session.INTERNAL_PRIVILEGED, 'message-sinks', sinkId);
+      let sink = await this.searchers.get(Session.INTERNAL_PRIVILEGED, 'message-sinks', sinkId);
 
       if (!sink) {
         throw new Error(`Tried to send a message to message sink ${sinkId} but it does not exist`, { status: 500 });

--- a/packages/hub/node-tests/computed-field-test.js
+++ b/packages/hub/node-tests/computed-field-test.js
@@ -177,22 +177,22 @@ describe('hub/computed-fields', function() {
     after(teardown);
 
     it("can depend on params", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.weight-in-grams', 448);
     });
 
     it("can depend on another computed field", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.weight-in-milligrams', 448000);
     });
 
     it("can depend on an attribute", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.echo-title', 'Apple');
     });
 
     it("can depend on id", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.echo-id');
       expect(model.data.attributes['echo-id']).to.equal(model.data.id);
     });
@@ -202,27 +202,27 @@ describe('hub/computed-fields', function() {
     // elasticsearch to blow up unless the dynamic type support is
     // working.
     it("can determine its type dynamically", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.echo-nutrients');
       expect(model.data.attributes['echo-nutrients']).to.deep.equal(model.data.attributes.nutrients);
     });
 
     it("can depend on fields on a related resource", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.good-with-red', false);
-      model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', banana.id);
+      model = await env.lookup('hub:searchers').getCard(env.session, 'foods', banana.id);
       expect(model.data).has.deep.property('attributes.good-with-red', true);
 
     });
 
     it("can compute a belongs-to relationship", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'foods', apple.id);
       expect(model.data).has.deep.property('relationships.auto-chocolate');
       expect(model.data.relationships['auto-chocolate']).deep.equals({ data: { type: 'foods', id: chocolate.id } });
     });
 
     it("can compute a has-many relationship", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', icecream.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'foods', icecream.id);
       expect(model.data).has.deep.property('relationships.ingredients');
       expect(model.data.relationships['ingredients']).deep.equals({
         data: [
@@ -248,12 +248,12 @@ describe('hub/computed-fields', function() {
     });
 
     it("can compute an attribute even when there are no real attributes", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'only-computed', '1');
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'only-computed', '1');
       expect(model.data).has.deep.property('attributes.always-42', 42);
     });
 
     it("can compute a relationship even when there are no real relationships", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'only-computed', '1');
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'only-computed', '1');
       expect(model.data).has.deep.property('relationships.auto-chocolate.data.id', chocolate.id);
     });
   });
@@ -276,23 +276,23 @@ describe('hub/computed-fields', function() {
     });
 
     it("includes computed field in update response", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', banana.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'foods', banana.id);
       model.data.attributes['weight-in-ounces'] = 1;
       let response = await env.lookup('hub:writers').update('master', env.session, 'foods', banana.id, model);
       expect(response.data).has.deep.property('attributes.weight-in-grams', 28);
     });
 
     it("updates computed field in response to a dependent model changing", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'foods', apple.id);
       model.data.attributes['color'] = 'blue';
       await env.lookup('hub:writers').update('master', env.session, 'foods', apple.id, model);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', banana.id);
+      model = await env.lookup('hub:searchers').getCard(env.session, 'foods', banana.id);
       expect(model.data).has.deep.property('attributes.good-with-red', false);
     });
 
     it("adds computed fields to custom searcher's get response", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-searcher-models', '1');
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'sample-searcher-models', '1');
       expect(model).has.deep.property('data.attributes.double-height', 2);
     });
 

--- a/packages/hub/node-tests/computed-field-test.js
+++ b/packages/hub/node-tests/computed-field-test.js
@@ -177,22 +177,22 @@ describe('hub/computed-fields', function() {
     after(teardown);
 
     it("can depend on params", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.weight-in-grams', 448);
     });
 
     it("can depend on another computed field", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.weight-in-milligrams', 448000);
     });
 
     it("can depend on an attribute", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.echo-title', 'Apple');
     });
 
     it("can depend on id", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.echo-id');
       expect(model.data.attributes['echo-id']).to.equal(model.data.id);
     });
@@ -202,27 +202,27 @@ describe('hub/computed-fields', function() {
     // elasticsearch to blow up unless the dynamic type support is
     // working.
     it("can determine its type dynamically", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.echo-nutrients');
       expect(model.data.attributes['echo-nutrients']).to.deep.equal(model.data.attributes.nutrients);
     });
 
     it("can depend on fields on a related resource", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.good-with-red', false);
-      model = await env.lookup('hub:searchers').get(env.session, 'foods', banana.id);
+      model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'foods', banana.id);
       expect(model.data).has.deep.property('attributes.good-with-red', true);
 
     });
 
     it("can compute a belongs-to relationship", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'foods', apple.id);
       expect(model.data).has.deep.property('relationships.auto-chocolate');
       expect(model.data.relationships['auto-chocolate']).deep.equals({ data: { type: 'foods', id: chocolate.id } });
     });
 
     it("can compute a has-many relationship", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'foods', icecream.id);
+      let model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'foods', icecream.id);
       expect(model.data).has.deep.property('relationships.ingredients');
       expect(model.data.relationships['ingredients']).deep.equals({
         data: [
@@ -248,12 +248,12 @@ describe('hub/computed-fields', function() {
     });
 
     it("can compute an attribute even when there are no real attributes", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'only-computed', '1');
+      let model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'only-computed', '1');
       expect(model.data).has.deep.property('attributes.always-42', 42);
     });
 
     it("can compute a relationship even when there are no real relationships", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'only-computed', '1');
+      let model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'only-computed', '1');
       expect(model.data).has.deep.property('relationships.auto-chocolate.data.id', chocolate.id);
     });
   });
@@ -276,23 +276,23 @@ describe('hub/computed-fields', function() {
     });
 
     it("includes computed field in update response", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'foods', banana.id);
+      let model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'foods', banana.id);
       model.data.attributes['weight-in-ounces'] = 1;
       let response = await env.lookup('hub:writers').update('master', env.session, 'foods', banana.id, model);
       expect(response.data).has.deep.property('attributes.weight-in-grams', 28);
     });
 
     it("updates computed field in response to a dependent model changing", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'foods', apple.id);
       model.data.attributes['color'] = 'blue';
       await env.lookup('hub:writers').update('master', env.session, 'foods', apple.id, model);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      model = await env.lookup('hub:searchers').get(env.session, 'foods', banana.id);
+      model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'foods', banana.id);
       expect(model.data).has.deep.property('attributes.good-with-red', false);
     });
 
     it("adds computed fields to custom searcher's get response", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'sample-searcher-models', '1');
+      let model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'sample-searcher-models', '1');
       expect(model).has.deep.property('data.attributes.double-height', 2);
     });
 

--- a/packages/hub/node-tests/computed-field-test.js
+++ b/packages/hub/node-tests/computed-field-test.js
@@ -234,14 +234,14 @@ describe('hub/computed-fields', function() {
     });
 
     it("can search a computed belongs-to relationship's included attributes", async function() {
-      let response = await env.lookup('hub:searchers').search(env.session, 'master', { filter: { 'auto-chocolate.title': 'Chocolate' }});
+      let response = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { filter: { 'auto-chocolate.title': 'Chocolate' }});
       expect(response.data).has.length(1);
       expect(response.data[0]).has.property('id', '1');
       expect(response.data[0]).has.property('type', 'only-computed');
     });
 
     it("can search a computed has-many relationship's included attributes", async function() {
-      let response = await env.lookup('hub:searchers').search(env.session, 'master', { filter: { 'ingredients.title': 'Ketchup' }});
+      let response = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { filter: { 'ingredients.title': 'Ketchup' }});
       expect(response.data).has.length(1);
       expect(response.data[0]).has.property('id', meatloaf.id);
       expect(response.data[0]).has.property('type', meatloaf.type);
@@ -297,7 +297,7 @@ describe('hub/computed-fields', function() {
     });
 
     it("adds computed fields to custom searcher's search response", async function() {
-      let response = await env.lookup('hub:searchers').search(env.session, 'master', { filter: { type: 'sample-searcher-models' } });
+      let response = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { filter: { type: 'sample-searcher-models' } });
       expect(response.data).has.length(1);
       expect(response.data[0]).has.deep.property('attributes.double-height', 2);
     });

--- a/packages/hub/node-tests/computed-field-test.js
+++ b/packages/hub/node-tests/computed-field-test.js
@@ -177,22 +177,22 @@ describe('hub/computed-fields', function() {
     after(teardown);
 
     it("can depend on params", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'master', 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.weight-in-grams', 448);
     });
 
     it("can depend on another computed field", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'master', 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.weight-in-milligrams', 448000);
     });
 
     it("can depend on an attribute", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'master', 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.echo-title', 'Apple');
     });
 
     it("can depend on id", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'master', 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.echo-id');
       expect(model.data.attributes['echo-id']).to.equal(model.data.id);
     });
@@ -202,27 +202,27 @@ describe('hub/computed-fields', function() {
     // elasticsearch to blow up unless the dynamic type support is
     // working.
     it("can determine its type dynamically", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'master', 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.echo-nutrients');
       expect(model.data.attributes['echo-nutrients']).to.deep.equal(model.data.attributes.nutrients);
     });
 
     it("can depend on fields on a related resource", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'master', 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', apple.id);
       expect(model.data).has.deep.property('attributes.good-with-red', false);
-      model = await env.lookup('hub:searchers').get(env.session, 'master', 'foods', banana.id);
+      model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', banana.id);
       expect(model.data).has.deep.property('attributes.good-with-red', true);
 
     });
 
     it("can compute a belongs-to relationship", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'master', 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', apple.id);
       expect(model.data).has.deep.property('relationships.auto-chocolate');
       expect(model.data.relationships['auto-chocolate']).deep.equals({ data: { type: 'foods', id: chocolate.id } });
     });
 
     it("can compute a has-many relationship", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'master', 'foods', icecream.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', icecream.id);
       expect(model.data).has.deep.property('relationships.ingredients');
       expect(model.data.relationships['ingredients']).deep.equals({
         data: [
@@ -248,12 +248,12 @@ describe('hub/computed-fields', function() {
     });
 
     it("can compute an attribute even when there are no real attributes", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'master', 'only-computed', '1');
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'only-computed', '1');
       expect(model.data).has.deep.property('attributes.always-42', 42);
     });
 
     it("can compute a relationship even when there are no real relationships", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'master', 'only-computed', '1');
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'only-computed', '1');
       expect(model.data).has.deep.property('relationships.auto-chocolate.data.id', chocolate.id);
     });
   });
@@ -276,23 +276,23 @@ describe('hub/computed-fields', function() {
     });
 
     it("includes computed field in update response", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'master', 'foods', banana.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', banana.id);
       model.data.attributes['weight-in-ounces'] = 1;
       let response = await env.lookup('hub:writers').update('master', env.session, 'foods', banana.id, model);
       expect(response.data).has.deep.property('attributes.weight-in-grams', 28);
     });
 
     it("updates computed field in response to a dependent model changing", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'master', 'foods', apple.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', apple.id);
       model.data.attributes['color'] = 'blue';
       await env.lookup('hub:writers').update('master', env.session, 'foods', apple.id, model);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      model = await env.lookup('hub:searchers').get(env.session, 'master', 'foods', banana.id);
+      model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'foods', banana.id);
       expect(model.data).has.deep.property('attributes.good-with-red', false);
     });
 
     it("adds computed fields to custom searcher's get response", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'master', 'sample-searcher-models', '1');
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'sample-searcher-models', '1');
       expect(model).has.deep.property('data.attributes.double-height', 2);
     });
 

--- a/packages/hub/node-tests/indexers-test.js
+++ b/packages/hub/node-tests/indexers-test.js
@@ -39,25 +39,25 @@ describe('hub/indexers', function() {
     });
 
     it("indexes plugins", async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'plugins', 'sample-plugin-one');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'plugins', 'sample-plugin-one');
       expect(doc).is.ok;
     });
 
     it("includes the data source on each resource", async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'plugins', 'sample-plugin-one');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'plugins', 'sample-plugin-one');
       expect(doc).has.deep.property('data.meta.source', 'plugins');
-      doc = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'fields');
+      doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'fields');
       expect(doc).has.deep.property('data.meta.source', 'static-models');
     });
 
     it("includes features within plugins", async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'plugins', 'sample-plugin-one');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'plugins', 'sample-plugin-one');
       expect(doc).has.property('included');
       expect(doc.included.map(r => r.id)).deep.equals(['sample-plugin-one::x']);
     });
 
     it("indexes plugin features", async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'field-types', 'sample-plugin-one::x');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'field-types', 'sample-plugin-one::x');
       expect(doc).is.ok;
     });
 
@@ -71,7 +71,7 @@ describe('hub/indexers', function() {
       // this test is deliberately writing directly to the ephemeral
       // backend instead of going through hub:writers. That ensures
       // we aren't relying on side-effects from the writers.
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'plugins', 'sample-plugin-one');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'plugins', 'sample-plugin-one');
       expect(doc).has.deep.property('data.attributes.plugin-enabled', true);
       let config = {
         id: 'sample-plugin-one',
@@ -85,7 +85,7 @@ describe('hub/indexers', function() {
       let storage = await source.writer.storage;
       storage.store(config.type, config.id, config, false, null);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      doc = await env.lookup('hub:searchers').get(env.session, 'master', 'plugins', 'sample-plugin-one');
+      doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'plugins', 'sample-plugin-one');
       expect(doc).has.deep.property('data.attributes.plugin-enabled', false);
     });
   });
@@ -166,9 +166,9 @@ describe('hub/indexers', function() {
 
       env = await createDefaultEnvironment(__dirname + '/../../../tests/ephemeral-test-app', seeds.getModels());
 
-      let response = await env.lookup('hub:searchers').get(env.session, 'master', 'posts', '1');
+      let response = await env.lookup('hub:searchers').getCard(env.session, 'master', 'posts', '1');
       expect(response).is.ok;
-      response = await env.lookup('hub:searchers').get(env.session, 'master', 'comments', '1');
+      response = await env.lookup('hub:searchers').getCard(env.session, 'master', 'comments', '1');
       expect(response).is.ok;
 
     });
@@ -298,14 +298,14 @@ describe('hub/indexers', function() {
 
 
     it("does not allow unknown attributes into search index", async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'samples', 'has-bogus-attribute');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'samples', 'has-bogus-attribute');
       expect(doc).has.deep.property('data.attributes');
       expect(doc.data.attributes).has.property('real-field');
       expect(doc.data.attributes).not.has.property('fake-field');
     });
 
     it("does not allow unknown relationships into search index", async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'samples', 'has-bogus-relationship');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'samples', 'has-bogus-relationship');
       expect(doc).has.deep.property('data.relationships');
       expect(doc.data.relationships).has.property('real-relationship');
       expect(doc.data.relationships).not.has.property('fake-relationship');

--- a/packages/hub/node-tests/indexers-test.js
+++ b/packages/hub/node-tests/indexers-test.js
@@ -39,25 +39,25 @@ describe('hub/indexers', function() {
     });
 
     it("indexes plugins", async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'plugins', 'sample-plugin-one');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'plugins', 'sample-plugin-one');
       expect(doc).is.ok;
     });
 
     it("includes the data source on each resource", async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'plugins', 'sample-plugin-one');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'plugins', 'sample-plugin-one');
       expect(doc).has.deep.property('data.meta.source', 'plugins');
-      doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'fields');
+      doc = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'fields');
       expect(doc).has.deep.property('data.meta.source', 'static-models');
     });
 
     it("includes features within plugins", async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'plugins', 'sample-plugin-one');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'plugins', 'sample-plugin-one');
       expect(doc).has.property('included');
       expect(doc.included.map(r => r.id)).deep.equals(['sample-plugin-one::x']);
     });
 
     it("indexes plugin features", async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'field-types', 'sample-plugin-one::x');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'field-types', 'sample-plugin-one::x');
       expect(doc).is.ok;
     });
 
@@ -71,7 +71,7 @@ describe('hub/indexers', function() {
       // this test is deliberately writing directly to the ephemeral
       // backend instead of going through hub:writers. That ensures
       // we aren't relying on side-effects from the writers.
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'plugins', 'sample-plugin-one');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'plugins', 'sample-plugin-one');
       expect(doc).has.deep.property('data.attributes.plugin-enabled', true);
       let config = {
         id: 'sample-plugin-one',
@@ -85,7 +85,7 @@ describe('hub/indexers', function() {
       let storage = await source.writer.storage;
       storage.store(config.type, config.id, config, false, null);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'plugins', 'sample-plugin-one');
+      doc = await env.lookup('hub:searchers').getCard(env.session, 'plugins', 'sample-plugin-one');
       expect(doc).has.deep.property('data.attributes.plugin-enabled', false);
     });
   });
@@ -166,9 +166,9 @@ describe('hub/indexers', function() {
 
       env = await createDefaultEnvironment(__dirname + '/../../../tests/ephemeral-test-app', seeds.getModels());
 
-      let response = await env.lookup('hub:searchers').getCard(env.session, 'master', 'posts', '1');
+      let response = await env.lookup('hub:searchers').getCard(env.session, 'posts', '1');
       expect(response).is.ok;
-      response = await env.lookup('hub:searchers').getCard(env.session, 'master', 'comments', '1');
+      response = await env.lookup('hub:searchers').getCard(env.session, 'comments', '1');
       expect(response).is.ok;
 
     });
@@ -298,14 +298,14 @@ describe('hub/indexers', function() {
 
 
     it("does not allow unknown attributes into search index", async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'samples', 'has-bogus-attribute');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'samples', 'has-bogus-attribute');
       expect(doc).has.deep.property('data.attributes');
       expect(doc.data.attributes).has.property('real-field');
       expect(doc.data.attributes).not.has.property('fake-field');
     });
 
     it("does not allow unknown relationships into search index", async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'samples', 'has-bogus-relationship');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'samples', 'has-bogus-relationship');
       expect(doc).has.deep.property('data.relationships');
       expect(doc.data.relationships).has.property('real-relationship');
       expect(doc.data.relationships).not.has.property('fake-relationship');

--- a/packages/hub/node-tests/indexers-test.js
+++ b/packages/hub/node-tests/indexers-test.js
@@ -26,12 +26,12 @@ describe('hub/indexers', function() {
 
     it("indexes seed models", async function() {
       // this seed model comes from createDefaultEnvironment
-      let response = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { filter: { type: 'plugin-configs' }});
+      let response = await env.lookup('hub:searchers').search(env.session, { filter: { type: 'plugin-configs' }});
       expect(response.data.map(m => m.id)).includes('@cardstack/hub');
     });
 
     it("indexes bootstrap models", async function() {
-      let response = await env.lookup('hub:searchers').searchForCard(env.session, 'master', {
+      let response = await env.lookup('hub:searchers').search(env.session, {
         filter: { type: 'content-types' },
         page: { size: 100 }
       });
@@ -39,25 +39,25 @@ describe('hub/indexers', function() {
     });
 
     it("indexes plugins", async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'plugins', 'sample-plugin-one');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'plugins', 'sample-plugin-one');
       expect(doc).is.ok;
     });
 
     it("includes the data source on each resource", async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'plugins', 'sample-plugin-one');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'plugins', 'sample-plugin-one');
       expect(doc).has.deep.property('data.meta.source', 'plugins');
-      doc = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'fields');
+      doc = await env.lookup('hub:searchers').get(env.session, 'content-types', 'fields');
       expect(doc).has.deep.property('data.meta.source', 'static-models');
     });
 
     it("includes features within plugins", async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'plugins', 'sample-plugin-one');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'plugins', 'sample-plugin-one');
       expect(doc).has.property('included');
       expect(doc.included.map(r => r.id)).deep.equals(['sample-plugin-one::x']);
     });
 
     it("indexes plugin features", async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'field-types', 'sample-plugin-one::x');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'field-types', 'sample-plugin-one::x');
       expect(doc).is.ok;
     });
 
@@ -71,7 +71,7 @@ describe('hub/indexers', function() {
       // this test is deliberately writing directly to the ephemeral
       // backend instead of going through hub:writers. That ensures
       // we aren't relying on side-effects from the writers.
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'plugins', 'sample-plugin-one');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'plugins', 'sample-plugin-one');
       expect(doc).has.deep.property('data.attributes.plugin-enabled', true);
       let config = {
         id: 'sample-plugin-one',
@@ -85,7 +85,7 @@ describe('hub/indexers', function() {
       let storage = await source.writer.storage;
       storage.store(config.type, config.id, config, false, null);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      doc = await env.lookup('hub:searchers').getCard(env.session, 'plugins', 'sample-plugin-one');
+      doc = await env.lookup('hub:searchers').get(env.session, 'plugins', 'sample-plugin-one');
       expect(doc).has.deep.property('data.attributes.plugin-enabled', false);
     });
   });
@@ -121,7 +121,7 @@ describe('hub/indexers', function() {
         await writers.createBinary('master', Session.INTERNAL_PRIVILEGED, 'cardstack-files', readStream);
       }));
 
-      let response = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { filter: { type: 'cardstack-files' }});
+      let response = await env.lookup('hub:searchers').search(env.session, { filter: { type: 'cardstack-files' }});
       expect(response.data.map(m => m.type)).includes('cardstack-files');
       expect(response.data).has.length(2);
       expect(response.data[0]).has.property('id').equal('cardstack-logo');
@@ -166,9 +166,9 @@ describe('hub/indexers', function() {
 
       env = await createDefaultEnvironment(__dirname + '/../../../tests/ephemeral-test-app', seeds.getModels());
 
-      let response = await env.lookup('hub:searchers').getCard(env.session, 'posts', '1');
+      let response = await env.lookup('hub:searchers').get(env.session, 'posts', '1');
       expect(response).is.ok;
-      response = await env.lookup('hub:searchers').getCard(env.session, 'comments', '1');
+      response = await env.lookup('hub:searchers').get(env.session, 'comments', '1');
       expect(response).is.ok;
 
     });
@@ -298,21 +298,21 @@ describe('hub/indexers', function() {
 
 
     it("does not allow unknown attributes into search index", async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'samples', 'has-bogus-attribute');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'samples', 'has-bogus-attribute');
       expect(doc).has.deep.property('data.attributes');
       expect(doc.data.attributes).has.property('real-field');
       expect(doc.data.attributes).not.has.property('fake-field');
     });
 
     it("does not allow unknown relationships into search index", async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'samples', 'has-bogus-relationship');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'samples', 'has-bogus-relationship');
       expect(doc).has.deep.property('data.relationships');
       expect(doc.data.relationships).has.property('real-relationship');
       expect(doc.data.relationships).not.has.property('fake-relationship');
     });
 
     it("does not allow unknown document types into search index", async function() {
-      let response = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { filter: { type: 'not-a-thing' }});
+      let response = await env.lookup('hub:searchers').search(env.session, { filter: { type: 'not-a-thing' }});
       expect(response.data).has.length(0);
     });
 

--- a/packages/hub/node-tests/indexers-test.js
+++ b/packages/hub/node-tests/indexers-test.js
@@ -39,25 +39,25 @@ describe('hub/indexers', function() {
     });
 
     it("indexes plugins", async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'plugins', 'sample-plugin-one');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'plugins', 'sample-plugin-one');
       expect(doc).is.ok;
     });
 
     it("includes the data source on each resource", async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'plugins', 'sample-plugin-one');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'plugins', 'sample-plugin-one');
       expect(doc).has.deep.property('data.meta.source', 'plugins');
-      doc = await env.lookup('hub:searchers').get(env.session, 'content-types', 'fields');
+      doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'fields');
       expect(doc).has.deep.property('data.meta.source', 'static-models');
     });
 
     it("includes features within plugins", async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'plugins', 'sample-plugin-one');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'plugins', 'sample-plugin-one');
       expect(doc).has.property('included');
       expect(doc.included.map(r => r.id)).deep.equals(['sample-plugin-one::x']);
     });
 
     it("indexes plugin features", async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'field-types', 'sample-plugin-one::x');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'field-types', 'sample-plugin-one::x');
       expect(doc).is.ok;
     });
 
@@ -71,7 +71,7 @@ describe('hub/indexers', function() {
       // this test is deliberately writing directly to the ephemeral
       // backend instead of going through hub:writers. That ensures
       // we aren't relying on side-effects from the writers.
-      let doc = await env.lookup('hub:searchers').get(env.session, 'plugins', 'sample-plugin-one');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'plugins', 'sample-plugin-one');
       expect(doc).has.deep.property('data.attributes.plugin-enabled', true);
       let config = {
         id: 'sample-plugin-one',
@@ -85,7 +85,7 @@ describe('hub/indexers', function() {
       let storage = await source.writer.storage;
       storage.store(config.type, config.id, config, false, null);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      doc = await env.lookup('hub:searchers').get(env.session, 'plugins', 'sample-plugin-one');
+      doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'plugins', 'sample-plugin-one');
       expect(doc).has.deep.property('data.attributes.plugin-enabled', false);
     });
   });
@@ -166,9 +166,9 @@ describe('hub/indexers', function() {
 
       env = await createDefaultEnvironment(__dirname + '/../../../tests/ephemeral-test-app', seeds.getModels());
 
-      let response = await env.lookup('hub:searchers').get(env.session, 'posts', '1');
+      let response = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'posts', '1');
       expect(response).is.ok;
-      response = await env.lookup('hub:searchers').get(env.session, 'comments', '1');
+      response = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'comments', '1');
       expect(response).is.ok;
 
     });
@@ -298,14 +298,14 @@ describe('hub/indexers', function() {
 
 
     it("does not allow unknown attributes into search index", async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'samples', 'has-bogus-attribute');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'samples', 'has-bogus-attribute');
       expect(doc).has.deep.property('data.attributes');
       expect(doc.data.attributes).has.property('real-field');
       expect(doc.data.attributes).not.has.property('fake-field');
     });
 
     it("does not allow unknown relationships into search index", async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'samples', 'has-bogus-relationship');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'samples', 'has-bogus-relationship');
       expect(doc).has.deep.property('data.relationships');
       expect(doc.data.relationships).has.property('real-relationship');
       expect(doc.data.relationships).not.has.property('fake-relationship');

--- a/packages/hub/node-tests/indexers-test.js
+++ b/packages/hub/node-tests/indexers-test.js
@@ -26,12 +26,12 @@ describe('hub/indexers', function() {
 
     it("indexes seed models", async function() {
       // this seed model comes from createDefaultEnvironment
-      let response = await env.lookup('hub:searchers').search(env.session, 'master', { filter: { type: 'plugin-configs' }});
+      let response = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { filter: { type: 'plugin-configs' }});
       expect(response.data.map(m => m.id)).includes('@cardstack/hub');
     });
 
     it("indexes bootstrap models", async function() {
-      let response = await env.lookup('hub:searchers').search(env.session, 'master', {
+      let response = await env.lookup('hub:searchers').searchForCard(env.session, 'master', {
         filter: { type: 'content-types' },
         page: { size: 100 }
       });
@@ -121,7 +121,7 @@ describe('hub/indexers', function() {
         await writers.createBinary('master', Session.INTERNAL_PRIVILEGED, 'cardstack-files', readStream);
       }));
 
-      let response = await env.lookup('hub:searchers').search(env.session, 'master', { filter: { type: 'cardstack-files' }});
+      let response = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { filter: { type: 'cardstack-files' }});
       expect(response.data.map(m => m.type)).includes('cardstack-files');
       expect(response.data).has.length(2);
       expect(response.data[0]).has.property('id').equal('cardstack-logo');
@@ -312,7 +312,7 @@ describe('hub/indexers', function() {
     });
 
     it("does not allow unknown document types into search index", async function() {
-      let response = await env.lookup('hub:searchers').search(env.session, 'master', { filter: { type: 'not-a-thing' }});
+      let response = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { filter: { type: 'not-a-thing' }});
       expect(response.data).has.length(0);
     });
 

--- a/packages/hub/node-tests/middleware-stack-test.js
+++ b/packages/hub/node-tests/middleware-stack-test.js
@@ -79,7 +79,7 @@ describe('middleware-stack', function() {
     afterEach(teardown);
 
     it('can dynamically mount more middleware', async function() {
-      let config = await env.lookup('hub:searchers').get(env.session, 'plugin-configs', 'stub-middleware-extra');
+      let config = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'plugin-configs', 'stub-middleware-extra');
       config.data.attributes.enabled = true;
       await env.lookup('hub:writers').update('master', env.session, config.data.type, config.data.id, config);
       await env.lookup('hub:indexers').update({ forceRefresh: true });

--- a/packages/hub/node-tests/middleware-stack-test.js
+++ b/packages/hub/node-tests/middleware-stack-test.js
@@ -79,7 +79,7 @@ describe('middleware-stack', function() {
     afterEach(teardown);
 
     it('can dynamically mount more middleware', async function() {
-      let config = await env.lookup('hub:searchers').getCard(env.session, 'master', 'plugin-configs', 'stub-middleware-extra');
+      let config = await env.lookup('hub:searchers').getCard(env.session, 'plugin-configs', 'stub-middleware-extra');
       config.data.attributes.enabled = true;
       await env.lookup('hub:writers').update('master', env.session, config.data.type, config.data.id, config);
       await env.lookup('hub:indexers').update({ forceRefresh: true });

--- a/packages/hub/node-tests/middleware-stack-test.js
+++ b/packages/hub/node-tests/middleware-stack-test.js
@@ -79,7 +79,7 @@ describe('middleware-stack', function() {
     afterEach(teardown);
 
     it('can dynamically mount more middleware', async function() {
-      let config = await env.lookup('hub:searchers').get(env.session, 'master', 'plugin-configs', 'stub-middleware-extra');
+      let config = await env.lookup('hub:searchers').getCard(env.session, 'master', 'plugin-configs', 'stub-middleware-extra');
       config.data.attributes.enabled = true;
       await env.lookup('hub:writers').update('master', env.session, config.data.type, config.data.id, config);
       await env.lookup('hub:indexers').update({ forceRefresh: true });

--- a/packages/hub/node-tests/middleware-stack-test.js
+++ b/packages/hub/node-tests/middleware-stack-test.js
@@ -79,7 +79,7 @@ describe('middleware-stack', function() {
     afterEach(teardown);
 
     it('can dynamically mount more middleware', async function() {
-      let config = await env.lookup('hub:searchers').getCard(env.session, 'plugin-configs', 'stub-middleware-extra');
+      let config = await env.lookup('hub:searchers').get(env.session, 'plugin-configs', 'stub-middleware-extra');
       config.data.attributes.enabled = true;
       await env.lookup('hub:writers').update('master', env.session, config.data.type, config.data.id, config);
       await env.lookup('hub:indexers').update({ forceRefresh: true });

--- a/packages/hub/node-tests/routers-test.js
+++ b/packages/hub/node-tests/routers-test.js
@@ -205,7 +205,7 @@ describe('hub/routers', function () {
     });
 
     it('can get the default "getting started" application card when no application card has been specified in the plugin-config', async function () {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/');
+      let { included, data: space } = await searchers.getSpace(env.session, '/');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/');
@@ -222,7 +222,7 @@ describe('hub/routers', function () {
     });
 
     it('uses statically mapped routing for the application card when no routing has been specified', async function() {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/puppies/vanGogh');
+      let { included, data: space } = await searchers.getSpace(env.session, '/puppies/vanGogh');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/puppies/vanGogh');
@@ -288,7 +288,7 @@ describe('hub/routers', function () {
     });
 
     it('can get the space of a route using a session based query', async function() {
-      let result = await searchers.get(session, 'master', 'spaces', '/puppy');
+      let result = await searchers.getSpace(session, '/puppy');
       let { included, data: space } = result;
 
       expect(space).has.property('type', 'spaces');
@@ -311,7 +311,7 @@ describe('hub/routers', function () {
     });
 
     it('can get the space of a route whose primary card is the session object', async function() {
-      let { included, data: space } = await searchers.get(session, 'master', 'spaces', '/');
+      let { included, data: space } = await searchers.getSpace(session, '/');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/');
@@ -421,7 +421,7 @@ describe('hub/routers', function () {
     });
 
     it('can return the routing card as the primary card when no query exists for the route', async function () {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/forward/rats/pizza-rat');
+      let { included, data: space } = await searchers.getSpace(env.session, '/forward/rats/pizza-rat');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/forward/rats/pizza-rat');
@@ -439,7 +439,7 @@ describe('hub/routers', function () {
     });
 
     it('can return the routing card as the primary card when primary card has query param based routes', async function () {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/forward/kitties/sally?kitties[foo]=bar&kitties[bee]=bop&ignore-me=true');
+      let { included, data: space } = await searchers.getSpace(env.session, '/forward/kitties/sally?kitties[foo]=bar&kitties[bee]=bop&ignore-me=true');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/forward/kitties/sally?kitties[foo]=bar&kitties[bee]=bop&ignore-me=true');
@@ -457,7 +457,7 @@ describe('hub/routers', function () {
     });
 
     it('can return the routing card as the primary card when no query exists for the route with query param', async function () {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/forward/kitties/sally');
+      let { included, data: space } = await searchers.getSpace(env.session, '/forward/kitties/sally');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/forward/kitties/sally');
@@ -475,7 +475,7 @@ describe('hub/routers', function () {
     });
 
     it('can return an error card when the path does not match any routes', async function () {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/route-that-doesnt-exist');
+      let { included, data: space } = await searchers.getSpace(env.session, '/route-that-doesnt-exist');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/route-that-doesnt-exist');
@@ -491,7 +491,7 @@ describe('hub/routers', function () {
     });
 
     it('can return an error card when the path does not correspond to a card that exists', async function () {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/forward/cards/route-that-doesnt-exist');
+      let { included, data: space } = await searchers.getSpace(env.session, '/forward/cards/route-that-doesnt-exist');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/forward/cards/route-that-doesnt-exist');
@@ -506,7 +506,7 @@ describe('hub/routers', function () {
     });
 
     it('can return error card if the router identifies a primary card and the path part of the URL has not been fully consumed', async function () {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/favorite-puppy/blah');
+      let { included, data: space } = await searchers.getSpace(env.session, '/favorite-puppy/blah');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/favorite-puppy/blah');
@@ -521,7 +521,7 @@ describe('hub/routers', function () {
     });
 
     it('can override the system error card with an error card specific to the routing card', async function () {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/forward/kitties/sally/whaaa');
+      let { included, data: space } = await searchers.getSpace(env.session, '/forward/kitties/sally/whaaa');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/forward/kitties/sally/whaaa');
@@ -536,7 +536,7 @@ describe('hub/routers', function () {
     });
 
     it('uses system error card if the custom error card doesnt have an instance with the id of "not-found"', async function() {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/forward/rats/pizza-rat/blah');
+      let { included, data: space } = await searchers.getSpace(env.session, '/forward/rats/pizza-rat/blah');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/forward/rats/pizza-rat/blah');
@@ -551,7 +551,7 @@ describe('hub/routers', function () {
     });
 
     it('uses system error card if the custom error card doesnt have an open grant', async function() {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/forward/fishes/nemo/blah');
+      let { included, data: space } = await searchers.getSpace(env.session, '/forward/fishes/nemo/blah');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/forward/fishes/nemo/blah');
@@ -566,17 +566,17 @@ describe('hub/routers', function () {
     });
 
     it('can return an http-status of 404 for the `not-found` error card', async function() {
-      let { data: space } = await searchers.get(env.session, 'master', 'spaces', '/non-existant-card');
+      let { data: space } = await searchers.getSpace(env.session, '/non-existant-card');
       expect(space).has.deep.property('attributes.http-status', 404);
     });
 
     it('can return an http-status of 200 for a card that is not an error card', async function() {
-      let { data: space } = await searchers.get(env.session, 'master', 'spaces', '/favorite-puppy');
+      let { data: space } = await searchers.getSpace(env.session, '/favorite-puppy');
       expect(space).has.deep.property('attributes.http-status', 200);
     });
 
     it('can get the space using a route that is static', async function () {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/favorite-puppy');
+      let { included, data: space } = await searchers.getSpace(env.session, '/favorite-puppy');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/favorite-puppy');
@@ -596,7 +596,7 @@ describe('hub/routers', function () {
     });
 
     it('can get the space using a route that has dynamic segments and additional-parameters', async function () {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/buddy/Ringo');
+      let { included, data: space } = await searchers.getSpace(env.session, '/buddy/Ringo');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/buddy/Ringo');
@@ -623,7 +623,7 @@ describe('hub/routers', function () {
     });
 
     it('can get the space using a route that uses contextual card data', async function () {
-      let {included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/contextual-favorite-toy/squeaky-snake');
+      let {included, data: space } = await searchers.getSpace(env.session, '/contextual-favorite-toy/squeaky-snake');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/contextual-favorite-toy/squeaky-snake');
@@ -643,7 +643,7 @@ describe('hub/routers', function () {
     });
 
     it('can get the space using a route that uses a query param', async function () {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/sorted?cards[sort]=favorite-toy&foo=bar&bee=bop');
+      let { included, data: space } = await searchers.getSpace(env.session, '/sorted?cards[sort]=favorite-toy&foo=bar&bee=bop');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/sorted?cards[sort]=favorite-toy&foo=bar&bee=bop');
@@ -663,7 +663,7 @@ describe('hub/routers', function () {
     });
 
     it('does not include query params that were not consumed', async function () {
-      let { data: space } = await searchers.get(env.session, 'master', 'spaces', '/favorite-puppy?foo=bar');
+      let { data: space } = await searchers.getSpace(env.session, '/favorite-puppy?foo=bar');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/favorite-puppy?foo=bar');
@@ -675,7 +675,7 @@ describe('hub/routers', function () {
     });
 
     it('can route to a path that includes routing card data', async function() {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/kitty-breeds/dalmatian/sally');
+      let { included, data: space } = await searchers.getSpace(env.session, '/kitty-breeds/dalmatian/sally');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/kitty-breeds/dalmatian/sally');
@@ -693,7 +693,7 @@ describe('hub/routers', function () {
     });
 
     it('can route to a path that includes routing card data in multiple nested routes', async function() {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/kitty-breeds/dalmatian/sally/Sally/puppy-friends/vanGogh');
+      let { included, data: space } = await searchers.getSpace(env.session, '/kitty-breeds/dalmatian/sally/Sally/puppy-friends/vanGogh');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/kitty-breeds/dalmatian/sally/Sally/puppy-friends/vanGogh');
@@ -711,7 +711,7 @@ describe('hub/routers', function () {
     });
 
     it('can route to a path that includes routing card data in multiple nested routes that terminates in query-less route', async function() {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/kitty-breeds/dalmatian/sally/Sally/fish-friend/nemo');
+      let { included, data: space } = await searchers.getSpace(env.session, '/kitty-breeds/dalmatian/sally/Sally/fish-friend/nemo');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/kitty-breeds/dalmatian/sally/Sally/fish-friend/nemo');
@@ -729,7 +729,7 @@ describe('hub/routers', function () {
     });
 
     it('can route to a path that includes routing card data whose routing card`s query uses card data', async function() {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/forward/rats/pizza-rat/Pizza%20Rat/fish-friend');
+      let { included, data: space } = await searchers.getSpace(env.session, '/forward/rats/pizza-rat/Pizza%20Rat/fish-friend');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/forward/rats/pizza-rat/Pizza%20Rat/fish-friend');
@@ -747,7 +747,7 @@ describe('hub/routers', function () {
     });
 
     it('can route to a path that includes routing card that is retrieved via upstream routing card data', async function() {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/forward/rats/pizza-rat/Pizza%20Rat/fish-friend/Nemo/dinner-for');
+      let { included, data: space } = await searchers.getSpace(env.session, '/forward/rats/pizza-rat/Pizza%20Rat/fish-friend/Nemo/dinner-for');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/forward/rats/pizza-rat/Pizza%20Rat/fish-friend/Nemo/dinner-for');
@@ -800,7 +800,7 @@ describe('hub/routers', function () {
     it('throws an error when it encounters a route that is missing a path', async function () {
       let error;
       try {
-        await searchers.get(env.session, 'master', 'spaces', '/');
+        await searchers.getSpace(env.session, '/');
       } catch (err) { error = err.message; }
 
       expect(error).to.equal(`The router for content type 'cards' has a route that is missing a path.`);
@@ -841,7 +841,7 @@ describe('hub/routers', function () {
     it('throws an error when it encounters a path definied in a route that does not start with "/"', async function () {
       let error;
       try {
-        await searchers.get(env.session, 'master', 'spaces', '/');
+        await searchers.getSpace(env.session, '/');
       } catch (err) { error = err.message; }
 
       expect(error).to.equal(`The path of the route for content type 'cards' at path 'app-card' does not begin with '/'.`);
@@ -898,7 +898,7 @@ describe('hub/routers', function () {
     it('throws an error maximum route stack size is exceeded while building router map', async function () {
       let error;
       try {
-        await searchers.get(env.session, 'master', 'spaces', '/deep');
+        await searchers.getSpace(env.session, '/deep');
       } catch (err) { error = err.message; }
 
       expect(error).to.match(/^Recursed through more than 50 routers when building routing map/);
@@ -958,7 +958,7 @@ describe('hub/routers', function () {
     });
 
     it('returns error card when a route has been matched, but its antecedant routing card does not exist', async function() {
-      let { included, data: space } = await searchers.get(env.session, 'master', 'spaces', '/router/puppy');
+      let { included, data: space } = await searchers.getSpace(env.session, '/router/puppy');
 
       expect(space).has.property('type', 'spaces');
       expect(space).has.property('id', '/router/puppy');

--- a/packages/hub/node-tests/schema-read-auth-test.js
+++ b/packages/hub/node-tests/schema-read-auth-test.js
@@ -24,7 +24,7 @@ async function find(type, id) {
 }
 
 async function findAll(type) {
-  return searchers.search(Session.INTERNAL_PRIVILEGED, 'master', { filter: { type } });
+  return searchers.searchForCard(Session.INTERNAL_PRIVILEGED, 'master', { filter: { type } });
 }
 
 function makeSession(schema, { type, id }) {

--- a/packages/hub/node-tests/schema-read-auth-test.js
+++ b/packages/hub/node-tests/schema-read-auth-test.js
@@ -20,7 +20,7 @@ async function update(session, document) {
 }
 
 async function find(type, id) {
-  return searchers.get(Session.INTERNAL_PRIVILEGED, type, id);
+  return searchers.get(Session.INTERNAL_PRIVILEGED, 'local-hub', type, id);
 }
 
 async function findAll(type) {

--- a/packages/hub/node-tests/schema-read-auth-test.js
+++ b/packages/hub/node-tests/schema-read-auth-test.js
@@ -20,7 +20,7 @@ async function update(session, document) {
 }
 
 async function find(type, id) {
-  return searchers.get(Session.INTERNAL_PRIVILEGED, 'master', type, id);
+  return searchers.getCard(Session.INTERNAL_PRIVILEGED, 'master', type, id);
 }
 
 async function findAll(type) {

--- a/packages/hub/node-tests/schema-read-auth-test.js
+++ b/packages/hub/node-tests/schema-read-auth-test.js
@@ -20,11 +20,11 @@ async function update(session, document) {
 }
 
 async function find(type, id) {
-  return searchers.getCard(Session.INTERNAL_PRIVILEGED, type, id);
+  return searchers.get(Session.INTERNAL_PRIVILEGED, type, id);
 }
 
 async function findAll(type) {
-  return searchers.searchForCard(Session.INTERNAL_PRIVILEGED, 'master', { filter: { type } });
+  return searchers.search(Session.INTERNAL_PRIVILEGED, { filter: { type } });
 }
 
 function makeSession(schema, { type, id }) {

--- a/packages/hub/node-tests/schema-read-auth-test.js
+++ b/packages/hub/node-tests/schema-read-auth-test.js
@@ -20,7 +20,7 @@ async function update(session, document) {
 }
 
 async function find(type, id) {
-  return searchers.getCard(Session.INTERNAL_PRIVILEGED, 'master', type, id);
+  return searchers.getCard(Session.INTERNAL_PRIVILEGED, type, id);
 }
 
 async function findAll(type) {

--- a/packages/hub/node-tests/searchers-auth-test.js
+++ b/packages/hub/node-tests/searchers-auth-test.js
@@ -71,7 +71,7 @@ describe('hub/searchers/auth', function() {
   it("returns 404 when user has no grant", async function() {
     await setup();
     try {
-      await searchers.getCard(Session.EVERYONE, 'posts', '1');
+      await searchers.get(Session.EVERYONE, 'posts', '1');
     } catch (err) {
       expect(err).has.property('status', 404);
       return;
@@ -85,7 +85,7 @@ describe('hub/searchers/auth', function() {
         .withAttributes({ mayReadResource: true, mayReadFields: true })
         .withRelated('who', [everyone]);
     });
-    let doc = await searchers.getCard(Session.EVERYONE, 'posts', '1');
+    let doc = await searchers.get(Session.EVERYONE, 'posts', '1');
     expect(doc).has.deep.property('data.attributes.title', 'First Post');
   });
 
@@ -96,7 +96,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('types', [{ type: 'content-types', id: 'posts' }]);
     });
-    let doc = await searchers.getCard(Session.EVERYONE, 'posts', '1');
+    let doc = await searchers.get(Session.EVERYONE, 'posts', '1');
     expect(doc).has.deep.property('data.attributes.title', 'First Post');
   });
 
@@ -108,7 +108,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('types', [{ type: 'content-types', id: 'fields' }]);
     });
     try {
-      await searchers.getCard(Session.EVERYONE, 'posts', '1');
+      await searchers.get(Session.EVERYONE, 'posts', '1');
     } catch (err) {
       expect(err).has.property('status', 404);
       return;
@@ -118,7 +118,7 @@ describe('hub/searchers/auth', function() {
 
   it("filters unauthorized resources from searches", async function() {
     await setup();
-    let response = await searchers.searchForCard(Session.EVERYONE, 'master', { filter: { type: 'posts' } });
+    let response = await searchers.search(Session.EVERYONE, { filter: { type: 'posts' } });
     expect(response.data).has.length(0);
   });
 
@@ -129,7 +129,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('types', [{ type: 'content-types', id: 'posts' }]);
     });
-    let response = await searchers.searchForCard(Session.EVERYONE, 'master', { filter: { type: 'posts' } });
+    let response = await searchers.search(Session.EVERYONE, { filter: { type: 'posts' } });
     expect(response.data).has.length(1);
   });
 
@@ -140,7 +140,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('fields', [{ type: 'fields', id: 'title' }]);
     });
-    let doc = await searchers.getCard(Session.EVERYONE, 'posts', '1');
+    let doc = await searchers.get(Session.EVERYONE, 'posts', '1');
     expect(doc).not.has.deep.property('data.attributes.subtitle');
   });
 
@@ -151,7 +151,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('fields', [{ type: 'fields', id: 'title' }]);
     });
-    let doc = await searchers.getCard(Session.EVERYONE, 'posts', '1');
+    let doc = await searchers.get(Session.EVERYONE, 'posts', '1');
     expect(doc).has.deep.property('data.attributes.title');
   });
 
@@ -162,7 +162,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('fields', [{ type: 'fields', id: 'title' }]);
     });
-    let doc = await searchers.searchForCard(Session.EVERYONE, 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(Session.EVERYONE, { filter: { type: 'posts' } });
     expect(doc.data[0]).not.has.deep.property('attributes.subtitle');
   });
 
@@ -173,7 +173,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('fields', [{ type: 'fields', id: 'title' }]);
     });
-    let doc = await searchers.searchForCard(Session.EVERYONE, 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(Session.EVERYONE, { filter: { type: 'posts' } });
     expect(doc.data[0]).has.deep.property('attributes.title');
   });
 
@@ -184,7 +184,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('fields', [{ type: 'fields', id: 'title' }]);
     });
-    let doc = await searchers.getCard(Session.EVERYONE, 'posts', '1');
+    let doc = await searchers.get(Session.EVERYONE, 'posts', '1');
     expect(doc).not.has.deep.property('data.relationships.author');
   });
 
@@ -198,7 +198,7 @@ describe('hub/searchers/auth', function() {
           { type: 'fields', id: 'author' }
         ]);
     });
-    let doc = await searchers.getCard(Session.EVERYONE, 'posts', '1');
+    let doc = await searchers.get(Session.EVERYONE, 'posts', '1');
     expect(doc).has.deep.property('data.relationships.author');
   });
 
@@ -208,7 +208,7 @@ describe('hub/searchers/auth', function() {
         .withAttributes({ mayReadResource: true, mayReadFields: true })
         .withRelated('who', [{ type: 'fields', id: 'author' }]);
     });
-    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(sessions.create('authors', 'arthur'), { filter: { type: 'posts' } });
     expect(doc.data).has.length(1);
     expect(doc.data[0]).has.deep.property('attributes.title', 'First Post');
     expect(doc.meta).has.deep.property('page.total', 1);
@@ -220,7 +220,7 @@ describe('hub/searchers/auth', function() {
         .withAttributes({ mayReadResource: true, mayReadFields: true })
         .withRelated('who', [{ type: 'fields', id: 'author' }]);
     });
-    let doc = await searchers.searchForCard(sessions.create('authors', 'other'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(sessions.create('authors', 'other'), { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 
@@ -234,7 +234,7 @@ describe('hub/searchers/auth', function() {
           searchQuery: { filter: { type: { exact: 'authors' }, name: { exact: 'Arthur Faulkner' } } }
         });
     });
-    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(sessions.create('authors', 'arthur'), { filter: { type: 'posts' } });
     expect(doc.data).has.length(1);
     expect(doc.data[0]).has.deep.property('attributes.title', 'First Post');
     expect(doc.meta).has.deep.property('page.total', 1);
@@ -250,7 +250,7 @@ describe('hub/searchers/auth', function() {
           searchQuery: { filter: { type: { exact: 'authors' }, name: { exact: 'Somebody Else' } } }
         });
     });
-    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(sessions.create('authors', 'arthur'), { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 
@@ -268,7 +268,7 @@ describe('hub/searchers/auth', function() {
           searchQuery: { filter: { type: { exact: 'authors' }, name: { exact: 'Arthur Faulkner' } } }
         });
     });
-    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(sessions.create('authors', 'arthur'), { filter: { type: 'posts' } });
     expect(doc.data).has.length(1);
     expect(doc.data[0]).has.deep.property('attributes.title', 'First Post');
     expect(doc.meta).has.deep.property('page.total', 1);
@@ -288,7 +288,7 @@ describe('hub/searchers/auth', function() {
           searchQuery: { filter: { type: { exact: 'authors' }, name: { exact: 'Arthur Faulkner' } } }
         });
     });
-    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(sessions.create('authors', 'arthur'), { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 
@@ -302,7 +302,7 @@ describe('hub/searchers/auth', function() {
           searchQuery: { filter: { type: { exact: 'authors' }, name: { exact: 'Arthur Faulkner' } } }
         });
     });
-    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(sessions.create('authors', 'arthur'), { filter: { type: 'posts' } });
     expect(doc.data).has.length(1);
     expect(doc.data[0]).has.deep.property('attributes.title', 'First Post');
     expect(doc.meta).has.deep.property('page.total', 1);
@@ -318,7 +318,7 @@ describe('hub/searchers/auth', function() {
           searchQuery: { filter: { type: { exact: 'authors' }, name: { exact: 'other' } } }
         });
     });
-    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(sessions.create('authors', 'arthur'), { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 
@@ -332,7 +332,7 @@ describe('hub/searchers/auth', function() {
           searchQuery: { filter: { type: { exact: 'authors' }, name: { exact: 'Quint Faulkner' } } }
         });
     });
-    let doc = await searchers.searchForCard(sessions.create('authors', 'quint'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(sessions.create('authors', 'quint'), { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 
@@ -346,7 +346,7 @@ describe('hub/searchers/auth', function() {
           searchQuery: { filter: { type: { exact: 'authors' }, name: { exact: 'Quint Faulkner' } } }
         });
     });
-    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(sessions.create('authors', 'arthur'), { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 
@@ -362,10 +362,10 @@ describe('hub/searchers/auth', function() {
     });
 
     let session = sessions.create('authors', 'arthur');
-    let user = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'authors', 'arthur');
+    let user = await searchers.get(Session.INTERNAL_PRIVILEGED, 'authors', 'arthur');
     await env.lookup('hub:writers').delete('master', Session.INTERNAL_PRIVILEGED, user.data.meta.version, user.data.type, user.data.id);
     await env.lookup('hub:indexers').update({ forceRefresh: true });
-    let doc = await searchers.searchForCard(session, 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(session, { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 
@@ -381,11 +381,11 @@ describe('hub/searchers/auth', function() {
     });
 
     let session = sessions.create('authors', 'arthur');
-    let user = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'authors', 'arthur');
+    let user = await searchers.get(Session.INTERNAL_PRIVILEGED, 'authors', 'arthur');
     user.data.attributes.name = 'Updated name';
     await env.lookup('hub:writers').update('master', Session.INTERNAL_PRIVILEGED, user.data.type, user.data.id, user);
     await env.lookup('hub:indexers').update({ forceRefresh: true });
-    let doc = await searchers.searchForCard(session, 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(session, { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 
@@ -401,11 +401,11 @@ describe('hub/searchers/auth', function() {
     });
 
     let session = sessions.create('authors', 'arthur');
-    let user = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'authors', 'arthur');
+    let user = await searchers.get(Session.INTERNAL_PRIVILEGED, 'authors', 'arthur');
     user.data.attributes.name = 'Updated name';
     await env.lookup('hub:writers').update('master', Session.INTERNAL_PRIVILEGED, user.data.type, user.data.id, user);
     await env.lookup('hub:indexers').update({ forceRefresh: true });
-    let doc = await searchers.searchForCard(session, 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(session, { filter: { type: 'posts' } });
     expect(doc.data).has.length(1);
     expect(doc.data[0]).has.deep.property('attributes.title', 'First Post');
     expect(doc.meta).has.deep.property('page.total', 1);
@@ -432,7 +432,7 @@ describe('hub/searchers/auth', function() {
       await writers.create('master', Session.INTERNAL_PRIVILEGED, type, { data: model });
     }
 
-    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(sessions.create('authors', 'arthur'), { filter: { type: 'posts' } });
     expect(doc.data).has.length(1);
     expect(doc.data[0]).has.deep.property('attributes.title', 'First Post');
     expect(doc.meta).has.deep.property('page.total', 1);
@@ -455,12 +455,12 @@ describe('hub/searchers/auth', function() {
 
     let writers = env.lookup('hub:writers');
     let searchers = env.lookup('hub:searchers');
-    let grant = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'grants', 'test-grant');
+    let grant = await searchers.get(Session.INTERNAL_PRIVILEGED, 'grants', 'test-grant');
 
     grant.data.relationships.who.data = [{ id: 'cool-kids', type: 'groups' }];
     await writers.update('master', Session.INTERNAL_PRIVILEGED, 'grants', 'test-grant', grant);
 
-    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(sessions.create('authors', 'arthur'), { filter: { type: 'posts' } });
     expect(doc.data).has.length(1);
     expect(doc.data[0]).has.deep.property('attributes.title', 'First Post');
     expect(doc.meta).has.deep.property('page.total', 1);
@@ -479,11 +479,11 @@ describe('hub/searchers/auth', function() {
 
     let writers = env.lookup('hub:writers');
     let searchers = env.lookup('hub:searchers');
-    let grant = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'grants', 'test-grant');
+    let grant = await searchers.get(Session.INTERNAL_PRIVILEGED, 'grants', 'test-grant');
 
     await writers.delete('master', Session.INTERNAL_PRIVILEGED, grant.data.meta.version, 'grants', 'test-grant');
 
-    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.search(sessions.create('authors', 'arthur'), { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 });

--- a/packages/hub/node-tests/searchers-auth-test.js
+++ b/packages/hub/node-tests/searchers-auth-test.js
@@ -71,7 +71,7 @@ describe('hub/searchers/auth', function() {
   it("returns 404 when user has no grant", async function() {
     await setup();
     try {
-      await searchers.get(Session.EVERYONE, 'master', 'posts', '1');
+      await searchers.getCard(Session.EVERYONE, 'master', 'posts', '1');
     } catch (err) {
       expect(err).has.property('status', 404);
       return;
@@ -85,7 +85,7 @@ describe('hub/searchers/auth', function() {
         .withAttributes({ mayReadResource: true, mayReadFields: true })
         .withRelated('who', [everyone]);
     });
-    let doc = await searchers.get(Session.EVERYONE, 'master', 'posts', '1');
+    let doc = await searchers.getCard(Session.EVERYONE, 'master', 'posts', '1');
     expect(doc).has.deep.property('data.attributes.title', 'First Post');
   });
 
@@ -96,7 +96,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('types', [{ type: 'content-types', id: 'posts' }]);
     });
-    let doc = await searchers.get(Session.EVERYONE, 'master', 'posts', '1');
+    let doc = await searchers.getCard(Session.EVERYONE, 'master', 'posts', '1');
     expect(doc).has.deep.property('data.attributes.title', 'First Post');
   });
 
@@ -108,7 +108,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('types', [{ type: 'content-types', id: 'fields' }]);
     });
     try {
-      await searchers.get(Session.EVERYONE, 'master', 'posts', '1');
+      await searchers.getCard(Session.EVERYONE, 'master', 'posts', '1');
     } catch (err) {
       expect(err).has.property('status', 404);
       return;
@@ -140,7 +140,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('fields', [{ type: 'fields', id: 'title' }]);
     });
-    let doc = await searchers.get(Session.EVERYONE, 'master', 'posts', '1');
+    let doc = await searchers.getCard(Session.EVERYONE, 'master', 'posts', '1');
     expect(doc).not.has.deep.property('data.attributes.subtitle');
   });
 
@@ -151,7 +151,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('fields', [{ type: 'fields', id: 'title' }]);
     });
-    let doc = await searchers.get(Session.EVERYONE, 'master', 'posts', '1');
+    let doc = await searchers.getCard(Session.EVERYONE, 'master', 'posts', '1');
     expect(doc).has.deep.property('data.attributes.title');
   });
 
@@ -184,7 +184,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('fields', [{ type: 'fields', id: 'title' }]);
     });
-    let doc = await searchers.get(Session.EVERYONE, 'master', 'posts', '1');
+    let doc = await searchers.getCard(Session.EVERYONE, 'master', 'posts', '1');
     expect(doc).not.has.deep.property('data.relationships.author');
   });
 
@@ -198,7 +198,7 @@ describe('hub/searchers/auth', function() {
           { type: 'fields', id: 'author' }
         ]);
     });
-    let doc = await searchers.get(Session.EVERYONE, 'master', 'posts', '1');
+    let doc = await searchers.getCard(Session.EVERYONE, 'master', 'posts', '1');
     expect(doc).has.deep.property('data.relationships.author');
   });
 
@@ -362,7 +362,7 @@ describe('hub/searchers/auth', function() {
     });
 
     let session = sessions.create('authors', 'arthur');
-    let user = await searchers.get(Session.INTERNAL_PRIVILEGED, 'master', 'authors', 'arthur');
+    let user = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'master', 'authors', 'arthur');
     await env.lookup('hub:writers').delete('master', Session.INTERNAL_PRIVILEGED, user.data.meta.version, user.data.type, user.data.id);
     await env.lookup('hub:indexers').update({ forceRefresh: true });
     let doc = await searchers.search(session, 'master', { filter: { type: 'posts' } });
@@ -381,7 +381,7 @@ describe('hub/searchers/auth', function() {
     });
 
     let session = sessions.create('authors', 'arthur');
-    let user = await searchers.get(Session.INTERNAL_PRIVILEGED, 'master', 'authors', 'arthur');
+    let user = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'master', 'authors', 'arthur');
     user.data.attributes.name = 'Updated name';
     await env.lookup('hub:writers').update('master', Session.INTERNAL_PRIVILEGED, user.data.type, user.data.id, user);
     await env.lookup('hub:indexers').update({ forceRefresh: true });
@@ -401,7 +401,7 @@ describe('hub/searchers/auth', function() {
     });
 
     let session = sessions.create('authors', 'arthur');
-    let user = await searchers.get(Session.INTERNAL_PRIVILEGED, 'master', 'authors', 'arthur');
+    let user = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'master', 'authors', 'arthur');
     user.data.attributes.name = 'Updated name';
     await env.lookup('hub:writers').update('master', Session.INTERNAL_PRIVILEGED, user.data.type, user.data.id, user);
     await env.lookup('hub:indexers').update({ forceRefresh: true });
@@ -455,7 +455,7 @@ describe('hub/searchers/auth', function() {
 
     let writers = env.lookup('hub:writers');
     let searchers = env.lookup('hub:searchers');
-    let grant = await searchers.get(Session.INTERNAL_PRIVILEGED, 'master', 'grants', 'test-grant');
+    let grant = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'master', 'grants', 'test-grant');
 
     grant.data.relationships.who.data = [{ id: 'cool-kids', type: 'groups' }];
     await writers.update('master', Session.INTERNAL_PRIVILEGED, 'grants', 'test-grant', grant);
@@ -479,7 +479,7 @@ describe('hub/searchers/auth', function() {
 
     let writers = env.lookup('hub:writers');
     let searchers = env.lookup('hub:searchers');
-    let grant = await searchers.get(Session.INTERNAL_PRIVILEGED, 'master', 'grants', 'test-grant');
+    let grant = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'master', 'grants', 'test-grant');
 
     await writers.delete('master', Session.INTERNAL_PRIVILEGED, grant.data.meta.version, 'grants', 'test-grant');
 

--- a/packages/hub/node-tests/searchers-auth-test.js
+++ b/packages/hub/node-tests/searchers-auth-test.js
@@ -71,7 +71,7 @@ describe('hub/searchers/auth', function() {
   it("returns 404 when user has no grant", async function() {
     await setup();
     try {
-      await searchers.get(Session.EVERYONE, 'posts', '1');
+      await searchers.get(Session.EVERYONE, 'local-hub', 'posts', '1');
     } catch (err) {
       expect(err).has.property('status', 404);
       return;
@@ -85,7 +85,7 @@ describe('hub/searchers/auth', function() {
         .withAttributes({ mayReadResource: true, mayReadFields: true })
         .withRelated('who', [everyone]);
     });
-    let doc = await searchers.get(Session.EVERYONE, 'posts', '1');
+    let doc = await searchers.get(Session.EVERYONE, 'local-hub', 'posts', '1');
     expect(doc).has.deep.property('data.attributes.title', 'First Post');
   });
 
@@ -96,7 +96,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('types', [{ type: 'content-types', id: 'posts' }]);
     });
-    let doc = await searchers.get(Session.EVERYONE, 'posts', '1');
+    let doc = await searchers.get(Session.EVERYONE, 'local-hub', 'posts', '1');
     expect(doc).has.deep.property('data.attributes.title', 'First Post');
   });
 
@@ -108,7 +108,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('types', [{ type: 'content-types', id: 'fields' }]);
     });
     try {
-      await searchers.get(Session.EVERYONE, 'posts', '1');
+      await searchers.get(Session.EVERYONE, 'local-hub', 'posts', '1');
     } catch (err) {
       expect(err).has.property('status', 404);
       return;
@@ -140,7 +140,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('fields', [{ type: 'fields', id: 'title' }]);
     });
-    let doc = await searchers.get(Session.EVERYONE, 'posts', '1');
+    let doc = await searchers.get(Session.EVERYONE, 'local-hub', 'posts', '1');
     expect(doc).not.has.deep.property('data.attributes.subtitle');
   });
 
@@ -151,7 +151,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('fields', [{ type: 'fields', id: 'title' }]);
     });
-    let doc = await searchers.get(Session.EVERYONE, 'posts', '1');
+    let doc = await searchers.get(Session.EVERYONE, 'local-hub', 'posts', '1');
     expect(doc).has.deep.property('data.attributes.title');
   });
 
@@ -184,7 +184,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('fields', [{ type: 'fields', id: 'title' }]);
     });
-    let doc = await searchers.get(Session.EVERYONE, 'posts', '1');
+    let doc = await searchers.get(Session.EVERYONE, 'local-hub', 'posts', '1');
     expect(doc).not.has.deep.property('data.relationships.author');
   });
 
@@ -198,7 +198,7 @@ describe('hub/searchers/auth', function() {
           { type: 'fields', id: 'author' }
         ]);
     });
-    let doc = await searchers.get(Session.EVERYONE, 'posts', '1');
+    let doc = await searchers.get(Session.EVERYONE, 'local-hub', 'posts', '1');
     expect(doc).has.deep.property('data.relationships.author');
   });
 
@@ -362,7 +362,7 @@ describe('hub/searchers/auth', function() {
     });
 
     let session = sessions.create('authors', 'arthur');
-    let user = await searchers.get(Session.INTERNAL_PRIVILEGED, 'authors', 'arthur');
+    let user = await searchers.get(Session.INTERNAL_PRIVILEGED, 'local-hub', 'authors', 'arthur');
     await env.lookup('hub:writers').delete('master', Session.INTERNAL_PRIVILEGED, user.data.meta.version, user.data.type, user.data.id);
     await env.lookup('hub:indexers').update({ forceRefresh: true });
     let doc = await searchers.search(session, { filter: { type: 'posts' } });
@@ -381,7 +381,7 @@ describe('hub/searchers/auth', function() {
     });
 
     let session = sessions.create('authors', 'arthur');
-    let user = await searchers.get(Session.INTERNAL_PRIVILEGED, 'authors', 'arthur');
+    let user = await searchers.get(Session.INTERNAL_PRIVILEGED, 'local-hub', 'authors', 'arthur');
     user.data.attributes.name = 'Updated name';
     await env.lookup('hub:writers').update('master', Session.INTERNAL_PRIVILEGED, user.data.type, user.data.id, user);
     await env.lookup('hub:indexers').update({ forceRefresh: true });
@@ -401,7 +401,7 @@ describe('hub/searchers/auth', function() {
     });
 
     let session = sessions.create('authors', 'arthur');
-    let user = await searchers.get(Session.INTERNAL_PRIVILEGED, 'authors', 'arthur');
+    let user = await searchers.get(Session.INTERNAL_PRIVILEGED, 'local-hub', 'authors', 'arthur');
     user.data.attributes.name = 'Updated name';
     await env.lookup('hub:writers').update('master', Session.INTERNAL_PRIVILEGED, user.data.type, user.data.id, user);
     await env.lookup('hub:indexers').update({ forceRefresh: true });
@@ -455,7 +455,7 @@ describe('hub/searchers/auth', function() {
 
     let writers = env.lookup('hub:writers');
     let searchers = env.lookup('hub:searchers');
-    let grant = await searchers.get(Session.INTERNAL_PRIVILEGED, 'grants', 'test-grant');
+    let grant = await searchers.get(Session.INTERNAL_PRIVILEGED, 'local-hub', 'grants', 'test-grant');
 
     grant.data.relationships.who.data = [{ id: 'cool-kids', type: 'groups' }];
     await writers.update('master', Session.INTERNAL_PRIVILEGED, 'grants', 'test-grant', grant);
@@ -479,7 +479,7 @@ describe('hub/searchers/auth', function() {
 
     let writers = env.lookup('hub:writers');
     let searchers = env.lookup('hub:searchers');
-    let grant = await searchers.get(Session.INTERNAL_PRIVILEGED, 'grants', 'test-grant');
+    let grant = await searchers.get(Session.INTERNAL_PRIVILEGED, 'local-hub', 'grants', 'test-grant');
 
     await writers.delete('master', Session.INTERNAL_PRIVILEGED, grant.data.meta.version, 'grants', 'test-grant');
 

--- a/packages/hub/node-tests/searchers-auth-test.js
+++ b/packages/hub/node-tests/searchers-auth-test.js
@@ -118,7 +118,7 @@ describe('hub/searchers/auth', function() {
 
   it("filters unauthorized resources from searches", async function() {
     await setup();
-    let response = await searchers.search(Session.EVERYONE, 'master', { filter: { type: 'posts' } });
+    let response = await searchers.searchForCard(Session.EVERYONE, 'master', { filter: { type: 'posts' } });
     expect(response.data).has.length(0);
   });
 
@@ -129,7 +129,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('types', [{ type: 'content-types', id: 'posts' }]);
     });
-    let response = await searchers.search(Session.EVERYONE, 'master', { filter: { type: 'posts' } });
+    let response = await searchers.searchForCard(Session.EVERYONE, 'master', { filter: { type: 'posts' } });
     expect(response.data).has.length(1);
   });
 
@@ -162,7 +162,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('fields', [{ type: 'fields', id: 'title' }]);
     });
-    let doc = await searchers.search(Session.EVERYONE, 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(Session.EVERYONE, 'master', { filter: { type: 'posts' } });
     expect(doc.data[0]).not.has.deep.property('attributes.subtitle');
   });
 
@@ -173,7 +173,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('fields', [{ type: 'fields', id: 'title' }]);
     });
-    let doc = await searchers.search(Session.EVERYONE, 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(Session.EVERYONE, 'master', { filter: { type: 'posts' } });
     expect(doc.data[0]).has.deep.property('attributes.title');
   });
 
@@ -208,7 +208,7 @@ describe('hub/searchers/auth', function() {
         .withAttributes({ mayReadResource: true, mayReadFields: true })
         .withRelated('who', [{ type: 'fields', id: 'author' }]);
     });
-    let doc = await searchers.search(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
     expect(doc.data).has.length(1);
     expect(doc.data[0]).has.deep.property('attributes.title', 'First Post');
     expect(doc.meta).has.deep.property('page.total', 1);
@@ -220,7 +220,7 @@ describe('hub/searchers/auth', function() {
         .withAttributes({ mayReadResource: true, mayReadFields: true })
         .withRelated('who', [{ type: 'fields', id: 'author' }]);
     });
-    let doc = await searchers.search(sessions.create('authors', 'other'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(sessions.create('authors', 'other'), 'master', { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 
@@ -234,7 +234,7 @@ describe('hub/searchers/auth', function() {
           searchQuery: { filter: { type: { exact: 'authors' }, name: { exact: 'Arthur Faulkner' } } }
         });
     });
-    let doc = await searchers.search(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
     expect(doc.data).has.length(1);
     expect(doc.data[0]).has.deep.property('attributes.title', 'First Post');
     expect(doc.meta).has.deep.property('page.total', 1);
@@ -250,7 +250,7 @@ describe('hub/searchers/auth', function() {
           searchQuery: { filter: { type: { exact: 'authors' }, name: { exact: 'Somebody Else' } } }
         });
     });
-    let doc = await searchers.search(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 
@@ -268,7 +268,7 @@ describe('hub/searchers/auth', function() {
           searchQuery: { filter: { type: { exact: 'authors' }, name: { exact: 'Arthur Faulkner' } } }
         });
     });
-    let doc = await searchers.search(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
     expect(doc.data).has.length(1);
     expect(doc.data[0]).has.deep.property('attributes.title', 'First Post');
     expect(doc.meta).has.deep.property('page.total', 1);
@@ -288,7 +288,7 @@ describe('hub/searchers/auth', function() {
           searchQuery: { filter: { type: { exact: 'authors' }, name: { exact: 'Arthur Faulkner' } } }
         });
     });
-    let doc = await searchers.search(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 
@@ -302,7 +302,7 @@ describe('hub/searchers/auth', function() {
           searchQuery: { filter: { type: { exact: 'authors' }, name: { exact: 'Arthur Faulkner' } } }
         });
     });
-    let doc = await searchers.search(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
     expect(doc.data).has.length(1);
     expect(doc.data[0]).has.deep.property('attributes.title', 'First Post');
     expect(doc.meta).has.deep.property('page.total', 1);
@@ -318,7 +318,7 @@ describe('hub/searchers/auth', function() {
           searchQuery: { filter: { type: { exact: 'authors' }, name: { exact: 'other' } } }
         });
     });
-    let doc = await searchers.search(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 
@@ -332,7 +332,7 @@ describe('hub/searchers/auth', function() {
           searchQuery: { filter: { type: { exact: 'authors' }, name: { exact: 'Quint Faulkner' } } }
         });
     });
-    let doc = await searchers.search(sessions.create('authors', 'quint'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(sessions.create('authors', 'quint'), 'master', { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 
@@ -346,7 +346,7 @@ describe('hub/searchers/auth', function() {
           searchQuery: { filter: { type: { exact: 'authors' }, name: { exact: 'Quint Faulkner' } } }
         });
     });
-    let doc = await searchers.search(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 
@@ -365,7 +365,7 @@ describe('hub/searchers/auth', function() {
     let user = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'master', 'authors', 'arthur');
     await env.lookup('hub:writers').delete('master', Session.INTERNAL_PRIVILEGED, user.data.meta.version, user.data.type, user.data.id);
     await env.lookup('hub:indexers').update({ forceRefresh: true });
-    let doc = await searchers.search(session, 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(session, 'master', { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 
@@ -385,7 +385,7 @@ describe('hub/searchers/auth', function() {
     user.data.attributes.name = 'Updated name';
     await env.lookup('hub:writers').update('master', Session.INTERNAL_PRIVILEGED, user.data.type, user.data.id, user);
     await env.lookup('hub:indexers').update({ forceRefresh: true });
-    let doc = await searchers.search(session, 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(session, 'master', { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 
@@ -405,7 +405,7 @@ describe('hub/searchers/auth', function() {
     user.data.attributes.name = 'Updated name';
     await env.lookup('hub:writers').update('master', Session.INTERNAL_PRIVILEGED, user.data.type, user.data.id, user);
     await env.lookup('hub:indexers').update({ forceRefresh: true });
-    let doc = await searchers.search(session, 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(session, 'master', { filter: { type: 'posts' } });
     expect(doc.data).has.length(1);
     expect(doc.data[0]).has.deep.property('attributes.title', 'First Post');
     expect(doc.meta).has.deep.property('page.total', 1);
@@ -432,7 +432,7 @@ describe('hub/searchers/auth', function() {
       await writers.create('master', Session.INTERNAL_PRIVILEGED, type, { data: model });
     }
 
-    let doc = await searchers.search(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
     expect(doc.data).has.length(1);
     expect(doc.data[0]).has.deep.property('attributes.title', 'First Post');
     expect(doc.meta).has.deep.property('page.total', 1);
@@ -460,7 +460,7 @@ describe('hub/searchers/auth', function() {
     grant.data.relationships.who.data = [{ id: 'cool-kids', type: 'groups' }];
     await writers.update('master', Session.INTERNAL_PRIVILEGED, 'grants', 'test-grant', grant);
 
-    let doc = await searchers.search(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
     expect(doc.data).has.length(1);
     expect(doc.data[0]).has.deep.property('attributes.title', 'First Post');
     expect(doc.meta).has.deep.property('page.total', 1);
@@ -483,7 +483,7 @@ describe('hub/searchers/auth', function() {
 
     await writers.delete('master', Session.INTERNAL_PRIVILEGED, grant.data.meta.version, 'grants', 'test-grant');
 
-    let doc = await searchers.search(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
+    let doc = await searchers.searchForCard(sessions.create('authors', 'arthur'), 'master', { filter: { type: 'posts' } });
     expect(doc.data).has.length(0);
   });
 });

--- a/packages/hub/node-tests/searchers-auth-test.js
+++ b/packages/hub/node-tests/searchers-auth-test.js
@@ -71,7 +71,7 @@ describe('hub/searchers/auth', function() {
   it("returns 404 when user has no grant", async function() {
     await setup();
     try {
-      await searchers.getCard(Session.EVERYONE, 'master', 'posts', '1');
+      await searchers.getCard(Session.EVERYONE, 'posts', '1');
     } catch (err) {
       expect(err).has.property('status', 404);
       return;
@@ -85,7 +85,7 @@ describe('hub/searchers/auth', function() {
         .withAttributes({ mayReadResource: true, mayReadFields: true })
         .withRelated('who', [everyone]);
     });
-    let doc = await searchers.getCard(Session.EVERYONE, 'master', 'posts', '1');
+    let doc = await searchers.getCard(Session.EVERYONE, 'posts', '1');
     expect(doc).has.deep.property('data.attributes.title', 'First Post');
   });
 
@@ -96,7 +96,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('types', [{ type: 'content-types', id: 'posts' }]);
     });
-    let doc = await searchers.getCard(Session.EVERYONE, 'master', 'posts', '1');
+    let doc = await searchers.getCard(Session.EVERYONE, 'posts', '1');
     expect(doc).has.deep.property('data.attributes.title', 'First Post');
   });
 
@@ -108,7 +108,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('types', [{ type: 'content-types', id: 'fields' }]);
     });
     try {
-      await searchers.getCard(Session.EVERYONE, 'master', 'posts', '1');
+      await searchers.getCard(Session.EVERYONE, 'posts', '1');
     } catch (err) {
       expect(err).has.property('status', 404);
       return;
@@ -140,7 +140,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('fields', [{ type: 'fields', id: 'title' }]);
     });
-    let doc = await searchers.getCard(Session.EVERYONE, 'master', 'posts', '1');
+    let doc = await searchers.getCard(Session.EVERYONE, 'posts', '1');
     expect(doc).not.has.deep.property('data.attributes.subtitle');
   });
 
@@ -151,7 +151,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('fields', [{ type: 'fields', id: 'title' }]);
     });
-    let doc = await searchers.getCard(Session.EVERYONE, 'master', 'posts', '1');
+    let doc = await searchers.getCard(Session.EVERYONE, 'posts', '1');
     expect(doc).has.deep.property('data.attributes.title');
   });
 
@@ -184,7 +184,7 @@ describe('hub/searchers/auth', function() {
         .withRelated('who', [everyone])
         .withRelated('fields', [{ type: 'fields', id: 'title' }]);
     });
-    let doc = await searchers.getCard(Session.EVERYONE, 'master', 'posts', '1');
+    let doc = await searchers.getCard(Session.EVERYONE, 'posts', '1');
     expect(doc).not.has.deep.property('data.relationships.author');
   });
 
@@ -198,7 +198,7 @@ describe('hub/searchers/auth', function() {
           { type: 'fields', id: 'author' }
         ]);
     });
-    let doc = await searchers.getCard(Session.EVERYONE, 'master', 'posts', '1');
+    let doc = await searchers.getCard(Session.EVERYONE, 'posts', '1');
     expect(doc).has.deep.property('data.relationships.author');
   });
 
@@ -362,7 +362,7 @@ describe('hub/searchers/auth', function() {
     });
 
     let session = sessions.create('authors', 'arthur');
-    let user = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'master', 'authors', 'arthur');
+    let user = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'authors', 'arthur');
     await env.lookup('hub:writers').delete('master', Session.INTERNAL_PRIVILEGED, user.data.meta.version, user.data.type, user.data.id);
     await env.lookup('hub:indexers').update({ forceRefresh: true });
     let doc = await searchers.searchForCard(session, 'master', { filter: { type: 'posts' } });
@@ -381,7 +381,7 @@ describe('hub/searchers/auth', function() {
     });
 
     let session = sessions.create('authors', 'arthur');
-    let user = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'master', 'authors', 'arthur');
+    let user = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'authors', 'arthur');
     user.data.attributes.name = 'Updated name';
     await env.lookup('hub:writers').update('master', Session.INTERNAL_PRIVILEGED, user.data.type, user.data.id, user);
     await env.lookup('hub:indexers').update({ forceRefresh: true });
@@ -401,7 +401,7 @@ describe('hub/searchers/auth', function() {
     });
 
     let session = sessions.create('authors', 'arthur');
-    let user = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'master', 'authors', 'arthur');
+    let user = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'authors', 'arthur');
     user.data.attributes.name = 'Updated name';
     await env.lookup('hub:writers').update('master', Session.INTERNAL_PRIVILEGED, user.data.type, user.data.id, user);
     await env.lookup('hub:indexers').update({ forceRefresh: true });
@@ -455,7 +455,7 @@ describe('hub/searchers/auth', function() {
 
     let writers = env.lookup('hub:writers');
     let searchers = env.lookup('hub:searchers');
-    let grant = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'master', 'grants', 'test-grant');
+    let grant = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'grants', 'test-grant');
 
     grant.data.relationships.who.data = [{ id: 'cool-kids', type: 'groups' }];
     await writers.update('master', Session.INTERNAL_PRIVILEGED, 'grants', 'test-grant', grant);
@@ -479,7 +479,7 @@ describe('hub/searchers/auth', function() {
 
     let writers = env.lookup('hub:writers');
     let searchers = env.lookup('hub:searchers');
-    let grant = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'master', 'grants', 'test-grant');
+    let grant = await searchers.getCard(Session.INTERNAL_PRIVILEGED, 'grants', 'test-grant');
 
     await writers.delete('master', Session.INTERNAL_PRIVILEGED, grant.data.meta.version, 'grants', 'test-grant');
 

--- a/packages/hub/node-tests/searchers-test.js
+++ b/packages/hub/node-tests/searchers-test.js
@@ -62,7 +62,7 @@ describe('hub/searchers/basics', function() {
 
     it("throws when no searcher#get has it", async function() {
       try {
-        await searchers.get(env.session, 'examples', 'nonexistent');
+        await searchers.get(env.session, 'local-hub', 'examples', 'nonexistent');
         throw new Error("should not get here");
       } catch (err) {
         expect(err.message).to.match(/No such resource master\/examples\/nonexist/);
@@ -70,7 +70,7 @@ describe('hub/searchers/basics', function() {
     });
 
     it("searchers#get finds record via internal searcher", async function() {
-      let response = await searchers.get(env.session, 'examples', chocolate.id);
+      let response = await searchers.get(env.session, 'local-hub', 'examples', chocolate.id);
       expect(response.data.attributes['example-flavor']).to.equal('chocolate');
     });
 
@@ -92,7 +92,7 @@ describe('hub/searchers/basics', function() {
     after(teardown);
 
     it("a plugin's searcher#get can run before the internal searcher", async function() {
-      let response = await searchers.get(env.session, 'examples', chocolate.id);
+      let response = await searchers.get(env.session, 'local-hub', 'examples', chocolate.id);
       expect(response.data.attributes['example-flavor']).to.equal('vanilla');
     });
 
@@ -103,7 +103,7 @@ describe('hub/searchers/basics', function() {
     });
 
     it("adds source id to model when using searcher#get", async function() {
-      let response = await searchers.get(env.session, 'examples', 'anything');
+      let response = await searchers.get(env.session, 'local-hub', 'examples', 'anything');
       expect(response.data).has.deep.property('meta.source', source.id);
     });
 
@@ -119,7 +119,7 @@ describe('hub/searchers/basics', function() {
     after(teardown);
 
     it("a plugin's searcher#get can run after the internal searcher", async function() {
-      let response = await searchers.get(env.session, 'examples', '10000');
+      let response = await searchers.get(env.session, 'local-hub', 'examples', '10000');
       expect(response.data.attributes['example-flavor']).to.equal('vanilla');
     });
   });
@@ -151,11 +151,11 @@ describe('hub/searchers/basics', function() {
     }
 
     it("can cache searcher#get responses", async function() {
-      let response = await searchers.get(env.session, 'examples', '1000');
+      let response = await searchers.get(env.session, 'local-hub', 'examples', '1000');
       await searchers._cachingPromise;
       expect(response).has.deep.property('data.attributes.example-counter');
       let firstCounter = response.data.attributes['example-counter'];
-      response = await searchers.get(env.session, 'examples', '1000');
+      response = await searchers.get(env.session, 'local-hub', 'examples', '1000');
       await searchers._cachingPromise;
       let secondCounter = response.data.attributes['example-counter'];
       expect(firstCounter).to.equal(secondCounter);
@@ -170,25 +170,25 @@ describe('hub/searchers/basics', function() {
           }
         }
       });
-      let response = (await searchers.get(env.session, type, id, { includePaths: ['example'] })).included[0];
+      let response = (await searchers.get(env.session, 'local-hub', type, id, { includePaths: ['example'] })).included[0];
       await searchers._cachingPromise;
       expect(response).has.deep.property('attributes.example-counter');
       let firstCounter = response.attributes['example-counter'];
-      response = (await searchers.get(env.session, type, id, { includePaths: ['example'] })).included[0];
+      response = (await searchers.get(env.session, 'local-hub', type, id, { includePaths: ['example'] })).included[0];
       await searchers._cachingPromise;
       let secondCounter = response.attributes['example-counter'];
       expect(firstCounter).to.equal(secondCounter);
     });
 
     it("does not return expired searcher#get responses", async function() {
-      let response = await searchers.get(env.session, 'examples', '1000');
+      let response = await searchers.get(env.session, 'local-hub', 'examples', '1000');
       await searchers._cachingPromise;
       expect(response).has.deep.property('data.attributes.example-counter');
       let firstCounter = response.data.attributes['example-counter'];
 
       await alterExpiration('master', 'examples', '1000', '-301 seconds');
 
-      response = await searchers.get(env.session, 'examples', '1000');
+      response = await searchers.get(env.session, 'local-hub', 'examples', '1000');
       await searchers._cachingPromise;
       let secondCounter = response.data.attributes['example-counter'];
       expect(firstCounter).to.not.equal(secondCounter);
@@ -203,21 +203,21 @@ describe('hub/searchers/basics', function() {
           }
         }
       });
-      let response = (await searchers.get(env.session, type, id, { includePaths: ['example'] })).included[0];
+      let response = (await searchers.get(env.session, 'local-hub', type, id, { includePaths: ['example'] })).included[0];
       await searchers._cachingPromise;
       expect(response).has.deep.property('attributes.example-counter');
       let firstCounter = response.attributes['example-counter'];
 
       await alterExpiration('master', 'examples', '1000', '-301 seconds');
 
-      response = (await searchers.get(env.session, type, id, { includePaths: ['example'] })).included[0];
+      response = (await searchers.get(env.session, 'local-hub', type, id, { includePaths: ['example'] })).included[0];
       await searchers._cachingPromise;
       let secondCounter = response.attributes['example-counter'];
       expect(firstCounter).to.not.equal(secondCounter);
     });
 
     it("does not return expired documents in searcher#search", async function() {
-      await searchers.get(env.session, 'examples', '1000');
+      await searchers.get(env.session, 'local-hub', 'examples', '1000');
       await searchers._cachingPromise;
       await alterExpiration('master', 'examples', '1000', '-301 seconds');
       let response = await searchers.search(env.session, { filter: { type: 'examples', id: '1000' }});

--- a/packages/hub/node-tests/searchers-test.js
+++ b/packages/hub/node-tests/searchers-test.js
@@ -62,7 +62,7 @@ describe('hub/searchers/basics', function() {
 
     it("throws when no searcher#get has it", async function() {
       try {
-        await searchers.getCard(env.session, 'examples', 'nonexistent');
+        await searchers.get(env.session, 'examples', 'nonexistent');
         throw new Error("should not get here");
       } catch (err) {
         expect(err.message).to.match(/No such resource master\/examples\/nonexist/);
@@ -70,18 +70,18 @@ describe('hub/searchers/basics', function() {
     });
 
     it("searchers#get finds record via internal searcher", async function() {
-      let response = await searchers.getCard(env.session, 'examples', chocolate.id);
+      let response = await searchers.get(env.session, 'examples', chocolate.id);
       expect(response.data.attributes['example-flavor']).to.equal('chocolate');
     });
 
     it("searchers#search finds record via internal searcher", async function() {
-      let response = await searchers.searchForCard(env.session, 'master', { filter: { 'example-flavor': { exact: 'chocolate' } } });
+      let response = await searchers.search(env.session, { filter: { 'example-flavor': { exact: 'chocolate' } } });
       expect(response.data).length(1);
       expect(response.data[0].attributes['example-flavor']).to.equal('chocolate');
     });
 
     it("searchers#search finds record via internal searcher with custom analyzer", async function() {
-      let response = await searchers.searchForCard(env.session, 'master', { filter: { 'topping': { exact: 'SPriNkLeS' } } });
+      let response = await searchers.search(env.session, { filter: { 'topping': { exact: 'SPriNkLeS' } } });
       expect(response.data).length(1);
       expect(response.data[0].attributes['topping']).to.equal('sprinkles');
     });
@@ -92,23 +92,23 @@ describe('hub/searchers/basics', function() {
     after(teardown);
 
     it("a plugin's searcher#get can run before the internal searcher", async function() {
-      let response = await searchers.getCard(env.session, 'examples', chocolate.id);
+      let response = await searchers.get(env.session, 'examples', chocolate.id);
       expect(response.data.attributes['example-flavor']).to.equal('vanilla');
     });
 
     it("a plugin's searchers#search can run before the internal searcher", async function() {
-      let response = await searchers.searchForCard(env.session, 'master', { filter: { 'example-flavor': { exact: 'chocolate' } } });
+      let response = await searchers.search(env.session, { filter: { 'example-flavor': { exact: 'chocolate' } } });
       expect(response.data).length(1);
       expect(response.data[0].attributes['example-flavor']).to.equal('vanilla');
     });
 
     it("adds source id to model when using searcher#get", async function() {
-      let response = await searchers.getCard(env.session, 'examples', 'anything');
+      let response = await searchers.get(env.session, 'examples', 'anything');
       expect(response.data).has.deep.property('meta.source', source.id);
     });
 
     it("adds source id to model when using searcher#search", async function() {
-      let response = await searchers.searchForCard(env.session, 'master', {});
+      let response = await searchers.search(env.session, {});
       expect(response.data[0]).has.deep.property('meta.source', source.id);
     });
 
@@ -119,7 +119,7 @@ describe('hub/searchers/basics', function() {
     after(teardown);
 
     it("a plugin's searcher#get can run after the internal searcher", async function() {
-      let response = await searchers.getCard(env.session, 'examples', '10000');
+      let response = await searchers.get(env.session, 'examples', '10000');
       expect(response.data.attributes['example-flavor']).to.equal('vanilla');
     });
   });
@@ -151,11 +151,11 @@ describe('hub/searchers/basics', function() {
     }
 
     it("can cache searcher#get responses", async function() {
-      let response = await searchers.getCard(env.session, 'examples', '1000');
+      let response = await searchers.get(env.session, 'examples', '1000');
       await searchers._cachingPromise;
       expect(response).has.deep.property('data.attributes.example-counter');
       let firstCounter = response.data.attributes['example-counter'];
-      response = await searchers.getCard(env.session, 'examples', '1000');
+      response = await searchers.get(env.session, 'examples', '1000');
       await searchers._cachingPromise;
       let secondCounter = response.data.attributes['example-counter'];
       expect(firstCounter).to.equal(secondCounter);
@@ -170,25 +170,25 @@ describe('hub/searchers/basics', function() {
           }
         }
       });
-      let response = (await searchers.getCard(env.session, type, id, { includePaths: ['example'] })).included[0];
+      let response = (await searchers.get(env.session, type, id, { includePaths: ['example'] })).included[0];
       await searchers._cachingPromise;
       expect(response).has.deep.property('attributes.example-counter');
       let firstCounter = response.attributes['example-counter'];
-      response = (await searchers.getCard(env.session, type, id, { includePaths: ['example'] })).included[0];
+      response = (await searchers.get(env.session, type, id, { includePaths: ['example'] })).included[0];
       await searchers._cachingPromise;
       let secondCounter = response.attributes['example-counter'];
       expect(firstCounter).to.equal(secondCounter);
     });
 
     it("does not return expired searcher#get responses", async function() {
-      let response = await searchers.getCard(env.session, 'examples', '1000');
+      let response = await searchers.get(env.session, 'examples', '1000');
       await searchers._cachingPromise;
       expect(response).has.deep.property('data.attributes.example-counter');
       let firstCounter = response.data.attributes['example-counter'];
 
       await alterExpiration('master', 'examples', '1000', '-301 seconds');
 
-      response = await searchers.getCard(env.session, 'examples', '1000');
+      response = await searchers.get(env.session, 'examples', '1000');
       await searchers._cachingPromise;
       let secondCounter = response.data.attributes['example-counter'];
       expect(firstCounter).to.not.equal(secondCounter);
@@ -203,24 +203,24 @@ describe('hub/searchers/basics', function() {
           }
         }
       });
-      let response = (await searchers.getCard(env.session, type, id, { includePaths: ['example'] })).included[0];
+      let response = (await searchers.get(env.session, type, id, { includePaths: ['example'] })).included[0];
       await searchers._cachingPromise;
       expect(response).has.deep.property('attributes.example-counter');
       let firstCounter = response.attributes['example-counter'];
 
       await alterExpiration('master', 'examples', '1000', '-301 seconds');
 
-      response = (await searchers.getCard(env.session, type, id, { includePaths: ['example'] })).included[0];
+      response = (await searchers.get(env.session, type, id, { includePaths: ['example'] })).included[0];
       await searchers._cachingPromise;
       let secondCounter = response.attributes['example-counter'];
       expect(firstCounter).to.not.equal(secondCounter);
     });
 
     it("does not return expired documents in searcher#search", async function() {
-      await searchers.getCard(env.session, 'examples', '1000');
+      await searchers.get(env.session, 'examples', '1000');
       await searchers._cachingPromise;
       await alterExpiration('master', 'examples', '1000', '-301 seconds');
-      let response = await searchers.searchForCard(env.session, 'master', { filter: { type: 'examples', id: '1000' }});
+      let response = await searchers.search(env.session, { filter: { type: 'examples', id: '1000' }});
       await searchers._cachingPromise;
       expect(response.data).length(0);
     });

--- a/packages/hub/node-tests/searchers-test.js
+++ b/packages/hub/node-tests/searchers-test.js
@@ -62,7 +62,7 @@ describe('hub/searchers/basics', function() {
 
     it("throws when no searcher#get has it", async function() {
       try {
-        await searchers.get(env.session, 'master', 'examples', 'nonexistent');
+        await searchers.getCard(env.session, 'master', 'examples', 'nonexistent');
         throw new Error("should not get here");
       } catch (err) {
         expect(err.message).to.match(/No such resource master\/examples\/nonexist/);
@@ -70,7 +70,7 @@ describe('hub/searchers/basics', function() {
     });
 
     it("searchers#get finds record via internal searcher", async function() {
-      let response = await searchers.get(env.session, 'master', 'examples', chocolate.id);
+      let response = await searchers.getCard(env.session, 'master', 'examples', chocolate.id);
       expect(response.data.attributes['example-flavor']).to.equal('chocolate');
     });
 
@@ -92,7 +92,7 @@ describe('hub/searchers/basics', function() {
     after(teardown);
 
     it("a plugin's searcher#get can run before the internal searcher", async function() {
-      let response = await searchers.get(env.session, 'master', 'examples', chocolate.id);
+      let response = await searchers.getCard(env.session, 'master', 'examples', chocolate.id);
       expect(response.data.attributes['example-flavor']).to.equal('vanilla');
     });
 
@@ -103,7 +103,7 @@ describe('hub/searchers/basics', function() {
     });
 
     it("adds source id to model when using searcher#get", async function() {
-      let response = await searchers.get(env.session, 'master', 'examples', 'anything');
+      let response = await searchers.getCard(env.session, 'master', 'examples', 'anything');
       expect(response.data).has.deep.property('meta.source', source.id);
     });
 
@@ -119,7 +119,7 @@ describe('hub/searchers/basics', function() {
     after(teardown);
 
     it("a plugin's searcher#get can run after the internal searcher", async function() {
-      let response = await searchers.get(env.session, 'master', 'examples', '10000');
+      let response = await searchers.getCard(env.session, 'master', 'examples', '10000');
       expect(response.data.attributes['example-flavor']).to.equal('vanilla');
     });
   });
@@ -151,11 +151,11 @@ describe('hub/searchers/basics', function() {
     }
 
     it("can cache searcher#get responses", async function() {
-      let response = await searchers.get(env.session, 'master', 'examples', '1000');
+      let response = await searchers.getCard(env.session, 'master', 'examples', '1000');
       await searchers._cachingPromise;
       expect(response).has.deep.property('data.attributes.example-counter');
       let firstCounter = response.data.attributes['example-counter'];
-      response = await searchers.get(env.session, 'master', 'examples', '1000');
+      response = await searchers.getCard(env.session, 'master', 'examples', '1000');
       await searchers._cachingPromise;
       let secondCounter = response.data.attributes['example-counter'];
       expect(firstCounter).to.equal(secondCounter);
@@ -170,25 +170,25 @@ describe('hub/searchers/basics', function() {
           }
         }
       });
-      let response = (await searchers.get(env.session, 'master', type, id, ['example'])).included[0];
+      let response = (await searchers.getCard(env.session, 'master', type, id, ['example'])).included[0];
       await searchers._cachingPromise;
       expect(response).has.deep.property('attributes.example-counter');
       let firstCounter = response.attributes['example-counter'];
-      response = (await searchers.get(env.session, 'master', type, id, ['example'])).included[0];
+      response = (await searchers.getCard(env.session, 'master', type, id, ['example'])).included[0];
       await searchers._cachingPromise;
       let secondCounter = response.attributes['example-counter'];
       expect(firstCounter).to.equal(secondCounter);
     });
 
     it("does not return expired searcher#get responses", async function() {
-      let response = await searchers.get(env.session, 'master', 'examples', '1000');
+      let response = await searchers.getCard(env.session, 'master', 'examples', '1000');
       await searchers._cachingPromise;
       expect(response).has.deep.property('data.attributes.example-counter');
       let firstCounter = response.data.attributes['example-counter'];
 
       await alterExpiration('master', 'examples', '1000', '-301 seconds');
 
-      response = await searchers.get(env.session, 'master', 'examples', '1000');
+      response = await searchers.getCard(env.session, 'master', 'examples', '1000');
       await searchers._cachingPromise;
       let secondCounter = response.data.attributes['example-counter'];
       expect(firstCounter).to.not.equal(secondCounter);
@@ -203,21 +203,21 @@ describe('hub/searchers/basics', function() {
           }
         }
       });
-      let response = (await searchers.get(env.session, 'master', type, id, ['example'])).included[0];
+      let response = (await searchers.getCard(env.session, 'master', type, id, ['example'])).included[0];
       await searchers._cachingPromise;
       expect(response).has.deep.property('attributes.example-counter');
       let firstCounter = response.attributes['example-counter'];
 
       await alterExpiration('master', 'examples', '1000', '-301 seconds');
 
-      response = (await searchers.get(env.session, 'master', type, id, ['example'])).included[0];
+      response = (await searchers.getCard(env.session, 'master', type, id, ['example'])).included[0];
       await searchers._cachingPromise;
       let secondCounter = response.attributes['example-counter'];
       expect(firstCounter).to.not.equal(secondCounter);
     });
 
     it("does not return expired documents in searcher#search", async function() {
-      await searchers.get(env.session, 'master', 'examples', '1000');
+      await searchers.getCard(env.session, 'master', 'examples', '1000');
       await searchers._cachingPromise;
       await alterExpiration('master', 'examples', '1000', '-301 seconds');
       let response = await searchers.search(env.session, 'master', { filter: { type: 'examples', id: '1000' }});

--- a/packages/hub/node-tests/searchers-test.js
+++ b/packages/hub/node-tests/searchers-test.js
@@ -75,13 +75,13 @@ describe('hub/searchers/basics', function() {
     });
 
     it("searchers#search finds record via internal searcher", async function() {
-      let response = await searchers.search(env.session, 'master', { filter: { 'example-flavor': { exact: 'chocolate' } } });
+      let response = await searchers.searchForCard(env.session, 'master', { filter: { 'example-flavor': { exact: 'chocolate' } } });
       expect(response.data).length(1);
       expect(response.data[0].attributes['example-flavor']).to.equal('chocolate');
     });
 
     it("searchers#search finds record via internal searcher with custom analyzer", async function() {
-      let response = await searchers.search(env.session, 'master', { filter: { 'topping': { exact: 'SPriNkLeS' } } });
+      let response = await searchers.searchForCard(env.session, 'master', { filter: { 'topping': { exact: 'SPriNkLeS' } } });
       expect(response.data).length(1);
       expect(response.data[0].attributes['topping']).to.equal('sprinkles');
     });
@@ -97,7 +97,7 @@ describe('hub/searchers/basics', function() {
     });
 
     it("a plugin's searchers#search can run before the internal searcher", async function() {
-      let response = await searchers.search(env.session, 'master', { filter: { 'example-flavor': { exact: 'chocolate' } } });
+      let response = await searchers.searchForCard(env.session, 'master', { filter: { 'example-flavor': { exact: 'chocolate' } } });
       expect(response.data).length(1);
       expect(response.data[0].attributes['example-flavor']).to.equal('vanilla');
     });
@@ -108,7 +108,7 @@ describe('hub/searchers/basics', function() {
     });
 
     it("adds source id to model when using searcher#search", async function() {
-      let response = await searchers.search(env.session, 'master', {});
+      let response = await searchers.searchForCard(env.session, 'master', {});
       expect(response.data[0]).has.deep.property('meta.source', source.id);
     });
 
@@ -220,7 +220,7 @@ describe('hub/searchers/basics', function() {
       await searchers.getCard(env.session, 'master', 'examples', '1000');
       await searchers._cachingPromise;
       await alterExpiration('master', 'examples', '1000', '-301 seconds');
-      let response = await searchers.search(env.session, 'master', { filter: { type: 'examples', id: '1000' }});
+      let response = await searchers.searchForCard(env.session, 'master', { filter: { type: 'examples', id: '1000' }});
       await searchers._cachingPromise;
       expect(response.data).length(0);
     });

--- a/packages/hub/node-tests/searchers-test.js
+++ b/packages/hub/node-tests/searchers-test.js
@@ -62,7 +62,7 @@ describe('hub/searchers/basics', function() {
 
     it("throws when no searcher#get has it", async function() {
       try {
-        await searchers.getCard(env.session, 'master', 'examples', 'nonexistent');
+        await searchers.getCard(env.session, 'examples', 'nonexistent');
         throw new Error("should not get here");
       } catch (err) {
         expect(err.message).to.match(/No such resource master\/examples\/nonexist/);
@@ -70,7 +70,7 @@ describe('hub/searchers/basics', function() {
     });
 
     it("searchers#get finds record via internal searcher", async function() {
-      let response = await searchers.getCard(env.session, 'master', 'examples', chocolate.id);
+      let response = await searchers.getCard(env.session, 'examples', chocolate.id);
       expect(response.data.attributes['example-flavor']).to.equal('chocolate');
     });
 
@@ -92,7 +92,7 @@ describe('hub/searchers/basics', function() {
     after(teardown);
 
     it("a plugin's searcher#get can run before the internal searcher", async function() {
-      let response = await searchers.getCard(env.session, 'master', 'examples', chocolate.id);
+      let response = await searchers.getCard(env.session, 'examples', chocolate.id);
       expect(response.data.attributes['example-flavor']).to.equal('vanilla');
     });
 
@@ -103,7 +103,7 @@ describe('hub/searchers/basics', function() {
     });
 
     it("adds source id to model when using searcher#get", async function() {
-      let response = await searchers.getCard(env.session, 'master', 'examples', 'anything');
+      let response = await searchers.getCard(env.session, 'examples', 'anything');
       expect(response.data).has.deep.property('meta.source', source.id);
     });
 
@@ -119,7 +119,7 @@ describe('hub/searchers/basics', function() {
     after(teardown);
 
     it("a plugin's searcher#get can run after the internal searcher", async function() {
-      let response = await searchers.getCard(env.session, 'master', 'examples', '10000');
+      let response = await searchers.getCard(env.session, 'examples', '10000');
       expect(response.data.attributes['example-flavor']).to.equal('vanilla');
     });
   });
@@ -151,11 +151,11 @@ describe('hub/searchers/basics', function() {
     }
 
     it("can cache searcher#get responses", async function() {
-      let response = await searchers.getCard(env.session, 'master', 'examples', '1000');
+      let response = await searchers.getCard(env.session, 'examples', '1000');
       await searchers._cachingPromise;
       expect(response).has.deep.property('data.attributes.example-counter');
       let firstCounter = response.data.attributes['example-counter'];
-      response = await searchers.getCard(env.session, 'master', 'examples', '1000');
+      response = await searchers.getCard(env.session, 'examples', '1000');
       await searchers._cachingPromise;
       let secondCounter = response.data.attributes['example-counter'];
       expect(firstCounter).to.equal(secondCounter);
@@ -170,25 +170,25 @@ describe('hub/searchers/basics', function() {
           }
         }
       });
-      let response = (await searchers.getCard(env.session, 'master', type, id, ['example'])).included[0];
+      let response = (await searchers.getCard(env.session, type, id, { includePaths: ['example'] })).included[0];
       await searchers._cachingPromise;
       expect(response).has.deep.property('attributes.example-counter');
       let firstCounter = response.attributes['example-counter'];
-      response = (await searchers.getCard(env.session, 'master', type, id, ['example'])).included[0];
+      response = (await searchers.getCard(env.session, type, id, { includePaths: ['example'] })).included[0];
       await searchers._cachingPromise;
       let secondCounter = response.attributes['example-counter'];
       expect(firstCounter).to.equal(secondCounter);
     });
 
     it("does not return expired searcher#get responses", async function() {
-      let response = await searchers.getCard(env.session, 'master', 'examples', '1000');
+      let response = await searchers.getCard(env.session, 'examples', '1000');
       await searchers._cachingPromise;
       expect(response).has.deep.property('data.attributes.example-counter');
       let firstCounter = response.data.attributes['example-counter'];
 
       await alterExpiration('master', 'examples', '1000', '-301 seconds');
 
-      response = await searchers.getCard(env.session, 'master', 'examples', '1000');
+      response = await searchers.getCard(env.session, 'examples', '1000');
       await searchers._cachingPromise;
       let secondCounter = response.data.attributes['example-counter'];
       expect(firstCounter).to.not.equal(secondCounter);
@@ -203,21 +203,21 @@ describe('hub/searchers/basics', function() {
           }
         }
       });
-      let response = (await searchers.getCard(env.session, 'master', type, id, ['example'])).included[0];
+      let response = (await searchers.getCard(env.session, type, id, { includePaths: ['example'] })).included[0];
       await searchers._cachingPromise;
       expect(response).has.deep.property('attributes.example-counter');
       let firstCounter = response.attributes['example-counter'];
 
       await alterExpiration('master', 'examples', '1000', '-301 seconds');
 
-      response = (await searchers.getCard(env.session, 'master', type, id, ['example'])).included[0];
+      response = (await searchers.getCard(env.session, type, id, { includePaths: ['example'] })).included[0];
       await searchers._cachingPromise;
       let secondCounter = response.attributes['example-counter'];
       expect(firstCounter).to.not.equal(secondCounter);
     });
 
     it("does not return expired documents in searcher#search", async function() {
-      await searchers.getCard(env.session, 'master', 'examples', '1000');
+      await searchers.getCard(env.session, 'examples', '1000');
       await searchers._cachingPromise;
       await alterExpiration('master', 'examples', '1000', '-301 seconds');
       let response = await searchers.searchForCard(env.session, 'master', { filter: { type: 'examples', id: '1000' }});

--- a/packages/hub/node-tests/static-indexer-test.js
+++ b/packages/hub/node-tests/static-indexer-test.js
@@ -29,12 +29,12 @@ describe('static-indexer', function() {
 
   it('can rely on static content', async function() {
     env = await createDefaultEnvironment(project, factory.getModels());
-    await env.lookup('hub:searchers').getCard(env.session, 'other-things', '2');
+    await env.lookup('hub:searchers').get(env.session, 'other-things', '2');
   });
 
   it('has access to data source params', async function() {
     env = await createDefaultEnvironment(project, factory.getModels());
-    let thing = await env.lookup('hub:searchers').getCard(env.session, 'other-things', '2');
+    let thing = await env.lookup('hub:searchers').get(env.session, 'other-things', '2');
     expect(thing).has.deep.property('data.attributes.title-of-thing', 'chocolate cake');
   });
 

--- a/packages/hub/node-tests/static-indexer-test.js
+++ b/packages/hub/node-tests/static-indexer-test.js
@@ -29,12 +29,12 @@ describe('static-indexer', function() {
 
   it('can rely on static content', async function() {
     env = await createDefaultEnvironment(project, factory.getModels());
-    await env.lookup('hub:searchers').get(env.session, 'master', 'other-things', '2');
+    await env.lookup('hub:searchers').getCard(env.session, 'master', 'other-things', '2');
   });
 
   it('has access to data source params', async function() {
     env = await createDefaultEnvironment(project, factory.getModels());
-    let thing = await env.lookup('hub:searchers').get(env.session, 'master', 'other-things', '2');
+    let thing = await env.lookup('hub:searchers').getCard(env.session, 'master', 'other-things', '2');
     expect(thing).has.deep.property('data.attributes.title-of-thing', 'chocolate cake');
   });
 

--- a/packages/hub/node-tests/static-indexer-test.js
+++ b/packages/hub/node-tests/static-indexer-test.js
@@ -29,12 +29,12 @@ describe('static-indexer', function() {
 
   it('can rely on static content', async function() {
     env = await createDefaultEnvironment(project, factory.getModels());
-    await env.lookup('hub:searchers').get(env.session, 'other-things', '2');
+    await env.lookup('hub:searchers').get(env.session, 'local-hub', 'other-things', '2');
   });
 
   it('has access to data source params', async function() {
     env = await createDefaultEnvironment(project, factory.getModels());
-    let thing = await env.lookup('hub:searchers').get(env.session, 'other-things', '2');
+    let thing = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'other-things', '2');
     expect(thing).has.deep.property('data.attributes.title-of-thing', 'chocolate cake');
   });
 

--- a/packages/hub/node-tests/static-indexer-test.js
+++ b/packages/hub/node-tests/static-indexer-test.js
@@ -29,12 +29,12 @@ describe('static-indexer', function() {
 
   it('can rely on static content', async function() {
     env = await createDefaultEnvironment(project, factory.getModels());
-    await env.lookup('hub:searchers').getCard(env.session, 'master', 'other-things', '2');
+    await env.lookup('hub:searchers').getCard(env.session, 'other-things', '2');
   });
 
   it('has access to data source params', async function() {
     env = await createDefaultEnvironment(project, factory.getModels());
-    let thing = await env.lookup('hub:searchers').getCard(env.session, 'master', 'other-things', '2');
+    let thing = await env.lookup('hub:searchers').getCard(env.session, 'other-things', '2');
     expect(thing).has.deep.property('data.attributes.title-of-thing', 'chocolate cake');
   });
 

--- a/packages/hub/node-tests/unknown-fields-validation-test.js
+++ b/packages/hub/node-tests/unknown-fields-validation-test.js
@@ -74,7 +74,7 @@ describe('unknown fields validation', function() {
    * Changes the `articles` content type from having a `title` field to having a `header` field.
    */
   async function changeArticleField() {
-    let articleContentType = await env.lookup('hub:searchers').get(env.session, 'content-types', 'articles');
+    let articleContentType = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'articles');
 
     await env.lookup('hub:writers').update('master', env.session, 'content-types', 'articles', {
       data: {
@@ -99,7 +99,7 @@ describe('unknown fields validation', function() {
   }
 
   async function readArticle(id) {
-    return await env.lookup('hub:searchers').get(env.session, 'articles', id);
+    return await env.lookup('hub:searchers').get(env.session, 'local-hub', 'articles', id);
   }
 
   async function updateArticle(id, attributes) {

--- a/packages/hub/node-tests/unknown-fields-validation-test.js
+++ b/packages/hub/node-tests/unknown-fields-validation-test.js
@@ -74,7 +74,7 @@ describe('unknown fields validation', function() {
    * Changes the `articles` content type from having a `title` field to having a `header` field.
    */
   async function changeArticleField() {
-    let articleContentType = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'articles');
+    let articleContentType = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'articles');
 
     await env.lookup('hub:writers').update('master', env.session, 'content-types', 'articles', {
       data: {
@@ -99,7 +99,7 @@ describe('unknown fields validation', function() {
   }
 
   async function readArticle(id) {
-    return await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', id);
+    return await env.lookup('hub:searchers').getCard(env.session, 'articles', id);
   }
 
   async function updateArticle(id, attributes) {

--- a/packages/hub/node-tests/unknown-fields-validation-test.js
+++ b/packages/hub/node-tests/unknown-fields-validation-test.js
@@ -74,7 +74,7 @@ describe('unknown fields validation', function() {
    * Changes the `articles` content type from having a `title` field to having a `header` field.
    */
   async function changeArticleField() {
-    let articleContentType = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'articles');
+    let articleContentType = await env.lookup('hub:searchers').get(env.session, 'content-types', 'articles');
 
     await env.lookup('hub:writers').update('master', env.session, 'content-types', 'articles', {
       data: {
@@ -99,7 +99,7 @@ describe('unknown fields validation', function() {
   }
 
   async function readArticle(id) {
-    return await env.lookup('hub:searchers').getCard(env.session, 'articles', id);
+    return await env.lookup('hub:searchers').get(env.session, 'articles', id);
   }
 
   async function updateArticle(id, attributes) {

--- a/packages/hub/node-tests/unknown-fields-validation-test.js
+++ b/packages/hub/node-tests/unknown-fields-validation-test.js
@@ -74,7 +74,7 @@ describe('unknown fields validation', function() {
    * Changes the `articles` content type from having a `title` field to having a `header` field.
    */
   async function changeArticleField() {
-    let articleContentType = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'articles');
+    let articleContentType = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'articles');
 
     await env.lookup('hub:writers').update('master', env.session, 'content-types', 'articles', {
       data: {
@@ -99,7 +99,7 @@ describe('unknown fields validation', function() {
   }
 
   async function readArticle(id) {
-    return await env.lookup('hub:searchers').get(env.session, 'master', 'articles', id);
+    return await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', id);
   }
 
   async function updateArticle(id, attributes) {

--- a/packages/hub/routers.js
+++ b/packages/hub/routers.js
@@ -49,7 +49,7 @@ class Routers {
       primaryCard = await this._getNotFoundErrorCard(schema);
     } else {
       let { data: cards, included } = query ?
-        await this.searchers.searchForCard(Session.INTERNAL_PRIVILEGED, branch, query) :
+        await this.searchers.search(Session.INTERNAL_PRIVILEGED, query, branch) :
         { data: [routingCard.data], included: routingCard.included };
 
       if (!cards || !cards.length) {
@@ -206,7 +206,7 @@ class Routers {
     let id, type, config;
     try {
       // TODO assume schema models are cards
-      config = (await this.searchers.getCard(Session.INTERNAL_PRIVILEGED, 'plugin-configs', '@cardstack/hub')).data;
+      config = (await this.searchers.get(Session.INTERNAL_PRIVILEGED, 'plugin-configs', '@cardstack/hub')).data;
     } catch (err) {
       if (err.status !== 404) { throw err; }
     }
@@ -217,7 +217,7 @@ class Routers {
     }
 
     if (id && type) {
-      let appCard = await this.searchers.getCard(Session.INTERNAL_PRIVILEGED, type, id);
+      let appCard = await this.searchers.get(Session.INTERNAL_PRIVILEGED, type, id);
       if (appCard) {
         return appCard;
       }
@@ -239,7 +239,7 @@ class Routers {
         } else {
           let errorCard;
           try {
-            errorCard = await this.searchers.getCard(Session.INTERNAL_PRIVILEGED, errorType, errorCardId);
+            errorCard = await this.searchers.get(Session.INTERNAL_PRIVILEGED, errorType, errorCardId);
           } catch (err) {
             if (err.status !== 404) { throw err; }
           }

--- a/packages/hub/routers.js
+++ b/packages/hub/routers.js
@@ -49,7 +49,7 @@ class Routers {
       primaryCard = await this._getNotFoundErrorCard(schema);
     } else {
       let { data: cards, included } = query ?
-        await this.searchers.search(Session.INTERNAL_PRIVILEGED, branch, query) :
+        await this.searchers.searchForCard(Session.INTERNAL_PRIVILEGED, branch, query) :
         { data: [routingCard.data], included: routingCard.included };
 
       if (!cards || !cards.length) {

--- a/packages/hub/routers.js
+++ b/packages/hub/routers.js
@@ -205,7 +205,8 @@ class Routers {
   async _getApplicationCard() {
     let id, type, config;
     try {
-      config = (await this.searchers.getFromControllingBranch(Session.INTERNAL_PRIVILEGED, 'plugin-configs', '@cardstack/hub')).data;
+      // TODO assume schema models are cards
+      config = (await this.searchers.getCurrentCard(Session.INTERNAL_PRIVILEGED, 'plugin-configs', '@cardstack/hub')).data;
     } catch (err) {
       if (err.status !== 404) { throw err; }
     }
@@ -216,7 +217,7 @@ class Routers {
     }
 
     if (id && type) {
-      let appCard = await this.searchers.getFromControllingBranch(Session.INTERNAL_PRIVILEGED, type, id);
+      let appCard = await this.searchers.getCurrentCard(Session.INTERNAL_PRIVILEGED, type, id);
       if (appCard) {
         return appCard;
       }
@@ -238,7 +239,7 @@ class Routers {
         } else {
           let errorCard;
           try {
-            errorCard = await this.searchers.getFromControllingBranch(Session.INTERNAL_PRIVILEGED, errorType, errorCardId);
+            errorCard = await this.searchers.getCurrentCard(Session.INTERNAL_PRIVILEGED, errorType, errorCardId);
           } catch (err) {
             if (err.status !== 404) { throw err; }
           }

--- a/packages/hub/routers.js
+++ b/packages/hub/routers.js
@@ -206,7 +206,7 @@ class Routers {
     let id, type, config;
     try {
       // TODO assume schema models are cards
-      config = (await this.searchers.getCurrentCard(Session.INTERNAL_PRIVILEGED, 'plugin-configs', '@cardstack/hub')).data;
+      config = (await this.searchers.getCard(Session.INTERNAL_PRIVILEGED, 'plugin-configs', '@cardstack/hub')).data;
     } catch (err) {
       if (err.status !== 404) { throw err; }
     }
@@ -217,7 +217,7 @@ class Routers {
     }
 
     if (id && type) {
-      let appCard = await this.searchers.getCurrentCard(Session.INTERNAL_PRIVILEGED, type, id);
+      let appCard = await this.searchers.getCard(Session.INTERNAL_PRIVILEGED, type, id);
       if (appCard) {
         return appCard;
       }
@@ -239,7 +239,7 @@ class Routers {
         } else {
           let errorCard;
           try {
-            errorCard = await this.searchers.getCurrentCard(Session.INTERNAL_PRIVILEGED, errorType, errorCardId);
+            errorCard = await this.searchers.getCard(Session.INTERNAL_PRIVILEGED, errorType, errorCardId);
           } catch (err) {
             if (err.status !== 404) { throw err; }
           }

--- a/packages/hub/routers.js
+++ b/packages/hub/routers.js
@@ -206,7 +206,7 @@ class Routers {
     let id, type, config;
     try {
       // TODO assume schema models are cards
-      config = (await this.searchers.get(Session.INTERNAL_PRIVILEGED, 'plugin-configs', '@cardstack/hub')).data;
+      config = (await this.searchers.get(Session.INTERNAL_PRIVILEGED, 'local-hub', 'plugin-configs', '@cardstack/hub')).data;
     } catch (err) {
       if (err.status !== 404) { throw err; }
     }
@@ -217,7 +217,7 @@ class Routers {
     }
 
     if (id && type) {
-      let appCard = await this.searchers.get(Session.INTERNAL_PRIVILEGED, type, id);
+      let appCard = await this.searchers.get(Session.INTERNAL_PRIVILEGED, 'local-hub', type, id);
       if (appCard) {
         return appCard;
       }
@@ -239,7 +239,7 @@ class Routers {
         } else {
           let errorCard;
           try {
-            errorCard = await this.searchers.get(Session.INTERNAL_PRIVILEGED, errorType, errorCardId);
+            errorCard = await this.searchers.get(Session.INTERNAL_PRIVILEGED, 'local-hub', errorType, errorCardId);
           } catch (err) {
             if (err.status !== 404) { throw err; }
           }

--- a/packages/hub/searchers.js
+++ b/packages/hub/searchers.js
@@ -130,6 +130,7 @@ class Searchers {
   }
 
   // TODO eventually we'll require that you can only get binary within your card context
+  // This is akin to getting a model...
   async getBinary(session, branch, type, id, includePaths) {
     // look up authorized result to check read is authorized by going through
     // the default auth stack for the JSON representation. Error will be thrown
@@ -154,16 +155,7 @@ class Searchers {
   }
 
   async getFromControllingBranch() {
-    throw new Error(`Searchers.getFromControllingBranch() has been deprecated. Use Searchers.getCurrentCard() or Searchers.getCurrentModel() instead.`);
-  }
-
-  // TODO eventually we'll require that you can only get Models within your card context
-  // Depending on how this refactor shakes out--we might end up removing this entirely...
-  async getCurrentModel(session, type, id, includePaths) {
-    if (arguments.length < 3) {
-      throw new Error(`session is a required argument to searchers.getCurrentModel`);
-    }
-    return await this.getModel(session, this.controllingBranch.name, type, id, includePaths);
+    throw new Error(`Searchers.getFromControllingBranch() has been deprecated. Use Searchers.getCurrentCard() instead.`);
   }
 
   async getCurrentCard(session, type, id, includePaths) {
@@ -173,7 +165,17 @@ class Searchers {
     return await this.getCard(session, this.controllingBranch.name, type, id, includePaths);
   }
 
-  async search(session, branchRequest, query) {
+  async search() {
+    throw new Error(`Searchers.search() has been deprecated. Use Searchers.searchForCard() or Searchers.searchForModel() instead.`);
+  }
+
+  // TODO eventually we'll require that you can only get Models within your card context
+  // Depending on how this refactor shakes out--we might end up removing this entirely...
+  async searchForModel(session, branchRequest, query) {
+    return await this.searchForCard(session, branchRequest, query);
+  }
+
+  async searchForCard(session, branchRequest, query) {
     if (arguments.length < 3) {
       throw new Error(`session is now a required argument to searchers.search`);
     }
@@ -228,8 +230,12 @@ class Searchers {
     }
   }
 
-  async searchFromControllingBranch(session, query) {
-    return this.search(session, this.controllingBranch.name, query);
+  async searchFromControllingBranch() {
+    throw new Error(`Searchers.searchFromControllingBranch() has been deprecated. Use Searchers.searchForCurrentCard() instead.`);
+  }
+
+  async searchForCurrentCard(session, query) {
+    return await this.search(session, this.controllingBranch.name, query);
   }
 
   createDocumentContext({ schema, type, id, branch, sourceId, generation, upstreamDoc, includePaths }) {

--- a/packages/hub/searchers.js
+++ b/packages/hub/searchers.js
@@ -92,9 +92,10 @@ class Searchers {
     return await this.getCurrentCard(session, 'spaces', path);
   }
 
-  async getCard(session, branchRequest, type, id, includePaths) {
-    if (arguments.length < 4) {
-      throw new Error(`session is now a required argument to searchers.get`);
+  async getCard(session, package, id, opts) {
+  // async getCard(session, branchRequest, type, id, includePaths) {
+    if (arguments.length === 4 && typeof opts !== 'object') {
+      throw new Error(`Searchers.get() expects parameters: 'session', 'package', 'id', and 'opts'. The 'branch' parameter has been deprecated, instead specify 'opts.version'`);
     }
 
     let branch = branchRequest;

--- a/packages/hub/searchers.js
+++ b/packages/hub/searchers.js
@@ -78,7 +78,21 @@ class Searchers {
     return this.routers;
   }
 
-  async get(session, branchRequest, type, id, includePaths) {
+  async get() {
+    throw new Error(`Searchers.get() has been deprecated. Use either Searchers.getModel() or Searchers.getCard()`);
+  }
+
+  // TODO eventually we'll require that you can only get Models within your card context
+  // Depending on how this refactor shakes out--we might end up removing this entirely...
+  async getModel(session, branchRequest, type, id, includePaths) {
+    return await this.getCard(session, branchRequest, type, id, includePaths);
+  }
+
+  async getSpace(session, path) {
+    return await this.getCurrentCard(session, 'spaces', path);
+  }
+
+  async getCard(session, branchRequest, type, id, includePaths) {
     if (arguments.length < 4) {
       throw new Error(`session is now a required argument to searchers.get`);
     }
@@ -115,11 +129,12 @@ class Searchers {
     return authorizedResult;
   }
 
+  // TODO eventually we'll require that you can only get binary within your card context
   async getBinary(session, branch, type, id, includePaths) {
     // look up authorized result to check read is authorized by going through
     // the default auth stack for the JSON representation. Error will be thrown
     // if authorization is not correct.
-    let document = await this.get(session, branch, type, id, includePaths);
+    let document = await this.getModel(session, branch, type, id, includePaths);
 
     let sourceId = document.data.meta.source;
 
@@ -138,11 +153,24 @@ class Searchers {
     return [result, document];
   }
 
-  async getFromControllingBranch(session, type, id, includePaths) {
+  async getFromControllingBranch() {
+    throw new Error(`Searchers.getFromControllingBranch() has been deprecated. Use Searchers.getCurrentCard() or Searchers.getCurrentModel() instead.`);
+  }
+
+  // TODO eventually we'll require that you can only get Models within your card context
+  // Depending on how this refactor shakes out--we might end up removing this entirely...
+  async getCurrentModel(session, type, id, includePaths) {
     if (arguments.length < 3) {
-      throw new Error(`session is now a required argument to searchers.getFromControllingBranch`);
+      throw new Error(`session is a required argument to searchers.getCurrentModel`);
     }
-    return this.get(session, this.controllingBranch.name, type, id, includePaths);
+    return await this.getModel(session, this.controllingBranch.name, type, id, includePaths);
+  }
+
+  async getCurrentCard(session, type, id, includePaths) {
+    if (arguments.length < 3) {
+      throw new Error(`session is a required argument to searchers.getCurrentCard`);
+    }
+    return await this.getCard(session, this.controllingBranch.name, type, id, includePaths);
   }
 
   async search(session, branchRequest, query) {

--- a/packages/hub/searchers/permissions.js
+++ b/packages/hub/searchers/permissions.js
@@ -47,7 +47,7 @@ class PermissionsSearcher {
         },
       };
     } else {
-      document = await this.searchers.get(session, queryType, queryId, { version: branch });
+      document = await this.searchers.get(session, 'local-hub', queryType, queryId, { version: branch });
       if (!document) { return; } // we don't have it or don't have permission to read it
     }
 

--- a/packages/hub/searchers/permissions.js
+++ b/packages/hub/searchers/permissions.js
@@ -47,7 +47,7 @@ class PermissionsSearcher {
         },
       };
     } else {
-      document = await this.searchers.get(session, branch, queryType, queryId);
+      document = await this.searchers.getCard(session, branch, queryType, queryId);
       if (!document) { return; } // we don't have it or don't have permission to read it
     }
 

--- a/packages/hub/searchers/permissions.js
+++ b/packages/hub/searchers/permissions.js
@@ -47,7 +47,7 @@ class PermissionsSearcher {
         },
       };
     } else {
-      document = await this.searchers.getCard(session, branch, queryType, queryId);
+      document = await this.searchers.getCard(session, queryType, queryId, { version: branch });
       if (!document) { return; } // we don't have it or don't have permission to read it
     }
 

--- a/packages/hub/searchers/permissions.js
+++ b/packages/hub/searchers/permissions.js
@@ -47,7 +47,7 @@ class PermissionsSearcher {
         },
       };
     } else {
-      document = await this.searchers.getCard(session, queryType, queryId, { version: branch });
+      document = await this.searchers.get(session, queryType, queryId, { version: branch });
       if (!document) { return; } // we don't have it or don't have permission to read it
     }
 

--- a/packages/hub/sessions.js
+++ b/packages/hub/sessions.js
@@ -16,10 +16,10 @@ class Sessions {
     if (!this._userSearcher) {
       this._userSearcher = {
         get: (type, userId) => {
-          return this.searcher.getCard(Session.INTERNAL_PRIVILEGED, type, userId, { version: this.controllingBranch.name });
+          return this.searcher.get(Session.INTERNAL_PRIVILEGED, type, userId, { version: this.controllingBranch.name });
         },
         search: (params) => {
-          return this.searcher.searchForCard(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, params);
+          return this.searcher.search(Session.INTERNAL_PRIVILEGED, params);
         }
       };
     }

--- a/packages/hub/sessions.js
+++ b/packages/hub/sessions.js
@@ -16,7 +16,7 @@ class Sessions {
     if (!this._userSearcher) {
       this._userSearcher = {
         get: (type, userId) => {
-          return this.searcher.get(Session.INTERNAL_PRIVILEGED, type, userId, { version: this.controllingBranch.name });
+          return this.searcher.get(Session.INTERNAL_PRIVILEGED, 'local-hub', type, userId, { version: this.controllingBranch.name });
         },
         search: (params) => {
           return this.searcher.search(Session.INTERNAL_PRIVILEGED, params);

--- a/packages/hub/sessions.js
+++ b/packages/hub/sessions.js
@@ -19,7 +19,7 @@ class Sessions {
           return this.searcher.getCard(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, type, userId);
         },
         search: (params) => {
-          return this.searcher.search(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, params);
+          return this.searcher.searchForCard(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, params);
         }
       };
     }

--- a/packages/hub/sessions.js
+++ b/packages/hub/sessions.js
@@ -16,7 +16,7 @@ class Sessions {
     if (!this._userSearcher) {
       this._userSearcher = {
         get: (type, userId) => {
-          return this.searcher.getCard(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, type, userId);
+          return this.searcher.getCard(Session.INTERNAL_PRIVILEGED, type, userId, { version: this.controllingBranch.name });
         },
         search: (params) => {
           return this.searcher.searchForCard(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, params);

--- a/packages/hub/sessions.js
+++ b/packages/hub/sessions.js
@@ -16,7 +16,7 @@ class Sessions {
     if (!this._userSearcher) {
       this._userSearcher = {
         get: (type, userId) => {
-          return this.searcher.get(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, type, userId);
+          return this.searcher.getCard(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, type, userId);
         },
         search: (params) => {
           return this.searcher.search(Session.INTERNAL_PRIVILEGED, this.controllingBranch.name, params);

--- a/packages/jsonapi/middleware.js
+++ b/packages/jsonapi/middleware.js
@@ -197,10 +197,14 @@ class Handler {
     this.ctxt.status = 200;
   }
 
-  // TODO how can we tel if the client wants to get a Card or Model?
   async handleIndividualGET(type, id) {
     let includePaths = (this.query.include || '').split(',');
-    let body = await this.searcher.getCard(this.session, type, id, { version: this.branch, includePaths });
+    let body;
+    if (type === 'spaces') {
+      body = await this.searcher.getSpace(this.session, id);
+    } else {
+      body = await this.searcher.get(this.session, type, id, { version: this.branch, includePaths });
+    }
     if (this.query.include === '') {
       delete body.included;
     }
@@ -238,7 +242,7 @@ class Handler {
   }
 
   async handleCollectionGET(type) {
-    let { data: models, meta: { page }, included } = await this.searcher.searchForCard(this.session, this.branch, {
+    let { data: models, meta: { page }, included } = await this.searcher.search(this.session, {
       filter: this.filterExpression(type),
       sort: this.query.sort,
       page: this.query.page,

--- a/packages/jsonapi/middleware.js
+++ b/packages/jsonapi/middleware.js
@@ -203,7 +203,7 @@ class Handler {
     if (type === 'spaces') {
       body = await this.searcher.getSpace(this.session, id);
     } else {
-      body = await this.searcher.get(this.session, type, id, { version: this.branch, includePaths });
+      body = await this.searcher.get(this.session, 'local-hub', type, id, { version: this.branch, includePaths });
     }
     if (this.query.include === '') {
       delete body.included;
@@ -212,7 +212,9 @@ class Handler {
   }
 
   async handleIndividualGETBinary(type, id) {
-    let [buffer, json] = await this.searcher.getBinary(this.session, this.branch, type, id);
+    // TODO requests for binary need to be made in a card context, e.g. GET /api/${source}/${package}/${cardId}/${modelType}/${modelId}
+    // stubbing the context out for now...
+    let [buffer, json] = await this.searcher.getBinary(this.session, 'local-hub', null, null, type, id, { version: this.branch });
     this.ctxt.set('content-type', json.data.attributes['content-type']);
     this.ctxt.body = buffer;
   }

--- a/packages/jsonapi/middleware.js
+++ b/packages/jsonapi/middleware.js
@@ -197,9 +197,10 @@ class Handler {
     this.ctxt.status = 200;
   }
 
+  // TODO how can we tel if the client wants to get a Card or Model?
   async handleIndividualGET(type, id) {
     let include = (this.query.include || '').split(',');
-    let body = await this.searcher.get(this.session, this.branch, type, id, include);
+    let body = await this.searcher.getCard(this.session, this.branch, type, id, include);
     if (this.query.include === '') {
       delete body.included;
     }

--- a/packages/jsonapi/middleware.js
+++ b/packages/jsonapi/middleware.js
@@ -238,7 +238,7 @@ class Handler {
   }
 
   async handleCollectionGET(type) {
-    let { data: models, meta: { page }, included } = await this.searcher.search(this.session, this.branch, {
+    let { data: models, meta: { page }, included } = await this.searcher.searchForCard(this.session, this.branch, {
       filter: this.filterExpression(type),
       sort: this.query.sort,
       page: this.query.page,

--- a/packages/jsonapi/middleware.js
+++ b/packages/jsonapi/middleware.js
@@ -199,8 +199,8 @@ class Handler {
 
   // TODO how can we tel if the client wants to get a Card or Model?
   async handleIndividualGET(type, id) {
-    let include = (this.query.include || '').split(',');
-    let body = await this.searcher.getCard(this.session, this.branch, type, id, include);
+    let includePaths = (this.query.include || '').split(',');
+    let body = await this.searcher.getCard(this.session, type, id, { version: this.branch, includePaths });
     if (this.query.include === '') {
       delete body.included;
     }

--- a/packages/mobiledoc/node-tests/mobiledoc-cards-test.js
+++ b/packages/mobiledoc/node-tests/mobiledoc-cards-test.js
@@ -77,7 +77,7 @@ describe('mobiledoc/mobiledoc-cards computed tests', function () {
     after(teardown);
 
     it('can derive relationships to cards embedded within mobiledoc', async function () {
-      let { data: model } = await env.lookup('hub:searchers').get(env.session, 'master', 'articles', article.id);
+      let { data: model } = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', article.id);
       expect(model.relationships['mobiledoc-cards'].data).to.eql([
         { type: 'cardstack-images', id: 'e252cbe3d8181bb14f68c7a78c776bdc494d7b37'},
         { type: 'cardstack-images', id: '627a28a74fe9d2aaf44ebeaa689ecba46dd44079'},

--- a/packages/mobiledoc/node-tests/mobiledoc-cards-test.js
+++ b/packages/mobiledoc/node-tests/mobiledoc-cards-test.js
@@ -77,7 +77,7 @@ describe('mobiledoc/mobiledoc-cards computed tests', function () {
     after(teardown);
 
     it('can derive relationships to cards embedded within mobiledoc', async function () {
-      let { data: model } = await env.lookup('hub:searchers').getCard(env.session, 'articles', article.id);
+      let { data: model } = await env.lookup('hub:searchers').get(env.session, 'articles', article.id);
       expect(model.relationships['mobiledoc-cards'].data).to.eql([
         { type: 'cardstack-images', id: 'e252cbe3d8181bb14f68c7a78c776bdc494d7b37'},
         { type: 'cardstack-images', id: '627a28a74fe9d2aaf44ebeaa689ecba46dd44079'},

--- a/packages/mobiledoc/node-tests/mobiledoc-cards-test.js
+++ b/packages/mobiledoc/node-tests/mobiledoc-cards-test.js
@@ -77,7 +77,7 @@ describe('mobiledoc/mobiledoc-cards computed tests', function () {
     after(teardown);
 
     it('can derive relationships to cards embedded within mobiledoc', async function () {
-      let { data: model } = await env.lookup('hub:searchers').get(env.session, 'articles', article.id);
+      let { data: model } = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'articles', article.id);
       expect(model.relationships['mobiledoc-cards'].data).to.eql([
         { type: 'cardstack-images', id: 'e252cbe3d8181bb14f68c7a78c776bdc494d7b37'},
         { type: 'cardstack-images', id: '627a28a74fe9d2aaf44ebeaa689ecba46dd44079'},

--- a/packages/mobiledoc/node-tests/mobiledoc-cards-test.js
+++ b/packages/mobiledoc/node-tests/mobiledoc-cards-test.js
@@ -77,7 +77,7 @@ describe('mobiledoc/mobiledoc-cards computed tests', function () {
     after(teardown);
 
     it('can derive relationships to cards embedded within mobiledoc', async function () {
-      let { data: model } = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', article.id);
+      let { data: model } = await env.lookup('hub:searchers').getCard(env.session, 'articles', article.id);
       expect(model.relationships['mobiledoc-cards'].data).to.eql([
         { type: 'cardstack-images', id: 'e252cbe3d8181bb14f68c7a78c776bdc494d7b37'},
         { type: 'cardstack-images', id: '627a28a74fe9d2aaf44ebeaa689ecba46dd44079'},

--- a/packages/mobiledoc/node-tests/read-time-test.js
+++ b/packages/mobiledoc/node-tests/read-time-test.js
@@ -65,17 +65,17 @@ describe('mobiledoc/read-time-computed-field', function() {
     after(teardown);
 
     it("can report a reasonable read time for a short article", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'articles', article1.id);
+      let model = await env.lookup('hub:searchers').get(env.session, 'articles', article1.id);
       expect(model.data).has.deep.property('attributes.read-time', 2);
     });
 
     it("can report a significantly longer time for a much longer article", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'articles', article2.id);
+      let model = await env.lookup('hub:searchers').get(env.session, 'articles', article2.id);
       expect(model.data).has.deep.property('attributes.read-time', 26);
     });
 
     it("reports 0 read-time for an article that has undefined sourceField", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'articles', article3.id);
+      let model = await env.lookup('hub:searchers').get(env.session, 'articles', article3.id);
       expect(model.data).has.deep.property('attributes.read-time', 0);
     });
   });

--- a/packages/mobiledoc/node-tests/read-time-test.js
+++ b/packages/mobiledoc/node-tests/read-time-test.js
@@ -65,17 +65,17 @@ describe('mobiledoc/read-time-computed-field', function() {
     after(teardown);
 
     it("can report a reasonable read time for a short article", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'master', 'articles', article1.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', article1.id);
       expect(model.data).has.deep.property('attributes.read-time', 2);
     });
 
     it("can report a significantly longer time for a much longer article", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'master', 'articles', article2.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', article2.id);
       expect(model.data).has.deep.property('attributes.read-time', 26);
     });
 
     it("reports 0 read-time for an article that has undefined sourceField", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'master', 'articles', article3.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', article3.id);
       expect(model.data).has.deep.property('attributes.read-time', 0);
     });
   });

--- a/packages/mobiledoc/node-tests/read-time-test.js
+++ b/packages/mobiledoc/node-tests/read-time-test.js
@@ -65,17 +65,17 @@ describe('mobiledoc/read-time-computed-field', function() {
     after(teardown);
 
     it("can report a reasonable read time for a short article", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', article1.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'articles', article1.id);
       expect(model.data).has.deep.property('attributes.read-time', 2);
     });
 
     it("can report a significantly longer time for a much longer article", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', article2.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'articles', article2.id);
       expect(model.data).has.deep.property('attributes.read-time', 26);
     });
 
     it("reports 0 read-time for an article that has undefined sourceField", async function() {
-      let model = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', article3.id);
+      let model = await env.lookup('hub:searchers').getCard(env.session, 'articles', article3.id);
       expect(model.data).has.deep.property('attributes.read-time', 0);
     });
   });

--- a/packages/mobiledoc/node-tests/read-time-test.js
+++ b/packages/mobiledoc/node-tests/read-time-test.js
@@ -65,17 +65,17 @@ describe('mobiledoc/read-time-computed-field', function() {
     after(teardown);
 
     it("can report a reasonable read time for a short article", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'articles', article1.id);
+      let model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'articles', article1.id);
       expect(model.data).has.deep.property('attributes.read-time', 2);
     });
 
     it("can report a significantly longer time for a much longer article", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'articles', article2.id);
+      let model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'articles', article2.id);
       expect(model.data).has.deep.property('attributes.read-time', 26);
     });
 
     it("reports 0 read-time for an article that has undefined sourceField", async function() {
-      let model = await env.lookup('hub:searchers').get(env.session, 'articles', article3.id);
+      let model = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'articles', article3.id);
       expect(model.data).has.deep.property('attributes.read-time', 0);
     });
   });

--- a/packages/pgsearch/node-tests/indexer-test.js
+++ b/packages/pgsearch/node-tests/indexer-test.js
@@ -105,7 +105,7 @@ describe('pgsearch/indexer', function() {
     });
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
-    let found = await searcher.get(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'local-hub', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
   });
@@ -133,7 +133,7 @@ describe('pgsearch/indexer', function() {
     });
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
-    let found = await searcher.get(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'local-hub', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -156,7 +156,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.get(env.session, 'people', person.id);
+    let found = await searcher.get(env.session, 'local-hub', 'people', person.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ friends: { data: [{ type: 'people', id: person.id }]}});
@@ -190,7 +190,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.get(env.session, 'people', person.id);
+    let found = await searcher.get(env.session, 'local-hub', 'people', person.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ friends: { data: [{ type: 'people', id: circularPerson.id }]}});
@@ -226,7 +226,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.get(env.session, 'people', person1.id);
+    let found = await searcher.get(env.session, 'local-hub', 'people', person1.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ friends: { data: [{ type: 'people', id: person2.id }]}});
@@ -263,7 +263,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.get(env.session, 'puppies', puppy1.id);
+    let found = await searcher.get(env.session, 'local-hub', 'puppies', puppy1.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ 'puppy-friends': { data: [{ type: 'puppies', id: puppy2.id }]}});
@@ -288,7 +288,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.get(env.session, 'puppies', puppy.id);
+    let found = await searcher.get(env.session, 'local-hub', 'puppies', puppy.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ 'puppy-friends': { data: [{ type: 'puppies', id: puppy.id }]}});
@@ -322,7 +322,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.get(env.session, 'puppies', puppy.id);
+    let found = await searcher.get(env.session, 'local-hub', 'puppies', puppy.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ 'puppy-friends': { data: [{ type: 'puppies', id: circularPuppy.id }]}});
@@ -380,7 +380,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.get(env.session, 'puppies', puppy.id);
+    let found = await searcher.get(env.session, 'local-hub', 'puppies', puppy.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ 'puppy-friends': { data: [{ type: 'puppies', id: puppy1.id }]}});
@@ -404,7 +404,7 @@ describe('pgsearch/indexer', function() {
       documentFetchCount++;
       let result;
       try {
-        result = await searcher.get(env.session, type, id);
+        result = await searcher.get(env.session, 'local-hub', type, id);
       } catch (err) {
         if (err.status !== 404) { throw err; }
       }
@@ -435,7 +435,7 @@ describe('pgsearch/indexer', function() {
     });
 
     let { id, type } = article;
-    let { data:resource, included } = await searcher.get(env.session, type, id);
+    let { data:resource, included } = await searcher.get(env.session, 'local-hub', type, id);
 
     let pristineDoc = await (new DocumentContext({ id, type, branch, schema, read,
       upstreamDoc: { data: resource },
@@ -482,7 +482,7 @@ describe('pgsearch/indexer', function() {
     await writer.update('master', env.session, 'people', person.id, { data: person });
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.get(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'local-hub', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -521,7 +521,7 @@ describe('pgsearch/indexer', function() {
     await writer.update('master', env.session, 'articles', article.id, { data: article });
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.get(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'local-hub', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title', 'A Better Title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -561,7 +561,7 @@ describe('pgsearch/indexer', function() {
 
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.get(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'local-hub', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title', 'A Better Title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -601,7 +601,7 @@ describe('pgsearch/indexer', function() {
 
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.get(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'local-hub', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title', 'A Better Title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -638,7 +638,7 @@ describe('pgsearch/indexer', function() {
 
     // note that indexer.update() is not called -- invalidation happens as a direct result of updating the doc
 
-    let found = await searcher.get(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'local-hub', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -670,7 +670,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.get(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'local-hub', 'articles', article.id);
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
     expect(found.included[0].attributes.name).to.equal('Quint');
 
@@ -678,7 +678,7 @@ describe('pgsearch/indexer', function() {
     // just need to touch any document to trigger expired resource invalidation
     await writer.update('master', env.session, 'articles', article.id, { data: article });
 
-    found = await searcher.get(env.session, 'articles', article.id);
+    found = await searcher.get(env.session, 'local-hub', 'articles', article.id);
     expect(found).to.not.have.property('included');
     expect(found).to.have.deep.property('data.relationships.author.data', null);
   });
@@ -697,7 +697,7 @@ describe('pgsearch/indexer', function() {
     });
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
-    let found = await searcher.get(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'local-hub', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.relationships.author.data', null);
   });
@@ -726,7 +726,7 @@ describe('pgsearch/indexer', function() {
     });
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
-    let found = await searcher.get(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'local-hub', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.relationships.reviewers.data');
     expect(found.data.relationships.reviewers.data).length(1);
@@ -749,7 +749,7 @@ describe('pgsearch/indexer', function() {
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.get(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'local-hub', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title', 'Hello World');
     expect(found).has.deep.property('data.relationships.author.data', null);
@@ -766,7 +766,7 @@ describe('pgsearch/indexer', function() {
 
     await indexer.update({ forceRefresh: true });
 
-    found = await searcher.get(env.session, 'articles', article.id);
+    found = await searcher.get(env.session, 'local-hub', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.relationships.author.data.id', 'x');
     expect(found).has.property('included');

--- a/packages/pgsearch/node-tests/indexer-test.js
+++ b/packages/pgsearch/node-tests/indexer-test.js
@@ -105,7 +105,7 @@ describe('pgsearch/indexer', function() {
     });
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
-    let found = await searcher.getCard(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
   });
@@ -133,7 +133,7 @@ describe('pgsearch/indexer', function() {
     });
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
-    let found = await searcher.getCard(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -156,7 +156,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.getCard(env.session, 'people', person.id);
+    let found = await searcher.get(env.session, 'people', person.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ friends: { data: [{ type: 'people', id: person.id }]}});
@@ -190,7 +190,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.getCard(env.session, 'people', person.id);
+    let found = await searcher.get(env.session, 'people', person.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ friends: { data: [{ type: 'people', id: circularPerson.id }]}});
@@ -226,7 +226,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.getCard(env.session, 'people', person1.id);
+    let found = await searcher.get(env.session, 'people', person1.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ friends: { data: [{ type: 'people', id: person2.id }]}});
@@ -263,7 +263,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.getCard(env.session, 'puppies', puppy1.id);
+    let found = await searcher.get(env.session, 'puppies', puppy1.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ 'puppy-friends': { data: [{ type: 'puppies', id: puppy2.id }]}});
@@ -288,7 +288,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.getCard(env.session, 'puppies', puppy.id);
+    let found = await searcher.get(env.session, 'puppies', puppy.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ 'puppy-friends': { data: [{ type: 'puppies', id: puppy.id }]}});
@@ -322,7 +322,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.getCard(env.session, 'puppies', puppy.id);
+    let found = await searcher.get(env.session, 'puppies', puppy.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ 'puppy-friends': { data: [{ type: 'puppies', id: circularPuppy.id }]}});
@@ -380,7 +380,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.getCard(env.session, 'puppies', puppy.id);
+    let found = await searcher.get(env.session, 'puppies', puppy.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ 'puppy-friends': { data: [{ type: 'puppies', id: puppy1.id }]}});
@@ -404,7 +404,7 @@ describe('pgsearch/indexer', function() {
       documentFetchCount++;
       let result;
       try {
-        result = await searcher.getCard(env.session, type, id);
+        result = await searcher.get(env.session, type, id);
       } catch (err) {
         if (err.status !== 404) { throw err; }
       }
@@ -435,7 +435,7 @@ describe('pgsearch/indexer', function() {
     });
 
     let { id, type } = article;
-    let { data:resource, included } = await searcher.getCard(env.session, type, id);
+    let { data:resource, included } = await searcher.get(env.session, type, id);
 
     let pristineDoc = await (new DocumentContext({ id, type, branch, schema, read,
       upstreamDoc: { data: resource },
@@ -482,7 +482,7 @@ describe('pgsearch/indexer', function() {
     await writer.update('master', env.session, 'people', person.id, { data: person });
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.getCard(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -521,7 +521,7 @@ describe('pgsearch/indexer', function() {
     await writer.update('master', env.session, 'articles', article.id, { data: article });
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.getCard(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title', 'A Better Title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -561,7 +561,7 @@ describe('pgsearch/indexer', function() {
 
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.getCard(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title', 'A Better Title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -601,7 +601,7 @@ describe('pgsearch/indexer', function() {
 
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.getCard(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title', 'A Better Title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -638,7 +638,7 @@ describe('pgsearch/indexer', function() {
 
     // note that indexer.update() is not called -- invalidation happens as a direct result of updating the doc
 
-    let found = await searcher.getCard(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -670,7 +670,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.getCard(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'articles', article.id);
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
     expect(found.included[0].attributes.name).to.equal('Quint');
 
@@ -678,7 +678,7 @@ describe('pgsearch/indexer', function() {
     // just need to touch any document to trigger expired resource invalidation
     await writer.update('master', env.session, 'articles', article.id, { data: article });
 
-    found = await searcher.getCard(env.session, 'articles', article.id);
+    found = await searcher.get(env.session, 'articles', article.id);
     expect(found).to.not.have.property('included');
     expect(found).to.have.deep.property('data.relationships.author.data', null);
   });
@@ -697,7 +697,7 @@ describe('pgsearch/indexer', function() {
     });
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
-    let found = await searcher.getCard(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.relationships.author.data', null);
   });
@@ -726,7 +726,7 @@ describe('pgsearch/indexer', function() {
     });
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
-    let found = await searcher.getCard(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.relationships.reviewers.data');
     expect(found.data.relationships.reviewers.data).length(1);
@@ -749,7 +749,7 @@ describe('pgsearch/indexer', function() {
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.getCard(env.session, 'articles', article.id);
+    let found = await searcher.get(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title', 'Hello World');
     expect(found).has.deep.property('data.relationships.author.data', null);
@@ -766,7 +766,7 @@ describe('pgsearch/indexer', function() {
 
     await indexer.update({ forceRefresh: true });
 
-    found = await searcher.getCard(env.session, 'articles', article.id);
+    found = await searcher.get(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.relationships.author.data.id', 'x');
     expect(found).has.property('included');

--- a/packages/pgsearch/node-tests/indexer-test.js
+++ b/packages/pgsearch/node-tests/indexer-test.js
@@ -105,7 +105,7 @@ describe('pgsearch/indexer', function() {
     });
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
-    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
   });
@@ -133,7 +133,7 @@ describe('pgsearch/indexer', function() {
     });
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
-    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -156,7 +156,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.getCard(env.session, 'master', 'people', person.id);
+    let found = await searcher.getCard(env.session, 'people', person.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ friends: { data: [{ type: 'people', id: person.id }]}});
@@ -190,7 +190,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.getCard(env.session, 'master', 'people', person.id);
+    let found = await searcher.getCard(env.session, 'people', person.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ friends: { data: [{ type: 'people', id: circularPerson.id }]}});
@@ -226,7 +226,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.getCard(env.session, 'master', 'people', person1.id);
+    let found = await searcher.getCard(env.session, 'people', person1.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ friends: { data: [{ type: 'people', id: person2.id }]}});
@@ -263,7 +263,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.getCard(env.session, 'master', 'puppies', puppy1.id);
+    let found = await searcher.getCard(env.session, 'puppies', puppy1.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ 'puppy-friends': { data: [{ type: 'puppies', id: puppy2.id }]}});
@@ -288,7 +288,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.getCard(env.session, 'master', 'puppies', puppy.id);
+    let found = await searcher.getCard(env.session, 'puppies', puppy.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ 'puppy-friends': { data: [{ type: 'puppies', id: puppy.id }]}});
@@ -322,7 +322,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.getCard(env.session, 'master', 'puppies', puppy.id);
+    let found = await searcher.getCard(env.session, 'puppies', puppy.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ 'puppy-friends': { data: [{ type: 'puppies', id: circularPuppy.id }]}});
@@ -380,7 +380,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.getCard(env.session, 'master', 'puppies', puppy.id);
+    let found = await searcher.getCard(env.session, 'puppies', puppy.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ 'puppy-friends': { data: [{ type: 'puppies', id: puppy1.id }]}});
@@ -404,7 +404,7 @@ describe('pgsearch/indexer', function() {
       documentFetchCount++;
       let result;
       try {
-        result = await searcher.getCard(env.session, branch, type, id);
+        result = await searcher.getCard(env.session, type, id);
       } catch (err) {
         if (err.status !== 404) { throw err; }
       }
@@ -435,7 +435,7 @@ describe('pgsearch/indexer', function() {
     });
 
     let { id, type } = article;
-    let { data:resource, included } = await searcher.getCard(env.session, branch, type, id);
+    let { data:resource, included } = await searcher.getCard(env.session, type, id);
 
     let pristineDoc = await (new DocumentContext({ id, type, branch, schema, read,
       upstreamDoc: { data: resource },
@@ -482,7 +482,7 @@ describe('pgsearch/indexer', function() {
     await writer.update('master', env.session, 'people', person.id, { data: person });
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -521,7 +521,7 @@ describe('pgsearch/indexer', function() {
     await writer.update('master', env.session, 'articles', article.id, { data: article });
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title', 'A Better Title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -561,7 +561,7 @@ describe('pgsearch/indexer', function() {
 
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title', 'A Better Title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -601,7 +601,7 @@ describe('pgsearch/indexer', function() {
 
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title', 'A Better Title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -638,7 +638,7 @@ describe('pgsearch/indexer', function() {
 
     // note that indexer.update() is not called -- invalidation happens as a direct result of updating the doc
 
-    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -670,7 +670,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'articles', article.id);
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
     expect(found.included[0].attributes.name).to.equal('Quint');
 
@@ -678,7 +678,7 @@ describe('pgsearch/indexer', function() {
     // just need to touch any document to trigger expired resource invalidation
     await writer.update('master', env.session, 'articles', article.id, { data: article });
 
-    found = await searcher.getCard(env.session, 'master', 'articles', article.id);
+    found = await searcher.getCard(env.session, 'articles', article.id);
     expect(found).to.not.have.property('included');
     expect(found).to.have.deep.property('data.relationships.author.data', null);
   });
@@ -697,7 +697,7 @@ describe('pgsearch/indexer', function() {
     });
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
-    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.relationships.author.data', null);
   });
@@ -726,7 +726,7 @@ describe('pgsearch/indexer', function() {
     });
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
-    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.relationships.reviewers.data');
     expect(found.data.relationships.reviewers.data).length(1);
@@ -749,7 +749,7 @@ describe('pgsearch/indexer', function() {
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title', 'Hello World');
     expect(found).has.deep.property('data.relationships.author.data', null);
@@ -766,7 +766,7 @@ describe('pgsearch/indexer', function() {
 
     await indexer.update({ forceRefresh: true });
 
-    found = await searcher.getCard(env.session, 'master', 'articles', article.id);
+    found = await searcher.getCard(env.session, 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.relationships.author.data.id', 'x');
     expect(found).has.property('included');

--- a/packages/pgsearch/node-tests/indexer-test.js
+++ b/packages/pgsearch/node-tests/indexer-test.js
@@ -105,7 +105,7 @@ describe('pgsearch/indexer', function() {
     });
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
-    let found = await searcher.get(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
   });
@@ -133,7 +133,7 @@ describe('pgsearch/indexer', function() {
     });
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
-    let found = await searcher.get(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -156,7 +156,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.get(env.session, 'master', 'people', person.id);
+    let found = await searcher.getCard(env.session, 'master', 'people', person.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ friends: { data: [{ type: 'people', id: person.id }]}});
@@ -190,7 +190,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.get(env.session, 'master', 'people', person.id);
+    let found = await searcher.getCard(env.session, 'master', 'people', person.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ friends: { data: [{ type: 'people', id: circularPerson.id }]}});
@@ -226,7 +226,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.get(env.session, 'master', 'people', person1.id);
+    let found = await searcher.getCard(env.session, 'master', 'people', person1.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ friends: { data: [{ type: 'people', id: person2.id }]}});
@@ -263,7 +263,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.get(env.session, 'master', 'puppies', puppy1.id);
+    let found = await searcher.getCard(env.session, 'master', 'puppies', puppy1.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ 'puppy-friends': { data: [{ type: 'puppies', id: puppy2.id }]}});
@@ -288,7 +288,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.get(env.session, 'master', 'puppies', puppy.id);
+    let found = await searcher.getCard(env.session, 'master', 'puppies', puppy.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ 'puppy-friends': { data: [{ type: 'puppies', id: puppy.id }]}});
@@ -322,7 +322,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.get(env.session, 'master', 'puppies', puppy.id);
+    let found = await searcher.getCard(env.session, 'master', 'puppies', puppy.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ 'puppy-friends': { data: [{ type: 'puppies', id: circularPuppy.id }]}});
@@ -380,7 +380,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.get(env.session, 'master', 'puppies', puppy.id);
+    let found = await searcher.getCard(env.session, 'master', 'puppies', puppy.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.name');
     expect(found.data.relationships).deep.equals({ 'puppy-friends': { data: [{ type: 'puppies', id: puppy1.id }]}});
@@ -404,7 +404,7 @@ describe('pgsearch/indexer', function() {
       documentFetchCount++;
       let result;
       try {
-        result = await searcher.get(env.session, branch, type, id);
+        result = await searcher.getCard(env.session, branch, type, id);
       } catch (err) {
         if (err.status !== 404) { throw err; }
       }
@@ -435,7 +435,7 @@ describe('pgsearch/indexer', function() {
     });
 
     let { id, type } = article;
-    let { data:resource, included } = await searcher.get(env.session, branch, type, id);
+    let { data:resource, included } = await searcher.getCard(env.session, branch, type, id);
 
     let pristineDoc = await (new DocumentContext({ id, type, branch, schema, read,
       upstreamDoc: { data: resource },
@@ -482,7 +482,7 @@ describe('pgsearch/indexer', function() {
     await writer.update('master', env.session, 'people', person.id, { data: person });
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.get(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -521,7 +521,7 @@ describe('pgsearch/indexer', function() {
     await writer.update('master', env.session, 'articles', article.id, { data: article });
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.get(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title', 'A Better Title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -561,7 +561,7 @@ describe('pgsearch/indexer', function() {
 
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.get(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title', 'A Better Title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -601,7 +601,7 @@ describe('pgsearch/indexer', function() {
 
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.get(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title', 'A Better Title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -638,7 +638,7 @@ describe('pgsearch/indexer', function() {
 
     // note that indexer.update() is not called -- invalidation happens as a direct result of updating the doc
 
-    let found = await searcher.get(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title');
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
@@ -670,7 +670,7 @@ describe('pgsearch/indexer', function() {
       }
     });
 
-    let found = await searcher.get(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
     expect(found).has.deep.property('data.relationships.author.data.id', person.id);
     expect(found.included[0].attributes.name).to.equal('Quint');
 
@@ -678,7 +678,7 @@ describe('pgsearch/indexer', function() {
     // just need to touch any document to trigger expired resource invalidation
     await writer.update('master', env.session, 'articles', article.id, { data: article });
 
-    found = await searcher.get(env.session, 'master', 'articles', article.id);
+    found = await searcher.getCard(env.session, 'master', 'articles', article.id);
     expect(found).to.not.have.property('included');
     expect(found).to.have.deep.property('data.relationships.author.data', null);
   });
@@ -697,7 +697,7 @@ describe('pgsearch/indexer', function() {
     });
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
-    let found = await searcher.get(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.relationships.author.data', null);
   });
@@ -726,7 +726,7 @@ describe('pgsearch/indexer', function() {
     });
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
-    let found = await searcher.get(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.relationships.reviewers.data');
     expect(found.data.relationships.reviewers.data).length(1);
@@ -749,7 +749,7 @@ describe('pgsearch/indexer', function() {
     expect(article).has.deep.property('id');
     await indexer.update({ forceRefresh: true });
 
-    let found = await searcher.get(env.session, 'master', 'articles', article.id);
+    let found = await searcher.getCard(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.attributes.title', 'Hello World');
     expect(found).has.deep.property('data.relationships.author.data', null);
@@ -766,7 +766,7 @@ describe('pgsearch/indexer', function() {
 
     await indexer.update({ forceRefresh: true });
 
-    found = await searcher.get(env.session, 'master', 'articles', article.id);
+    found = await searcher.getCard(env.session, 'master', 'articles', article.id);
     expect(found).is.ok;
     expect(found).has.deep.property('data.relationships.author.data.id', 'x');
     expect(found).has.property('included');

--- a/packages/pgsearch/node-tests/searcher-test.js
+++ b/packages/pgsearch/node-tests/searcher-test.js
@@ -169,7 +169,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('returns properly formatted records', async function() {
-    let model = (await searcher.getCard(env.session, 'master', 'people', '1')).data;
+    let model = (await searcher.getCard(env.session, 'people', '1')).data;
     let meta = model.meta;
     expect(Object.keys(meta).sort()).deep.equals(['source', 'version']);
     delete model.meta;
@@ -610,7 +610,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can get an individual record', async function() {
-    let model = await searcher.getCard(env.session, 'master', 'articles', '1');
+    let model = await searcher.getCard(env.session, 'articles', '1');
     expect(model).has.deep.property('data.attributes.hello', 'magic words');
   });
 

--- a/packages/pgsearch/node-tests/searcher-test.js
+++ b/packages/pgsearch/node-tests/searcher-test.js
@@ -169,7 +169,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('returns properly formatted records', async function() {
-    let model = (await searcher.get(env.session, 'people', '1')).data;
+    let model = (await searcher.get(env.session, 'local-hub', 'people', '1')).data;
     let meta = model.meta;
     expect(Object.keys(meta).sort()).deep.equals(['source', 'version']);
     delete model.meta;
@@ -610,7 +610,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can get an individual record', async function() {
-    let model = await searcher.get(env.session, 'articles', '1');
+    let model = await searcher.get(env.session, 'local-hub', 'articles', '1');
     expect(model).has.deep.property('data.attributes.hello', 'magic words');
   });
 

--- a/packages/pgsearch/node-tests/searcher-test.js
+++ b/packages/pgsearch/node-tests/searcher-test.js
@@ -169,7 +169,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('returns properly formatted records', async function() {
-    let model = (await searcher.get(env.session, 'master', 'people', '1')).data;
+    let model = (await searcher.getCard(env.session, 'master', 'people', '1')).data;
     let meta = model.meta;
     expect(Object.keys(meta).sort()).deep.equals(['source', 'version']);
     delete model.meta;
@@ -610,7 +610,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can get an individual record', async function() {
-    let model = await searcher.get(env.session, 'master', 'articles', '1');
+    let model = await searcher.getCard(env.session, 'master', 'articles', '1');
     expect(model).has.deep.property('data.attributes.hello', 'magic words');
   });
 

--- a/packages/pgsearch/node-tests/searcher-test.js
+++ b/packages/pgsearch/node-tests/searcher-test.js
@@ -160,7 +160,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can be searched for all content', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       page: { size: 1000 }
     });
     expect(models.filter(m => m.type === 'comments')).to.have.length(20);
@@ -197,7 +197,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can be searched via queryString', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       queryString: 'magic'
     });
     expect(models.filter(m => m.type === 'articles')).to.have.length(1);
@@ -206,14 +206,14 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can be searched via queryString, negative result', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       queryString: 'thisisanunusedterm'
     });
     expect(models).to.have.length(0);
   });
 
   it('can filter by type', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         type: 'articles'
       }
@@ -223,7 +223,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can sort by type', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         type: ['articles', 'people']
       },
@@ -234,7 +234,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can sort by type in reverse', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         type: ['articles', 'people']
       },
@@ -246,7 +246,7 @@ describe('pgsearch/searcher', function() {
 
 
   it('can filter by id', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         id: '1',
         type: ['articles', 'people']
@@ -258,7 +258,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter a string-array field by terms', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'favorite-shapes': ['hexagon', 'square']
       }
@@ -267,7 +267,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter a string-array field one term', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'favorite-shapes': 'pentagon'
       }
@@ -276,7 +276,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can sort by id', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         type: ['articles', 'people']
       },
@@ -286,7 +286,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can sort by id in reverse', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         type: ['articles', 'people']
       },
@@ -297,7 +297,7 @@ describe('pgsearch/searcher', function() {
 
 
   it('can filter a field by one term', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'first-name': 'Quint'
       }
@@ -307,7 +307,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter a field by multiple terms', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'first-name': ['Quint', 'Arthur']
       }
@@ -316,7 +316,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can use OR expressions in filters', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         or: [
           { 'first-name': ['Quint'], type: 'people' },
@@ -330,7 +330,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can use AND expressions in filters', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         and: [
           { 'favorite-color': 'red' },
@@ -343,7 +343,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can use NOT expressions in filters', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         type: 'people',
         not: { 'first-name': 'Quint' }
@@ -355,7 +355,7 @@ describe('pgsearch/searcher', function() {
 
 
   it('can filter by range', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         age: {
           range: {
@@ -369,7 +369,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter by field existence (string)', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'favorite-color': {
           exists: 'true'
@@ -382,7 +382,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter by field nonexistence (string)', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'favorite-color': {
           exists: 'false'
@@ -395,7 +395,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter by field existence (bool)', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'favorite-color': {
           exists: true
@@ -408,7 +408,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter by field nonexistence (bool)', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'favorite-color': {
           exists: false
@@ -421,7 +421,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can search within a field with custom indexing behavior', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         description: 'atoms'
       }
@@ -431,7 +431,7 @@ describe('pgsearch/searcher', function() {
 
   it('gives helpful error when filtering unknown field', async function() {
     try {
-      await searcher.search(env.session, 'master', {
+      await searcher.searchForCard(env.session, 'master', {
         filter: {
           flavor: 'chocolate'
         }
@@ -447,7 +447,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can sort', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         type: 'people'
       },
@@ -458,7 +458,7 @@ describe('pgsearch/searcher', function() {
 
 
   it('can sort reverse', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         type: 'people'
       },
@@ -471,7 +471,7 @@ describe('pgsearch/searcher', function() {
     // string fields are only sortable because of the sortFieldName
     // in @cardstack/core-field-types/string. So this is a test that
     // we're using that capability.
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         type: 'people'
       },
@@ -485,7 +485,7 @@ describe('pgsearch/searcher', function() {
     // string fields are only sortable because of the sortFieldName
     // in @cardstack/core-field-types/string. So this is a test that
     // we're using that capability.
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         type: 'people'
       },
@@ -496,7 +496,7 @@ describe('pgsearch/searcher', function() {
 
   it('has helpful error when sorting by nonexistent field', async function() {
     try {
-      await searcher.search(env.session, 'master', {
+      await searcher.searchForCard(env.session, 'master', {
         sort: 'something-that-does-not-exist'
       });
       throw new Error("should not get here");
@@ -510,7 +510,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can paginate', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: { type: 'comments' },
       page: {
         size: 7
@@ -522,7 +522,7 @@ describe('pgsearch/searcher', function() {
 
     let allModels = response.data;
 
-    response = await searcher.search(env.session, 'master', {
+    response = await searcher.searchForCard(env.session, 'master', {
       filter: { type: 'comments' },
       page: {
         size: 7,
@@ -536,7 +536,7 @@ describe('pgsearch/searcher', function() {
 
     allModels = allModels.concat(response.data);
 
-    response = await searcher.search(env.session, 'master', {
+    response = await searcher.searchForCard(env.session, 'master', {
       filter: { type: 'comments' },
       page: {
         size: 7,
@@ -554,7 +554,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can paginate when results exactly fill final page', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: { type: 'comments' },
       page: {
         size: 10
@@ -566,7 +566,7 @@ describe('pgsearch/searcher', function() {
 
     let allModels = response.data;
 
-    response = await searcher.search(env.session, 'master', {
+    response = await searcher.searchForCard(env.session, 'master', {
       filter: { type: 'comments' },
       page: {
         size: 10,
@@ -583,7 +583,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can paginate when sorting by custom field', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: { type: 'comments' },
       sort: 'score',
       page: {
@@ -596,7 +596,7 @@ describe('pgsearch/searcher', function() {
     expect(response.data[1].id).to.equal('11'); // this relies on knowing that the fallback sort order is branch/type/id
     expect(response.data[2].id).to.equal('9');
 
-    response = await searcher.search(env.session, 'master', {
+    response = await searcher.searchForCard(env.session, 'master', {
       filter: { type: 'comments' },
       sort: 'score',
       page: {
@@ -615,7 +615,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can do analyzed term matching', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         hello: 'magic'
       }
@@ -625,7 +625,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('matches reordered phrase when using analyzed field', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         hello: 'words magic'
       }
@@ -634,7 +634,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('does not match reordered phrase when using exact field', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         hello: { exact: 'words magic' }
       }
@@ -644,7 +644,7 @@ describe('pgsearch/searcher', function() {
 
 
   it('can do exact term matching with a phrase', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         hello: { exact: 'magic words' }
       }
@@ -654,7 +654,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can do exact term matching with a field that contains a capital letter', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'favorite-toy': { exact: 'Sneaky Snake' }
       }
@@ -662,7 +662,7 @@ describe('pgsearch/searcher', function() {
     expect(response.data).length(1);
     expect(response.data[0]).has.deep.property('attributes.favorite-toy', 'Sneaky Snake');
 
-    response = await searcher.search(env.session, 'master', {
+    response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'favorite-toy': { exact: ['Sneaky Snake', 'boisterous baboon'] }
       }
@@ -673,7 +673,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can ignore case when doing exact term matching for a case insensitive field', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'email-address': { exact: 'HASSAN@EXAMPLE.COM' }
       }
@@ -683,7 +683,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('incomplete phrase does not match', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         hello: { exact: 'magic words extra' }
       }
@@ -692,7 +692,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can do exact term matching with multiple phrases', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         hello: { exact: ['something else', 'magic words'] }
       }
@@ -702,7 +702,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter non-searchable belongsTo by id', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'article.id': { exact: '1' }
       }
@@ -711,7 +711,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter searchable belongsTo by id', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'searchable-article.id': { exact: '1' }
       }
@@ -720,7 +720,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter non-searchable belongsTo by multiple ids', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'article.id': { exact: ['1', '2'] }
       }
@@ -729,7 +729,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter searchable belongsTo by multiple ids', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'searchable-article.id': { exact: ['1', '2'] }
       }
@@ -739,7 +739,7 @@ describe('pgsearch/searcher', function() {
 
   it('can filter non-searchable hasMany by id', async function() {
     // todo: select array(select jsonb_array_elements(search_doc->'members')->>'id') from documents;
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'members.id': { exact: '1' }
       }
@@ -748,7 +748,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter searchable hasMany by id', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'searchable-members.id': { exact: '1' }
       }
@@ -757,7 +757,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter non-searchable hasMany by multiple id', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'members.id': { exact: ['1', 'bogus'] }
       }
@@ -766,7 +766,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter searchable hasMany by multiple id', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'searchable-members.id': { exact: ['1', 'bogus'] }
       }
@@ -775,7 +775,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('belongs-to attributes are not indexed by default', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'article.hello': 'magic'
       }
@@ -784,7 +784,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter searchable belongs-to by an attribute', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'searchable-article.hello': 'magic'
       }
@@ -793,7 +793,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('hasMany attributes are not indexed by default', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'members.first-name': 'Quint'
       }
@@ -802,7 +802,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter searchable has-many by an attribute', async function() {
-    let response = await searcher.search(env.session, 'master', {
+    let response = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'searchable-members.first-name': 'Quint'
       }
@@ -811,7 +811,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can do prefix matching', async function() {
-    let { data: models } = await searcher.search(env.session, 'master', {
+    let { data: models } = await searcher.searchForCard(env.session, 'master', {
       filter: {
         'last-name': {
           prefix: 'Faulk'

--- a/packages/pgsearch/node-tests/searcher-test.js
+++ b/packages/pgsearch/node-tests/searcher-test.js
@@ -160,7 +160,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can be searched for all content', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       page: { size: 1000 }
     });
     expect(models.filter(m => m.type === 'comments')).to.have.length(20);
@@ -169,7 +169,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('returns properly formatted records', async function() {
-    let model = (await searcher.getCard(env.session, 'people', '1')).data;
+    let model = (await searcher.get(env.session, 'people', '1')).data;
     let meta = model.meta;
     expect(Object.keys(meta).sort()).deep.equals(['source', 'version']);
     delete model.meta;
@@ -197,7 +197,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can be searched via queryString', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       queryString: 'magic'
     });
     expect(models.filter(m => m.type === 'articles')).to.have.length(1);
@@ -206,14 +206,14 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can be searched via queryString, negative result', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       queryString: 'thisisanunusedterm'
     });
     expect(models).to.have.length(0);
   });
 
   it('can filter by type', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         type: 'articles'
       }
@@ -223,7 +223,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can sort by type', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         type: ['articles', 'people']
       },
@@ -234,7 +234,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can sort by type in reverse', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         type: ['articles', 'people']
       },
@@ -246,7 +246,7 @@ describe('pgsearch/searcher', function() {
 
 
   it('can filter by id', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         id: '1',
         type: ['articles', 'people']
@@ -258,7 +258,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter a string-array field by terms', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         'favorite-shapes': ['hexagon', 'square']
       }
@@ -267,7 +267,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter a string-array field one term', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         'favorite-shapes': 'pentagon'
       }
@@ -276,7 +276,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can sort by id', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         type: ['articles', 'people']
       },
@@ -286,7 +286,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can sort by id in reverse', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         type: ['articles', 'people']
       },
@@ -297,7 +297,7 @@ describe('pgsearch/searcher', function() {
 
 
   it('can filter a field by one term', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         'first-name': 'Quint'
       }
@@ -307,7 +307,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter a field by multiple terms', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         'first-name': ['Quint', 'Arthur']
       }
@@ -316,7 +316,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can use OR expressions in filters', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         or: [
           { 'first-name': ['Quint'], type: 'people' },
@@ -330,7 +330,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can use AND expressions in filters', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         and: [
           { 'favorite-color': 'red' },
@@ -343,7 +343,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can use NOT expressions in filters', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         type: 'people',
         not: { 'first-name': 'Quint' }
@@ -355,7 +355,7 @@ describe('pgsearch/searcher', function() {
 
 
   it('can filter by range', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         age: {
           range: {
@@ -369,7 +369,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter by field existence (string)', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         'favorite-color': {
           exists: 'true'
@@ -382,7 +382,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter by field nonexistence (string)', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         'favorite-color': {
           exists: 'false'
@@ -395,7 +395,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter by field existence (bool)', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         'favorite-color': {
           exists: true
@@ -408,7 +408,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter by field nonexistence (bool)', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         'favorite-color': {
           exists: false
@@ -421,7 +421,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can search within a field with custom indexing behavior', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         description: 'atoms'
       }
@@ -431,7 +431,7 @@ describe('pgsearch/searcher', function() {
 
   it('gives helpful error when filtering unknown field', async function() {
     try {
-      await searcher.searchForCard(env.session, 'master', {
+      await searcher.search(env.session, {
         filter: {
           flavor: 'chocolate'
         }
@@ -447,7 +447,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can sort', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         type: 'people'
       },
@@ -458,7 +458,7 @@ describe('pgsearch/searcher', function() {
 
 
   it('can sort reverse', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         type: 'people'
       },
@@ -471,7 +471,7 @@ describe('pgsearch/searcher', function() {
     // string fields are only sortable because of the sortFieldName
     // in @cardstack/core-field-types/string. So this is a test that
     // we're using that capability.
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         type: 'people'
       },
@@ -485,7 +485,7 @@ describe('pgsearch/searcher', function() {
     // string fields are only sortable because of the sortFieldName
     // in @cardstack/core-field-types/string. So this is a test that
     // we're using that capability.
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         type: 'people'
       },
@@ -496,7 +496,7 @@ describe('pgsearch/searcher', function() {
 
   it('has helpful error when sorting by nonexistent field', async function() {
     try {
-      await searcher.searchForCard(env.session, 'master', {
+      await searcher.search(env.session, {
         sort: 'something-that-does-not-exist'
       });
       throw new Error("should not get here");
@@ -510,7 +510,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can paginate', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: { type: 'comments' },
       page: {
         size: 7
@@ -522,7 +522,7 @@ describe('pgsearch/searcher', function() {
 
     let allModels = response.data;
 
-    response = await searcher.searchForCard(env.session, 'master', {
+    response = await searcher.search(env.session, {
       filter: { type: 'comments' },
       page: {
         size: 7,
@@ -536,7 +536,7 @@ describe('pgsearch/searcher', function() {
 
     allModels = allModels.concat(response.data);
 
-    response = await searcher.searchForCard(env.session, 'master', {
+    response = await searcher.search(env.session, {
       filter: { type: 'comments' },
       page: {
         size: 7,
@@ -554,7 +554,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can paginate when results exactly fill final page', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: { type: 'comments' },
       page: {
         size: 10
@@ -566,7 +566,7 @@ describe('pgsearch/searcher', function() {
 
     let allModels = response.data;
 
-    response = await searcher.searchForCard(env.session, 'master', {
+    response = await searcher.search(env.session, {
       filter: { type: 'comments' },
       page: {
         size: 10,
@@ -583,7 +583,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can paginate when sorting by custom field', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: { type: 'comments' },
       sort: 'score',
       page: {
@@ -596,7 +596,7 @@ describe('pgsearch/searcher', function() {
     expect(response.data[1].id).to.equal('11'); // this relies on knowing that the fallback sort order is branch/type/id
     expect(response.data[2].id).to.equal('9');
 
-    response = await searcher.searchForCard(env.session, 'master', {
+    response = await searcher.search(env.session, {
       filter: { type: 'comments' },
       sort: 'score',
       page: {
@@ -610,12 +610,12 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can get an individual record', async function() {
-    let model = await searcher.getCard(env.session, 'articles', '1');
+    let model = await searcher.get(env.session, 'articles', '1');
     expect(model).has.deep.property('data.attributes.hello', 'magic words');
   });
 
   it('can do analyzed term matching', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         hello: 'magic'
       }
@@ -625,7 +625,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('matches reordered phrase when using analyzed field', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         hello: 'words magic'
       }
@@ -634,7 +634,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('does not match reordered phrase when using exact field', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         hello: { exact: 'words magic' }
       }
@@ -644,7 +644,7 @@ describe('pgsearch/searcher', function() {
 
 
   it('can do exact term matching with a phrase', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         hello: { exact: 'magic words' }
       }
@@ -654,7 +654,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can do exact term matching with a field that contains a capital letter', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         'favorite-toy': { exact: 'Sneaky Snake' }
       }
@@ -662,7 +662,7 @@ describe('pgsearch/searcher', function() {
     expect(response.data).length(1);
     expect(response.data[0]).has.deep.property('attributes.favorite-toy', 'Sneaky Snake');
 
-    response = await searcher.searchForCard(env.session, 'master', {
+    response = await searcher.search(env.session, {
       filter: {
         'favorite-toy': { exact: ['Sneaky Snake', 'boisterous baboon'] }
       }
@@ -673,7 +673,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can ignore case when doing exact term matching for a case insensitive field', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         'email-address': { exact: 'HASSAN@EXAMPLE.COM' }
       }
@@ -683,7 +683,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('incomplete phrase does not match', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         hello: { exact: 'magic words extra' }
       }
@@ -692,7 +692,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can do exact term matching with multiple phrases', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         hello: { exact: ['something else', 'magic words'] }
       }
@@ -702,7 +702,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter non-searchable belongsTo by id', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         'article.id': { exact: '1' }
       }
@@ -711,7 +711,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter searchable belongsTo by id', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         'searchable-article.id': { exact: '1' }
       }
@@ -720,7 +720,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter non-searchable belongsTo by multiple ids', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         'article.id': { exact: ['1', '2'] }
       }
@@ -729,7 +729,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter searchable belongsTo by multiple ids', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         'searchable-article.id': { exact: ['1', '2'] }
       }
@@ -739,7 +739,7 @@ describe('pgsearch/searcher', function() {
 
   it('can filter non-searchable hasMany by id', async function() {
     // todo: select array(select jsonb_array_elements(search_doc->'members')->>'id') from documents;
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         'members.id': { exact: '1' }
       }
@@ -748,7 +748,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter searchable hasMany by id', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         'searchable-members.id': { exact: '1' }
       }
@@ -757,7 +757,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter non-searchable hasMany by multiple id', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         'members.id': { exact: ['1', 'bogus'] }
       }
@@ -766,7 +766,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter searchable hasMany by multiple id', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         'searchable-members.id': { exact: ['1', 'bogus'] }
       }
@@ -775,7 +775,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('belongs-to attributes are not indexed by default', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         'article.hello': 'magic'
       }
@@ -784,7 +784,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter searchable belongs-to by an attribute', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         'searchable-article.hello': 'magic'
       }
@@ -793,7 +793,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('hasMany attributes are not indexed by default', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         'members.first-name': 'Quint'
       }
@@ -802,7 +802,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can filter searchable has-many by an attribute', async function() {
-    let response = await searcher.searchForCard(env.session, 'master', {
+    let response = await searcher.search(env.session, {
       filter: {
         'searchable-members.first-name': 'Quint'
       }
@@ -811,7 +811,7 @@ describe('pgsearch/searcher', function() {
   });
 
   it('can do prefix matching', async function() {
-    let { data: models } = await searcher.searchForCard(env.session, 'master', {
+    let { data: models } = await searcher.search(env.session, {
       filter: {
         'last-name': {
           prefix: 'Faulk'

--- a/packages/postgresql/node-tests/indexer-test.js
+++ b/packages/postgresql/node-tests/indexer-test.js
@@ -96,7 +96,7 @@ describe('postgresql/indexer', function() {
     });
 
     it('discovers content types', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'articles');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'articles');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -107,7 +107,7 @@ describe('postgresql/indexer', function() {
     });
 
     it('handles relationships with underscored names', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'doggies');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'doggies');
       expect(doc).is.ok;
       let model = doc.data;
 
@@ -119,7 +119,7 @@ describe('postgresql/indexer', function() {
     });
 
     it('discovers initial records', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'articles', '0');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '0');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -127,40 +127,40 @@ describe('postgresql/indexer', function() {
     });
 
     it('can read an integer column', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'articles', '0');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '0');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('attributes.length', 100);
     });
 
     it('can read a boolean column', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'articles', '1');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '1');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('attributes.published', false);
     });
 
     it('can read null string', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'articles', '1');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '1');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('attributes.title', null);
     });
 
     it('can read null integer', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'articles', '1');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '1');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('attributes.length', null);
     });
 
     it('can rename tables', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'real-editors');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'real-editors');
       expect(doc).is.ok;
     });
 
     it('can rename columns', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'articles');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'articles');
       expect(doc).is.ok;
       expect(doc.data.relationships.fields.data.map(f => f.id)).contains('real-topic');
     });
@@ -172,20 +172,20 @@ describe('postgresql/indexer', function() {
     });
 
     it('can customize discovered schema', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'articles');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'articles');
       expect(doc.data.attributes).has.property('default-includes');
       expect(doc.data.attributes['default-includes']).deep.equals(['editor']);
     });
 
     it('supports default includes', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'articles', '0');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '0');
       expect(doc).has.property('included');
       expect(doc.included).has.length(1);
       expect(doc.included[0]).has.deep.property('attributes.name', 'Some Editor');
     });
 
     it('can use type hints to make a relationship into an attribute', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'report-cards', '0');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'report-cards', '0');
       expect(doc.data.attributes).has.property('history-grade', 'A');
     });
 
@@ -198,7 +198,7 @@ describe('postgresql/indexer', function() {
     it('discovers new records', async function() {
       await client.query('insert into articles values ($1, $2)', ['2', 'second article']);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'articles', '2');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '2');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -209,7 +209,7 @@ describe('postgresql/indexer', function() {
     it('updates records', async function() {
       await client.query('update articles set title=$1 where id=$2', ['I was updated', '0']);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'articles', '0');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '0');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -220,7 +220,7 @@ describe('postgresql/indexer', function() {
       await client.query('delete from articles where id=$1', ['0']);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
       try {
-        await env.lookup('hub:searchers').get(env.session, 'master', 'articles', '0');
+        await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '0');
         throw new Error("should not get here");
       } catch (err) {
         expect(err.status).to.equal(404);
@@ -230,7 +230,7 @@ describe('postgresql/indexer', function() {
     it('discovers newly added content type', async function() {
       await client.query('create table humans (id varchar primary key, name varchar)');
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'humans');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'humans');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -242,7 +242,7 @@ describe('postgresql/indexer', function() {
       await client.query('drop table articles');
       await env.lookup('hub:indexers').update({ forceRefresh: true });
       try {
-        await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'articles');
+        await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'articles');
         throw new Error("should not get here");
       } catch (err) {
         expect(err.status).to.equal(404);
@@ -253,12 +253,12 @@ describe('postgresql/indexer', function() {
       await client.query('alter table articles add column author varchar');
       await client.query('update articles set author=$1 where id=$2', ['Arthur', '0']);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      let doc = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'articles');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'articles');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('relationships.fields.data');
       expect(model.relationships.fields.data).collectionContains({ id: 'author' });
-      doc = await env.lookup('hub:searchers').get(env.session, 'master', 'articles', '0');
+      doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '0');
       expect(doc).has.deep.property('data.attributes.author', 'Arthur');
     });
 

--- a/packages/postgresql/node-tests/indexer-test.js
+++ b/packages/postgresql/node-tests/indexer-test.js
@@ -166,7 +166,7 @@ describe('postgresql/indexer', function() {
     });
 
     it('can use type hints', async function() {
-      let response = await env.lookup('hub:searchers').search(env.session, 'master', { filter: { 'toy-name': { exact: 'SQueAkY sNakE' } } });
+      let response = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { filter: { 'toy-name': { exact: 'SQueAkY sNakE' } } });
       expect(response.data).length(1);
       expect(response.data[0].attributes['toy-name']).to.equal('Squeaky Snake');
     });

--- a/packages/postgresql/node-tests/indexer-test.js
+++ b/packages/postgresql/node-tests/indexer-test.js
@@ -96,7 +96,7 @@ describe('postgresql/indexer', function() {
     });
 
     it('discovers content types', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'articles');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'content-types', 'articles');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -107,7 +107,7 @@ describe('postgresql/indexer', function() {
     });
 
     it('handles relationships with underscored names', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'doggies');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'content-types', 'doggies');
       expect(doc).is.ok;
       let model = doc.data;
 
@@ -119,7 +119,7 @@ describe('postgresql/indexer', function() {
     });
 
     it('discovers initial records', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '0');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'articles', '0');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -127,65 +127,65 @@ describe('postgresql/indexer', function() {
     });
 
     it('can read an integer column', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '0');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'articles', '0');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('attributes.length', 100);
     });
 
     it('can read a boolean column', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '1');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'articles', '1');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('attributes.published', false);
     });
 
     it('can read null string', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '1');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'articles', '1');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('attributes.title', null);
     });
 
     it('can read null integer', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '1');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'articles', '1');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('attributes.length', null);
     });
 
     it('can rename tables', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'real-editors');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'content-types', 'real-editors');
       expect(doc).is.ok;
     });
 
     it('can rename columns', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'articles');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'content-types', 'articles');
       expect(doc).is.ok;
       expect(doc.data.relationships.fields.data.map(f => f.id)).contains('real-topic');
     });
 
     it('can use type hints', async function() {
-      let response = await env.lookup('hub:searchers').searchForCard(env.session, 'master', { filter: { 'toy-name': { exact: 'SQueAkY sNakE' } } });
+      let response = await env.lookup('hub:searchers').search(env.session, { filter: { 'toy-name': { exact: 'SQueAkY sNakE' } } });
       expect(response.data).length(1);
       expect(response.data[0].attributes['toy-name']).to.equal('Squeaky Snake');
     });
 
     it('can customize discovered schema', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'articles');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'content-types', 'articles');
       expect(doc.data.attributes).has.property('default-includes');
       expect(doc.data.attributes['default-includes']).deep.equals(['editor']);
     });
 
     it('supports default includes', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '0');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'articles', '0');
       expect(doc).has.property('included');
       expect(doc.included).has.length(1);
       expect(doc.included[0]).has.deep.property('attributes.name', 'Some Editor');
     });
 
     it('can use type hints to make a relationship into an attribute', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'report-cards', '0');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'report-cards', '0');
       expect(doc.data.attributes).has.property('history-grade', 'A');
     });
 
@@ -198,7 +198,7 @@ describe('postgresql/indexer', function() {
     it('discovers new records', async function() {
       await client.query('insert into articles values ($1, $2)', ['2', 'second article']);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '2');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'articles', '2');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -209,7 +209,7 @@ describe('postgresql/indexer', function() {
     it('updates records', async function() {
       await client.query('update articles set title=$1 where id=$2', ['I was updated', '0']);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '0');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'articles', '0');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -220,7 +220,7 @@ describe('postgresql/indexer', function() {
       await client.query('delete from articles where id=$1', ['0']);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
       try {
-        await env.lookup('hub:searchers').getCard(env.session, 'articles', '0');
+        await env.lookup('hub:searchers').get(env.session, 'articles', '0');
         throw new Error("should not get here");
       } catch (err) {
         expect(err.status).to.equal(404);
@@ -230,7 +230,7 @@ describe('postgresql/indexer', function() {
     it('discovers newly added content type', async function() {
       await client.query('create table humans (id varchar primary key, name varchar)');
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'humans');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'content-types', 'humans');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -242,7 +242,7 @@ describe('postgresql/indexer', function() {
       await client.query('drop table articles');
       await env.lookup('hub:indexers').update({ forceRefresh: true });
       try {
-        await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'articles');
+        await env.lookup('hub:searchers').get(env.session, 'content-types', 'articles');
         throw new Error("should not get here");
       } catch (err) {
         expect(err.status).to.equal(404);
@@ -253,12 +253,12 @@ describe('postgresql/indexer', function() {
       await client.query('alter table articles add column author varchar');
       await client.query('update articles set author=$1 where id=$2', ['Arthur', '0']);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'articles');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'content-types', 'articles');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('relationships.fields.data');
       expect(model.relationships.fields.data).collectionContains({ id: 'author' });
-      doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '0');
+      doc = await env.lookup('hub:searchers').get(env.session, 'articles', '0');
       expect(doc).has.deep.property('data.attributes.author', 'Arthur');
     });
 

--- a/packages/postgresql/node-tests/indexer-test.js
+++ b/packages/postgresql/node-tests/indexer-test.js
@@ -96,7 +96,7 @@ describe('postgresql/indexer', function() {
     });
 
     it('discovers content types', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'articles');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'articles');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -107,7 +107,7 @@ describe('postgresql/indexer', function() {
     });
 
     it('handles relationships with underscored names', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'doggies');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'doggies');
       expect(doc).is.ok;
       let model = doc.data;
 
@@ -119,7 +119,7 @@ describe('postgresql/indexer', function() {
     });
 
     it('discovers initial records', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '0');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '0');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -127,40 +127,40 @@ describe('postgresql/indexer', function() {
     });
 
     it('can read an integer column', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '0');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '0');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('attributes.length', 100);
     });
 
     it('can read a boolean column', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '1');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '1');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('attributes.published', false);
     });
 
     it('can read null string', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '1');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '1');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('attributes.title', null);
     });
 
     it('can read null integer', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '1');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '1');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('attributes.length', null);
     });
 
     it('can rename tables', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'real-editors');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'real-editors');
       expect(doc).is.ok;
     });
 
     it('can rename columns', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'articles');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'articles');
       expect(doc).is.ok;
       expect(doc.data.relationships.fields.data.map(f => f.id)).contains('real-topic');
     });
@@ -172,20 +172,20 @@ describe('postgresql/indexer', function() {
     });
 
     it('can customize discovered schema', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'articles');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'articles');
       expect(doc.data.attributes).has.property('default-includes');
       expect(doc.data.attributes['default-includes']).deep.equals(['editor']);
     });
 
     it('supports default includes', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '0');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '0');
       expect(doc).has.property('included');
       expect(doc.included).has.length(1);
       expect(doc.included[0]).has.deep.property('attributes.name', 'Some Editor');
     });
 
     it('can use type hints to make a relationship into an attribute', async function() {
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'report-cards', '0');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'report-cards', '0');
       expect(doc.data.attributes).has.property('history-grade', 'A');
     });
 
@@ -198,7 +198,7 @@ describe('postgresql/indexer', function() {
     it('discovers new records', async function() {
       await client.query('insert into articles values ($1, $2)', ['2', 'second article']);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '2');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '2');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -209,7 +209,7 @@ describe('postgresql/indexer', function() {
     it('updates records', async function() {
       await client.query('update articles set title=$1 where id=$2', ['I was updated', '0']);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '0');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '0');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -220,7 +220,7 @@ describe('postgresql/indexer', function() {
       await client.query('delete from articles where id=$1', ['0']);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
       try {
-        await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '0');
+        await env.lookup('hub:searchers').getCard(env.session, 'articles', '0');
         throw new Error("should not get here");
       } catch (err) {
         expect(err.status).to.equal(404);
@@ -230,7 +230,7 @@ describe('postgresql/indexer', function() {
     it('discovers newly added content type', async function() {
       await client.query('create table humans (id varchar primary key, name varchar)');
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'humans');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'humans');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -242,7 +242,7 @@ describe('postgresql/indexer', function() {
       await client.query('drop table articles');
       await env.lookup('hub:indexers').update({ forceRefresh: true });
       try {
-        await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'articles');
+        await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'articles');
         throw new Error("should not get here");
       } catch (err) {
         expect(err.status).to.equal(404);
@@ -253,12 +253,12 @@ describe('postgresql/indexer', function() {
       await client.query('alter table articles add column author varchar');
       await client.query('update articles set author=$1 where id=$2', ['Arthur', '0']);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      let doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'articles');
+      let doc = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'articles');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('relationships.fields.data');
       expect(model.relationships.fields.data).collectionContains({ id: 'author' });
-      doc = await env.lookup('hub:searchers').getCard(env.session, 'master', 'articles', '0');
+      doc = await env.lookup('hub:searchers').getCard(env.session, 'articles', '0');
       expect(doc).has.deep.property('data.attributes.author', 'Arthur');
     });
 

--- a/packages/postgresql/node-tests/indexer-test.js
+++ b/packages/postgresql/node-tests/indexer-test.js
@@ -96,7 +96,7 @@ describe('postgresql/indexer', function() {
     });
 
     it('discovers content types', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'content-types', 'articles');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'articles');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -107,7 +107,7 @@ describe('postgresql/indexer', function() {
     });
 
     it('handles relationships with underscored names', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'content-types', 'doggies');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'doggies');
       expect(doc).is.ok;
       let model = doc.data;
 
@@ -119,7 +119,7 @@ describe('postgresql/indexer', function() {
     });
 
     it('discovers initial records', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'articles', '0');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'articles', '0');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -127,40 +127,40 @@ describe('postgresql/indexer', function() {
     });
 
     it('can read an integer column', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'articles', '0');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'articles', '0');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('attributes.length', 100);
     });
 
     it('can read a boolean column', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'articles', '1');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'articles', '1');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('attributes.published', false);
     });
 
     it('can read null string', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'articles', '1');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'articles', '1');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('attributes.title', null);
     });
 
     it('can read null integer', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'articles', '1');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'articles', '1');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('attributes.length', null);
     });
 
     it('can rename tables', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'content-types', 'real-editors');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'real-editors');
       expect(doc).is.ok;
     });
 
     it('can rename columns', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'content-types', 'articles');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'articles');
       expect(doc).is.ok;
       expect(doc.data.relationships.fields.data.map(f => f.id)).contains('real-topic');
     });
@@ -172,20 +172,20 @@ describe('postgresql/indexer', function() {
     });
 
     it('can customize discovered schema', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'content-types', 'articles');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'articles');
       expect(doc.data.attributes).has.property('default-includes');
       expect(doc.data.attributes['default-includes']).deep.equals(['editor']);
     });
 
     it('supports default includes', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'articles', '0');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'articles', '0');
       expect(doc).has.property('included');
       expect(doc.included).has.length(1);
       expect(doc.included[0]).has.deep.property('attributes.name', 'Some Editor');
     });
 
     it('can use type hints to make a relationship into an attribute', async function() {
-      let doc = await env.lookup('hub:searchers').get(env.session, 'report-cards', '0');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'report-cards', '0');
       expect(doc.data.attributes).has.property('history-grade', 'A');
     });
 
@@ -198,7 +198,7 @@ describe('postgresql/indexer', function() {
     it('discovers new records', async function() {
       await client.query('insert into articles values ($1, $2)', ['2', 'second article']);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      let doc = await env.lookup('hub:searchers').get(env.session, 'articles', '2');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'articles', '2');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -209,7 +209,7 @@ describe('postgresql/indexer', function() {
     it('updates records', async function() {
       await client.query('update articles set title=$1 where id=$2', ['I was updated', '0']);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      let doc = await env.lookup('hub:searchers').get(env.session, 'articles', '0');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'articles', '0');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -220,7 +220,7 @@ describe('postgresql/indexer', function() {
       await client.query('delete from articles where id=$1', ['0']);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
       try {
-        await env.lookup('hub:searchers').get(env.session, 'articles', '0');
+        await env.lookup('hub:searchers').get(env.session, 'local-hub', 'articles', '0');
         throw new Error("should not get here");
       } catch (err) {
         expect(err.status).to.equal(404);
@@ -230,7 +230,7 @@ describe('postgresql/indexer', function() {
     it('discovers newly added content type', async function() {
       await client.query('create table humans (id varchar primary key, name varchar)');
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      let doc = await env.lookup('hub:searchers').get(env.session, 'content-types', 'humans');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'humans');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).is.ok;
@@ -242,7 +242,7 @@ describe('postgresql/indexer', function() {
       await client.query('drop table articles');
       await env.lookup('hub:indexers').update({ forceRefresh: true });
       try {
-        await env.lookup('hub:searchers').get(env.session, 'content-types', 'articles');
+        await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'articles');
         throw new Error("should not get here");
       } catch (err) {
         expect(err.status).to.equal(404);
@@ -253,12 +253,12 @@ describe('postgresql/indexer', function() {
       await client.query('alter table articles add column author varchar');
       await client.query('update articles set author=$1 where id=$2', ['Arthur', '0']);
       await env.lookup('hub:indexers').update({ forceRefresh: true });
-      let doc = await env.lookup('hub:searchers').get(env.session, 'content-types', 'articles');
+      let doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'articles');
       expect(doc).is.ok;
       let model = doc.data;
       expect(model).has.deep.property('relationships.fields.data');
       expect(model.relationships.fields.data).collectionContains({ id: 'author' });
-      doc = await env.lookup('hub:searchers').get(env.session, 'articles', '0');
+      doc = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'articles', '0');
       expect(doc).has.deep.property('data.attributes.author', 'Arthur');
     });
 

--- a/packages/postgresql/node-tests/migrations-test.js
+++ b/packages/postgresql/node-tests/migrations-test.js
@@ -40,18 +40,18 @@ describe('postgresql/migrations', function() {
 
   it('can run a simple migration', async function() {
     env = await setup('good-scenario');
-    let type = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'posts');
+    let type = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'posts');
     expect(type).has.deep.property('data.relationships.fields.data');
     expect(type.data.relationships.fields.data).collectionContains({ id: 'title'});
   });
 
   it('migrations are idempotent', async function() {
     env = await setup('good-scenario');
-    await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'posts');
+    await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'posts');
     await destroyDefaultEnvironment(env);
     await pgClient.query(`select pg_drop_replication_slot(slot_name) from pg_replication_slots;`);
     env = await setup('good-scenario');
-    let type = await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'posts');
+    let type = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'posts');
     expect(type).has.deep.property('data.relationships.fields.data');
     expect(type.data.relationships.fields.data).collectionContains({ id: 'title'});
   });
@@ -67,7 +67,7 @@ describe('postgresql/migrations', function() {
     env = await setup();
 
     try {
-      await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'comments');
+      await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'comments');
       throw new Error("earlier statements in the failing migration were not rolled back");
     } catch (err) {
       expect(err.message).to.match(/No such resource master\/content-types\/comments/);
@@ -75,7 +75,7 @@ describe('postgresql/migrations', function() {
 
 
     try {
-      await env.lookup('hub:searchers').get(env.session, 'master', 'content-types', 'posts');
+      await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'posts');
       throw new Error("other concurrent migrations were not rolled back");
     } catch (err) {
       expect(err.message).to.match(/No such resource master\/content-types\/posts/);

--- a/packages/postgresql/node-tests/migrations-test.js
+++ b/packages/postgresql/node-tests/migrations-test.js
@@ -40,18 +40,18 @@ describe('postgresql/migrations', function() {
 
   it('can run a simple migration', async function() {
     env = await setup('good-scenario');
-    let type = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'posts');
+    let type = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'posts');
     expect(type).has.deep.property('data.relationships.fields.data');
     expect(type.data.relationships.fields.data).collectionContains({ id: 'title'});
   });
 
   it('migrations are idempotent', async function() {
     env = await setup('good-scenario');
-    await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'posts');
+    await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'posts');
     await destroyDefaultEnvironment(env);
     await pgClient.query(`select pg_drop_replication_slot(slot_name) from pg_replication_slots;`);
     env = await setup('good-scenario');
-    let type = await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'posts');
+    let type = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'posts');
     expect(type).has.deep.property('data.relationships.fields.data');
     expect(type.data.relationships.fields.data).collectionContains({ id: 'title'});
   });
@@ -67,7 +67,7 @@ describe('postgresql/migrations', function() {
     env = await setup();
 
     try {
-      await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'comments');
+      await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'comments');
       throw new Error("earlier statements in the failing migration were not rolled back");
     } catch (err) {
       expect(err.message).to.match(/No such resource master\/content-types\/comments/);
@@ -75,7 +75,7 @@ describe('postgresql/migrations', function() {
 
 
     try {
-      await env.lookup('hub:searchers').getCard(env.session, 'master', 'content-types', 'posts');
+      await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'posts');
       throw new Error("other concurrent migrations were not rolled back");
     } catch (err) {
       expect(err.message).to.match(/No such resource master\/content-types\/posts/);

--- a/packages/postgresql/node-tests/migrations-test.js
+++ b/packages/postgresql/node-tests/migrations-test.js
@@ -40,18 +40,18 @@ describe('postgresql/migrations', function() {
 
   it('can run a simple migration', async function() {
     env = await setup('good-scenario');
-    let type = await env.lookup('hub:searchers').get(env.session, 'content-types', 'posts');
+    let type = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'posts');
     expect(type).has.deep.property('data.relationships.fields.data');
     expect(type.data.relationships.fields.data).collectionContains({ id: 'title'});
   });
 
   it('migrations are idempotent', async function() {
     env = await setup('good-scenario');
-    await env.lookup('hub:searchers').get(env.session, 'content-types', 'posts');
+    await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'posts');
     await destroyDefaultEnvironment(env);
     await pgClient.query(`select pg_drop_replication_slot(slot_name) from pg_replication_slots;`);
     env = await setup('good-scenario');
-    let type = await env.lookup('hub:searchers').get(env.session, 'content-types', 'posts');
+    let type = await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'posts');
     expect(type).has.deep.property('data.relationships.fields.data');
     expect(type.data.relationships.fields.data).collectionContains({ id: 'title'});
   });
@@ -67,7 +67,7 @@ describe('postgresql/migrations', function() {
     env = await setup();
 
     try {
-      await env.lookup('hub:searchers').get(env.session, 'content-types', 'comments');
+      await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'comments');
       throw new Error("earlier statements in the failing migration were not rolled back");
     } catch (err) {
       expect(err.message).to.match(/No such resource master\/content-types\/comments/);
@@ -75,7 +75,7 @@ describe('postgresql/migrations', function() {
 
 
     try {
-      await env.lookup('hub:searchers').get(env.session, 'content-types', 'posts');
+      await env.lookup('hub:searchers').get(env.session, 'local-hub', 'content-types', 'posts');
       throw new Error("other concurrent migrations were not rolled back");
     } catch (err) {
       expect(err.message).to.match(/No such resource master\/content-types\/posts/);

--- a/packages/postgresql/node-tests/migrations-test.js
+++ b/packages/postgresql/node-tests/migrations-test.js
@@ -40,18 +40,18 @@ describe('postgresql/migrations', function() {
 
   it('can run a simple migration', async function() {
     env = await setup('good-scenario');
-    let type = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'posts');
+    let type = await env.lookup('hub:searchers').get(env.session, 'content-types', 'posts');
     expect(type).has.deep.property('data.relationships.fields.data');
     expect(type.data.relationships.fields.data).collectionContains({ id: 'title'});
   });
 
   it('migrations are idempotent', async function() {
     env = await setup('good-scenario');
-    await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'posts');
+    await env.lookup('hub:searchers').get(env.session, 'content-types', 'posts');
     await destroyDefaultEnvironment(env);
     await pgClient.query(`select pg_drop_replication_slot(slot_name) from pg_replication_slots;`);
     env = await setup('good-scenario');
-    let type = await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'posts');
+    let type = await env.lookup('hub:searchers').get(env.session, 'content-types', 'posts');
     expect(type).has.deep.property('data.relationships.fields.data');
     expect(type.data.relationships.fields.data).collectionContains({ id: 'title'});
   });
@@ -67,7 +67,7 @@ describe('postgresql/migrations', function() {
     env = await setup();
 
     try {
-      await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'comments');
+      await env.lookup('hub:searchers').get(env.session, 'content-types', 'comments');
       throw new Error("earlier statements in the failing migration were not rolled back");
     } catch (err) {
       expect(err.message).to.match(/No such resource master\/content-types\/comments/);
@@ -75,7 +75,7 @@ describe('postgresql/migrations', function() {
 
 
     try {
-      await env.lookup('hub:searchers').getCard(env.session, 'content-types', 'posts');
+      await env.lookup('hub:searchers').get(env.session, 'content-types', 'posts');
       throw new Error("other concurrent migrations were not rolled back");
     } catch (err) {
       expect(err.message).to.match(/No such resource master\/content-types\/posts/);

--- a/packages/routing/cardstack/index.js
+++ b/packages/routing/cardstack/index.js
@@ -94,7 +94,7 @@ async function buildRoutingCardsCache({ searchers, branch, resolvedPath, context
         if (query.includes(':card:')) {
           query = resolveRoutingCardReplacementTags(get(routingCards, `antecedantResolution.${route.contentType}`), query, routingCards);
         }
-        let { data: cards } = await searchers.search(Session.INTERNAL_PRIVILEGED, branch, JSON.parse(query));
+        let { data: cards } = await searchers.searchForCard(Session.INTERNAL_PRIVILEGED, branch, JSON.parse(query));
         if (cards.length) {
           if (route === cardRoute) {
             routingCards.antecedantResolution[type] = { data: cards[0] };
@@ -153,7 +153,7 @@ async function getRoutingCardForRoute(searchers, route, branch, path, routingCar
     let query = resolveReplacementTagsFromPath(parentRoute, path, JSON.stringify(parentRoute.query));
     let routingCardType = route.routeStack.length ? route.routeStack[0].contentType : null;
     query = resolveRoutingCardReplacementTags(get(routingCardsCache, `antecedantResolution.${routingCardType}`), query, routingCardsCache);
-    let { data:routingCards } = await searchers.search(Session.INTERNAL_PRIVILEGED, branch, JSON.parse(query));
+    let { data:routingCards } = await searchers.searchForCard(Session.INTERNAL_PRIVILEGED, branch, JSON.parse(query));
     return routingCards.length ? { data: routingCards[0] } : null;
   }
 }

--- a/packages/routing/cardstack/index.js
+++ b/packages/routing/cardstack/index.js
@@ -94,7 +94,7 @@ async function buildRoutingCardsCache({ searchers, branch, resolvedPath, context
         if (query.includes(':card:')) {
           query = resolveRoutingCardReplacementTags(get(routingCards, `antecedantResolution.${route.contentType}`), query, routingCards);
         }
-        let { data: cards } = await searchers.searchForCard(Session.INTERNAL_PRIVILEGED, branch, JSON.parse(query));
+        let { data: cards } = await searchers.search(Session.INTERNAL_PRIVILEGED, JSON.parse(query), branch);
         if (cards.length) {
           if (route === cardRoute) {
             routingCards.antecedantResolution[type] = { data: cards[0] };
@@ -153,7 +153,7 @@ async function getRoutingCardForRoute(searchers, route, branch, path, routingCar
     let query = resolveReplacementTagsFromPath(parentRoute, path, JSON.stringify(parentRoute.query));
     let routingCardType = route.routeStack.length ? route.routeStack[0].contentType : null;
     query = resolveRoutingCardReplacementTags(get(routingCardsCache, `antecedantResolution.${routingCardType}`), query, routingCardsCache);
-    let { data:routingCards } = await searchers.searchForCard(Session.INTERNAL_PRIVILEGED, branch, JSON.parse(query));
+    let { data:routingCards } = await searchers.search(Session.INTERNAL_PRIVILEGED, JSON.parse(query), branch);
     return routingCards.length ? { data: routingCards[0] } : null;
   }
 }

--- a/packages/routing/node-tests/card-paths-test.js
+++ b/packages/routing/node-tests/card-paths-test.js
@@ -167,7 +167,7 @@ describe('routing/paths', function () {
     });
 
     it('doesnt get a path for "spaces" content-type', async function() {
-      let space = await (await env.lookup('hub:searchers')).getFromControllingBranch(env.session, 'spaces', '/');
+      let space = await (await env.lookup('hub:searchers')).getSpace(env.session, '/');
       let path = await getCardPath(space);
       expect(path).is.not.ok;
     });

--- a/packages/s3/cardstack/searcher.js
+++ b/packages/s3/cardstack/searcher.js
@@ -1,25 +1,24 @@
 const { declareInjections }   = require('@cardstack/di');
 const log = require('@cardstack/logger')('cardstack/s3');
 const { makeS3Client } = require('./s3');
-const { get } = require('lodash');
 const { basename } = require('path');
 const { lookup } = require('mime-types');
 const moment = require('moment');
 
 
 module.exports = declareInjections({
-  searcher: 'hub:searchers'
+  currentSchema: 'hub:current-schema'
 },
 
 class S3Searcher {
   static create(...args) {
     return new this(...args);
   }
-  constructor({ dataSource, config, searcher, branches }) {
-    this.config       = config;
-    this.branches     = branches;
-    this.dataSource   = dataSource;
-    this.searcher     = searcher;
+  constructor({ dataSource, config, currentSchema, branches }) {
+    this.config        = config;
+    this.branches      = branches;
+    this.dataSource    = dataSource;
+    this.currentSchema = currentSchema;
   }
 
   async get(session, branch, type, id, next) {
@@ -29,25 +28,24 @@ class S3Searcher {
 
     if (type === 'content-types') { return next(); }
 
-    let contentType = await this.searcher.get(session, branch, 'content-types', type);
+    let schema = await this.currentSchema.forBranch(branch);
+    let contentType = schema.types.get(type);
+    if (!contentType) { return result; }
 
-    let dataSourceId = get(contentType, 'data.relationships.data-source.data.id');
-
-    // only look for files in s3 if the content type is actually stored
+    // only look for files on the server if the content type is actually stored
     // in this data source
-    if (dataSourceId !== this.dataSource.id) {
-      return result;
-    }
+    let dataSource = contentType.dataSource;
+    if (!dataSource || dataSource.id !== this.dataSource.id) { return result; }
 
     try {
       let name = basename(id);
       let result = await this.getObject(branch, { Key: id });
-      let contentType = lookup(name) || 'application/octet-stream';
+      let mimeContentType = lookup(name) || 'application/octet-stream';
 
 
       let attributes = {
         'created-at':  moment(result.LastModified).format(),
-        'content-type': contentType,
+        'content-type': mimeContentType,
         'size':         result.ContentLength,
         'file-name':    name
       };

--- a/packages/sftp/cardstack/searcher.js
+++ b/packages/sftp/cardstack/searcher.js
@@ -2,22 +2,21 @@ const { declareInjections }   = require('@cardstack/di');
 const SftpClient = require('ssh2-sftp-client');
 const { dirname, basename } = require('path');
 const moment = require('moment');
-const { get } = require('lodash');
 const { lookup } = require('mime-types');
 
 module.exports = declareInjections({
-  searcher: 'hub:searchers'
+  currentSchema: 'hub:current-schema'
 },
 
 class SftpSearcher {
   static create(...args) {
     return new this(...args);
   }
-  constructor({ dataSource, config, searcher, branches }) {
-    this.config       = config;
-    this.branches     = branches;
-    this.dataSource   = dataSource;
-    this.searcher     = searcher;
+  constructor({ dataSource, config, currentSchema, branches }) {
+    this.config        = config;
+    this.branches      = branches;
+    this.dataSource    = dataSource;
+    this.currentSchema = currentSchema;
   }
 
   async get(session, branch, type, id, next) {
@@ -28,15 +27,14 @@ class SftpSearcher {
 
     if (type === 'content-types') { return next(); }
 
-    let contentType = await this.searcher.get(session, branch, 'content-types', type);
-
-    let dataSourceId = get(contentType, 'data.relationships.data-source.data.id');
+    let schema = await this.currentSchema.forBranch(branch);
+    let contentType = schema.types.get(type);
+    if (!contentType) { return result; }
 
     // only look for files on the server if the content type is actually stored
     // in this data source
-    if (dataSourceId !== this.dataSource.id) {
-      return result;
-    }
+    let dataSource = contentType.dataSource;
+    if (!dataSource || dataSource.id !== this.dataSource.id) { return result; }
 
     let client = await this.makeClient(branch);
     let list = await client.list(dirname(id));
@@ -45,14 +43,14 @@ class SftpSearcher {
     let entry = list.find(e => e.name === name );
 
     if (entry) {
-      let contentType = lookup(name) || 'application/octet-stream';
+      let mimeContentType = lookup(name) || 'application/octet-stream';
 
       let attributes = {
         'access-time':  moment(entry.accessTime).format(),
         'modify-time':  moment(entry.modifyTime).format(),
         'size':         entry.size,
         'file-name':    name,
-        'content-type': contentType
+        'content-type': mimeContentType
       };
 
       let data = {

--- a/packages/test-support/env.js
+++ b/packages/test-support/env.js
@@ -78,7 +78,7 @@ exports.createDefaultEnvironment = async function(projectDir, initialModels = []
     await ephemeralStorage.validateModels(models, async(type, id) => {
       let result;
       try {
-        result = await searchers.get(Session.INTERNAL_PRIVILEGED, type, id);
+        result = await searchers.get(Session.INTERNAL_PRIVILEGED, 'local-hub', type, id);
       } catch (err) {
         if (err.status !== 404) { throw err; }
       }

--- a/packages/test-support/env.js
+++ b/packages/test-support/env.js
@@ -78,7 +78,7 @@ exports.createDefaultEnvironment = async function(projectDir, initialModels = []
     await ephemeralStorage.validateModels(models, async(type, id) => {
       let result;
       try {
-        result = await searchers.getFromControllingBranch(Session.INTERNAL_PRIVILEGED, type, id);
+        result = await searchers.getCurrentCard(Session.INTERNAL_PRIVILEGED, type, id);
       } catch (err) {
         if (err.status !== 404) { throw err; }
       }

--- a/packages/test-support/env.js
+++ b/packages/test-support/env.js
@@ -78,7 +78,7 @@ exports.createDefaultEnvironment = async function(projectDir, initialModels = []
     await ephemeralStorage.validateModels(models, async(type, id) => {
       let result;
       try {
-        result = await searchers.getCurrentCard(Session.INTERNAL_PRIVILEGED, type, id);
+        result = await searchers.getCard(Session.INTERNAL_PRIVILEGED, type, id);
       } catch (err) {
         if (err.status !== 404) { throw err; }
       }

--- a/packages/test-support/env.js
+++ b/packages/test-support/env.js
@@ -78,7 +78,7 @@ exports.createDefaultEnvironment = async function(projectDir, initialModels = []
     await ephemeralStorage.validateModels(models, async(type, id) => {
       let result;
       try {
-        result = await searchers.getCard(Session.INTERNAL_PRIVILEGED, type, id);
+        result = await searchers.get(Session.INTERNAL_PRIVILEGED, type, id);
       } catch (err) {
         if (err.status !== 404) { throw err; }
       }


### PR DESCRIPTION
***BREAKING CHANGE***

This is part of the work for #733.  Using newer API for `hub:searchers.get` and `hub:searchers.search`. After going thru the homework of seeing where all `Searchers.get()` and `Searchers.search()` is being called from, it becomes evident that from the outside of `Searchers`, for the most part only cards are actually requested. A few notable exceptions:
- schema: for the time being we are going to treat schema as cards until that doesn't make sense
- spaces: spaces are inherently not cards. To resolve this I've added a `Searchers.getSpace()` method that we can embellish as time goes on.
- binary data: There exists a `Searchers.getBinary()` that allows us to retrieve the binary data that can back a model. This represents what we'd consider an internal model of a card. We should follow up with another PR that allows access to the `Searchers.getBinary()` only from an internal model API endpoint that is namespaced with a card (e.g. `GET /api/${repo}/${package}/${cardId}/${modelType}/${modelId}`). Additionally, from inside the hub, you should also have to provide the `repo`, `package`, and `cardId` to the `Searchers.getBinary()` method.

I've updated the `Searchers.get` method signature to look like this (`package` is actually a reserved keyword in javascript when in `strict` mode--hence `packageName`):
```
  async get(session, packageName, id, opts={})
```
Where opts can include: `version` and `includePaths`. Omitting the `version` would imply that you want the current card.

I've updated the `Searchers.search` method signature to look like this:
```
  async search(session, query, version)
```
I'm a little unsure about the `version`. right now it is the placeholder for what we are currently calling the `branch`--but honestly it might make more sense to include the `version` in the query itself.

For the searcher hub feature, I have left that unchanged. This implies that the searcher hub feature is used to return cards. I opted not to split the searcher feature to supply separate hooks for returning models and cards, since it looks like in practice are are not consuming models outside of hub:searchers--based on how everything shakes out, we may revisit that. 

Finally, if you call `Searchers.search` or `Searchers.get` in what looks like to be the old way, you'll get a helpful deprecation exception informing you of the new way these are called.