### PR TITLE
writes cards on disk as a side effect of loading card schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /packages/*/dist
 /packages/*/tmp
 /packages/*/vendor
+/card_modules
 .eslintcache
 .vagrant
 .nvmrc
@@ -27,6 +28,9 @@ package-lock.json
 /packages/hub/indexing/operations.js
 /packages/hub/indexing/operations.js.map
 
+/packages/plugin-utils/error.d.ts
+/packages/plugin-utils/error.js
+/packages/plugin-utils/error.js.map
 /packages/plugin-utils/session.d.ts
 /packages/plugin-utils/session.js
 /packages/plugin-utils/session.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 /packages/*/dist
 /packages/*/tmp
 /packages/*/vendor
-/card_modules
 .eslintcache
 .vagrant
 .nvmrc

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -103,14 +103,15 @@
       "console": "integratedTerminal",
       "cwd": "${workspaceRoot}",
       "env": {
-        "HUB_ENVIRONMENT": "test"
+        "HUB_ENVIRONMENT": "test",
+        // "LOG_LEVELS": "cardstack/card-utils=debug"
       },
       "args": [
         "packages/test-support/bin/run.js",
         "--timeout",
         "200000",
         //  "--grep",
-        //  "reuses included resources"
+        //  "hub/card-services"
       ]
     },
     {

--- a/packages/authentication/app/authorizers/cardstack.js
+++ b/packages/authentication/app/authorizers/cardstack.js
@@ -1,1 +1,0 @@
-export { default } from '@cardstack/authentication/authorizers/cardstack';

--- a/packages/hub/bootstrap-schema.js
+++ b/packages/hub/bootstrap-schema.js
@@ -38,13 +38,10 @@ const models = [
     relationships: {
       fields: {
         data: [
-          { type: 'fields', id: 'edit-template' },
           { type: 'fields', id: 'isolated-template' },
           { type: 'fields', id: 'embedded-template' },
-          { type: 'fields', id: 'edit-js' },
           { type: 'fields', id: 'isolated-js' },
           { type: 'fields', id: 'embedded-js' },
-          { type: 'fields', id: 'edit-css' },
           { type: 'fields', id: 'isolated-css' },
           { type: 'fields', id: 'embedded-css' },
           // This relationship is used to define the metadata fields that the card contains,

--- a/packages/hub/indexing/card-utils.ts
+++ b/packages/hub/indexing/card-utils.ts
@@ -4,6 +4,7 @@ import { SingleResourceDoc, ResourceObject, ResourceIdentifierObject, Collection
 import { get, uniqBy, isEqual, sortBy } from 'lodash';
 import logger from '@cardstack/logger';
 import { join } from "path";
+import { tmpdir } from 'os';
 import {
   ensureDirSync,
   pathExistsSync,
@@ -11,7 +12,7 @@ import {
   removeSync,
 } from "fs-extra";
 
-const cardsDir: string = join(process.cwd(), 'card_modules');
+const cardsDir: string = join(tmpdir(), 'card_modules');
 const cardFileName = 'card.js';
 const log = logger('cardstack/card-utils');
 

--- a/packages/hub/indexing/document-context.js
+++ b/packages/hub/indexing/document-context.js
@@ -8,7 +8,7 @@ const {
   cardIdDelim,
   cardContextToId,
   cardContextFromId,
-  schemaModelsForCard,
+  loadCard,
   adaptCardToFormat,
   adaptCardCollectionToFormat,
   getCardIncludePaths
@@ -440,14 +440,17 @@ module.exports = class DocumentContext {
 
     if (this._cardCache[id]) {
       await this._cardCache[id];
-      await this._loadingCardSchema;
       return;
     }
 
-    let card = await this._getCard(id);
-    let cardSchema = schemaModelsForCard(this.schema, card);
-    let schema = this._loadingCardSchema = this.schema.applyChanges(cardSchema.map(document => ({ id:document.id, type:document.type, document })));
-    this.schema = await schema;
+    this._cardCache[id] = this._updateSchema(id);
+    await this._cardCache[id];
+  }
+
+  async _updateSchema(cardId) {
+    let card = await this._getCard(cardId);
+    let cardSchema = await loadCard(this.schema, card);
+    this.schema = await this.schema.applyChanges(cardSchema.map(document => ({ id:document.id, type:document.type, document })));
   }
 
   async _buildCachedResponse() {

--- a/packages/hub/node-tests/cards-test.js
+++ b/packages/hub/node-tests/cards-test.js
@@ -6,10 +6,11 @@ const {
 const { removeSync, pathExistsSync } = require('fs-extra');
 const { readFileSync } = require('fs');
 const { join } = require('path');
+const { tmpdir } = require('os');
 const { sortBy } = require('lodash');
 let factory = new JSONAPIFactory();
 
-const cardsDir = join(process.cwd(), 'card_modules');
+const cardsDir = join(tmpdir(), 'card_modules');
 
 function cleanup() {
   removeSync(cardsDir);

--- a/packages/plugin-utils/error.ts
+++ b/packages/plugin-utils/error.ts
@@ -7,14 +7,28 @@
 
 */
 
-const { STATUS_CODES } = require('http');
+import { todo } from './todo-any';
+import { STATUS_CODES } from 'http';
+
+interface ErrorDetails {
+  status?: number;
+  title?: string;
+  source?: todo;
+}
 
 class E extends Error {
-  constructor(detail, { status, title, source} = {}) {
+  detail: string;
+  status: number;
+  title?: string;
+  source?: todo;
+  isCardstackError: boolean;
+  additionalErrors: todo;
+
+  constructor(detail: todo, { status, title, source}: ErrorDetails = {}) {
     super(detail);
     this.detail = detail;
     this.status = status || 500;
-    this.title = title || STATUS_CODES[status];
+    this.title = title || STATUS_CODES[this.status];
     this.source = source;
     this.isCardstackError = true;
     this.additionalErrors = null;
@@ -28,7 +42,7 @@ class E extends Error {
     };
   }
 
-  static async withJsonErrorHandling(ctxt, fn) {
+  static async withJsonErrorHandling(ctxt: todo, fn: todo) {
     try {
       return await fn();
     } catch (err) {
@@ -44,4 +58,5 @@ class E extends Error {
     }
   }
 }
-module.exports = E;
+
+export = E;


### PR DESCRIPTION
Adding logic to write discovered cards to the hub's filesystem so we will be well positioned to perform embroider builds from the discovered card's browser assets (also removing the edit format stuff--we can re-add this when we actually tackle custom card edit mode components/templates). Also fixed a bug around how we are caching cards in the DocumentContext.