### PR TITLE
bugfix - can scroll in card catalog in all views

### DIFF
--- a/packages/cardhost/app/templates/components/card-creator.hbs
+++ b/packages/cardhost/app/templates/components/card-creator.hbs
@@ -22,27 +22,29 @@
       <header class="ch-catalog--header">
         <h3 class="ch-catalog--title">Card Catalog</h3>
       </header>
-      <div class="ch-catalog--fields">
-        {{#each this.fieldComponents as |field|}}
-          <div
-            class="ch-catalog-field"
-            role="button"
-            draggable="true"
-            {{on "mousedown" (action this.initDrag field)}}
-            {{on "dragend" (action (mut this.isDragging) false)}}
-            {{on "dragstart" (action this.startDragging field)}}
-            data-test-card-add-field-draggable={{field.type}}
-          >
-            {{! template-lint-disable no-inline-styles}}
-            <div class="ch-catalog-field--icon" style={{css-url "background-image" field.icon}}></div>
-            <div>
-              <h4 class="ch-catalog-field--title">{{field.title}}</h4>
-              {{#if field.description}}
-                <p class="ch-catalog-field--description">{{field.description}}</p>
-              {{/if}}
+      <div class="ch-catalog--content">
+        <div class="ch-catalog--fields">
+          {{#each this.fieldComponents as |field|}}
+            <div
+              class="ch-catalog-field"
+              role="button"
+              draggable="true"
+              {{on "mousedown" (action this.initDrag field)}}
+              {{on "dragend" (action (mut this.isDragging) false)}}
+              {{on "dragstart" (action this.startDragging field)}}
+              data-test-card-add-field-draggable={{field.type}}
+            >
+              {{! template-lint-disable no-inline-styles}}
+              <div class="ch-catalog-field--icon" style={{css-url "background-image" field.icon}}></div>
+              <div>
+                <h4 class="ch-catalog-field--title">{{field.title}}</h4>
+                {{#if field.description}}
+                  <p class="ch-catalog-field--description">{{field.description}}</p>
+                {{/if}}
+              </div>
             </div>
-          </div>
-        {{/each}}
+          {{/each}}
+        </div>
       </div>
     </section>
   </CardhostLeftEdge>


### PR DESCRIPTION
Tiny adjustment to add a container that was missing on one catalog layout.

We should refactor this catalog to be its own component in the future.

Despite how the diff looks, this just adds a `<div class="ch-catalog--content">` wrapping the `<div class="ch-catalog--fields">`