### PR TITLE
Allow new fields to take full width on event card template grid

### DIFF
--- a/packages/cardhost/app/styles/cards/event-card-isolated.css
+++ b/packages/cardhost/app/styles/cards/event-card-isolated.css
@@ -16,7 +16,7 @@
 }
 
 .event-card-isolated .field {
-  padding-bottom: 0;
+  grid-column: 1 / -1;
 }
 
 .event-card-isolated .title-label,
@@ -46,24 +46,26 @@
 
 .event-card-isolated .title-field {
   grid-area: title;
-  padding-bottom: 30px;
   font-size: 28px;
   line-height: 1.285;
 }
 .event-card-isolated .cta-field {
   grid-area: cta;
+  padding-bottom: 0;
   font-size: 13px;
   line-height: 1.285;
   font-weight: 600;
 }
 .event-card-isolated .city-field {
   grid-area: city;
+  padding-bottom: 0;
   opacity: 0.5;
   font-size: 13px;
   line-height: 1.285;
 }
 .event-card-isolated .admission-field {
   grid-area: admission;
+  padding-bottom: 0;
   font-size: 13px;
   line-height: 1.285;
   font-weight: 700;
@@ -76,11 +78,9 @@
 }
 .event-card-isolated .location-field {
   grid-area: location;
-  margin-top: 30px;
 }
 .event-card-isolated .description-field {
   grid-area: description;
-  margin-top: 30px;
 }
 
 .event-card-isolated .city-field,


### PR DESCRIPTION
Closes #1192 

Fixed padding and added `grid-column: 1 / -1` to event card template's field class so any new field aligns with the rest of the fields.

<img width="621" alt="new-fields" src="https://user-images.githubusercontent.com/16160806/71635045-ffad9c00-2bee-11ea-941b-66fb01dbb8d6.png">
