### PR TITLE
Refactor top edge buttons

### DIFF
--- a/packages/cardhost/app/styles/components/button.css
+++ b/packages/cardhost/app/styles/components/button.css
@@ -151,7 +151,8 @@
 .ch-button--icon.responsive {
   --icon-url: url('/assets/images/buttons/responsive-inactive.svg');
   --width: auto;
-  --height: 60px;
+  --height: auto;
+  padding-top: 25px;
   background-size: 25px 25px;
   background-position: top;
   justify-content: center;
@@ -171,7 +172,8 @@
 .ch-button--icon.full-width {
   --icon-url: url('/assets/images/buttons/full-width-inactive.svg');
   --width: auto;
-  --height: 40px;
+  --height: auto;
+  padding-top: 25px;
   background-size: 20px 20px;
   background-position: top;
   display: inline-flex;

--- a/packages/cardhost/app/styles/components/button.css
+++ b/packages/cardhost/app/styles/components/button.css
@@ -158,6 +158,7 @@
   justify-content: center;
   align-items: flex-end;
   box-shadow: none;
+  border-radius: 0;
 }
 
 .ch-button--icon.responsive.selected {
@@ -180,6 +181,7 @@
   justify-content: center;
   align-items: flex-end;
   box-shadow: none;
+  border-radius: 0;
 }
 
 .ch-button--icon.full-width.selected {

--- a/packages/cardhost/app/styles/components/button.css
+++ b/packages/cardhost/app/styles/components/button.css
@@ -150,7 +150,13 @@
 
 .ch-button--icon.responsive {
   --icon-url: url('/assets/images/buttons/responsive-inactive.svg');
-  background-size: 30px 30px;
+  --width: auto;
+  --height: 60px;
+  background-size: 25px 25px;
+  background-position: top;
+  justify-content: center;
+  align-items: flex-end;
+  box-shadow: none;
 }
 
 .ch-button--icon.responsive.selected {
@@ -164,8 +170,14 @@
 
 .ch-button--icon.full-width {
   --icon-url: url('/assets/images/buttons/full-width-inactive.svg');
-  background-size: 25px 25px;
-  margin-right: 20px;
+  --width: auto;
+  --height: 40px;
+  background-size: 20px 20px;
+  background-position: top;
+  display: inline-flex;
+  justify-content: center;
+  align-items: flex-end;
+  box-shadow: none;
 }
 
 .ch-button--icon.full-width.selected {

--- a/packages/cardhost/app/styles/components/themer.css
+++ b/packages/cardhost/app/styles/components/themer.css
@@ -113,18 +113,18 @@
   background-color: #1e1e1e;
 }
 
-.card-renderer--top-edge-buttons .show-editor-btn, .card-renderer--top-edge-buttons .hide-editor-btn {
+.themer--top-edge-container .show-editor-btn, .themer--top-edge-container .hide-editor-btn {
   margin-top: 10px;
   margin-right: 15px;
   cursor: pointer;
 }
 
-.card-renderer--top-edge-buttons .dock-btn {
+.themer--top-edge-container .dock-btn {
   margin: 10px 15px;
   cursor: pointer;
 }
 
-.card-renderer--top-edge-buttons .close-editor-btn {
+.themer--top-edge-container .close-editor-btn {
   --width: 125px;
   margin-left: 20px;
 }
@@ -148,4 +148,31 @@
 
 .cardhost-cards.editing-css.full-width {
   padding-right: 0;
+}
+
+.themer--top-edge-container {
+  display: grid;
+  position: fixed;
+  top: var(--ch-spacing);
+  right: var(--ch-spacing);
+  left: 40px;
+  z-index: var(--ch-actions-z-index);
+  grid-template-columns: auto auto;
+}
+
+.themer--top-edge-container .ch-button {
+  --color: var(--ch-light);
+}
+
+.themer--top-edge-container .ch-button.selected {
+  --color: var(--ch-highlight);
+}
+
+.themer--top-edge-width-controls {
+  justify-self: start;
+  
+}
+
+.themer--top-edge-pane-controls {
+  justify-self: end;
 }

--- a/packages/cardhost/app/styles/components/themer.css
+++ b/packages/cardhost/app/styles/components/themer.css
@@ -125,8 +125,12 @@
 }
 
 .themer--top-edge-container .close-editor-btn {
-  --width: 125px;
+  width: 125px;
   margin-left: 20px;
+  align-self: start;
+  display: inline-block;
+  vertical-align: top;
+  color: var(--ch-dark);
 }
 
 .cardhost-card-theme-editor .editor-container.editor-pane--container-highlighted {
@@ -175,4 +179,8 @@
 
 .themer--top-edge-pane-controls {
   justify-self: end;
+}
+
+.themer--top-edge-width-controls .ch-button + .ch-button {
+  margin-left: 45px;
 }

--- a/packages/cardhost/app/styles/ui-components.css
+++ b/packages/cardhost/app/styles/ui-components.css
@@ -90,3 +90,8 @@
 .ui-components .right-edge {
   position: static;
 }
+
+.ui-components .ch-button--icon.responsive,
+.ui-components .ch-button--icon.full-width {
+  color: var(--ch-light);
+}

--- a/packages/cardhost/app/templates/cards/view.hbs
+++ b/packages/cardhost/app/templates/cards/view.hbs
@@ -1,7 +1,7 @@
-<div class="card-renderer--top-edge-buttons">
-  {{#if this.cssModeToggle.editingCss}}
-    <ThemerToolbar @closeEditor={{this.closeEditor}} />
-  {{else}}
+{{#if this.cssModeToggle.editingCss}}
+  <ThemerToolbar @closeEditor={{this.closeEditor}} />
+{{else}}
+  <div class="card-renderer--top-edge-buttons">
     <button
       class="ch-button ch-button--icon share"
       aria-label="Share button"
@@ -14,8 +14,8 @@
       Preview
     </button>
     <SaveButton @card={{this.card}}/>
-  {{/if}}
-</div>
+  </div>
+{{/if}}
 
 {{#unless this.cssModeToggle.editingCss}}
   <CardhostLeftEdge />

--- a/packages/cardhost/app/templates/components/themer-toolbar.hbs
+++ b/packages/cardhost/app/templates/components/themer-toolbar.hbs
@@ -1,54 +1,56 @@
-<button 
-  class="ch-button ch-button--icon responsive {{if this.cssModeToggle.isResponsive "selected"}}"
-  {{on "click" this.cssModeToggle.useResponsiveWidth}}
-  aria-label="Show the card in responsive size"
-  data-test-responsive-btn
->
-</button>
-
-<button 
-  class="ch-button ch-button--icon full-width {{if this.cssModeToggle.isResponsive "" "selected"}}"
-  {{on "click" this.cssModeToggle.useFullWidth}}
-  aria-label="Show the card in full width size"
-  data-test-full-width-btn
->
-</button>
-
-{{#if this.cssModeToggle.visible}}
+<header class="themer--top-edge card-renderer--top-edge-buttons">
   <button 
-    class="ch-button ch-button--icon eye-on"
-    aria-label="Hide the CSS editor"
-    {{on "click" this.cssModeToggle.hideEditor}}
-    data-test-hide-editor-btn
+    class="ch-button ch-button--icon responsive {{if this.cssModeToggle.isResponsive "selected"}}"
+    {{on "click" this.cssModeToggle.useResponsiveWidth}}
+    aria-label="Show the card in responsive size"
+    data-test-responsive-btn
   >
   </button>
-{{else}}
+
   <button 
-    class="ch-button ch-button--icon eye-off"
-    aria-label="Show the CSS editor"
-    {{on "click" this.cssModeToggle.showEditor}}
-    data-test-show-editor-btn
+    class="ch-button ch-button--icon full-width {{if this.cssModeToggle.isResponsive "" "selected"}}"
+    {{on "click" this.cssModeToggle.useFullWidth}}
+    aria-label="Show the card in full width size"
+    data-test-full-width-btn
   >
   </button>
-{{/if}}
-<button 
-  class="ch-button ch-button--icon dock-bottom {{if (eq this.cssModeToggle.dockLocation "bottom") "selected"}}"
-  {{on "click" this.cssModeToggle.dockBottom}}
-  aria-label="Dock the CSS editor to the bottom"
-  data-test-dock-bottom
->
-</button>
 
-<button 
-  class="ch-button ch-button--icon dock-right {{if (eq this.cssModeToggle.dockLocation "right") "selected"}}"
-  {{on "click" this.cssModeToggle.dockRight}}
-  aria-label="Dock the CSS editor to the right"
-  data-test-dock-right
->
-</button>
-<button {{on "click" @closeEditor}}
-  class="ch-button close-editor-btn"
-  data-test-close-editor
->
-  Close Editor
-</button>
+  {{#if this.cssModeToggle.visible}}
+    <button 
+      class="ch-button ch-button--icon eye-on"
+      aria-label="Hide the CSS editor"
+      {{on "click" this.cssModeToggle.hideEditor}}
+      data-test-hide-editor-btn
+    >
+    </button>
+  {{else}}
+    <button 
+      class="ch-button ch-button--icon eye-off"
+      aria-label="Show the CSS editor"
+      {{on "click" this.cssModeToggle.showEditor}}
+      data-test-show-editor-btn
+    >
+    </button>
+  {{/if}}
+  <button 
+    class="ch-button ch-button--icon dock-bottom {{if (eq this.cssModeToggle.dockLocation "bottom") "selected"}}"
+    {{on "click" this.cssModeToggle.dockBottom}}
+    aria-label="Dock the CSS editor to the bottom"
+    data-test-dock-bottom
+  >
+  </button>
+
+  <button 
+    class="ch-button ch-button--icon dock-right {{if (eq this.cssModeToggle.dockLocation "right") "selected"}}"
+    {{on "click" this.cssModeToggle.dockRight}}
+    aria-label="Dock the CSS editor to the right"
+    data-test-dock-right
+  >
+  </button>
+  <button {{on "click" @closeEditor}}
+    class="ch-button close-editor-btn"
+    data-test-close-editor
+  >
+    Close Editor
+  </button>
+</header>

--- a/packages/cardhost/app/templates/components/themer-toolbar.hbs
+++ b/packages/cardhost/app/templates/components/themer-toolbar.hbs
@@ -1,56 +1,63 @@
-<header class="themer--top-edge card-renderer--top-edge-buttons">
-  <button 
-    class="ch-button ch-button--icon responsive {{if this.cssModeToggle.isResponsive "selected"}}"
-    {{on "click" this.cssModeToggle.useResponsiveWidth}}
-    aria-label="Show the card in responsive size"
-    data-test-responsive-btn
-  >
-  </button>
-
-  <button 
-    class="ch-button ch-button--icon full-width {{if this.cssModeToggle.isResponsive "" "selected"}}"
-    {{on "click" this.cssModeToggle.useFullWidth}}
-    aria-label="Show the card in full width size"
-    data-test-full-width-btn
-  >
-  </button>
-
-  {{#if this.cssModeToggle.visible}}
+<header class="themer--top-edge-container">
+  <div class="themer--top-edge-width-controls">
     <button 
-      class="ch-button ch-button--icon eye-on"
-      aria-label="Hide the CSS editor"
-      {{on "click" this.cssModeToggle.hideEditor}}
-      data-test-hide-editor-btn
+      class="ch-button ch-button--icon responsive {{if this.cssModeToggle.isResponsive "selected"}}"
+      {{on "click" this.cssModeToggle.useResponsiveWidth}}
+      aria-label="Show the card in responsive size"
+      data-test-responsive-btn
+    >
+      Responsive
+    </button>
+
+    <button 
+      class="ch-button ch-button--icon full-width {{if this.cssModeToggle.isResponsive "" "selected"}}"
+      {{on "click" this.cssModeToggle.useFullWidth}}
+      aria-label="Show the card in full width size"
+      data-test-full-width-btn
+    >
+      Full Width
+    </button>
+  </div>
+
+  <div class="themer--top-edge-pane-controls">
+    {{#if this.cssModeToggle.visible}}
+      <button 
+        class="ch-button ch-button--icon eye-on"
+        aria-label="Hide the CSS editor"
+        {{on "click" this.cssModeToggle.hideEditor}}
+        data-test-hide-editor-btn
+      >
+      </button>
+    {{else}}
+      <button 
+        class="ch-button ch-button--icon eye-off"
+        aria-label="Show the CSS editor"
+        {{on "click" this.cssModeToggle.showEditor}}
+        data-test-show-editor-btn
+      >
+      </button>
+    {{/if}}
+
+    <button 
+      class="ch-button ch-button--icon dock-bottom {{if (eq this.cssModeToggle.dockLocation "bottom") "selected"}}"
+      {{on "click" this.cssModeToggle.dockBottom}}
+      aria-label="Dock the CSS editor to the bottom"
+      data-test-dock-bottom
     >
     </button>
-  {{else}}
+
     <button 
-      class="ch-button ch-button--icon eye-off"
-      aria-label="Show the CSS editor"
-      {{on "click" this.cssModeToggle.showEditor}}
-      data-test-show-editor-btn
+      class="ch-button ch-button--icon dock-right {{if (eq this.cssModeToggle.dockLocation "right") "selected"}}"
+      {{on "click" this.cssModeToggle.dockRight}}
+      aria-label="Dock the CSS editor to the right"
+      data-test-dock-right
     >
     </button>
-  {{/if}}
-  <button 
-    class="ch-button ch-button--icon dock-bottom {{if (eq this.cssModeToggle.dockLocation "bottom") "selected"}}"
-    {{on "click" this.cssModeToggle.dockBottom}}
-    aria-label="Dock the CSS editor to the bottom"
-    data-test-dock-bottom
-  >
-  </button>
-
-  <button 
-    class="ch-button ch-button--icon dock-right {{if (eq this.cssModeToggle.dockLocation "right") "selected"}}"
-    {{on "click" this.cssModeToggle.dockRight}}
-    aria-label="Dock the CSS editor to the right"
-    data-test-dock-right
-  >
-  </button>
-  <button {{on "click" @closeEditor}}
-    class="ch-button close-editor-btn"
-    data-test-close-editor
-  >
-    Close Editor
-  </button>
+    <button {{on "click" @closeEditor}}
+      class="ch-button close-editor-btn"
+      data-test-close-editor
+    >
+      Close Editor
+    </button>
+  </div>
 </header>

--- a/packages/cardhost/app/templates/ui-components.hbs
+++ b/packages/cardhost/app/templates/ui-components.hbs
@@ -79,8 +79,6 @@
       <button class="ch-button ch-button--icon dock-bottom" aria-label="Dock bottom"></button>
       <button class="ch-button ch-button--icon eye-on" aria-label="Visible"></button>
       <button class="ch-button ch-button--icon eye-off" aria-label="Hidden"></button>
-      <button class="ch-button ch-button--icon responsive" aria-label="Responsive"></button>
-      <button class="ch-button ch-button--icon full-width" aria-label="Full Width"></button>
     </div>
     <div>
       <CodeEditor @code='<button class="ch-button ch-button--icon user" aria-label="User"></button>
@@ -90,15 +88,22 @@
 <button class="ch-button ch-button--icon dock-right" aria-label="Dock right">
 <button class="ch-button ch-button--icon dock-bottom" aria-label="Dock bottom">
 <button class="ch-button ch-button--icon eye-on" aria-label="Visible"></button>
-<button class="ch-button ch-button--icon eye-off" aria-label="Hidden"></button>
-<button class="ch-button ch-button--icon responsive" aria-label="Responsive"></button>
-<button class="ch-button ch-button--icon full-width" aria-label="Full Width"></button>'
+<button class="ch-button ch-button--icon eye-off" aria-label="Hidden"></button>'
       @language="html" />
     </div>
 
     <h3>Secondary Icon button</h3>
     <button class="ch-button ch-button--icon-secondary delete" aria-label="Delete"></button>
     <CodeEditor @code='<button class="ch-button ch-button--icon-secondary delete" aria-label="Delete"></button>'
+      @language="html" />
+
+    <h3>Icon with text</h3>
+    <div>
+      <button class="ch-button ch-button--icon responsive" aria-label="Responsive">Responsive</button>
+      <button class="ch-button ch-button--icon full-width" aria-label="Full Width">Full Width</button>
+    </div>
+    <CodeEditor @code='<button class="ch-button ch-button--icon responsive" aria-label="Responsive"></button>
+<button class="ch-button ch-button--icon full-width" aria-label="Full Width"></button>'
       @language="html" />
 
     <h3>Disabled Icon button</h3>

--- a/packages/cardhost/public/assets/images/buttons/dock-bottom-secondary.svg
+++ b/packages/cardhost/public/assets/images/buttons/dock-bottom-secondary.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg"  width="18" height="16"  viewBox="0 0 18.063 16">
   <g id="Group_602" data-name="Group 602" transform="translate(-1085.937 -31.025)">
-    <rect data-name="Rectangle 285" width="16" height="14" rx="2" transform="translate(1087 32.025)" stroke-width="2" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-    <path data-name="Path 252" d="M19.627,16.423H3.7" transform="translate(1083.237 24.44)" fill="none" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+    <rect data-name="Rectangle 285" width="16" height="14" rx="2" transform="translate(1087 32.025)" stroke-width="2" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <path data-name="Path 252" d="M19.627,16.423H3.7" transform="translate(1083.237 24.44)" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
   </g>
 </svg>

--- a/packages/cardhost/public/assets/images/buttons/dock-right-secondary.svg
+++ b/packages/cardhost/public/assets/images/buttons/dock-right-secondary.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="16" viewBox="0 0 18 16">
   <g id="Group_603" data-name="Group 603" transform="translate(1104 47.025) rotate(180)">
-    <rect data-name="Rectangle 285" width="16" height="14" rx="2" transform="translate(1087 32.025)" stroke-width="2" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-    <path data-name="Path 252" d="M9.273,22.585V9" transform="translate(1083.237 23.44)" fill="none" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+    <rect data-name="Rectangle 285" width="16" height="14" rx="2" transform="translate(1087 32.025)" stroke-width="2" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <path data-name="Path 252" d="M9.273,22.585V9" transform="translate(1083.237 23.44)" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
   </g>
 </svg>

--- a/packages/cardhost/public/assets/images/buttons/full-width-inactive.svg
+++ b/packages/cardhost/public/assets/images/buttons/full-width-inactive.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="22" height="20" viewBox="0 0 22 20">
   <g id="Icon_Desktop" transform="translate(1 1)">
     <g id="Group_625" data-name="Group 625">
-      <rect id="Rectangle_581" data-name="Rectangle 581" width="20" height="14" rx="2" fill="none" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-      <path id="Path_456" data-name="Path 456" d="M8,21h8" transform="translate(-2 -3)" fill="none" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-      <path id="Path_457" data-name="Path 457" d="M12,17v4" transform="translate(-2 -3)" fill="none" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      <rect id="Rectangle_581" data-name="Rectangle 581" width="20" height="14" rx="2" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      <path id="Path_456" data-name="Path 456" d="M8,21h8" transform="translate(-2 -3)" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+      <path id="Path_457" data-name="Path 457" d="M12,17v4" transform="translate(-2 -3)" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
     </g>
   </g>
 </svg>

--- a/packages/cardhost/public/assets/images/buttons/responsive-active.svg
+++ b/packages/cardhost/public/assets/images/buttons/responsive-active.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="26" height="16" viewBox="0 0 26 16">
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 2 26 20">
   <g id="Icon_phone" transform="translate(1 1)">
     <rect id="Rectangle_580" data-name="Rectangle 580" width="11" height="14" rx="2" transform="translate(13)" stroke-width="2" stroke="#00ebe5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
     <rect id="Rectangle_587" data-name="Rectangle 587" width="6" height="9" rx="2" transform="translate(0 5)" stroke-width="2" stroke="#00ebe5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>

--- a/packages/cardhost/public/assets/images/buttons/responsive-inactive.svg
+++ b/packages/cardhost/public/assets/images/buttons/responsive-inactive.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="26" height="16" viewBox="0 0 26 16">
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 2 26 20">
   <g id="Icon_phone" transform="translate(1 1)">
-    <rect id="Rectangle_580" data-name="Rectangle 580" width="11" height="14" rx="2" transform="translate(13)" stroke-width="2" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-    <rect id="Rectangle_587" data-name="Rectangle 587" width="6" height="9" rx="2" transform="translate(0 5)" stroke-width="2" stroke="#afafb7" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <rect id="Rectangle_580" data-name="Rectangle 580" width="11" height="14" rx="2" transform="translate(13)" stroke-width="2" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <rect id="Rectangle_587" data-name="Rectangle 587" width="6" height="9" rx="2" transform="translate(0 5)" stroke-width="2" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
   </g>
 </svg>

--- a/packages/cardhost/tests/integration/components/themer-toolbar-test.js
+++ b/packages/cardhost/tests/integration/components/themer-toolbar-test.js
@@ -9,6 +9,6 @@ module('Integration | Component | themer-toolbar', function(hooks) {
   test('it renders', async function(assert) {
     this.set('closeEditor', () => {});
     await render(hbs`<ThemerToolbar @closeEditor={{this.closeEditor}} />`);
-    assert.equal(this.element.textContent.trim(), 'Close Editor');
+    assert.ok(this.element.textContent.includes('Close Editor'));
   });
 });


### PR DESCRIPTION
Changed:
- arrange themer buttons using CSS grid instead of flex
- create a container for top edge buttons
- use white for inactive state text/icons. The gray I was using was not in the palette and was insufficient for text contrast.

Added:
- text inside the full width and responsive buttons. Done with changes to button size and SVG viewbox. These buttons themselves use flexbox since I need nice text centering.

About the grid:
- There is one grid container that specifies columns of auto width
- There are two groups of buttons, those that run to the left and those that go to the right, using justify-self
- the size/position of the grid is meant to match the boundaries of the rest of the elements on the page

Closes #1145