### PR TITLE
bugfix - card width in the themer, closes #1264

### DIFF
--- a/packages/cardhost/app/styles/components/themer.css
+++ b/packages/cardhost/app/styles/components/themer.css
@@ -146,18 +146,6 @@
   color :var(--ch-default);
 }
 
-.editing-css {
-  padding-left: 0;
-  width: 100%;
-  padding-right: 40%;
-  transition: var(--ch-card-padding-animate), var(--ch-card-background-color-animate);
-  background-color: var(--ch-dark-background);
-}
-
-.editing-css.full-width {
-  padding-right: 0;
-}
-
 .themer--top-edge-container {
   display: grid;
   position: fixed;
@@ -274,4 +262,22 @@
 
 .ch-button--icon.full-width.selected {
   --icon-url: url('/assets/images/buttons/full-width-active.svg');
+}
+
+.editing-css {
+  padding-left: 0;
+  padding-right: 0;
+  width: 100%;
+  transition: var(--ch-card-padding-animate), var(--ch-card-background-color-animate);
+  background-color: var(--ch-dark-background);
+}
+
+.full-width.editing-css .themer.view {
+  width: 100%;
+  padding-right: var(--ch-spacing);
+}
+
+.themer.view {
+  width: var(--ch-card-size);
+  padding: var(--ch-spacing)
 }

--- a/packages/cardhost/app/styles/resizable.css
+++ b/packages/cardhost/app/styles/resizable.css
@@ -80,3 +80,9 @@
   top: -10px;
   cursor: se-resize;
 }
+
+/* change this when we make this drag accessible */
+
+.resizer:focus {
+  outline: none;
+}

--- a/packages/cardhost/app/templates/cards/card/edit/layout/themer.hbs
+++ b/packages/cardhost/app/templates/cards/card/edit/layout/themer.hbs
@@ -1,7 +1,7 @@
 <CardhostTopEdge @mode="themer" />
 <ThemerToolbar @model={{this.model}} />
 
-<section class="card-view" data-test-card-view={{this.model.name}}>
+<section data-test-card-view={{this.model.name}}>
   <CardRenderer
     @card={{this.model}}
     @format="isolated"


### PR DESCRIPTION
## Changed
- The card width in the Themer is the same as shown on other pages when you are in responsive mode

## Removed
- temporary - remove outline/focus styling for the drag handle. I will fix this in a followup PR for #1269. My work here is cheating, and it's temporary so I can record the demo, then fix it later this week/later today. I know the work that needs to be done and it's not hard, just finicky.

Before:

<img width="1423" alt="Screen Shot 2020-01-22 at 12 22 47 PM" src="https://user-images.githubusercontent.com/16627268/72917489-ee4d4080-3d11-11ea-987b-1c584477f455.png">

After:

<img width="1440" alt="Screen Shot 2020-01-22 at 12 18 37 PM" src="https://user-images.githubusercontent.com/16627268/72917501-f60ce500-3d11-11ea-8e6b-4dd0f939b8e8.png">
