### PR TITLE
clean up unused vars

### DIFF
--- a/packages/git/indexer.ts
+++ b/packages/git/indexer.ts
@@ -72,10 +72,10 @@ import Change from './change';
 import logger from '@cardstack/logger';
 const log = logger('cardstack/git');
 import service from './service';
-import { set, intersection } from 'lodash';
+import { set } from 'lodash';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-const { isInternalCard, adoptionChain } = require('@cardstack/plugin-utils/card-utils');
+const { isInternalCard } = require('@cardstack/plugin-utils/card-utils');
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const { declareInjections } = require('@cardstack/di');
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports


### PR DESCRIPTION
This commit directly to master introduced some linting errors: https://github.com/cardstack/cardstack/commit/e7b9f6bff52d579fe03f25914cc1650a41b016a8 

This PR fixes them.

After merge, the hub needs to be revved.