### PR TITLE
Removing card namespacing in our external card format

### DIFF
--- a/packages/cardhost/app/components/card-creator.js
+++ b/packages/cardhost/app/components/card-creator.js
@@ -33,10 +33,10 @@ export default class CardCreator extends Component {
         relationships: {
           fields: {
             data: [
-              { type: 'fields', id: 'local-hub::article-card::millenial-puppies::title' },
-              { type: 'fields', id: 'local-hub::article-card::millenial-puppies::author' },
-              { type: 'fields', id: 'local-hub::article-card::millenial-puppies::body' },
-              { type: 'fields', id: 'local-hub::article-card::millenial-puppies::internal-field' },
+              { type: 'fields', id: 'title' },
+              { type: 'fields', id: 'author' },
+              { type: 'fields', id: 'body' },
+              { type: 'fields', id: 'internal-field' },
             ]
           },
           model: {
@@ -56,7 +56,7 @@ export default class CardCreator extends Component {
       },
       {
         type: 'fields',
-        id: 'local-hub::article-card::millenial-puppies::title',
+        id: 'title',
         attributes: {
           'is-metadata': true,
           'needed-when-embedded': true,
@@ -65,7 +65,7 @@ export default class CardCreator extends Component {
       },
       {
         type: 'fields',
-        id: 'local-hub::article-card::millenial-puppies::author',
+        id: 'author',
         attributes: {
           'is-metadata': true,
           'needed-when-embedded': true,
@@ -74,7 +74,7 @@ export default class CardCreator extends Component {
       },
       {
         type: 'fields',
-        id: 'local-hub::article-card::millenial-puppies::body',
+        id: 'body',
         attributes: {
           'is-metadata': true,
           'field-type': '@cardstack/core-types::string'
@@ -82,7 +82,7 @@ export default class CardCreator extends Component {
       },
       {
         type: 'fields',
-        id: 'local-hub::article-card::millenial-puppies::internal-field',
+        id: 'internal-field',
         attributes: {
           'field-type': '@cardstack/core-types::string'
         }

--- a/packages/cardhost/app/components/card-inspector.js
+++ b/packages/cardhost/app/components/card-inspector.js
@@ -11,7 +11,7 @@ export default class CardInspector extends Component {
       let field = (card.included || []).find(i => `${i.type}/${i.id}` === `${fieldRef.type}/${fieldRef.id}`);
       if (!field) { continue; }
 
-      let [, , , fieldName] = fieldRef.id.split('::');
+      let fieldName = fieldRef.id;
       let { attributes:fieldSchema } = field;
       let fieldValue = this.modelFields[fieldName];
 

--- a/packages/cardhost/tests/acceptance/create-card-test.js
+++ b/packages/cardhost/tests/acceptance/create-card-test.js
@@ -88,12 +88,12 @@ module('Acceptance | create card', function(hooks) {
     await createCard(factory.getDocumentFor(
       factory.addResource('cards', 'local-hub::user-card::van-gogh')
         .withRelated('fields', [
-          factory.addResource('fields', 'local-hub::user-card::van-gogh::name').withAttributes({
+          factory.addResource('fields', 'name').withAttributes({
             'is-metadata': true,
             'needed-when-embedded': true,
             'field-type': '@cardstack/core-types::string'
           }),
-          factory.addResource('fields', 'local-hub::user-card::van-gogh::email').withAttributes({
+          factory.addResource('fields', 'email').withAttributes({
             'is-metadata': true,
             'field-type': '@cardstack/core-types::case-insensitive'
           }),
@@ -110,11 +110,11 @@ module('Acceptance | create card', function(hooks) {
     await createCard(factory.getDocumentFor(
       factory.addResource('cards', 'local-hub::article-card::millenial-puppies')
         .withRelated('fields', [
-          factory.addResource('fields', 'local-hub::article-card::millenial-puppies::body').withAttributes({
+          factory.addResource('fields', 'body').withAttributes({
             'is-metadata': true,
             'field-type': '@cardstack/core-types::string'
           }),
-          factory.addResource('fields', 'local-hub::article-card::millenial-puppies::author').withAttributes({
+          factory.addResource('fields', 'author').withAttributes({
             'is-metadata': true,
             'needed-when-embedded': true,
             'field-type': '@cardstack/core-types::belongs-to'

--- a/packages/cardhost/tests/acceptance/update-card-test.js
+++ b/packages/cardhost/tests/acceptance/update-card-test.js
@@ -10,7 +10,7 @@ let factory = new JSONAPIFactory();
 let articleCard = factory.getDocumentFor(
   factory.addResource('cards', 'local-hub::article-card::millenial-puppies')
     .withRelated('fields', [
-      factory.addResource('fields', 'local-hub::article-card::millenial-puppies::body').withAttributes({
+      factory.addResource('fields', 'body').withAttributes({
         'is-metadata': true,
         'field-type': '@cardstack/core-types::string'
       }),
@@ -60,10 +60,10 @@ module('Acceptance | updating a card', function(hooks) {
 
     let cardStr = getCodeMirrorValue();
     let card = JSON.parse(cardStr);
-    card.data.relationships.fields.data.push({ type: 'fields', id: 'local-hub::article-card::millenial-puppies::title' });
+    card.data.relationships.fields.data.push({ type: 'fields', id: 'title' });
     card.included.push({
       type: 'fields',
-      id: 'local-hub::article-card::millenial-puppies::title',
+      id: 'title',
       attributes: {
         'is-metadata': true,
         'needed-when-embedded': true,
@@ -87,8 +87,8 @@ module('Acceptance | updating a card', function(hooks) {
 
     let cardStr = getCodeMirrorValue();
     let card = JSON.parse(cardStr);
-    card.data.relationships.fields.data = card.data.relationships.fields.data.filter(i => i.id !== 'local-hub::article-card::millenial-puppies::body');
-    card.included = card.included.filter(i => i.id !== 'local-hub::article-card::millenial-puppies::body');
+    card.data.relationships.fields.data = card.data.relationships.fields.data.filter(i => i.id !== 'body');
+    card.included = card.included.filter(i => i.id !== 'body');
     setCodeMirrorValue(JSON.stringify(card, null, 2));
 
     await click('[data-test-card-updator-update-btn]');
@@ -107,10 +107,10 @@ module('Acceptance | updating a card', function(hooks) {
     let card = JSON.parse(cardStr);
     let internalModel = card.included.find(i => i.type = 'local-hub::article-card::millenial-puppies');
     internalModel.attributes.title = 'Millenial Puppies';
-    card.data.relationships.fields.data.push({ type: 'fields', id: 'local-hub::article-card::millenial-puppies::title' });
+    card.data.relationships.fields.data.push({ type: 'fields', id: 'title' });
     card.included.push({
       type: 'fields',
-      id: 'local-hub::article-card::millenial-puppies::title',
+      id: 'title',
       attributes: {
         'is-metadata': true,
         'needed-when-embedded': true,

--- a/packages/hub/node-tests/cards-test.js
+++ b/packages/hub/node-tests/cards-test.js
@@ -71,9 +71,9 @@ function assertIsolatedCardMetadata(card) {
   expect(data.relationships.author.data).to.eql({ type: 'cards', id: 'local-hub::user-card::van-gogh' });
   expect(data.attributes['tag-names']).to.eql(['millenials', 'puppies', 'belly-rubs']);
   expect(data.relationships.tags.data).to.eql([
-    { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::millenials' },
-    { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::puppies' },
-    { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::belly-rubs' },
+    { type: 'tags', id: 'millenials' },
+    { type: 'tags', id: 'puppies' },
+    { type: 'tags', id: 'belly-rubs' },
   ]);
   expect(data.attributes['internal-field']).to.be.undefined;
 }
@@ -90,9 +90,9 @@ function assertEmbeddedCardMetadata(card) {
   expect(data.attributes['internal-field']).to.be.undefined;
 
   expect(includedIdentifiers).to.not.include.members([
-    'local-hub::article-card::millenial-puppies::tags/local-hub::article-card::millenial-puppies::millenials',
-    'local-hub::article-card::millenial-puppies::tags/local-hub::article-card::millenial-puppies::puppies',
-    'local-hub::article-card::millenial-puppies::tags/local-hub::article-card::millenial-puppies::belly-rubs',
+    'tags/millenials',
+    'tags/puppies',
+    'tags/belly-rubs',
   ]);
   expect(includedIdentifiers).to.include.members([
     'cards/local-hub::user-card::van-gogh',
@@ -109,19 +109,19 @@ function assertCardModels(card) {
   expect(includedIdentifiers).to.include.members(['local-hub::article-card::millenial-puppies/local-hub::article-card::millenial-puppies']);
   expect(includedIdentifiers).to.include.members([
     'cards/local-hub::user-card::van-gogh',
-    'local-hub::article-card::millenial-puppies::tags/local-hub::article-card::millenial-puppies::millenials',
-    'local-hub::article-card::millenial-puppies::tags/local-hub::article-card::millenial-puppies::puppies',
-    'local-hub::article-card::millenial-puppies::tags/local-hub::article-card::millenial-puppies::belly-rubs',
+    'tags/millenials',
+    'tags/puppies',
+    'tags/belly-rubs',
   ]);
 
   let model = included.find(i => `${i.type}/${i.id}` === 'local-hub::article-card::millenial-puppies/local-hub::article-card::millenial-puppies');
   expect(model.attributes.title).to.equal('The Millenial Puppy');
   expect(model.attributes.body).to.match(/discerning tastes of the millenial puppy/);
- expect(model.attributes['tag-names']).to.eql(['millenials', 'puppies', 'belly-rubs']);
+  expect(model.attributes['tag-names']).to.eql(['millenials', 'puppies', 'belly-rubs']);
   expect(model.relationships.tags.data).to.eql([
-    { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::millenials' },
-    { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::puppies' },
-    { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::belly-rubs' },
+    { type: 'tags', id: 'millenials' },
+    { type: 'tags', id: 'puppies' },
+    { type: 'tags', id: 'belly-rubs' },
   ]);
   expect(model.attributes['internal-field']).to.equal('this is internal data');
 
@@ -135,22 +135,22 @@ function assertCardSchema(card) {
   let includedIdentifiers = included.map(i => `${i.type}/${i.id}`);
 
   expect(data.relationships.fields.data).to.eql([
-    { type: 'fields', id: 'local-hub::article-card::millenial-puppies::title' },
-    { type: 'fields', id: 'local-hub::article-card::millenial-puppies::author' },
-    { type: 'fields', id: 'local-hub::article-card::millenial-puppies::body' },
-    { type: 'fields', id: 'local-hub::article-card::millenial-puppies::internal-field' },
-    { type: 'computed-fields', id: 'local-hub::article-card::millenial-puppies::tag-names' },
-    { type: 'fields', id: 'local-hub::article-card::millenial-puppies::tags' },
+    { type: 'fields', id: 'title' },
+    { type: 'fields', id: 'author' },
+    { type: 'fields', id: 'body' },
+    { type: 'fields', id: 'internal-field' },
+    { type: 'computed-fields', id: 'tag-names' },
+    { type: 'fields', id: 'tags' },
   ]);
   expect(includedIdentifiers).to.include.members([
-    'fields/local-hub::article-card::millenial-puppies::title',
-    'fields/local-hub::article-card::millenial-puppies::body',
-    'fields/local-hub::article-card::millenial-puppies::author',
-    'fields/local-hub::article-card::millenial-puppies::internal-field',
-    'fields/local-hub::article-card::millenial-puppies::tags',
-    'computed-fields/local-hub::article-card::millenial-puppies::tag-names',
-    'content-types/local-hub::article-card::millenial-puppies::tags',
-    'constraints/local-hub::article-card::millenial-puppies::title-not-null'
+    'fields/title',
+    'fields/body',
+    'fields/author',
+    'fields/internal-field',
+    'fields/tags',
+    'computed-fields/tag-names',
+    'content-types/tags',
+    'constraints/title-not-null'
   ]);
 
   // Card does not include the primary model content type schema--as that is derived by the hub,
@@ -319,6 +319,7 @@ describe('hub/card-services', function () {
         assertCardOnDisk();
       });
 
+      // Hassan: I'm skeptical we want to be able to return search results in the isolated format...
       it("will load a card implicitly when a searcher's search() hook returns a card document in isolated format", async function () {
         let { data: [article] } = await cardServices.search(env.session, 'isolated', {
           filter: {
@@ -348,9 +349,9 @@ describe('hub/card-services', function () {
 
         expect(includedIdentifiers).to.include.members([ 'cards/local-hub::user-card::van-gogh' ]);
         expect(includedIdentifiers).to.not.include.members([
-          'local-hub::article-card::millenial-puppies::tags/local-hub::article-card::millenial-puppies::millenials',
-          'local-hub::article-card::millenial-puppies::tags/local-hub::article-card::millenial-puppies::puppies',
-          'local-hub::article-card::millenial-puppies::tags/local-hub::article-card::millenial-puppies::belly-rubs',
+          'tags/millenials',
+          'tags/puppies',
+          'tags/belly-rubs',
         ]);
 
         assertCardOnDisk();
@@ -455,10 +456,10 @@ describe('hub/card-services', function () {
 
     it("can add a field to a card's schema", async function() {
       let card = await cardServices.create(env.session, externalArticleCard);
-      card.data.relationships.fields.data.push({ type: 'fields', id: 'local-hub::article-card::millenial-puppies::editor'});
+      card.data.relationships.fields.data.push({ type: 'fields', id: 'editor'});
       card.included.push({
         type: 'fields',
-        id: 'local-hub::article-card::millenial-puppies::editor',
+        id: 'editor',
         attributes: {
           'is-metadata': true,
           'needed-when-embedded': true,
@@ -471,22 +472,22 @@ describe('hub/card-services', function () {
       let includedIdentifiers = included.map(i => `${i.type}/${i.id}`);
       let fieldRelationships = data.relationships.fields.data.map(i => `${i.type}/${i.id}`);
 
-      expect(includedIdentifiers).to.include('fields/local-hub::article-card::millenial-puppies::editor');
-      expect(fieldRelationships).to.include('fields/local-hub::article-card::millenial-puppies::editor');
+      expect(includedIdentifiers).to.include('fields/editor');
+      expect(fieldRelationships).to.include('fields/editor');
 
       card = await cardServices.get(env.session, 'local-hub::article-card::millenial-puppies', 'isolated');
       data = card.data;
       included = card.included;
       includedIdentifiers = included.map(i => `${i.type}/${i.id}`);
       fieldRelationships = data.relationships.fields.data.map(i => `${i.type}/${i.id}`);
-      expect(includedIdentifiers).to.include('fields/local-hub::article-card::millenial-puppies::editor');
-      expect(fieldRelationships).to.include('fields/local-hub::article-card::millenial-puppies::editor');
+      expect(includedIdentifiers).to.include('fields/editor');
+      expect(fieldRelationships).to.include('fields/editor');
     });
 
     it("can remove a field from the card's schema", async function() {
       let card = await cardServices.create(env.session, externalArticleCard);
-      card.data.relationships.fields.data = card.data.relationships.fields.data.filter(i => i.id !== 'local-hub::article-card::millenial-puppies::body');
-      card.included = card.included.filter(i => i.id !== 'local-hub::article-card::millenial-puppies::body');
+      card.data.relationships.fields.data = card.data.relationships.fields.data.filter(i => i.id !== 'body');
+      card.included = card.included.filter(i => i.id !== 'body');
 
       card = await cardServices.update(env.session, 'local-hub::article-card::millenial-puppies', card);
       let { data, included } = card;
@@ -494,8 +495,8 @@ describe('hub/card-services', function () {
       let fieldRelationships = data.relationships.fields.data.map(i => `${i.type}/${i.id}`);
 
       expect(card.data.attributes.body).to.be.undefined;
-      expect(includedIdentifiers).to.not.include('fields/local-hub::article-card::millenial-puppies::body');
-      expect(fieldRelationships).to.not.include('fields/local-hub::article-card::millenial-puppies::body');
+      expect(includedIdentifiers).to.not.include('fields/body');
+      expect(fieldRelationships).to.not.include('fields/body');
 
       card = await cardServices.get(env.session, 'local-hub::article-card::millenial-puppies', 'isolated');
       data = card.data;
@@ -503,8 +504,8 @@ describe('hub/card-services', function () {
       includedIdentifiers = included.map(i => `${i.type}/${i.id}`);
       fieldRelationships = data.relationships.fields.data.map(i => `${i.type}/${i.id}`);
       expect(card.data.attributes.body).to.be.undefined;
-      expect(includedIdentifiers).to.not.include('fields/local-hub::article-card::millenial-puppies::body');
-      expect(fieldRelationships).to.not.include('fields/local-hub::article-card::millenial-puppies::body');
+      expect(includedIdentifiers).to.not.include('fields/body');
+      expect(fieldRelationships).to.not.include('fields/body');
     });
 
     it("can update a card's internal model", async function() {
@@ -546,10 +547,10 @@ describe('hub/card-services', function () {
       let card = await cardServices.create(env.session, externalArticleCard);
       let internalModel = card.included.find(i => i.type = 'local-hub::article-card::millenial-puppies');
       internalModel.attributes.editor = 'Hassan';
-      card.data.relationships.fields.data.push({ type: 'fields', id: 'local-hub::article-card::millenial-puppies::editor'});
+      card.data.relationships.fields.data.push({ type: 'fields', id: 'editor'});
       card.included.push({
         type: 'fields',
-        id: 'local-hub::article-card::millenial-puppies::editor',
+        id: 'editor',
         attributes: {
           'is-metadata': true,
           'needed-when-embedded': true,
@@ -562,8 +563,8 @@ describe('hub/card-services', function () {
       let includedIdentifiers = included.map(i => `${i.type}/${i.id}`);
       let fieldRelationships = data.relationships.fields.data.map(i => `${i.type}/${i.id}`);
 
-      expect(includedIdentifiers).to.include('fields/local-hub::article-card::millenial-puppies::editor');
-      expect(fieldRelationships).to.include('fields/local-hub::article-card::millenial-puppies::editor');
+      expect(includedIdentifiers).to.include('fields/editor');
+      expect(fieldRelationships).to.include('fields/editor');
       expect(card.data.attributes.editor).to.equal('Hassan');
       expect(internalModel.attributes.editor).to.equal('Hassan');
 
@@ -572,8 +573,8 @@ describe('hub/card-services', function () {
       included = card.included;
       includedIdentifiers = included.map(i => `${i.type}/${i.id}`);
       fieldRelationships = data.relationships.fields.data.map(i => `${i.type}/${i.id}`);
-      expect(includedIdentifiers).to.include('fields/local-hub::article-card::millenial-puppies::editor');
-      expect(fieldRelationships).to.include('fields/local-hub::article-card::millenial-puppies::editor');
+      expect(includedIdentifiers).to.include('fields/editor');
+      expect(fieldRelationships).to.include('fields/editor');
       expect(card.data.attributes.editor).to.equal('Hassan');
       expect(internalModel.attributes.editor).to.equal('Hassan');
     });
@@ -793,9 +794,9 @@ describe('hub/card-services', function () {
         expect(data.attributes.body).to.match(/discerning tastes of the millenial puppy/);
         expect(data.relationships.author.data).to.eql({ type: 'cards', id: 'local-hub::user-card::van-gogh' });
         expect(data.relationships.tags.data).to.eql([
-          { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::millenials' },
-          { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::puppies' },
-          { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::belly-rubs' },
+          { type: 'tags', id: 'millenials' },
+          { type: 'tags', id: 'puppies' },
+          { type: 'tags', id: 'belly-rubs' },
         ]);
         expect(data.attributes['internal-field']).to.be.undefined;
 
@@ -804,9 +805,9 @@ describe('hub/card-services', function () {
         expect(model.attributes.body).to.match(/discerning tastes of the millenial puppy/);
         expect(model.relationships.author.data).to.eql({ type: 'cards', id: 'local-hub::user-card::van-gogh' });
         expect(model.relationships.tags.data).to.eql([
-          { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::millenials' },
-          { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::puppies' },
-          { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::belly-rubs' },
+          { type: 'tags', id: 'millenials' },
+          { type: 'tags', id: 'puppies' },
+          { type: 'tags', id: 'belly-rubs' },
         ]);
         expect(model.attributes['internal-field']).to.be.undefined;
       });
@@ -830,8 +831,11 @@ describe('hub/card-services', function () {
 
         expect(includedIdentifiers).to.not.include.members([
           'local-hub::user-card::van-gogh/local-hub::user-card::van-gogh',
+          // intentionally asserting both the namespaced schema elements and non-namespaced schema elements dont exist
           'fields/local-hub::user-card::van-gogh::name',
           'fields/local-hub::user-card::van-gogh::email',
+          'fields/name',
+          'fields/email',
         ]);
         let card = included.find(i => `${i.type}/${i.id}` === 'cards/local-hub::user-card::van-gogh');
         expect(card.attributes.name).to.equal('Van Gogh');
@@ -877,9 +881,9 @@ describe('hub/card-services', function () {
         expect(card.attributes.body).to.match(/discerning tastes of the millenial puppy/);
         expect(card.relationships.author.data).to.eql({ type: 'cards', id: 'local-hub::user-card::van-gogh' });
         expect(card.relationships.tags.data).to.eql([
-          { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::millenials' },
-          { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::puppies' },
-          { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::belly-rubs' },
+          { type: 'tags', id: 'millenials' },
+          { type: 'tags', id: 'puppies' },
+          { type: 'tags', id: 'belly-rubs' },
         ]);
         expect(card.attributes['internal-field']).to.be.undefined;
 
@@ -887,9 +891,9 @@ describe('hub/card-services', function () {
         expect(model.attributes.body).to.match(/discerning tastes of the millenial puppy/);
         expect(model.relationships.author.data).to.eql({ type: 'cards', id: 'local-hub::user-card::van-gogh' });
         expect(model.relationships.tags.data).to.eql([
-          { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::millenials' },
-          { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::puppies' },
-          { type: 'local-hub::article-card::millenial-puppies::tags', id: 'local-hub::article-card::millenial-puppies::belly-rubs' },
+          { type: 'tags', id: 'millenials' },
+          { type: 'tags', id: 'puppies' },
+          { type: 'tags', id: 'belly-rubs' },
         ]);
         expect(model.attributes['internal-field']).to.be.undefined;
       });
@@ -923,8 +927,11 @@ describe('hub/card-services', function () {
 
         expect(includedIdentifiers).to.not.include.members([
           'local-hub::user-card::van-gogh/local-hub::user-card::van-gogh',
+          // intentionally asserting both the namespaced schema elements and non-namespaced schema elements dont exist
           'fields/local-hub::user-card::van-gogh::name',
           'fields/local-hub::user-card::van-gogh::email',
+          'fields/name',
+          'fields/email',
         ]);
         let card = included.find(i => `${i.type}/${i.id}` === 'cards/local-hub::user-card::van-gogh');
         expect(card.attributes.name).to.equal('Van Gogh');

--- a/packages/hub/node-tests/external-cards/foreign-model-id.js
+++ b/packages/hub/node-tests/external-cards/foreign-model-id.js
@@ -4,7 +4,7 @@ let factory = new JSONAPIFactory();
 module.exports = factory.getDocumentFor(
   factory.addResource('cards', 'local-hub::foreign-model-id-card::bad')
     .withRelated('fields', [
-      factory.addResource('fields', 'local-hub::foreign-model-id-card::bad::title').withAttributes({
+      factory.addResource('fields', 'title').withAttributes({
         'is-metadata': true,
         'field-type': '@cardstack/core-types::string'
       }),

--- a/packages/hub/node-tests/external-cards/foreign-model-type.js
+++ b/packages/hub/node-tests/external-cards/foreign-model-type.js
@@ -4,7 +4,7 @@ let factory = new JSONAPIFactory();
 module.exports = factory.getDocumentFor(
   factory.addResource('cards', 'local-hub::foreign-model-type-card::bad')
     .withRelated('fields', [
-      factory.addResource('fields', 'local-hub::foreign-model-type-card::bad::title').withAttributes({
+      factory.addResource('fields', 'title').withAttributes({
         'is-metadata': true,
         'field-type': '@cardstack/core-types::string'
       }),

--- a/packages/hub/writers.js
+++ b/packages/hub/writers.js
@@ -352,7 +352,7 @@ class Writers {
   }
 
   async _loadInternalCard(card) {
-    let internalCard = generateInternalCardFormat(card);
+    let internalCard = generateInternalCardFormat(await this.currentSchema.getSchema(), card);
     return { internalCard, schema: await this._loadInternalCardSchema(internalCard) };
   }
 

--- a/packages/jsonapi/node-tests/middleware-test.js
+++ b/packages/jsonapi/node-tests/middleware-test.js
@@ -1001,10 +1001,10 @@ describe('jsonapi/middleware', function() {
         let { body: card } = await request.post('/api/cards').send(externalArticleCard);
         let internalModel = card.included.find(i => i.type = 'local-hub::article-card::millenial-puppies');
         internalModel.attributes.author = 'Van Gogh';
-        card.data.relationships.fields.data.push({ type: 'fields', id: 'local-hub::article-card::millenial-puppies::author' });
+        card.data.relationships.fields.data.push({ type: 'fields', id: 'author' });
         card.included.push({
           type: 'fields',
-          id: 'local-hub::article-card::millenial-puppies::author',
+          id: 'author',
           attributes: {
             'is-metadata': true,
             'needed-when-embedded': true,


### PR DESCRIPTION
This eliminates the card namespacing in our external card format. The only resource in a card document that needs to be namespaced after this change is the card's model resource. Aside from that, all other non-card resources are assumed to be in the enclosing card's context.

One ramification of this is that it means that we cannot include schema from embedded cards (which we were not doing anyways), as the schema in the card document is assumed to be schema for the enclosing card. This should be fine.