### PR TITLE
Add card toString function

### DIFF
--- a/packages/hub/card.ts
+++ b/packages/hub/card.ts
@@ -238,6 +238,10 @@ export class Card {
     }
   }
 
+  toString() {
+    return `Card [${this.csId}]`;
+  }
+
   @Memoize()
   get document(): CardDocument {
     let jsonapi: SingleResourceDoc = { data: { type: 'cards' } };

--- a/packages/hub/node-tests/card-service-test.ts
+++ b/packages/hub/node-tests/card-service-test.ts
@@ -60,6 +60,15 @@ describe('hub/card-service', function() {
       expect(url.toString()).to.equal('https://cardstack.com/');
     });
 
+    it('has a meaningful toString function', async function() {
+      let doc = cardDocument()
+        .withAttributes({ link: 'https://cardstack.com', csId: 'my-card' })
+        .withField('link', 'url-field');
+      let card = await service.create(`${myOrigin}/api/realms/first-ephemeral-realm`, doc.jsonapi);
+
+      expect(card.toString()).to.equal('Card [my-card]');
+    });
+
     it('deserializes date field values as strings', async function() {
       let doc = cardDocument()
         .withAttributes({ birthday: '2019-10-30' })


### PR DESCRIPTION
When a card should be represented as a string, show something more meaningful
than `[object object]`

Fixes #1494 (and any similar places where this would show up)