### PR TITLE
bugfix narrow schema width, closes 1294

### DIFF
--- a/packages/cardhost/app/styles/components/card-renderer.css
+++ b/packages/cardhost/app/styles/components/card-renderer.css
@@ -24,9 +24,7 @@
   letter-spacing: 0.015em;
 }
 
-.card-renderer-isolated.schema {
-  min-width: 400px;
-}
+
 
 .card-renderer-isolated.schema,
 .card-renderer-isolated.edit {

--- a/packages/cardhost/app/styles/components/field-renderer.css
+++ b/packages/cardhost/app/styles/components/field-renderer.css
@@ -38,6 +38,7 @@
   padding-top: 0;
   background-color: var(--ch-dark-background);
   border-bottom: 2px solid var(--ch-default);
+  grid-column-gap: unset; /* needed for firefox, or the grid rules for .cardstack_base-card-embedded .field will conflict */
 }
 
 .card-renderer-isolated.schema .field.with-buttons:last-of-type {


### PR DESCRIPTION
closes #1294

This fixes very broken Firefox layout, and in Chrome, there is slightly more space around the trash can. Is this enough to fix the issue that things are too narrow, or should they be wider?

See the percy tests for smaller screen widths. The screenshots below are large monitor proportions.

Before - Firefox
<img width="1548" alt="before-firefox" src="https://user-images.githubusercontent.com/16627268/73674410-6d316a00-467e-11ea-9db0-83426846c1a4.png">

After - Firefox
<img width="1548" alt="after-firefox" src="https://user-images.githubusercontent.com/16627268/73674396-66a2f280-467e-11ea-8f35-4dad0bdffd7a.png">

Before - Chrome
<img width="1435" alt="before-chrome" src="https://user-images.githubusercontent.com/16627268/73674466-90f4b000-467e-11ea-92ea-d5c2ac93641c.png">

After - Chrome
<img width="1436" alt="after-chrome" src="https://user-images.githubusercontent.com/16627268/73674372-5b4fc700-467e-11ea-93da-901b88c59190.png">

