### PR TITLE
Making a temporary home for the card and field css

### DIFF
--- a/packages/cardhost/app/styles/app.css
+++ b/packages/cardhost/app/styles/app.css
@@ -4,6 +4,27 @@
 @import '/assets/components/cardhost-left-edge.css';
 @import '/assets/components/cardhost-top-edge.css';
 
+
+/* TODO eventually these will be dynamically added to the DOM.
+Until that work is done we are statically adding this css
+*/
+@import '/assets/cards/base-card-isolated.css';
+@import '/assets/cards/base-card-embedded.css';
+@import '/assets/fields/belongs-to-editor.css';
+@import '/assets/fields/belongs-to-viewer.css';
+@import '/assets/fields/boolean-editor.css';
+@import '/assets/fields/boolean-viewer.css';
+@import '/assets/fields/case-insensitive-editor.css';
+@import '/assets/fields/case-insensitive-viewer.css';
+@import '/assets/fields/date-editor.css';
+@import '/assets/fields/date-viewer.css';
+@import '/assets/fields/has-many-editor.css';
+@import '/assets/fields/has-many-viewer.css';
+@import '/assets/fields/integer-editor.css';
+@import '/assets/fields/integer-viewer.css';
+@import '/assets/fields/string-editor.css';
+@import '/assets/fields/string-viewer.css';
+
 :root {
   --ch-font-family: "Open Sans", Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
 

--- a/packages/cardhost/app/styles/cards/base-card-embedded.css
+++ b/packages/cardhost/app/styles/cards/base-card-embedded.css
@@ -1,0 +1,16 @@
+/*
+".cardstack_base-card" is the sanitized @card.id for the
+card for which this css applies. Until we begin to support
+custom CSS for each card, all cards will inherit the
+@cardstack/base-card css.
+*/
+.embedded-card.cardstack_base-card {
+  /* This is just placeholder CSS to test that everuthing works--please change as necessary */
+  background-color: white;
+  color: black;
+  margin: .5rem;
+  padding: .5rem;
+  border-radius: 5px;
+  max-width: 30rem;
+  border-radius: 5px;
+}

--- a/packages/cardhost/app/styles/cards/base-card-isolated.css
+++ b/packages/cardhost/app/styles/cards/base-card-isolated.css
@@ -1,0 +1,14 @@
+/*
+".cardstack_base-card" is the sanitized @card.id for the
+card for which this css applies. Until we begin to support
+custom CSS for each card, all cards will inherit the
+@cardstack/base-card css.
+*/
+.isolated-card.cardstack_base-card {
+  /* This is just placeholder CSS to test that everuthing works--please change as necessary */
+  background-color: white;
+  color: black;
+  margin: 1rem;
+  padding: .5rem;
+  border-radius: 5px;
+}

--- a/packages/cardhost/app/styles/fields/belongs-to-editor.css
+++ b/packages/cardhost/app/styles/fields/belongs-to-editor.css
@@ -1,0 +1,3 @@
+.field-type-cardstack-core-types-belongs-to.edit-field {
+
+}

--- a/packages/cardhost/app/styles/fields/belongs-to-viewer.css
+++ b/packages/cardhost/app/styles/fields/belongs-to-viewer.css
@@ -1,0 +1,3 @@
+.field-type-cardstack-core-types-belongs-to.view-field {
+
+}

--- a/packages/cardhost/app/styles/fields/boolean-editor.css
+++ b/packages/cardhost/app/styles/fields/boolean-editor.css
@@ -1,0 +1,3 @@
+.field-type-cardstack-core-types-boolean.edit-field {
+
+}

--- a/packages/cardhost/app/styles/fields/boolean-viewer.css
+++ b/packages/cardhost/app/styles/fields/boolean-viewer.css
@@ -1,0 +1,3 @@
+.field-type-cardstack-core-types-boolean.view-field {
+
+}

--- a/packages/cardhost/app/styles/fields/case-insensitive-editor.css
+++ b/packages/cardhost/app/styles/fields/case-insensitive-editor.css
@@ -1,0 +1,3 @@
+.field-type-cardstack-core-types-case-insensitive.edit-field {
+
+}

--- a/packages/cardhost/app/styles/fields/case-insensitive-viewer.css
+++ b/packages/cardhost/app/styles/fields/case-insensitive-viewer.css
@@ -1,0 +1,3 @@
+.field-type-cardstack-core-types-case-insensitive.view-field {
+
+}

--- a/packages/cardhost/app/styles/fields/date-editor.css
+++ b/packages/cardhost/app/styles/fields/date-editor.css
@@ -1,0 +1,3 @@
+.field-type-cardstack-core-types-date.edit-field {
+
+}

--- a/packages/cardhost/app/styles/fields/date-viewer.css
+++ b/packages/cardhost/app/styles/fields/date-viewer.css
@@ -1,0 +1,3 @@
+.field-type-cardstack-core-types-date.view-field {
+
+}

--- a/packages/cardhost/app/styles/fields/has-many-editor.css
+++ b/packages/cardhost/app/styles/fields/has-many-editor.css
@@ -1,0 +1,3 @@
+.field-type-cardstack-core-types-has-many.edit-field {
+
+}

--- a/packages/cardhost/app/styles/fields/has-many-viewer.css
+++ b/packages/cardhost/app/styles/fields/has-many-viewer.css
@@ -1,0 +1,3 @@
+.field-type-cardstack-core-types-has-many.view-field {
+
+}

--- a/packages/cardhost/app/styles/fields/integer-editor.css
+++ b/packages/cardhost/app/styles/fields/integer-editor.css
@@ -1,0 +1,3 @@
+.field-type-cardstack-core-types-integer.edit-field {
+
+}

--- a/packages/cardhost/app/styles/fields/integer-viewer.css
+++ b/packages/cardhost/app/styles/fields/integer-viewer.css
@@ -1,0 +1,3 @@
+.field-type-cardstack-core-types-integer.view-field {
+
+}

--- a/packages/cardhost/app/styles/fields/string-editor.css
+++ b/packages/cardhost/app/styles/fields/string-editor.css
@@ -1,0 +1,3 @@
+.field-type-cardstack-core-types-string.edit-field {
+
+}

--- a/packages/cardhost/app/styles/fields/string-viewer.css
+++ b/packages/cardhost/app/styles/fields/string-viewer.css
@@ -1,0 +1,3 @@
+.field-type-cardstack-core-types-string.view-field {
+
+}


### PR DESCRIPTION
@burieberry Here is the temporary home for the card and field css. Eventually this will find a permanent place in actual card packages. Until then, just use these fields for the CSS for the isolated and embedded formats for cards, as well as css for specific fields in either their view or edit mode.