### PR TITLE
Set animation speed to be super fast in testing

### DIFF
--- a/packages/cardhost/app/components/card-renderer.js
+++ b/packages/cardhost/app/components/card-renderer.js
@@ -6,12 +6,14 @@ import { action } from '@ember/object';
 import move from 'ember-animated/motions/move';
 import adjustCSS from 'ember-animated/motions/adjust-css';
 import { inject as service } from '@ember/service';
+import ENV from '@cardstack/cardhost/config/environment';
 
 // TODO we'll need to use EC in order to be able to isolate cards
 // (due to the need to await the load of the isolated format of a card)
 // import { task } from "ember-concurrency";
+const { animationSpeed } = ENV;
+const duration = animationSpeed || 250;
 
-const duration = 250;
 // TODO This will be part of the official API. Move this into core as it solidifies
 export default class CardRenderer extends Component {
   @service cardstackSession;

--- a/packages/cardhost/app/services/scroller.js
+++ b/packages/cardhost/app/services/scroller.js
@@ -1,5 +1,9 @@
 import Service from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import ENV from '@cardstack/cardhost/config/environment';
+
+const { animationSpeed } = ENV;
+const duration = animationSpeed || 1000;
 
 function easeInOutCubic(t) {
   return t < 0.5 ? 4 * t * t * t : (t - 1) * (2 * t - 2) * (2 * t - 2) + 1;
@@ -14,7 +18,7 @@ export default class ScrollerService extends Service {
     this.scrollingElementSelector = element;
   }
 
-  scrollToSection({ selector, duration = 1000, elementOffset = 60, doneScrolling }) {
+  scrollToSection({ selector, elementOffset = 60, doneScrolling }) {
     if (this.currentlyScrolledTo === selector) {
       return;
     }


### PR DESCRIPTION
![must-go-faster](https://user-images.githubusercontent.com/16627268/74276139-27f6e300-4ce3-11ea-8b4d-5ff89da89ec2.gif)

Changed:
Our CI runs were really long due to 250ms animations on card renderer and 1000ms on the index page. Will fixed this at one point, but it looks like we missed a few spots in subsequent work. This PR sets animation duration to 20ms everywhere that I could find it.
