### PR TITLE
Add `cardstack new <card-name>` command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,13 +1,46 @@
 # Cardstack CLI
 
+The Cardstack CLI is a work-in-progress project to
+create a smooth quickstart experience for new developers and
+a straightforward way to use the Card SDK.
+It handles tasks like creating new Cards, starting the Hub,
+installing dependencies, and generating code from templates.
+
+Under the hood, the CLI uses [Embroider](https://github.com/embroider-build/embroider)
+for the build and [yargs](https://github.com/yargs/yargs) to manage user inputs.
+
+## Using the CLI
+
 To run the CLI:
 
 ```sh
-node ./bin/cardstack.js run
+yarn compile --watch
+node ./bin/cardstack.js <command>
 ```
 
-To disable rebuilds of the Ember App:
+To see a list of commands:
 
 ```sh
-CARDSTACK_DEV=true node ./bin/cardstack.js run
+yarn compile --watch
+node ./bin/cardstack.js --help
 ```
+
+Apps are served from `localhost:4200`.
+
+## Contributing to the CLI
+
+The CLI codebase uses [TypeScript](https://www.typescriptlang.org/),
+so make sure you always have a compiler running while you work:
+
+```sh
+yarn compile --watch
+```
+
+To disable rebuilds of the Ember App as you make changes:
+
+```sh
+CARDSTACK_DEV=true node ./bin/cardstack.js start
+```
+
+To view the built app, follow the path printed in the console
+by Embroider.

--- a/packages/cli/bin/cardstack.ts
+++ b/packages/cli/bin/cardstack.ts
@@ -11,12 +11,12 @@ const ui = new UI();
 yargs
   .scriptName("cardstack")
   .command(
-    "run",
-    "Run a card",
+    "start",
+    "Start the Cardstack environment",
     args => {
       return args.option("dir", {
         alias: "d",
-        describe: "path to your card",
+        describe: "path to your .cardstack local data storage directory",
         type: "string",
         default: process.cwd()
       });
@@ -42,7 +42,29 @@ yargs
       await preBuild.default(Object.assign({ ui }, argv));
     }
   )
-  .demandCommand(1, "Use any of the commands below.\n")
+
+  .command('new <card-name>', 'Create a card', (args) => {
+    return args.positional('card-name', {
+      describe: 'the name for the new Card',
+      type: 'string',
+      demandOption: true,
+      normalize: true
+    });
+  }, async function (argv) {
+    let newCard = await import('../new-card');
+    await newCard.default(Object.assign({ ui }, argv));
+  })
+  .command('play <card-name>', 'Choose a card to render', (args) => {
+    return args.positional('card-name', {
+      describe: 'the name of an existing card',
+      type: 'string',
+      demandOption: true,
+      normalize: true
+    });
+  }, async function () {
+    ui.write('coming soon!');
+  })
+  .demandCommand(1, 'Use any of the commands below.\n')
   .strict()
   .fail((msg, err) => {
     if (msg) {

--- a/packages/cli/blueprint.ts
+++ b/packages/cli/blueprint.ts
@@ -1,0 +1,46 @@
+interface File {
+  filename: string;
+  contents: string;
+  [key: string]: string;
+}
+
+interface Blueprint {
+  [key: string]: File[];
+}
+
+const blueprint: Blueprint = {
+  components: [
+    {
+      filename: "embedded.css",
+      contents: ""
+    },
+    {
+      filename: "embedded.hbs",
+      contents: "{{outlet}}"
+    },
+    {
+      filename: "embedded.js",
+      contents: `import Component from '@glimmer/component';
+
+export default class EmbeddedComponent extends Component {}
+`
+    },
+    {
+      filename: "isolated.css",
+      contents: ""
+    },
+    {
+      filename: "isolated.hbs",
+      contents: "{{outlet}}"
+    },
+    {
+      filename: "isolated.js",
+      contents: `import Component from '@glimmer/component';
+
+export default class IsolatedComponent extends Component {}
+`
+    }
+  ]
+};
+
+export default blueprint;

--- a/packages/cli/new-card.ts
+++ b/packages/cli/new-card.ts
@@ -1,0 +1,39 @@
+import { join } from "path";
+import { writeFileSync, ensureDirSync } from "fs-extra";
+import UI from "console-ui";
+import { todo } from "@cardstack/plugin-utils/todo-any";
+import blueprint from "./blueprint";
+
+interface Options {
+  cardName?: todo; // todo - figure out how to make this required in TS
+  ui: UI;
+}
+
+class CardGenerator {
+  private cardName: string;
+  private ui: UI;
+
+  constructor({ cardName, ui }: Options) {
+    this.cardName = cardName;
+    this.ui = ui;
+    ui.writeInfoLine(
+      `Creating a Card named ${this.cardName} in the current directory`
+    );
+  }
+
+  async createFiles() {
+    // iterate over blueprint one level deep and create files
+    // creates files like some-card-name/components/embedded.hbs
+    for (let key in blueprint) {
+      blueprint[key].forEach((file) => {
+        ensureDirSync(join(this.cardName, key));
+        writeFileSync(join(this.cardName, key, file.filename), file.contents);
+      });
+    }
+  }
+}
+
+export default async function newCard(options: Options) {
+  let generator = new CardGenerator(options);
+  return generator.createFiles();
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,7 @@
   "repository": "https://github.com/cardstack/cardstack",
   "description": "Command line tools for Cardstack.",
   "dependencies": {
+    "@cardstack/plugin-utils": "0.14.21",
     "@ember/octane-app-blueprint": "0.20.0",
     "@types/console-ui": "^2.2.0",
     "@types/fs-extra": "^5.0.5",


### PR DESCRIPTION
The command `cardstack new my-card-name` creates `/my-card-name/components/` in the directory that the command was run in. `components` contains `embedded.[js. hbs, css]` and `isolated.[js. hbs, css]. If no card name is specified, it errors.

Once I get some feedback, I will write a test for the functionality. I could use some help with the TS interpretation of the `cardName` arg.

Next steps in later PRs are:
- make the Component import come from a Cardstack package instead of Ember?
- initialize git for the card?
- include a readme and package.json in generated files?
- incorporate generated files into the build