### PR TITLE
Animate drag & drop fields in schema mode

### DIFF
--- a/packages/cardhost/app/styles/components/card-renderer.css
+++ b/packages/cardhost/app/styles/components/card-renderer.css
@@ -30,6 +30,8 @@
 }
 
 .card-renderer-isolated.no-fields .drop-zone {
+  position: static;
+  height: initial;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -37,6 +39,7 @@
 }
 
 .card-renderer-isolated.no-fields .drop-zone .drop-zone-text {
+  display: block;
   border: none;
   font-size: 16px;
 }

--- a/packages/cardhost/app/styles/components/card-renderer.css
+++ b/packages/cardhost/app/styles/components/card-renderer.css
@@ -38,10 +38,13 @@
   min-height: calc(var(--card-renderer-height) - var(--card-renderer-header-height));
 }
 
-.card-renderer-isolated.no-fields .drop-zone .drop-zone-text {
-  display: block;
+.card-renderer-isolated.no-fields .drop-zone .drop-zone--description {
   border: none;
   font-size: 16px;
+}
+
+.card-renderer-isolated.no-fields .drop-zone .drop-zone--description .drop-zone--description--text {
+  text-indent: 0;
 }
 
 .card-renderer-isolated.no-fields .drop-zone .drop-zone--drag-drop-icon {

--- a/packages/cardhost/app/styles/components/card-renderer.css
+++ b/packages/cardhost/app/styles/components/card-renderer.css
@@ -39,12 +39,13 @@
 }
 
 .card-renderer-isolated.no-fields .drop-zone .drop-zone--description {
+  width: 100%;
   border: none;
   font-size: 16px;
 }
 
 .card-renderer-isolated.no-fields .drop-zone .drop-zone--description .drop-zone--description--text {
-  text-indent: 0;
+  display: block;
 }
 
 .card-renderer-isolated.no-fields .drop-zone .drop-zone--drag-drop-icon {

--- a/packages/cardhost/app/styles/components/drop-zone.css
+++ b/packages/cardhost/app/styles/components/drop-zone.css
@@ -1,31 +1,33 @@
 :root {
-  --ch-drop-zone-transition-duration: 300ms;
+  --ch-drop-zone-transition-duration: 200ms;
 }
 .drop-zone--container {
-  position: relative;
+  height: 20px;
+  background-color: var(--ch-dark-background);
+}
+
+.drop-zone--container.outside {
+  transition: height var(--ch-drop-zone-transition-duration) cubic-bezier(0.445, 0.05, 0.55, 0.95);
+}
+
+.drop-zone--container.dragging {
+  height: 158px;
+  transition: height var(--ch-drop-zone-transition-duration) cubic-bezier(0.445, 0.05, 0.55, 0.95);
 }
 
 .drop-zone {
   background-color: transparent;
-  position: absolute;
-  top: -60px;
-  height: 120px;
   width: 100%;
-  border: solid 1px red;
 }
 
-.drop-zone--container .drop-zone--preview {
-  height: 2px;
+.drop-zone--container .drop-zone--description .drop-zone--preview--container {
   pointer-events: none;
+  padding: 20px 53px;
 }
 
-.drop-zone--container .drop-zone--preview.active {
+.drop-zone .drop-zone--description {
+  pointer-events: none;
   height: 120px;
-}
-
-.drop-zone .drop-zone-text {
-  display: none;
-  height: 2px;
   opacity: 0.5;
   padding: 0;
   background-color: var(--ch-medium-purple);
@@ -33,18 +35,14 @@
   font-size: 16px;
   line-height: 22px;
   text-align: center;
-  border-top: 1px solid rgba(255, 255, 255, 0.15);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
-  transition:
-    opacity var(--ch-drop-zone-transition-duration),
-    height var(--ch-drop-zone-transition-duration),
-    padding var(--ch-drop-zone-transition-duration);
 }
 
-.drop-zone .drop-zone-text.active {
+.drop-zone--description--text {
+  display: none;
+}
+
+.drop-zone .drop-zone--description.dragging {
   opacity: 1;
-  padding: var(--ch-spacing);
-  height: 120px;
 }
 
 .drop-zone .drop-zone--drag-drop-icon {

--- a/packages/cardhost/app/styles/components/drop-zone.css
+++ b/packages/cardhost/app/styles/components/drop-zone.css
@@ -1,10 +1,33 @@
+:root {
+  --ch-drop-zone-transition-duration: 300ms;
+}
+.drop-zone--container {
+  position: relative;
+}
+
 .drop-zone {
-  background-color: var(--ch-dark-background);
+  background-color: transparent;
+  position: absolute;
+  top: -60px;
+  height: 120px;
+  width: 100%;
+  border: solid 1px red;
+}
+
+.drop-zone--container .drop-zone--preview {
+  height: 2px;
+  pointer-events: none;
+}
+
+.drop-zone--container .drop-zone--preview.active {
+  height: 120px;
 }
 
 .drop-zone .drop-zone-text {
+  display: none;
+  height: 2px;
   opacity: 0.5;
-  padding: var(--ch-spacing);
+  padding: 0;
   background-color: var(--ch-medium-purple);
   color: white;
   font-size: 16px;
@@ -12,11 +35,16 @@
   text-align: center;
   border-top: 1px solid rgba(255, 255, 255, 0.15);
   border-bottom: 1px solid rgba(255, 255, 255, 0.15);
-  transition: opacity 250ms;
+  transition:
+    opacity var(--ch-drop-zone-transition-duration),
+    height var(--ch-drop-zone-transition-duration),
+    padding var(--ch-drop-zone-transition-duration);
 }
 
 .drop-zone .drop-zone-text.active {
   opacity: 1;
+  padding: var(--ch-spacing);
+  height: 120px;
 }
 
 .drop-zone .drop-zone--drag-drop-icon {

--- a/packages/cardhost/app/styles/components/field-renderer-schema-field.css
+++ b/packages/cardhost/app/styles/components/field-renderer-schema-field.css
@@ -1,5 +1,5 @@
 .field-renderer.schema-field {
-  padding: var(--ch-spacing) 0;
+  padding: 0;
   color: white;
   font: 400 13px/18px var(--ch-font-family);
   letter-spacing: 0.035em;

--- a/packages/cardhost/app/styles/components/field-renderer.css
+++ b/packages/cardhost/app/styles/components/field-renderer.css
@@ -7,7 +7,7 @@
 
 .field-renderer.with-buttons {
   --field-container-width: 496px;
-  --field-container-height: 154px;
+  --field-container-height: 118px;
 
   display: flex;
   align-items: center;

--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
   root: true,
-  extends: '@cardstack/eslint-config/ember-addon'
+  extends: '@cardstack/eslint-config/ember-addon',
+  rules: {
+    'require-yield': 0,
+  }
 };

--- a/packages/core/addon/components/drop-zone.js
+++ b/packages/core/addon/components/drop-zone.js
@@ -3,30 +3,42 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import fade from 'ember-animated/transitions/fade';
 import resize from 'ember-animated/motions/resize';
+import { fadeIn, fadeOut } from 'ember-animated/motions/opacity';
 import { easeInAndOut } from 'ember-animated/easings/cosine';
 import { printSprites } from 'ember-animated';
 
-export default class DropZone extends Component {
-  @tracked isOverDropZone = false;
+const duration = 250;
 
+export default class DropZone extends Component {
+  @tracked dropZoneStatus = 'outside';
   fade = fade;
 
   get stubField() {
     return {
       name: 'new field',
       label: 'New Field',
-      type: '@cardstack/core-types::string'
+      type: '@cardstack/core-types::string',
     };
+  }
+
+  get isOverDropZone() {
+    return this.dropZoneStatus === 'dragging';
   }
 
   @action dragOver(event) {
     event.preventDefault();
   }
 
-  *expandPreview({ keptSprites }) {
+  *expandPreview({ insertedSprites, removedSprites, keptSprites }) {
     printSprites(arguments[0], 'outerTransition');
-    keptSprites.forEach(sprite => {
-      resize(sprite, { easing: easeInAndOut });
+    insertedSprites.forEach(sprite => {
+      fadeIn(sprite, { duration });
     });
+    removedSprites.forEach(sprite => {
+      fadeOut(sprite, { duration });
+    });
+    // keptSprites.forEach(sprite => {
+    //   resize(sprite, { easing: easeInAndOut });
+    // });
   }
 }

--- a/packages/core/addon/components/drop-zone.js
+++ b/packages/core/addon/components/drop-zone.js
@@ -1,15 +1,12 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import fade from 'ember-animated/transitions/fade';
 import { fadeIn, fadeOut } from 'ember-animated/motions/opacity';
-import { printSprites } from 'ember-animated';
 
 const duration = 250;
 
 export default class DropZone extends Component {
   @tracked dropZoneStatus = 'outside';
-  fade = fade;
 
   get stubField() {
     return {
@@ -28,15 +25,11 @@ export default class DropZone extends Component {
   }
 
   *expandPreview({ insertedSprites, removedSprites }) {
-    printSprites(arguments[0], 'outerTransition');
     insertedSprites.forEach(sprite => {
       fadeIn(sprite, { duration });
     });
     removedSprites.forEach(sprite => {
       fadeOut(sprite, { duration });
     });
-    // keptSprites.forEach(sprite => {
-    //   resize(sprite, { easing: easeInAndOut });
-    // });
   }
 }

--- a/packages/core/addon/components/drop-zone.js
+++ b/packages/core/addon/components/drop-zone.js
@@ -1,11 +1,32 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import fade from 'ember-animated/transitions/fade';
+import resize from 'ember-animated/motions/resize';
+import { easeInAndOut } from 'ember-animated/easings/cosine';
+import { printSprites } from 'ember-animated';
 
 export default class DropZone extends Component {
   @tracked isOverDropZone = false;
 
+  fade = fade;
+
+  get stubField() {
+    return {
+      name: 'new field',
+      label: 'New Field',
+      type: '@cardstack/core-types::string'
+    };
+  }
+
   @action dragOver(event) {
     event.preventDefault();
+  }
+
+  *expandPreview({ keptSprites }) {
+    printSprites(arguments[0], 'outerTransition');
+    keptSprites.forEach(sprite => {
+      resize(sprite, { easing: easeInAndOut });
+    });
   }
 }

--- a/packages/core/addon/components/drop-zone.js
+++ b/packages/core/addon/components/drop-zone.js
@@ -2,9 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import fade from 'ember-animated/transitions/fade';
-import resize from 'ember-animated/motions/resize';
 import { fadeIn, fadeOut } from 'ember-animated/motions/opacity';
-import { easeInAndOut } from 'ember-animated/easings/cosine';
 import { printSprites } from 'ember-animated';
 
 const duration = 250;
@@ -29,7 +27,7 @@ export default class DropZone extends Component {
     event.preventDefault();
   }
 
-  *expandPreview({ insertedSprites, removedSprites, keptSprites }) {
+  *expandPreview({ insertedSprites, removedSprites }) {
     printSprites(arguments[0], 'outerTransition');
     insertedSprites.forEach(sprite => {
       fadeIn(sprite, { duration });

--- a/packages/core/addon/templates/components/drop-zone.hbs
+++ b/packages/core/addon/templates/components/drop-zone.hbs
@@ -1,16 +1,23 @@
-{{! eslint is confused by on helper }}
-{{! template-lint-disable attribute-indentation}}
-<div
-  class="drop-zone"
-  role="button"
-  {{on "drop" (action @dropField @position (fn (mut this.isOverDropZone) false))}}
-  {{on "dragover" (action this.dragOver)}}
-  {{on "dragenter" (action (mut this.isOverDropZone) true)}}
-  {{on "dragleave" (action (mut this.isOverDropZone) false)}}
-  data-test-drop-zone={{@position}}
->
-  <div class="drop-zone-text {{if this.isOverDropZone "active"}}">
-    Drag &amp; drop from the catalog
-    <div class="drop-zone--drag-drop-icon">{{svg-jar "drag-drop"}}</div>
+<div class="drop-zone--container">
+  <div
+    class="drop-zone"
+    role="button"
+    {{on "drop" (action @dropField @position (fn (mut this.isOverDropZone) false))}}
+    {{on "dragover" (action this.dragOver)}}
+    {{on "dragenter" (action (mut this.isOverDropZone) true)}}
+    {{on "dragleave" (action (mut this.isOverDropZone) false)}}
+    data-test-drop-zone={{@position}}
+  >
+    <div class="drop-zone-text {{if this.isOverDropZone "active"}}">
+        Drag &amp; drop from the catalog
+        <div class="drop-zone--drag-drop-icon">{{svg-jar "drag-drop"}}</div>
+    </div>
+    <AnimatedContainer>
+      {{#animated-if this.isOverDropZone use=this.expandPreview as |overDropZone|}}
+        <div class="drop-zone--preview {{if overDropZone "active"}}">
+          <FieldRenderer @field={{this.stubField}} @mode="schema"/>
+        </div>
+      {{/animated-if}}
+    </AnimatedContainer>
   </div>
 </div>

--- a/packages/core/addon/templates/components/drop-zone.hbs
+++ b/packages/core/addon/templates/components/drop-zone.hbs
@@ -1,23 +1,23 @@
-<div class="drop-zone--container">
+<div class="drop-zone--container {{this.dropZoneStatus}}">
   <div
     class="drop-zone"
     role="button"
-    {{on "drop" (action @dropField @position (fn (mut this.isOverDropZone) false))}}
+    {{on "drop" (action @dropField @position (fn (mut this.dropZoneStatus) 'dropped'))}}
     {{on "dragover" (action this.dragOver)}}
-    {{on "dragenter" (action (mut this.isOverDropZone) true)}}
-    {{on "dragleave" (action (mut this.isOverDropZone) false)}}
+    {{on "dragenter" (action (mut this.dropZoneStatus) 'dragging')}}
+    {{on "dragleave" (action (mut this.dropZoneStatus) 'outside')}}
     data-test-drop-zone={{@position}}
   >
-    <div class="drop-zone-text {{if this.isOverDropZone "active"}}">
-        Drag &amp; drop from the catalog
+    <div class="drop-zone--description {{this.dropZoneStatus}}">
+        <span class="drop-zone--description--text">Drag &amp; drop from the catalog</span>
         <div class="drop-zone--drag-drop-icon">{{svg-jar "drag-drop"}}</div>
+        <AnimatedContainer class="drop-zone--preview--container">
+          {{#animated-if this.isOverDropZone use=this.expandPreview as |overDropZone|}}
+            <div class="drop-zone--preview {{if overDropZone "active"}}">
+              <FieldRenderer @field={{this.stubField}} @mode="schema"/>
+            </div>
+          {{/animated-if}}
+        </AnimatedContainer>
     </div>
-    <AnimatedContainer>
-      {{#animated-if this.isOverDropZone use=this.expandPreview as |overDropZone|}}
-        <div class="drop-zone--preview {{if overDropZone "active"}}">
-          <FieldRenderer @field={{this.stubField}} @mode="schema"/>
-        </div>
-      {{/animated-if}}
-    </AnimatedContainer>
   </div>
 </div>

--- a/packages/core/addon/templates/components/field-renderer.hbs
+++ b/packages/core/addon/templates/components/field-renderer.hbs
@@ -151,7 +151,7 @@
             @value={{this.newFieldName}}
             @key-up={{action this.updateFieldName}}
             @disabled={{@field.isAdopted}}
-          />
+          />`
         </div>
       {{else if (eq schemaAttr "is-meta")}}
         <div class="field-renderer--display" data-test-schema-attr={{schemaAttr}}>

--- a/packages/core/addon/templates/components/field-renderer.hbs
+++ b/packages/core/addon/templates/components/field-renderer.hbs
@@ -151,7 +151,7 @@
             @value={{this.newFieldName}}
             @key-up={{action this.updateFieldName}}
             @disabled={{@field.isAdopted}}
-          />`
+          />
         </div>
       {{else if (eq schemaAttr "is-meta")}}
         <div class="field-renderer--display" data-test-schema-attr={{schemaAttr}}>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,6 +47,7 @@
     "@ember/render-modifiers": "1.0.2",
     "@glimmer/component": "^0.14.0-alpha.13",
     "broccoli-asset-rev": "^2.7.0",
+    "ember-animated": "^0.10.0",
     "ember-cli": "~3.8.2",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7205,7 +7205,7 @@ ember-animated-tools@^0.4.1:
     ember-cli-htmlbars "^3.0.0"
     resolve "^1.5.0"
 
-ember-animated@0.10.0:
+ember-animated@0.10.0, ember-animated@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/ember-animated/-/ember-animated-0.10.0.tgz#71d6ebc004a44608638c31876006a5dbd11dbd3e"
   integrity sha512-USx3qzv7vX09wWV79UgKzSQMDaE9fxg6iYWWWepRpTBueWrT2QPfm0Adt2wA29UV8z011AtiVIhy/sDheK7Sbg==


### PR DESCRIPTION
Closes #934

To do (create as separate issues): 

1. Use `ember-animated` instead of native HTML drag & drop, so that we have more control over dragging UI/state
1. When moving fields via D&D, remove the dragged field while you are dragging it