### PR TITLE
Fix ghost field when dragging from bottom of list

### DIFF
--- a/packages/cardhost/app/styles/components/catalog.css
+++ b/packages/cardhost/app/styles/components/catalog.css
@@ -26,6 +26,8 @@
 
 .ch-catalog--header {
   position: relative;
+  background-color: var(--ch-dark-background);
+  z-index: 10;
 }
 
 .ch-catalog--header-btns {

--- a/packages/cardhost/app/templates/components/card-schema-updator.hbs
+++ b/packages/cardhost/app/templates/components/card-schema-updator.hbs
@@ -12,7 +12,7 @@
           <div
             class="ch-catalog-field"
             tabindex="-1"
-            {{on "mousedown" (fn this.beginDragging field)}}
+            {{on "mousedown" (perform this.beginDragging field)}}
             {{on "click" (fn this.selectFieldType field)}}
             data-test-card-add-field-draggable={{field.type}}
           >


### PR DESCRIPTION
This *mostly* addresses #1341, it attempts to mitigate the `mousedown` -> `mouseup` -> `click` sequence by introducing a short debounce for the main drag action (which is now a `restartableTask`).

It can still be "broken" by clicking for longer than the debounce time, i.e. holding down the mouse button for a period of time without moving the mouse, then letting go of the button. In reality, no one really clicks like that. but it's still a thing. That said I would be curious to know if anyone can think of a better approach.