### PR TITLE
Bugfix: Handle `everyone` group

### DIFF
--- a/packages/hub/bootstrap-schema.js
+++ b/packages/hub/bootstrap-schema.js
@@ -831,7 +831,20 @@ const models = [
     attributes: {
       'source-type': '@cardstack/routing'
     }
-  }
+  },
+  /* 
+  The `everyone` group handles users who do not get assigned a role, so they
+  default to everyone. Use this grant for things like universal, anonymous
+  read of public info. An entry here is required so that the searcher runs.
+  Also see everyone-group.js.
+  */
+  {
+    type: 'data-sources',
+    id: 'everyone-group',
+    attributes: {
+      'source-type': '@cardstack/hub::everyone-group',
+    }
+  },
 
 ];
 

--- a/packages/hub/schema/group.js
+++ b/packages/hub/schema/group.js
@@ -1,44 +1,29 @@
-const { get, isEqual, intersection } = require('lodash');
+const {
+  get,
+  isEqual,
+  intersection
+} = require('lodash');
 
 module.exports = class Group {
   constructor(model, allFields) {
-    let searchQuery = get(model, 'attributes.search-query');
-    if (!searchQuery) {
-      throw new Error(`group must have a search-query attribute: ${JSON.stringify(model, null, 2)}`);
+    if (model.type === 'groups' && model.id === 'everyone') {
+      // Skip validation for the `everyone` group. All users get assigned this group.
+      // See also bootstrap-schema.js and everyone-group.js for special handling.
+      this.id = model.id;
+      this.types = []; // required for downstream typechecks
+    } else {
+      let searchQuery = get(model, 'attributes.search-query');
+      this.types = validatedTypes(searchQuery, model);
+      this._fieldFilters = validatedFieldFilters(allFields,  searchQuery, model);
+      this._allFields = allFields;
+      this.id = model.id;
     }
-    let types = get(searchQuery, 'filter.type.exact');
-    if (!types) {
-      throw new Error(`group ${model.id} search-query is required to filter by exact types: ${JSON.stringify(searchQuery, null, 2)}`);
-    }
-    if (!Array.isArray(types)) {
-      types = [types];
-    }
-    this.types = types;
-
-    let fieldFilters = new Map();
-    for (let [field, values] of Object.entries(searchQuery.filter)) {
-      if (field === 'type') {
-        continue;
-      }
-      if (!allFields.has(field)) {
-        throw new Error(`group ${model.id}'s search query is targeting unknown field ${field}: ${JSON.stringify(searchQuery, null, 2)}`);
-      }
-      if (!values.exact) {
-        throw new Error(`group ${model.id}'s search query must use an exact filter for field ${field}: ${JSON.stringify(searchQuery, null, 2)}`);
-      }
-      if (Array.isArray(values.exact)) {
-        fieldFilters.set(field, values.exact);
-      } else {
-        fieldFilters.set(field, [values.exact]);
-      }
-    }
-    this._fieldFilters = fieldFilters;
-    this._allFields = allFields;
-    this.id = model.id;
   }
 
   test(document) {
-    let change = { finalDocument: document };
+    let change = {
+      finalDocument: document
+    };
     return [...this._fieldFilters.entries()].every(([fieldName, allowedValues]) => {
       let field = this._allFields.get(fieldName);
       // TODO: update this to use Model.getField() as we do in Grant.readRealmsFromField
@@ -51,5 +36,39 @@ module.exports = class Group {
       }
     });
   }
+};
 
+const validatedFieldFilters = function(allFields,  searchQuery, model) {
+  let fieldFilters = new Map();
+  for (let [field, values] of Object.entries(searchQuery.filter)) {
+    if (field === 'type') {
+      continue;
+    }
+    if (!allFields.has(field)) {
+      throw new Error(`group ${model.id}'s search query is targeting unknown field ${field}: ${JSON.stringify(searchQuery, null, 2)}`);
+    }
+    if (!values.exact) {
+      throw new Error(`group ${model.id}'s search query must use an exact filter for field ${field}: ${JSON.stringify(searchQuery, null, 2)}`);
+    }
+    if (Array.isArray(values.exact)) {
+      fieldFilters.set(field, values.exact);
+    } else {
+      fieldFilters.set(field, [values.exact]);
+    }
+  }
+  return fieldFilters;
+};
+
+const validatedTypes = function (searchQuery, model) {
+  let types = get(searchQuery, 'filter.type.exact');
+  if (!searchQuery) {
+    throw new Error(`group must have a search-query attribute: ${JSON.stringify(model, null, 2)}`);
+  }
+  if (!types) {
+    throw new Error(`group ${model.id} search-query is required to filter by exact types: ${JSON.stringify(searchQuery, null, 2)}`);
+  }
+  if (!Array.isArray(types)) {
+    types = [types];
+  }
+  return types;
 };

--- a/packages/hub/searchers/everyone-group.js
+++ b/packages/hub/searchers/everyone-group.js
@@ -1,0 +1,47 @@
+const { declareInjections } = require('@cardstack/di');
+
+module.exports = declareInjections({
+  currentSchema: 'hub:current-schema',
+  searchers: 'hub:searchers'
+},
+
+/*
+This Searcher handles resources that have anonymous read, 
+such as a blog post that should be visible to non-logged-in users.
+It skips validation and returns the "everyone" groups document.
+The purpose of this Searcher is to avoid an unnecessary
+database query. See bootstrap-schema and group.js for
+special handling of "everyone" groups.
+*/
+
+class EveryoneGroupsSearcher {
+  static create(...args) {
+    return new this(...args);
+  }
+  constructor({ dataSource, currentSchema, searchers}) {
+    this.dataSource = dataSource;
+    this.currentSchema = currentSchema;
+    this.searchers = searchers;
+  }
+
+  async get(session, type, id, next) {
+    if (type === 'groups' && id === 'everyone') {
+      return {
+        data: {
+           id: 'everyone',
+           type: 'groups',
+           attributes: {
+             'search-query': {}
+           }
+        }
+      };
+    } else {
+      return next();
+    }
+  }
+
+  async search(session, query, next) {
+    return next();
+  }
+
+});

--- a/packages/hub/searchers/everyone-group.js
+++ b/packages/hub/searchers/everyone-group.js
@@ -14,7 +14,7 @@ database query. See bootstrap-schema and group.js for
 special handling of "everyone" groups.
 */
 
-class EveryoneGroupsSearcher {
+class EveryoneGroupSearcher {
   static create(...args) {
     return new this(...args);
   }


### PR DESCRIPTION
As part of the review, I would like help figuring out what kind of test this should have. I was not able to call the searcher directly as a unit test, and the [failing test in Cardboard](https://github.com/cardstack/cardboard/blob/6eec2990ee2b661c79357a6627039877e153b18f/cards/article/node-tests/grant-test.js#L141) is not portable.

Added:
- `EveryoneGroup` searcher that returns a document for the everyone group, in order to skip group validations and an unnecessary database query
- an entry into `bootstrap-schema` so the new searcher will run

Changed:
- I had to add a validation exception to `group.js`, since the `everyone` group has no search queries and filters. The constructor function was handling too much after that, so I split it into functions, with no change in behavior for those sections.

Still needs:
- a test