### PR TITLE
Add hide-in-percy css selector

### DIFF
--- a/packages/cardhost/app/components/card-creator.js
+++ b/packages/cardhost/app/components/card-creator.js
@@ -5,6 +5,10 @@ export default class CardCreator extends CardManipulator {
   constructor(...args) {
     super(...args);
 
+    /*
+      Remove `hide-in-percy` css selectors from places
+      where we display card IDs once we remove this
+    */
     let defaultCardId = `new-card-${Math.floor(Math.random() * 1E7)}`;
 
     this.updateCardId(defaultCardId);

--- a/packages/cardhost/app/styles/app.css
+++ b/packages/cardhost/app/styles/app.css
@@ -72,9 +72,18 @@ Until that work is done we are statically adding this css
   - better positioning for edges (esp on/off state)
   - link and button focus and disabled states styling
 */
-
 * {
   box-sizing: border-box;
+}
+
+/*
+  Use the `hide-in-percy` css selector when you want to visually
+  hide page elements that can change, i.e. random numbers, etc
+*/
+@media only percy {
+  .hide-in-percy {
+    visibility: hidden;
+  }
 }
 
 body {

--- a/packages/cardhost/app/templates/components/right-edge.hbs
+++ b/packages/cardhost/app/templates/components/right-edge.hbs
@@ -25,7 +25,7 @@
         </label>
         <Input
           @id="card__id"
-          @class="ch-input"
+          @class="ch-input hide-in-percy"
           @size="60"
           @placeholder="e.g. millenial-puppies"
           @value={{this.cardName}}
@@ -35,7 +35,7 @@
       </div>
       <div class="right-edge--item">
         <div class="ch-label right-edge--label">Internal ID</div>
-        <div data-test-internal-card-id>
+        <div class="hide-in-percy" data-test-internal-card-id>
           {{@card.id}}
         </div>
       </div>

--- a/packages/core/addon/templates/components/card-renderer.hbs
+++ b/packages/core/addon/templates/components/card-renderer.hbs
@@ -22,7 +22,7 @@ Ember Concurrency into the rendering of the card component here.
         {{#if (or (eq (safe-css-string @card.adoptedFromName) "event-card") (eq (safe-css-string @card.name) "event-card"))}}
           {{svg-jar "event" width="18px" height="20px"}}
         {{/if}}
-        <span class="card-renderer-{{@format}}--header-title">{{or @card.name "Blank Card"}}</span>
+        <span class="card-renderer-{{@format}}--header-title hide-in-percy">{{or @card.name "Blank Card"}}</span>
       </header>
       <div class="card-renderer-{{@format}}--content">
         <Isolated


### PR DESCRIPTION
We use [percy.io](https://percy.io/) for visual testing in `cardhost`, this provides the ability to visually hide page elements so that Percy ignores them during testing, for example randomly generated IDs that appear on the page.