### PR TITLE
Reenable interactive elements lint rule

### DIFF
--- a/packages/cardhost/.template-lintrc.js
+++ b/packages/cardhost/.template-lintrc.js
@@ -5,6 +5,5 @@ module.exports = {
   rules: {
     'no-implicit-this': true,
     'attribute-indentation': false,
-    'no-invalid-interactive': false,
   },
 };

--- a/packages/cardhost/app/styles/index.css
+++ b/packages/cardhost/app/styles/index.css
@@ -35,7 +35,8 @@
   box-shadow: none;
   border: none;
   cursor: pointer;
-  font-size: 1rem;
+  font: 400 13px/18px var(--ch-font-family);
+  letter-spacing: 0.015em;
 }
 
 .cardhost-welcome-left-edge--nav ul {

--- a/packages/cardhost/app/styles/index.css
+++ b/packages/cardhost/app/styles/index.css
@@ -30,6 +30,14 @@
   background: url(/assets/images/cardstack-logo.svg) 30px 30px/24px 25px no-repeat;
 }
 
+.cardhost-welcome-left-edge--nav button {
+  background: none;
+  box-shadow: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
 .cardhost-welcome-left-edge--nav ul {
   list-style-type: none;
   margin: 0;
@@ -89,11 +97,14 @@
   letter-spacing: 0.015em;
 }
 
-.cardhost-section--header > svg {
+.cardhost-section--header svg {
   --icon-color: var(--ch-highlight);
-
   margin-right: 20px;
   fill: var(--ch-highlight);
+}
+
+.cardhost-section--header .permalink {
+  font-size: 36px;
 }
 
 

--- a/packages/cardhost/app/styles/resizable.css
+++ b/packages/cardhost/app/styles/resizable.css
@@ -11,6 +11,12 @@
   position: absolute;
 }
 
+.resizer {
+  background: none;
+  border: none;
+  box-shadow: none;
+}
+
 .resizer.top,
 .resizer.bottom {
   width: 100%;

--- a/packages/cardhost/app/templates/components/re-sizable.hbs
+++ b/packages/cardhost/app/templates/components/re-sizable.hbs
@@ -9,12 +9,12 @@
   >
 
   {{#each this.directions as |dir|}}
-    <div
+    <button
       class={{concat "resizer " dir}}
       {{on "mousedown" (fn this._onResizeStart dir)}}
       {{on "touchstart" (fn this._onResizeStart dir)}}
     >
-    </div>
+    </button>
   {{/each}}
 
   {{yield}}

--- a/packages/cardhost/app/templates/index.hbs
+++ b/packages/cardhost/app/templates/index.hbs
@@ -2,28 +2,28 @@
   <nav class="cardhost-welcome-left-edge--nav" data-test-cardhost-welcome-left-edge>
     <ul>
       <li>
-        <a {{on "click" (fn this.scrollToSection "recent-cards")}} class="left-edge-icon {{if (eq this.selectedSection "recent-cards") "active"}}">
-          {{svg-jar "clock" width="15px" height="15px"}}
+        <button {{on "click" (fn this.scrollToSection "recent-cards")}} class="left-edge-icon {{if (eq this.selectedSection "recent-cards") "active"}}">
+          {{svg-jar "clock" width="15px" height="15px" aria-hidden="true"}}
           Recent Cards
-        </a>
+        </button>
       </li>
       <li>
-        <a {{on "click" (fn this.scrollToSection "saved-templates")}} class="left-edge-icon {{if (eq this.selectedSection "saved-templates") "active"}}">
-          {{svg-jar "saved" width="15px" height="15px"}}
+        <button {{on "click" (fn this.scrollToSection "saved-templates")}} class="left-edge-icon {{if (eq this.selectedSection "saved-templates") "active"}}">
+          {{svg-jar "saved" width="15px" height="15px" aria-hidden="true"}}
           Saved Templates
-        </a>
+        </button>
       </li>
       <li>
-        <a {{on "click" (fn this.scrollToSection "common-cards")}} class="left-edge-icon {{if (eq this.selectedSection "common-cards") "active"}}">
-          {{svg-jar "cards" width="15px" height="15px"}}
+        <button {{on "click" (fn this.scrollToSection "common-cards")}} class="left-edge-icon {{if (eq this.selectedSection "common-cards") "active"}}">
+          {{svg-jar "cards" width="15px" height="15px" aria-hidden="true"}}
           Common Cards
-        </a>
+        </button>
       </li>
       <li>
-        <a {{on "click" (fn this.scrollToSection "add-card")}} class="left-edge-icon {{if (eq this.selectedSection "add-card") "active"}}">
-          {{svg-jar "add" width="15px" height="15px"}}
+        <button {{on "click" (fn this.scrollToSection "add-card")}} class="left-edge-icon {{if (eq this.selectedSection "add-card") "active"}}">
+          {{svg-jar "add" width="15px" height="15px" aria-hidden="true"}}
           New Blank Card
-        </a>
+        </button>
       </li>
     </ul>
   </nav>
@@ -96,7 +96,9 @@
 
     <section class="cardhost-section cardhost-section--add-card">
       <header class="cardhost-section--header add-card">
-        {{svg-jar "add" width="28px" height="28px"}}
+        <a href="#new-blank-card" title="New Blank Card" class="permalink">
+          {{svg-jar "add" width="28px" height="28px"}}
+        </a>
         New Blank Card
       </header>
       <div class="card-catalog">

--- a/packages/cardhost/tests/integration/components/re-sizable-test.js
+++ b/packages/cardhost/tests/integration/components/re-sizable-test.js
@@ -34,13 +34,13 @@ module('Integration | Component | re-sizable', function(hooks) {
     await render(hbs`<ReSizable @directions={{this.directions}}>Hello</ReSizable>`);
     await settled();
 
-    assert.equal(this.element.querySelectorAll('div.resizer').length, 8);
+    assert.equal(this.element.querySelectorAll('button.resizer').length, 8);
 
     this.set('directions', ['top', 'right']);
 
-    assert.equal(this.element.querySelectorAll('div.resizer').length, 2);
-    assert.ok(this.element.querySelector('div.resizer.top'));
-    assert.notOk(this.element.querySelector('div.resizer.bottom'));
+    assert.equal(this.element.querySelectorAll('button.resizer').length, 2);
+    assert.ok(this.element.querySelector('button.resizer.top'));
+    assert.notOk(this.element.querySelector('button.resizer.bottom'));
   });
 
   test('should react to width/height changes', async function(assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11657,7 +11657,7 @@ is-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
   integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
-is-resolvable@^1.0.0, is-resolvable@^1.1.0:
+is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
@@ -15294,15 +15294,7 @@ quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quick-temp@^0.1.8:
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
 
-qunit-dom@^0.8.0:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/qunit-dom/-/qunit-dom-0.8.5.tgz#34b7cffb338e631c39955b21bdbe4d774090124e"
-  integrity sha512-I4GSy22ESUkoZYDSYsqFJoMvqhpmgd2iCYlrN7aWLEOdmumUkao3qz24/qVNZd1PAnoOQA78FefzNPRHePFx1A==
-  dependencies:
-    broccoli-funnel "^2.0.2"
-    broccoli-merge-trees "^3.0.1"
-
-qunit-dom@^0.8.1:
+qunit-dom@^0.8.0, qunit-dom@^0.8.1:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/qunit-dom/-/qunit-dom-0.8.5.tgz#34b7cffb338e631c39955b21bdbe4d774090124e"
   integrity sha512-I4GSy22ESUkoZYDSYsqFJoMvqhpmgd2iCYlrN7aWLEOdmumUkao3qz24/qVNZd1PAnoOQA78FefzNPRHePFx1A==


### PR DESCRIPTION
Closes #1139 

We still use `div role="button"` on the draggable components. I didn't mess with those. I figure we can tackle that during "make drag & drop accessible" tickets. Switching them to buttons without doing that other work doesn't fix anything.

Added:
- some styles to get rid of button styling
- the lint rule that was removed in #1122 

Changed:
- clickable divs become buttons
- added aria-hidden to icons that are only for display
- some styles to account for these changes