### PR TITLE
Decoupling card rendering concerns from card loading concerns

### DIFF
--- a/packages/cardhost/app/templates/components/card-creator.hbs
+++ b/packages/cardhost/app/templates/components/card-creator.hbs
@@ -39,7 +39,7 @@
   <br>
 
   <FieldCreator
-    @numFields={{this.card.fields.length}}
+    @numFields={{this.card.isolatedFields.length}}
     @fieldTypeMappings={{this.fieldTypeMappings}}
     @addField={{action this.addField}}
   />

--- a/packages/cardhost/app/templates/components/card-renderer.hbs
+++ b/packages/cardhost/app/templates/components/card-renderer.hbs
@@ -5,7 +5,7 @@
     {{yield}}
 
     <dl>
-      {{#each @card.fields key="name" as | field index |}}
+      {{#each @card.isolatedFields key="name" as | field index |}}
         <fieldset data-test-card-renderer-field={{field.name}}>
           <legend><strong><code>{{field.name}}</code></strong></legend>
 
@@ -72,7 +72,7 @@
                   <strong>▲</strong>
                 </button>
               {{/if}}
-              {{#if (lt index (dec @card.fields.length))}}
+              {{#if (lt index (dec @card.isolatedFields.length))}}
                 <button {{on "click" (fn @setPosition field.name (inc index))}}
                   data-test-card-renderer-move-down-btn
                 >

--- a/packages/cardhost/app/templates/components/card-schema-updator.hbs
+++ b/packages/cardhost/app/templates/components/card-schema-updator.hbs
@@ -26,7 +26,7 @@
   </div>
 
   <FieldCreator
-    @numFields={{this.card.fields}}
+    @numFields={{this.card.isolatedFields}}
     @fieldTypeMappings={{this.fieldTypeMappings}}
     @addField={{action this.addField}}
   />

--- a/packages/core/tests/helpers/card-helpers.js
+++ b/packages/core/tests/helpers/card-helpers.js
@@ -3,13 +3,13 @@ import { ciSessionId } from '@cardstack/test-support/environment'
 import { get } from 'lodash';
 
 export function cleanupDefaulValueArtifacts(document) {
-  if (!Object.keys(document.data.attributes).length) {
+  if (!Object.keys(get(document, 'data.attributes') || {}).length) {
     delete document.data.attributes;
   }
-  if (!Object.keys(document.data.relationships).length) {
+  if (!Object.keys(get(document, 'data.relationships') || {}).length) {
     delete document.data.relationships;
   }
-  for (let field of Object.keys(document.data.attributes || {})) {
+  for (let field of Object.keys(get(document, 'data.attributes') || {})) {
     if (document.data.attributes && document.data.attributes[field] == null) {
       delete document.data.attributes[field];
     }


### PR DESCRIPTION
This PR decouples card rendering concerns from card loading concerns, such that a card loaded in an isolated format can still determine the fields that are embedded.