### PR TITLE
Update deposit (transaction-setup) card UI

### DIFF
--- a/packages/web-client/app/components/action-card-container/index.css
+++ b/packages/web-client/app/components/action-card-container/index.css
@@ -1,0 +1,28 @@
+.action-card-container {
+  width: 100%;
+  max-width: 43.75rem; /* 700px */
+  color: var(--boxel-dark);
+  font: var(--boxel-font);
+  letter-spacing: var(--boxel-lsp);
+  box-shadow: 0 15px 30px rgba(0, 0, 0, 0.15);
+  transition: all var(--boxel-transition);
+}
+
+.action-card-container--is-complete {
+  max-width: 36.25rem; /* 580px */
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+}
+
+.action-card-container__header {
+  --boxel-header-text-color: var(--boxel-purple-400);
+  --boxel-header-background-color: transparent;
+
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.action-card-container:hover .action-card-container__header {
+  background-color: var(--boxel-purple-100);
+  color: var(--boxel-dark);
+}

--- a/packages/web-client/app/components/action-card-container/index.hbs
+++ b/packages/web-client/app/components/action-card-container/index.hbs
@@ -1,0 +1,10 @@
+<Boxel::CardContainer class={{cn "action-card-container" action-card-container--is-complete=@isComplete}} ...attributes>
+  {{#if (and @header (not @suppressHeader))}}
+    <Boxel::Header
+      class="action-card-container__header"
+      @header={{@header}}
+    />
+  {{/if}}
+
+  {{yield}}
+</Boxel::CardContainer>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.css
@@ -1,0 +1,93 @@
+.deposit-card__section {
+  padding: var(--boxel-sp-xxl) var(--boxel-sp-lg);
+}
+
+.deposit-card__section > * + *,
+.deposit-card__fieldset > * + * {
+  margin-top: var(--boxel-sp-xxl);
+}
+
+.deposit-card__fieldset {
+  padding: 0;
+  border: none;
+}
+
+.deposit-card__legend {
+  margin: 0;
+  padding: 0;
+  font: 700 1.125rem/calc(24/18) var(--boxel-font-family);
+  letter-spacing: 0;
+}
+
+.deposit-card__field {
+  grid-template-columns: 2.5rem 1fr;
+  row-gap: 0;
+}
+
+.deposit-card__field-value {
+  font: 600 var(--boxel-font);
+  letter-spacing: var(--boxel-lsp-xs);
+}
+
+.deposit-card__field-value-sm {
+  font: 600 var(--boxel-font-sm);
+}
+
+.deposit-card__field-address {
+  color: var(--boxel-purple-400);
+  font-family: var(--boxel-monospace-font-family);
+  font-size: var(--boxel-font-size);
+  line-height: calc(22 / 16);
+  letter-spacing: var(--boxel-lsp-sm);
+  word-break: break-all;
+}
+
+.deposit-card__field-address--view-only {
+  max-width: 23ch;
+}
+
+.deposit-card__field-address-sm {
+  color: var(--boxel-purple-500);
+  font-size: var(--boxel-font-size-sm);
+  line-height: calc(18 / 13);
+}
+
+.deposit-card__field-info {
+  grid-column: 2;
+}
+
+.deposit-card__field-info--full-width {
+  grid-column: 1 / -1;
+  margin-top: var(--boxel-sp);
+}
+
+.deposit-card__field-info--full-width > * + * {
+  margin-top: var(--boxel-sp);
+}
+
+.deposit-card__account {
+  display: flex;
+  align-items: center;
+  margin-top: var(--boxel-sp-xxs);
+}
+
+.deposit-card__depot {
+  display: flex;
+  align-items: center;
+  margin-top: var(--boxel-sp-xxxs);
+  margin-left: var(--boxel-sp-sm);
+  padding-top: var(--boxel-sp);
+  padding-left: var(--boxel-sp-sm);
+  border-left: 1px solid var(--boxel-purple-300);
+}
+
+.deposit-card__field-icon {
+  align-self: flex-start;
+  margin-right: var(--boxel-sp-sm);
+}
+
+.deposit-card__field-icon-sm {
+  /* width: 1.25rem;
+  height: 1.25rem; */
+  margin-right: var(--boxel-sp-xs);
+}

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
@@ -1,32 +1,65 @@
-<Boxel::CardContainer>
-  <label>Deposit funds from Ethereum Mainnet wallet</label>
-  <button data-test-layer-1-source-trigger type="button" {{on 'click' (set this 'isShowingLayer1SourceOptions' true)}}>
-    Layer 1
-  </button>
-  {{#if this.isShowingLayer1SourceOptions}}
-    <button data-test-ethereum-option type="button" {{on 'click' (fn this.chooseSource 'default-token')}}>
-      Ethereum<br>
-      <span data-test-eth-balance>{{format-token-amount this.layer1Network.defaultTokenBalance}}</span>
-    </button>
-    <button data-test-dai-option type="button" {{on 'click' (fn this.chooseSource 'DAI')}}>
-      DAI<br>
-      <span data-test-dai-balance>{{format-token-amount this.layer1Network.daiBalance}}</span>
-    </button>
-    <button data-test-card-option type="button" {{on 'click' (fn this.chooseSource 'CARD')}}>
-      CARD<br>
-      <span data-test-card-balance>{{format-token-amount this.layer1Network.cardBalance}}</span>
-    </button>
-  {{/if}}
-  <label>Receive balance in xDai Chain wallet</label>
-  <button data-test-layer-2-target-trigger type="button" {{on 'click' (set this 'isShowingLayer2TargetOptions' true)}}>
-    Layer 2
-  </button>
-  {{#if this.isShowingLayer2TargetOptions}}
-    <div data-test-new-depot-option>
-      New Depot
-    </div>
-  {{/if}}
-  <Boxel::Button {{on 'click' @onComplete}} data-test-continue-button>
-    Continue
-  </Boxel::Button>
-</Boxel::CardContainer>
+<ActionCardContainer
+  @isComplete={{this.isComplete}}
+  @header="Deposit"
+  data-test-deposit-transaction-setup-is-complete={{this.isComplete}}
+>
+  <section class="deposit-card__section">
+    <fieldset class="deposit-card__fieldset">
+      <legend class="deposit-card__legend">Deposit tokens</legend>
+      <CardPay::LabeledValue @label="From:" class="deposit-card__field">
+        <div>
+          <div class="deposit-card__field-value">{{this.layer1Network.chainName}} wallet</div>
+          <div class="deposit-card__field-address" data-test-deposit-transaction-setup-from-address>{{this.layer1Network.walletInfo.firstAddress}}</div>
+        </div>
+        <div class={{cn "deposit-card__field-info" (unless this.isComplete "deposit-card__field-info--full-width")}}>
+          {{#each this.tokens as |token|}}
+            <CardPay::DepositWorkflow::TransactionSetup::TokenOption
+              @checked={{eq @workflowSession.state.depositSourceToken token.symbol}}
+              @onInput={{fn this.chooseSource token.symbol}}
+              @balance={{format-token-amount (if (eq token.symbol 'CARD') this.layer1Network.cardBalance this.layer1Network.daiBalance)}}
+              @tokenSymbol={{token.symbol}}
+              @tokenDescription={{token.description}}
+              @tokenIcon={{token.icon}}
+              @viewOnly={{this.isComplete}}
+            />
+          {{/each}}
+        </div>
+      </CardPay::LabeledValue>
+    </fieldset>
+    <fieldset class="deposit-card__fieldset">
+      <legend class="deposit-card__legend">Receive tokens</legend>
+      <CardPay::LabeledValue @label="In:" class="deposit-card__field">
+        <div class="deposit-card__field-value">{{this.layer2Network.chainName}} wallet</div>
+        <div class="deposit-card__field-info">
+          <div class="deposit-card__account">
+            <span class="deposit-card__field-icon deposit-card__field-icon-sm">
+              {{!-- placeholder for account icon --}}
+            </span>
+            <div>
+              <div class="deposit-card__field-value deposit-card__field-value-sm">Account</div>
+              <div class="deposit-card__field-address deposit-card__field-address-sm" data-test-deposit-transaction-setup-to-address>
+                {{truncate-middle this.layer2Network.walletInfo.firstAddress 7 4}}
+              </div>
+            </div>
+          </div>
+          <div class="deposit-card__depot">
+            {{svg-jar "depot" width="40" height="40" class="deposit-card__field-icon" role="presentation"}}
+            <div>
+              <div class="deposit-card__field-value">DEPOT:</div>
+              <div class={{cn "deposit-card__field-address" "deposit-card__field-address-sm" deposit-card__field-address--view-only=this.isComplete}} data-test-deposit-transaction-setup-depot-address>
+                {{!-- TODO: depot address --}}
+              </div>
+            </div>
+          </div>
+        </div>
+      </CardPay::LabeledValue>
+    </fieldset>
+  </section>
+  <Boxel::ActionChin
+    @disabled={{not @workflowSession.state.depositSourceToken}}
+    @mode={{if this.isComplete "memorialized" "data-entry"}}
+    @buttonText={{if this.isComplete "Edit" "Continue"}}
+    @onClickButton={{this.onComplete}}
+    data-test-deposit-transaction-setup
+  />
+</ActionCardContainer>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.ts
@@ -1,21 +1,67 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { equal, and } from 'macro-decorators';
 import { inject as service } from '@ember/service';
 import Layer1Network from '@cardstack/web-client/services/layer1-network';
+import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import WorkflowSession from '../../../../models/workflow/workflow-session';
+
 interface CardPayDepositWorkflowTransactionSetupComponentArgs {
   workflowSession: WorkflowSession;
   onComplete: (() => void) | undefined;
   onIncomplete: (() => void) | undefined;
 }
+interface token {
+  symbol: string;
+  description: string;
+  icon: string;
+}
+const TOKENS: token[] = [
+  {
+    symbol: 'DAI',
+    description: 'USD-based stablecoin',
+    icon: 'dai-token',
+  },
+  {
+    symbol: 'CARD',
+    description: 'ERC-20 Cardstack token',
+    icon: 'card-token',
+  },
+];
+
 class CardPayDepositWorkflowTransactionSetupComponent extends Component<CardPayDepositWorkflowTransactionSetupComponentArgs> {
+  tokens = TOKENS;
   @service declare layer1Network: Layer1Network;
-  @tracked isShowingLayer1SourceOptions = false;
-  @tracked isShowingLayer2TargetOptions = false;
+  @service declare layer2Network: Layer2Network;
+
+  @equal('args.workflowSession.state.depositSourceToken', 'CARD')
+  cardSelected: Boolean | undefined;
+  @equal('args.workflowSession.state.depositSourceToken', 'DAI')
+  daiSelected: Boolean | undefined;
+  @and('cardSelected', 'layer1Network.cardBalance')
+  hasCardBalance: Boolean | undefined;
+  @and('daiSelected', 'layer1Network.daiBalance')
+  hasDaiBalance: Boolean | undefined;
+
+  @tracked isComplete: boolean | undefined;
 
   @action chooseSource(tokenSymbol: string) {
     this.args.workflowSession.update('depositSourceToken', tokenSymbol);
+  }
+
+  @action onComplete() {
+    if (this.hasCardBalance || this.hasDaiBalance) {
+      this.isComplete = !this.isComplete;
+      if (this.args.onComplete) {
+        this.args.onComplete();
+      }
+    } else {
+      this.isComplete = false;
+      if (this.args.onIncomplete) {
+        this.args.onIncomplete();
+      }
+    }
   }
 }
 

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.css
@@ -1,0 +1,82 @@
+.token-option {
+  display: grid;
+  grid-template-columns: auto 1fr 1fr;
+  align-items: center;
+  gap: var(--boxel-sp);
+  padding: var(--boxel-sp);
+  border-radius: var(--boxel-border-radius);
+  box-shadow: 0 0 0 1px var(--boxel-light-400);
+  transition: box-shadow var(--boxel-transition);
+}
+
+.token-option:hover {
+  box-shadow: 0 0 0 1px var(--boxel-dark);
+}
+
+.token-option--checked,
+.token-option:focus,
+.token-option:focus-within {
+  box-shadow: 0 0 0 2px var(--boxel-highlight);
+  outline-color: transparent;
+  outline-width: 0px;
+}
+
+.token-option__input {
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  margin: 0;
+  border: 1.5px solid var(--boxel-dark);
+  border-radius: 100px;
+  background-color: transparent;
+}
+
+.token-option__input--checked {
+  background-color: var(--boxel-highlight);
+  border-width: 3px;
+}
+
+.token-option__input:focus {
+  outline-color: transparent;
+  outline-width: 0px;
+}
+
+.token-option__currency {
+  display: flex;
+  align-items: center;
+}
+
+.token-option__icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  object-fit: contain;
+  margin-right: var(--boxel-sp-sm);
+}
+
+.token-option__title {
+  color: var(--boxel-dark);
+  font: 600 var(--boxel-font);
+  letter-spacing: var(--boxel-lsp-xs);
+}
+
+.token-option__value {
+  color: var(--boxel-dark);
+  font: var(--boxel-font);
+  letter-spacing: var(--boxel-lsp-xs);
+}
+
+.token-option__desc {
+  color: var(--boxel-purple-500);
+  font: var(--boxel-font-sm);
+  letter-spacing: var(--boxel-lsp-xs);
+}
+
+/* view-only */
+.token-option__currency-display {
+  display: flex;
+  align-items: center;
+  margin-top: var(--boxel-sp-xxxs);
+  padding-top: var(--boxel-sp);
+  padding-left: var(--boxel-sp-sm);
+  border-left: 1px solid var(--boxel-purple-300);
+}

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.css
@@ -17,8 +17,7 @@
 .token-option:focus,
 .token-option:focus-within {
   box-shadow: 0 0 0 2px var(--boxel-highlight);
-  outline-color: transparent;
-  outline-width: 0px;
+  outline: 1px solid transparent;
 }
 
 .token-option__input {
@@ -37,8 +36,7 @@
 }
 
 .token-option__input:focus {
-  outline-color: transparent;
-  outline-width: 0px;
+  outline: 1px solid transparent;
 }
 
 .token-option__currency {

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.hbs
@@ -1,0 +1,49 @@
+{{#if @viewOnly}}
+  {{#if @checked}}
+    <div class="token-option__currency-display" data-test-option-view-only>
+      {{svg-jar @tokenIcon class="token-option__icon" role="presentation" width="40" height="40"}}
+      <div>
+        <div class="token-option__title" data-test-balance-view-only={{@tokenSymbol}}>
+          {{@balance}} {{uppercase @tokenSymbol}}
+        </div>
+        <div class="token-option__desc" data-test-usd-balance-view-only={{@tokenSymbol}}>
+          {{!-- TODO: usd balance --}}
+          ≈ $ USD
+        </div>
+      </div>
+    </div>
+  {{/if}}
+{{else}}
+  <label class={{cn "token-option" token-option--checked=@checked}} ...attributes>
+    <Input
+      name="deposit-token"
+      class={{cn "token-option__input" token-option__input--checked=@checked}}
+      @type="radio"
+      @checked={{@checked}}
+      {{on "input" @onInput}}
+    />
+    <div class="token-option__currency">
+      {{svg-jar @tokenIcon class="token-option__icon" role="presentation" width="40" height="40"}}
+      <div>
+        <div class="token-option__title" data-test-option={{@tokenSymbol}}>
+          {{@tokenSymbol}}
+        </div>
+        <div class="token-option__desc">
+          {{@tokenDescription}}
+        </div>
+      </div>
+    </div>
+    <div>
+      <div class="token-option__desc">
+        Balance
+      </div>
+      <div class="token-option__value" data-test-balance={{@tokenSymbol}}>
+        {{@balance}} {{@tokenSymbol}}
+      </div>
+      <div class="token-option__desc" data-test-usd-balance={{@tokenSymbol}}>
+        {{!-- TODO: usd balance --}}
+        ≈ $ USD
+      </div>
+    </div>
+  </label>
+{{/if}}

--- a/packages/web-client/app/components/card-pay/labeled-value/index.css
+++ b/packages/web-client/app/components/card-pay/labeled-value/index.css
@@ -10,17 +10,18 @@
 }
 
 .card-pay-labeled-value__contents {
-  font-size: 1rem;
+  font-size: var(--boxel-font-size);
   line-height: var(--field-text-line-height);
+  letter-spacing: var(--boxel-lsp-sm);
 }
 
-/* 
+/*
   hardcode max-width to a value that should break at 21 characters.
   this creates a display that matches the spec at full width but
   still respects flow
  */
  .card-pay-labeled-value--address .card-pay-labeled-value__contents {
-  font-family: "Roboto Mono";
+  font-family: var(--boxel-monospace-font-family);
   max-width: 22ch;
   word-break: break-all;
 }

--- a/packages/web-client/public/images/icons/depot.svg
+++ b/packages/web-client/public/images/icons/depot.svg
@@ -1,0 +1,1 @@
+<svg height="40" viewBox="0 0 40 40" width="40" xmlns="http://www.w3.org/2000/svg"><circle cx="20" cy="20" r="20"/><g fill="#fff"><circle cx="20" cy="20" r="6"/><path d="m23 19h12v2h-12z"/></g></svg>

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -130,15 +130,41 @@ module('Acceptance | deposit', function (hooks) {
 
     post = postableSel(2, 1);
 
-    await click(`${post} [data-test-layer-1-source-trigger]`);
-    await waitFor(`${post} [data-test-eth-balance]`);
-    assert.dom(`${post} [data-test-eth-balance]`).containsText('2.1411');
-    assert.dom(`${post} [data-test-dai-balance]`).containsText('250.5');
-    assert.dom(`${post} [data-test-card-balance]`).containsText('10000.0');
-    await click(`${post} [data-test-dai-option]`);
-    await click(`${post} [data-test-layer-2-target-trigger]`);
-    await click(`${post} [data-test-new-depot-option]`);
-    await click(`${post} [data-test-continue-button]`);
+    // transaction-setup card (not complete)
+    await waitFor(`${post} [data-test-balance="DAI"]`);
+    assert.dom(`${post} [data-test-balance="DAI"]`).containsText('250.5');
+    // TODO assert.dom(`${post} [data-test-usd-balance="DAI"]`).containsText('');
+    assert.dom(`${post} [data-test-balance="CARD"]`).containsText('10000.0');
+    // TODO assert.dom(`${post} [data-test-usd-balance="CARD"]`).containsText('');
+    assert
+      .dom(`${post} [data-test-deposit-transaction-setup-from-address]`)
+      .hasText(layer1AccountAddress);
+    assert
+      .dom(`${post} [data-test-deposit-transaction-setup-to-address]`)
+      .hasText('0x18261...6E44');
+    // TODO assert.dom(`${post} [data-test-deposit-transaction-setup-depot-address]`).hasText('');
+    assert
+      .dom('[data-test-deposit-transaction-setup-is-complete]')
+      .doesNotExist();
+    assert.dom(`${post} [data-test-option-view-only]`).doesNotExist();
+    assert
+      .dom('[data-test-deposit-transaction-setup] [data-test-boxel-button]')
+      .isDisabled();
+
+    await click(`${post} [data-test-option="DAI"]`);
+    await click(
+      `${post} [data-test-deposit-transaction-setup] [data-test-boxel-button]`
+    );
+    // transaction-setup card (completed)
+    assert.dom(`${post} [data-test-option]`).doesNotExist();
+    assert.dom(`${post} [data-test-option-view-only]`).exists({ count: 1 });
+    assert
+      .dom('[data-test-deposit-transaction-setup] [data-test-boxel-button]')
+      .isNotDisabled();
+    assert.dom('[data-test-deposit-transaction-setup-is-complete]').exists();
+    assert
+      .dom(`${post} [data-test-balance-view-only="DAI"]`)
+      .containsText('250.5');
 
     assert
       .dom(postableSel(2, 2))


### PR DESCRIPTION
Changes:
- Brought over the ActionContainer component to this repo (It's easier to make changes, as needed. We can also use the one in boxel, I'm fine with it either way.)
- Deposit (Transaction Setup) card template and styling

"Continue" button is disabled until a selection is made:
<img width="712" alt="deposit-data-entry" src="https://user-images.githubusercontent.com/16160806/116935398-4d4b7600-ac34-11eb-901b-9cdc6757b252.png">

Selection made:
<img width="696" alt="deposit-selected" src="https://user-images.githubusercontent.com/16160806/116935440-5e948280-ac34-11eb-9f43-dd5ce67722ba.png">

View-only mode after pressing "Continue":
<img width="671" alt="deposit-view" src="https://user-images.githubusercontent.com/16160806/116935522-72d87f80-ac34-11eb-8d0c-749dd97af52a.png">