### PR TITLE
Update outdated core pkg tests; display field instructions on edit mode

### DIFF
--- a/packages/cardhost/app/components/fields/cardstack/core-types/belongs-to-editor.js
+++ b/packages/cardhost/app/components/fields/cardstack/core-types/belongs-to-editor.js
@@ -1,11 +1,18 @@
 import BaseEditor from './base-editor';
 import { action } from '@ember/object';
+
 export default class BelongsToEditor extends BaseEditor {
   constructor(...args) {
     super(...args);
 
     if (this.args.field && this.args.field.value) {
       this.fieldValue = this.args.field.value.name;
+    }
+
+    if (this.args.field.instructions) {
+      this.fieldInstructions = this.args.field.instructions;
+    } else {
+      this.fieldInstructions = 'Please enter card ID';
     }
   }
 

--- a/packages/cardhost/app/components/fields/cardstack/core-types/has-many-editor.js
+++ b/packages/cardhost/app/components/fields/cardstack/core-types/has-many-editor.js
@@ -8,6 +8,12 @@ export default class HasManyEditor extends BaseEditor {
     if (this.args.field && this.args.field.value) {
       this.fieldValue = this.args.field.value.map(i => i.name).join(', ');
     }
+
+    if (this.args.field.instructions) {
+      this.fieldInstructions = this.args.field.instructions;
+    } else {
+      this.fieldInstructions = 'Please enter card IDs separated by commas';
+    }
   }
 
   @action

--- a/packages/cardhost/app/templates/components/fields/cardstack/core-types/belongs-to-editor.hbs
+++ b/packages/cardhost/app/templates/components/fields/cardstack/core-types/belongs-to-editor.hbs
@@ -1,6 +1,6 @@
 <TextField
   @id={{concat "edit-" @field.name "-field-value"}}
   @label={{@field.label}}
-  @placeholder="Card ID"
+  @helperText={{this.fieldInstructions}}
   @value={{this.fieldValue}}
-  @changeAction={{action this.updateFieldValue}} />
+  @setValue={{action this.updateFieldValue}} />

--- a/packages/cardhost/app/templates/components/fields/cardstack/core-types/case-insensitive-editor.hbs
+++ b/packages/cardhost/app/templates/components/fields/cardstack/core-types/case-insensitive-editor.hbs
@@ -1,5 +1,6 @@
 <TextField
   @id={{concat "edit-" @field.name "-field-value"}}
   @label={{@field.label}}
+  @helperText={{@field.instructions}}
   @value={{this.fieldValue}}
-  @changeAction={{action this.updateFieldValue}} />
+  @setValue={{action this.updateFieldValue}} />

--- a/packages/cardhost/app/templates/components/fields/cardstack/core-types/date-editor.hbs
+++ b/packages/cardhost/app/templates/components/fields/cardstack/core-types/date-editor.hbs
@@ -2,5 +2,6 @@
   @type="date"
   @id={{concat "edit-" @field.name "-field-value"}}
   @label={{@field.label}}
+  @helperText={{@field.instructions}}
   @value={{this.fieldValue}}
-  @changeAction={{action this.updateFieldValue}} />
+  @setValue={{action this.updateFieldValue}} />

--- a/packages/cardhost/app/templates/components/fields/cardstack/core-types/has-many-editor.hbs
+++ b/packages/cardhost/app/templates/components/fields/cardstack/core-types/has-many-editor.hbs
@@ -1,7 +1,6 @@
 <TextField
   @id={{concat "edit-" @field.name "-field-value"}}
   @label={{@field.label}}
-  @placeholder="Comma separated Card ID's"
-  @size="60"
+  @helperText={{this.fieldInstructions}}
   @value={{this.fieldValue}}
-  @changeAction={{action this.updateFieldValue}} />
+  @setValue={{action this.updateFieldValue}} />

--- a/packages/cardhost/app/templates/components/fields/cardstack/core-types/integer-editor.hbs
+++ b/packages/cardhost/app/templates/components/fields/cardstack/core-types/integer-editor.hbs
@@ -2,5 +2,6 @@
   @type="number"
   @id={{concat "edit-" @field.name "-field-value"}}
   @label={{@field.name}}
+  @helperText={{@field.instructions}}
   @value={{this.fieldValue}}
-  @changeAction={{action this.updateFieldValue}} />
+  @setValue={{action this.updateFieldValue}} />

--- a/packages/cardhost/app/templates/components/fields/cardstack/core-types/string-editor.hbs
+++ b/packages/cardhost/app/templates/components/fields/cardstack/core-types/string-editor.hbs
@@ -1,5 +1,7 @@
 <TextField
   @id={{concat "edit-" @field.name "-field-value"}}
+  @className={{if @field.instructions "with-instructions"}}
   @label={{@field.label}}
+  @helperText={{@field.instructions}}
   @value={{this.fieldValue}}
-  @changeAction={{action this.updateFieldValue}} />
+  @setValue={{action this.updateFieldValue}} />

--- a/packages/cardhost/tests/acceptance/card-schema-test.js
+++ b/packages/cardhost/tests/acceptance/card-schema-test.js
@@ -107,6 +107,9 @@ module('Acceptance | card schema', function(hooks) {
     await visit(`/cards/${card1Id}/edit`);
     assert.dom('[data-test-field="subtitle"] input').hasValue('test title');
     assert.dom('[data-test-field="subtitle"] [data-test-cs-component-label="text-field"]').hasText('subtitle');
+    assert
+      .dom('[data-test-field="subtitle"] [data-test-cs-component-validation]')
+      .hasText('fill this in with your subheader');
     assert.dom('[data-test-field="title"]').doesNotExist();
 
     await visit(`/cards/${card1Id}/schema`);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,6 @@
     "@ember/optional-features": "^0.6.3",
     "@ember/render-modifiers": "1.0.2",
     "@glimmer/component": "^0.14.0-alpha.13",
-    "babel-eslint": "^10.0.2",
     "broccoli-asset-rev": "^2.7.0",
     "ember-animated": "^0.10.0",
     "ember-cli": "~3.8.2",
@@ -69,8 +68,6 @@
     "ember-source-channel-url": "^1.1.0",
     "ember-try": "^1.0.0",
     "eslint-plugin-ember": "^7.1.0",
-    "eslint-plugin-mocha": "^5.2.0",
-    "eslint-plugin-node": "^10.0.0",
     "loader.js": "^4.7.0",
     "qunit-dom": "^0.8.0"
   },

--- a/packages/core/tests/dummy/app/templates/components/cards/cardstack/base-card/isolated.hbs
+++ b/packages/core/tests/dummy/app/templates/components/cards/cardstack/base-card/isolated.hbs
@@ -17,21 +17,17 @@
       <FieldRenderer
         @field={{field}}
         @mode={{@mode}}
+        @dropField={{@dropField}}
         @removeField={{@removeField}}
         @setPosition={{@setPosition}}
         @setNeededWhenEmbedded={{@setNeededWhenEmbedded}}
         @setFieldName={{@setFieldName}}
         @selectField={{@selectField}}
+        @selectedField={{@selectedField}}
       />
     {{else}}
       <FieldRenderer @field={{field}} @mode={{@mode}}/>
     {{/if}}
     <br>
   {{/each}}
-  {{#if @dropField}}
-    <DropZone
-      @dropField={{@dropField}}
-      @position={{@card.isolatedFields.length}}
-    />
-  {{/if}}
 </div>

--- a/packages/core/tests/dummy/app/templates/components/fields/cardstack/core-types/string-editor.hbs
+++ b/packages/core/tests/dummy/app/templates/components/fields/cardstack/core-types/string-editor.hbs
@@ -1,11 +1,6 @@
-<label
-  data-test-string-field-editor-label
-  for={{concat "edit-" @field.name "-field-value"}}
->
-  {{@field.name}}:
-</label>
-<Input
+<TextField
   @id={{concat "edit-" @field.name "-field-value"}}
+  @label={{@field.label}}
+  @helperText={{@field.instructions}}
   @value={{this.fieldValue}}
-  @key-up={{action this.updateFieldValue}}
-/>
+  @setValue={{action this.updateFieldValue}} />

--- a/packages/core/tests/dummy/app/templates/components/fields/cardstack/core-types/string-viewer.hbs
+++ b/packages/core/tests/dummy/app/templates/components/fields/cardstack/core-types/string-viewer.hbs
@@ -1,6 +1,6 @@
-<span data-test-string-field-viewer-label>
-  {{@field.name}}:
-</span>
-<span data-test-string-field-viewer-value>
+<div class="view-field--label" data-test-string-field-viewer-label>
+  {{@field.label}}
+</div>
+<div class="view-field--value" data-test-string-field-viewer-value>
   {{@field.value}}
-</span>
+</div>

--- a/packages/core/tests/integration/components/field-renderer-test.js
+++ b/packages/core/tests/integration/components/field-renderer-test.js
@@ -91,15 +91,19 @@ module('Integration | Component | field-renderer', function(hooks) {
     let card = service.createCard(qualifiedCard1Id);
     let field = card.addField({
       name: 'title',
+      label: 'Field Title',
       type: '@cardstack/core-types::string',
       neededWhenEmbedded: true,
       value: 'test title',
+      instructions: 'field instructions',
     });
     this.set('field', field);
 
     await render(hbs`<FieldRenderer @field={{field}} @mode="view"/>`);
 
     assert.dom('[data-test-string-field-viewer-value]').hasText('test title');
+    assert.dom('[data-test-string-field-viewer-label]').hasText('Field Title');
+    assert.dom('[data-test-field="title"]').doesNotContainText('field instructions');
     assert.dom('input').doesNotExist();
     assert.dom('button').doesNotExist();
   });
@@ -112,6 +116,7 @@ module('Integration | Component | field-renderer', function(hooks) {
       type: '@cardstack/core-types::string',
       neededWhenEmbedded: true,
       value: 'test title',
+      instructions: 'test instructions',
     });
     this.set('field', field);
     this.set('noop', () => {});
@@ -124,11 +129,15 @@ module('Integration | Component | field-renderer', function(hooks) {
     />
     `);
 
-    assert.dom('[data-test-string-field-editor-label]').hasText('title:');
-    assert.dom('input').hasValue('test title');
+    assert.dom('[data-test-field-mode="edit"][data-test-field="title"]').exists();
+    assert.dom('[data-test-field-mode="edit"][data-test-field="title"] label').hasText('title');
+    assert.dom('[data-test-field-mode="edit"][data-test-field="title"] input').hasValue('test title');
+    assert
+      .dom('[data-test-field-mode="edit"][data-test-field="title"] [data-test-cs-component-validation]')
+      .hasText('test instructions');
     assert.dom('button').doesNotExist;
-    assert.dom('.field-renderer-field-name-input').doesNotExist();
-    assert.dom('.field-renderer--needed-when-embedded-chbx').doesNotExist();
+    assert.dom('[data-test-field-mode="schema"]').doesNotExist();
+    assert.dom('[data-test-field-mode="view"]').doesNotExist();
   });
 
   test('it can update field value in edit mode', async function(assert) {


### PR DESCRIPTION
- Use `setValue` instead of `changeAction` on editor ui-components
- Allow editor components to display field instructions if present
- Sync the outdated dummy templates that core pkg was using for its tests
- Update tests
- Removed unnecessary deps installed while debugging eslint validation issue