### PR TITLE
improve contrast for monaco line numbers and comments

### DIFF
--- a/packages/cardhost/app/components/code-editor.js
+++ b/packages/cardhost/app/components/code-editor.js
@@ -89,10 +89,13 @@ export default class CodeEditor extends Component {
     } else {
       el.style.height = '100%';
     }
+
+    let customThemeName = 'vsCodeA11y';
+    this.createCustomTheme(customThemeName);
     // `create` constructs a code editor and inserts it into the DOM
     let editor = monaco.editor.create(el, {
       model: codeModel,
-      theme: 'vs-dark',
+      theme: customThemeName,
       readOnly: this.readOnly,
       minimap: { enabled: false },
       wordWrap: 'on',
@@ -110,6 +113,21 @@ export default class CodeEditor extends Component {
     if (this.resizable && ENV.environment !== 'test') {
       this.startResizeWatcher.perform(el);
     }
+  }
+
+  createCustomTheme(customThemeName) {
+    // Increase the contrast of a few things so they pass color contrast checks.
+    // This modifies the monaco instance so we don't return anything.
+    // Token rules follow partial matches. string will match a token with type: string,
+    // string.double.js or string.html. Tokens can be inspected using F1 > Developer: Inspect Tokens
+    monaco.editor.defineTheme(customThemeName, {
+      base: 'vs-dark',
+      inherit: true,
+      rules: [{ token: 'comment', foreground: 'ffffff' }],
+      colors: {
+        'editorLineNumber.foreground': '#FFF',
+      },
+    });
   }
 
   @action


### PR DESCRIPTION
closes #1381

I've already confirmed that this works. I just used white for line numbers and code comments. @habdelra do you think that's good enough for now?