### PR TITLE
Themer focus 1083

### DIFF
--- a/packages/cardhost/app/components/code-editor.js
+++ b/packages/cardhost/app/components/code-editor.js
@@ -32,7 +32,7 @@ export default class CodeEditor extends Component {
   // Sets default resize interval check in milliseconds.
   // This limits how often updatedDimensions is called.
   get resizeCheckIntervalMs() {
-    return this.args.resizeCheckIntervalMs || 2000;
+    return this.args.resizeCheckIntervalMs || 1000;
   }
 
   // readOnly defaults to true. Affects whether the editor lets you type in it

--- a/packages/cardhost/app/components/code-editor.js
+++ b/packages/cardhost/app/components/code-editor.js
@@ -87,7 +87,14 @@ export default class CodeEditor extends Component {
     // `create` constructs a code editor and inserts it into the DOM.
     // el is the element that {{did-insert}} was used on.
     let codeModel = monaco.editor.createModel(this.args.code, this.args.language);
-    el.style.height = '100%';
+
+    // use calculated height for the ui-components page
+    if (!this.resizable) {
+      let height = codeModel.getLineCount() * 23;
+      el.style.height = height.toString() + 'px';
+    } else {
+      el.style.height = '100%';
+    }
 
     let editor = monaco.editor.create(el, {
       model: codeModel,

--- a/packages/cardhost/app/components/code-editor.js
+++ b/packages/cardhost/app/components/code-editor.js
@@ -4,6 +4,7 @@ import * as monaco from 'monaco-editor';
 import { action } from '@ember/object';
 import { restartableTask } from 'ember-concurrency-decorators';
 import { timeout } from 'ember-concurrency';
+import ENV from '@cardstack/cardhost/config/environment';
 
 /**
  * <CodeEditor> takes the following arguments:
@@ -102,7 +103,9 @@ export default class CodeEditor extends Component {
     // Save editor instance locally, so we can reference it in other methods
     this.editor = editor;
 
-    if (this.resizable) {
+    // turn off resize in testing, otherwise it breaks any acceptance test
+    // that visits a page with a resizable code editor
+    if (this.resizable && ENV.environment !== 'test') {
       this.startResizeWatcher.perform(el);
     }
   }

--- a/packages/cardhost/app/components/code-editor.js
+++ b/packages/cardhost/app/components/code-editor.js
@@ -86,12 +86,7 @@ export default class CodeEditor extends Component {
     // `create` constructs a code editor and inserts it into the DOM.
     // el is the element that {{did-insert}} was used on.
     let codeModel = monaco.editor.createModel(this.args.code, this.args.language);
-    if (!this.resizable) {
-      let height = codeModel.getLineCount() * 20;
-      el.style.height = height.toString() + 'px';
-    } else {
-      el.style.height = '100%';
-    }
+    el.style.height = '100%';
 
     let editor = monaco.editor.create(el, {
       model: codeModel,
@@ -108,7 +103,7 @@ export default class CodeEditor extends Component {
     this.editor = editor;
 
     if (this.resizable) {
-      // this.startResizeWatcher.perform(el);
+      this.startResizeWatcher.perform(el);
     }
   }
 
@@ -130,7 +125,7 @@ export default class CodeEditor extends Component {
 
   @restartableTask
   *startResizeWatcher(wrapper) {
-    wrapper.style['padding-bottom'] = '20px';
+    wrapper.style['padding-bottom'] = '2px';
 
     let { offsetWidth, offsetHeight } = wrapper;
 

--- a/packages/cardhost/app/components/editor-pane.js
+++ b/packages/cardhost/app/components/editor-pane.js
@@ -7,6 +7,8 @@ export default class EditorPane extends Component {
   @service cssModeToggle;
   @tracked markup;
   @tracked css = this.args.model.isolatedCss;
+  monacoKeyboardInstructions =
+    'Once you focus on the editable code blocks, Tab becomes a tab character in the code. To escape Tab trapping, use Ctrl+M on Windows and Linux, or use Ctrl+Shift+M on OSX. Then the next Tab key will move focus out of the editor.';
 
   constructor() {
     super(...arguments);

--- a/packages/cardhost/app/components/re-sizable.js
+++ b/packages/cardhost/app/components/re-sizable.js
@@ -18,10 +18,6 @@ const getSize = n => (!isNaN(parseFloat(n)) && isFinite(n) ? `${n}px` : n);
 
 export default class ReSizable extends Component {
   @tracked elementId = guidFor(this);
-  minWidth = 10;
-  minHeight = 10;
-  maxWidth = null;
-  maxHeight = null;
   grid = [1, 1];
   @tracked isActive = false;
   @tracked elementWidth = this.args.width;
@@ -161,6 +157,13 @@ export default class ReSizable extends Component {
         newHeight = newWidth * ratio;
       }
     }
+
+    // prevent resize from exceeding browser window dimensions
+    let maxHeight = document.body.clientHeight;
+    let maxWidth = document.body.clientWidth;
+
+    newHeight = newHeight > maxHeight ? maxHeight : newHeight;
+    newWidth = newWidth > maxWidth ? maxWidth : newWidth;
 
     this.elementWidth = newWidth;
     this.elementHeight = newHeight;

--- a/packages/cardhost/app/components/re-sizable.js
+++ b/packages/cardhost/app/components/re-sizable.js
@@ -31,6 +31,14 @@ export default class ReSizable extends Component {
     );
   }
 
+  get maxWidth() {
+    return typeof this.args.maxWidth === 'number' ? this.args.maxWidth : document.body.clientWidth;
+  }
+
+  get maxHeight() {
+    return typeof this.args.maxHeight === 'number' ? this.args.maxWidth : document.body.clientHeight;
+  }
+
   @action
   setElement() {
     // done this way so that we only query once. If this was a getter instead,
@@ -158,12 +166,9 @@ export default class ReSizable extends Component {
       }
     }
 
-    // prevent resize from exceeding browser window dimensions
-    let maxHeight = document.body.clientHeight;
-    let maxWidth = document.body.clientWidth;
-
-    newHeight = newHeight > maxHeight ? maxHeight : newHeight;
-    newWidth = newWidth > maxWidth ? maxWidth : newWidth;
+    // prevent resize from exceeding browser window dimensions or maximums
+    newHeight = newHeight > this.maxHeight ? this.maxHeight : newHeight;
+    newWidth = newWidth > this.maxWidth ? this.maxWidth : newWidth;
 
     this.elementWidth = newWidth;
     this.elementHeight = newHeight;

--- a/packages/cardhost/app/styles/app.css
+++ b/packages/cardhost/app/styles/app.css
@@ -67,6 +67,7 @@ Until that work is done we are statically adding this css
   --ch-transition-time: 250ms;
   --ch-card-transition-duration: 300ms;
   --ch-card-background-color-animate: background-color 0.5s ease;
+  --ch-card-padding-animate: padding-right 0.3s ease;
 }
 
 /*

--- a/packages/cardhost/app/styles/app.css
+++ b/packages/cardhost/app/styles/app.css
@@ -16,6 +16,7 @@
 @import '/assets/components/catalog.css';
 @import '/assets/components/catalog-field.css';
 @import '/assets/components/adopted-from.css';
+@import '/assets/components/themer.css';
 
 /* Cardhost styling for core package templates */
 @import '/assets/components/card-renderer.css';
@@ -65,6 +66,7 @@ Until that work is done we are statically adding this css
   --ch-actions-z-index: 11;
   --ch-transition-time: 250ms;
   --ch-card-transition-duration: 300ms;
+  --ch-card-background-color-animate: background-color 0.5s ease;
 }
 
 /*
@@ -125,22 +127,6 @@ a:hover {
   right: var(--ch-spacing);
   display: flex;
   z-index: var(--ch-actions-z-index);
-}
-
-.card-renderer--top-edge-buttons .show-editor-btn, .card-renderer--top-edge-buttons .hide-editor-btn {
-  margin-top: 10px;
-  margin-right: 15px;
-  cursor: pointer;
-}
-
-.card-renderer--top-edge-buttons .dock-btn {
-  margin: 10px 15px;
-  cursor: pointer;
-}
-
-.card-renderer--top-edge-buttons .close-editor-btn {
-  --width: 125px;
-  margin-left: 20px;
 }
 
 .card-schema-updator--search-bar {
@@ -206,122 +192,4 @@ a:hover {
   visibility: hidden;
   height: 0;
   overflow: hidden;
-}
-
-.cardhost-card-theme-editor {
-  position: fixed;
-  right: 0;
-  top: 0;
-  width: 40%;
-  height: 100%;
-  background: var(--ch-deep-background);
-  z-index: 10;
-  padding: 20px;
-  transform: translateX(0%);
-  opacity: 0.95;
-}
-
-.cardhost-card-theme-editor.bottom-docked {
-  top: auto;
-  bottom: 0;
-  left: 0;
-  height: 40%;
-  width: 100%;
-  transform: translateY(0%);
-}
-
-.cardhost-card-theme-editor.right-docked .resizable-content {
-  padding-top: 50px;
-}
-
-.cardhost-card-theme-editor.hidden {
-  transform: translateX(100%);
-}
-
-.cardhost-card-theme-editor.bottom-docked.hidden {
-  transform: translateY(100%);
-}
-
-
-.cardhost-card-theme-editor .resizable-content {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-}
-
-.cardhost-card-theme-editor.bottom-docked .resizable-content {
-  flex-direction: row;
-}
-
-.cardhost-card-theme-editor .editor-section {
-  height: 50%;
-  width: 100%;
-  padding: 12px 0 12px 12px;
-}
-
-.cardhost-card-theme-editor.bottom-docked .editor-section {
-  padding: 12px;
-}
-
-.cardhost-card-theme-editor.bottom-docked .editor-section {
-  height: 100%;
-  width: 50%;
-}
-
-.cardhost-card-theme-editor .editor-container {
-  border: 1px solid var(--ch-default);
-  border-radius: 10px;
-  overflow: hidden;
-  height: 100%;
-}
-
-.cardhost-card-theme-editor .editor-container__title {
-  background-color: var(--ch-default);
-  padding: 12px;
-}
-
-
-.cardhost-card-theme-editor .resizer.left {
-  left: 5px;
-  width: 25px;
-}
-
-.cardhost-card-theme-editor .resizer.top {
-  height: 25px;
-}
-
-.cardhost-card-theme-editor .drag-handle {
-  position: absolute;
-  left: -12px;
-  top: 50%;
-  transform: rotate(180deg);
-  z-index: -1;
-}
-
-.cardhost-card-theme-editor.bottom-docked .drag-handle {
-  left: 49.5%;
-  top: -18px;
-  transform: rotate(-90deg);
-}
-
-.cardhost-card-theme-editor .drag-handle path {
-  stroke: var(--ch-light-background);
-}
-
-.cardhost-card-document--codeblock {
-  height: 0;
-}
-
-.cardhost-monaco-container {
-  min-height: 50px;
-  margin-bottom: 1em;
-  overflow: hidden;
-  resize: vertical;
-  background-color: #1e1e1e;
-}
-
-.cardhost-monaco-container.editor-pane-code {
-  min-height: 32vh;
 }

--- a/packages/cardhost/app/styles/cards.css
+++ b/packages/cardhost/app/styles/cards.css
@@ -8,23 +8,13 @@
 
   width: 100%;
   height: 100vh;
+  transition: var(--ch-card-background-color-animate);
   background-color: var(--ch-default);
   overflow: hidden;
   padding-top: var(--padding-top);
   padding-left: var(--padding-left);
   padding-right: var(--padding-right);
   padding-bottom: var(--padding-bottom);
-}
-
-.cardhost-cards.editing-css {
-  padding-left: 0;
-  width: 40%;
-  transition: width 0.3s ease-in-out;
-  padding-right: 0;
-}
-
-.cardhost-cards.editing-css.full-width {
-  width: 100%;
 }
 
 /* TODO: Remove this after right-edge is displayed on edit view */

--- a/packages/cardhost/app/styles/cards.css
+++ b/packages/cardhost/app/styles/cards.css
@@ -8,7 +8,7 @@
 
   width: 100%;
   height: 100vh;
-  transition: var(--ch-card-background-color-animate);
+  transition: var(--ch-card-background-color-animate), var(--ch-card-padding-animate);
   background-color: var(--ch-default);
   overflow: hidden;
   padding-top: var(--padding-top);

--- a/packages/cardhost/app/styles/components/themer.css
+++ b/packages/cardhost/app/styles/components/themer.css
@@ -144,7 +144,7 @@
   transition: width 0.3s ease-in-out;
   padding-right: 0;
   transition: var(--ch-card-background-color-animate);
-  background-color: var(--ch-foreground);
+  background-color: var(--ch-dark-background);
 }
 
 .cardhost-cards.editing-css.full-width {

--- a/packages/cardhost/app/styles/components/themer.css
+++ b/packages/cardhost/app/styles/components/themer.css
@@ -1,0 +1,152 @@
+.cardhost-card-theme-editor {
+  position: fixed;
+  right: 0;
+  top: 0;
+  width: 40%;
+  height: 100%;
+  background: var(--ch-dark);
+  z-index: 10;
+  padding: 20px;
+  transform: translateX(0%);
+  opacity: 0.92;
+}
+
+.cardhost-card-theme-editor.bottom-docked {
+  top: auto;
+  bottom: 0;
+  left: 0;
+  height: 40%;
+  width: 100%;
+  transform: translateY(0%);
+}
+
+.cardhost-card-theme-editor.right-docked .resizable-content {
+  padding-top: 50px;
+}
+
+.cardhost-card-theme-editor.hidden {
+  transform: translateX(100%);
+}
+
+.cardhost-card-theme-editor.bottom-docked.hidden {
+  transform: translateY(100%);
+}
+
+
+.cardhost-card-theme-editor .resizable-content {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.cardhost-card-theme-editor.bottom-docked .resizable-content {
+  flex-direction: row;
+}
+
+.cardhost-card-theme-editor .editor-section {
+  height: 50%;
+  width: 100%;
+  padding: 12px 0 12px 12px;
+}
+
+.cardhost-card-theme-editor.bottom-docked .editor-section {
+  padding: 12px;
+}
+
+.cardhost-card-theme-editor.bottom-docked .editor-section {
+  height: 100%;
+  width: 50%;
+}
+
+.cardhost-card-theme-editor .editor-container {
+  border: 1px solid var(--ch-default);
+  border-radius: 10px;
+  overflow: hidden;
+  height: 100%;
+}
+
+.cardhost-card-theme-editor .editor-container__title {
+  background-color: var(--ch-default);
+  padding: 12px;
+}
+
+
+.cardhost-card-theme-editor .resizer.left {
+  left: 5px;
+  width: 25px;
+}
+
+.cardhost-card-theme-editor .resizer.top {
+  height: 25px;
+}
+
+.cardhost-card-theme-editor .drag-handle {
+  position: absolute;
+  left: -12px;
+  top: 50%;
+  transform: rotate(180deg);
+  z-index: -1;
+}
+
+.cardhost-card-theme-editor.bottom-docked .drag-handle {
+  left: 49.5%;
+  top: -18px;
+  transform: rotate(-90deg);
+}
+
+.cardhost-card-theme-editor .drag-handle path {
+  stroke: var(--ch-light-background);
+}
+
+.cardhost-card-document--codeblock {
+  height: 0;
+}
+
+.cardhost-monaco-container {
+  min-height: 50px;
+  margin-bottom: 1em;
+  padding-top: 1em;
+  overflow: hidden;
+  resize: vertical;
+  background-color: #1e1e1e;
+}
+
+.card-renderer--top-edge-buttons .show-editor-btn, .card-renderer--top-edge-buttons .hide-editor-btn {
+  margin-top: 10px;
+  margin-right: 15px;
+  cursor: pointer;
+}
+
+.card-renderer--top-edge-buttons .dock-btn {
+  margin: 10px 15px;
+  cursor: pointer;
+}
+
+.card-renderer--top-edge-buttons .close-editor-btn {
+  --width: 125px;
+  margin-left: 20px;
+}
+
+.cardhost-card-theme-editor .editor-container.editor-pane--container-highlighted {
+  border: 2px solid var(--ch-highlight);
+}
+
+.editor-pane--container-highlighted .editor-container__title {
+  background-color: var(--ch-highlight);
+  color :var(--ch-default);
+}
+
+.cardhost-cards.editing-css {
+  padding-left: 0;
+  width: 40%;
+  transition: width 0.3s ease-in-out;
+  padding-right: 0;
+  transition: var(--ch-card-background-color-animate);
+  background-color: var(--ch-foreground);
+}
+
+.cardhost-cards.editing-css.full-width {
+  width: 100%;
+}

--- a/packages/cardhost/app/styles/components/themer.css
+++ b/packages/cardhost/app/styles/components/themer.css
@@ -140,13 +140,12 @@
 
 .cardhost-cards.editing-css {
   padding-left: 0;
-  width: 40%;
-  transition: width 0.3s ease-in-out;
-  padding-right: 0;
-  transition: var(--ch-card-background-color-animate);
+  width: 100%;
+  padding-right: 60%;
+  transition: var(--ch-card-padding-animate), var(--ch-card-background-color-animate);
   background-color: var(--ch-dark-background);
 }
 
 .cardhost-cards.editing-css.full-width {
-  width: 100%;
+  padding-right: 0;
 }

--- a/packages/cardhost/app/templates/components/card-schema-updator.hbs
+++ b/packages/cardhost/app/templates/components/card-schema-updator.hbs
@@ -82,6 +82,6 @@
 {{#if this.cssModeToggle.editingCss}}
   <section class="cardhost-card-theme-editor">
     <h3>Card Theme Editor</h3>
-    <CodeEditor @code=".a {}" @language="css" @readOnly={{false}} @resizable={{true}} />
+    <CodeEditor @code=".a {}" @language="css" @readOnly={{false}} />
   </section>
 {{/if}}

--- a/packages/cardhost/app/templates/components/code-editor.hbs
+++ b/packages/cardhost/app/templates/components/code-editor.hbs
@@ -1,9 +1,8 @@
-<div class="editor-container">
+<div class="editor-container" ...attributes>
   {{#if @title}}
     <div class="editor-container__title">{{@title}} ({{if this.readOnly "read-only" "editable"}})</div>
   {{/if}}
   <div {{did-insert this.renderEditor}}
-    ...attributes
     data-test-code-block={{@code}}
     class="cardhost-monaco-container"
   >

--- a/packages/cardhost/app/templates/components/editor-pane.hbs
+++ b/packages/cardhost/app/templates/components/editor-pane.hbs
@@ -1,15 +1,32 @@
-<ReSizable ...attributes class="cardhost-card-theme-editor"
-  @width={{this.width}} @directions={{this.directions}} @height={{this.height}}
-  @classNames={{this.classNames}}>
+<ReSizable
+  ...attributes
+  class="cardhost-card-theme-editor"
+  @width={{this.width}}
+  @directions={{this.directions}}
+  @height={{this.height}}
+  @classNames={{this.classNames}}
+>
   <div class="resizable-content">
-    <div class="editor-section">
-      <CodeEditor @title="CSS" @code={{@model.isolatedCss}} @language="css" @readOnly={{false}} @resizable={{true}}
-        @updateCode={{action "updateCode"}} class="editor-pane-code" />
+    <div class="editor-section" aria-label={{this.monacoKeyboardInstructions}}>
+      <CodeEditor
+        @title="CSS"
+        @code={{@model.isolatedCss}}
+        @language="css"
+        @readOnly={{false}}
+        @resizable={{true}}
+        @updateCode={{action "updateCode"}}
+        class="editor-pane--container-highlighted"
+      />
     </div>
 
     <div class="editor-section">
-      <CodeEditor @title="HTML" @code={{this.markup}} @language="handlebars" @readOnly={{true}} @resizable={{true}}
-        class="editor-pane-code" />
+      <CodeEditor
+        @title="HTML"
+        @code={{this.markup}}
+        @language="handlebars"
+        @readOnly={{true}}
+        @resizable={{true}} 
+      />
     </div>
     {{svg-jar "icon-grabber" class="drag-handle"}}
   </div>

--- a/packages/cardhost/app/templates/ui-components.hbs
+++ b/packages/cardhost/app/templates/ui-components.hbs
@@ -560,4 +560,22 @@
       @language="html"
     />
   </section>
+
+  <section class="ui-components--section">
+    <h2>Code Editor</h2>
+    <CodeEditor @language="handlebars" @code='<CodeEditor @language="javascript" @code="let a;" @resizable={{true}} />
+
+/** <CodeEditor> takes the following arguments:
+ * @code - the code to display, in string form, like `let a = 2;`
+ * @language - string like javascript, json, etc.
+ * @readOnly - optional boolean. Defaults to true.
+ * @updateCode - optional action that is called when content of the editor changes. It receives the full code as an argument.
+ * @editorReady - optional action used for testing and animations. Fires every time an editor has finished rendering.
+ * @validate - optional action that should return a bool. Blocks calling updateCode if it returns false. Defaults to returning true.
+ * @debounceMsForValidate - optional number in ms, rate limits how often @validate is called. Default 500.
+ * @resizable - optional boolean that determines whether the code editor should respond to size changes of the parent container. Defaults to false.
+ * @resizeCheckInterval - optional number in ms to rate limit how quickly the container resizes
+ */'
+ />
+  </section>
 </section>

--- a/packages/cardhost/tests/integration/components/re-sizable-test.js
+++ b/packages/cardhost/tests/integration/components/re-sizable-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, triggerEvent, settled } from '@ember/test-helpers';
+import { render, triggerEvent, settled, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { dasherize } from '@ember/string';
 
@@ -102,5 +102,43 @@ module('Integration | Component | re-sizable', function(hooks) {
       assert.dom('.re-sizable').hasStyle({ width: `${width}px` });
       assert.dom('.re-sizable').hasStyle({ height: `${height}px` });
     }
+  });
+
+  test('width should not exceed window dimensions', async function(assert) {
+    this.set('width', 200);
+    this.set('height', 150);
+    let direction = 'left';
+    this.set('directions', [direction]);
+    this.set('maxWidth', 800);
+    // as the component resizes, capture the resulting dimensions as this.width and this.height
+    this.set('onResize', (direction, dimensions) => this.setProperties(dimensions));
+    await render(
+      hbs`<ReSizable @width={{this.width}} @height={{this.height}} @onResize={{this.onResize}} @directions={{this.directions}}>Hello</ReSizable>`
+    );
+    await settled();
+    await triggerEvent(`.resizer.${direction}`, 'mousedown', { clientX: 110, clientY: 40 });
+    await triggerEvent(`.resizer.${direction}`, 'mousemove', { clientX: 2000 });
+    await triggerEvent(`.resizer.${direction}`, 'mouseup', {});
+    let actualWidth = Number(find('.re-sizable').style.width.replace('px', ''));
+    assert.ok(actualWidth < 800);
+  });
+
+  test('height should not exceed window dimensions', async function(assert) {
+    this.set('width', 200);
+    this.set('height', 150);
+    let direction = 'top';
+    this.set('directions', [direction]);
+    this.set('maxWidth', 800);
+    // as the component resizes, capture the resulting dimensions as this.width and this.height
+    this.set('onResize', (direction, dimensions) => this.setProperties(dimensions));
+    await render(
+      hbs`<ReSizable @width={{this.width}} @height={{this.height}} @onResize={{this.onResize}} @directions={{this.directions}}>Hello</ReSizable>`
+    );
+    await settled();
+    await triggerEvent(`.resizer.${direction}`, 'mousedown', { clientX: 110, clientY: 40 });
+    await triggerEvent(`.resizer.${direction}`, 'mousemove', { clientY: 2000 });
+    await triggerEvent(`.resizer.${direction}`, 'mouseup', {});
+    let actualHeight = Number(find('.re-sizable').style.height.replace('px', ''));
+    assert.ok(actualHeight < 800);
   });
 });


### PR DESCRIPTION
Closes #0183 and #1133 

Added:
- background color animation between themer and editor pages
- bright blue border around CSS editor
- aria-label with Tab trap escape instructions
- enable responsive resize of the themer pane
- check for testing ENV before turning responsive resize checker on. Could refactor this in the future to only resize after the resize motion finishes, depending on the UX we want

Changed
- Moved themer-related styles into their own file, `themer.css`
- Added some height to ui-components code blocks so that fewer are cut off
- minor whitespace formatting

