### PR TITLE
turn off attribute-indentation lint rule for cardhost

### DIFF
--- a/packages/cardhost/.template-lintrc.js
+++ b/packages/cardhost/.template-lintrc.js
@@ -4,5 +4,6 @@ module.exports = {
   extends: 'recommended',
   rules: {
     'no-implicit-this': true,
-  }
+    'attribute-indentation': false,
+  },
 };

--- a/packages/cardhost/app/templates/cards/view.hbs
+++ b/packages/cardhost/app/templates/cards/view.hbs
@@ -20,8 +20,6 @@
     </button>
 
   {{else}}
-    {{! eslint is confused by on helper }}
-    {{! template-lint-disable attribute-indentation}}
     <button
       class="ch-button ch-button--icon share"
       aria-label="Share button"

--- a/packages/cardhost/app/templates/components/adopted-from.hbs
+++ b/packages/cardhost/app/templates/components/adopted-from.hbs
@@ -39,7 +39,6 @@
 
   </LinkTo>
   <div class="section-btn-container">
-    {{! template-lint-disable attribute-indentation}}
     <button
       class={{concat
         "section-btn "

--- a/packages/cardhost/app/templates/components/card-creator.hbs
+++ b/packages/cardhost/app/templates/components/card-creator.hbs
@@ -2,8 +2,6 @@
   {{!-- TODO: DRY buttons --}}
   {{#if this.cardstackSession.isAuthenticated}}
     <div class="card-renderer--top-edge-buttons">
-      {{! eslint is confused by on helper }}
-      {{! template-lint-disable attribute-indentation}}
       <button
         {{on "click" this.preview}}
         class="ch-button ch-button--secondary"
@@ -37,7 +35,6 @@
       <header class="ch-catalog--header">
         <h3 class="ch-catalog--title">Card Catalog</h3>
         <div class="ch-catalog--header-btns">
-          {{! template-lint-disable attribute-indentation}}
           <button class="ch-catalog--header-btn sidebar active" aria-label="View as sidebar"></button>
           <button class="ch-catalog--header-btn grid" aria-label="View as grid"></button>
         </div>
@@ -48,8 +45,6 @@
       </header>
       <div class="ch-catalog--fields">
         {{#each this.fieldComponents as |field|}}
-          {{! eslint is confused by on helper }}
-          {{! template-lint-disable attribute-indentation}}
           <div
             class="ch-catalog-field"
             role="button"

--- a/packages/cardhost/app/templates/components/card-editor.hbs
+++ b/packages/cardhost/app/templates/components/card-editor.hbs
@@ -1,7 +1,5 @@
 {{#if this.cardstackSession.isAuthenticated}}
   <div class="card-renderer--top-edge-buttons">
-    {{! eslint is confused by on helper }}
-    {{! template-lint-disable attribute-indentation}}
     <button
       {{on "click" this.delete}}
       class="ch-button ch-button--icon-secondary delete"
@@ -37,7 +35,6 @@
 
 <CardhostLeftEdge />
 
-{{! template-lint-disable attribute-indentation}}
 <section
   class="card-editor"
   data-test-card-edit={{this.card.name}}

--- a/packages/cardhost/app/templates/components/card-schema-updator.hbs
+++ b/packages/cardhost/app/templates/components/card-schema-updator.hbs
@@ -1,7 +1,5 @@
 {{#if this.cardstackSession.isAuthenticated}}
   <div class="card-renderer--top-edge-buttons">
-    {{! eslint is confused by on helper }}
-    {{! template-lint-disable attribute-indentation}}
     <button
       class="ch-button ch-button--icon share"
       aria-label="Share button"
@@ -38,7 +36,6 @@
       <header class="ch-catalog--header">
         <h3 class="ch-catalog--title">Card Catalog</h3>
         <div class="ch-catalog--header-btns">
-          {{! template-lint-disable attribute-indentation}}
           <button class="ch-catalog--header-btn sidebar active" aria-label="View as sidebar"></button>
           <button class="ch-catalog--header-btn grid" aria-label="View as grid"></button>
         </div>
@@ -49,8 +46,6 @@
       </header>
       <div class="ch-catalog--fields">
         {{#each this.fieldComponents as |field|}}
-          {{! eslint is confused by on helper }}
-          {{! template-lint-disable attribute-indentation}}
           <div
             class="ch-catalog-field"
             role="button"

--- a/packages/cardhost/app/templates/components/field-creator.hbs
+++ b/packages/cardhost/app/templates/components/field-creator.hbs
@@ -40,7 +40,6 @@
       />
     {{/if}}
 
-    {{! template-lint-disable attribute-indentation}}
     <button {{on "click" this.addField}} class="ch-button" data-test-field-creator-add-field-btn>Add</button>
   </div>
 </fieldset>

--- a/packages/cardhost/app/templates/components/right-edge.hbs
+++ b/packages/cardhost/app/templates/components/right-edge.hbs
@@ -1,4 +1,3 @@
-{{! template-lint-disable attribute-indentation}}
 <div
   class="right-edge"
   data-test-right-edge

--- a/packages/cardhost/app/templates/index.hbs
+++ b/packages/cardhost/app/templates/index.hbs
@@ -1,5 +1,4 @@
 <div class="cardhost-welcome-page">
-  {{! template-lint-disable attribute-indentation}}
   <nav class="cardhost-welcome-left-edge--nav" data-test-cardhost-welcome-left-edge>
     <ul>
       <li>


### PR DESCRIPTION
A poem about template linting:

```
Now
     we can do
{{whatever}}

         <WeWant @feeling={{this.soLight}} @dreams={{this.soFree}}  @isNice={{true}} />
```

We are turning off attribute-indentation on account of our liberal use of data-test-helpers and the on helper.
