### PR TITLE
Prevent overscroll, closes #1358

### DIFF
--- a/packages/cardhost/app/styles/app.css
+++ b/packages/cardhost/app/styles/app.css
@@ -117,6 +117,11 @@ body {
   line-height: 1.2;
 }
 
+/* Prevent overscroll bounce across all browsers. Should use `overscroll-behavior: none` once there is better cross-browser support. */
+html {
+  overflow: hidden;
+}
+
 a {
   color: inherit;
   text-decoration: none;

--- a/packages/cardhost/app/styles/app.css
+++ b/packages/cardhost/app/styles/app.css
@@ -117,9 +117,19 @@ body {
   line-height: 1.2;
 }
 
-/* Prevent overscroll bounce across all browsers. Should use `overscroll-behavior: none` once there is better cross-browser support. */
+/* The next two rules prevent overscroll bounce across all browsers. We should use solely `overscroll-behavior: none` once there is better cross-browser support. */
 html {
   overflow: hidden;
+}
+
+@supports (overscroll-behavior: none) {
+  html {
+    overflow: initial;
+  }
+
+  body {
+    overscroll-behavior: none;
+  }
 }
 
 a {


### PR DESCRIPTION
Closes #1358 

Please see the ticket for the goal and the reason I chose this approach.

How to test:
Open the builder in multiple browsers. Using the touchpad, try scrolling too far down or up a page. You should not see exposed edges like in the gif Dmitry put in the ticket.