### PR TITLE
Add shadow to scrolled view

### DIFF
--- a/packages/cardhost/app/styles/components/card-renderer.css
+++ b/packages/cardhost/app/styles/components/card-renderer.css
@@ -67,6 +67,12 @@
   background-color: var(--ch-highlight);
   color: var(--ch-dark);
 }
+        
+.card-renderer-isolated.view .card-renderer-isolated--header.scrolled {
+  box-shadow: 0px 5px 5px 0px rgba(0, 0, 0, 0.4);
+  position: relative;
+  z-index: 1;
+}
 
 .card-renderer-isolated--header svg {
   --icon-color: var(--ch-light);

--- a/packages/core/addon/components/card-renderer.js
+++ b/packages/core/addon/components/card-renderer.js
@@ -12,6 +12,7 @@ export default class CardRenderer extends Component {
   @tracked componentName;
   @tracked mode;
   @tracked cardFocused = () => {};
+  @tracked scrolled = '';
 
   constructor(...args) {
     super(...args);
@@ -47,5 +48,24 @@ export default class CardRenderer extends Component {
 
   get isolatedComponentName() {
     return `cards/${dasherize(this.sanitizedName)}/isolated`;
+  }
+
+  @action
+  registerScrollListener(el) {
+    // needed for styling the scrolled card
+    this.scrolled = el.scrollTop > 0 ? 'scrolled' : '';
+
+    el.addEventListener('scroll', scrollEvent => {
+      let position = scrollEvent.currentTarget.scrollTop;
+      if (position > 3) {
+        this.scrolled = 'scrolled';
+      } else {
+        this.scrolled = '';
+      }
+    });
+  }
+
+  removeScrollListener(el) {
+    el.removeEventListener('scroll');
   }
 }

--- a/packages/core/addon/templates/components/card-renderer.hbs
+++ b/packages/core/addon/templates/components/card-renderer.hbs
@@ -19,13 +19,13 @@ Ember Concurrency into the rendering of the card component here.
       {{on "focus" (action this.cardIsFocused true)}}
       {{did-insert this.focusCard true}}
     >
-      <header class="card-renderer-{{@format}}--header {{this.scrolled}}">
+      <header class="card-renderer-{{@format}}--header {{this.scrolled}}" data-test-card-renderer-header>
         {{#if (or (eq (safe-css-string @card.adoptedFromName) "event-card") (eq (safe-css-string @card.name) "event-card"))}}
           {{svg-jar "event" width="18px" height="20px"}}
         {{/if}}
         <span class="card-renderer-{{@format}}--header-title hide-in-percy">{{or @card.name "Blank Card"}}</span>
       </header>
-      <div class="card-renderer-{{@format}}--content" {{did-insert this.registerScrollListener}}>
+      <div class="card-renderer-{{@format}}--content" {{did-insert this.registerScrollListener}} data-test-scroll-target>
         <Isolated
           @card={{@card}}
           @mode={{this.mode}}

--- a/packages/core/addon/templates/components/card-renderer.hbs
+++ b/packages/core/addon/templates/components/card-renderer.hbs
@@ -25,7 +25,11 @@ Ember Concurrency into the rendering of the card component here.
         {{/if}}
         <span class="card-renderer-{{@format}}--header-title hide-in-percy">{{or @card.name "Blank Card"}}</span>
       </header>
-      <div class="card-renderer-{{@format}}--content" {{did-insert this.registerScrollListener}} data-test-scroll-target>
+      <div class="card-renderer-{{@format}}--content"
+        {{did-insert this.registerScrollListener}} 
+        {{will-destroy this.removeScrollListener}}
+        data-test-scroll-targe
+      >
         <Isolated
           @card={{@card}}
           @mode={{this.mode}}

--- a/packages/core/addon/templates/components/card-renderer.hbs
+++ b/packages/core/addon/templates/components/card-renderer.hbs
@@ -19,13 +19,13 @@ Ember Concurrency into the rendering of the card component here.
       {{on "focus" (action this.cardIsFocused true)}}
       {{did-insert this.focusCard true}}
     >
-      <header class="card-renderer-{{@format}}--header">
+      <header class="card-renderer-{{@format}}--header {{this.scrolled}}">
         {{#if (or (eq (safe-css-string @card.adoptedFromName) "event-card") (eq (safe-css-string @card.name) "event-card"))}}
           {{svg-jar "event" width="18px" height="20px"}}
         {{/if}}
         <span class="card-renderer-{{@format}}--header-title hide-in-percy">{{or @card.name "Blank Card"}}</span>
       </header>
-      <div class="card-renderer-{{@format}}--content">
+      <div class="card-renderer-{{@format}}--content" {{did-insert this.registerScrollListener}}>
         <Isolated
           @card={{@card}}
           @mode={{this.mode}}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
     "ember-cli-babel": "^7.1.2",
     "ember-cli-htmlbars": "^3.0.0",
     "ember-concurrency": "^0.10.0",
+    "ember-concurrency-decorators": "^1.0.0",
     "ember-svg-jar": "^2.2.3",
     "lodash": "^4.17.11"
   },


### PR DESCRIPTION
Added:
- "scrolled" style that is optionally applied to the header
- code for detecting, debouncing, and cleaning up scroll events
- test to simulate scrolling
- CSS for the shadow

We'll probably want to use this elsewhere in any fixed containers with scrollbars.

The debounce timeout is really, really short, but anything more than that and there was a noticeable lag.

Before scrolling:

<img width="1367" alt="Screen Shot 2019-12-18 at 6 28 01 PM" src="https://user-images.githubusercontent.com/16627268/71132167-c45da700-21c4-11ea-828b-39defc45ec6a.png">

After scrolling:
<img width="1368" alt="Screen Shot 2019-12-18 at 6 28 09 PM" src="https://user-images.githubusercontent.com/16627268/71132175-c9baf180-21c4-11ea-8883-db1819429942.png">
