### PR TITLE
restrict monaco-editor-webpack-plugin version

### DIFF
--- a/packages/cardhost/package.json
+++ b/packages/cardhost/package.json
@@ -89,7 +89,7 @@
     "eslint-plugin-node": "^10.0.0",
     "loader.js": "^4.7.0",
     "monaco-editor": "^0.18.1",
-    "monaco-editor-webpack-plugin": "^1.7.0",
+    "monaco-editor-webpack-plugin": "~1.7.0",
     "prember": "^1.0.0",
     "qunit-dom": "^0.8.1",
     "scope-css": "^1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13389,7 +13389,7 @@ moment-timezone@^0.5.11, moment-timezone@^0.5.13:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
-monaco-editor-webpack-plugin@^1.7.0:
+monaco-editor-webpack-plugin@~1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-1.7.0.tgz#920cbeecca25f15d70d568a7e11b0ba4daf1ae83"
   integrity sha512-oItymcnlL14Sjd7EF7q+CMhucfwR/2BxsqrXIBrWL6LQplFfAfV+grLEQRmVHeGSBZ/Gk9ptzfueXnWcoEcFuA==


### PR DESCRIPTION
`^1.7.0` allows `1.8.1`, but `1.8.1` requires monaco-editor `^0.19`, which isn't compatible with our range for monaco-editor of `^0.18.1`. So right now, rebuilding yarn.lock causes a build error.

This change prevents the problem by restricting monaco-editor-webpack-plugin more.

See https://github.com/microsoft/monaco-editor-webpack-plugin/issues/92#issuecomment-574718653