### PR TITLE
Percy snapshots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ before_install:
   - ssh-keyscan -p 9022 -t rsa,ecdsa-sha2-nistp256 localhost >> $HOME/.ssh/known_hosts
   - chmod 600 packages/git/node-tests/git-ssh-server/cardstack-test-key
   - export PATH=$HOME/.yarn/bin:$PATH
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then PERCY_TOKEN="skip percy"'
 
 install:
   - yarn install

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_install:
   - ssh-keyscan -p 9022 -t rsa,ecdsa-sha2-nistp256 localhost >> $HOME/.ssh/known_hosts
   - chmod 600 packages/git/node-tests/git-ssh-server/cardstack-test-key
   - export PATH=$HOME/.yarn/bin:$PATH
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then PERCY_TOKEN="skip percy"'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then PERCY_TOKEN="skip percy"; fi'
 
 install:
   - yarn install


### PR DESCRIPTION
This PR turns off Percy snapshots for everything but Pull Requests.

We were triggering unnecessary snapshots because we run CI on all branches, not just PRs.

Note that a long-standing WIP pr with many pushes should be closed instead until it is ready, to avoid unnecessary charges.

Sister PR https://github.com/cardstack/ui-components/pull/148