### PR TITLE
add return to editing button link, closes #1220

### DIFF
--- a/packages/cardhost/app/templates/components/right-edge.hbs
+++ b/packages/cardhost/app/templates/components/right-edge.hbs
@@ -38,16 +38,27 @@
                     {{#if (eq @mode "fields")}}
                       <div class="right-edge--items-container">
                         <div class="right-edge--item">
-                          <Cta @variant="secondary responsive" @theme="cs-dark">
-                            <LinkTo
-                              @route="cards.card.edit.fields.schema"
-                              @class="right-edge--configure-schema-link"
-                              @model={{@card}}
-                              data-test-configure-schema-btn
-                            >
-                              Configure Schema
-                            </LinkTo>
-                          </Cta>
+                          <LinkTo
+                            @route="cards.card.edit.fields.schema"
+                            @class="right-edge--configure-schema-link cs-component-cta secondary responsive cs-dark-cta"
+                            @model={{@card}}
+                            data-test-configure-schema-btn
+                          >
+                            Configure Schema
+                          </LinkTo>
+                        </div>
+                      </div>
+                    {{else}}
+                      <div class="right-edge--items-container">
+                        <div class="right-edge--item">
+                          <LinkTo
+                            @route="cards.card.edit.fields"
+                            @class="right-edge--configure-schema-link cs-component-cta secondary responsive cs-dark-cta"
+                            @model={{@card}}
+                            data-test-return-to-editing
+                          >
+                            Return to Editing
+                          </LinkTo>
                         </div>
                       </div>
                     {{/if}}

--- a/packages/cardhost/app/templates/components/right-edge.hbs
+++ b/packages/cardhost/app/templates/components/right-edge.hbs
@@ -48,7 +48,7 @@
                           </LinkTo>
                         </div>
                       </div>
-                    {{else}}
+                    {{else if (eq @mode "schema")}}
                       <div class="right-edge--items-container">
                         <div class="right-edge--item">
                           <LinkTo

--- a/packages/cardhost/tests/acceptance/card-schema-test.js
+++ b/packages/cardhost/tests/acceptance/card-schema-test.js
@@ -377,4 +377,13 @@ module('Acceptance | card schema', function(hooks) {
 
     assert.dom(`[data-test-right-edge] [data-test-no-adoption]`).hasText('No Adoption');
   });
+
+  test(`can navigate from schema to edit via return to editing button `, async function(assert) {
+    await login();
+    await visit(`/cards/@cardstack%2Fbase-card/edit/fields/schema`);
+    assert.equal(currentURL(), `/cards/@cardstack%2Fbase-card/edit/fields/schema`);
+    assert.dom('[data-test-return-to-editing]').hasText('Return to Editing');
+    await click('[data-test-return-to-editing]');
+    assert.equal(currentURL(), `/cards/@cardstack%2Fbase-card/edit/fields`);
+  });
 });


### PR DESCRIPTION
Added:
Return to editing button

Changed:
I fixed a bug where you had to click on the words inside the button to change routes, when you should be able to click anywhere inside the button. Using a link inside a CTA button doesn't work great. I took the styles from the CTA button and used them on the link-to.

I opened a ticket in ui-components to create a link-to variation of our CTA: https://github.com/cardstack/ui-components/issues/155

<img width="373" alt="Screen Shot 2020-02-03 at 12 41 25 PM" src="https://user-images.githubusercontent.com/16627268/73676677-cc917900-4682-11ea-95e3-7f63608e2922.png">
