### PR TITLE
Fix moving catalog card label bug

### DIFF
--- a/packages/cardhost/app/styles/index.css
+++ b/packages/cardhost/app/styles/index.css
@@ -139,12 +139,13 @@
   transition: transform var(--ch-card-transition-duration) ease-in-out calc(var(--ch-card-transition-duration) / 3);
 }
 
-.card-catalog .embedded-card {
+.card-catalog .embedded-card, .card-catalog--embedded-card-placeholder {
   box-shadow: 0px 0px 0px 0px none;
   transition: all 0.3s ease;
 }
 
-.card-catalog > *:hover > * > .embedded-card {
+.card-catalog > *:hover > * > .embedded-card,
+.card-catalog > *:hover > * > .card-catalog--embedded-card-placeholder {
   transform: scale(0.9);
   box-shadow: 0px 0px 0px 35px var(--ch-hover);
 }

--- a/packages/cardhost/app/styles/index.css
+++ b/packages/cardhost/app/styles/index.css
@@ -140,7 +140,7 @@
 }
 
 .card-catalog .embedded-card {
-  box-shadow: 0px 0px 0px 0px var(--ch-hover);
+  box-shadow: 0px 0px 0px 0px none;
   transition: all 0.3s ease;
 }
 
@@ -177,10 +177,6 @@
   text-align: center;
   position: absolute;
   top: 225px;
-}
-
-.card-catalog .embedded-card-label {
-  
 }
 
 .card-catalog > *:hover .embedded-card-label {

--- a/packages/cardhost/app/styles/index.css
+++ b/packages/cardhost/app/styles/index.css
@@ -127,6 +127,8 @@
 
 .card-catalog a {
   display: block;
+  /* relative so that the labels can be absolutely positioned */
+  position: relative;
 }
 
 .card-catalog > * > *,
@@ -137,13 +139,14 @@
   transition: transform var(--ch-card-transition-duration) ease-in-out calc(var(--ch-card-transition-duration) / 3);
 }
 
-.card-catalog > *:hover > * {
-  background-color: var(--ch-hover);
-  transform: scale(1.2);
+.card-catalog .embedded-card {
+  box-shadow: 0px 0px 0px 0px var(--ch-hover);
+  transition: all 0.3s ease;
 }
 
-.card-catalog > *:hover > * > * {
-  transform: scale(0.75);
+.card-catalog > *:hover > * > .embedded-card {
+  transform: scale(0.9);
+  box-shadow: 0px 0px 0px 35px var(--ch-hover);
 }
 
 .card-catalog--embedded-card-placeholder {
@@ -172,11 +175,14 @@
   padding-top: 30px;
   font-size: 13px;
   text-align: center;
-  transform: none;
-  transition: padding var(--ch-card-transition-duration) ease-in-out calc(var(--ch-card-transition-duration) / 3), transform var(--ch-card-transition-duration) ease-in-out calc(var(--ch-card-transition-duration) / 3);
+  position: absolute;
+  top: 225px;
+}
+
+.card-catalog .embedded-card-label {
+  
 }
 
 .card-catalog > *:hover .embedded-card-label {
-  padding-top: 6px;
-  transform: scale(.85);
+  color: var(--ch-link)
 }


### PR DESCRIPTION
Closes #1146 

This PR positions the label absolutely and then uses box-shadow to show the lighter gray tray. By using Box Shadow, it avoids shifting things around and simplifies the animation.

The downside is that we can't directly control the border radius, however when it is time to put tools in the tray, we'll need to refactor the CSS and markup anyway, and can make a dedicated tray container.

<img width="1171" alt="Screen Shot 2019-12-30 at 5 11 05 PM" src="https://user-images.githubusercontent.com/16627268/71602668-64052880-2b27-11ea-812d-996855ea51b4.png">
