### PR TITLE
Autosave new and adopted cards

### DIFF
--- a/packages/cardhost/app/components/save-button.js
+++ b/packages/cardhost/app/components/save-button.js
@@ -63,7 +63,7 @@ export default class SaveButton extends Component {
 
   @action
   autoSave(element, [isDirty]) {
-    if (isDirty && !this.cardIsNew && !this.autosaveDisabled) {
+    if (isDirty && !this.autosaveDisabled) {
       if (this.args.clickAction) {
         this.args.clickAction();
       } else {

--- a/packages/cardhost/app/templates/components/save-button.hbs
+++ b/packages/cardhost/app/templates/components/save-button.hbs
@@ -7,6 +7,7 @@
     (if (not (or @card.isDirty this.saveCard.isRunning)) "saved ")
   }}
   data-test-card-save-btn
+  {{did-insert this.autoSave @card.isDirty}}
   {{did-update this.autoSave @card.isDirty}}
 >
   {{#if this.saveCard.isRunning}}


### PR DESCRIPTION
Previous to having the new/adopted card name dialog, we didn't want to autosave them because we wanted to give the user an opportunity to change the `id`. Now that they are setting it up front via the dialog, we don't have that limitation, and we should autosave them.