### PR TITLE
Increase contrast for inactive library and nav items

### DIFF
--- a/packages/cardhost/app/styles/components/cardhost-left-edge.css
+++ b/packages/cardhost/app/styles/components/cardhost-left-edge.css
@@ -83,7 +83,7 @@
 }
 
 .cardhost-left-edge--nav-button:disabled {
-  --icon-color: var(--ch-light-op40);
+  --icon-color: var(--ch-light-op50);
 }
 
 .cardhost-left-edge--nav.expanded {

--- a/packages/cardhost/app/styles/components/library.css
+++ b/packages/cardhost/app/styles/components/library.css
@@ -47,19 +47,21 @@
   min-width: 124px;
   background: none;
   border: none;
+  cursor: pointer;
 }
 
 .hide-library--button-text {
   display: inline-block;
-  color: var(--ch-light);
+  color: var(--ch-light-op50);
   font-size: 13px;
   line-height: calc(18 / 13);
   letter-spacing: 0.015em;
-  opacity: 0.5;
-  transition: opacity var(--ch-card-transition-duration);
-}
-.hide-library--button:hover .hide-library--button-text {
   opacity: 1;
+  transition: color var(--ch-card-transition-duration);
+}
+
+.hide-library--button:hover .hide-library--button-text {
+  color: var(--ch-light);
 }
 
 .hide-library--button-icon {
@@ -94,14 +96,14 @@
 }
 
 .library--nav-button {
-  --icon-color: var(--library-nav-color);
+  --icon-color: var(--ch-light-op50);
   display: flex;
   align-items: center;
   background: none;
   box-shadow: none;
   border: none;
   font: 400 13px/18px var(--ch-font-family);
-  color: var(--library-nav-color);
+  color: var(--ch-light-op50);
   letter-spacing: 0.015em;
   transition: color var(--ch-card-transition-duration);
 }


### PR DESCRIPTION
Closes #1380

Changed:
- slight color adjustments for inactive and disabled items
- Remove use of opacity on text and replace with color transitions
- Hover on "hide library" applies the active color effect
- hover on hide library uses the pointer - this was not in the ticket but seems to be the pattern we use everywhere else
