### PR TITLE
testing - only take desktop screenshots with percy

### DIFF
--- a/packages/cardhost/config/environment.js
+++ b/packages/cardhost/config/environment.js
@@ -69,10 +69,10 @@ module.exports = function(environment) {
 
     ENV.percy = {
       breakpointsConfig: {
-        desktop: 1280
+        desktop: 1280,
       },
-      defaultBreakpoints: ['desktop']
-    }
+      defaultBreakpoints: ['desktop'],
+    };
   }
 
   // if (environment === 'production') {

--- a/packages/cardhost/config/environment.js
+++ b/packages/cardhost/config/environment.js
@@ -66,6 +66,13 @@ module.exports = function(environment) {
     ENV['@cardstack/ui-components'] = {
       debounceSpeed: 10,
     };
+
+    ENV.percy = {
+      breakpointsConfig: {
+        desktop: 1280
+      },
+      defaultBreakpoints: ['desktop']
+    }
   }
 
   // if (environment === 'production') {


### PR DESCRIPTION
So, the reason we had such high Percy totals is that we take 18 snapshots, but they are repeated for all widths (mobile, desktop) and browsers (Chrome, firefox). So that turns into 72 screenshots for every push to a PR. I can cut this in half by removing mobile, since we intend this as a desktop app for the time being.