### PR TITLE
Reduce dev build times by 30% 

### DIFF
--- a/packages/cardhost/app/components/code-editor.js
+++ b/packages/cardhost/app/components/code-editor.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import requirejsPolyfill from '@cardstack/requirejs-monaco-ember-polyfill';
-import * as monaco from 'monaco-editor';
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
 import { action } from '@ember/object';
 import { restartableTask } from 'ember-concurrency-decorators';
 import { timeout } from 'ember-concurrency';

--- a/packages/cardhost/ember-cli-build.js
+++ b/packages/cardhost/ember-cli-build.js
@@ -31,7 +31,8 @@ module.exports = function(defaults) {
   // along with the exports of each module as its value.
   app.import('node_modules/monaco-editor/dev/vs/editor/editor.main.css');
 
-  let languages = ['typescript', 'javascript', 'html', 'css'];
+  const languages = ['html', 'css'];
+  const features = ['accessibilityHelp', 'colorDetector', 'find', 'folding', 'hover', 'suggest', 'toggleHighContrast'];
 
   return (function() {
     const Webpack = require('@embroider/webpack').Webpack;
@@ -48,7 +49,7 @@ module.exports = function(defaults) {
       },
       packagerOptions: {
         webpackConfig: {
-          plugins: [new MonacoWebpackPlugin({ languages })],
+          plugins: [new MonacoWebpackPlugin({ languages, features })],
         },
       },
       packageRules: [

--- a/packages/cardhost/ember-cli-build.js
+++ b/packages/cardhost/ember-cli-build.js
@@ -31,6 +31,8 @@ module.exports = function(defaults) {
   // along with the exports of each module as its value.
   app.import('node_modules/monaco-editor/dev/vs/editor/editor.main.css');
 
+  let languages = ['typescript', 'javascript', 'html', 'css'];
+
   return (function() {
     const Webpack = require('@embroider/webpack').Webpack;
     const { join } = require('path');
@@ -46,7 +48,7 @@ module.exports = function(defaults) {
       },
       packagerOptions: {
         webpackConfig: {
-          plugins: [new MonacoWebpackPlugin(/*{languages: ['javascript', 'typescript']}*/)],
+          plugins: [new MonacoWebpackPlugin({ languages })],
         },
       },
       packageRules: [


### PR DESCRIPTION
Closes #1336 

Also reduces monaco dependency bundle size by about a third.

To test - run it locally. Make changes in the code editor. Confirm that it works how you would expect.