### PR TITLE
Improve how header and border show when hovering over a card

### DIFF
--- a/packages/cardhost/app/components/card-renderer.hbs
+++ b/packages/cardhost/app/components/card-renderer.hbs
@@ -13,6 +13,7 @@
       data-test-card-renderer={{@card.canonicalURL}}
       data-test-card-loaded={{stringify this.loadCard.isIdle}}
       {{on "focus" (action this.cardIsFocused true)}}
+      {{on "mouseenter" (action this.setIsSelected true)}} {{on "mouseleave" (action this.setIsSelected false)}}
       {{did-insert this.focusCard true}}
       {{did-update this.cardUpdated @card @suppressCss @mode}}
       {{will-destroy this.removeCardCss}}
@@ -20,7 +21,7 @@
       {{#unless @suppressHeader}}
         {{#if (eq @mode "view")}}
           <AnimatedContainer class="card-renderer-isolated--animated-view-header">
-            {{#animated-value @card watch=this.animatedWatchField use=this.headerAnimation group="header"}}
+            {{#animated-value this watch=this.animatedWatchFields use=this.headerAnimation group="header"}}
               <CardRendererHeader
                 @cardSelected={{if (and this.cardstackSession.isAuthenticated @cardSelected) true}}
                 @card={{@card}}
@@ -34,7 +35,7 @@
           </AnimatedContainer>
         {{else}}
           <AnimatedContainer class="card-renderer-isolated--animated-header">
-            {{#animated-value @card watch=this.animatedWatchField use=this.headerAnimation group="header"}}
+            {{#animated-value this watch=this.animatedWatchFields use=this.headerAnimation group="header"}}
               <CardRendererHeader
                 @cardSelected={{true}}
                 @card={{@card}}
@@ -55,18 +56,18 @@
           {{concat (safe-css-string (if @card.canonicalURL @card.canonicalURL @card.adoptsFromURL)) "--isolated" }}
         "
       >
-        {{#animated-value @card watch=this.animatedWatchField use=this.cardTransition group="body"}}
+        {{#animated-value this watch=this.animatedWatchFields use=this.cardTransition group="body"}}
           {{!-- the "card-boundary" class in the div below is necessary for the card's custom CSS.
           This is the top level selector that people should be specifying in the themer when they
           style their cards. --}}
           <div
             class="card-renderer-isolated--card-container card-boundary
-            {{if (and this.cardstackSession.isAuthenticated @card.isSelected) "selected"}}
+            {{if (and this.cardstackSession.isAuthenticated @cardSelected) "selected"}}
             "
           >
             <div>
               <AnimatedContainer>
-                {{#animated-value @card watch=this.animatedWatchField use=@contentTransition group="content"}}
+                {{#animated-value this watch=this.animatedWatchFields use=@contentTransition group="content"}}
                   <div>
                     {{#if @dropField}}
                       <DropZone
@@ -108,6 +109,8 @@
         {{concat (safe-css-string (if @card.canonicalURL @card.canonicalURL @card.adoptsFromURL)) "--embedded" }}
         {{@class}}
       "
+      {{on "mouseenter" (action this.setIsSelected true)}} {{on "mouseleave" (action this.setIsSelected false)}}
+      role="button"
       data-test-card-renderer-embedded={{@card.canonicalURL}}
       data-test-card-renderer={{@card.canonicalURL}}
       data-test-card-loaded={{stringify this.loadCard.isIdle}}

--- a/packages/cardhost/app/components/card-viewer.hbs
+++ b/packages/cardhost/app/components/card-viewer.hbs
@@ -1,15 +1,15 @@
 <section class="card-renderer--container"
   data-test-card-view={{@card.canonicalURL}}
 >
-  {{!-- ugh, we're monkey patching the Card API --}}
-  <div role="button" class="card-renderer--inner-container {{@mode}}-container" {{on "mouseenter" (action (mut @card.isSelected) true)}} {{on "mouseleave" (action (mut @card.isSelected) false)}}>
+  <div role="button" class="card-renderer--inner-container {{@mode}}-container">
     <CardRenderer
       @card={{@card}}
       @mode={{@mode}}
       @format="isolated"
-      @cardSelected={{@card.isSelected}}
+      @cardSelected={{this.isSelected}}
       @contextMenuOpen={{this.contextMenuOpen}}
       @setContextMenu={{this.setContextMenu}}
+      @setIsSelected={{action (mut this.isSelected)}}
     />
   </div>
 </section>

--- a/packages/cardhost/app/components/card-viewer.js
+++ b/packages/cardhost/app/components/card-viewer.js
@@ -3,21 +3,9 @@ import { tracked } from '@glimmer/tracking';
 import CardManipulator from './card-manipulator';
 
 export default class CardViewer extends CardManipulator {
-  @tracked isSelected = false;
   @tracked contextMenuOpen = false;
 
   resizeable = true;
-
-  @action
-  setSelected(bool) {
-    this.isSelected = bool;
-    if (!bool) {
-      // When the card header is closed, we need to set the context menu to closed as well.
-      // Otherwise, when you hover over the card again, you will see the context menu
-      // without clicking on the ... button
-      this.contextMenuOpen = false;
-    }
-  }
 
   @action
   setContextMenu(bool) {


### PR DESCRIPTION
Prevent header and border showing when hovering outside of the visible card
boundary.

Also clean up some monkey patching of the card api by making the property live
on the component instead of the card and changing what the animated-value component
watches

Fixes #1389 