### PR TITLE
Show card in responsive and full width

### DIFF
--- a/packages/cardhost/app/components/editor-pane.js
+++ b/packages/cardhost/app/components/editor-pane.js
@@ -30,7 +30,7 @@ export default class EditorPane extends Component {
 
   get width() {
     if (this.cssModeToggle.dockLocation === 'right') {
-      return '40%';
+      return '60%';
     } else {
       return '100%';
     }

--- a/packages/cardhost/app/components/themer-toolbar.js
+++ b/packages/cardhost/app/components/themer-toolbar.js
@@ -1,0 +1,6 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class ThemerToolbarComponent extends Component {
+  @service cssModeToggle;
+}

--- a/packages/cardhost/app/controllers/cards.js
+++ b/packages/cardhost/app/controllers/cards.js
@@ -3,4 +3,15 @@ import { inject as service } from '@ember/service';
 
 export default class CardsController extends Controller {
   @service cssModeToggle;
+
+  get themerClasses() {
+    let editing = this.cssModeToggle.editingCss;
+    if (editing && this.cssModeToggle.isResponsive) {
+      return 'responsive editing-css';
+    } else if (editing && !this.cssModeToggle.isResponsive) {
+      return 'full-width editing-css';
+    } else {
+      return '';
+    }
+  }
 }

--- a/packages/cardhost/app/services/css-mode-toggle.js
+++ b/packages/cardhost/app/services/css-mode-toggle.js
@@ -4,9 +4,9 @@ import { action } from '@ember/object';
 
 export default class CssModeToggleService extends Service {
   @tracked editingCss;
-
   @tracked visible = true;
   @tracked dockLocation = 'right';
+  @tracked isResponsive = true;
 
   setEditingCss(value) {
     this.editingCss = value;
@@ -30,5 +30,15 @@ export default class CssModeToggleService extends Service {
   @action
   showEditor() {
     this.visible = true;
+  }
+
+  @action
+  useFullWidth() {
+    this.isResponsive = false;
+  }
+
+  @action
+  useResponsiveWidth() {
+    this.isResponsive = true;
   }
 }

--- a/packages/cardhost/app/styles/app.css
+++ b/packages/cardhost/app/styles/app.css
@@ -218,6 +218,7 @@ a:hover {
   z-index: 10;
   padding: 20px;
   transform: translateX(0%);
+  opacity: 0.95;
 }
 
 .cardhost-card-theme-editor.bottom-docked {

--- a/packages/cardhost/app/styles/cards.css
+++ b/packages/cardhost/app/styles/cards.css
@@ -18,7 +18,13 @@
 
 .cardhost-cards.editing-css {
   padding-left: 0;
-  width: 85%;
+  width: 40%;
+  transition: width 0.3s ease-in-out;
+  padding-right: 0;
+}
+
+.cardhost-cards.editing-css.full-width {
+  width: 100%;
 }
 
 /* TODO: Remove this after right-edge is displayed on edit view */

--- a/packages/cardhost/app/styles/components/button.css
+++ b/packages/cardhost/app/styles/components/button.css
@@ -105,7 +105,7 @@
 .ch-button--icon.eye-on {
   --icon-url: url('/assets/images/buttons/eye-on.svg');
   background-size: 30px;
-  margin-right: 15px;
+  margin-right: 20px;
 }
 .ch-button--icon.eye-on:hover {
   --icon-url: url('/assets/images/buttons/eye-on.svg');
@@ -116,7 +116,7 @@
 .ch-button--icon.eye-off {
   --icon-url: url('/assets/images/buttons/eye-off.svg');
   background-size: 30px;
-  margin-right: 15px;
+  margin-right: 20px;
 }
 
 .ch-button--icon.eye-off:hover {
@@ -150,16 +150,22 @@
 
 .ch-button--icon.responsive {
   --icon-url: url('/assets/images/buttons/responsive-inactive.svg');
-  background-size: 25px 25px;
+  background-size: 30px 30px;
 }
 
 .ch-button--icon.responsive.selected {
   --icon-url: url('/assets/images/buttons/responsive-active.svg');
 }
 
+.ch-button--icon.responsive:hover, .ch-button--icon.full-width:hover {
+  opacity: 0.5;
+  filter: alpha(opacity=50);
+}
+
 .ch-button--icon.full-width {
   --icon-url: url('/assets/images/buttons/full-width-inactive.svg');
   background-size: 25px 25px;
+  margin-right: 20px;
 }
 
 .ch-button--icon.full-width.selected {

--- a/packages/cardhost/app/styles/components/button.css
+++ b/packages/cardhost/app/styles/components/button.css
@@ -148,6 +148,24 @@
   filter: alpha(opacity=50);
 }
 
+.ch-button--icon.responsive {
+  --icon-url: url('/assets/images/buttons/responsive-inactive.svg');
+  background-size: 25px 25px;
+}
+
+.ch-button--icon.responsive.selected {
+  --icon-url: url('/assets/images/buttons/responsive-active.svg');
+}
+
+.ch-button--icon.full-width {
+  --icon-url: url('/assets/images/buttons/full-width-inactive.svg');
+  background-size: 25px 25px;
+}
+
+.ch-button--icon.full-width.selected {
+  --icon-url: url('/assets/images/buttons/full-width-active.svg');
+}
+
 .ch-button--save {
   --width: 140px;
   position: relative;

--- a/packages/cardhost/app/templates/cards.hbs
+++ b/packages/cardhost/app/templates/cards.hbs
@@ -1,5 +1,5 @@
 {{#let this.target.currentRoute.localName as |mode|}}
-  <div class="cardhost-cards {{mode}} {{if this.cssModeToggle.editingCss "editing-css"}}">
+  <div class="cardhost-cards {{mode}} {{this.themerClasses}}" data-test-cardhost-cards>
     {{#if (not this.cssModeToggle.editingCss)}}
       <CardhostTopEdge @mode={{mode}}>
         {{#if (or (eq mode "schema") (eq mode "edit") (eq mode "view"))}}

--- a/packages/cardhost/app/templates/cards/view.hbs
+++ b/packages/cardhost/app/templates/cards/view.hbs
@@ -1,44 +1,6 @@
 <div class="card-renderer--top-edge-buttons">
   {{#if this.cssModeToggle.editingCss}}
-    {{#if this.cssModeToggle.visible}}
-      <button 
-        class="ch-button ch-button--icon eye-on"
-        aria-label="Hide the CSS editor"
-        {{on "click" this.cssModeToggle.hideEditor}}
-        data-test-hide-editor-btn
-      >
-      </button>
-    {{else}}
-      <button 
-        class="ch-button ch-button--icon eye-off"
-        aria-label="Show the CSS editor"
-        {{on "click" this.cssModeToggle.showEditor}}
-        data-test-show-editor-btn
-      >
-      </button>
-    {{/if}}
-    <button 
-      class="ch-button ch-button--icon dock-bottom {{if (eq this.cssModeToggle.dockLocation "bottom") "selected"}}"
-      {{on "click" this.cssModeToggle.dockBottom}}
-      aria-label="Dock the CSS editor to the bottom"
-      data-test-dock-bottom
-    >
-    </button>
-
-    <button 
-      class="ch-button ch-button--icon dock-right {{if (eq this.cssModeToggle.dockLocation "right") "selected"}}"
-      {{on "click" this.cssModeToggle.dockRight}}
-      aria-label="Dock the CSS editor to the right"
-      data-test-dock-right
-    >
-    </button>
-    <button {{on "click" this.closeEditor}}
-      class="ch-button close-editor-btn"
-      data-test-close-editor
-    >
-      Close Editor
-    </button>
-
+    <ThemerToolbar @closeEditor={{this.closeEditor}} />
   {{else}}
     <button
       class="ch-button ch-button--icon share"

--- a/packages/cardhost/app/templates/components/themer-toolbar.hbs
+++ b/packages/cardhost/app/templates/components/themer-toolbar.hbs
@@ -1,0 +1,38 @@
+{{#if this.cssModeToggle.visible}}
+  <button 
+    class="ch-button ch-button--icon eye-on"
+    aria-label="Hide the CSS editor"
+    {{on "click" this.cssModeToggle.hideEditor}}
+    data-test-hide-editor-btn
+  >
+  </button>
+{{else}}
+  <button 
+    class="ch-button ch-button--icon eye-off"
+    aria-label="Show the CSS editor"
+    {{on "click" this.cssModeToggle.showEditor}}
+    data-test-show-editor-btn
+  >
+  </button>
+{{/if}}
+<button 
+  class="ch-button ch-button--icon dock-bottom {{if (eq this.cssModeToggle.dockLocation "bottom") "selected"}}"
+  {{on "click" this.cssModeToggle.dockBottom}}
+  aria-label="Dock the CSS editor to the bottom"
+  data-test-dock-bottom
+>
+</button>
+
+<button 
+  class="ch-button ch-button--icon dock-right {{if (eq this.cssModeToggle.dockLocation "right") "selected"}}"
+  {{on "click" this.cssModeToggle.dockRight}}
+  aria-label="Dock the CSS editor to the right"
+  data-test-dock-right
+>
+</button>
+<button {{on "click" @closeEditor}}
+  class="ch-button close-editor-btn"
+  data-test-close-editor
+>
+  Close Editor
+</button>

--- a/packages/cardhost/app/templates/components/themer-toolbar.hbs
+++ b/packages/cardhost/app/templates/components/themer-toolbar.hbs
@@ -1,3 +1,19 @@
+<button 
+  class="ch-button ch-button--icon responsive {{if this.cssModeToggle.isResponsive "selected"}}"
+  {{on "click" this.cssModeToggle.useResponsiveWidth}}
+  aria-label="Show the card in responsive size"
+  data-test-responsive-btn
+>
+</button>
+
+<button 
+  class="ch-button ch-button--icon full-width {{if this.cssModeToggle.isResponsive "" "selected"}}"
+  {{on "click" this.cssModeToggle.useFullWidth}}
+  aria-label="Show the card in full width size"
+  data-test-full-width-btn
+>
+</button>
+
 {{#if this.cssModeToggle.visible}}
   <button 
     class="ch-button ch-button--icon eye-on"

--- a/packages/cardhost/app/templates/ui-components.hbs
+++ b/packages/cardhost/app/templates/ui-components.hbs
@@ -79,6 +79,8 @@
       <button class="ch-button ch-button--icon dock-bottom" aria-label="Dock bottom"></button>
       <button class="ch-button ch-button--icon eye-on" aria-label="Visible"></button>
       <button class="ch-button ch-button--icon eye-off" aria-label="Hidden"></button>
+      <button class="ch-button ch-button--icon responsive" aria-label="Responsive"></button>
+      <button class="ch-button ch-button--icon full-width" aria-label="Full Width"></button>
     </div>
     <div>
       <CodeEditor @code='<button class="ch-button ch-button--icon user" aria-label="User"></button>
@@ -88,7 +90,9 @@
 <button class="ch-button ch-button--icon dock-right" aria-label="Dock right">
 <button class="ch-button ch-button--icon dock-bottom" aria-label="Dock bottom">
 <button class="ch-button ch-button--icon eye-on" aria-label="Visible"></button>
-<button class="ch-button ch-button--icon eye-off" aria-label="Hidden"></button>'
+<button class="ch-button ch-button--icon eye-off" aria-label="Hidden"></button>
+<button class="ch-button ch-button--icon responsive" aria-label="Responsive"></button>
+<button class="ch-button ch-button--icon full-width" aria-label="Full Width"></button>'
       @language="html" />
     </div>
 

--- a/packages/cardhost/public/assets/images/buttons/dock-bottom-secondary.svg
+++ b/packages/cardhost/public/assets/images/buttons/dock-bottom-secondary.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg"  width="18" height="16"  viewBox="0 0 18.063 16">
   <g id="Group_602" data-name="Group 602" transform="translate(-1085.937 -31.025)">
-    <rect data-name="Rectangle 285" width="16" height="14" rx="2" transform="translate(1087 32.025)" stroke-width="2" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-    <path data-name="Path 252" d="M19.627,16.423H3.7" transform="translate(1083.237 24.44)" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+    <rect data-name="Rectangle 285" width="16" height="14" rx="2" transform="translate(1087 32.025)" stroke-width="2" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <path data-name="Path 252" d="M19.627,16.423H3.7" transform="translate(1083.237 24.44)" fill="none" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
   </g>
 </svg>

--- a/packages/cardhost/public/assets/images/buttons/dock-right-secondary.svg
+++ b/packages/cardhost/public/assets/images/buttons/dock-right-secondary.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="16" viewBox="0 0 18 16">
   <g id="Group_603" data-name="Group 603" transform="translate(1104 47.025) rotate(180)">
-    <rect data-name="Rectangle 285" width="16" height="14" rx="2" transform="translate(1087 32.025)" stroke-width="2" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-    <path data-name="Path 252" d="M9.273,22.585V9" transform="translate(1083.237 23.44)" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+    <rect data-name="Rectangle 285" width="16" height="14" rx="2" transform="translate(1087 32.025)" stroke-width="2" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <path data-name="Path 252" d="M9.273,22.585V9" transform="translate(1083.237 23.44)" fill="none" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
   </g>
 </svg>

--- a/packages/cardhost/public/assets/images/buttons/full-width-active.svg
+++ b/packages/cardhost/public/assets/images/buttons/full-width-active.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="20" viewBox="0 0 22 20">
+  <g id="Icon_Desktop" transform="translate(1 1)">
+    <g id="Group_625" data-name="Group 625">
+      <rect id="Rectangle_581" data-name="Rectangle 581" width="20" height="14" rx="2" fill="none" stroke="#00ebe5" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      <path id="Path_456" data-name="Path 456" d="M8,21h8" transform="translate(-2 -3)" fill="none" stroke="#00ebe5" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      <path id="Path_457" data-name="Path 457" d="M12,17v4" transform="translate(-2 -3)" fill="none" stroke="#00ebe5" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+    </g>
+  </g>
+</svg>

--- a/packages/cardhost/public/assets/images/buttons/full-width-inactive.svg
+++ b/packages/cardhost/public/assets/images/buttons/full-width-inactive.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="20" viewBox="0 0 22 20">
+  <g id="Icon_Desktop" transform="translate(1 1)">
+    <g id="Group_625" data-name="Group 625">
+      <rect id="Rectangle_581" data-name="Rectangle 581" width="20" height="14" rx="2" fill="none" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      <path id="Path_456" data-name="Path 456" d="M8,21h8" transform="translate(-2 -3)" fill="none" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      <path id="Path_457" data-name="Path 457" d="M12,17v4" transform="translate(-2 -3)" fill="none" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+    </g>
+  </g>
+</svg>

--- a/packages/cardhost/public/assets/images/buttons/responsive-active.svg
+++ b/packages/cardhost/public/assets/images/buttons/responsive-active.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="16" viewBox="0 0 26 16">
+  <g id="Icon_phone" transform="translate(1 1)">
+    <rect id="Rectangle_580" data-name="Rectangle 580" width="11" height="14" rx="2" transform="translate(13)" stroke-width="2" stroke="#00ebe5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <rect id="Rectangle_587" data-name="Rectangle 587" width="6" height="9" rx="2" transform="translate(0 5)" stroke-width="2" stroke="#00ebe5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  </g>
+</svg>

--- a/packages/cardhost/public/assets/images/buttons/responsive-inactive.svg
+++ b/packages/cardhost/public/assets/images/buttons/responsive-inactive.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="16" viewBox="0 0 26 16">
+  <g id="Icon_phone" transform="translate(1 1)">
+    <rect id="Rectangle_580" data-name="Rectangle 580" width="11" height="14" rx="2" transform="translate(13)" stroke-width="2" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <rect id="Rectangle_587" data-name="Rectangle 587" width="6" height="9" rx="2" transform="translate(0 5)" stroke-width="2" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  </g>
+</svg>

--- a/packages/cardhost/tests/acceptance/css-editing-test.js
+++ b/packages/cardhost/tests/acceptance/css-editing-test.js
@@ -95,4 +95,30 @@ module('Acceptance | css editing', function(hooks) {
     await click('[data-test-dock-right]');
     assert.dom('[data-test-dock-location="right"]');
   });
+
+  test('toggling card width', async function(assert) {
+    await login();
+    await createCards(cardData);
+    await click('[data-test-card-custom-style-button]');
+    assert.equal(currentURL(), `/cards/${card1Id}?editingCss=true`);
+    // make sure initial state is correct
+    assert.dom('[data-test-responsive-btn]').exists();
+    assert.dom('[data-test-responsive-btn]').hasClass('selected');
+    assert.dom('[data-test-full-width-btn]').exists();
+    assert.dom('[data-test-full-width-btn]').doesNotHaveClass('selected');
+    assert.dom('[data-test-cardhost-cards]').hasClass('responsive');
+    // toggle to full width
+    await click('[data-test-full-width-btn]');
+    assert.dom('[data-test-full-width-btn]').hasClass('selected');
+    assert.dom('[data-test-cardhost-cards]').hasClass('full-width');
+
+    // let animation finish before taking screenshot
+    const waitForAnimation = new Promise(resolve => {
+      setTimeout(() => {
+        percySnapshot(assert);
+        resolve('done');
+      }, 1000);
+    });
+    await waitForAnimation;
+  });
 });

--- a/packages/cardhost/tests/acceptance/css-editing-test.js
+++ b/packages/cardhost/tests/acceptance/css-editing-test.js
@@ -22,6 +22,17 @@ const cardData = {
   ],
 };
 
+// let animation finish before taking screenshot
+
+const waitForAnimation = function(cb) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      cb();
+      resolve('done');
+    }, 1000);
+  });
+};
+
 const scenario = new Fixtures({
   create(factory) {
     setupMockUser(factory);
@@ -78,7 +89,7 @@ module('Acceptance | css editing', function(hooks) {
     assert.dom('[data-test-editor-pane]').exists();
     await click('[data-test-hide-editor-btn]');
     assert.dom('.cardhost-card-theme-editor.hidden').exists();
-    percySnapshot(assert);
+    await waitForAnimation(() => percySnapshot(assert));
   });
 
   test('toggling editor docking', async function(assert) {
@@ -88,10 +99,10 @@ module('Acceptance | css editing', function(hooks) {
     assert.equal(currentURL(), `/cards/${card1Id}?editingCss=true`);
     assert.dom('[data-test-dock-bottom]').exists();
     assert.dom('[data-test-dock-location="right"]');
-    percySnapshot('css editor docked right');
+    await waitForAnimation(() => percySnapshot('css editor docked right'));
     await click('[data-test-dock-bottom]');
     assert.dom('[data-test-dock-location="bottom"]');
-    percySnapshot('css editor docked bottom');
+    await waitForAnimation(() => percySnapshot('css editor docked bottom'));
     await click('[data-test-dock-right]');
     assert.dom('[data-test-dock-location="right"]');
   });
@@ -111,14 +122,6 @@ module('Acceptance | css editing', function(hooks) {
     await click('[data-test-full-width-btn]');
     assert.dom('[data-test-full-width-btn]').hasClass('selected');
     assert.dom('[data-test-cardhost-cards]').hasClass('full-width');
-
-    // let animation finish before taking screenshot
-    const waitForAnimation = new Promise(resolve => {
-      setTimeout(() => {
-        percySnapshot(assert);
-        resolve('done');
-      }, 1000);
-    });
-    await waitForAnimation;
+    await waitForAnimation(() => percySnapshot(assert));
   });
 });

--- a/packages/cardhost/tests/acceptance/ui-components-test.js
+++ b/packages/cardhost/tests/acceptance/ui-components-test.js
@@ -3,6 +3,17 @@ import { visit, currentURL, settled } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { percySnapshot } from 'ember-percy';
 
+// Monaco takes a while to render, and it varies, so we pause
+// for 2s in order to get more stable Percy Snapshots.
+const waitForMonacoRender = function(cb) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      cb();
+      resolve('done');
+    }, 2000);
+  });
+};
+
 module('Acceptance | ui components', function(hooks) {
   setupApplicationTest(hooks);
 
@@ -11,6 +22,6 @@ module('Acceptance | ui components', function(hooks) {
 
     assert.equal(currentURL(), '/ui-components');
     await settled();
-    await percySnapshot(assert);
+    await waitForMonacoRender(() => percySnapshot(assert));
   });
 });

--- a/packages/cardhost/tests/integration/components/themer-toolbar-test.js
+++ b/packages/cardhost/tests/integration/components/themer-toolbar-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | themer-toolbar', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('closeEditor', () => {});
+    await render(hbs`<ThemerToolbar @closeEditor={{this.closeEditor}} />`);
+    assert.equal(this.element.textContent.trim(), 'Close Editor');
+  });
+});


### PR DESCRIPTION
## Added
- buttons for responsive vs full width, with active and inactive states
- hover styling
- transparent background for the editor pane
- tests for the interactions above
- light animation

## Changed
- moved css controls into its own component
- set inactive buttons to the correct color

## Known issues
I am not sure of the best way to handle the width of the contents inside the card viewer changing, since this seems to be a "standard" styling.

The code blocks are still the wrong size.

If you make the screen tiny, the buttons flow off the edge. 

The button positioning is not true to the mockups. This will be fixed with the item above.

Closes #1130 