### PR TITLE
[DOC] write some API docs for the git plugin, closes #830

### DIFF
--- a/packages/git/README.md
+++ b/packages/git/README.md
@@ -1,7 +1,109 @@
-This is a Cardstack data source plugin for reading and writing to Git.
+# @cardstack/git
 
-Building native nodegit dep on osx
---------------------------------
+This is a Cardstack data source plugin for reading and writing to Git.
+Always have access to see how data has changed across time.
+
+Features:
+
+- Just like using git for code, your data is versioned. A deleted or changed record can be retrieved!
+- Card data can be saved to either local or remote git repositories
+- Data can be stored in either the same repository as the project code,
+or a separate repository
+- Data for multiple projects can be saved to the same repository
+
+## Installing in a Cardstack project
+
+To use a git as a data source, include `@cardstack/git` in the `devDependencies`
+of `cardhost/package.json`
+
+```bash
+yarn add --dev @cardstack/git
+yarn install
+```
+
+See the "Troubleshooting" section of this README if you encounter any issues installing.
+
+## Configuration
+
+Data plugins are configured in `cardhost/data-sources`.
+The only required configuration is to set either the `repo` or `remote`.
+
+| Parameter | Type |  Description |
+|-----------|------|-------------|
+| `remote` | object |  Use a remote git repository, such as one hosted on Github. The object should contain a `url` and `privateKey` as strings. Example: `remote: { url: 'some-url', privateKey: process.env.GIT_PRIVATE_KEY}`|
+| `repo` | string | The path to a local git repository that already exists on disk |
+| `branchPrefix` | string | optional - a prefix to prepend to the git branch when saving data. This is especially useful when you are storing data in the same repository as your project, or you have one repository that holds code for multiple projects. Example: if you set `basePath: 'cs-'`, data will be stored at `cs-master`|
+| `basePath` | string | optional - specify the directory within a repository where the data should be stored. Example: if you set `basePath` to `my/base` and you save an `article` Card, data will be stored at `my/base/contents/articles/`|
+
+### Example configuration
+
+For example, the configuration below is set in `cardhost/data-sources/default.js`.
+It would use a local git repository for local development,
+and point to a repository on GitHub once it is deployed to production.
+Remember, keep your private keys safe and do not commit them!
+
+```js
+let sources = [
+  {
+    type: 'plugin-configs',
+    id: '@cardstack/hub',
+    attributes: {
+      'plugin-config': {
+        'application-card': { type: 'app-cards', id: 'cardhost' }
+      }
+    },
+    relationships: {
+      'default-data-source': {
+        data: { type: 'data-sources', id: 'default' }
+      }
+    }
+  }
+];
+
+if (process.env.HUB_ENVIRONMENT === 'production') {
+  sources.push({
+    type: 'data-sources',
+    id: 'default',
+    attributes: {
+      'source-type': '@cardstack/git',
+      params: {
+        branchPrefix: 'cs-',
+        remote: {
+          url: 'git@github.com:cardstack/some-git-repo.git',
+          privateKey: process.env.GIT_PRIVATE_KEY,
+        }
+      }
+    }
+  });
+} else {
+  sources.push({
+    type: 'data-sources',
+    id: 'default',
+    attributes: {
+      'source-type': '@cardstack/git',
+      params: {
+        repo: '/path/to/some-git-repo'
+      }
+    },
+  });
+}
+
+module.exports = sources;
+```
+
+## Learn more
+
+To learn more about how it can be used in your project,
+see the [Cardstack Guides about git](https://docs.cardstack.com/release/data/git/).
+
+## Troubleshooting
+
+### Windows installation - Building native nodegit dep
+
+Windows users should install [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools),
+which are needed in order to build the `nodegit` dependency.
+
+### OSX installation - Building native nodegit dep
 
 You need the latest Xcode *and* you need to manually tell it to get the latest CLI tools via
 

--- a/packages/git/README.md
+++ b/packages/git/README.md
@@ -26,12 +26,12 @@ See the "Troubleshooting" section of this README if you encounter any issues ins
 ## Configuration
 
 Data plugins are configured in `cardhost/data-sources`.
-The only required configuration is to set either the `repo` or `remote`.
+The only required configuration is to set either `repo` or `remote`.
 
 | Parameter | Type |  Description |
 |-----------|------|-------------|
 | `remote` | object |  Use a remote git repository, such as one hosted on Github. The object should contain a `url` string and the absolute path to your `privateKey` as a string. Example: `remote: { url: 'some-url', privateKey: process.env.GIT_PRIVATE_KEY}`|
-| `repo` | string | The path to a local git repository that already exists on disk |
+| `repo` | string | The path to a local git repository that already exists on disk, and has an initial commit |
 | `branchPrefix` | string | optional - a prefix to prepend to the git branch when saving data. This is especially useful when you are storing data in the same repository as your project, or you have one repository that holds code for multiple projects. Example: if you set `basePath: 'cs-'`, data will be stored at `cs-master`|
 | `basePath` | string | optional - specify the directory within a repository where the data should be stored. Example: if you set `basePath` to `my/base` and you save an `article` Card, data will be stored at `my/base/contents/articles/`|
 
@@ -44,9 +44,8 @@ GIT_PRIVATE_KEY="/path/to/your/key/id_rsa"
 ### Example configuration
 
 For example, the configuration below is set in `cardhost/data-sources/default.js`.
-It would use a local git repository for local development,
-and point to a repository on GitHub once it is deployed to production.
-Remember, keep your private keys safe and do not commit them!
+The Hub has a `default-data-source` relationship that points to `@cardstack/git`.
+The result for this example is that Cards will use a local git repository by default.
 
 ```js
 let sources = [
@@ -63,26 +62,8 @@ let sources = [
         data: { type: 'data-sources', id: 'default' }
       }
     }
-  }
-];
-
-if (process.env.HUB_ENVIRONMENT === 'production') {
-  sources.push({
-    type: 'data-sources',
-    id: 'default',
-    attributes: {
-      'source-type': '@cardstack/git',
-      params: {
-        branchPrefix: 'cs-',
-        remote: {
-          url: 'git@github.com:cardstack/some-git-repo.git',
-          privateKey: process.env.GIT_PRIVATE_KEY,
-        }
-      }
-    }
-  });
-} else {
-  sources.push({
+  },
+  {
     type: 'data-sources',
     id: 'default',
     attributes: {
@@ -90,9 +71,9 @@ if (process.env.HUB_ENVIRONMENT === 'production') {
       params: {
         repo: '/path/to/some-git-repo'
       }
-    },
-  });
-}
+    }
+  }
+];
 
 module.exports = sources;
 ```

--- a/packages/git/README.md
+++ b/packages/git/README.md
@@ -30,10 +30,16 @@ The only required configuration is to set either the `repo` or `remote`.
 
 | Parameter | Type |  Description |
 |-----------|------|-------------|
-| `remote` | object |  Use a remote git repository, such as one hosted on Github. The object should contain a `url` and `privateKey` as strings. Example: `remote: { url: 'some-url', privateKey: process.env.GIT_PRIVATE_KEY}`|
+| `remote` | object |  Use a remote git repository, such as one hosted on Github. The object should contain a `url` string and the absolute path to your `privateKey` as a string. Example: `remote: { url: 'some-url', privateKey: process.env.GIT_PRIVATE_KEY}`|
 | `repo` | string | The path to a local git repository that already exists on disk |
 | `branchPrefix` | string | optional - a prefix to prepend to the git branch when saving data. This is especially useful when you are storing data in the same repository as your project, or you have one repository that holds code for multiple projects. Example: if you set `basePath: 'cs-'`, data will be stored at `cs-master`|
 | `basePath` | string | optional - specify the directory within a repository where the data should be stored. Example: if you set `basePath` to `my/base` and you save an `article` Card, data will be stored at `my/base/contents/articles/`|
+
+You can set variables such as `process.env.GIT_PRIVATE_KEY` from the command line. For the example below, substitute your own path to the key:
+
+```bash
+GIT_PRIVATE_KEY="/path/to/your/key/id_rsa"
+```
 
 ### Example configuration
 

--- a/packages/git/README.md
+++ b/packages/git/README.md
@@ -44,8 +44,9 @@ GIT_PRIVATE_KEY="/path/to/your/key/id_rsa"
 ### Example configuration
 
 For example, the configuration below is set in `cardhost/data-sources/default.js`.
-The Hub has a `default-data-source` relationship that points to `@cardstack/git`.
-The result for this example is that Cards will use a local git repository by default.
+This config creates a `@cardstack/git` data source named `default` and configures it 
+as the Hub's `default-data-source`.
+Now, if a Card does not have its own data source defined, it will use git.
 
 ```js
 let sources = [


### PR DESCRIPTION
I read through the tests and determined that this seems to be the public API for using the git plugin. This documentation is needed so that I can link to it from the Guides/Tutorial