### PR TITLE
create provider when sokol strategy initialized

### DIFF
--- a/packages/web-client/app/utils/web3-strategies/sokol.ts
+++ b/packages/web-client/app/utils/web3-strategies/sokol.ts
@@ -13,18 +13,7 @@ import { BigNumber } from '@ethersproject/bignumber';
 export default class SokolWeb3Strategy implements Layer2Web3Strategy {
   chainName = 'Sokol Testnet';
   chainId = 77;
-  provider = new WalletConnectProvider({
-    chainId: this.chainId,
-    rpc: {
-      77: 'https://sokol.poa.network',
-    },
-    connector: new CustomStorageWalletConnect(
-      {
-        bridge: BRIDGE,
-      },
-      this.chainId
-    ),
-  });
+  provider: any | undefined;
 
   @reads('provider.connector') connector!: IConnector;
   @tracked isConnected = false;
@@ -41,6 +30,18 @@ export default class SokolWeb3Strategy implements Layer2Web3Strategy {
   @tracked xdaiBalance: BigNumber | undefined;
 
   async initialize() {
+    this.provider = new WalletConnectProvider({
+      chainId: this.chainId,
+      rpc: {
+        77: 'https://sokol.poa.network',
+      },
+      connector: new CustomStorageWalletConnect(
+        {
+          bridge: BRIDGE,
+        },
+        this.chainId
+      ),
+    });
     this.connector.on('display_uri', (err, payload) => {
       if (err) {
         console.error('Error in display_uri callback', err);


### PR DESCRIPTION
CS-633 - fixes reconnection issues with WalletConnect

WalletConnect doesn't recommend reusing connectors, we should create a new one each time to prevent this from happening. This bug? is documented (with solutions) at:

https://github.com/WalletConnect/walletconnect-monorepo/pull/370

We could try replacing the WalletConnect connector with a new one but keeping the provider. However the provider appears to perform quite a few asynchronous operations with its connector (https://github.com/WalletConnect/walletconnect-monorepo/blob/next/packages/providers/web3-provider/src/index.ts), so to me recreating the provider seems better than only replacing the connector.

I'm not sure what edge cases might happen if an operation is incomplete when the user disconnects their wallet from the wallet side - we might want to look into this when we get to the unlock and deposit part of the workflow.