### PR TITLE
updating cardhost to support a mock catalog

### DIFF
--- a/packages/cardhost/app/components/card-renderer.js
+++ b/packages/cardhost/app/components/card-renderer.js
@@ -9,6 +9,7 @@ import { tracked } from '@glimmer/tracking';
 // TODO This will be part of the official API. Move this into core as it solidifies
 export default class CardRenderer extends Component {
   @tracked componentName;
+  @tracked mode;
 
   constructor(...args) {
     super(...args);
@@ -16,6 +17,7 @@ export default class CardRenderer extends Component {
     // TODO eventually this will be derived based on the presence of a card's
     // custom template/component assets.
     this.componentName = 'default';
+    this.mode = this.args.mode || 'view';
   }
 
   get embeddedComponentName() {

--- a/packages/cardhost/app/controllers/index.js
+++ b/packages/cardhost/app/controllers/index.js
@@ -8,4 +8,9 @@ export default class IndexController extends Controller {
   viewCard(id) {
     this.router.transitionTo('cards.view', id);
   }
+
+  @action
+  refreshCatalog() {
+    this.send('refreshModel');
+  }
 }

--- a/packages/cardhost/app/routes/index.js
+++ b/packages/cardhost/app/routes/index.js
@@ -1,0 +1,18 @@
+import Route from '@ember/routing/route';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default class IndexRoute extends Route {
+  @service data;
+
+  async model() {
+    // prime the store with seed models
+    await this.data.getCard('local-hub::article-card::why-doors', 'isolated');
+    return await this.data.allCardsInStore();
+  }
+
+  @action
+  refreshModel() {
+    this.refresh();
+  }
+}

--- a/packages/cardhost/app/styles/app.css
+++ b/packages/cardhost/app/styles/app.css
@@ -14,7 +14,7 @@
   text-align: right;
 }
 
-.card-renderer--field-btn-wrapper {
+.field-renderer--field-btn-wrapper {
   text-align: right;
 }
 

--- a/packages/cardhost/app/templates/components/card-creator.hbs
+++ b/packages/cardhost/app/templates/components/card-creator.hbs
@@ -23,6 +23,7 @@
   <CardRenderer
     @card={{this.card}}
     @format="isolated"
+    @mode="schema"
     @removeField={{action this.removeField}}
     @setNeededWhenEmbedded={{action this.setNeededWhenEmbedded}}
     @setPosition={{action this.setPosition}}

--- a/packages/cardhost/app/templates/components/card-editor.hbs
+++ b/packages/cardhost/app/templates/components/card-editor.hbs
@@ -6,6 +6,7 @@
 
 <CardRenderer
   @card={{this.card}}
+  @mode="edit"
   @setFieldValue={{action this.setFieldValue}}
   @format="isolated"
 >

--- a/packages/cardhost/app/templates/components/card-renderer.hbs
+++ b/packages/cardhost/app/templates/components/card-renderer.hbs
@@ -1,34 +1,56 @@
 {{!--
-This stuff that is wrapping the card components is just throw-away scaffolding.
+This fieldset stuff that is wrapping the card components is just throw-away scaffolding.
 Feel free to get rid of it as soon as it no longer makes sense.
 --}}
-<fieldset>
-  <legend><strong><code>card: {{@card.id}}</code></strong></legend>
 
-  {{!-- TODO let's work on moving this yield out of this component--it's only here for scaffolding --}}
-  {{yield}}
+{{!--
+TODO this component should be responsible for deciding which format of the card to render.
+The process of rendering a card is fundamentally async as we'll need to load the card data,
+as well as waiting for the card component to be compiled by embroider. Make sure to build in
+Ember Concurrency into the rendering of the card component here.
+--}}
+{{#if (eq @format "isolated")}}
+  {{#let (component this.isolatedComponentName) as | Isolated |}}
+    <fieldset>
+      <legend><strong><code>card: {{@card.id}}</code></strong></legend>
 
-  <dl>
-    {{!--
-    TODO this component should be responsible for deciding which format of the card to render.
-    The process of rendering a card is fundamentally async as we'll need to load the card data,
-    as well as waiting for the card component to be compiled by embroider. Make sure to build in
-    Ember Concurrency into the rendering of the card component here.
-    --}}
-    {{#if (eq @format "isolated")}}
-      {{#let (component this.isolatedComponentName) as | Isolated |}}
+      {{!-- TODO let's work on moving this yield out of this component--it's only here for scaffolding --}}
+      {{yield}}
+
+      <dl>
         <Isolated
           @card={{@card}}
+          @mode={{this.mode}}
           @setFieldValue={{@setFieldValue}}
           @removeField={{@removeField}}
           @setNeededWhenEmbedded={{@setNeededWhenEmbedded}}
           @setPosition={{@setPosition}}
         />
-      {{/let}}
-    {{else if (eq @format "embedded")}}
-      {{#let (component this.embeddedComponentName) as | Embedded |}}
-        <Embedded @card={{@card}} />
-      {{/let}}
+      </dl>
+    </fieldset>
+  {{/let}}
+{{else if (eq @format "embedded")}}
+  {{#let (component this.embeddedComponentName) as | Embedded |}}
+    {{#if (eq this.mode "view")}}
+      <LinkTo
+        @class="card-renderer--embedded-card-link"
+        @route="cards.view"
+        @model={{@card.id}}
+      >
+        <fieldset>
+          <legend><strong><code>card: {{@card.id}}</code></strong></legend>
+          <dl>
+            <Embedded @card={{@card}} @mode={{this.mode}}/>
+          </dl>
+        </fieldset>
+      </LinkTo>
+    {{else}}
+      <fieldset>
+        <legend><strong><code>card: {{@card.id}}</code></strong></legend>
+        <dl>
+          <Embedded @card={{@card}} @mode={{this.mode}}/>
+        </dl>
+      </fieldset>
     {{/if}}
-  </dl>
-</fieldset>
+  {{/let}}
+{{/if}}

--- a/packages/cardhost/app/templates/components/card-schema-updator.hbs
+++ b/packages/cardhost/app/templates/components/card-schema-updator.hbs
@@ -7,6 +7,7 @@
 <CardRenderer
   @card={{this.card}}
   @format="isolated"
+  @mode="schema"
   @removeField={{action this.removeField}}
   @setNeededWhenEmbedded={{action this.setNeededWhenEmbedded}}
   @setPosition={{action this.setPosition}}

--- a/packages/cardhost/app/templates/components/cards/default/embedded.hbs
+++ b/packages/cardhost/app/templates/components/cards/default/embedded.hbs
@@ -1,9 +1,8 @@
-{{!-- TODO need to make embedded clickable so that when clicked they transition into isolated card --}}
 <div
   data-test-embedded-card={{@card.id}}
   class="embedded-card default-card"
 >
   {{#each @card.embeddedFields key="name" as | field |}}
-    <FieldRenderer @field={{field}} @mode="view"/>
+    <FieldRenderer @field={{field}} @mode={{@mode}}/>
   {{/each}}
 </div>

--- a/packages/cardhost/app/templates/components/cards/default/isolated.hbs
+++ b/packages/cardhost/app/templates/components/cards/default/isolated.hbs
@@ -6,20 +6,20 @@
     {{#if @setFieldValue}}
       <FieldRenderer
         @field={{field}}
-        @mode="edit"
+        @mode={{@mode}}
         @setFieldValue={{fn @setFieldValue field.name}}
       />
     {{else if (or @setNeededWhenEmbedded @setPosition @removeField)}}
       <FieldRenderer
         @field={{field}}
-        @mode="schema"
+        @mode={{@mode}}
         @position={{index}}
         @removeField={{@removeField}}
         @setPosition={{@setPosition}}
         @setNeededWhenEmbedded={{@setNeededWhenEmbedded}}
       />
     {{else}}
-      <FieldRenderer @field={{field}} @mode="view"/>
+      <FieldRenderer @field={{field}} @mode={{@mode}}/>
     {{/if}}
     <br>
   {{/each}}

--- a/packages/cardhost/app/templates/index.hbs
+++ b/packages/cardhost/app/templates/index.hbs
@@ -7,6 +7,7 @@
   </li>
   <li>
     <Input
+      @size="60"
       @value={{this.cardId}}
       @placeholder="Card ID to View"
       @enter={{action this.viewCard this.cardId}}
@@ -16,3 +17,22 @@
     {{/if}}
   </li>
 </ul>
+
+<div>
+  <h2>Catalog</h2>
+  <p>
+    Right now we are emulating a catalog by just listing out all the cards in
+    the local store. Any card that you create or view will be added to the list below.
+  </p>
+
+  <div>
+    <button data-test-refresh-catalog-btn {{on "click" this.refreshCatalog}}>
+      Refresh Catalog
+    </button>
+  </div>
+  <div class="card-catalog">
+    {{#each this.model as |card|}}
+      <CardRenderer @card={{card}} @format="embedded"/>
+    {{/each}}
+  </div>
+</div>

--- a/packages/cardhost/cardstack/seeds/ephemeral.js
+++ b/packages/cardhost/cardstack/seeds/ephemeral.js
@@ -1,8 +1,15 @@
 const Factory = require('@cardstack/test-support/jsonapi-factory');
 
+let factory = new Factory();
+factory.addResource('grants', 'world-read')
+  .withAttributes({
+    mayReadFields: true,
+    mayReadResource: true,
+  })
+  .withRelated('who', [{ type: 'groups', id: 'everyone' }]);
+
 // TODO this is for testing only--eventually we should
 // only use mock-auth in the development and test environments
-let factory = new Factory();
 factory.addResource('grants', 'mock-user-access')
   .withAttributes({
     mayWriteFields: true,
@@ -15,4 +22,54 @@ factory.addResource('grants', 'mock-user-access')
   })
   .withRelated('who', [{ type: 'mock-users', id: 'user1' }]);
 
-module.exports = factory.getModels();
+let articleFactory = new Factory();
+let articleCard = articleFactory.getDocumentFor(
+  articleFactory.addResource('cards', 'local-hub::article-card::why-doors')
+    .withRelated('fields', [
+      articleFactory.addResource('fields', 'title').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::string',
+        'needed-when-embedded': true
+      }),
+      articleFactory.addResource('fields', 'body').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::string',
+      }),
+      articleFactory.addResource('fields', 'author').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::belongs-to',
+        'needed-when-embedded': true
+      }),
+    ])
+    .withRelated('model', articleFactory.addResource('local-hub::article-card::why-doors', 'local-hub::article-card::why-doors')
+      .withAttributes({
+        title: "Why Doors?",
+        body: "What is the deal with doors, and how come there are so many of them?",
+      })
+      .withRelated('author', { type: 'cards', id: 'local-hub::user-card::ringo' })
+    )
+);
+
+let userFactory = new Factory();
+let userCard = userFactory.getDocumentFor(
+  userFactory.addResource('cards', 'local-hub::user-card::ringo')
+    .withRelated('fields', [
+      userFactory.addResource('fields', 'name').withAttributes({
+        'is-metadata': true,
+        'needed-when-embedded': true,
+        'field-type': '@cardstack/core-types::string',
+      }),
+      userFactory.addResource('fields', 'email').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::case-insensitive',
+      }),
+    ])
+    .withRelated('model', userFactory.addResource('local-hub::user-card::ringo', 'local-hub::user-card::ringo')
+      .withAttributes({
+        name: "Ringo",
+        email: "ringo@nowhere.dog",
+      })
+    )
+);
+
+module.exports = factory.getModels().concat([articleCard, userCard]);

--- a/packages/cardhost/tests/acceptance/card-view-test.js
+++ b/packages/cardhost/tests/acceptance/card-view-test.js
@@ -5,6 +5,7 @@ import Fixtures from '@cardstack/test-support/fixtures'
 import { createCards } from '../helpers/card-helpers';
 import { setupMockUser, login } from '../helpers/login';
 
+const timeout = 5000;
 const card1Id = 'local-hub::article-card::millenial-puppies';
 const card2Id = 'local-hub::user-card::van-gogh';
 const card3Id = 'local-hub::user-card::hassan';
@@ -82,7 +83,7 @@ module('Acceptance | card view', function(hooks) {
     await visit(`/cards/${card1Id}`);
 
     await click(`a[href="/cards/${card1Id}/edit"]`);
-    await waitFor(`[data-test-card-edit="${card1Id}"]`);
+    await waitFor(`[data-test-card-edit="${card1Id}"]`, { timeout });
 
     assert.equal(currentURL(), `/cards/${card1Id}/edit`);
     assert.dom(`[data-test-card-edit="${card1Id}"]`).exists();
@@ -100,7 +101,7 @@ module('Acceptance | card view', function(hooks) {
     await visit(`/cards/${card1Id}`);
 
     await click(`a[href="/cards/${card1Id}/schema"]`);
-    await waitFor(`[data-test-card-schema="${card1Id}"]`);
+    await waitFor(`[data-test-card-schema="${card1Id}"]`, { timeout });
 
     assert.equal(currentURL(), `/cards/${card1Id}/schema`);
     assert.dom(`[data-test-card-schema="${card1Id}"]`).exists();

--- a/packages/cardhost/tests/acceptance/catalog-test.js
+++ b/packages/cardhost/tests/acceptance/catalog-test.js
@@ -1,0 +1,69 @@
+
+import { module, test } from 'qunit';
+import { click, visit, currentURL, waitFor } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import Fixtures from '@cardstack/test-support/fixtures'
+import { createCards } from '../helpers/card-helpers';
+import { setupMockUser, login } from '../helpers/login';
+
+const timeout = 5000;
+const card1Id = 'local-hub::article-card::millenial-puppies';
+const card2Id = 'local-hub::user-card::van-gogh';
+const card3Id = 'local-hub::user-card::hassan';
+
+const scenario = new Fixtures({
+  create(factory) {
+    setupMockUser(factory);
+  },
+  destroy() {
+    return [
+      { type: 'cards', id: card1Id },
+      { type: 'cards', id: card2Id },
+      { type: 'cards', id: card3Id }
+    ];
+  }
+});
+
+module('Acceptance | catalog', function(hooks) {
+  setupApplicationTest(hooks);
+  scenario.setupTest(hooks);
+
+  hooks.beforeEach(async function () {
+    // Until we have searching capabilities, we'll just render the contents of the
+    // local store. So the first step is to warm up the store.
+    await login();
+    await createCards({
+      [card3Id]: [
+        ['name', 'string', true, 'Hassan Abdel-Rahman'],
+        ['email', 'case-insensitive string', false, 'hassan@nowhere.dog'],
+      ],
+      [card2Id]: [
+        ['name', 'string', true, 'Van Gogh'],
+        ['email', 'string', false, 'vangogh@nowhere.dog'],
+      ],
+      [card1Id]: [
+        ['title', 'string', true, 'The Millenial Puppy'],
+        ['author', 'related card', true, card2Id],
+        ['reviewers', 'related cards', true, `${card2Id},${card3Id}`],
+      ]
+    });
+    await visit(`/cards/${card1Id}`);
+  });
+
+  test(`viewing catalog`, async function(assert) {
+    await visit(`/`);
+
+    assert.dom(`.card-catalog > .card-renderer--embedded-card-link[href="/cards/${card1Id}"]`).exists();
+    assert.dom(`.card-catalog > .card-renderer--embedded-card-link[href="/cards/${card2Id}"]`).exists();
+    assert.dom(`.card-catalog > .card-renderer--embedded-card-link[href="/cards/${card3Id}"]`).exists();
+  });
+
+  test(`isolating a card`, async function(assert) {
+    await visit(`/`);
+
+    await click(`.card-catalog > .card-renderer--embedded-card-link[href="/cards/${card3Id}"]`);
+    await waitFor(`[data-test-card-view="${card3Id}"]`, { timeout });
+
+    assert.equal(currentURL(), `/cards/${card3Id}`);
+  });
+});

--- a/packages/ephemeral/indexer.js
+++ b/packages/ephemeral/indexer.js
@@ -1,3 +1,4 @@
+const { get } = require('lodash');
 const { declareInjections } = require('@cardstack/di');
 
 module.exports = declareInjections({
@@ -13,6 +14,7 @@ module.exports = declareInjections({
     if (typeof this.loadInitialModels === 'function') {
       initialModels = initialModels.concat(await this.loadInitialModels());
     }
+    initialModels = initialModels.filter(Boolean).filter(i => get(i, 'data.type') !== 'cards');
     let storage = await this.service.findOrCreateStorage(this.dataSource.id, initialModels);
     return new Updater(storage, this.dataSource.id);
   }


### PR DESCRIPTION
This update adds a mock catalog to cardhost by just rendering all the cards in the local store. Also as part of this I added support for providing cards (in their external card format) as seeds to the hub. Also, I've made the throwing of exceptions when you try to use `Card` and `Field` getters after you have deleted a card less aggressive, as there are many time that the template is just trying to do its job after you have deleted a card but nothing untoward is happening.