### PR TITLE
(3 of 4) Card relationships and validation

### DIFF
--- a/packages/cardhost/app/components/card-creator.js
+++ b/packages/cardhost/app/components/card-creator.js
@@ -110,6 +110,7 @@ export default class CardCreator extends Component {
       json = yield response.json();
       if (!response.ok) {
         this.statusMsg = `Error creating card: ${response.status}: ${response.statusText} - ${JSON.stringify(json)}`;
+        return;
       }
     } catch (e) {
       console.error(e); // eslint-disable-line no-console

--- a/packages/cardhost/app/templates/components/card-creator.hbs
+++ b/packages/cardhost/app/templates/components/card-creator.hbs
@@ -6,7 +6,7 @@
 [[TODO add controls to add/remove metadata fields...]]<br>
 
 {{#if this.statusMsg}}
-  <div><strong>{{this.statusMsg}}</strong></div>
+  <div data-test-card-creator-msg><strong>{{this.statusMsg}}</strong></div>
 {{/if}}
 
 <CardInspector @card={{this.cardData}}></CardInspector>

--- a/packages/cardhost/tests/acceptance/create-card-test.js
+++ b/packages/cardhost/tests/acceptance/create-card-test.js
@@ -2,11 +2,16 @@ import { module, test } from 'qunit';
 import { click, visit, currentURL, waitFor } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import Fixtures from '@cardstack/test-support/fixtures'
-import { getCodeMirrorValue } from '../helpers/code-mirror';
+import { getCodeMirrorValue, setCodeMirrorValue } from '../helpers/code-mirror';
+import JSONAPIFactory from '@cardstack/test-support/jsonapi-factory';
+import { createCard } from '../helpers/card-helpers';
 
 const scenario = new Fixtures({
   destroy() {
-    return [{ type: 'cards', id: 'local-hub::article-card::millenial-puppies' }];
+    return [
+      { type: 'cards', id: 'local-hub::article-card::millenial-puppies' },
+      { type: 'cards', id: 'local-hub::user-card::van-gogh' }
+    ];
   }
 });
 
@@ -48,5 +53,96 @@ module('Acceptance | create card', function(hooks) {
     assert.equal(card.data.attributes.author, 'Van Gogh');
     assert.equal(card.data.attributes.body, `It can be difficult these days to deal with the discerning tastes of the millenial puppy.`);
     assert.equal(card.data.attributes['internal-field'], undefined);
+  });
+
+  test('cannot create card with invalid model', async function(assert) {
+    let factory = new JSONAPIFactory();
+    let card = factory.getDocumentFor(
+      factory.addResource('cards', 'local-hub::foreign-model-id-card::bad')
+        .withRelated('fields', [
+          factory.addResource('fields', 'local-hub::foreign-model-id-card::bad::title').withAttributes({
+            'is-metadata': true,
+            'field-type': '@cardstack/core-types::string'
+          }),
+        ])
+        .withRelated('model', factory.addResource('local-hub::foreign-model-id-card::bad', 'local-hub::foreign-model-id-card::ugh')
+          .withAttributes({
+            'title': "I don't belong to you"
+          })
+        )
+    );
+
+    await visit('/cards/new');
+    setCodeMirrorValue(JSON.stringify(card, null, 2));
+
+    await click('[data-test-card-creator-add-btn]');
+    await waitFor('[data-test-card-creator-msg]');
+
+    assert.equal(currentURL(), '/cards/new');
+    assert.dom('[data-test-card-creator-msg]').includesText('the card model does not match the card id');
+  });
+
+  test('can create a card that has a relationship to another card', async function(assert) {
+    let factory = new JSONAPIFactory();
+
+    await createCard(factory.getDocumentFor(
+      factory.addResource('cards', 'local-hub::user-card::van-gogh')
+        .withRelated('fields', [
+          factory.addResource('fields', 'local-hub::user-card::van-gogh::name').withAttributes({
+            'is-metadata': true,
+            'needed-when-embedded': true,
+            'field-type': '@cardstack/core-types::string'
+          }),
+          factory.addResource('fields', 'local-hub::user-card::van-gogh::email').withAttributes({
+            'is-metadata': true,
+            'field-type': '@cardstack/core-types::case-insensitive'
+          }),
+        ])
+        .withRelated('model', factory.addResource('local-hub::user-card::van-gogh', 'local-hub::user-card::van-gogh')
+          .withAttributes({
+            name: 'Van Gogh',
+            email: 'vangogh@nowhere.dog'
+          })
+        )
+    ));
+
+    factory = new JSONAPIFactory();
+    await createCard(factory.getDocumentFor(
+      factory.addResource('cards', 'local-hub::article-card::millenial-puppies')
+        .withRelated('fields', [
+          factory.addResource('fields', 'local-hub::article-card::millenial-puppies::body').withAttributes({
+            'is-metadata': true,
+            'field-type': '@cardstack/core-types::string'
+          }),
+          factory.addResource('fields', 'local-hub::article-card::millenial-puppies::author').withAttributes({
+            'is-metadata': true,
+            'needed-when-embedded': true,
+            'field-type': '@cardstack/core-types::belongs-to'
+          }),
+        ])
+        .withRelated('model', factory.addResource('local-hub::article-card::millenial-puppies', 'local-hub::article-card::millenial-puppies')
+          .withAttributes({
+            body: 'It can be difficult these days to deal with the discerning tastes of the millenial puppy.'
+          })
+          .withRelated('author', { type: 'cards', id: 'local-hub::user-card::van-gogh'})
+        )
+    ));
+
+    assert.equal(currentURL(), '/cards/local-hub::article-card::millenial-puppies');
+    assert.dom('[data-test-card-inspector-field="body"] [data-test-card-inspector-value]').hasText(`It can be difficult these days to deal with the discerning tastes of the millenial puppy.`);
+    assert.dom('[data-test-card-inspector-field="body"] [data-test-card-inspector-field-type]').hasText('@cardstack/core-types::string');
+    assert.dom('[data-test-card-inspector-field="body"] [data-test-card-inspector-is-meta]').hasText('true');
+    assert.dom('[data-test-card-inspector-field="body"] [data-test-card-inspector-embedded]').hasText('false');
+
+    assert.dom('[data-test-card-inspector-field="author"] [data-test-card-inspector-value]').includesText('{ "type": "cards", "id": "local-hub::user-card::van-gogh" }');
+    assert.dom('[data-test-card-inspector-field="author"] [data-test-card-inspector-field-type]').hasText('@cardstack/core-types::belongs-to');
+    assert.dom('[data-test-card-inspector-field="author"] [data-test-card-inspector-is-meta]').hasText('true');
+    assert.dom('[data-test-card-inspector-field="author"] [data-test-card-inspector-embedded]').hasText('true');
+
+    let card = JSON.parse(getCodeMirrorValue());
+    assert.deepEqual(card.data.relationships.author.data, { type: 'cards', id: 'local-hub::user-card::van-gogh' });
+    let userCard = card.included.find(i => `${i.type}/${i.id}` === 'cards/local-hub::user-card::van-gogh');
+    assert.equal(userCard.attributes.name, 'Van Gogh');
+    assert.equal(userCard.attributes.email, undefined);
   });
 });

--- a/packages/cardhost/tests/acceptance/update-card-test.js
+++ b/packages/cardhost/tests/acceptance/update-card-test.js
@@ -1,10 +1,10 @@
-
 import { module, test } from 'qunit';
 import { click, visit, currentURL, waitFor } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import JSONAPIFactory from '@cardstack/test-support/jsonapi-factory';
 import Fixtures from '@cardstack/test-support/fixtures'
 import { setCodeMirrorValue, getCodeMirrorValue } from '../helpers/code-mirror';
+import { createCard } from '../helpers/card-helpers';
 
 let factory = new JSONAPIFactory();
 let articleCard = factory.getDocumentFor(
@@ -21,15 +21,6 @@ let articleCard = factory.getDocumentFor(
       })
     )
 );
-
-async function createCard(card) {
-  await visit('/cards/new');
-  if (card) {
-    setCodeMirrorValue(JSON.stringify(card, null, 2));
-  }
-  await click('[data-test-card-creator-add-btn]');
-  await waitFor('[data-test-card-updator="local-hub::article-card::millenial-puppies"]');
-}
 
 const scenario = new Fixtures({
   destroy() {

--- a/packages/cardhost/tests/helpers/card-helpers.js
+++ b/packages/cardhost/tests/helpers/card-helpers.js
@@ -1,0 +1,11 @@
+import { click, visit, waitFor } from '@ember/test-helpers';
+import { setCodeMirrorValue } from './code-mirror';
+
+export async function createCard(card) {
+  await visit('/cards/new');
+  if (card) {
+    setCodeMirrorValue(JSON.stringify(card, null, 2));
+  }
+  await click('[data-test-card-creator-add-btn]');
+  await waitFor(`[data-test-card-updator="${card.data.id}"]`);
+}

--- a/packages/hub/card-services.ts
+++ b/packages/hub/card-services.ts
@@ -25,12 +25,12 @@ class CardServices {
 
   async get(session: Session, id: string, format: string) {
     let card: SingleResourceDoc = await this.searchers.get(session, 'local-hub', id, id, { format }) as SingleResourceDoc;
-    return await adaptCardToFormat(await this.currentSchema.getSchema(), card, format);
+    return await adaptCardToFormat(await this.currentSchema.getSchema(), session, card, format, this);
   }
 
   async search(session: Session, format: string, query: todo) {
     let cards: CollectionResourceDoc = await this.searchers.search(session, query, { format }) as CollectionResourceDoc;
-    return await adaptCardCollectionToFormat(await this.currentSchema.getSchema(), cards, format);
+    return await adaptCardCollectionToFormat(await this.currentSchema.getSchema(), session, cards, format, this);
   }
 
   async create(session: Session, card: SingleResourceDoc) {

--- a/packages/hub/node-tests/external-cards/foreign-model-id.js
+++ b/packages/hub/node-tests/external-cards/foreign-model-id.js
@@ -1,0 +1,17 @@
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
+let factory = new JSONAPIFactory();
+
+module.exports = factory.getDocumentFor(
+  factory.addResource('cards', 'local-hub::foreign-model-id-card::bad')
+    .withRelated('fields', [
+      factory.addResource('fields', 'local-hub::foreign-model-id-card::bad::title').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::string'
+      }),
+    ])
+    .withRelated('model', factory.addResource('local-hub::foreign-model-id-card::bad', 'local-hub::foreign-model-id-card::ugh')
+      .withAttributes({
+        'title': "I don't belong to you"
+      })
+    )
+);

--- a/packages/hub/node-tests/external-cards/foreign-model-type.js
+++ b/packages/hub/node-tests/external-cards/foreign-model-type.js
@@ -1,0 +1,17 @@
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
+let factory = new JSONAPIFactory();
+
+module.exports = factory.getDocumentFor(
+  factory.addResource('cards', 'local-hub::foreign-model-type-card::bad')
+    .withRelated('fields', [
+      factory.addResource('fields', 'local-hub::foreign-model-type-card::bad::title').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::string'
+      }),
+    ])
+    .withRelated('model', factory.addResource('local-hub::article-card::bad', 'local-hub::foreign-model-type-card::bad')
+      .withAttributes({
+        'title': "I don't belong to you"
+      })
+    )
+);

--- a/packages/hub/node-tests/internal-cards/article-card.js
+++ b/packages/hub/node-tests/internal-cards/article-card.js
@@ -1,0 +1,107 @@
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
+let factory = new JSONAPIFactory();
+
+// This is the internal representation of a card. Browser clients do not
+// encounter this form of a card. Look at the jsonapi tests and browser
+// tests for the structure of a card as it is known externally.
+let card = factory.getDocumentFor(
+  factory.addResource('local-hub::article-card::millenial-puppies', 'local-hub::article-card::millenial-puppies')
+    .withAttributes({
+      'isolated-template': `
+        <h1>{{this.title}}</h1>
+        <h3>By {{this.author}}</h3>
+        <ul>
+          {{#each this.tags as |tag|}}
+            <li>{{tag.id}}</li>
+          {{/each}}
+        </ul>
+        <div>{{this.body}}</div>
+      `,
+      'isolated-js': `
+        import Component from '@glimmer/component';
+        export default class ArticleIsolatedComponent extends Component {};
+      `,
+      'isolated-css': `
+        .article-card-isolated {}
+      `,
+      'embedded-template': `
+        <h3>{{this.title}}</h3>
+        <p>By {{this.author}}</p>
+      `,
+      'embedded-js': `
+        import Component from '@glimmer/component';
+        export default class ArticleEmbeddedComponent extends Component {};
+      `,
+      'embedded-css': `
+        .article-card-embedded {}
+      `,
+      'local-hub::article-card::millenial-puppies::internal-field': 'this is internal data',
+      'local-hub::article-card::millenial-puppies::title': 'The Millenial Puppy',
+      'local-hub::article-card::millenial-puppies::body': `
+        It can be difficult these days to deal with the
+        discerning tastes of the millenial puppy. In this
+        article we probe the needs and desires of millenial
+        puppies and why they love belly rubs so much.
+      `
+    })
+    .withRelated('fields', [
+      factory.addResource('fields', 'local-hub::article-card::millenial-puppies::title').withAttributes({
+        'is-metadata': true,
+        'needed-when-embedded': true,
+        'field-type': '@cardstack/core-types::string' //TODO rework for fields-as-cards
+      }).withRelated('constraints', [
+        factory.addResource('constraints', 'local-hub::article-card::millenial-puppies::title-not-null')
+          .withAttributes({
+            'constraint-type': '@cardstack/core-types::not-null',
+            'error-message': 'The title must not be empty.'
+          })
+      ]),
+      // TODO add the idea of "related-cards" after we support adopts and implements
+      factory.addResource('fields', 'local-hub::article-card::millenial-puppies::author').withAttributes({
+        'is-metadata': true,
+        'needed-when-embedded': true,
+        'field-type': '@cardstack/core-types::belongs-to'
+      }),
+      factory.addResource('fields', 'local-hub::article-card::millenial-puppies::body').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::string'
+      }),
+      factory.addResource('fields', 'local-hub::article-card::millenial-puppies::internal-field').withAttributes({
+        'field-type': '@cardstack/core-types::string'
+      }),
+      factory.addResource('computed-fields', 'local-hub::article-card::millenial-puppies::tag-names').withAttributes({
+        'is-metadata': true,
+        'needed-when-embedded': true,
+        'computed-field-type': 'stub-card-project::tags'
+      }),
+
+      // TODO is this a legit scenario where a card has a metadata relationship field
+      // to an internal model? Maybe instead, cards' metadata relationships can only be to other cards?
+      // Maybe a better test involving relationships to internal models would be to consume
+      // this relationship in a computed that is a metadata field (and probably we
+      // should have a test that involves a card that has a relationship to another card).
+      factory.addResource('fields', 'local-hub::article-card::millenial-puppies::tags').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::has-many'
+      }).withRelated('related-types', [
+        // this is modeling an enumeration using a private model.
+        // this content type name will be prefixed with the card's
+        // package and card name, such that other cards can also
+        // have their own 'tags' internal content types.
+        factory.addResource('content-types', 'local-hub::article-card::millenial-puppies::tags')
+      ]),
+    ])
+    .withRelated('local-hub::article-card::millenial-puppies::tags', [
+      // Note that the tags models will be prefixed with this card's ID
+      // such that you will never run into model collisions for tags
+      // of different article cards
+      factory.addResource('local-hub::article-card::millenial-puppies::tags', 'local-hub::article-card::millenial-puppies::millenials'),
+      factory.addResource('local-hub::article-card::millenial-puppies::tags', 'local-hub::article-card::millenial-puppies::puppies'),
+      factory.addResource('local-hub::article-card::millenial-puppies::tags', 'local-hub::article-card::millenial-puppies::belly-rubs'),
+    ])
+    .withRelated('local-hub::article-card::millenial-puppies::author',
+      { type: 'local-hub::user-card::van-gogh', id: 'local-hub::user-card::van-gogh'}
+    )
+);
+
+module.exports = card;

--- a/packages/hub/node-tests/internal-cards/foreign-internal-model-belongs-to-relationship.js
+++ b/packages/hub/node-tests/internal-cards/foreign-internal-model-belongs-to-relationship.js
@@ -1,0 +1,18 @@
+
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
+let factory = new JSONAPIFactory();
+
+let card = factory.getDocumentFor(
+  factory.addResource('local-hub::foreign-internal-belongs-to-relationship::bad', 'local-hub::foreign-internal-belongs-to-relationship::bad')
+    .withRelated('local-hub::foreign-internal-belongs-to-relationship::bad::related-thing',
+      { type: 'local-hub::foreign-internal-belongs-to-relationship::bad', id: 'local-hub::foreign-internal-belongs-to-relationship::millenial-puppies::owner' }
+    )
+    .withRelated('fields', [
+      factory.addResource('fields', 'local-hub::foreign-internal-belongs-to-relationship::bad::related-thing').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::belongs-to'
+      }),
+    ])
+);
+
+module.exports = card;

--- a/packages/hub/node-tests/internal-cards/foreign-internal-model-has-many-relationship.js
+++ b/packages/hub/node-tests/internal-cards/foreign-internal-model-has-many-relationship.js
@@ -1,0 +1,18 @@
+
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
+let factory = new JSONAPIFactory();
+
+let card = factory.getDocumentFor(
+  factory.addResource('local-hub::foreign-internal-has-many-relationship::bad', 'local-hub::foreign-internal-has-many-relationship::bad')
+    .withRelated('local-hub::foreign-internal-has-many-relationship::bad::related-things', [
+      { type: 'local-hub::foreign-internal-has-many-relationship::bad', id: 'local-hub::foreign-internal-has-many-relationship::millenial-puppies::owner' }
+    ])
+    .withRelated('fields', [
+      factory.addResource('fields', 'local-hub::foreign-internal-has-many-relationship::bad::related-things').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::has-many'
+      }),
+    ])
+);
+
+module.exports = card;

--- a/packages/hub/node-tests/internal-cards/foreign-internal-model-included.js
+++ b/packages/hub/node-tests/internal-cards/foreign-internal-model-included.js
@@ -1,0 +1,17 @@
+
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
+let factory = new JSONAPIFactory();
+
+let card = factory.getDocumentFor(
+  factory.addResource('local-hub::foreign-included::bad', 'local-hub::foreign-included::bad')
+    .withRelated('fields', [
+      factory.addResource('fields', 'local-hub::foreign-included::bad::tags').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::has-many'
+      }).withRelated('related-types', [
+        factory.addResource('content-types', 'local-hub::foreign-included::millenial-puppies::tags')
+      ]),
+    ])
+);
+
+module.exports = card;

--- a/packages/hub/node-tests/internal-cards/foreign-schema.js
+++ b/packages/hub/node-tests/internal-cards/foreign-schema.js
@@ -1,0 +1,12 @@
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
+let factory = new JSONAPIFactory();
+
+module.exports = factory.getDocumentFor(
+  factory.addResource('local-hub::foreign-schema-card::bad', 'local-hub::foreign-schema-card::bad')
+    .withRelated('fields', [
+      factory.addResource('fields', 'local-hub::article-card::bad::not-your-field').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::string'
+      }),
+    ])
+);

--- a/packages/hub/node-tests/internal-cards/mismatched-model.js
+++ b/packages/hub/node-tests/internal-cards/mismatched-model.js
@@ -1,0 +1,6 @@
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
+let factory = new JSONAPIFactory();
+
+module.exports = factory.getDocumentFor(
+  factory.addResource('local-hub::article-card::bad', 'local-hub::mismatched-model::bad')
+);

--- a/packages/hub/node-tests/internal-cards/user-card.js
+++ b/packages/hub/node-tests/internal-cards/user-card.js
@@ -1,0 +1,26 @@
+const JSONAPIFactory = require('@cardstack/test-support/jsonapi-factory');
+let factory = new JSONAPIFactory();
+
+// This is the internal representation of a card. Browser clients do not
+// encounter this form of a card. Look at the jsonapi tests and browser
+// tests for the structure of a card as it is known externally.
+let card = factory.getDocumentFor(
+  factory.addResource('local-hub::user-card::van-gogh', 'local-hub::user-card::van-gogh')
+    .withAttributes({
+      'local-hub::user-card::van-gogh::name': 'Van Gogh',
+      'local-hub::user-card::van-gogh::email': 'van-gogh@nowhere.dog'
+    })
+    .withRelated('fields', [
+      factory.addResource('fields', 'local-hub::user-card::van-gogh::name').withAttributes({
+        'is-metadata': true,
+        'needed-when-embedded': true,
+        'field-type': '@cardstack/core-types::string'
+      }),
+      factory.addResource('fields', 'local-hub::user-card::van-gogh::email').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::case-insensitive'
+      }),
+    ])
+);
+
+module.exports = card;

--- a/packages/hub/writers.js
+++ b/packages/hub/writers.js
@@ -23,6 +23,11 @@ class Writers {
     return this.schemaLoader.ownTypes();
   }
 
+  // not using DI to prevent circular dependency
+  _getCardServices() {
+    if (this.cardServices) { return this.cardServices; }
+    return this.cardServices = this.__owner__.lookup('hub:card-services');
+  }
   async create(session, type, document) {
     log.info("creating type=%s", type);
     if (!document.data) {
@@ -168,7 +173,7 @@ class Writers {
 
     let authorizedDocument = await context.applyReadAuthorization({ session });
     if (isCard(authorizedDocument.data.type, authorizedDocument.data.id)) {
-      return await adaptCardToFormat(schema, authorizedDocument, 'isolated');
+      return await adaptCardToFormat(schema, session, authorizedDocument, 'isolated', this._getCardServices());
     }
     return authorizedDocument;
   }
@@ -228,7 +233,7 @@ class Writers {
 
     let authorizedDocument = await context.applyReadAuthorization({ session });
     if (isCard(authorizedDocument.data.type, authorizedDocument.data.id)) {
-      return await adaptCardToFormat(schema, authorizedDocument, 'isolated');
+      return await adaptCardToFormat(schema, session, authorizedDocument, 'isolated', this._getCardServices());
     }
     return authorizedDocument;
   }


### PR DESCRIPTION
This PR adds support for relationships to cards and card validation. A notable change is that in the Model API, the act of getting a related field could result in returning a card you didn't know about--in which case we need to load that card's schema, and then share that schema with the DocumentContext that was trying to traverse the relationship.