### PR TITLE
Fix issue where githereum with a remote git source would not push latest

### DIFF
--- a/packages/git/change.js
+++ b/packages/git/change.js
@@ -112,6 +112,11 @@ class Change {
         continue;
       }
 
+      if (this.fetchOpts && !this.repo.isBare()) {
+        await this.repo.fetchAll(this.fetchOpts);
+        await this.repo.mergeBranches(this.targetBranch, `origin/${this.targetBranch}`, null, Merge.PREFERENCE.FASTFORWARD_ONLY);
+      }
+
       return mergeCommit.id().tostrS();
     }
 


### PR DESCRIPTION
The local cached repo was not updated after pushing to the remote, and therefore
githereum, which operates on the local repo, was not pushing the correct latest
commit.

Ensure the repo is up to date in the finalizer, and add a test, also fix two
tests this change caused to fail