### PR TITLE
bugfix - loading page never resolved for new card

### DIFF
--- a/packages/cardhost/app/components/card-name-dialog.js
+++ b/packages/cardhost/app/components/card-name-dialog.js
@@ -54,17 +54,21 @@ export default class CardNameDialog extends Component {
 
     if (environment !== 'test') {
       this.overlays.setOverlayState('showLoading', true);
-      yield newCard.save().catch(() => {
-        // if there's a problem saving, go back to showing the dialog
-        this.overlays.setOverlayState('showLoading', false);
-        return;
-      });
-    }
-    this.overlays.reset();
-    if (adoptedFrom) {
-      this.router.transitionTo('cards.card.edit.fields', newCard);
-    } else {
-      this.router.transitionTo('cards.card.edit.fields.schema', newCard);
+      yield newCard
+        .save()
+        .then(() => {
+          this.overlays.reset();
+          if (adoptedFrom) {
+            this.router.transitionTo('cards.card.edit.fields', newCard);
+          } else {
+            this.router.transitionTo('cards.card.edit.fields.schema', newCard);
+          }
+        })
+        .catch(() => {
+          // if there's a problem saving, go back to showing the dialog
+          this.overlays.setOverlayState('showLoading', false);
+          return;
+        });
     }
   })
   createCardTask;

--- a/packages/cardhost/app/components/card-name-dialog.js
+++ b/packages/cardhost/app/components/card-name-dialog.js
@@ -54,21 +54,19 @@ export default class CardNameDialog extends Component {
 
     if (environment !== 'test') {
       this.overlays.setOverlayState('showLoading', true);
-      yield newCard
-        .save()
-        .then(() => {
-          this.overlays.reset();
-          if (adoptedFrom) {
-            this.router.transitionTo('cards.card.edit.fields', newCard);
-          } else {
-            this.router.transitionTo('cards.card.edit.fields.schema', newCard);
-          }
-        })
-        .catch(() => {
-          // if there's a problem saving, go back to showing the dialog
-          this.overlays.setOverlayState('showLoading', false);
-          return;
-        });
+      try {
+        yield newCard.save();
+      } catch (err) {
+        this.overlays.setOverlayState('showLoading', false);
+        return;
+      }
+    }
+
+    this.overlays.reset();
+    if (adoptedFrom) {
+      this.router.transitionTo('cards.card.edit.fields', newCard);
+    } else {
+      this.router.transitionTo('cards.card.edit.fields.schema', newCard);
     }
   })
   createCardTask;

--- a/packages/cardhost/app/controllers/application.js
+++ b/packages/cardhost/app/controllers/application.js
@@ -1,9 +1,10 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
-import fade from 'ember-animated/transitions/fade';
 
 export default class ApplicationController extends Controller {
   @service overlays;
 
-  fade = fade;
+  get showLoading() {
+    return this.overlays.showLoading;
+  }
 }

--- a/packages/cardhost/app/templates/application.hbs
+++ b/packages/cardhost/app/templates/application.hbs
@@ -4,8 +4,8 @@
 
 <AnimatedTools @hideUntilKeys="Ctrl-Shift-KeyA" />
 
-{{#animated-if this.overlays.showLoading use=this.fade}}
+{{#if this.showLoading }}
   <Loading />
 {{else}}
   <CardhostModalTarget/>
-{{/animated-if}}
+{{/if}}


### PR DESCRIPTION
Whenever you created a new card in a production environment, it would just hang with the loading icon spinning, even on a successful server response. I am still a little fuzzy on what `yield` should have done here/why my previous code din't work. My understanding was that for ember-concurrency, `yield` was like `await`, but perhaps my `.catch` caused a problem. So, I moved it into a `.then` which is more canonical anyway.

You can see this issue in our .space stack currently.

If we need to get it working immediately, we can comment out the `this.overlays` lines in this same file and it will have the old behavior.