### PR TITLE
Drop Node 8 and update ember-toolbars version

### DIFF
--- a/packages/cardhost/.travis.yml
+++ b/packages/cardhost/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "6"
+  - "10"
 
 sudo: false
 dist: trusty

--- a/packages/cardhost/package.json
+++ b/packages/cardhost/package.json
@@ -86,7 +86,7 @@
     "ember-resolver": "^7.0.0",
     "ember-source": "~3.15.0",
     "ember-test-selectors": "^3.0.0",
-    "ember-toolbars": "^0.5.1",
+    "ember-toolbars": "^0.6.0",
     "eslint-plugin-ember": "^7.7.1",
     "eslint-plugin-mocha": "^5.2.0",
     "eslint-plugin-node": "^10.0.0",
@@ -98,7 +98,7 @@
     "scope-css": "^1.2.1"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": ">= 10.*"
   },
   "ember": {
     "edition": "octane"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8925,6 +8925,16 @@ ember-toolbars@^0.5.1:
     ember-elsewhere "^1.1.0"
     liquid-fire "^0.30.0"
 
+ember-toolbars@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/ember-toolbars/-/ember-toolbars-0.6.0.tgz#0dca9479630e5f3079c8b8956e1540d5a6543efc"
+  integrity sha512-nil5uxYIAH6dLI2xTzuaOmNXrCIL+jUDjBiE2rsjDXpeTTiTxa2LJmefcYLWwUF2zVEmlsV6MmoL94Um55ip5g==
+  dependencies:
+    ember-cli-babel "^7.13.0"
+    ember-cli-htmlbars "^4.2.0"
+    ember-elsewhere "^1.1.0"
+    liquid-fire "^0.31.0"
+
 ember-truth-helpers@^2.0.0, ember-truth-helpers@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-2.1.0.tgz#d4dab4eee7945aa2388126485977baeb33ca0798"
@@ -12643,6 +12653,20 @@ liquid-fire@^0.30.0:
     ember-cli-htmlbars "^3.0.1"
     ember-cli-version-checker "^3.1.3"
     ember-copy "^1.0.0"
+    match-media "^0.2.0"
+    velocity-animate "^1.5.2"
+
+liquid-fire@^0.31.0:
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/liquid-fire/-/liquid-fire-0.31.0.tgz#6dc9f4785b5a06dcbe1a7ca4e8b130ac595ee2f5"
+  integrity sha512-KVI2vBB+6I1kvkOSD/S/Vjq5hYqlFw3zBLiRoCSIDj9LMWmm2GEKvQcmpxiqgsdjMS2VAFaqUd+9BJFRvCmIjA==
+  dependencies:
+    broccoli-funnel "^2.0.2"
+    broccoli-merge-trees "^3.0.2"
+    broccoli-stew "^2.1.0"
+    ember-cli-babel "^7.7.3"
+    ember-cli-htmlbars "^3.0.1"
+    ember-cli-version-checker "^3.1.3"
     match-media "^0.2.0"
     velocity-animate "^1.5.2"
 


### PR DESCRIPTION
This gets rid of the `this.$` is deprecated in all builder tests.