### PR TITLE
Left-align card titles with icons, closes #1356

### DIFF
--- a/packages/cardhost/app/components/card-renderer-header.hbs
+++ b/packages/cardhost/app/components/card-renderer-header.hbs
@@ -4,7 +4,7 @@
 >
   <header class="card-renderer-isolated--header">
     {{#if (or (eq (safe-css-string @card.adoptedFromName) "event-card") (eq (safe-css-string @card.name) "event-card"))}}
-      {{svg-jar "event" width="18px" height="20px"}}
+      {{svg-jar "event" width="30px" height="20px" class="card-renderer-isolated--header-icon"}}
     {{/if}}
     <span class="card-renderer-isolated--header-title hide-in-percy">{{or @card.name "Blank Card"}}</span>
     {{#if this.cardstackSession.isAuthenticated}}

--- a/packages/cardhost/app/styles/components/card-renderer.css
+++ b/packages/cardhost/app/styles/components/card-renderer.css
@@ -230,6 +230,15 @@
 }
 
 
+.card-renderer-isolated--header-icon {
+  padding-right: 10px;
+  width: 40px;
+}
+
+.card-renderer-isolated--header-title {
+  width: 100%;
+}
+
 /* TODO: fade card if field-renderer is selected */
 /* .card-renderer-isolated.faded::before {
   content: '';


### PR DESCRIPTION
closes #1356 

## Before:

<img width="1166" alt="Screen Shot 2020-02-24 at 4 07 43 PM" src="https://user-images.githubusercontent.com/16627268/75191158-d0636900-571f-11ea-9284-0d33bd73cc9d.png">


## After:

<img width="1430" alt="Screen Shot 2020-02-24 at 4 04 07 PM" src="https://user-images.githubusercontent.com/16627268/75191183-db1dfe00-571f-11ea-9151-caf761a891a6.png">
<img width="1188" alt="Screen Shot 2020-02-24 at 4 05 09 PM" src="https://user-images.githubusercontent.com/16627268/75191184-dbb69480-571f-11ea-9d3e-d78ba8070754.png">
