### PR TITLE
bugfix: context menu position #1464

### DIFF
--- a/packages/cardhost/app/styles/components/card-renderer-header.css
+++ b/packages/cardhost/app/styles/components/card-renderer-header.css
@@ -112,7 +112,7 @@
   border-radius: 10px;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.4);
   top: 42px;
-  right: -130px;
+  right: -180px;
   width: 230px;
   padding-bottom: 10px;
 }
@@ -121,9 +121,9 @@
 
 .fields .context-menu-nav {
   position: fixed;
-  top: auto;
   margin-left: 405px;
   margin-top: -13px;
+  top: 135px;
   right: auto;
 }
 


### PR DESCRIPTION
The context menu was misaligned in the View Mode and its position drifted in the Schema mode (due to "top: auto").

This fix uses magic numbers. @burieberry is there something better I should do here?

How to test:
Use the context menu to switch modes at different screen sizes.

## Before

See screenshots in https://github.com/cardstack/cardstack/issues/1464

## After

<img width="555" alt="Screen Shot 2020-03-20 at 2 51 41 PM" src="https://user-images.githubusercontent.com/16627268/77197140-05fb3800-6abb-11ea-879a-868c84d764f4.png">

<img width="555" alt="Screen Shot 2020-03-20 at 2 51 41 PM" src="https://user-images.githubusercontent.com/16627268/77197154-0bf11900-6abb-11ea-9653-beedce05e081.png">
