### PR TITLE
Fix card width on css-editing view

### DIFF
--- a/packages/cardhost/app/styles/components/themer.css
+++ b/packages/cardhost/app/styles/components/themer.css
@@ -150,7 +150,7 @@
 .cardhost-cards.editing-css {
   padding-left: 0;
   width: 100%;
-  padding-right: 60%;
+  padding-right: 40%;
   transition: var(--ch-card-padding-animate), var(--ch-card-background-color-animate);
   background-color: var(--ch-dark-background);
 }


### PR DESCRIPTION
CSS editing panel was no longer overlapping the card, and card was getting too small. It was probably broken during one of our recent PRs. This fixes it.