### PR TITLE
fix for sharing git realm cards in different hubs (that have different filesystems)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,7 +31,7 @@
         "HUB_ENVIRONMENT": "test"
         // "LOG_LEVELS": "cardstack/card-utils=debug"
       },
-      "args": ["-r", "esm", "packages/test-support/bin/run.js", "--timeout", "600000", "--grep", "indexes a url-encoded id card"],
+      "args": ["-r", "esm", "packages/test-support/bin/run.js", "--timeout", "600000", "--grep", "hub/git/indexing"],
     },
     {
       "type": "node",

--- a/cards/git-realm/package.json
+++ b/cards/git-realm/package.json
@@ -13,6 +13,7 @@
     "delay": "^4.1.0",
     "filenamify-url": "^1.0.0",
     "isomorphic-git": "0.78.0",
+    "fs-extra": "^8.1.0",
     "json-stable-stringify": "^1.0.1",
     "jsonapi-typescript": "^0.1.3",
     "lodash": "^4.17.11",

--- a/packages/hub/node-tests/git/card-service-test.ts
+++ b/packages/hub/node-tests/git/card-service-test.ts
@@ -1,5 +1,3 @@
-// import { AddressableCard } from '@cardstack/core/card';
-// import { canonicalURL } from '@cardstack/core/card-id';
 import { ScopedCardService } from '../../cards-service';
 import { myOrigin } from '@cardstack/core/origin';
 import { CARDSTACK_PUBLIC_REALM } from '@cardstack/core/realm';
@@ -7,8 +5,8 @@ import { Session } from '@cardstack/core/session';
 import { createTestEnv, TestEnv } from '../helpers';
 import { cardDocument } from '@cardstack/core/card-document';
 import { makeRepo } from './support';
+import { join } from 'path';
 import { dir as mkTmpDir, DirectoryResult } from 'tmp-promise';
-// import { Value } from 'json-typescript';
 
 describe('hub/git/card-service', function() {
   describe('read-write', function() {
@@ -24,9 +22,10 @@ describe('hub/git/card-service', function() {
       service = await (await env.container.lookup('cards')).as(Session.EVERYONE);
 
       tmpDir = await mkTmpDir({ unsafeCleanup: true });
-      repoPath = tmpDir.path;
+      process.env.REPO_ROOT_DIR = tmpDir.path;
+      repoPath = 'test-repo';
 
-      await makeRepo(repoPath);
+      await makeRepo(join(tmpDir.path, repoPath));
 
       repoDoc = cardDocument()
         .adoptingFrom({ csRealm: CARDSTACK_PUBLIC_REALM, csId: 'git-realm' })

--- a/packages/hub/node-tests/git/indexing-remote-test.ts
+++ b/packages/hub/node-tests/git/indexing-remote-test.ts
@@ -35,19 +35,14 @@ async function resetRemote() {
 describe('hub/git/indexing-remote', function() {
   let env: TestEnv, indexing: IndexingService, cards: CardsService, service: ScopedCardService;
   let repoRealm = `${myOrigin}/api/realms/test-git-repo`;
-  // let tmpDir: DirectoryResult;
-  // let root: string;
   let head: string;
   let repoDoc: CardDocument;
-  let tempRepoDir: DirectoryResult, tempRepoPath: string;
-  // tempRemoteRepoPath: string;
+  let tempRepoDir: DirectoryResult;
 
   beforeEach(async function() {
     env = await createTestEnv();
     indexing = await env.container.lookup('indexing');
     cards = await env.container.lookup('cards');
-    // tmpDir = await mkTmpDir({ unsafeCleanup: true });
-    // root = tmpDir.path;
     service = cards.as(Session.EVERYONE);
 
     let tempRepo = await resetRemote();
@@ -55,15 +50,14 @@ describe('hub/git/indexing-remote', function() {
     head = tempRepo.head;
 
     tempRepoDir = await mkTmpDir({ unsafeCleanup: true });
-    // tempRemoteRepoDir = await mkTmpDir({ unsafeCleanup: true });
-    tempRepoPath = tempRepoDir.path;
-    // tempRemoteRepoPath = tempRemoteRepoDir.path;
+    process.env.REPO_ROOT_DIR = tempRepoDir.path;
+    let remoteCacheDir = 'test-repo';
 
     repoDoc = cardDocument()
       .adoptingFrom({ csRealm: CARDSTACK_PUBLIC_REALM, csId: 'git-realm' })
       .withAttributes({
         remoteUrl: 'http://root:password@localhost:8838/git/repo',
-        remoteCacheDir: tempRepoPath,
+        remoteCacheDir,
         csId: repoRealm,
       });
 

--- a/packages/hub/node-tests/git/indexing-test.ts
+++ b/packages/hub/node-tests/git/indexing-test.ts
@@ -7,6 +7,7 @@ import { Session } from '@cardstack/core/session';
 import { dir as mkTmpDir, DirectoryResult } from 'tmp-promise';
 import { CARDSTACK_PUBLIC_REALM } from '@cardstack/core/realm';
 import Change from '../../../../cards/git-realm/lib/change';
+import { join } from 'path';
 import { commitOpts, makeRepo, inRepo } from './support';
 
 describe('hub/git/indexing', function() {
@@ -21,12 +22,14 @@ describe('hub/git/indexing', function() {
     indexing = await env.container.lookup('indexing');
     cards = await env.container.lookup('cards');
     tmpDir = await mkTmpDir({ unsafeCleanup: true });
-    root = tmpDir.path;
+    process.env.REPO_ROOT_DIR = tmpDir.path;
+    let repo = 'test-repo';
+    root = join(tmpDir.path, repo);
     service = cards.as(Session.EVERYONE);
 
     repoDoc = cardDocument()
       .adoptingFrom({ csRealm: CARDSTACK_PUBLIC_REALM, csId: 'git-realm' })
-      .withAttributes({ repo: root, csId: repoRealm });
+      .withAttributes({ repo, csId: repoRealm });
 
     await service.create(`${myOrigin}/api/realms/meta`, repoDoc.jsonapi);
   });

--- a/packages/hub/node-tests/git/writer-remote-test.ts
+++ b/packages/hub/node-tests/git/writer-remote-test.ts
@@ -68,10 +68,7 @@ describe('hub/git/writer with remote', function() {
     repo: Repository,
     tempRepoDir: DirectoryResult,
     tempRemoteRepoDir: DirectoryResult,
-    tempRepoPath: string,
     tempRemoteRepoPath: string,
-    // head: string,
-    // remoteRepo: Repository,
     service: ScopedCardService,
     repoDoc: CardDocument;
 
@@ -90,8 +87,9 @@ describe('hub/git/writer with remote', function() {
 
     tempRepoDir = await mkTmpDir({ unsafeCleanup: true });
     tempRemoteRepoDir = await mkTmpDir({ unsafeCleanup: true });
-    tempRepoPath = tempRepoDir.path;
+    process.env.REPO_ROOT_DIR = tempRepoDir.path;
     tempRemoteRepoPath = tempRemoteRepoDir.path;
+    let remoteCacheDir = 'test-repo';
 
     repo = await Repository.clone('http://root:password@localhost:8838/git/repo', tempRemoteRepoPath);
 
@@ -99,7 +97,7 @@ describe('hub/git/writer with remote', function() {
       .adoptingFrom({ csRealm: CARDSTACK_PUBLIC_REALM, csId: 'git-realm' })
       .withAttributes({
         remoteUrl: 'http://root:password@localhost:8838/git/repo',
-        remoteCacheDir: tempRepoPath,
+        remoteCacheDir,
         csId: repoRealm,
       });
 

--- a/packages/hub/node-tests/git/writer-test.ts
+++ b/packages/hub/node-tests/git/writer-test.ts
@@ -14,6 +14,7 @@ import { createTestEnv, TestEnv } from '../helpers';
 import { cardDocument, CardDocument } from '@cardstack/core/card-document';
 import { makeRepo, inRepo } from './support';
 import { dir as mkTmpDir, DirectoryResult } from 'tmp-promise';
+import { join } from 'path';
 
 describe('hub/git/writer', function() {
   this.timeout(10000);
@@ -29,13 +30,15 @@ describe('hub/git/writer', function() {
     service = await (await env.container.lookup('cards')).as(Session.EVERYONE);
 
     tmpDir = await mkTmpDir({ unsafeCleanup: true });
-    repoPath = tmpDir.path;
+    process.env.REPO_ROOT_DIR = tmpDir.path;
+    let repo = 'test-repo';
+    repoPath = join(tmpDir.path, repo);
 
     await makeRepo(repoPath);
 
     repoDoc = cardDocument()
       .adoptingFrom({ csRealm: CARDSTACK_PUBLIC_REALM, csId: 'git-realm' })
-      .withAttributes({ repo: repoPath, csId: repoRealm });
+      .withAttributes({ repo, csId: repoRealm });
 
     await service.create(`${myOrigin}/api/realms/meta`, repoDoc.jsonapi);
 


### PR DESCRIPTION
only using relative paths in the git realm cards so that can be portable across different hubs that have different filesystems