### PR TITLE
Save css

### DIFF
--- a/packages/cardhost/app/components/editor-pane.js
+++ b/packages/cardhost/app/components/editor-pane.js
@@ -17,26 +17,7 @@ export default class EditorPane extends Component {
   }
 
   @action
-  preview() {
-    var css = this.css
-    let newStyle = document.createElement('style')
-    newStyle.setAttribute('id', 'card-styles')
-
-    document.querySelector('#card-styles').replaceWith(newStyle)
-
-    newStyle.type = 'text/css';
-    if (newStyle.styleSheet){
-      // This is required for IE8 and below.
-      newStyle.styleSheet.cssText = css;
-    } else {
-      newStyle.appendChild(document.createTextNode(css));
-    }
-  }
-
-  @action
   updateCode(code) {
-    this.css = code
     this.args.model.setIsolatedCss(code);
-    this.preview()
   }
 }

--- a/packages/cardhost/app/components/editor-pane.js
+++ b/packages/cardhost/app/components/editor-pane.js
@@ -1,7 +1,42 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
 export default class EditorPane extends Component {
-  @service cssModeToggle
+  @service cssModeToggle;
+  @tracked markup;
+  @tracked css = this.args.model.isolatedCss;
 
+  constructor() {
+    super(...arguments)
+    // getting markup must be done in the constuctor to guarantee that it
+    // resolves before the code editor is rendered.
+    let cardMarkup = document.querySelector('.card-renderer-isolated--content')
+    this.markup = cardMarkup ? cardMarkup.innerHTML.toString().trim() : "";
+  }
+
+  @action
+  preview() {
+    var css = this.css
+    let newStyle = document.createElement('style')
+    newStyle.setAttribute('id', 'card-styles')
+
+    document.querySelector('#card-styles').replaceWith(newStyle)
+
+    newStyle.type = 'text/css';
+    if (newStyle.styleSheet){
+      // This is required for IE8 and below.
+      newStyle.styleSheet.cssText = css;
+    } else {
+      newStyle.appendChild(document.createTextNode(css));
+    }
+  }
+
+  @action
+  updateCode(code) {
+    this.css = code
+    this.args.model.setIsolatedCss(code);
+    this.preview()
+  }
 }

--- a/packages/cardhost/app/controllers/cards/view.js
+++ b/packages/cardhost/app/controllers/cards/view.js
@@ -6,6 +6,7 @@ import { tracked } from '@glimmer/tracking';
 export default class ViewCardController extends Controller {
   @service cssModeToggle
   @service router
+  @service cardstackSession;
   resizeable = true;
 
   get cardJson() {
@@ -28,5 +29,16 @@ export default class ViewCardController extends Controller {
     this.cssModeToggle.setEditingCss(true)
     this.themerOptions.push({name: 'Custom theme'})
     this.router.transitionTo('cards.view', this.model, { queryParams:{ editingCss: true } })
+  }
+
+  @action
+  save() {
+    this.model.save()
+  }
+
+  @action
+  closeEditor() {
+    this.cssModeToggle.setEditingCss(false);
+    this.router.transitionTo('cards.view', this.model, {queryParams:{editingCss: false}})
   }
 }

--- a/packages/cardhost/app/controllers/cards/view.js
+++ b/packages/cardhost/app/controllers/cards/view.js
@@ -39,6 +39,6 @@ export default class ViewCardController extends Controller {
   @action
   closeEditor() {
     this.cssModeToggle.setEditingCss(false);
-    this.router.transitionTo('cards.view', this.model, {queryParams:{editingCss: false}})
+    this.router.transitionTo('cards.view', this.model, {queryParams:{editingCss: undefined}})
   }
 }

--- a/packages/cardhost/app/routes/cards.js
+++ b/packages/cardhost/app/routes/cards.js
@@ -6,6 +6,7 @@ export default class CardsRoute extends Route {
   queryParams = { editingCss: {} }
 
   model({ editingCss }) {
-    this.cssModeToggle.setEditingCss(editingCss);
+    let editingBool = editingCss === "true" ? true : false;
+    this.cssModeToggle.setEditingCss(editingBool);
   }
 }

--- a/packages/cardhost/app/styles/app.css
+++ b/packages/cardhost/app/styles/app.css
@@ -264,3 +264,7 @@ a:hover {
   resize: vertical;
   background-color: #1e1e1e;
 }
+
+.cardhost-monaco-container.editor-pane-code {
+  min-height: 35vh;
+}

--- a/packages/cardhost/app/templates/cards/view.hbs
+++ b/packages/cardhost/app/templates/cards/view.hbs
@@ -53,10 +53,10 @@
 
 <section class="cardhost-card-document">
   <h3>Card Document</h3>
-  {{!-- <CodeEditor
+  <CodeEditor
     @code={{this.cardJson}}
     @language="json"
-  /> --}}
+  />
 </section>
 
 

--- a/packages/cardhost/app/templates/cards/view.hbs
+++ b/packages/cardhost/app/templates/cards/view.hbs
@@ -12,7 +12,10 @@
     >
       {{svg-jar "dock-right"}}
     </div>
-    <button class="ch-button close-editor-btn" {{on "click" this.closeEditor}}>
+    <button {{on "click" this.closeEditor}}
+      class="ch-button close-editor-btn"
+      data-test-close-editor
+    >
       Close Editor
     </button>
 

--- a/packages/cardhost/app/templates/cards/view.hbs
+++ b/packages/cardhost/app/templates/cards/view.hbs
@@ -12,7 +12,9 @@
     >
       {{svg-jar "dock-right"}}
     </div>
-    <button class="ch-button close-editor-btn">Close Editor</button>
+    <button class="ch-button close-editor-btn" {{on "click" this.closeEditor}}>
+      Close Editor
+    </button>
 
   {{else}}
     {{! eslint is confused by on helper }}
@@ -31,6 +33,7 @@
     <button
       class="ch-button"
       disabled={{not this.cardstackSession.isAuthenticated}}
+      {{on "click" this.save}}
     >
       Save
     </button>
@@ -50,15 +53,18 @@
 
 <section class="cardhost-card-document">
   <h3>Card Document</h3>
-  <CodeEditor
+  {{!-- <CodeEditor
     @code={{this.cardJson}}
     @language="json"
-  />
+  /> --}}
 </section>
 
 
 {{#if this.cssModeToggle.editingCss}}
-  <EditorPane data-test-dock-location={{this.cssModeToggle.dockLocation}} />
+  <EditorPane data-test-dock-location={{this.cssModeToggle.dockLocation}}
+    @model={{this.model}}
+    @saveCss={{this.saveCss}}
+  />
 {{else}}
   <RightEdge
     @card={{this.card}}
@@ -83,3 +89,5 @@
     </div>
   </RightEdge>
 {{/if}}
+
+<style id="card-styles">{{this.model.isolatedCss}}</style>

--- a/packages/cardhost/app/templates/components/editor-pane.hbs
+++ b/packages/cardhost/app/templates/components/editor-pane.hbs
@@ -21,4 +21,4 @@
   />
 </section>
 
-<style id="card-styles" {{did-insert this.preview}}></style>
+<style id="card-styles">{{@model.isolatedCss}}</style>

--- a/packages/cardhost/app/templates/components/editor-pane.hbs
+++ b/packages/cardhost/app/templates/components/editor-pane.hbs
@@ -5,9 +5,20 @@
 >
   <h3>Card Theme Editor</h3>
   <CodeEditor
-    @code=".a {}"
+    @code={{@model.isolatedCss}}
     @language="css"
     @readOnly={{false}}
-    @resizable={{true}}
+    @updateCode={{action "updateCode"}}
+    class="editor-pane-code"
+  />
+
+  <h3>HTML Viewer</h3>
+  <CodeEditor
+    @code={{this.markup}}
+    @language="handlebars"
+    @readOnly={{true}}
+    class="editor-pane-code"
   />
 </section>
+
+<style id="card-styles" {{did-insert this.preview}}></style>

--- a/packages/cardhost/tests/acceptance/css-editing-test.js
+++ b/packages/cardhost/tests/acceptance/css-editing-test.js
@@ -58,7 +58,7 @@ module('Acceptance | css editing', function(hooks) {
     assert.equal(currentURL(), `/cards/${card1Id}?editingCss=true`);
     assert.dom('[data-test-close-editor]').exists();
     await click('[data-test-close-editor]')
-    assert.equal(currentURL(), `/cards/${card1Id}?editingCss=false`);
+    assert.equal(currentURL(), `/cards/${card1Id}`);
     assert.dom('[data-test-editor-pane]').doesNotExist();
   });
 });

--- a/packages/cardhost/tests/acceptance/css-editing-test.js
+++ b/packages/cardhost/tests/acceptance/css-editing-test.js
@@ -8,6 +8,13 @@ import { setupMockUser, login } from '../helpers/login';
 const timeout = 20000;
 const card1Id = 'millenial-puppies';
 const qualifiedCard1Id = `local-hub::${card1Id}`;
+const cardData  = {
+  [card1Id]: [
+    ['title', 'string', true, 'The Millenial Puppy'],
+    ['author', 'string', true, 'Van Gogh'],
+    ['body', 'string', false, 'It can be difficult these days to deal with the discerning tastes of the millenial puppy.']
+  ]
+}
 
 const scenario = new Fixtures({
   create(factory) {
@@ -30,15 +37,9 @@ module('Acceptance | css editing', function(hooks) {
     this.owner.lookup('controller:cards.view').resizable = false;
   });
 
-  test(`navigating to custom styles`, async function(assert) {
+  test('navigating to custom styles', async function(assert) {
     await login();
-    await createCards({
-      [card1Id]: [
-        ['title', 'string', true, 'The Millenial Puppy'],
-        ['author', 'string', true, 'Van Gogh'],
-        ['body', 'string', false, 'It can be difficult these days to deal with the discerning tastes of the millenial puppy.']
-      ]
-    });
+    await createCards(cardData);
     await visit(`/cards/${card1Id}`);
 
     await fillIn('[data-test-mode-switcher]', 'view');
@@ -48,5 +49,16 @@ module('Acceptance | css editing', function(hooks) {
     assert.dom(`[data-test-card-view="${card1Id}"]`).exists();
     await click('[data-test-card-custom-style-button]')
     assert.dom('[data-test-editor-pane]').exists();
+  });
+
+  test('closing the editor', async function(assert) {
+    await login();
+    await createCards(cardData);
+    await click('[data-test-card-custom-style-button]')
+    assert.equal(currentURL(), `/cards/${card1Id}?editingCss=true`);
+    assert.dom('[data-test-close-editor]').exists();
+    await click('[data-test-close-editor]')
+    assert.equal(currentURL(), `/cards/${card1Id}?editingCss=false`);
+    assert.dom('[data-test-editor-pane]').doesNotExist();
   });
 });


### PR DESCRIPTION
closes #1065

## Added
- code that applies the Card's CSS (if it has any) to the layout view
- Can edit CSS and see an immediate preview
- code that gets the Card markup via query selectors and renders it in an "HTML Viewer" code editor that is read-only
- add functionality to the save button in the layout view
- test for closing the editor

## Changed
- pass the card model to the EditorPanell
- bugfix - closing the editor works
- bugfix - resolve type error on the editingCss query param

## How to test

Create a new card, add a field (like `title`), save it, open the Custom Theme editor from the Right Edge in the layout view. Try adding styles, i.e. `.field-title { border: 2px solid red; }`. Close Editor. Save. Refresh.

## Known issues
- no CSS scoping
- Save button has no visual feedback
- Cannot edit CSS of existing templates
- Adding a custom theme does not affect the dropdown (it's just for show, at the moment)
- does not include error handling