### PR TITLE
assign provider on pre-connected layer one card

### DIFF
--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
@@ -10,10 +10,10 @@
   {{/unless}}
 
   <section class="layer-one-connect-card__body">
-    {{#if (eq this.cardState 'memorialized')}}
-      <header aria-label="Layer 1 Connected Header" class="layer-one-connect-card__body-header">
-        {{this.currentWalletProvider.name}}
-        <img class="layer-one-connect-card__body-header-logo" src={{this.currentWalletProvider.logo}} alt="" role="presentation">
+    {{#if this.connectedWalletProvider}}
+      <header aria-label="Layer 1 Connected Header" class="layer-one-connect-card__body-header" data-test-mainnet-connection-header>
+        {{this.connectedWalletProvider.name}}
+        <img class="layer-one-connect-card__body-header-logo" src={{this.connectedWalletProvider.logo}} alt="" role="presentation">
       </header>
       <CardPay::FieldStack>
         <CardPay::LabeledValue
@@ -45,17 +45,17 @@
   It may not reflect all the tokens in your wallet.
       </div>
     {{else}}
-      <header aria-label="Layer 1 Connection Header" class="layer-one-connect-card__body-header">Connect your Ethereum mainnet wallet</header>
+      <header aria-label="Layer 1 Connection Header" class="layer-one-connect-card__body-header" data-test-mainnet-connection-header>Connect your Ethereum mainnet wallet</header>
       <CardPay::LayerOneWalletProviderSelection
         @walletProviders={{this.walletProviders}}
-        @currentWalletProviderId={{this.currentWalletProviderId}}
+        @currentWalletProviderId={{this.radioWalletProviderId}}
         @changeWalletProvider={{this.changeWalletProvider}}
         @isConnecting={{this.isWaitingForConnection}}
         class="layer-one-connect-card__wallet-provider-selection"
       />
     {{/if}}
   </section>
-  <Boxel::CtaBlock @state={{this.cardState}}>
+  <Boxel::CtaBlock @state={{this.ctaState}}>
     <:default as |a|>
       <a.ActionButton {{on "click" this.connect}}>
         Connect Wallet
@@ -82,7 +82,7 @@
     <div class="layer-one-connect-card__connection-icons">
       <img src={{this.cardstackLogo}} alt="" role="presentation" class="layer-one-connect-card__connection-cardstack-logo">
       <img src={{this.connectionSymbol}} alt="" role="presentation" class="layer-one-connect-card__connection-symbol">
-      <img src={{this.currentWalletLogo}} alt="" role="presentation" class="layer-one-connect-card__connection-wallet-logo">
+      <img src={{this.connectedWalletLogo}} alt="" role="presentation" class="layer-one-connect-card__connection-wallet-logo">
     </div>
     <div class="layer-one-connect-card__connection-text">Waiting for you to connect Card Pay with your mainnet wallet...</div>
   </Boxel::CardContainer>

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
@@ -27,7 +27,7 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
   @service declare layer1Network: Layer1Network;
   @reads('layer1Network.hasAccount') declare hasAccount: boolean;
   @tracked isWaitingForConnection = false;
-  @tracked currentWalletProviderId = '';
+  @tracked radioWalletProviderId = '';
 
   constructor(
     owner: unknown,
@@ -36,24 +36,23 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
     super(owner, args);
     if (this.hasAccount) {
       next(this, () => {
-        this.currentWalletProviderId =
-          this.layer1Network.strategy.currentProviderId || '';
         this.args.onComplete?.();
       });
     }
   }
-  get currentWalletProvider(): WalletProvider | undefined {
+  get connectedWalletProvider(): WalletProvider | undefined {
     return this.walletProviders.find(
-      (walletProvider) => walletProvider.id === this.currentWalletProviderId
+      (walletProvider) =>
+        walletProvider.id === this.layer1Network.strategy.currentProviderId
     );
   }
-  get currentWalletLogo(): string {
-    let { currentWalletProvider } = this;
-    if (currentWalletProvider) return currentWalletProvider.logo;
+  get connectedWalletLogo(): string {
+    let { connectedWalletProvider } = this;
+    if (connectedWalletProvider) return connectedWalletProvider.logo;
     else return '';
   }
 
-  get cardState(): string {
+  get ctaState(): string {
     if (this.hasAccount) {
       return 'memorialized';
     } else if (this.isWaitingForConnection) {
@@ -64,7 +63,7 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
   }
 
   @action changeWalletProvider(id: string): void {
-    this.currentWalletProviderId = id;
+    this.radioWalletProviderId = id;
   }
   @action connect() {
     if (!this.hasAccount) {
@@ -86,8 +85,10 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
   }
   @task *connectWalletTask() {
     this.isWaitingForConnection = true;
-    if (this.currentWalletProvider) {
-      yield this.layer1Network.connect(this.currentWalletProvider);
+    if (this.radioWalletProviderId) {
+      yield this.layer1Network.connect({
+        id: this.radioWalletProviderId,
+      } as WalletProvider);
     }
     this.isWaitingForConnection = false;
     this.args.onConnect?.();

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
@@ -36,6 +36,8 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
     super(owner, args);
     if (this.hasAccount) {
       next(this, () => {
+        this.currentWalletProviderId =
+          this.layer1Network.strategy.currentProviderId || '';
         this.args.onComplete?.();
       });
     }

--- a/packages/web-client/app/components/card-pay/layer-one-wallet-provider-selection/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-one-wallet-provider-selection/index.hbs
@@ -5,6 +5,7 @@
   @checkedId={{@currentWalletProviderId}}
   @disabled={{@isConnecting}}
   ...attributes
+  data-test-wallet-selection
   as |item|
 >
   <item.component

--- a/packages/web-client/app/utils/web3-strategies/ethereum.ts
+++ b/packages/web-client/app/utils/web3-strategies/ethereum.ts
@@ -9,6 +9,7 @@ export default class EthereumWeb3Strategy implements Layer1Web3Strategy {
   chainName = 'Ethereum Mainnet';
   chainId = 1;
   isConnected: boolean = false;
+  currentProviderId: string | undefined;
   walletConnectUri: string | undefined;
   #waitForAccountDeferred = defer<void>();
   get waitForAccount(): Promise<void> {

--- a/packages/web-client/app/utils/web3-strategies/ethereum.ts
+++ b/packages/web-client/app/utils/web3-strategies/ethereum.ts
@@ -9,13 +9,13 @@ export default class EthereumWeb3Strategy implements Layer1Web3Strategy {
   chainName = 'Ethereum Mainnet';
   chainId = 1;
   isConnected: boolean = false;
-  currentProviderId: string | undefined;
   walletConnectUri: string | undefined;
   #waitForAccountDeferred = defer<void>();
   get waitForAccount(): Promise<void> {
     return this.#waitForAccountDeferred.promise;
   }
 
+  @tracked currentProviderId: string | undefined;
   @tracked defaultTokenBalance: BigNumber | undefined;
   @tracked daiBalance: BigNumber | undefined;
   @tracked cardBalance: BigNumber | undefined;

--- a/packages/web-client/app/utils/web3-strategies/kovan.ts
+++ b/packages/web-client/app/utils/web3-strategies/kovan.ts
@@ -38,7 +38,6 @@ export default class KovanWeb3Strategy implements Layer1Web3Strategy {
   chainId = networkIds['kovan'];
   bridgeableTokens = [daiToken, cardToken];
   walletConnectUri: string | undefined;
-  currentProviderId: string | undefined;
   provider: any | undefined;
   web3 = new Web3();
   cardTokenContract = new this.web3.eth.Contract(
@@ -47,6 +46,7 @@ export default class KovanWeb3Strategy implements Layer1Web3Strategy {
   );
   daiTokenContract = new this.web3.eth.Contract(daiToken.abi, daiToken.address);
 
+  @tracked currentProviderId: string | undefined;
   @tracked walletInfo = new WalletInfo([], this.chainId);
 
   @tracked defaultTokenBalance: BigNumber | undefined;

--- a/packages/web-client/app/utils/web3-strategies/test-layer1.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer1.ts
@@ -30,7 +30,7 @@ export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
   }
 
   disconnect(): Promise<void> {
-    this.test__simulateAccountsChanged([]);
+    this.test__simulateAccountsChanged([], '');
     return this.waitForAccount;
   }
 

--- a/packages/web-client/app/utils/web3-strategies/test-layer1.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer1.ts
@@ -10,7 +10,7 @@ import { TransactionReceipt } from 'web3-core';
 export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
   chainName = 'L1 Test Chain';
   chainId = -1;
-  currentProviderId: string | undefined;
+  @tracked currentProviderId: string | undefined;
   @tracked walletConnectUri: string | undefined;
   @tracked isConnected = false;
   @tracked walletInfo: WalletInfo = new WalletInfo([], -1);

--- a/packages/web-client/app/utils/web3-strategies/test-layer1.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer1.ts
@@ -10,6 +10,7 @@ import { TransactionReceipt } from 'web3-core';
 export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
   chainName = 'L1 Test Chain';
   chainId = -1;
+  currentProviderId: string | undefined;
   @tracked walletConnectUri: string | undefined;
   @tracked isConnected = false;
   @tracked walletInfo: WalletInfo = new WalletInfo([], -1);

--- a/packages/web-client/app/utils/web3-strategies/test-layer1.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer1.ts
@@ -57,10 +57,18 @@ export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
     this.walletConnectUri = 'This is a test of Layer2 Wallet Connect';
   }
 
-  test__simulateAccountsChanged(accounts: string[]) {
-    this.isConnected = true;
-    this.walletInfo = new WalletInfo(accounts, this.chainId);
-    this.waitForAccountDeferred.resolve();
+  test__simulateAccountsChanged(accounts: string[], walletProviderId?: string) {
+    if (accounts.length && walletProviderId) {
+      this.isConnected = true;
+      this.currentProviderId = walletProviderId;
+      this.walletInfo = new WalletInfo(accounts, this.chainId);
+      this.waitForAccountDeferred.resolve();
+    } else {
+      this.isConnected = false;
+      this.currentProviderId = '';
+      this.walletInfo = new WalletInfo([], this.chainId);
+      this.waitForAccountDeferred.resolve();
+    }
   }
 
   test__simulateBalances(balances: {

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -13,6 +13,7 @@ export interface Web3Strategy {
 
 export interface Layer1Web3Strategy extends Web3Strategy {
   defaultTokenBalance: BigNumber | undefined;
+  currentProviderId: string | undefined;
   daiBalance: BigNumber | undefined;
   cardBalance: BigNumber | undefined;
   connect(walletProvider: WalletProvider): Promise<void>; // eslint-disable-line no-unused-vars

--- a/packages/web-client/tests/acceptance/connect-wallet-test.ts
+++ b/packages/web-client/tests/acceptance/connect-wallet-test.ts
@@ -33,7 +33,10 @@ module('Acceptance | Connect Wallet', function (hooks) {
 
     // Simulate the user connecting their Metamask wallet
     let layer1AccountAddress = '0xaCD5f5534B756b856ae3B2CAcF54B3321dd6654Fb6';
-    layer1Service.test__simulateAccountsChanged([layer1AccountAddress]);
+    layer1Service.test__simulateAccountsChanged(
+      [layer1AccountAddress],
+      'metamask'
+    );
     await waitUntil(
       () => !document.querySelector('[data-test-layer-one-connect-modal]')
     );

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -63,12 +63,16 @@ module('Acceptance | deposit', function (hooks) {
     let layer1AccountAddress = '0xaCD5f5534B756b856ae3B2CAcF54B3321dd6654Fb6';
     let layer1Service = this.owner.lookup('service:layer1-network')
       .strategy as Layer1TestWeb3Strategy;
-    layer1Service.test__simulateAccountsChanged([layer1AccountAddress]);
+    layer1Service.test__simulateAccountsChanged(
+      [layer1AccountAddress],
+      'metamask'
+    );
     layer1Service.test__simulateBalances({
       defaultToken: BigNumber.from('2141100000000000000'),
       dai: BigNumber.from('250500000000000000000'),
       card: BigNumber.from('10000000000000000000000'),
     });
+
     await waitFor(`${post} [data-test-balance="ETH"]`);
     assert.dom(`${post} [data-test-balance="ETH"]`).containsText('2.1411');
     assert.dom(`${post} [data-test-balance="DAI"]`).containsText('250.5');
@@ -245,7 +249,10 @@ module('Acceptance | deposit', function (hooks) {
       .strategy as Layer1TestWeb3Strategy;
 
     let layer1AccountAddress = '0xaCD5f5534B756b856ae3B2CAcF54B3321dd6654Fb6';
-    layer1Service.test__simulateAccountsChanged([layer1AccountAddress]);
+    layer1Service.test__simulateAccountsChanged(
+      [layer1AccountAddress],
+      'metamask'
+    );
     await waitUntil(
       () => !document.querySelector('[data-test-layer-one-connect-modal]')
     );
@@ -368,7 +375,10 @@ module('Acceptance | deposit', function (hooks) {
     let layer1AccountAddress = '0xaCD5f5534B756b856ae3B2CAcF54B3321dd6654Fb6';
     let layer1Service = this.owner.lookup('service:layer1-network')
       .strategy as Layer1TestWeb3Strategy;
-    layer1Service.test__simulateAccountsChanged([layer1AccountAddress]);
+    layer1Service.test__simulateAccountsChanged(
+      [layer1AccountAddress],
+      'metamask'
+    );
 
     await waitFor(milestoneCompletedSel(0));
     assert
@@ -395,7 +405,10 @@ module('Acceptance | deposit', function (hooks) {
     let layer1Service = this.owner.lookup('service:layer1-network')
       .strategy as Layer1TestWeb3Strategy;
     let layer1AccountAddress = '0xaCD5f5534B756b856ae3B2CAcF54B3321dd6654Fb6';
-    layer1Service.test__simulateAccountsChanged([layer1AccountAddress]);
+    layer1Service.test__simulateAccountsChanged(
+      [layer1AccountAddress],
+      'metamask'
+    );
     layer1Service.test__simulateBalances({
       defaultToken: BigNumber.from('2141100000000000000'),
       dai: BigNumber.from('250500000000000000000'),
@@ -454,7 +467,10 @@ module('Acceptance | deposit', function (hooks) {
     let layer1Service = this.owner.lookup('service:layer1-network')
       .strategy as Layer1TestWeb3Strategy;
     let layer1AccountAddress = '0xaCD5f5534B756b856ae3B2CAcF54B3321dd6654Fb6';
-    layer1Service.test__simulateAccountsChanged([layer1AccountAddress]);
+    layer1Service.test__simulateAccountsChanged(
+      [layer1AccountAddress],
+      'metamask'
+    );
     layer1Service.test__simulateBalances({
       defaultToken: BigNumber.from('2141100000000000000'),
       dai: BigNumber.from('250500000000000000000'),

--- a/packages/web-client/tests/integration/components/layer-one-connect-card-test.ts
+++ b/packages/web-client/tests/integration/components/layer-one-connect-card-test.ts
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
+
+module('Integration | Component | layer-one-connect-card', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("It should render the wallet provider's name if provided at the start", async function (assert) {
+    let layer1Service = this.owner.lookup('service:layer1-network')
+      .strategy as Layer1TestWeb3Strategy;
+
+    layer1Service.test__simulateAccountsChanged(['address'], 'metamask');
+
+    await render(hbs`
+        <CardPay::LayerOneConnectCard/>
+      `);
+
+    assert
+      .dom('[data-test-mainnet-connection-header]')
+      .containsText('Metamask');
+  });
+
+  test('If should show a selection UI if layer 1 is not connected', async function (assert) {
+    await render(hbs`
+        <CardPay::LayerOneConnectCard/>
+      `);
+
+    assert
+      .dom('[data-test-mainnet-connection-header]')
+      .containsText('Connect your Ethereum mainnet wallet');
+
+    assert.dom('[data-test-wallet-selection]').isVisible();
+  });
+});


### PR DESCRIPTION
CS-653

- Adds `currentProviderId` property to the `Layer1WebStrategy` type
- Assigns provider for layer one connection card by checking `layer1Network.strategy.currentProviderId` if there is a connected layer 1 account.