### PR TITLE
prevent dupe field previews

### DIFF
--- a/packages/cardhost/app/components/card-manipulator.js
+++ b/packages/cardhost/app/components/card-manipulator.js
@@ -312,19 +312,14 @@ export default class CardManipulator extends Component {
 
       self.draggable.setDragging(true);
 
-      // in order for the drop zone to trigger a mouseenter/mouseleave event
-      // we need to temporarily hide the dragged element
-      let fieldEl = dragEvent.target.closest('.ch-catalog-field');
-      fieldEl.style.visibility = 'hidden';
-      let elemBelow = document.elementFromPoint(event.clientX, event.clientY);
-      fieldEl.style.visibility = 'visible';
+      let elemsBelow = document.elementsFromPoint(event.clientX, event.clientY);
 
       // this can happen when you drag the mouse outside the viewport
-      if (!elemBelow) {
+      if (!elemsBelow.length) {
         return;
       }
 
-      let dropzoneBelow = elemBelow.closest('.drop-zone');
+      let dropzoneBelow = elemsBelow.find(el => el.classList.contains('drop-zone'));
       let currentDropzone = self.draggable.getDropzone();
 
       if (currentDropzone !== dropzoneBelow) {
@@ -332,7 +327,7 @@ export default class CardManipulator extends Component {
           self.draggable.clearDropzone();
         }
         if (dropzoneBelow) {
-          self.draggable.setDropzone(elemBelow);
+          self.draggable.setDropzone(dropzoneBelow);
         }
       }
     }

--- a/packages/cardhost/app/components/card-manipulator.js
+++ b/packages/cardhost/app/components/card-manipulator.js
@@ -262,18 +262,21 @@ export default class CardManipulator extends Component {
     if (!this.draggable.isDragging && !this.justDropped) {
       this.beginDragging(field, event);
     } else {
-      this.draggable.clearField();
       this.draggable.setDragging(false);
     }
   }
 
   @action
   beginDragging(field, dragEvent) {
+    // we're clicking on a draggable that's already being dragged
+    if (this.draggable.isDragging) {
+      return;
+    }
     let dragState;
     let self = this;
 
     function stopMouse() {
-      field.dragState = null;
+      field.dragState = dragState = null;
       let dropzone = self.draggable.getDropzone();
       if (dropzone) {
         self.draggable.drop();
@@ -286,8 +289,9 @@ export default class CardManipulator extends Component {
         }, 1000);
       } else {
         // we mouseup somewhere that isn't a dropzone
-        self.draggable.clearField();
       }
+      self.draggable.clearField();
+
       // we do this so that we can animate the field back to the left edge
       self.fieldComponents = self.fieldComponents.map(obj => obj); // oh glimmer, you so silly...
 

--- a/packages/cardhost/app/components/card-renderer.js
+++ b/packages/cardhost/app/components/card-renderer.js
@@ -53,9 +53,19 @@ export default class CardRenderer extends Component {
   toggleStubField(field, position, addField) {
     if (position || position === 0) {
       if (addField) {
-        this.fields.insertAt(position, field);
+        // remove other stub fields first
+        this.fields = this.fields.filter(field => !field.preview);
+        // check if adding at the end
+        if (position < this.fields.length) {
+          this.fields.insertAt(position, field);
+        } else {
+          this.fields.addObject(field);
+        }
       } else {
-        this.fields.removeAt(position);
+        // don't remove a field that's not a stub field
+        if (this.fields[position].preview) {
+          this.fields.removeAt(position);
+        }
       }
     }
   }

--- a/packages/cardhost/app/components/drop-zone.js
+++ b/packages/cardhost/app/components/drop-zone.js
@@ -25,10 +25,11 @@ export default class DropZone extends Component {
   }
 
   @action
-  updateStatus(status) {
+  updateStatus(status, event) {
     let draggedField = this.draggable.getField();
 
-    if (!draggedField) {
+    // either no dragged field, or event triggered by a human
+    if (!draggedField || event.isTrusted) {
       return;
     }
 

--- a/packages/cardhost/app/components/drop-zone.js
+++ b/packages/cardhost/app/components/drop-zone.js
@@ -33,7 +33,6 @@ export default class DropZone extends Component {
       return;
     }
 
-    console.log('event.type: ', event.type);
     this.dropZoneStatus = status;
 
     if (this.args.toggleStubField) {

--- a/packages/cardhost/app/components/drop-zone.js
+++ b/packages/cardhost/app/components/drop-zone.js
@@ -28,11 +28,12 @@ export default class DropZone extends Component {
   updateStatus(status, event) {
     let draggedField = this.draggable.getField();
 
-    // either no dragged field, or event triggered by a human
-    if (!draggedField || event.isTrusted) {
+    // either no dragged field, or mouse event triggered by a human
+    if (!draggedField || (event.isTrusted && (event.type === 'mouseenter' || event.type === 'mouseleave'))) {
       return;
     }
 
+    console.log('event.type: ', event.type);
     this.dropZoneStatus = status;
 
     if (this.args.toggleStubField) {

--- a/packages/cardhost/app/components/field-renderer.js
+++ b/packages/cardhost/app/components/field-renderer.js
@@ -116,12 +116,12 @@ export default class FieldRenderer extends Component {
 
   @action initDrag(field, evt) {
     evt.target.parentNode.setAttribute('draggable', 'true');
-    this.isDragging = field;
+    this.draggable.setDragging(true);
   }
 
   @action endDrag(evt) {
     evt.target.parentNode.setAttribute('draggable', 'false');
-    this.isDragging = null;
+    this.draggable.setDragging(false);
   }
 
   @action startDragging(field, evt) {

--- a/packages/cardhost/app/styles/components/drop-zone.css
+++ b/packages/cardhost/app/styles/components/drop-zone.css
@@ -9,6 +9,7 @@
   height: 50px;
   position: absolute;
   top: -25px;
+  /* border: dashed 3px red; */
   z-index: 100;
 }
 
@@ -29,12 +30,17 @@
 
 /* ember-animated drag has started, and is over a dropzone */
 .cardhost-cards.dragging .drop-zone--container.dragging .drop-zone {
+  height: 270px;
+}
+
+/* native drag has started, and is over a dropzone */
+.cardhost-cards:not(.dragging) .drop-zone--container.dragging .drop-zone {
   height: 220px;
 }
 
 /* native drag has started, and is over a dropzone */
 .cardhost-cards:not(.dragging) .drop-zone--container.dragging .drop-zone {
-  height: 170px;
+  height: 220px;
 }
 
 .drop-zone--container .drop-zone--description .drop-zone--preview--container {

--- a/packages/cardhost/app/styles/components/drop-zone.css
+++ b/packages/cardhost/app/styles/components/drop-zone.css
@@ -9,7 +9,6 @@
   height: 50px;
   position: absolute;
   top: -25px;
-  /* border: dashed 3px red; */
   z-index: 100;
 }
 

--- a/packages/cardhost/app/styles/components/drop-zone.css
+++ b/packages/cardhost/app/styles/components/drop-zone.css
@@ -17,29 +17,19 @@
   background-color: var(--ch-light-background);
 }
 
-/* ember-animated drag has started */
+/* drag has started */
 .cardhost-cards.dragging .drop-zone--container .drop-zone {
   top: -75px;
 }
 
-/* ember-animated drag has started, but is not yet over a dropzone */
+/* drag has started, but is not yet over a dropzone */
 .cardhost-cards.dragging .drop-zone--container:not(.dragging) .drop-zone {
   height: 150px;
 }
 
-/* ember-animated drag has started, and is over a dropzone */
+/* drag has started, and is over a dropzone */
 .cardhost-cards.dragging .drop-zone--container.dragging .drop-zone {
   height: 270px;
-}
-
-/* native drag has started, and is over a dropzone */
-.cardhost-cards:not(.dragging) .drop-zone--container.dragging .drop-zone {
-  height: 220px;
-}
-
-/* native drag has started, and is over a dropzone */
-.cardhost-cards:not(.dragging) .drop-zone--container.dragging .drop-zone {
-  height: 220px;
 }
 
 .drop-zone--container .drop-zone--description .drop-zone--preview--container {

--- a/packages/cardhost/app/templates/components/drop-zone.hbs
+++ b/packages/cardhost/app/templates/components/drop-zone.hbs
@@ -2,15 +2,15 @@
   <div
     class="drop-zone"
     role="button"
-    {{on "mouseup" (action @dropField @position (fn this.updateStatus "dropped"))}}
-    {{on "click" (action @dropField @position (fn this.updateStatus "dropped"))}}
-    {{on "drop" (action @dropField @position (fn this.updateStatus "dropped"))}}
-    {{on "mouseover" (action this.dragOver)}}
-    {{on "mouseenter" (action this.updateStatus "dragging")}}
-    {{on "mouseleave" (action this.updateStatus "outside")}}
-    {{on "dragover" (action this.dragOver)}}
-    {{on "dragenter" (action this.updateStatus "dragging")}}
-    {{on "dragleave" (action this.updateStatus "outside")}}
+    {{on "mouseup" (fn @dropField @position (fn this.updateStatus "dropped"))}}
+    {{on "click" (fn @dropField @position (fn this.updateStatus "dropped"))}}
+    {{on "drop" (fn @dropField @position (fn this.updateStatus "dropped"))}}
+    {{on "mouseover" (fn this.dragOver)}}
+    {{on "mouseenter" (fn this.updateStatus "dragging")}}
+    {{on "mouseleave" (fn this.updateStatus "outside")}}
+    {{on "dragover" (fn this.dragOver)}}
+    {{on "dragenter" (fn this.updateStatus "dragging")}}
+    {{on "dragleave" (fn this.updateStatus "outside")}}
     data-test-drop-zone={{@position}}
     aria-label="drop zone {{@position}}"
   >

--- a/packages/cardhost/app/templates/components/field-renderer.hbs
+++ b/packages/cardhost/app/templates/components/field-renderer.hbs
@@ -14,7 +14,7 @@
   {{did-update this.updateFieldProperties this.nonce}}
 >
   {{#if @setPosition}}
-    <button {{on "mousedown" (action this.initDrag @field)}} {{on "mouseup" (action this.endDrag)}} {{on "dragend" (action (mut this.isDragging) false)}}
+    <button {{on "mousedown" (action this.initDrag @field)}} {{on "mouseup" (action this.endDrag)}} {{on "dragend" (fn this.draggable.setDragging false)}}
       class="field--move-btn"
       aria-label="Drag field"
       data-test-field-renderer-move-btn


### PR DESCRIPTION
also fixes a bug where we weren't setting `this.draggable.dragging` to `false` when clicking on a dragged card.