### PR TITLE
Create a minimum view width for the Builder, closes #1167

### DIFF
--- a/packages/cardhost/app/styles/app.css
+++ b/packages/cardhost/app/styles/app.css
@@ -18,6 +18,9 @@
 @import '/assets/components/themer.css';
 @import '/assets/components/dialog.css';
 
+/* Handling minimum screen sizes for desktop */
+@import '/assets/responsive.css';
+
 /* Cardhost styling for core package templates */
 @import '/assets/components/card-renderer.css';
 @import '/assets/components/field-renderer.css';
@@ -90,7 +93,7 @@ Until that work is done we are statically adding this css
 }
 
 body {
-  min-width: 100%;
+  min-width: 900px;
   min-height: 100%;
   width: 100%;
   height: auto;

--- a/packages/cardhost/app/styles/responsive.css
+++ b/packages/cardhost/app/styles/responsive.css
@@ -3,27 +3,37 @@
   .right-edge {
     right: unset;
     left: 560px;
+    position: absolute;
   }
 
-  .card-renderer--top-edge-buttons {
+  .view .card-renderer--top-edge-buttons,
+  .edit .card-renderer--top-edge-buttons {
     right: unset;
     left: 590px;
+    position: absolute;
   }
   
   .cardhost-top-edge {
     min-width: 900px;
+    position: absolute;
   }
 
   .themer--top-edge-container {
     min-width: 700px;
   }
+
+  html {
+    background-color: var(--ch-deep-background);
+  }
 }
 
 /* remove this media query when we implement responsive designs */
-@media (max-width: 1330px) {
+@media (max-width: 1230px) {
+
   .schema .right-edge {
     right: unset;
     left: 900px;
+    position: absolute;
   }
 
   .schema .card-renderer--top-edge-buttons {

--- a/packages/cardhost/app/styles/responsive.css
+++ b/packages/cardhost/app/styles/responsive.css
@@ -1,0 +1,41 @@
+/* remove this media query when we implement responsive designs */
+@media (max-width: 900px) {
+  .right-edge {
+    right: unset;
+    left: 560px;
+  }
+
+  .card-renderer--top-edge-buttons {
+    right: unset;
+    left: 590px;
+  }
+  
+  .cardhost-top-edge {
+    min-width: 900px;
+  }
+
+  .themer--top-edge-container {
+    min-width: 700px;
+  }
+}
+
+/* remove this media query when we implement responsive designs */
+@media (max-width: 1330px) {
+  .schema .right-edge {
+    right: unset;
+    left: 900px;
+  }
+
+  .schema .card-renderer--top-edge-buttons {
+    right: unset;
+    left: 940px;
+  }
+  
+  .schema.cardhost-top-edge {
+    min-width: 1250px;
+  }
+
+  .card-creator, .card-schema-updator, .card-view, .card-editor {
+    min-width: 490px;
+  }
+}


### PR DESCRIPTION
The goal of this PR is to make minimal changes to help the Builder be usable at smaller screen widths, and overall look not-broken during UX testing. It does not aim to be truly responsive.

## How to test
In each main page view, try viewing it in a half-size browser. Compare with what is currently deployed.

I'm open to any feedback about how to tackle this differently.