### PR TITLE
Bugfix - enable string field editor

### DIFF
--- a/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
+++ b/packages/tools/addon/templates/components/cs-active-composition-panel.hbs
@@ -40,7 +40,7 @@
                   content=field.model
                   field=field.name
                   editorOptions=editorOptions
-                  enabled=enabled
+                  enabled=editingEnabled
                   permissions=fieldModelPermissions
                   onchange=(action "validate")
                   class="cs-active-composition-panel--field-editor"

--- a/packages/tools/tests/acceptance/tools-test.js
+++ b/packages/tools/tests/acceptance/tools-test.js
@@ -282,6 +282,15 @@ module('Acceptance | tools', function(hooks) {
     assert.dom('.top-post .post-embedded').hasText('Adventures in Pirating');
   });
 
+  test('header sections strings are editable', async function(assert) {
+    await visit('/hub/posts/1');
+    await login();
+    await click('[data-test-cardstack-tools-launcher]');
+    await waitFor('[data-test-cs-active-composition-panel-main]');
+    let keywords = '[data-test-cs-field-editor="keywords"] input';
+    assert.dom(keywords).isNotDisabled();
+  })
+
   test('saving a new document changes the URL to the canonical path of the saved document', async function(assert) {
     await visit('/hub/posts/1');
     await login();


### PR DESCRIPTION
See #813 

To test this fix, you can copy the new test into `master` for `packages/tools` and run it with `ember test`, and see it fail. Another way is to run `ember s` on master for `packages/tools`, and try editing the `keywords` of an article (you can't), then do the same for this branch (now you can).

It appears that the `fillIn` test helper doesn't check for the `disabled` property on inputs. See an upstream bugfix in ember-test-helpers https://github.com/emberjs/ember-test-helpers/pull/681