### PR TITLE
Make common cards launch behavior match New Blank Card

### DIFF
--- a/packages/cardhost/app/templates/components/library.hbs
+++ b/packages/cardhost/app/templates/components/library.hbs
@@ -87,24 +87,24 @@
         Common Cards
       </header>
       <div class="library-section--grid">
-        <LinkTo @route="cards.add" @class="library--card-link" data-test-library-common-card-link>
+        <Cta {{on "click" (fn this.openCardNameDialog "Create a New Card")}} class="library--card-link" data-test-library-common-card-button>
           <div class="library--card-renderer">
             <div class="library--card-placeholder icon-common-form"></div>
             <div class="library--card-label">Form</div>
           </div>
-        </LinkTo>
-        <LinkTo @route="cards.add" @class="library--card-link" data-test-library-common-card-link>
+        </Cta>
+        <Cta {{on "click" (fn this.openCardNameDialog "Create a New Card")}} class="library--card-link" data-test-library-common-card-button>
           <div class="library--card-renderer">
             <div class="library--card-placeholder icon-common-layout"></div>
             <div class="library--card-label">Layout</div>
           </div>
-        </LinkTo>
-        <LinkTo @route="cards.add" @class="library--card-link" data-test-library-common-card-link>
+        </Cta>
+        <Cta {{on "click" (fn this.openCardNameDialog "Create a New Card")}} class="library--card-link" data-test-library-common-card-button>
           <div class="library--card-renderer">
             <div class="library--card-placeholder icon-common-collection"></div>
             <div class="library--card-label">Collection</div>
           </div>
-        </LinkTo>
+        </Cta>
       </div>
     </section>
 

--- a/packages/cardhost/tests/acceptance/library-test.js
+++ b/packages/cardhost/tests/acceptance/library-test.js
@@ -68,7 +68,7 @@ module('Acceptance | library', function(hooks) {
     assert.dom(`[data-test-embedded-card=${card3Id}]`).exists();
     assert.dom('[data-test-library-recent-card-link]').exists({ count: 3 });
     assert.dom('[data-test-library-adopt-card-btn]').exists({ count: 6 });
-    assert.dom('[data-test-library-common-card-link]').exists({ count: 3 });
+    assert.dom('[data-test-library-common-card-button]').exists({ count: 3 });
     assert.dom('[data-test-library-new-blank-card-btn]').exists({ count: 1 });
     await percySnapshot(assert);
 
@@ -81,7 +81,7 @@ module('Acceptance | library', function(hooks) {
     assert.dom(`[data-test-embedded-card=${card3Id}]`).exists();
     assert.dom('[data-test-library-recent-card-link]').exists({ count: 3 });
     assert.dom('[data-test-library-adopt-card-btn]').exists({ count: 6 });
-    assert.dom('[data-test-library-common-card-link]').exists({ count: 3 });
+    assert.dom('[data-test-library-common-card-button]').exists({ count: 3 });
     assert.dom('[data-test-library-new-blank-card-btn]').exists({ count: 1 });
 
     await visit(`/cards/${card1Id}/edit/fields`);
@@ -92,7 +92,7 @@ module('Acceptance | library', function(hooks) {
     assert.dom(`[data-test-embedded-card=${card3Id}]`).exists();
     assert.dom('[data-test-library-recent-card-link]').exists({ count: 3 });
     assert.dom('[data-test-library-adopt-card-btn]').exists({ count: 6 });
-    assert.dom('[data-test-library-common-card-link]').exists({ count: 3 });
+    assert.dom('[data-test-library-common-card-button]').exists({ count: 3 });
     assert.dom('[data-test-library-new-blank-card-btn]').exists({ count: 1 });
 
     await visit(`/cards/${card1Id}/edit/fields/schema`);
@@ -103,7 +103,7 @@ module('Acceptance | library', function(hooks) {
     assert.dom(`[data-test-embedded-card=${card3Id}]`).exists();
     assert.dom('[data-test-library-recent-card-link]').exists({ count: 3 });
     assert.dom('[data-test-library-adopt-card-btn]').exists({ count: 6 });
-    assert.dom('[data-test-library-common-card-link]').exists({ count: 3 });
+    assert.dom('[data-test-library-common-card-button]').exists({ count: 3 });
     assert.dom('[data-test-library-new-blank-card-btn]').exists({ count: 1 });
   });
 


### PR DESCRIPTION
Closes #1390 

What changed is that if you click on a common card, it follows the exact same behavior as New Blank Card. So, it shows the exact same dialog, complete with a cancel button.

I renamed the test selector since these are buttons now.