### PR TITLE
added thoughts around how to not blow away fields when the id changes

### DIFF
--- a/packages/cardhost/app/components/card-creator.js
+++ b/packages/cardhost/app/components/card-creator.js
@@ -14,5 +14,19 @@ export default class CardCreator extends CardManipulator {
   @action
   updateCardId(id) {
     this.card = this.data.createCard(`local-hub::${id}`);
+
+    // right now when the id changes we bascially throw away the
+    // card in progress and create a new card with no fields. A
+    // more consistent approach from the UX perspective would be
+    // to clone all the fields of the old card into the new card.
+
+    // something like:
+    // let newCard = this.data.createCard(`local-hub::${id}`);
+    // if (this.card) {
+    //   for (let field of this.card.fields) {
+    //     newCard.addField(field);
+    //   }
+    // }
+    // this.card = newCard;
   }
 }


### PR DESCRIPTION
@bagby I was thinking about how to retain the fields when the ID changes for a card. copying fields from one card to another should be pretty easy. we should be able to just do something like this:

```js
  let field = oldCard.getField('blah');
  newCard.addField(field);
```

(this will change a little bit after we have card adoption, since there will be no need to copy adopted fields)