### PR TITLE
WIP show card CSS and markup in themer

### DIFF
--- a/packages/cardhost/app/components/editor-pane.js
+++ b/packages/cardhost/app/components/editor-pane.js
@@ -4,6 +4,17 @@ import { action } from '@ember/object';
 
 export default class EditorPane extends Component {
   @tracked dockLocation = "bottom";
+  @tracked markup;
+  @tracked css = this.args.model.isolatedCss;
+
+
+  constructor() {
+    super(...arguments)
+    // getting markup must be done in the constuctor to guarantee that it
+    // resolves before the code editor is rendered.
+    let cardMarkup = document.querySelector('.card-renderer-isolated--main')
+    this.markup = cardMarkup ? cardMarkup.innerHTML : "";
+  }
 
   @action
   dockRight() {
@@ -15,4 +26,26 @@ export default class EditorPane extends Component {
     this.dockLocation = "bottom";
   }
 
+  @action
+  preview() {
+    var css = this.css
+    let newStyle = document.createElement('style')
+    newStyle.setAttribute('id', 'card-styles')
+
+    document.querySelector('#card-styles').replaceWith(newStyle)
+
+    newStyle.type = 'text/css';
+    if (newStyle.styleSheet){
+      // This is required for IE8 and below.
+      newStyle.styleSheet.cssText = css;
+    } else {
+      newStyle.appendChild(document.createTextNode(css));
+    }
+  }
+
+  @action
+  updateCode(code) {
+    this.css = code
+    this.preview()
+  }
 }

--- a/packages/cardhost/app/controllers/cards/view.js
+++ b/packages/cardhost/app/controllers/cards/view.js
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class ViewCardController extends Controller {
   @service cssModeToggle
@@ -7,5 +8,11 @@ export default class ViewCardController extends Controller {
   get cardJson() {
     if (!this.model) { return null; }
     return JSON.stringify(this.model.json, null, 2);
+  }
+
+  saveCss(css) {
+    this.model.isolatedCss = css;
+    console.log(this.model)
+    // this.model.save()
   }
 }

--- a/packages/cardhost/app/controllers/cards/view.js
+++ b/packages/cardhost/app/controllers/cards/view.js
@@ -9,10 +9,10 @@ export default class ViewCardController extends Controller {
     if (!this.model) { return null; }
     return JSON.stringify(this.model.json, null, 2);
   }
-
+  
+  @action
   saveCss(css) {
-    this.model.isolatedCss = css;
-    console.log(this.model)
-    // this.model.save()
+    this.model.setIsolatedCss(css);
+    this.model.save()
   }
 }

--- a/packages/cardhost/app/templates/cards/view.hbs
+++ b/packages/cardhost/app/templates/cards/view.hbs
@@ -50,5 +50,5 @@
 
 
 {{#if this.cssModeToggle.editingCss}}
-  <EditorPane />
+  <EditorPane @model={{this.model}} />
 {{/if}}

--- a/packages/cardhost/app/templates/cards/view.hbs
+++ b/packages/cardhost/app/templates/cards/view.hbs
@@ -50,5 +50,5 @@
 
 
 {{#if this.cssModeToggle.editingCss}}
-  <EditorPane @model={{this.model}} />
+  <EditorPane @model={{this.model}} @saveCss={{this.saveCss}}/>
 {{/if}}

--- a/packages/cardhost/app/templates/components/editor-pane.hbs
+++ b/packages/cardhost/app/templates/components/editor-pane.hbs
@@ -1,6 +1,7 @@
   <section  class="cardhost-card-theme-editor {{if (eq this.dockLocation "bottom") "bottom-docked"}}">
     <div {{on "click" this.dockRight}}>right</div>
     <div {{on "click" this.dockBottom}}>bottom</div>
+    <button {{on "click" (fn @saveCss this.css)}}>save</button>
     <h3>Card Theme Editor</h3>
     <CodeEditor
       @code={{@model.isolatedCss}}

--- a/packages/cardhost/app/templates/components/editor-pane.hbs
+++ b/packages/cardhost/app/templates/components/editor-pane.hbs
@@ -1,11 +1,22 @@
-  <section class="cardhost-card-theme-editor {{if (eq this.dockLocation "bottom") "bottom-docked"}}">
+  <section  class="cardhost-card-theme-editor {{if (eq this.dockLocation "bottom") "bottom-docked"}}">
     <div {{on "click" this.dockRight}}>right</div>
     <div {{on "click" this.dockBottom}}>bottom</div>
     <h3>Card Theme Editor</h3>
     <CodeEditor
-      @code=".a {}"
+      @code={{@model.isolatedCss}}
       @language="css"
       @readOnly={{false}}
       @resizable={{true}}
+      @updateCode={{action "updateCode"}}
+    />
+
+    <h3>HTML Viewer</h3>
+    <CodeEditor
+      @code={{this.markup}}
+      @language="handlebars"
+      @readOnly={{true}}
+      @resizable={{true}}
     />
   </section>
+
+<style id="card-styles" {{did-insert this.preview}}></style>


### PR DESCRIPTION
closes #1065

This is a draft PR that we can merge together with Derrick's work when it makes sense to. It targets the WIP `1066-dock-editor` branch.

## Added
- code that applies the Card's CSS (if it has any) and renders any changes. 
- Can edit CSS and see an immediate preview
- code that gets the Card markup via query selectors and renders it in an "HTML Viewer" code editor that is read-only
- temporary "save" button, that should be replaced/removed before merging this. Save will persist the CSS changes

## Changed
- pass the card model to the EditorPanel
- pass a saveCss action to the editor panel