### PR TITLE
Pin node version when using volta

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
   "workspaces": [
     "packages/*"
   ],
-  "private": true
+  "private": true,
+  "volta": {
+    "node": "10.16.3"
+  }
 }


### PR DESCRIPTION
This helps ensure you're using the right node version, if you have [volta](https://volta.sh). It's pretty good.