### PR TITLE
Focus new/adopted card

### DIFF
--- a/packages/cardhost/app/components/card-manipulator.js
+++ b/packages/cardhost/app/components/card-manipulator.js
@@ -111,7 +111,7 @@ export default class CardManipulator extends Component {
   @tracked selectedField;
   @tracked isDragging;
   @tracked cardId;
-  @tracked displayCardMetadata = true;
+  @tracked cardSelected = true;
 
   constructor(...args) {
     super(...args);
@@ -183,7 +183,7 @@ export default class CardManipulator extends Component {
     let field = this.card.getFieldByNonce(fieldNonce);
 
     if (field === this.selectedField) {
-      this.displayCardMetadata = true;
+      this.cardSelected = true;
     }
 
     field.remove();
@@ -313,7 +313,7 @@ export default class CardManipulator extends Component {
     }
 
     this.selectedField = field;
-    this.displayCardMetadata = false;
+    this.cardSelected = false;
   }
 
   @action startDragging(field, evt) {

--- a/packages/cardhost/app/components/right-edge.js
+++ b/packages/cardhost/app/components/right-edge.js
@@ -5,7 +5,6 @@ import { action } from '@ember/object';
 
 export default class RightEdge extends Component {
   @tracked cardName;
-  @tracked displayCardMetadata;
 
   constructor(...args) {
     super(...args);

--- a/packages/cardhost/app/styles/components/card-renderer.css
+++ b/packages/cardhost/app/styles/components/card-renderer.css
@@ -102,20 +102,20 @@
   outline: 0; /* TODO: make this accessible */
 }
 
-.card-renderer-isolated:focus .card-renderer-isolated--header {
+.card-renderer-isolated.selected .card-renderer-isolated--header {
   color: black;
   background-color: var(--card-highlight);
   /* background-image: url('/images/icons/event.svg'); */
 }
 
-.card-renderer-isolated:focus .card-renderer-isolated--header svg g {
+.card-renderer-isolated.selected .card-renderer-isolated--header svg g {
   stroke: black;
 }
 
-.card-renderer-isolated:focus .card-renderer-isolated--header-overlay {
+.card-renderer-isolated.selected .card-renderer-isolated--header-overlay {
   visibility: hidden;
 }
 
-.card-renderer-isolated:focus .card-renderer-isolated--content {
+.card-renderer-isolated.selected .card-renderer-isolated--content {
   border-color: var(--card-highlight);
 }

--- a/packages/cardhost/app/styles/components/field-renderer-schema-field.css
+++ b/packages/cardhost/app/styles/components/field-renderer-schema-field.css
@@ -86,17 +86,20 @@
   cursor: pointer;
 }
 
-.schema-field-renderer:focus {
-  border: 3px solid var(--field-highlight);
+.field-renderer:focus {
   outline: 0;
   /* TODO: Make this accessible */
 }
 
-.schema-field-renderer:focus .schema-field-renderer--header {
+.field-renderer:focus .schema-field-renderer {
+  border: 3px solid var(--field-highlight);
+}
+
+.field-renderer:focus .schema-field-renderer .schema-field-renderer--header {
   background-color: var(--field-highlight);
   border-radius: 2px 2px 0 0;
 }
 
-.schema-field-renderer:focus .schema-field-renderer--content {
+.field-renderer:focus .schema-field-renderer .schema-field-renderer--content {
   border-radius: 0 0 2px 2px;
 }

--- a/packages/cardhost/app/styles/components/field-renderer-schema-field.css
+++ b/packages/cardhost/app/styles/components/field-renderer-schema-field.css
@@ -91,15 +91,18 @@
   /* TODO: Make this accessible */
 }
 
-.field-renderer:focus .schema-field-renderer {
+.field-renderer:focus .schema-field-renderer,
+.card-renderer:not(.selected) .field-renderer.selected .schema-field-renderer {
   border: 3px solid var(--field-highlight);
 }
 
-.field-renderer:focus .schema-field-renderer .schema-field-renderer--header {
+.field-renderer:focus .schema-field-renderer .schema-field-renderer--header,
+.card-renderer:not(.selected) .field-renderer.selected .schema-field-renderer .schema-field-renderer--header {
   background-color: var(--field-highlight);
   border-radius: 2px 2px 0 0;
 }
 
-.field-renderer:focus .schema-field-renderer .schema-field-renderer--content {
+.field-renderer:focus .schema-field-renderer .schema-field-renderer--content,
+.card-renderer:not(.selected) .field-renderer.selected .schema-field-renderer .schema-field-renderer--content {
   border-radius: 0 0 2px 2px;
 }

--- a/packages/cardhost/app/templates/components/card-creator.hbs
+++ b/packages/cardhost/app/templates/components/card-creator.hbs
@@ -83,7 +83,7 @@
   @setFieldLabel={{this.setFieldLabel}}
   @setFieldInstructions={{this.setFieldInstructions}}
   @updateCardId={{this.updateCardId}}
-  @displayCardMetadata={{this.displayCardMetadata}}
+  @cardSelected={{this.cardSelected}}
 />
 
 <section class="card-creator" data-test-card-creator {{did-update this.updateCard @card}}>
@@ -97,8 +97,8 @@
       @selectField={{action this.selectField}}
       @selectedField={{this.selectedField}}
       @dropField={{action this.dropField}}
-      @displayCardMetadata={{this.displayCardMetadata}}
-      @cardFocused={{action (mut this.displayCardMetadata)}}
+      @cardSelected={{this.cardSelected}}
+      @cardFocused={{action (mut this.cardSelected)}}
     />
   {{/if}}
 </section>

--- a/packages/cardhost/app/templates/components/card-creator.hbs
+++ b/packages/cardhost/app/templates/components/card-creator.hbs
@@ -95,6 +95,7 @@
       @removeField={{action this.removeField}}
       @setPosition={{action this.setPosition}}
       @selectField={{action this.selectField}}
+      @selectedField={{this.selectedField}}
       @dropField={{action this.dropField}}
       @cardFocused={{action (mut this.displayCardMetadata)}}
     />

--- a/packages/cardhost/app/templates/components/card-creator.hbs
+++ b/packages/cardhost/app/templates/components/card-creator.hbs
@@ -97,6 +97,7 @@
       @selectField={{action this.selectField}}
       @selectedField={{this.selectedField}}
       @dropField={{action this.dropField}}
+      @displayCardMetadata={{this.displayCardMetadata}}
       @cardFocused={{action (mut this.displayCardMetadata)}}
     />
   {{/if}}

--- a/packages/cardhost/app/templates/components/card-schema-updator.hbs
+++ b/packages/cardhost/app/templates/components/card-schema-updator.hbs
@@ -83,7 +83,7 @@
   @setFieldName={{this.setFieldName}}
   @setFieldLabel={{this.setFieldLabel}}
   @setFieldInstructions={{this.setFieldInstructions}}
-  @displayCardMetadata={{this.displayCardMetadata}}
+  @cardSelected={{this.cardSelected}}
 />
 
 <div class="card-schema-updator--search-bar">
@@ -104,8 +104,8 @@
     @setPosition={{action this.setPosition}}
     @selectedField={{this.selectedField}}
     @dropField={{action this.dropField}}
-    @displayCardMetadata={{this.displayCardMetadata}}
-    @cardFocused={{action (mut this.displayCardMetadata)}}
+    @cardSelected={{this.cardSelected}}
+    @cardFocused={{action (mut this.cardSelected)}}
   />
 </section>
 

--- a/packages/cardhost/app/templates/components/card-schema-updator.hbs
+++ b/packages/cardhost/app/templates/components/card-schema-updator.hbs
@@ -102,7 +102,9 @@
     @removeField={{action this.removeField}}
     @selectField={{action this.selectField}}
     @setPosition={{action this.setPosition}}
+    @selectedField={{this.selectedField}}
     @dropField={{action this.dropField}}
+    @displayCardMetadata={{this.displayCardMetadata}}
     @cardFocused={{action (mut this.displayCardMetadata)}}
   />
 </section>

--- a/packages/cardhost/app/templates/components/cards/cardstack/base-card/isolated.hbs
+++ b/packages/cardhost/app/templates/components/cards/cardstack/base-card/isolated.hbs
@@ -22,6 +22,7 @@
         @setNeededWhenEmbedded={{@setNeededWhenEmbedded}}
         @setFieldName={{@setFieldName}}
         @selectField={{@selectField}}
+        @selectedField={{@selectedField}}
       />
     {{else}}
       <FieldRenderer @field={{field}} @mode={{@mode}}/>

--- a/packages/cardhost/app/templates/components/right-edge.hbs
+++ b/packages/cardhost/app/templates/components/right-edge.hbs
@@ -11,7 +11,7 @@
       <div class="pill-option">Structure</div>
     </div>
   </div>
-  {{#if @displayCardMetadata}}
+  {{#if @cardSelected}}
     {{!--
     TODO each of these section is collapsable.
     Waiting until ember animated/liquid fire is available

--- a/packages/cardhost/tests/acceptance/create-card-test.js
+++ b/packages/cardhost/tests/acceptance/create-card-test.js
@@ -1,10 +1,11 @@
 import { module, test } from 'qunit';
-import { click, fillIn, find, visit, currentURL, triggerEvent, focus } from '@ember/test-helpers';
+import { click, fillIn, find, visit, currentURL, triggerEvent, focus, waitFor } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import Fixtures from '@cardstack/test-support/fixtures'
 import { addField, setCardId, createCards, saveCard, dragAndDropNewField, removeField } from '@cardstack/test-support/card-ui-helpers';
 import { setupMockUser, login } from '../helpers/login';
 
+const timeout = 20000;
 const card1Id = 'millenial-puppies';
 const qualifiedCard1Id = `local-hub::${card1Id}`;
 
@@ -100,6 +101,7 @@ module('Acceptance | card create', function(hooks) {
     assert.dom('[data-test-right-edge] [data-test-schema-attr="embedded"] input').isChecked();
 
     await focus('[data-test-card-renderer-isolated]');
+    await waitFor('.card-renderer.selected', { timeout });
     assert.dom('.field-renderer').doesNotHaveClass('selected');
     assert.dom('.card-renderer-isolated--header').hasText('millenial-puppies');
     assert.dom('[data-test-internal-card-id]').hasText('local-hub::millenial-puppies');

--- a/packages/cardhost/tests/acceptance/create-card-test.js
+++ b/packages/cardhost/tests/acceptance/create-card-test.js
@@ -37,13 +37,13 @@ module('Acceptance | card create', function(hooks) {
     assert.ok(currentURL().match(/\/cards\/new-card-[0-9]+\/schema/));
   });
 
-  test('card element is focused on initial render', async function(assert) {
+  test('card element is selected on initial render', async function(assert) {
     await login();
     await visit('/cards/new');
 
     assert.equal(currentURL(), '/cards/new');
 
-    assert.dom('.card-renderer').isFocused('card renderer element is focused');
+    assert.dom('.card-renderer').hasClass('selected');
   });
 
   test("changing a card's id does not clear the card fields", async function(assert) {

--- a/packages/cardhost/tests/acceptance/create-card-test.js
+++ b/packages/cardhost/tests/acceptance/create-card-test.js
@@ -37,6 +37,15 @@ module('Acceptance | card create', function(hooks) {
     assert.ok(currentURL().match(/\/cards\/new-card-[0-9]+\/schema/));
   });
 
+  test('card element is focused on initial render', async function(assert) {
+    await login();
+    await visit('/cards/new');
+
+    assert.equal(currentURL(), '/cards/new');
+
+    assert.dom('.card-renderer').isFocused('card renderer element is focused')
+  });
+
   test("changing a card's id does not clear the card fields", async function(assert) {
     await login();
     await visit('/cards/new');

--- a/packages/cardhost/tests/acceptance/create-card-test.js
+++ b/packages/cardhost/tests/acceptance/create-card-test.js
@@ -80,27 +80,27 @@ module('Acceptance | card create', function(hooks) {
     assert.dom('[data-test-internal-card-id]').hasText('local-hub::millenial-puppies');
 
     await click('[data-test-field="title"] [data-test-field-schema-renderer]');
-    assert.dom('[data-test-field="title"] [data-test-field-schema-renderer]').isFocused();
+    assert.dom('[data-test-isolated-card="millenial-puppies"] [data-test-field="title"]').hasClass('selected');
     assert.dom('[data-test-field="title"] [data-test-field-renderer-type]').hasText('@cardstack/core-types::string');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="embedded"] input').isChecked();
 
     await click('[data-test-field="body"] [data-test-field-schema-renderer]');
-    assert.dom('[data-test-field="body"] [data-test-field-schema-renderer]').isFocused();
+    assert.dom('[data-test-isolated-card="millenial-puppies"] [data-test-field="body"]').hasClass('selected');
     assert.dom('[data-test-field="body"] [data-test-field-renderer-type]').hasText('@cardstack/core-types::string');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="embedded"] input').isNotChecked();
 
     await click('[data-test-field="author"] [data-test-field-schema-renderer]');
-    assert.dom('[data-test-field="author"] [data-test-field-schema-renderer]').isFocused();
+    assert.dom('[data-test-isolated-card="millenial-puppies"] [data-test-field="author"]').hasClass('selected');
     assert.dom('[data-test-field="author"] [data-test-field-renderer-type]').hasText('@cardstack/core-types::belongs-to');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="embedded"] input').isChecked();
 
     await click('[data-test-field="reviewers"] [data-test-field-schema-renderer]');
-    assert.dom('[data-test-field="reviewers"] [data-test-field-schema-renderer]').isFocused();
+    assert.dom('[data-test-isolated-card="millenial-puppies"] [data-test-field="reviewers"]').hasClass('selected');
     assert.dom('[data-test-field="reviewers"] [data-test-field-renderer-type]').hasText('@cardstack/core-types::has-many');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="embedded"] input').isChecked();
 
     await focus('[data-test-card-renderer-isolated]');
-    assert.dom('.field-renderer .schema-field-renderer').isNotFocused();
+    assert.dom('.field-renderer').doesNotHaveClass('selected');
     assert.dom('.card-renderer-isolated--header').hasText('millenial-puppies');
     assert.dom('[data-test-internal-card-id]').hasText('local-hub::millenial-puppies');
 
@@ -137,19 +137,19 @@ module('Acceptance | card create', function(hooks) {
     assert.dom('[data-test-right-edge] [data-test-schema-attr="instructions"] textarea').hasValue('This is the subtitle');
 
     await click('[data-test-field="body"] [data-test-field-schema-renderer]');
-    assert.dom('[data-test-field="body"] [data-test-field-schema-renderer]').isFocused();
+    assert.dom('[data-test-isolated-card="millenial-puppies"] [data-test-field="body"]').hasClass('selected');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="name"] input').hasValue('body');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="label"] input').hasValue('body');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="instructions"] textarea').hasValue('');
 
     await click('[data-test-field="subtitle"] [data-test-field-schema-renderer]');
-    assert.dom('[data-test-field="subtitle"] [data-test-field-schema-renderer]').isFocused();
+    assert.dom('[data-test-isolated-card="millenial-puppies"] [data-test-field="subtitle"]').hasClass('selected');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="name"] input').hasValue('subtitle');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="label"] input').hasValue('Subtitle');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="instructions"] textarea').hasValue('This is the subtitle');
 
     await dragAndDropNewField('string');
-    assert.dom('[data-test-field="new-field-2"] [data-test-field-schema-renderer]').isFocused();
+    assert.dom('[data-test-isolated-card="millenial-puppies"] [data-test-field="new-field-2"]').hasClass('selected');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="name"] input').hasValue('new-field-2');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="label"] input').hasValue('new-field-2');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="instructions"] textarea').hasValue('');

--- a/packages/cardhost/tests/acceptance/create-card-test.js
+++ b/packages/cardhost/tests/acceptance/create-card-test.js
@@ -1,11 +1,10 @@
 import { module, test } from 'qunit';
-import { click, fillIn, find, visit, currentURL, triggerEvent, focus, waitFor } from '@ember/test-helpers';
+import { click, fillIn, find, visit, currentURL, triggerEvent, focus } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import Fixtures from '@cardstack/test-support/fixtures'
 import { addField, setCardId, createCards, saveCard, dragAndDropNewField, removeField } from '@cardstack/test-support/card-ui-helpers';
 import { setupMockUser, login } from '../helpers/login';
 
-const timeout = 20000;
 const card1Id = 'millenial-puppies';
 const qualifiedCard1Id = `local-hub::${card1Id}`;
 
@@ -101,10 +100,11 @@ module('Acceptance | card create', function(hooks) {
     assert.dom('[data-test-right-edge] [data-test-schema-attr="embedded"] input').isChecked();
 
     await focus('[data-test-card-renderer-isolated]');
-    await waitFor('.card-renderer.selected', { timeout });
-    assert.dom('.field-renderer').doesNotHaveClass('selected');
     assert.dom('.card-renderer-isolated--header').hasText('millenial-puppies');
     assert.dom('[data-test-internal-card-id]').hasText('local-hub::millenial-puppies');
+    // TODO: figure out why having the following assertions before the line above ^^^ causes a test failure
+    assert.dom('.card-renderer').hasClass('selected');
+    assert.dom('.field-renderer').doesNotHaveClass('selected');
 
     let cardJson = find('[data-test-code-block]').getAttribute('data-test-code-block')
     let card = JSON.parse(cardJson);

--- a/packages/cardhost/tests/acceptance/create-card-test.js
+++ b/packages/cardhost/tests/acceptance/create-card-test.js
@@ -43,7 +43,7 @@ module('Acceptance | card create', function(hooks) {
 
     assert.equal(currentURL(), '/cards/new');
 
-    assert.dom('.card-renderer').isFocused('card renderer element is focused')
+    assert.dom('.card-renderer').isFocused('card renderer element is focused');
   });
 
   test("changing a card's id does not clear the card fields", async function(assert) {
@@ -79,23 +79,28 @@ module('Acceptance | card create', function(hooks) {
     assert.dom('.card-renderer-isolated--header').hasText('millenial-puppies');
     assert.dom('[data-test-internal-card-id]').hasText('local-hub::millenial-puppies');
 
-    await click('[data-test-field="title"]');
+    await click('[data-test-field="title"] [data-test-field-schema-renderer]');
+    assert.dom('[data-test-field="title"] [data-test-field-schema-renderer]').isFocused();
     assert.dom('[data-test-field="title"] [data-test-field-renderer-type]').hasText('@cardstack/core-types::string');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="embedded"] input').isChecked();
 
-    await click('[data-test-field="body"]');
+    await click('[data-test-field="body"] [data-test-field-schema-renderer]');
+    assert.dom('[data-test-field="body"] [data-test-field-schema-renderer]').isFocused();
     assert.dom('[data-test-field="body"] [data-test-field-renderer-type]').hasText('@cardstack/core-types::string');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="embedded"] input').isNotChecked();
 
-    await click('[data-test-field="author"]');
+    await click('[data-test-field="author"] [data-test-field-schema-renderer]');
+    assert.dom('[data-test-field="author"] [data-test-field-schema-renderer]').isFocused();
     assert.dom('[data-test-field="author"] [data-test-field-renderer-type]').hasText('@cardstack/core-types::belongs-to');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="embedded"] input').isChecked();
 
-    await click('[data-test-field="reviewers"]');
+    await click('[data-test-field="reviewers"] [data-test-field-schema-renderer]');
+    assert.dom('[data-test-field="reviewers"] [data-test-field-schema-renderer]').isFocused();
     assert.dom('[data-test-field="reviewers"] [data-test-field-renderer-type]').hasText('@cardstack/core-types::has-many');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="embedded"] input').isChecked();
 
     await focus('[data-test-card-renderer-isolated]');
+    assert.dom('.field-renderer .schema-field-renderer').isNotFocused();
     assert.dom('.card-renderer-isolated--header').hasText('millenial-puppies');
     assert.dom('[data-test-internal-card-id]').hasText('local-hub::millenial-puppies');
 
@@ -131,18 +136,20 @@ module('Acceptance | card create', function(hooks) {
     await triggerEvent(`[data-test-right-edge] [data-test-schema-attr="instructions"] textarea`, 'keyup');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="instructions"] textarea').hasValue('This is the subtitle');
 
-    await click('[data-test-field="body"]');
+    await click('[data-test-field="body"] [data-test-field-schema-renderer]');
+    assert.dom('[data-test-field="body"] [data-test-field-schema-renderer]').isFocused();
     assert.dom('[data-test-right-edge] [data-test-schema-attr="name"] input').hasValue('body');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="label"] input').hasValue('body');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="instructions"] textarea').hasValue('');
 
-    await click('[data-test-field="subtitle"]');
+    await click('[data-test-field="subtitle"] [data-test-field-schema-renderer]');
+    assert.dom('[data-test-field="subtitle"] [data-test-field-schema-renderer]').isFocused();
     assert.dom('[data-test-right-edge] [data-test-schema-attr="name"] input').hasValue('subtitle');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="label"] input').hasValue('Subtitle');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="instructions"] textarea').hasValue('This is the subtitle');
 
     await dragAndDropNewField('string');
-    await click('[data-test-field="new-field-2"]');
+    assert.dom('[data-test-field="new-field-2"] [data-test-field-schema-renderer]').isFocused();
     assert.dom('[data-test-right-edge] [data-test-schema-attr="name"] input').hasValue('new-field-2');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="label"] input').hasValue('new-field-2');
     assert.dom('[data-test-right-edge] [data-test-schema-attr="instructions"] textarea').hasValue('');

--- a/packages/core/addon/components/card-renderer.js
+++ b/packages/core/addon/components/card-renderer.js
@@ -28,8 +28,15 @@ export default class CardRenderer extends Component {
   }
 
   @action
-  focusCard(value) {
+  cardIsFocused(value) {
     this.cardFocused(value);
+  }
+
+  @action
+  focusElement(element) {
+    if (this.mode === 'schema') {
+      element.focus({ preventScroll: true });
+    }
   }
 
   get sanitizedName() {

--- a/packages/core/addon/components/card-renderer.js
+++ b/packages/core/addon/components/card-renderer.js
@@ -12,6 +12,7 @@ export default class CardRenderer extends Component {
   @tracked componentName;
   @tracked mode;
   @tracked cardFocused = () => {};
+  @tracked cardSelected = true;
 
   constructor(...args) {
     super(...args);
@@ -30,6 +31,7 @@ export default class CardRenderer extends Component {
   @action
   cardIsFocused(value) {
     this.cardFocused(value);
+    this.cardSelected = value;
   }
 
   @action
@@ -37,6 +39,7 @@ export default class CardRenderer extends Component {
     if (this.mode === 'schema') {
       element.focus({ preventScroll: true });
     }
+    this.cardSelected = true;
   }
 
   get sanitizedName() {

--- a/packages/core/addon/components/card-renderer.js
+++ b/packages/core/addon/components/card-renderer.js
@@ -12,7 +12,6 @@ export default class CardRenderer extends Component {
   @tracked componentName;
   @tracked mode;
   @tracked cardFocused = () => {};
-  @tracked cardSelected = true;
 
   constructor(...args) {
     super(...args);
@@ -31,7 +30,6 @@ export default class CardRenderer extends Component {
   @action
   cardIsFocused(value) {
     this.cardFocused(value);
-    this.cardSelected = value;
   }
 
   @action
@@ -39,7 +37,6 @@ export default class CardRenderer extends Component {
     if (this.mode === 'schema') {
       element.focus({ preventScroll: true });
     }
-    this.cardSelected = true;
   }
 
   get sanitizedName() {

--- a/packages/core/addon/components/card-renderer.js
+++ b/packages/core/addon/components/card-renderer.js
@@ -33,10 +33,8 @@ export default class CardRenderer extends Component {
   }
 
   @action
-  focusElement(element) {
-    if (this.mode === 'schema') {
-      element.focus({ preventScroll: true });
-    }
+  focusCard(element, [value]) {
+    this.cardFocused(value);
   }
 
   get sanitizedName() {

--- a/packages/core/addon/components/field-renderer.js
+++ b/packages/core/addon/components/field-renderer.js
@@ -59,10 +59,8 @@ export default class FieldRenderer extends Component {
   }
 
   @action
-  focusElement(element) {
-    if (this.args.mode === 'schema') {
-      element.focus({ preventScroll: true });
-    }
+  focusParentElement(element) {
+    element.parentElement.focus({ preventScroll: true });
   }
 
   get nonce() {

--- a/packages/core/addon/components/field-renderer.js
+++ b/packages/core/addon/components/field-renderer.js
@@ -58,6 +58,13 @@ export default class FieldRenderer extends Component {
     return null;
   }
 
+  @action
+  focusElement(element) {
+    if (this.args.mode === 'schema') {
+      element.focus({ preventScroll: true });
+    }
+  }
+
   get nonce() {
     return onFieldChangedDependencies.map(i => this.args.field[i]).join('::');
   }

--- a/packages/core/addon/templates/components/card-renderer.hbs
+++ b/packages/core/addon/templates/components/card-renderer.hbs
@@ -7,10 +7,11 @@ Ember Concurrency into the rendering of the card component here.
 {{#if (eq @format "isolated")}}
   {{#let (component this.isolatedComponentName) as | Isolated |}}
     <section
-      class="card-renderer card-renderer-{{@format}} {{this.mode}}"
+      class="card-renderer card-renderer-{{@format}} {{this.mode}} {{if this.cardSelected "selected"}}"
       tabindex="0"
       data-test-card-renderer-isolated
       {{on "focus" (action this.cardIsFocused true)}}
+      {{on "blur" (action this.cardIsFocused false)}}
       {{did-insert this.focusElement}}
     >
       <header class="card-renderer-{{@format}}--header">
@@ -34,6 +35,7 @@ Ember Concurrency into the rendering of the card component here.
             @setNeededWhenEmbedded={{@setNeededWhenEmbedded}}
             @setPosition={{@setPosition}}
             @selectField={{@selectField}}
+            @selectedField={{@selectedField}}
             @dropField={{@dropField}}
           />
           {{#if (and @dropField (eq @mode "schema")) }}

--- a/packages/core/addon/templates/components/card-renderer.hbs
+++ b/packages/core/addon/templates/components/card-renderer.hbs
@@ -7,11 +7,10 @@ Ember Concurrency into the rendering of the card component here.
 {{#if (eq @format "isolated")}}
   {{#let (component this.isolatedComponentName) as | Isolated |}}
     <section
-      class="card-renderer card-renderer-{{@format}} {{this.mode}} {{if this.cardSelected "selected"}}"
+      class="card-renderer card-renderer-{{@format}} {{this.mode}} {{if (and @displayCardMetadata this.cardSelected) "selected"}}"
       tabindex="0"
       data-test-card-renderer-isolated
       {{on "focus" (action this.cardIsFocused true)}}
-      {{on "blur" (action this.cardIsFocused false)}}
       {{did-insert this.focusElement}}
     >
       <header class="card-renderer-{{@format}}--header">

--- a/packages/core/addon/templates/components/card-renderer.hbs
+++ b/packages/core/addon/templates/components/card-renderer.hbs
@@ -7,7 +7,7 @@ Ember Concurrency into the rendering of the card component here.
 {{#if (eq @format "isolated")}}
   {{#let (component this.isolatedComponentName) as | Isolated |}}
     <section
-      class="card-renderer card-renderer-{{@format}} {{this.mode}} {{if (and @displayCardMetadata this.cardSelected) "selected"}}"
+      class="card-renderer card-renderer-{{@format}} {{this.mode}} {{if @cardSelected "selected"}}"
       tabindex="0"
       data-test-card-renderer-isolated
       {{on "focus" (action this.cardIsFocused true)}}

--- a/packages/core/addon/templates/components/card-renderer.hbs
+++ b/packages/core/addon/templates/components/card-renderer.hbs
@@ -7,10 +7,11 @@ Ember Concurrency into the rendering of the card component here.
 {{#if (eq @format "isolated")}}
   {{#let (component this.isolatedComponentName) as | Isolated |}}
     <section
-      class="card-renderer-{{@format}} {{this.mode}}"
+      class="card-renderer card-renderer-{{@format}} {{this.mode}}"
       tabindex="0"
       data-test-card-renderer-isolated
-      {{on "focus" (action this.focusCard true)}}
+      {{on "focus" (action this.cardIsFocused true)}}
+      {{did-insert this.focusElement}}
     >
       <header class="card-renderer-{{@format}}--header">
         {{!--

--- a/packages/core/addon/templates/components/card-renderer.hbs
+++ b/packages/core/addon/templates/components/card-renderer.hbs
@@ -11,7 +11,7 @@ Ember Concurrency into the rendering of the card component here.
       tabindex="0"
       data-test-card-renderer-isolated
       {{on "focus" (action this.cardIsFocused true)}}
-      {{did-insert this.focusElement}}
+      {{did-insert this.focusCard true}}
     >
       <header class="card-renderer-{{@format}}--header">
         {{!--

--- a/packages/core/addon/templates/components/field-renderer.hbs
+++ b/packages/core/addon/templates/components/field-renderer.hbs
@@ -47,7 +47,12 @@
   {{else if (eq @mode "schema")}}
     {{!-- TODO we should extract the schema editing stuff into a seaprate component --}}
       {{#if (includes this.schemaAttrs "title")}}
-        <div class="schema-field-renderer" tabindex="0">
+        <div
+          tabindex="0"
+          class="schema-field-renderer"
+          data-test-field-schema-renderer
+          {{did-insert this.focusElement}}
+        >
           {{!-- TODO: Change displayed logo depending on field --}}
           {{! template-lint-disable no-inline-styles }}
           <header

--- a/packages/core/addon/templates/components/field-renderer.hbs
+++ b/packages/core/addon/templates/components/field-renderer.hbs
@@ -17,6 +17,7 @@
     " field-type-"
     this.dasherizedType
     (if (or @setPosition @removeField) " with-buttons")
+    (if (eq @field @selectedField) " selected")
   }}
   tabindex={{@field.position}}
   data-test-field={{@field.name}}

--- a/packages/core/addon/templates/components/field-renderer.hbs
+++ b/packages/core/addon/templates/components/field-renderer.hbs
@@ -18,6 +18,7 @@
     this.dasherizedType
     (if (or @setPosition @removeField) " with-buttons")
   }}
+  tabindex={{@field.position}}
   data-test-field={{@field.name}}
   data-test-field-type={{@field.type}}
   data-test-field-mode={{@mode}}
@@ -48,10 +49,9 @@
     {{!-- TODO we should extract the schema editing stuff into a seaprate component --}}
       {{#if (includes this.schemaAttrs "title")}}
         <div
-          tabindex="0"
           class="schema-field-renderer"
           data-test-field-schema-renderer
-          {{did-insert this.focusElement}}
+          {{did-insert this.focusParentElement}}
         >
           {{!-- TODO: Change displayed logo depending on field --}}
           {{! template-lint-disable no-inline-styles }}

--- a/packages/core/tests/integration/components/card-renderer-test.js
+++ b/packages/core/tests/integration/components/card-renderer-test.js
@@ -289,7 +289,7 @@ module('Integration | Component | card-renderer', function(hooks) {
     assert.dom('.embedded-card-label').hasText(card1Id);
   });
 
-  test('isolated card in schema mode is focused on initial render', async function(assert) {
+  test('isolated card in schema mode is selected on initial render', async function(assert) {
     let service = this.owner.lookup('service:data');
     let card = service.createCard(qualifiedCard1Id);
     this.set('card', card);
@@ -302,10 +302,10 @@ module('Integration | Component | card-renderer', function(hooks) {
       />
     `);
 
-    assert.dom('[data-test-card-renderer-isolated]').isFocused();
+    assert.dom('[data-test-card-renderer-isolated]').hasClass('selected');
   });
 
-  test('isolated card in view mode is not focused on initial render', async function(assert) {
+  test('isolated card in view mode is not selected on initial render', async function(assert) {
     let service = this.owner.lookup('service:data');
     let card = service.createCard(qualifiedCard1Id);
     this.set('card', card);
@@ -318,7 +318,7 @@ module('Integration | Component | card-renderer', function(hooks) {
       />
     `);
 
-    assert.dom('[data-test-card-renderer-isolated]').isNotFocused();
+    assert.dom('[data-test-card-renderer-isolated]').doesNotHaveClass('selected');
   });
 
   test('isolated card in edit mode is not focused on initial render', async function(assert) {
@@ -334,7 +334,7 @@ module('Integration | Component | card-renderer', function(hooks) {
       />
     `);
 
-    assert.dom('[data-test-card-renderer-isolated]').isNotFocused();
+    assert.dom('[data-test-card-renderer-isolated]').doesNotHaveClass('selected');
   });
 
   skip('TODO it adds isolated css into the page when rendering an isolated card', async function(/*assert*/) {

--- a/packages/core/tests/integration/components/card-renderer-test.js
+++ b/packages/core/tests/integration/components/card-renderer-test.js
@@ -289,6 +289,54 @@ module('Integration | Component | card-renderer', function(hooks) {
     assert.dom('.embedded-card-label').hasText(card1Id);
   });
 
+  test('isolated card in schema mode is focused on initial render', async function(assert) {
+    let service = this.owner.lookup('service:data');
+    let card = service.createCard(qualifiedCard1Id);
+    this.set('card', card);
+
+    await render(hbs`
+      <CardRenderer
+        @card={{card}}
+        @format="isolated"
+        @mode="schema"
+      />
+    `);
+
+    assert.dom('[data-test-card-renderer-isolated]').isFocused();
+  });
+
+  test('isolated card in view mode is not focused on initial render', async function(assert) {
+    let service = this.owner.lookup('service:data');
+    let card = service.createCard(qualifiedCard1Id);
+    this.set('card', card);
+
+    await render(hbs`
+      <CardRenderer
+        @card={{card}}
+        @format="isolated"
+        @mode="view"
+      />
+    `);
+
+    assert.dom('[data-test-card-renderer-isolated]').isNotFocused();
+  });
+
+  test('isolated card in edit mode is not focused on initial render', async function(assert) {
+    let service = this.owner.lookup('service:data');
+    let card = service.createCard(qualifiedCard1Id);
+    this.set('card', card);
+
+    await render(hbs`
+      <CardRenderer
+        @card={{card}}
+        @format="isolated"
+        @mode="edit"
+      />
+    `);
+
+    assert.dom('[data-test-card-renderer-isolated]').isNotFocused();
+  });
+
   skip('TODO it adds isolated css into the page when rendering an isolated card', async function(/*assert*/) {
   });
 

--- a/packages/core/tests/integration/components/card-renderer-test.js
+++ b/packages/core/tests/integration/components/card-renderer-test.js
@@ -289,52 +289,15 @@ module('Integration | Component | card-renderer', function(hooks) {
     assert.dom('.embedded-card-label').hasText(card1Id);
   });
 
-  test('isolated card in schema mode is selected on initial render', async function(assert) {
-    let service = this.owner.lookup('service:data');
-    let card = service.createCard(qualifiedCard1Id);
-    this.set('card', card);
-
+  test('isolated card can be selected', async function(assert) {
     await render(hbs`
       <CardRenderer
-        @card={{card}}
         @format="isolated"
-        @mode="schema"
+        @cardSelected={{true}}
       />
     `);
 
     assert.dom('[data-test-card-renderer-isolated]').hasClass('selected');
-  });
-
-  test('isolated card in view mode is not selected on initial render', async function(assert) {
-    let service = this.owner.lookup('service:data');
-    let card = service.createCard(qualifiedCard1Id);
-    this.set('card', card);
-
-    await render(hbs`
-      <CardRenderer
-        @card={{card}}
-        @format="isolated"
-        @mode="view"
-      />
-    `);
-
-    assert.dom('[data-test-card-renderer-isolated]').doesNotHaveClass('selected');
-  });
-
-  test('isolated card in edit mode is not focused on initial render', async function(assert) {
-    let service = this.owner.lookup('service:data');
-    let card = service.createCard(qualifiedCard1Id);
-    this.set('card', card);
-
-    await render(hbs`
-      <CardRenderer
-        @card={{card}}
-        @format="isolated"
-        @mode="edit"
-      />
-    `);
-
-    assert.dom('[data-test-card-renderer-isolated]').doesNotHaveClass('selected');
   });
 
   skip('TODO it adds isolated css into the page when rendering an isolated card', async function(/*assert*/) {


### PR DESCRIPTION
Closes #993 

- [x] The highlighted card/component has its header and a border around it in the highlight color. 
- [x] The border should be on the outside of the component so that inner dimensions are not affected and there is no shifting of contents when the component is highlighted/unhighlighted (related to #965). 
- [x] When a new card is created/adopted, the card itself should be highlighted
- [x] When a new UI component is added to the card it should immediately be highlighted
- [x] Any action that selects a UI component (clicking on it, clicking on its gripper, etc) should also highlight it
- [x] Card and field headers should be highlighted only in schema view. Don't highlight in layout or edit views