### PR TITLE
Add new scenarios to templates

### DIFF
--- a/packages/cardhost/cardstack/seeds/templates.js
+++ b/packages/cardhost/cardstack/seeds/templates.js
@@ -112,8 +112,8 @@ let eventCardTemplate = eventFactory.getDocumentFor(
       'model',
       eventFactory.addResource('local-hub::event-card', 'local-hub::event-card').withAttributes({
         image: 'https://images.unsplash.com/photo-1542296140-47fd7d838e76',
-        title: 'Ember Meetup NYC',
-        date: '2019-09-26',
+        title: 'Quarterly Planning Meeting',
+        date: '2020-05-26',
         location: 'One World Trade Center',
         city: 'New York, NY',
         admission: 'Free',

--- a/packages/cardhost/cardstack/seeds/templates.js
+++ b/packages/cardhost/cardstack/seeds/templates.js
@@ -161,8 +161,10 @@ let jobCardTemplate = eventFactory.getDocumentFor(
       eventFactory.addResource('local-hub::job-description', 'local-hub::job-description').withAttributes({
         company: 'StackBox Creative LLC',
         jobTitle: 'Videographer',
-        jobDescription: 'Join our marketing team, as we open a new flagship store in New York City, and create compelling videos.',
-        responsibilities: 'Follow the marketing team to events, create camera footage for a B-roll film, produce a sales pitch for a client, conduct interviews.'
+        jobDescription:
+          'Join our marketing team, as we open a new flagship store in New York City, and create compelling videos.',
+        responsibilities:
+          'Follow the marketing team to events, create camera footage for a B-roll film, produce a sales pitch for a client, conduct interviews.',
       })
     )
 );
@@ -213,11 +215,11 @@ let jobApplicantProfileTemplate = eventFactory.getDocumentFor(
       'model',
       eventFactory.addResource('local-hub::job-applicant-profile', 'local-hub::job-applicant-profile').withAttributes({
         name: 'Marcel Bridges',
-        portfolio: "marcel-bridges.example.com/portfolio",
+        portfolio: 'marcel-bridges.example.com/portfolio',
         address: 'Chicago, IL',
         phoneNumber: '555-555-5555',
         email: 'marcel_bridges@example.com',
-        dateStart: '2020-02-01'
+        dateStart: '2020-02-01',
       })
     )
 );

--- a/packages/cardhost/cardstack/seeds/templates.js
+++ b/packages/cardhost/cardstack/seeds/templates.js
@@ -79,7 +79,7 @@ let eventCardTemplate = eventFactory.getDocumentFor(
         'is-metadata': true,
         'field-type': '@cardstack/core-types::string',
         required: true,
-        'needed-when-embedded': true,
+        'needed-when-embedded': false,
       }),
       eventFactory.addResource('fields', 'cta').withAttributes({
         'is-metadata': true,
@@ -124,4 +124,102 @@ let eventCardTemplate = eventFactory.getDocumentFor(
     )
 );
 
-module.exports = [locationCardTemplate, eventCardTemplate];
+let jobCardTemplate = eventFactory.getDocumentFor(
+  eventFactory
+    .addResource('cards', 'local-hub::job-description')
+    .withRelated('adopted-from', { type: 'cards', id: 'local-hub::@cardstack/base-card' })
+    .withRelated('fields', [
+      eventFactory.addResource('fields', 'company').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::string',
+        'needed-when-embedded': true,
+        required: true,
+        caption: 'Company',
+      }),
+      eventFactory.addResource('fields', 'job-title').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::string',
+        'needed-when-embedded': true,
+        required: true,
+        caption: 'Job Title',
+      }),
+      eventFactory.addResource('fields', 'job-description').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::string',
+        required: true,
+        caption: 'Job Description',
+      }),
+      eventFactory.addResource('fields', 'responsibilities').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::string',
+        required: true,
+        caption: 'Responsibilities',
+      }),
+    ])
+    .withRelated(
+      'model',
+      eventFactory.addResource('local-hub::job-description', 'local-hub::job-description').withAttributes({
+        company: 'StackBox Creative LLC',
+        jobTitle: 'Videographer',
+        jobDescription: 'Join our marketing team, as we open a new flagship store in New York City, and create compelling videos.',
+        responsibilities: 'Follow the marketing team to events, create camera footage for a B-roll film, produce a sales pitch for a client, conduct interviews.'
+      })
+    )
+);
+
+let jobApplicantProfileTemplate = eventFactory.getDocumentFor(
+  eventFactory
+    .addResource('cards', 'local-hub::job-applicant-profile')
+    .withRelated('adopted-from', { type: 'cards', id: 'local-hub::@cardstack/base-card' })
+    .withRelated('fields', [
+      eventFactory.addResource('fields', 'name').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::string',
+        'needed-when-embedded': true,
+        required: true,
+        caption: 'Name',
+      }),
+      eventFactory.addResource('fields', 'portfolio').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::string',
+        required: true,
+        caption: 'Link to your portfolio',
+      }),
+      eventFactory.addResource('fields', 'address').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::string',
+        caption: 'Address',
+      }),
+      eventFactory.addResource('fields', 'phone-number').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::string',
+        required: false,
+        caption: 'Phone Number',
+      }),
+      eventFactory.addResource('fields', 'email').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::string',
+        required: false,
+        caption: 'Email',
+      }),
+      eventFactory.addResource('fields', 'date-start').withAttributes({
+        'is-metadata': true,
+        'field-type': '@cardstack/core-types::date',
+        required: false,
+        caption: 'What is the earliest date you would be available to start?',
+      }),
+    ])
+    .withRelated(
+      'model',
+      eventFactory.addResource('local-hub::job-applicant-profile', 'local-hub::job-applicant-profile').withAttributes({
+        name: 'Marcel Bridges',
+        portfolio: "marcel-bridges.example.com/portfolio",
+        address: 'Chicago, IL',
+        phoneNumber: '555-555-5555',
+        email: 'marcel_bridges@example.com',
+        dateStart: '2020-02-01'
+      })
+    )
+);
+
+module.exports = [locationCardTemplate, eventCardTemplate, jobCardTemplate, jobApplicantProfileTemplate];

--- a/packages/cardhost/config/environment.js
+++ b/packages/cardhost/config/environment.js
@@ -39,6 +39,8 @@ module.exports = function(environment) {
     ENV.cardTemplates = JSON.parse(process.env.CARD_TEMPLATES || null) || [
       'local-hub::location-card',
       'local-hub::event-card',
+      'local-hub::job-description',
+      'local-hub::job-applicant-profile',
     ];
   }
 

--- a/packages/cardhost/tests/acceptance/event-card-test.js
+++ b/packages/cardhost/tests/acceptance/event-card-test.js
@@ -8,8 +8,8 @@ import { setupMockUser, login } from '../helpers/login';
 
 const eventData = [
   ['image', 'string', true, "https',//images.unsplash.com/]photo-1542296140-47fd7d838e76"],
-  ['title', 'string', true, 'Ember Meetup NYC'],
-  ['date', 'date', true, '2019-09-26'],
+  ['title', 'string', true, 'Quarterly Planning Meeting'],
+  ['date', 'date', true, '2020-05-26'],
   ['location', 'string', true, 'One World Trade Center'],
   ['city', 'string', true, 'New York, NY'],
   ['admission', 'string', true, 'Free'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -807,10 +807,10 @@
     ember-radio-button "^2.0.1"
     ember-truth-helpers "^2.1.0"
 
-"@cardstack/ui-components@^0.2.15":
-  version "0.2.15"
-  resolved "https://registry.yarnpkg.com/@cardstack/ui-components/-/ui-components-0.2.15.tgz#770c7f66477e0d4c000f9350de689044b9c534c2"
-  integrity sha512-cmcrZ5YKBHYMCmJ0iH+DcFe+12bEJH1A/1Y7hcrq2fPCGY/wbDWYY+YvYxTnsmLbTXb/akh5hdtLsisXkloDnA==
+"@cardstack/ui-components@^0.2.16":
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/@cardstack/ui-components/-/ui-components-0.2.16.tgz#12f31ff71e71201d9b14783f62ff6cd9c1528b93"
+  integrity sha512-XlLcuLdAKgPRc0BFUnUGtxeH18OpJz0eqXq+XZnKXNElXBmJUcgGLlFTnZm9FwOY+lX2SYdv0pzDL8lUHWNnDQ==
   dependencies:
     broccoli-funnel "^2.0.2"
     broccoli-merge-trees "^3.0.2"


### PR DESCRIPTION
After this is merged, we should add the templates to the env vars.

Changed:
- Removed uses of "Ember NYC" and replaced with something more business-y
- Added 2 new templates - applicant profile and job description

Screenshots below for "company" have test data that I typed, which is different from the seed data.

<img width="553" alt="Screen Shot 2019-12-24 at 4 16 55 PM" src="https://user-images.githubusercontent.com/16627268/71425370-f742e780-2669-11ea-9dd7-5ed43e91204c.png">

<img width="1489" alt="Screen Shot 2019-12-24 at 4 17 24 PM" src="https://user-images.githubusercontent.com/16627268/71425375-fa3dd800-2669-11ea-8346-96af903a5914.png">

<img width="1459" alt="Screen Shot 2019-12-24 at 4 17 37 PM" src="https://user-images.githubusercontent.com/16627268/71425376-fca03200-2669-11ea-9d36-7872b157ede4.png">

<img width="1376" alt="Screen Shot 2019-12-24 at 4 18 04 PM" src="https://user-images.githubusercontent.com/16627268/71425377-0033b900-266a-11ea-8a3e-57b4a493a98b.png">

<img width="1495" alt="Screen Shot 2019-12-24 at 4 30 27 PM" src="https://user-images.githubusercontent.com/16627268/71425433-bf886f80-266a-11ea-861a-6bbf33a328e8.png">

<img width="1496" alt="Screen Shot 2019-12-24 at 4 30 16 PM" src="https://user-images.githubusercontent.com/16627268/71425434-c4e5ba00-266a-11ea-8c86-cfd26e9faff9.png">

<img width="722" alt="Screen Shot 2019-12-24 at 4 30 08 PM" src="https://user-images.githubusercontent.com/16627268/71425435-ca430480-266a-11ea-877e-f730386bc9a4.png">
