### PR TITLE
Fix typo causing strangeness in transition to photo-card schema mode

### DIFF
--- a/packages/cardhost/app/components/scaffolding/photo-card/isolated-layout.js
+++ b/packages/cardhost/app/components/scaffolding/photo-card/isolated-layout.js
@@ -27,6 +27,6 @@ export default class PhotoCardIsolatedComponent extends BaseIsolatedLayoutCompon
   }
 
   get bylineIsEditable() {
-    return this.args.mode === 'edit' || this.args.model === 'schema';
+    return this.args.mode === 'edit' || this.args.mode === 'schema';
   }
 }


### PR DESCRIPTION
Found a typo on the condition for how the byline-card was rendered. It was breaking a lot of things when transitioning to the photo-card's schema mode from another mode:

Before:
<img width="1036" alt="photo-card-schema-broken" src="https://user-images.githubusercontent.com/16160806/77356606-0a269000-6d1d-11ea-8024-556cf1433d68.png">

After:
<img width="1036" alt="photo-card-schema" src="https://user-images.githubusercontent.com/16160806/77356809-67224600-6d1d-11ea-90da-2cd3368b93c4.png">


