### PR TITLE
Display right-edge in all views

### DIFF
--- a/packages/cardhost/app/controllers/cards/view.js
+++ b/packages/cardhost/app/controllers/cards/view.js
@@ -19,15 +19,20 @@ export default class ViewCardController extends Controller {
   @tracked
   themerOptions = [{ name: 'Cardstack default' }];
 
+  @tracked
+  selectedTheme = this.themerOptions[0];
+
   @action
-  handleThemeChange(/*val*/) {
-    // TODO
+  handleThemeChange(val) {
+    this.selectedTheme = val;
+    //  TODO
   }
 
   @action
   createTheme() {
     this.cssModeToggle.setEditingCss(true);
     this.themerOptions.push({ name: 'Custom theme' });
+    this.selectedTheme = this.themerOptions[this.themerOptions.length - 1];
     this.router.transitionTo('cards.view', this.model, { queryParams: { editingCss: true } });
   }
 

--- a/packages/cardhost/app/styles/app.css
+++ b/packages/cardhost/app/styles/app.css
@@ -188,3 +188,10 @@ a:hover {
 .animated-tools {
   z-index: 20;
 }
+
+/* TODO: Move to ui-components repo */
+.cs-dark-input.cs-input:disabled,
+.cs-dark-input.cs-input.disabled {
+  -webkit-text-fill-color: var(--cs-dark-field-disabled-text); /* For strangeness in safari */
+  -webkit-text-stroke-color: var(--cs-dark-field-disabled-text);
+}

--- a/packages/cardhost/app/styles/cards.css
+++ b/packages/cardhost/app/styles/cards.css
@@ -8,17 +8,19 @@
 
   width: 100%;
   height: 100vh;
-  transition: var(--ch-card-background-color-animate), var(--ch-card-padding-animate);
   background-color: var(--ch-default);
   overflow: hidden;
   padding-top: var(--padding-top);
   padding-left: var(--padding-left);
   padding-right: var(--padding-right);
+
+  transition: padding-left var(--ch-transition-time) ease-in-out,
+              var(--ch-card-padding-animate),
+              var(--ch-card-background-color-animate);
 }
 
-.cardhost-cards.edit,
 .cardhost-cards.view {
-  --padding-left: var(--ch-left-edge-navbar-width);
+  padding-left: var(--ch-left-edge-navbar-width);
 }
 
 .cardhost-cards.schema {
@@ -34,4 +36,11 @@
   justify-items: center;
   height: 100%;
   padding: 0 20px;
+}
+
+
+@media (max-width: 1440px) {
+  .cardhost-cards.edit {
+    padding-left: var(--ch-left-edge-navbar-width);
+  }
 }

--- a/packages/cardhost/app/styles/cards.css
+++ b/packages/cardhost/app/styles/cards.css
@@ -16,12 +16,7 @@
   padding-right: var(--padding-right);
 }
 
-/* TODO: Remove this after right-edge is displayed on edit view */
-.cardhost-cards.edit {
-  --padding-left: var(--ch-left-edge-navbar-width);
-  --padding-right: 0;
-}
-
+.cardhost-cards.edit,
 .cardhost-cards.view {
   --padding-left: var(--ch-left-edge-navbar-width);
 }

--- a/packages/cardhost/app/styles/components/card-renderer.css
+++ b/packages/cardhost/app/styles/components/card-renderer.css
@@ -27,8 +27,7 @@
 /* Card Renderer Header */
 .card-renderer-isolated--header {
   display: flex;
-  align-items: center;
-  height: var(--card-renderer-header-height);
+  height: calc(var(--card-renderer-header-height) + 150px); /* to counteract the safari scroll bounce */
   padding: 14px 20px;
   color: var(--ch-light-op50);
   background-color: var(--ch-dark-background);
@@ -70,6 +69,7 @@
   border: none;
   overflow-x: hidden;
   overflow-y: auto;
+  margin-top: -150px; /* to counteract the safari scroll bounce */
 
   transition: var(--ch-card-background-color-animate);
 }

--- a/packages/cardhost/app/styles/components/card-renderer.css
+++ b/packages/cardhost/app/styles/components/card-renderer.css
@@ -102,7 +102,6 @@
 
 .card-renderer-isolated.view .card-renderer-isolated--card-container {
   background: var(--ch-light);
-  border: none;
 }
 
 

--- a/packages/cardhost/app/styles/components/card-renderer.css
+++ b/packages/cardhost/app/styles/components/card-renderer.css
@@ -55,22 +55,6 @@
   transition: stroke var(--ch-transition-time);
 }
 
-.card-renderer-isolated:focus {
-  outline: 0;
-}
-
-.card-renderer-isolated.selected .card-renderer-isolated--header,
-.card-renderer-isolated.edit:focus .card-renderer-isolated--header {
-  background-color: var(--ch-highlight);
-  border-color: var(--ch-highlight);
-  color: var(--ch-dark);
-}
-
-.card-renderer-isolated.selected .card-renderer-isolated--header svg,
-.card-renderer-isolated.edit:focus .card-renderer-isolated--header svg {
-  --icon-color: var(--ch-dark);
-}
-
 
 /* Card Renderer - Outer Wrapper */
 /* Needed for scroll behavior */
@@ -121,10 +105,27 @@
   border: none;
 }
 
-.card-renderer-isolated.schema.selected .card-renderer-isolated--card-container,
-.card-renderer-isolated.edit:focus .card-renderer-isolated--card-container {
+
+/* Focus state */
+.card-renderer-isolated:focus {
+  outline: 0;
+}
+
+.card-renderer-isolated.selected .card-renderer-isolated--header {
+  background-color: var(--ch-highlight);
+  border-color: var(--ch-highlight);
+  color: var(--ch-dark);
+}
+
+.card-renderer-isolated.selected .card-renderer-isolated--header svg {
+  --icon-color: var(--ch-dark);
+}
+
+.card-renderer-isolated.selected .card-renderer-isolated--card-container {
   border-color: var(--ch-highlight);
 }
+
+
 
 /* TODO: fade card if field-renderer is selected */
 /* .card-renderer-isolated.faded::before {

--- a/packages/cardhost/app/styles/components/cardhost-top-edge.css
+++ b/packages/cardhost/app/styles/components/cardhost-top-edge.css
@@ -34,3 +34,10 @@
 .login-box > button:hover {
   --color: var(--ch-highlight);
 }
+
+@media (max-width: 1440px) {
+  .cardhost-top-edge.view,
+  .cardhost-top-edge.edit {
+    --padding-left: var(--ch-left-edge-navbar-width);
+  }
+}

--- a/packages/cardhost/app/styles/components/drop-zone.css
+++ b/packages/cardhost/app/styles/components/drop-zone.css
@@ -38,7 +38,6 @@
   color: white;
   font-size: 16px;
   line-height: 22px;
-  text-align: center;
 }
 
 .drop-zone--description--text {
@@ -77,9 +76,11 @@
 
 .card-renderer-isolated.no-fields .drop-zone .drop-zone--description .drop-zone--description--text {
   display: block;
+  text-align: center;
 }
 
 .card-renderer-isolated.no-fields .drop-zone .drop-zone--drag-drop-icon {
   display: block;
   margin-top: 10px;
+  text-align: center;
 }

--- a/packages/cardhost/app/styles/components/schema-field-renderer.css
+++ b/packages/cardhost/app/styles/components/schema-field-renderer.css
@@ -7,6 +7,8 @@
   max-width: var(--field-width);
   min-height: var(--field-height);
   color: var(--ch-dark-op50);
+  -webkit-text-fill-color: var(--ch-dark-op50); /* For strangeness in safari */
+  -webkit-text-stroke-color: var(--ch-dark-op50);
   font: 400 16px/22px var(--ch-font-family);
   letter-spacing: 0.015em;
   overflow: hidden;

--- a/packages/cardhost/app/templates/cards/view.hbs
+++ b/packages/cardhost/app/templates/cards/view.hbs
@@ -25,7 +25,7 @@
   <CardRenderer
     @card={{this.model}}
     @format="isolated"
-    @cardSelected={{true}} {{!-- Card is always selected --}}
+    @cardSelected={{not this.cssModeToggle.editingCss}} {{!-- Card is highlighted (unless the themer is open) --}}
   />
 </section>
 

--- a/packages/cardhost/app/templates/cards/view.hbs
+++ b/packages/cardhost/app/templates/cards/view.hbs
@@ -61,6 +61,7 @@
           @searchEnabled={{false}}
           @label="Choose a theme:"
           @options={{this.themerOptions}}
+          @selected={{this.selectedTheme}}
           @setValue={{this.handleThemeChange}}
         />
         <button {{on "click" this.createTheme}}

--- a/packages/cardhost/app/templates/cards/view.hbs
+++ b/packages/cardhost/app/templates/cards/view.hbs
@@ -59,7 +59,7 @@
           @searchEnabled={{false}}
           @label="Choose a theme:"
           @options={{this.themerOptions}}
-          {{!-- @handleChange={{this.handleThemeChange}} --}}
+          @setValue={{this.handleThemeChange}}
         />
         <button {{on "click" this.createTheme}}
           class="ch-button ch-button--secondary ch-button--responsive"

--- a/packages/cardhost/app/templates/cards/view.hbs
+++ b/packages/cardhost/app/templates/cards/view.hbs
@@ -25,6 +25,7 @@
   <CardRenderer
     @card={{this.model}}
     @format="isolated"
+    @cardSelected={{true}} {{!-- Card is always selected --}}
   />
 </section>
 
@@ -48,7 +49,7 @@
 {{else}}
   <RightEdge
     @card={{this.model}}
-    @cardSelected={{true}}
+    @cardSelected={{true}} {{!-- Change this when we want to display different right-edge options --}}
   >
     <div class="right-edge--section">
       <div class="right-edge--section-header" data-test-section-header>

--- a/packages/cardhost/app/templates/cards/view.hbs
+++ b/packages/cardhost/app/templates/cards/view.hbs
@@ -47,7 +47,7 @@
   </div>
 {{else}}
   <RightEdge
-    @card={{this.card}}
+    @card={{this.model}}
     @cardSelected={{true}}
   >
     <div class="right-edge--section">

--- a/packages/cardhost/app/templates/cards/view.hbs
+++ b/packages/cardhost/app/templates/cards/view.hbs
@@ -51,7 +51,7 @@
     @card={{this.model}}
     @cardSelected={{true}} {{!-- Change this when we want to display different right-edge options --}}
   >
-    <div class="right-edge--section">
+    <div class="right-edge--section" data-test-right-edge-section="appearance">
       <div class="right-edge--section-header" data-test-section-header>
         Appearance
       </div>

--- a/packages/cardhost/app/templates/cards/view.hbs
+++ b/packages/cardhost/app/templates/cards/view.hbs
@@ -51,7 +51,7 @@
     @card={{this.model}}
     @cardSelected={{true}} {{!-- Change this when we want to display different right-edge options --}}
   >
-    <div class="right-edge--section" data-test-right-edge-section="appearance">
+    <div class="right-edge--section" data-test-appearance-section>
       <div class="right-edge--section-header" data-test-section-header>
         Appearance
       </div>

--- a/packages/cardhost/app/templates/cards/view.hbs
+++ b/packages/cardhost/app/templates/cards/view.hbs
@@ -48,6 +48,7 @@
 {{else}}
   <RightEdge
     @card={{this.card}}
+    @cardSelected={{true}}
   >
     <div class="right-edge--section">
       <div class="right-edge--section-header" data-test-section-header>

--- a/packages/cardhost/app/templates/components/card-creator.hbs
+++ b/packages/cardhost/app/templates/components/card-creator.hbs
@@ -52,6 +52,7 @@
 
 <RightEdge
   @card={{this.card}}
+  @mode="schema"
   @selectedField={{this.selectedField}}
   @selectField={{action this.selectField}}
   @setNeededWhenEmbedded={{this.setNeededWhenEmbedded}}

--- a/packages/cardhost/app/templates/components/card-editor.hbs
+++ b/packages/cardhost/app/templates/components/card-editor.hbs
@@ -22,6 +22,10 @@
 
 <CardhostLeftEdge />
 
+<RightEdge
+  @card={{this.card}}
+  @mode="edit" />
+
 <section
   class="card-editor"
   data-test-card-edit={{this.card.name}}
@@ -32,7 +36,8 @@
     @mode="edit"
     @setFieldValue={{action this.setFieldValue}}
     @format="isolated"
-  />
+    @cardSelected={{this.cardSelected}}
+    @cardFocused={{action (mut this.cardSelected)}} />
 </section>
 
 <section class="cardhost-card-document">

--- a/packages/cardhost/app/templates/components/card-editor.hbs
+++ b/packages/cardhost/app/templates/components/card-editor.hbs
@@ -24,7 +24,9 @@
 
 <RightEdge
   @card={{this.card}}
-  @mode="edit" />
+  @mode="edit"
+  @cardSelected={{true}} {{!-- Change this when we want to display different right-edge options --}}
+/>
 
 <section
   class="card-editor"
@@ -36,6 +38,8 @@
     @mode="edit"
     @setFieldValue={{action this.setFieldValue}}
     @format="isolated"
+    @selectField={{action this.selectField}}
+    @selectedField={{this.selectedField}}
     @cardSelected={{this.cardSelected}}
     @cardFocused={{action (mut this.cardSelected)}} />
 </section>

--- a/packages/cardhost/app/templates/components/card-schema-updator.hbs
+++ b/packages/cardhost/app/templates/components/card-schema-updator.hbs
@@ -50,6 +50,7 @@
 
 <RightEdge
   @card={{this.card}}
+  @mode="schema"
   @selectedField={{this.selectedField}}
   @selectField={{action this.selectField}}
   @setNeededWhenEmbedded={{this.setNeededWhenEmbedded}}

--- a/packages/cardhost/app/templates/components/cards/cardstack/base-card/isolated.hbs
+++ b/packages/cardhost/app/templates/components/cards/cardstack/base-card/isolated.hbs
@@ -9,6 +9,8 @@
         @field={{field}}
         @mode={{@mode}}
         @setFieldValue={{fn @setFieldValue field.name}}
+        @selectField={{@selectField}}
+        @selectedField={{@selectedField}}
       />
     {{else if (or @setNeededWhenEmbedded @setPosition @removeField @setFieldName)}}
       <FieldRenderer

--- a/packages/cardhost/app/templates/components/right-edge.hbs
+++ b/packages/cardhost/app/templates/components/right-edge.hbs
@@ -17,26 +17,28 @@
             before implemnenting that, as that will make this easy
             --}}
             <div class="right-edge--sections">
-              <div class="right-edge--section">
-                <div class="right-edge--section-header" data-test-section-header>ID</div>
-                <div class="right-edge--item">
-                  <TextField
-                    @theme="cs-dark"
-                    @class="hide-in-percy"
-                    @id="card__id"
-                    @label="Card ID"
-                    @placeholder="e.g. millenial-puppies"
-                    @value={{this.cardName}}
-                    @setValue={{action this.updateCardId}}
-                    @disabled={{or (not @updateCardId) (not @card.isNew)}} />
-                </div>
-                <div class="right-edge--item">
-                  <div class="right-edge--label">Internal ID</div>
-                  <div class="hide-in-percy" data-test-internal-card-id>
-                    {{@card.id}}
+              {{#if (eq @mode "schema")}}
+                <div class="right-edge--section">
+                  <div class="right-edge--section-header" data-test-section-header>ID</div>
+                  <div class="right-edge--item">
+                    <TextField
+                      @theme="cs-dark"
+                      @class="hide-in-percy"
+                      @id="card__id"
+                      @label="Card ID"
+                      @placeholder="e.g. millenial-puppies"
+                      @value={{this.cardName}}
+                      @setValue={{action this.updateCardId}}
+                      @disabled={{or (not @updateCardId) (not @card.isNew)}} />
+                  </div>
+                  <div class="right-edge--item">
+                    <div class="right-edge--label">Internal ID</div>
+                    <div class="hide-in-percy" data-test-internal-card-id>
+                      {{@card.id}}
+                    </div>
                   </div>
                 </div>
-              </div>
+              {{/if}}
 
               <div class="right-edge--section">
                 <div class="right-edge--section-header" data-test-section-header>

--- a/packages/cardhost/tests/acceptance/card-view-test.js
+++ b/packages/cardhost/tests/acceptance/card-view-test.js
@@ -98,6 +98,12 @@ module('Acceptance | card view', function(hooks) {
       [card2Id, card3Id]
     );
 
+    assert.dom('[data-test-right-edge]').exists();
+    assert.dom('[data-test-internal-card-id]').doesNotExist();
+    assert.dom('[data-test-no-adoption]').exists();
+    assert.dom('[data-test-right-edge-section="appearance"] [data-test-cs-component="dropdown"]').exists();
+    assert.dom('[data-test-card-custom-style-button]').exists();
+
     let cardJson = find('[data-test-code-block]').getAttribute('data-test-code-block');
     let card = JSON.parse(cardJson);
     assert.equal(card.data.attributes.title, 'The Millenial Puppy');

--- a/packages/cardhost/tests/acceptance/card-view-test.js
+++ b/packages/cardhost/tests/acceptance/card-view-test.js
@@ -100,10 +100,8 @@ module('Acceptance | card view', function(hooks) {
 
     assert.dom('[data-test-right-edge]').exists();
     assert.dom('[data-test-internal-card-id]').doesNotExist();
-    assert.dom('[data-test-no-adoption]').exists();
-    assert
-      .dom('[data-test-right-edge-section="appearance"] [data-test-cs-component="dropdown"]')
-      .hasText('Cardstack default');
+    assert.dom('[data-test-right-edge] [data-test-adopted-card-name]').hasText('Base Card');
+    assert.dom('[data-test-appearance-section] .ember-power-select-selected-item').hasText('Cardstack default');
     assert.dom('[data-test-card-custom-style-button]').exists();
 
     let cardJson = find('[data-test-code-block]').getAttribute('data-test-code-block');

--- a/packages/cardhost/tests/acceptance/card-view-test.js
+++ b/packages/cardhost/tests/acceptance/card-view-test.js
@@ -101,7 +101,9 @@ module('Acceptance | card view', function(hooks) {
     assert.dom('[data-test-right-edge]').exists();
     assert.dom('[data-test-internal-card-id]').doesNotExist();
     assert.dom('[data-test-no-adoption]').exists();
-    assert.dom('[data-test-right-edge-section="appearance"] [data-test-cs-component="dropdown"]').exists();
+    assert
+      .dom('[data-test-right-edge-section="appearance"] [data-test-cs-component="dropdown"]')
+      .hasText('Cardstack default');
     assert.dom('[data-test-card-custom-style-button]').exists();
 
     let cardJson = find('[data-test-code-block]').getAttribute('data-test-code-block');

--- a/packages/cardhost/tests/acceptance/css-editing-test.js
+++ b/packages/cardhost/tests/acceptance/css-editing-test.js
@@ -63,8 +63,10 @@ module('Acceptance | css editing', function(hooks) {
 
     assert.equal(currentURL(), `/cards/${card1Id}`);
     assert.dom(`[data-test-card-view="${card1Id}"]`).exists();
+    assert.dom('[data-test-card-renderer-isolated]').hasClass('selected');
     await click('[data-test-card-custom-style-button]');
     assert.dom('[data-test-editor-pane]').exists();
+    assert.dom('[data-test-card-renderer-isolated]').doesNotHaveClass('selected');
   });
 
   test('closing the editor', async function(assert) {
@@ -73,10 +75,12 @@ module('Acceptance | css editing', function(hooks) {
     await click('[data-test-card-custom-style-button]');
     assert.equal(currentURL(), `/cards/${card1Id}?editingCss=true`);
     assert.dom('[data-test-close-editor]').exists();
+    assert.dom('[data-test-card-renderer-isolated]').doesNotHaveClass('selected');
     await click('[data-test-close-editor]');
     assert.equal(currentURL(), `/cards/${card1Id}`);
     assert.dom('[data-test-editor-pane]').doesNotExist();
     assert.dom('[data-test-card-custom-style-button]').exists();
+    assert.dom('[data-test-card-renderer-isolated]').hasClass('selected');
   });
 
   test('hiding the editor', async function(assert) {

--- a/packages/cardhost/tests/acceptance/edit-card-test.js
+++ b/packages/cardhost/tests/acceptance/edit-card-test.js
@@ -287,7 +287,7 @@ module('Acceptance | card edit', function(hooks) {
 
     assert.dom('[data-test-right-edge]').exists();
     assert.dom('[data-test-internal-card-id]').doesNotExist();
-    assert.dom('[data-test-no-adoption]').exists();
-    assert.dom('[data-test-right-edge-section="appearance"]').doesNotExist();
+    assert.dom('[data-test-appearance-section]').doesNotExist();
+    assert.dom('[data-test-right-edge] [data-test-adopted-card-name]').hasText('Base Card');
   });
 });

--- a/packages/cardhost/tests/acceptance/edit-card-test.js
+++ b/packages/cardhost/tests/acceptance/edit-card-test.js
@@ -276,4 +276,18 @@ module('Acceptance | card edit', function(hooks) {
     await visit(`/cards/${card1Id}`);
     assert.dom('h2').includesText('Not Found');
   });
+
+  test(`displays the right edge`, async function(assert) {
+    await login();
+    await createCards({
+      [card1Id]: [['body', 'string', false, 'test body']],
+    });
+    await visit(`/cards/${card1Id}/edit`);
+    assert.equal(currentURL(), `/cards/${card1Id}/edit`);
+
+    assert.dom('[data-test-right-edge]').exists();
+    assert.dom('[data-test-internal-card-id]').doesNotExist();
+    assert.dom('[data-test-no-adoption]').exists();
+    assert.dom('[data-test-right-edge-section="appearance"]').doesNotExist();
+  });
 });


### PR DESCRIPTION
Closes #1033 

Updated this PR to only handle #1033. 

Highlights card and displays the right-edge template section in edit view and layout view. "Cardstack default" theme is selected by default on the themer.

<img width="1430" alt="layout-view" src="https://user-images.githubusercontent.com/16160806/71730181-83de6a00-2e0f-11ea-9375-3240c724ba0a.png">

<img width="1428" alt="edit-view" src="https://user-images.githubusercontent.com/16160806/71730174-7fb24c80-2e0f-11ea-96e2-43b7d86245a1.png">

Added some media queries for smaller viewports:

<img width="959" alt="edit-smaller" src="https://user-images.githubusercontent.com/16160806/71730188-893bb480-2e0f-11ea-827e-473742b089d6.png">

