### PR TITLE
Index interval is configurable via env variable

### DIFF
--- a/packages/cardhost/README.md
+++ b/packages/cardhost/README.md
@@ -22,12 +22,15 @@ You will need the following things properly installed on your computer.
 ## Running / Development
 
 * `yarn start-prereqs`
-* `yarn start-hub`
+* `INDEX_INTERVAL=120 yarn start-hub`
 * In a new tab, `yarn start-ember`
 
 
 * Visit your app at [http://localhost:4200](http://localhost:4200).
 * Visit your tests at [http://localhost:4200/tests](http://localhost:4200/tests).
+
+`INDEX_INTERVAL` determines how often the hub should reindex data, in minutes.
+It is recommended to set this number high for local development.
 
 ### Code Generators
 

--- a/packages/cardhost/deploy/deploy.sh
+++ b/packages/cardhost/deploy/deploy.sh
@@ -28,7 +28,8 @@ if [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
                   CARD_TEMPLATES \
                   GIT_PRIVATE_KEY \
                   GIT_BRANCH_PREFIX \
-                  CARDSTACK_SESSIONS_KEY; do
+                  CARDSTACK_SESSIONS_KEY \
+                  INDEX_INTERVAL; do
       command="export ${variable}=\$${target_env}_${variable}"
       eval $command
   done

--- a/packages/cardhost/deploy/docker-compose.yml
+++ b/packages/cardhost/deploy/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - GITHUB_CLIENT_SECRET
       - GITHUB_TOKEN
       - WEBHOOK_URL
+      - INDEX_INTERVAL
 
 networks:
   default:

--- a/packages/hub/main.js
+++ b/packages/hub/main.js
@@ -114,7 +114,8 @@ async function startIndexing(environment, container) {
     );
   }
 
-  let interval = process.env.INDEX_INTERVAL || 600000;
+  let millisecondsPerMinute = 60000;
+  let interval = process.env.INDEX_INTERVAL * millisecondsPerMinute || 600000;
   setInterval(() => container.lookup('hub:indexers').update({ dontWaitForJob: true }), interval);
 }
 

--- a/packages/hub/main.js
+++ b/packages/hub/main.js
@@ -114,7 +114,8 @@ async function startIndexing(environment, container) {
     );
   }
 
-  setInterval(() => container.lookup('hub:indexers').update({ dontWaitForJob: true }), 600000);
+  let interval = process.env.INDEX_INTERVAL || 600000;
+  setInterval(() => container.lookup('hub:indexers').update({ dontWaitForJob: true }), interval);
 }
 
 async function loadSeeds(container, seedModels) {


### PR DESCRIPTION
Part of #1070

This allows for us to set the interval to a high value, and sidestep the problem where data disappears locally on reindex. The `INDEX_INTERVAL` is specified in minutes.

Usage:
```
INDEX_INTERVAL=120 yarn start
```

This PR will require revving the hub afterwards.