### PR TITLE
Use action container component

### DIFF
--- a/packages/web-client/app/components/action-card-container/index.css
+++ b/packages/web-client/app/components/action-card-container/index.css
@@ -1,15 +1,13 @@
 .action-card-container {
-  width: 100%;
-  max-width: 43.75rem; /* 700px */
   color: var(--boxel-dark);
   font: var(--boxel-font);
   letter-spacing: var(--boxel-lsp);
   box-shadow: 0 15px 30px rgba(0, 0, 0, 0.15);
-  transition: all var(--boxel-transition);
+  /* box-shadow is implemented here so it follows the border-radius of this container */
+  transition: box-shadow var(--boxel-transition);
 }
 
 .action-card-container--is-complete {
-  max-width: 36.25rem; /* 580px */
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
 }
 

--- a/packages/web-client/app/components/card-pay/deposit-workflow/confirmation/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/confirmation/index.hbs
@@ -1,3 +1,6 @@
-<Boxel::CardContainer>
+<ActionCardContainer
+  @header="Confirmation"
+  @isComplete={{@isComplete}}
+>
   Confirmation
-</Boxel::CardContainer>
+</ActionCardContainer>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/index.ts
@@ -41,8 +41,12 @@ class DepositWorkflow extends Workflow {
           author: cardbot,
           message: `In order to make a deposit, you need to connect two wallets:
 
-  * Ethereum Mainnet Wallet: linked to the Ethereum blockchain on mainnet
-  * xDai Chain Wallet: linked to the xDai blockchain for low-cost transactions
+  * **Ethereum mainnet wallet:**
+
+      Linked to the Ethereum blockchain on mainnet
+  * **xDai chain wallet:**
+
+      Linked to the xDai blockchain for low-cost transactions
 `,
         }),
         new WorkflowMessage({

--- a/packages/web-client/app/components/card-pay/deposit-workflow/next-steps/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/next-steps/index.hbs
@@ -1,3 +1,1 @@
-<Boxel::CardContainer>
-  Suggested Next Steps
-</Boxel::CardContainer>
+<Boxel::NextStepsBox />

--- a/packages/web-client/app/components/card-pay/deposit-workflow/supplier-badge/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/supplier-badge/index.hbs
@@ -1,3 +1,6 @@
-<Boxel::CardContainer>
+<ActionCardContainer
+  @header="Badge"
+  @isComplete={{true}}
+>
   Supplier Badge
-</Boxel::CardContainer>
+</ActionCardContainer>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/supplier-badge/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/supplier-badge/index.hbs
@@ -1,6 +1,6 @@
 <ActionCardContainer
   @header="Badge"
-  @isComplete={{true}}
+  @isComplete={{@isComplete}}
 >
   Supplier Badge
 </ActionCardContainer>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -1,9 +1,8 @@
-<Boxel::CardContainer
+<ActionCardContainer
   class="card-pay-transaction-amount"
+  @header="Deposit Amount"
+  @isComplete={{@isComplete}}
 >
-  <Boxel::Header
-    @header="Deposit amount"
-  />
   <section class="card-pay-transaction-amount__body">
     <header class="card-pay-transaction-amount__body-header">
       Choose an amount to deposit into the reserve pool
@@ -24,7 +23,7 @@
         @value={{concat this.amount " " this.currentTokenDetails.symbol}}
       />
       {{else}}
-      <Boxel::Field 
+      <Boxel::Field
         @label="Amount to deposit"
         @fieldMode="edit"
         class="card-pay-transaction-amount__field"
@@ -32,8 +31,8 @@
       >
       <div class="card-pay-transaction-amount__amount-field-input-container">
         {{svg-jar this.currentTokenDetails.icon class="card-pay-transaction-amount__amount-field-currency-icon" role="presentation"}}
-        {{!-- 
-          .boxel-input is a hack to get the boxel styles.  
+        {{!--
+          .boxel-input is a hack to get the boxel styles.
           depending on how we plan to handle validation of this input,
           we may need to change Boxel's input to use a more DDAU pattern
         --}}
@@ -117,4 +116,4 @@
       {{/if}}
     </:memorialized>
   </Boxel::CtaBlock>
-</Boxel::CardContainer>
+</ActionCardContainer>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -53,7 +53,7 @@
       <CardPay::LabeledValue
         @icon="dollar"
         @label="Approximate value"
-        @value={{concat this.amountInUsd " USD"}}
+        {{!-- TODO @value={{concat this.amountInUsd " USD"}} --}}
       />
 
     </div>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
@@ -13,6 +13,7 @@ import { parseEther } from '@ethersproject/units';
 interface CardPayDepositWorkflowTransactionAmountComponentArgs {
   workflowSession: WorkflowSession;
   onComplete: () => void;
+  isComplete: boolean;
 }
 
 interface TokenDisplayDetails {

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
@@ -1,7 +1,7 @@
 <ActionCardContainer
-  @isComplete={{this.isComplete}}
   @header="Deposit"
-  data-test-deposit-transaction-setup-is-complete={{this.isComplete}}
+  @isComplete={{@isComplete}}
+  data-test-deposit-transaction-setup-is-complete={{@isComplete}}
 >
   <section class="deposit-card__section">
     <fieldset class="deposit-card__fieldset">
@@ -11,7 +11,7 @@
           <div class="deposit-card__field-value">{{this.layer1Network.chainName}} wallet</div>
           <div class="deposit-card__field-address" data-test-deposit-transaction-setup-from-address>{{this.layer1Network.walletInfo.firstAddress}}</div>
         </div>
-        <div class={{cn "deposit-card__field-info" (unless this.isComplete "deposit-card__field-info--full-width")}}>
+        <div class={{cn "deposit-card__field-info" (unless @isComplete "deposit-card__field-info--full-width")}}>
           {{#each this.tokens as |token|}}
             <CardPay::DepositWorkflow::TransactionSetup::TokenOption
               @checked={{eq @workflowSession.state.depositSourceToken token.symbol}}
@@ -20,7 +20,7 @@
               @tokenSymbol={{token.symbol}}
               @tokenDescription={{token.description}}
               @tokenIcon={{token.icon}}
-              @viewOnly={{this.isComplete}}
+              @viewOnly={{@isComplete}}
             />
           {{/each}}
         </div>
@@ -46,7 +46,7 @@
             {{svg-jar "depot" width="40" height="40" class="deposit-card__field-icon" role="presentation"}}
             <div>
               <div class="deposit-card__field-value">DEPOT:</div>
-              <div class={{cn "deposit-card__field-address" "deposit-card__field-address-sm" deposit-card__field-address--view-only=this.isComplete}} data-test-deposit-transaction-setup-depot-address>
+              <div class={{cn "deposit-card__field-address" "deposit-card__field-address-sm" deposit-card__field-address--view-only=@isComplete}} data-test-deposit-transaction-setup-depot-address>
                 {{!-- TODO: depot address --}}
               </div>
             </div>
@@ -57,9 +57,9 @@
   </section>
   <Boxel::ActionChin
     @disabled={{not @workflowSession.state.depositSourceToken}}
-    @mode={{if this.isComplete "memorialized" "data-entry"}}
-    @buttonText={{if this.isComplete "Edit" "Continue"}}
-    @onClickButton={{this.onComplete}}
+    @mode={{if @isComplete "memorialized" "data-entry"}}
+    @buttonText={{if @isComplete "Edit" "Continue"}}
+    @onClickButton={{this.toggleComplete}}
     data-test-deposit-transaction-setup
   />
 </ActionCardContainer>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.ts
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 import { equal, and } from 'macro-decorators';
 import { inject as service } from '@ember/service';
 import Layer1Network from '@cardstack/web-client/services/layer1-network';
@@ -11,6 +10,7 @@ interface CardPayDepositWorkflowTransactionSetupComponentArgs {
   workflowSession: WorkflowSession;
   onComplete: (() => void) | undefined;
   onIncomplete: (() => void) | undefined;
+  isComplete: boolean;
 }
 interface token {
   symbol: string;
@@ -44,23 +44,17 @@ class CardPayDepositWorkflowTransactionSetupComponent extends Component<CardPayD
   @and('daiSelected', 'layer1Network.daiBalance')
   hasDaiBalance: Boolean | undefined;
 
-  @tracked isComplete: boolean | undefined;
-
   @action chooseSource(tokenSymbol: string) {
     this.args.workflowSession.update('depositSourceToken', tokenSymbol);
   }
 
-  @action onComplete() {
-    if (this.hasCardBalance || this.hasDaiBalance) {
-      this.isComplete = !this.isComplete;
-      if (this.args.onComplete) {
-        this.args.onComplete();
-      }
+  @action toggleComplete() {
+    if (this.args.isComplete) {
+      this.args?.onIncomplete();
+    } else if (this.hasCardBalance || this.hasDaiBalance) {
+      this.args?.onComplete();
     } else {
-      this.isComplete = false;
-      if (this.args.onIncomplete) {
-        this.args.onIncomplete();
-      }
+      // TODO error message
     }
   }
 }

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.hbs
@@ -1,4 +1,7 @@
-<Boxel::CardContainer>
+<ActionCardContainer
+  @header="Token Bridge"
+  @isComplete={{@isComplete}}
+>
   <Boxel::ProgressSteps
     @progressSteps={{this.progressSteps}}
     @completedCount={{this.completedCount}}
@@ -31,4 +34,4 @@
       {{/if}}
     {{/if}}
   </Boxel::ProgressSteps>
-</Boxel::CardContainer>
+</ActionCardContainer>

--- a/packages/web-client/app/components/card-pay/layer-connect-modal/index.css
+++ b/packages/web-client/app/components/card-pay/layer-connect-modal/index.css
@@ -1,4 +1,6 @@
 .layer-connect-modal {
+  --layer-max-width: 43.75rem; /* 700px */
+  --layer-connected-max-width: 36.25rem; /* 580px */
   --boxel-modal-max-width: unset;
   --boxel-modal-offset-top: 0px;
 }
@@ -11,13 +13,18 @@
 }
 
 .layer-connect-modal__scroll-wrapper {
-  min-width: 36.25rem; /* 580px */
-  max-width: 43.75rem; /* 700px */
+  width: 100%;
+  max-width: var(--layer-max-width);
   height: auto;
   max-height: 100%;
   margin: auto;
   padding: var(--boxel-sp-xs) 0;
   overflow-y: auto;
+  transition: max-width var(--boxel-transition);
+}
+
+.layer-connect-modal--connected .layer-connect-modal__scroll-wrapper {
+  max-width: var(--layer-connected-max-width);
 }
 
 @media screen and (max-width: 40rem) {

--- a/packages/web-client/app/components/card-pay/layer-connect-modal/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-connect-modal/index.hbs
@@ -1,5 +1,5 @@
 <Boxel::Modal
-  class="layer-connect-modal"
+  class={{cn "layer-connect-modal" layer-connect-modal--connected=@isLayerConnected}}
   @isOpen={{@isOpen}}
   @onClose={{@onClose}}
   data-test-layer-connect-modal={{@name}}

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
@@ -1,14 +1,11 @@
-<Boxel::CardContainer
+<ActionCardContainer
+  @suppressHeader={{@suppressHeader}}
+  @header="Wallet Connection - Ethereum Mainnet"
+  @isComplete={{@isComplete}}
   class="layer-one-connect-card"
   data-test-mainnnet-connection-action-container
   ...attributes
 >
-  {{#unless @suppressHeader}}
-    <Boxel::Header
-      @header="Wallet Connection - Ethereum Mainnet"
-    />
-  {{/unless}}
-
   <section class="layer-one-connect-card__body">
     {{#if this.connectedWalletProvider}}
       <header aria-label="Layer 1 Connected Header" class="layer-one-connect-card__body-header" data-test-mainnet-connection-header>
@@ -41,8 +38,8 @@
       </CardPay::FieldStack>
 
       <div class="layer-one-connect-card__disclaimer">
-        * This balance reflects some of the tokens that are accepted in the Card Pay network. 
-  It may not reflect all the tokens in your wallet.
+        * This balance reflects some of the tokens that are accepted in the Card Pay network.
+          It may not reflect all the tokens in your wallet.
       </div>
     {{else}}
       <header aria-label="Layer 1 Connection Header" class="layer-one-connect-card__body-header" data-test-mainnet-connection-header>Connect your Ethereum mainnet wallet</header>
@@ -75,15 +72,15 @@
       </m.ActionButton>
     </:memorialized>
   </Boxel::CtaBlock>
-</Boxel::CardContainer>
+</ActionCardContainer>
 
 {{#if (and this.isWaitingForConnection (not @suppressConnectingCard))}}
-  <Boxel::CardContainer class="layer-one-connect-card__connection">
+  <ActionCardContainer class="layer-one-connect-card__connection">
     <div class="layer-one-connect-card__connection-icons">
       <img src={{this.cardstackLogo}} alt="" role="presentation" class="layer-one-connect-card__connection-cardstack-logo">
       <img src={{this.connectionSymbol}} alt="" role="presentation" class="layer-one-connect-card__connection-symbol">
       <img src={{this.connectedWalletLogo}} alt="" role="presentation" class="layer-one-connect-card__connection-wallet-logo">
     </div>
     <div class="layer-one-connect-card__connection-text">Waiting for you to connect Card Pay with your mainnet wallet...</div>
-  </Boxel::CardContainer>
+  </ActionCardContainer>
 {{/if}}

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
@@ -18,6 +18,7 @@ interface CardPayDepositWorkflowConnectLayer1ComponentArgs {
   onIncomplete: (() => void) | undefined;
   onConnect: (() => void) | undefined;
   onDisconnect: (() => void) | undefined;
+  isComplete: boolean;
 }
 class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepositWorkflowConnectLayer1ComponentArgs> {
   cardstackLogo = cardstackLogo;

--- a/packages/web-client/app/components/card-pay/layer-two-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-two-connect-card/index.hbs
@@ -1,12 +1,11 @@
-<Boxel::CardContainer
+<ActionCardContainer
+  @suppressHeader={{@suppressHeader}}
+  @header="Wallet Connection - xDai Chain"
+  @isComplete={{@isComplete}}
   class={{if @includeExplanations 'layer-two-connect-card--with-explanations'}}
   data-test-layer-2-wallet-card
   ...attributes
 >
-  {{#unless @suppressHeader}}
-    <Boxel::Header @header="Wallet Connection - xDai Chain"></Boxel::Header>
-  {{/unless}}
-
   {{#if (eq this.cardState 'memorialized')}}
     <section class="layer-two-connect-card__body">
       <header aria-label="Layer 2 Connected Header" class="layer-two-connect-card__body-header">
@@ -101,7 +100,7 @@
             @margin={{15}}
             @backgroundColor="#ffffff"
             @dotType="dots"
-            @dotColor="#272330"
+            @dotColor="#000"
             @cornerDotType="dot"
             @cornerSquareType="extra-rounded"
             @imageMargin={{5}}
@@ -122,4 +121,4 @@
       {{svg-jar "caret-thin-right" class="layer-two-connect-card__alternate-wallet-caret"}}
     </button>
   {{/if}}
-</Boxel::CardContainer>
+</ActionCardContainer>

--- a/packages/web-client/app/components/card-pay/layer-two-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-two-connect-card/index.ts
@@ -20,6 +20,7 @@ interface CardPayLayerTwoConnectCardComponentArgs {
   onIncomplete: (() => void) | undefined;
   onConnect: (() => void) | undefined;
   onDisconnect: (() => void) | undefined;
+  isComplete: boolean;
 }
 
 class CardPayLayerTwoConnectCardComponent extends Component<CardPayLayerTwoConnectCardComponentArgs> {

--- a/packages/web-client/app/components/workflow-thread/index.css
+++ b/packages/web-client/app/components/workflow-thread/index.css
@@ -1,5 +1,5 @@
 .workflow-thread {
-  --inner-max-width: 36.6rem; /* ~585px */
+  --inner-max-width: 36.25rem; /* 580px */
   --outer-max-width: 43.75rem; /* 700px; */
 }
 
@@ -8,49 +8,6 @@
   font: 600 var(--boxel-font-sm);
   letter-spacing: var(--boxel-lsp);
   text-align: center;
-}
-
-.workflow-thread__card > .action-card-container {
-  max-width: var(--outer-max-width);
-  box-shadow: 0 15px 30px rgba(0, 0, 0, 0.15);
-  transition: all var(--boxel-transition);
-}
-
-.workflow-thread__card--view-only > .action-card-container {
-  max-width: var(--inner-max-width);
-  margin-left: var(--boxel-thread-message-margin-left);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
-}
-
-.workflow-thread__markdown {
-  max-width: var(--inner-max-width);
-  font-size: 0.9375rem;
-  line-height: calc(23/15);
-  letter-spacing: var(--boxel-lsp-sm);
-  text-align: start;
-}
-
-.workflow-thread__markdown > * {
-  margin: 0;
-}
-
-.workflow-thread__markdown > * + * {
-  margin-top: var(--boxel-sp-lg);
-}
-
-.workflow-thread__markdown ul,
-.workflow-thread__markdown ol {
-  margin: 0;
-  padding-left: 0;
-  list-style-position: inside;
-}
-
-.workflow-thread__markdown ul li::marker {
-  content: '- ';
-}
-
-.workflow-thread__markdown ol li::marker {
-  font: inherit;
 }
 
 .workflow-thread:focus {

--- a/packages/web-client/app/components/workflow-thread/index.css
+++ b/packages/web-client/app/components/workflow-thread/index.css
@@ -1,3 +1,8 @@
+.workflow-thread {
+  --inner-max-width: 36.6rem; /* ~585px */
+  --outer-max-width: 43.75rem; /* 700px; */
+}
+
 .workflow-thread__status {
   color: var(--boxel-dark);
   font: 600 var(--boxel-font-sm);
@@ -5,7 +10,20 @@
   text-align: center;
 }
 
+.workflow-thread__card > .action-card-container {
+  max-width: var(--outer-max-width);
+  box-shadow: 0 15px 30px rgba(0, 0, 0, 0.15);
+  transition: all var(--boxel-transition);
+}
+
+.workflow-thread__card--view-only > .action-card-container {
+  max-width: var(--inner-max-width);
+  margin-left: var(--boxel-thread-message-margin-left);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+}
+
 .workflow-thread__markdown {
+  max-width: var(--inner-max-width);
   font-size: 0.9375rem;
   line-height: calc(23/15);
   letter-spacing: var(--boxel-lsp-sm);

--- a/packages/web-client/app/components/workflow-thread/postable/index.css
+++ b/packages/web-client/app/components/workflow-thread/postable/index.css
@@ -1,0 +1,49 @@
+/* Postable card container */
+.workflow-thread-postable__card {
+  /* Note: the size restriction and transition should only apply to action card container.
+     ActionCardContainer is a holding container for an action card.
+     Might make sense to apply these styles there instead. However, margin-left is only if it's inside a thread.
+     It's unclear if every thread card will be wrapped an action container, probably not.
+  */
+  max-width: var(--outer-max-width);
+  transition:
+    margin-left var(--boxel-transition),
+    max-width var(--boxel-transition);
+}
+
+.workflow-thread-postable__card--is-complete {
+  max-width: var(--inner-max-width);
+  margin-left: var(--boxel-thread-message-margin-left);
+}
+
+/* Postable markdown styles */
+.workflow-thread-postable__markdown {
+  max-width: var(--inner-max-width);
+  font-size: 0.9375rem;
+  line-height: calc(23/15);
+  letter-spacing: var(--boxel-lsp-sm);
+  text-align: start;
+}
+
+.workflow-thread-postable__markdown > * {
+  margin: 0;
+}
+
+.workflow-thread-postable__markdown > * + * {
+  margin-top: var(--boxel-sp-xs);
+}
+
+.workflow-thread-postable__markdown ul,
+.workflow-thread-postable__markdown ol {
+  padding-left: var(--boxel-sp);
+  list-style-position: outside;
+  list-style-type: disc;
+}
+
+.workflow-thread-postable__markdown li + li {
+  margin-top: var(--boxel-sp-xs);
+}
+
+.workflow-thread-postable__markdown strong {
+  font-weight: 600;
+}

--- a/packages/web-client/app/components/workflow-thread/postable/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/postable/index.hbs
@@ -15,7 +15,7 @@
     data-test-postable={{@index}}
     ...attributes
   >
-    <div class="workflow-thread__markdown">
+    <div class="workflow-thread-postable__markdown">
       {{format-workflow-message @postable.message}}
     </div>
   </Boxel::ThreadMessage>
@@ -30,7 +30,10 @@
     data-test-postable={{@index}}
     ...attributes
   >
-    <div class={{cn "workflow-thread__card" workflow-thread__card--view-only=@postable.isComplete}}>
+    <div class={{cn
+      "workflow-thread-postable__card"
+      workflow-thread-postable__card--is-complete=@postable.isComplete
+    }}>
       {{component
         @postable.componentName
         workflowSession=@postable.session

--- a/packages/web-client/app/components/workflow-thread/postable/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/postable/index.hbs
@@ -21,6 +21,7 @@
   </Boxel::ThreadMessage>
 {{else}}
   <Boxel::ThreadMessage
+    @fullWidth={{true}}
     @datetime={{@postable.timestamp}}
     @imgURL={{@postable.author.imgURL}}
     @name={{@postable.author.name}}
@@ -29,11 +30,14 @@
     data-test-postable={{@index}}
     ...attributes
   >
-    {{component
-      @postable.componentName
-      workflowSession=@postable.session
-      onComplete=(optional @postable.onComplete)
-      onIncomplete=(optional @postable.onIncomplete)
-    }}
+    <div class={{cn "workflow-thread__card" workflow-thread__card--view-only=@postable.isComplete}}>
+      {{component
+        @postable.componentName
+        workflowSession=@postable.session
+        onComplete=(optional @postable.onComplete)
+        onIncomplete=(optional @postable.onIncomplete)
+        isComplete=@postable.isComplete
+      }}
+    </div>
   </Boxel::ThreadMessage>
 {{/if}}

--- a/packages/web-client/app/templates/card-pay.hbs
+++ b/packages/web-client/app/templates/card-pay.hbs
@@ -31,10 +31,12 @@
   @name="layer1"
   @isOpen={{this.isShowingLayer1ConnectModal}}
   @onClose={{set this 'isShowingLayer1ConnectModal' false}}
+  @isLayerConnected={{this.layer1Network.isConnected}}
 />
 
 <CardPay::LayerConnectModal
   @name="layer2"
   @isOpen={{this.isShowingLayer2ConnectModal}}
   @onClose={{set this 'isShowingLayer2ConnectModal' false}}
+  @isLayerConnected={{this.layer2Network.isConnected}}
 />

--- a/packages/web-client/app/templates/card-pay/balances.hbs
+++ b/packages/web-client/app/templates/card-pay/balances.hbs
@@ -9,6 +9,7 @@
 </section>
 
 <Boxel::Modal
+  style={{css-var boxel-modal-max-width="65rem"}} {{!-- ~1040px --}}
   @isOpen={{this.isShowingDepositWorkflow}}
   @onClose={{set this "isShowingDepositWorkflow" false}}
 >

--- a/yarn.lock
+++ b/yarn.lock
@@ -6037,7 +6037,7 @@ broccoli-funnel@^3.0.1, broccoli-funnel@^3.0.3:
     path-posix "^1.0.0"
     walk-sync "^2.0.2"
 
-broccoli-funnel@ef4/broccoli-funnel#c70d060076e14793e8495571f304a976afc754ac, "broccoli-funnel@github:ef4/broccoli-funnel#c70d060076e14793e8495571f304a976afc754ac":
+broccoli-funnel@ef4/broccoli-funnel#c70d060076e14793e8495571f304a976afc754ac:
   version "2.0.2-ef4.0"
   resolved "https://codeload.github.com/ef4/broccoli-funnel/tar.gz/c70d060076e14793e8495571f304a976afc754ac"
   dependencies:
@@ -9497,7 +9497,7 @@ ember-page-title@^6.2.1:
   dependencies:
     ember-cli-babel "^7.22.1"
 
-"ember-power-select-typeahead@github:alexspeller/ember-power-select-typeahead#6d279fb":
+ember-power-select-typeahead@alexspeller/ember-power-select-typeahead#6d279fb:
   version "0.8.0"
   resolved "https://codeload.github.com/alexspeller/ember-power-select-typeahead/tar.gz/6d279fb9e6a640282a2dc887fe06f1d09a062148"
   dependencies:


### PR DESCRIPTION
- Uses the ActionContainer component created in #451 across the relevant Card Pay cards. 
- Incorporates ThreadMessage updates from latest Boxel release

See the styling differences for the cards below for different card modes:

Data-entry mode:
<img width="1298" alt="data-entry-view" src="https://user-images.githubusercontent.com/16160806/117075808-725aea00-ad03-11eb-9c3d-06e1979e6378.png">

Memorialized view:
<img width="766" alt="memorialized-view" src="https://user-images.githubusercontent.com/16160806/117075813-738c1700-ad03-11eb-91ab-92d3f8abcf53.png">