### PR TITLE
emit generated app modules in treeForApp

### DIFF
--- a/packages/hub/docker-host/broccoli-connector.js
+++ b/packages/hub/docker-host/broccoli-connector.js
@@ -8,10 +8,9 @@ const Plugin = require("broccoli-plugin");
 const { WatchedDir } = require("broccoli-source");
 
 class CodeWriter extends Plugin {
-  constructor(codeGenUrlPromise, appModulePrefix, trigger) {
+  constructor(codeGenUrlPromise, trigger) {
     super([trigger], { name: "@cardstack/hub", needsCache: false });
     this.codeGenUrlPromise = codeGenUrlPromise;
-    this.appModulePrefix = appModulePrefix;
   }
 
   async build() {
@@ -23,12 +22,12 @@ class CodeWriter extends Plugin {
     try {
       let response = (await request.get(url).buffer(true)).body;
       for (let [name, source] of response.modules) {
-        let target = join(this.outputPath, name + ".js");
+        let target = join(this.outputPath, 'addon', name + ".js");
         ensureDirSync(dirname(target));
         writeFileSync(target, source);
       }
       for (let [name, source] of response.appModules) {
-        let target = join(this.outputPath, this.appModulePrefix, name + ".js");
+        let target = join(this.outputPath, 'app', name + ".js");
         ensureDirSync(dirname(target));
         writeFileSync(target, source);
       }
@@ -53,12 +52,12 @@ class CodeWriter extends Plugin {
 }
 
 module.exports = class BroccoliConnector {
-  constructor(codeGenUrl, appModulePrefix) {
+  constructor(codeGenUrl) {
     quickTemp.makeOrRemake(this, "_triggerDir", "cardstack-hub");
     this._trigger = new WatchedDir(this._triggerDir, {
       annotation: "@cardstack/hub",
     });
-    this.tree = new CodeWriter(codeGenUrl, appModulePrefix, this._trigger);
+    this.tree = new CodeWriter(codeGenUrl, this._trigger);
     this._buildCounter = 0;
   }
   triggerRebuild() {

--- a/packages/hub/index.js
+++ b/packages/hub/index.js
@@ -2,6 +2,7 @@ const CONTAINER_MODE = process.env.CONTAINERIZED_HUB != null;
 const BroccoliConnector = require("./docker-host/broccoli-connector");
 const path = require("path");
 const fs = require("fs");
+const Funnel = require('broccoli-funnel');
 
 let addon = {
   name: "@cardstack/hub",
@@ -70,9 +71,6 @@ let addon = {
       return;
     }
     this.url(); // kicks off the actual hub as needed
-    this._modulePrefix = require(this.project.configPath())(
-      this._env
-    ).modulePrefix;
   },
 
   async _startHub() {
@@ -98,17 +96,34 @@ let addon = {
     }
   },
 
+  _broccoliConnector() {
+    if (!this._cachedBroccoliConnector) {
+      let codeGenUrlPromise = this._hub.then(url => {
+        if (url) {
+          return `${url}/codegen-modules`;
+        }
+      });
+      this._cachedBroccoliConnector = new BroccoliConnector(codeGenUrlPromise);
+    }
+    return this._cachedBroccoliConnector;
+  },
+
+  treeForApp() {
+    if (!this._active) {
+      this._super.apply(this, arguments);
+      return;
+    }
+
+    return this._super.call(this, new Funnel(this._broccoliConnector().tree, { srcDir: 'app' }));
+  },
+
   treeForAddon() {
     if (!this._active) {
       this._super.apply(this, arguments);
       return;
     }
-    let codeGenUrlPromise = this._hub.then(url => {
-      if (url) {
-        return `${url}/codegen-modules`;
-      }
-    });
-    let tree = new BroccoliConnector(codeGenUrlPromise, this._modulePrefix).tree;
+
+    let tree = new Funnel(this._broccoliConnector().tree, { srcDir: 'addon' });
     return this.preprocessJs(tree, '/', this.name, {
       registry: this.registry,
     });

--- a/packages/hub/index.js
+++ b/packages/hub/index.js
@@ -114,7 +114,7 @@ let addon = {
       return;
     }
 
-    return this._super.call(this, new Funnel(this._broccoliConnector().tree, { srcDir: 'app' }));
+    return this._super.call(this, new Funnel(this._broccoliConnector().tree, { srcDir: 'app', allowEmpty: true }));
   },
 
   treeForAddon() {
@@ -123,7 +123,7 @@ let addon = {
       return;
     }
 
-    let tree = new Funnel(this._broccoliConnector().tree, { srcDir: 'addon' });
+    let tree = new Funnel(this._broccoliConnector().tree, { srcDir: 'addon', allowEmpty: true });
     return this.preprocessJs(tree, '/', this.name, {
       registry: this.registry,
     });

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -29,6 +29,7 @@
     "@cardstack/routing": "0.13.71",
     "@types/fs-extra": "^5.0.5",
     "broccoli-concat": "^3.2.2",
+    "broccoli-funnel": "^2.0.1",
     "broccoli-plugin": "^1.3.0",
     "broccoli-source": "^1.1.0",
     "chalk": "^2.3.0",


### PR DESCRIPTION
This is less weird than trying to get things into the app's namespace via `treeForAddon` (which turned out to also be too much for embroider).

Co-Authored-By: Jen Weber <j@jenweber.me>