### PR TITLE
update radio for new implementation in boxel

### DIFF
--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
@@ -57,8 +57,8 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
       return 'default';
     }
   }
-  @action changeWalletProvider(e: Event): void {
-    this.currentWalletProviderId = (e.target as HTMLInputElement).id;
+  @action changeWalletProvider(id: string): void {
+    this.currentWalletProviderId = id;
   }
   @action connect() {
     if (!this.hasAccount) {

--- a/packages/web-client/app/components/card-pay/layer-one-wallet-provider-selection/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-one-wallet-provider-selection/index.hbs
@@ -12,7 +12,7 @@
     @id={{item.data.id}}
     @value={{item.data.name}}
     @checked={{item.checked}}
-    @onChange={{@changeWalletProvider}}
+    @onChange={{fn (optional @changeWalletProvider) item.data.id}}
     @focusedClass="card-pay-layer-one-wallet-provider-selection__item--focused"
     @checkedClass="card-pay-layer-one-wallet-provider-selection__item--checked"
     class={{cn 


### PR DESCRIPTION
New implementation of CustomRadio in Boxel does not use the `id` attribute, so we need to adjust the code to use another way to update.

https://github.com/cardstack/boxel/blob/main/addon/components/boxel/custom-radio/item/index.hbs