### PR TITLE
Change default field icon #1495

### DIFF
--- a/packages/cardhost/app/helpers/catalog-field-icon.ts
+++ b/packages/cardhost/app/helpers/catalog-field-icon.ts
@@ -53,6 +53,8 @@ export default helper(function catalogFieldIcon([title]) {
   if (matched) {
     return matched.icon;
   } else {
-    return 'string-field-icon';
+    // Default to base-card icon if there's no match.
+    // svg-jar errors if no svg is provided.
+    return 'has-many-field-icon';
   }
 });

--- a/packages/cardhost/tests/integration/helpers/catalog-field-icon-test.js
+++ b/packages/cardhost/tests/integration/helpers/catalog-field-icon-test.js
@@ -6,12 +6,19 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Helper | catalog-field-icon', function(hooks) {
   setupRenderingTest(hooks);
 
-  // Replace this with your real tests.
   test('it renders', async function(assert) {
     this.set('inputValue', 'Text');
 
     await render(hbs`{{catalog-field-icon this.inputValue}}`);
 
     assert.equal(this.element.textContent.trim(), 'string-field-icon');
+  });
+
+  test('it has a default icon', async function(assert) {
+    this.set('inputValue', 'something nonexistant');
+
+    await render(hbs`{{catalog-field-icon this.inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), 'has-many-field-icon');
   });
 });


### PR DESCRIPTION
Swap the default field icon to be the same as "base card" instead of "string"

## Changed
Default in the field icon helper

## Added
A test for the default