### PR TITLE
Add Exchange Rates API

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -138,7 +138,7 @@
       "console": "integratedTerminal",
       "env": {},
       "args": [
-        "oracle-updated-at",
+        "price-oracle-updated-at",
         "DAI",
         "1",
         "--network", "sokol",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -95,6 +95,56 @@
         // Hassan's testing mnemonic feel free to use your own
         "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
       ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Cardpay: USD Price",
+      "program": "${workspaceFolder}/packages/cardpay-cli/entrypoint.js",
+      "console": "integratedTerminal",
+      "env": {},
+      "args": [
+        "usd-price",
+        "DAI",
+        "100",
+        "1",
+        "--network", "sokol",
+        // Hassan's testing mnemonic feel free to use your own
+        "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Cardpay: ETH Price",
+      "program": "${workspaceFolder}/packages/cardpay-cli/entrypoint.js",
+      "console": "integratedTerminal",
+      "env": {},
+      "args": [
+        "eth-price",
+        "DAI",
+        "100",
+        "1",
+        "--network", "sokol",
+        // Hassan's testing mnemonic feel free to use your own
+        "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Cardpay: Oracle Update Time",
+      "program": "${workspaceFolder}/packages/cardpay-cli/entrypoint.js",
+      "console": "integratedTerminal",
+      "env": {},
+      "args": [
+        "oracle-updated-at",
+        "DAI",
+        "1",
+        "--network", "sokol",
+        // Hassan's testing mnemonic feel free to use your own
+        "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
+      ]
     }
   ]
 }

--- a/packages/cardpay-cli/README.md
+++ b/packages/cardpay-cli/README.md
@@ -10,9 +10,9 @@ CLI tool for basic actions in Cardpay
   - [`yarn cardpay await-bridged <FROM_BLOCK> [RECIPIENT] --network=_NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-await-bridged-from_block-recipient---network_network---mnemonicmnemonic)
   - [`yarn cardpay prepaidcard-create <SAFE_ADDRESS> <TOKEN_ADDRESS> <amounts..> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-prepaidcard-create-safe_address-token_address-amounts---networknetwork---mnemonicmnemonic)
   - [`yarn cardpay safes-view [ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-safes-view-address---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay usd-price <TOKEN> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-usd-price-token-amount---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay eth-price <TOKEN> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-eth-price-token-amount---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay oracle-updated-at <TOKEN> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-oracle-updated-at-token---networknetwork---mnemonicmnemonic)
+  - [`yarn cardpay usd-price <TOKEN> [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-usd-price-token-amount---networknetwork---mnemonicmnemonic)
+  - [`yarn cardpay eth-price <TOKEN> [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-eth-price-token-amount---networknetwork---mnemonicmnemonic)
+  - [`yarn cardpay price-oracle-updated-at <TOKEN> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-price-oracle-updated-at-token---networknetwork---mnemonicmnemonic)
 
 
 
@@ -79,7 +79,7 @@ ARGUMENTS
   MNEMONIC  (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
 ```
 
-## `yarn cardpay usd-price <TOKEN> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay usd-price <TOKEN> [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC]`
 Get the USD value for the specified token name in the specified amount. This returns a floating point number in units of USD.
 ```
 USAGE
@@ -87,12 +87,12 @@ USAGE
 
 ARGUMENTS
   TOKEN     The token symbol (without the .CPXD suffix)
-  AMOUNT    The amount of the specified token (not in units of wei)
+  AMOUNT    (Optional) The amount of the specified token (not in units of wei).
   NETWORK   The network to use ("sokol" or "xdai")
   MNEMONIC  (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
 ```
 
-## `yarn cardpay eth-price <TOKEN> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay eth-price <TOKEN> [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC]`
 Get the ETH value for the specified token name in the specified amount (in units `ether`).
 ```
 USAGE
@@ -101,16 +101,17 @@ USAGE
 ARGUMENTS
   TOKEN     The token symbol (without the .CPXD suffix)
   AMOUNT    The amount of the specified token (not in units of wei)
+  AMOUNT    (Optional) The amount of the specified token (not in units of wei).
   NETWORK   The network to use ("sokol" or "xdai")
   MNEMONIC  (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
 ```
 
-## `yarn cardpay oracle-updated-at <TOKEN> --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay price-oracle-updated-at <TOKEN> --network=NETWORK [--mnemonic=MNEMONIC]`
 This returns the date that the oracle was last updated for the specified token.
 
 ```
 USAGE
-  $ yarn cardpay oracle-updated-at <TOKEN> --network=NETWORK [--mnemonic=MNEMONIC]
+  $ yarn cardpay price-oracle-updated-at <TOKEN> --network=NETWORK [--mnemonic=MNEMONIC]
 
 ARGUMENTS
   TOKEN     The token symbol (without the .CPXD suffix)

--- a/packages/cardpay-cli/README.md
+++ b/packages/cardpay-cli/README.md
@@ -9,6 +9,9 @@ CLI tool for basic actions in Cardpay
   - [`yarn cardpay bridge <TOKEN_ADDRESS> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-bridge-token_address-amount---networknetwork---mnemonicmnemonic)
   - [`yarn cardpay prepaidcard-create <SAFE_ADDRESS> <TOKEN_ADDRESS> <amounts..> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-prepaidcard-create-safe_address-token_address-amounts---networknetwork---mnemonicmnemonic)
   - [`yarn cardpay safes-view [ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-safes-view-address---networknetwork---mnemonicmnemonic)
+  - [`yarn cardpay usd-price <TOKEN> <AMOUNT> --network=NETWORK [--mnemonic=mnmonic]`](#yarn-cardpay-usd-price-token-amount---networknetwork---mnemonicmnmonic)
+  - [`yarn cardpay eth-price <TOKEN> <AMOUNT> --network=NETWORK [--mnemonic=mnmonic]`](#yarn-cardpay-eth-price-token-amount---networknetwork---mnemonicmnmonic)
+  - [`yarn cardpay oracle-updated-at <TOKEN> --network=NETWORK [--mnemonic=mnmonic]`](#yarn-cardpay-oracle-updated-at-token---networknetwork---mnemonicmnmonic)
 
 
 
@@ -22,7 +25,7 @@ USAGE
 
 ARGUMENTS
   TOKEN_ADDRESS   The token address of the token to bridge
-  AMOUNT          Amount in ether you would like bridged
+  AMOUNT          Amount in ether you would like bridged (not in units of wei)
   NETWORK         The network to use ("kovan" or "mainnet")
   MNEMONIC        (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
 ```
@@ -37,7 +40,7 @@ USAGE
   $ yarn cardpay prepaidcard-create <SAFE_ADDRESS> <TOKEN_ADDRESS> <AMOUNTS..> --network=NETWORK [--mnemonic=MNEMONIC]
 
 ARGUMENTS
-  AMOUNTS           A list of amounts (separated by spaces) in ether you would like created for each prepaid card
+  AMOUNTS           A list of amounts (separated by spaces) in ether you would like created for each prepaid card (not in units of wei)
   SAFE_ADDRESS      Layer 2 safe address with DAI CPXD tokens
   TOKEN_ADDRESS     The token address of the token to use to pay for the prepaid cards
   NETWORK           The network to use ("sokol" or "xdai")
@@ -56,6 +59,45 @@ USAGE
 
 ARGUMENTS
   ADDRESS   (Optional) an address of an owner whose safes you wish to view (defaults to the wallet's default account)
+  NETWORK   The network to use ("sokol" or "xdai")
+  MNEMONIC  (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+```
+
+## `yarn cardpay usd-price <TOKEN> <AMOUNT> --network=NETWORK [--mnemonic=mnmonic]`
+Get the USD value for the specified token name in the specified amount. This returns a floating point number in units of USD.
+```
+USAGE
+  $ yarn cardpay usd-price <TOKEN> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC]
+
+ARGUMENTS
+  TOKEN     The token symbol (without the .CPXD suffix)
+  AMOUNT    The amount of the specified token (not in units of wei)
+  NETWORK   The network to use ("sokol" or "xdai")
+  MNEMONIC  (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+```
+
+## `yarn cardpay eth-price <TOKEN> <AMOUNT> --network=NETWORK [--mnemonic=mnmonic]`
+Get the ETH value for the specified token name in the specified amount (in units `ether`).
+```
+USAGE
+  $ yarn cardpay eth-price <TOKEN> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC]
+
+ARGUMENTS
+  TOKEN     The token symbol (without the .CPXD suffix)
+  AMOUNT    The amount of the specified token (not in units of wei)
+  NETWORK   The network to use ("sokol" or "xdai")
+  MNEMONIC  (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+```
+
+## `yarn cardpay oracle-updated-at <TOKEN> --network=NETWORK [--mnemonic=mnmonic]`
+This returns the date that the oracle was last updated for the specified token.
+
+```
+USAGE
+  $ yarn cardpay oracle-updated-at <TOKEN> --network=NETWORK [--mnemonic=MNEMONIC]
+
+ARGUMENTS
+  TOKEN     The token symbol (without the .CPXD suffix)
   NETWORK   The network to use ("sokol" or "xdai")
   MNEMONIC  (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
 ```

--- a/packages/cardpay-cli/await-bridged.ts
+++ b/packages/cardpay-cli/await-bridged.ts
@@ -1,6 +1,5 @@
-import HDWalletProvider from 'parity-hdwallet-provider';
-import Web3 from 'web3';
-import { HttpProvider, TokenBridgeHomeSide, getConstant, networkIds } from '@cardstack/cardpay-sdk';
+import { TokenBridgeHomeSide, getConstant } from '@cardstack/cardpay-sdk';
+import { getWeb3 } from './utils';
 
 export default async function (
   network: string,
@@ -8,15 +7,7 @@ export default async function (
   fromBlock: number,
   recipient?: string
 ): Promise<void> {
-  let web3 = new Web3(
-    new HDWalletProvider({
-      chainId: networkIds[network],
-      mnemonic: {
-        phrase: mnemonic,
-      },
-      providerOrUrl: new HttpProvider(await getConstant('rpcNode', network)),
-    })
-  );
+  let web3 = await getWeb3(network, mnemonic);
   let tokenBridge = new TokenBridgeHomeSide(web3);
   recipient = recipient ?? (await web3.eth.getAccounts())[0];
 

--- a/packages/cardpay-cli/bridge.ts
+++ b/packages/cardpay-cli/bridge.ts
@@ -1,6 +1,6 @@
-import HDWalletProvider from 'parity-hdwallet-provider';
 import Web3 from 'web3';
-import { HttpProvider, TokenBridge, getConstant, networkIds, getAddress } from '@cardstack/cardpay-sdk';
+import { TokenBridge, getConstant, getAddress } from '@cardstack/cardpay-sdk';
+import { getWeb3 } from './utils';
 
 const { toWei } = Web3.utils;
 
@@ -12,15 +12,7 @@ export default async function (
 ): Promise<void> {
   const amountInWei = toWei(amount.toString()).toString();
 
-  let web3 = new Web3(
-    new HDWalletProvider({
-      chainId: networkIds[network],
-      mnemonic: {
-        phrase: mnemonic,
-      },
-      providerOrUrl: new HttpProvider(await getConstant('rpcNode', network)),
-    })
-  );
+  let web3 = await getWeb3(network, mnemonic);
   let tokenBridge = new TokenBridge(web3);
   tokenAddress = tokenAddress ?? (await getAddress('daiToken', web3));
   let blockExplorer = await getConstant('blockExplorer', web3);

--- a/packages/cardpay-cli/create-prepaid-card.ts
+++ b/packages/cardpay-cli/create-prepaid-card.ts
@@ -1,6 +1,6 @@
-import HDWalletProvider from 'parity-hdwallet-provider';
 import Web3 from 'web3';
-import { HttpProvider, PrepaidCard, getConstant, networkIds, getAddress } from '@cardstack/cardpay-sdk';
+import { PrepaidCard, getConstant, getAddress } from '@cardstack/cardpay-sdk';
+import { getWeb3 } from './utils';
 
 const { toWei } = Web3.utils;
 
@@ -11,15 +11,7 @@ export default async function (
   amounts: number[],
   tokenAddress?: string
 ): Promise<void> {
-  let web3 = new Web3(
-    new HDWalletProvider({
-      chainId: networkIds[network],
-      mnemonic: {
-        phrase: mnemonic,
-      },
-      providerOrUrl: new HttpProvider(await getConstant('rpcNode', network)),
-    })
-  );
+  let web3 = await getWeb3(network, mnemonic);
   tokenAddress = tokenAddress ?? (await getAddress('daiCpxd', web3));
 
   const amountsInWei = amounts.map((amount) => toWei(amount.toString()).toString());

--- a/packages/cardpay-cli/exchange-rate.ts
+++ b/packages/cardpay-cli/exchange-rate.ts
@@ -1,0 +1,25 @@
+import Web3 from 'web3';
+import { getWeb3 } from './utils';
+import { ExchangeRate } from '@cardstack/cardpay-sdk';
+const { toWei, fromWei } = Web3.utils;
+
+export async function usdPrice(network: string, mnemonic: string, token: string, amount: number): Promise<void> {
+  let web3 = await getWeb3(network, mnemonic);
+  let amountInWei = toWei(amount.toString());
+  let exchangeRate = new ExchangeRate(web3);
+  let usdPrice = await exchangeRate.getUSDPrice(token, amountInWei);
+  console.log(`USD value: $${usdPrice.toFixed(2)} USD`);
+}
+export async function ethPrice(network: string, mnemonic: string, token: string, amount: number): Promise<void> {
+  let web3 = await getWeb3(network, mnemonic);
+  let amountInWei = toWei(amount.toString());
+  let exchangeRate = new ExchangeRate(web3);
+  let ethWeiPrice = await exchangeRate.getETHPrice(token, amountInWei);
+  console.log(`ETH value: ${fromWei(ethWeiPrice)} ETH`);
+}
+export async function oracleUpdatedAt(network: string, mnemonic: string, token: string): Promise<void> {
+  let web3 = await getWeb3(network, mnemonic);
+  let exchangeRate = new ExchangeRate(web3);
+  let date = await exchangeRate.getUpdatedAt(token);
+  console.log(`The ${token} rate was last updated at ${date.toString()}`);
+}

--- a/packages/cardpay-cli/exchange-rate.ts
+++ b/packages/cardpay-cli/exchange-rate.ts
@@ -3,21 +3,21 @@ import { getWeb3 } from './utils';
 import { ExchangeRate } from '@cardstack/cardpay-sdk';
 const { toWei, fromWei } = Web3.utils;
 
-export async function usdPrice(network: string, mnemonic: string, token: string, amount: number): Promise<void> {
+export async function usdPrice(network: string, mnemonic: string, token: string, amount: number = 1): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let amountInWei = toWei(amount.toString());
   let exchangeRate = new ExchangeRate(web3);
   let usdPrice = await exchangeRate.getUSDPrice(token, amountInWei);
   console.log(`USD value: $${usdPrice.toFixed(2)} USD`);
 }
-export async function ethPrice(network: string, mnemonic: string, token: string, amount: number): Promise<void> {
+export async function ethPrice(network: string, mnemonic: string, token: string, amount: number = 1): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let amountInWei = toWei(amount.toString());
   let exchangeRate = new ExchangeRate(web3);
   let ethWeiPrice = await exchangeRate.getETHPrice(token, amountInWei);
   console.log(`ETH value: ${fromWei(ethWeiPrice)} ETH`);
 }
-export async function oracleUpdatedAt(network: string, mnemonic: string, token: string): Promise<void> {
+export async function priceOracleUpdatedAt(network: string, mnemonic: string, token: string): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let exchangeRate = new ExchangeRate(web3);
   let date = await exchangeRate.getUpdatedAt(token);

--- a/packages/cardpay-cli/exchange-rate.ts
+++ b/packages/cardpay-cli/exchange-rate.ts
@@ -3,14 +3,14 @@ import { getWeb3 } from './utils';
 import { ExchangeRate } from '@cardstack/cardpay-sdk';
 const { toWei, fromWei } = Web3.utils;
 
-export async function usdPrice(network: string, mnemonic: string, token: string, amount: number = 1): Promise<void> {
+export async function usdPrice(network: string, mnemonic: string, token: string, amount = 1): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let amountInWei = toWei(amount.toString());
   let exchangeRate = new ExchangeRate(web3);
   let usdPrice = await exchangeRate.getUSDPrice(token, amountInWei);
   console.log(`USD value: $${usdPrice.toFixed(2)} USD`);
 }
-export async function ethPrice(network: string, mnemonic: string, token: string, amount: number = 1): Promise<void> {
+export async function ethPrice(network: string, mnemonic: string, token: string, amount = 1): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let amountInWei = toWei(amount.toString());
   let exchangeRate = new ExchangeRate(web3);

--- a/packages/cardpay-cli/index.ts
+++ b/packages/cardpay-cli/index.ts
@@ -5,7 +5,7 @@ import bridge from './bridge.js';
 import awaitBridged from './await-bridged.js';
 import viewSafes from './view-safes.js';
 import createPrepaidCard from './create-prepaid-card.js';
-import { usdPrice, ethPrice, oracleUpdatedAt } from './exchange-rate';
+import { usdPrice, ethPrice, priceOracleUpdatedAt } from './exchange-rate';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -17,7 +17,7 @@ type Commands =
   | 'prepaidCardCreate'
   | 'usdPrice'
   | 'ethPrice'
-  | 'oracleUpdatedAt';
+  | 'priceOracleUpdatedAt';
 
 let command: Commands | undefined;
 interface Options {
@@ -100,7 +100,7 @@ const {
         description: 'The token address (defaults to Kovan DAI)',
       });
       yargs.positional('amounts', {
-        type: 'string',
+        type: 'number',
         description: 'The amount of tokens used to create each prepaid card (*not* in units of wei)',
       });
       command = 'prepaidCardCreate';
@@ -115,7 +115,8 @@ const {
         description: 'The token symbol (without the .CPXD suffix)',
       });
       yargs.positional('amount', {
-        type: 'string',
+        type: 'number',
+        default: 1,
         description: 'The amount of the specified token (*not* in units of wei)',
       });
       command = 'usdPrice';
@@ -130,21 +131,22 @@ const {
         description: 'The token symbol (without the .CPXD suffix)',
       });
       yargs.positional('amount', {
-        type: 'string',
+        type: 'number',
+        default: 1,
         description: 'The amount of the specified token (*not* in units of wei)',
       });
       command = 'ethPrice';
     }
   )
   .command(
-    'oracle-updated-at <token>',
+    'price-oracle-updated-at <token>',
     'Get the date that the oracle was last updated for the specified token',
     (yargs) => {
       yargs.positional('token', {
         type: 'string',
         description: 'The token symbol (without the .CPXD suffix)',
       });
-      command = 'oracleUpdatedAt';
+      command = 'priceOracleUpdatedAt';
     }
   )
   .options({
@@ -214,12 +216,12 @@ if (!command) {
       }
       await ethPrice(network, mnemonic, token, amount);
       break;
-    case 'oracleUpdatedAt':
+    case 'priceOracleUpdatedAt':
       if (token == null) {
         yargs.showHelp('token is a required value');
         process.exit(1);
       }
-      await oracleUpdatedAt(network, mnemonic, token);
+      await priceOracleUpdatedAt(network, mnemonic, token);
       break;
     default:
       assertNever(command);

--- a/packages/cardpay-cli/utils.ts
+++ b/packages/cardpay-cli/utils.ts
@@ -1,0 +1,15 @@
+import HDWalletProvider from 'parity-hdwallet-provider';
+import Web3 from 'web3';
+import { HttpProvider, getConstant, networkIds } from '@cardstack/cardpay-sdk';
+
+export async function getWeb3(network: string, mnemonic: string): Promise<Web3> {
+  return new Web3(
+    new HDWalletProvider({
+      chainId: networkIds[network],
+      mnemonic: {
+        phrase: mnemonic,
+      },
+      providerOrUrl: new HttpProvider(await getConstant('rpcNode', network)),
+    })
+  );
+}

--- a/packages/cardpay-cli/view-safes.ts
+++ b/packages/cardpay-cli/view-safes.ts
@@ -1,17 +1,9 @@
 import Web3 from 'web3';
-import HDWalletProvider from 'parity-hdwallet-provider';
-import { HttpProvider, Safes, getConstant, networkIds } from '@cardstack/cardpay-sdk';
+import { Safes } from '@cardstack/cardpay-sdk';
+import { getWeb3 } from './utils';
 
 export default async function (network: string, mnemonic: string, address?: string): Promise<void> {
-  let web3 = new Web3(
-    new HDWalletProvider({
-      chainId: networkIds[network],
-      mnemonic: {
-        phrase: mnemonic,
-      },
-      providerOrUrl: new HttpProvider(await getConstant('rpcNode', network)),
-    })
-  );
+  let web3 = await getWeb3(network, mnemonic);
 
   let safes = new Safes(web3);
   console.log('Getting safes');

--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -203,7 +203,7 @@ This call will return the USD value for the specified amount of the specified to
 
 ```js
 let exchangeRate = new ExchangeRate(web3);
-let usdPrice = await exchangeRate.getUSDPrice(token, amountInWei);
+let usdPrice = await exchangeRate.getUSDPrice("DAI", amountInWei);
 console.log(`USD value: $${usdPrice.toFixed(2)} USD`);
 ```
 ### `ExchangeRate.getETHPrice`
@@ -211,7 +211,7 @@ This call will return the ETH value for the specified amount of the specified to
 
 ```js
 let exchangeRate = new ExchangeRate(web3);
-let ethWeiPrice = await exchangeRate.getETHPrice(token, amountInWei);
+let ethWeiPrice = await exchangeRate.getETHPrice("CARD", amountInWei);
 console.log(`ETH value: ${fromWei(ethWeiPrice)} ETH`);
 ```
 ### `ExchangeRate.getUpdatedAt`
@@ -219,7 +219,7 @@ This call will return a `Date` instance that indicates the date the token rate w
 
 ```js
 let exchangeRate = new ExchangeRate(web3);
-let date = await exchangeRate.getUpdatedAt(token);
+let date = await exchangeRate.getUpdatedAt("DAI");
 console.log(`The ${token} rate was last updated at ${date.toString()}`);
 ```
 ## `getAddress`

--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -22,7 +22,12 @@ This is a package that provides an SDK to use the Cardpay protocol.
 - [`RewardPool` (TBD)](#rewardpool-tbd)
   - [`RewardPool.balanceOf` (TBD)](#rewardpoolbalanceof-tbd)
   - [`RewardPool.withdraw` (TBD)](#rewardpoolwithdraw-tbd)
+- [`ExchangeRate`](#exchangerate)
+  - [`ExchangeRate.getUSDPrice`](#exchangerategetusdprice)
+  - [`ExchangeRate.getETHPrice`](#exchangerategetethprice)
+  - [`ExchangeRate.getUpdatedAt`](#exchangerategetupdatedat)
 - [`getAddress`](#getaddress)
+- [`getOracle`](#getoracle)
 - [`getConstant`](#getconstant)
 - [`networkIds`](#networkids)
 - [ABI's](#abis)
@@ -186,6 +191,15 @@ interface RelayTransaction {
 ### `RewardPool.balanceOf` (TBD)
 ### `RewardPool.withdraw` (TBD)
 
+## `ExchangeRate`
+The `ExchangeRate` API is used to get the current exchange rates in USD and ETH for the various stablecoin that we support. These rates are fed by the Chainlink price feeds for the stablecoin rates and the DIA oracle for the CARD token rates. As we onboard new stablecoin we'll add more exchange rates. The price oracles that we use reside in layer 2, so please supply a layer 2 web3 instance when instantiating an `ExchangeRate` instance.
+### `ExchangeRate.getUSDPrice`
+This call will return the USD value for the specified amount of the specified token. If we do not have an exchange rate for the token, then an exception will be thrown. This API requires that the token amount be specified in `wei` (10<sup>18</sup> `wei` = 1 token) as a string, and will return a floating point value in units of USD. You can easily convert a token value to wei by using the `Web3.utils.toWei()` function.
+### `ExchangeRate.getETHPrice`
+This call will return the ETH value for the specified amount of the specified token. If we do not have an exchange rate for the token, then an exception will be thrown. This API requires that the token amount be specified in `wei` (10<sup>18</sup> `wei` = 1 token) as a string, and will return a string that represents the ETH value in units of `wei` as well. You can easily convert a token value to wei by using the `Web3.utils.toWei()` function. You can also easily convert units of `wei` back into `ethers` by using the `Web3.utils.fromWei()` function.
+### `ExchangeRate.getUpdatedAt`
+This call will return a `Date` instance that indicates the date the token rate was last updated.
+
 ## `getAddress`
 `getAddress` is a utility that will retrieve the contract address for a contract that is part of the Card Protocol in the specified network. The easiest way to use this function is to just pass your web3 instance to the function, and the function will query the web3 instance to see what network it is currently using. You can also just pass in the network name.
 
@@ -195,6 +209,13 @@ let daiToken = await getAddress("daiToken", web3);
 let foreignBridge = await getAddress("foreignBridge", web3);
 let homeBridge = await getAddress("homeBridge", web3);
 let prepaidCardManager = await getAddress("prepaidCardManager", web3);
+```
+
+## `getOracle`
+`getOracle` is a utility that will retrieve the contract address for a price oracle for the specified token in the specified network. The easiest way to use this function is to just pass your web3 instance to the function, and the function will query the web3 instance to see what network it is currently using. You can also just pass in the network name. Please omit the ".CPXD" suffix in the token name that you provide.
+```js
+let daiOracle = await getOracle("DAI", web3);
+let cardOracle = await getOracle("CARD", web3);
 ```
 
 ## `getConstant`

--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -193,13 +193,35 @@ interface RelayTransaction {
 
 ## `ExchangeRate`
 The `ExchangeRate` API is used to get the current exchange rates in USD and ETH for the various stablecoin that we support. These rates are fed by the Chainlink price feeds for the stablecoin rates and the DIA oracle for the CARD token rates. As we onboard new stablecoin we'll add more exchange rates. The price oracles that we use reside in layer 2, so please supply a layer 2 web3 instance when instantiating an `ExchangeRate` instance.
+```js
+import { ExchangeRate } from "@cardstack/cardpay-sdk";
+let web3 = new Web3(myProvider);
+let exchangeRate = new ExchangeRate(web3); // Layer 2 web3 instance
+```
 ### `ExchangeRate.getUSDPrice`
 This call will return the USD value for the specified amount of the specified token. If we do not have an exchange rate for the token, then an exception will be thrown. This API requires that the token amount be specified in `wei` (10<sup>18</sup> `wei` = 1 token) as a string, and will return a floating point value in units of USD. You can easily convert a token value to wei by using the `Web3.utils.toWei()` function.
+
+```js
+let exchangeRate = new ExchangeRate(web3);
+let usdPrice = await exchangeRate.getUSDPrice(token, amountInWei);
+console.log(`USD value: $${usdPrice.toFixed(2)} USD`);
+```
 ### `ExchangeRate.getETHPrice`
 This call will return the ETH value for the specified amount of the specified token. If we do not have an exchange rate for the token, then an exception will be thrown. This API requires that the token amount be specified in `wei` (10<sup>18</sup> `wei` = 1 token) as a string, and will return a string that represents the ETH value in units of `wei` as well. You can easily convert a token value to wei by using the `Web3.utils.toWei()` function. You can also easily convert units of `wei` back into `ethers` by using the `Web3.utils.fromWei()` function.
+
+```js
+let exchangeRate = new ExchangeRate(web3);
+let ethWeiPrice = await exchangeRate.getETHPrice(token, amountInWei);
+console.log(`ETH value: ${fromWei(ethWeiPrice)} ETH`);
+```
 ### `ExchangeRate.getUpdatedAt`
 This call will return a `Date` instance that indicates the date the token rate was last updated.
 
+```js
+let exchangeRate = new ExchangeRate(web3);
+let date = await exchangeRate.getUpdatedAt(token);
+console.log(`The ${token} rate was last updated at ${date.toString()}`);
+```
 ## `getAddress`
 `getAddress` is a utility that will retrieve the contract address for a contract that is part of the Card Protocol in the specified network. The easiest way to use this function is to just pass your web3 instance to the function, and the function will query the web3 instance to see what network it is currently using. You can also just pass in the network name.
 

--- a/packages/cardpay-sdk/contracts/abi/price-oracle.ts
+++ b/packages/cardpay-sdk/contracts/abi/price-oracle.ts
@@ -1,0 +1,72 @@
+export default [
+  {
+    constant: true,
+    inputs: [],
+    name: 'decimals',
+    outputs: [
+      {
+        internalType: 'uint8',
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'description',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'usdPrice',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'price',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'updatedAt',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'ethPrice',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'price',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'updatedAt',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+];

--- a/packages/cardpay-sdk/contracts/addresses.ts
+++ b/packages/cardpay-sdk/contracts/addresses.ts
@@ -17,8 +17,8 @@ const addresses: {
     cardCpxd: '0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee',
     prepaidCardManager: '0x0ecAF3d3729C99F6b5F37b29A29acB4bB047Ee92',
     oracles: {
-      DAI: '0xA58489902326b530F087e269484263E71356479a',
-      CARD: '0xC91c577DA795fb5917956dB9e3BBEFa709E6b3Ae',
+      DAI: '0xA58489902326b530F087e269484263E71356479a', // eslint-disable-line @typescript-eslint/naming-convention
+      CARD: '0xC91c577DA795fb5917956dB9e3BBEFa709E6b3Ae', // eslint-disable-line @typescript-eslint/naming-convention
     },
   },
   mainnet: {

--- a/packages/cardpay-sdk/index.ts
+++ b/packages/cardpay-sdk/index.ts
@@ -1,13 +1,15 @@
 export { default as TokenBridge } from './sdk/token-bridge';
 export { default as Safes } from './sdk/safes';
 export { default as PrepaidCard } from './sdk/prepaid-card';
+export { default as ExchangeRate } from './sdk/exchange-rate';
 
-export { getAddress, getAddressByNetwork } from './contracts/addresses';
+export { getAddress, getAddressByNetwork, getOracle, getOracleByNetwork } from './contracts/addresses';
 export { getConstant, getConstantByNetwork, networks, networkIds } from './sdk/constants';
 
 export { default as ERC20ABI } from './contracts/abi/erc-20';
 export { default as ERC677ABI } from './contracts/abi/erc-677';
 export { default as ForeignBridgeMediatorABI } from './contracts/abi/foreign-bridge-mediator';
 export { default as PrepaidCardManagerABI } from './contracts/abi/prepaid-card-manager';
+export { default as PriceOracle } from './contracts/abi/price-oracle';
 
 export { default as HttpProvider } from './providers/http-provider';

--- a/packages/cardpay-sdk/package.json
+++ b/packages/cardpay-sdk/package.json
@@ -21,7 +21,8 @@
     "web3": "^1.3.5",
     "web3-core": "^1.3.5",
     "web3-eth-contract": "^1.3.5",
-    "web3-provider-engine": "^16.0.1"
+    "web3-provider-engine": "^16.0.1",
+    "web3-utils": "^1.3.5"
   },
   "homepage": "https://github.com/cardstack/cardstack",
   "license": "MIT",

--- a/packages/cardpay-sdk/sdk/exchange-rate.ts
+++ b/packages/cardpay-sdk/sdk/exchange-rate.ts
@@ -1,0 +1,49 @@
+import Web3 from 'web3';
+import { Contract } from 'web3-eth-contract';
+import { AbiItem } from 'web3-utils';
+import PriceOracle from '../contracts/abi/price-oracle';
+import { getOracle } from '../contracts/addresses';
+import BN from 'bn.js';
+
+const tokenDecimals = new BN('18');
+const ten = new BN('10');
+
+export default class ExchangeRate {
+  constructor(private layer2Web3: Web3) {}
+
+  async getUSDPrice(token: string, amount: string): Promise<number> {
+    let oracle = await this.getOracleContract(token);
+    let usdRawRate = new BN((await oracle.methods.usdPrice().call()).price);
+    let oracleDecimals = Number(await oracle.methods.decimals().call());
+    let rawAmount = usdRawRate.mul(new BN(amount)).div(ten.pow(tokenDecimals));
+    return safeFloatConvert(rawAmount, oracleDecimals);
+  }
+
+  async getETHPrice(token: string, amount: string): Promise<string> {
+    let oracle = await this.getOracleContract(token);
+    let ethRawRate = new BN((await oracle.methods.ethPrice().call()).price);
+    let oracleDecimals = new BN(await oracle.methods.decimals().call());
+    let weiAmount = ethRawRate.mul(new BN(amount)).div(ten.pow(oracleDecimals));
+    return weiAmount.toString();
+  }
+
+  async getUpdatedAt(token: string): Promise<Date> {
+    let oracle = await this.getOracleContract(token);
+    let unixTime = Number((await oracle.methods.usdPrice().call()).updatedAt);
+    return new Date(unixTime * 1000);
+  }
+
+  private async getOracleContract(token: string): Promise<Contract> {
+    let address = await getOracle(token, this.layer2Web3);
+    return new this.layer2Web3.eth.Contract(PriceOracle as AbiItem[], address);
+  }
+}
+
+// because BN does not handle floating point, and the numbers from ethereum
+// might be too large for JS to handle, we'll use string manipulation to move
+// the decimal point. After this operation, the number should be safely in JS's
+// territory.
+function safeFloatConvert(rawAmount: BN, decimals: number): number {
+  let amountStr = rawAmount.toString();
+  return Number(`${amountStr.slice(0, -1 * decimals)}.${amountStr.slice(-1 * decimals)}`);
+}

--- a/packages/cardpay-sdk/sdk/prepaid-card.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card.ts
@@ -2,6 +2,7 @@
 
 import BN from 'bn.js';
 import Web3 from 'web3';
+import { AbiItem } from 'web3-utils';
 import { ContractOptions } from 'web3-eth-contract';
 import ERC677ABI from '../contracts/abi/erc-677.js';
 import { getAddress } from '../contracts/addresses.js';
@@ -111,7 +112,7 @@ export default class PrepaidCard {
 
   private async getPayload(owner: string, tokenAddress: string, amounts: BN[]): Promise<string> {
     let prepaidCardManagerAddress = await getAddress('prepaidCardManager', this.layer2Web3);
-    let token = new this.layer2Web3.eth.Contract(ERC677ABI as any, tokenAddress);
+    let token = new this.layer2Web3.eth.Contract(ERC677ABI as AbiItem[], tokenAddress);
     let sum = new BN(0);
     for (let amount of amounts) {
       sum = sum.add(amount);

--- a/packages/cardpay-sdk/sdk/safes.ts
+++ b/packages/cardpay-sdk/sdk/safes.ts
@@ -2,6 +2,7 @@
 
 import Web3 from 'web3';
 import PrepaidCardManagerABI from '../contracts/abi/prepaid-card-manager';
+import { AbiItem } from 'web3-utils';
 import { getAddress } from '../contracts/addresses';
 import { getConstant, ZERO_ADDRESS } from './constants';
 
@@ -30,7 +31,7 @@ export default class Safes {
     let response = await fetch(`${transactionServiceURL}/v1/owners/${owner}/`);
     let { safes } = (await response.json()) as { safes: string[] };
     let prepaidCardManager = new this.layer2Web3.eth.Contract(
-      PrepaidCardManagerABI as any,
+      PrepaidCardManagerABI as AbiItem[],
       await getAddress('prepaidCardManager', this.layer2Web3)
     );
 

--- a/packages/cardpay-sdk/sdk/token-bridge.ts
+++ b/packages/cardpay-sdk/sdk/token-bridge.ts
@@ -1,6 +1,7 @@
 import Web3 from 'web3';
 import { TransactionReceipt } from 'web3-core';
 import { ContractOptions } from 'web3-eth-contract';
+import { AbiItem } from 'web3-utils';
 import ERC20ABI from '../contracts/abi/erc-20';
 import ForeignBridgeABI from '../contracts/abi/foreign-bridge-mediator';
 import { getAddress } from '../contracts/addresses';
@@ -10,7 +11,7 @@ export default class TokenBridge {
 
   async unlockTokens(tokenAddress: string, amount: string, options?: ContractOptions): Promise<TransactionReceipt> {
     let from = options?.from ?? (await this.layer1Web3.eth.getAccounts())[0];
-    let token = new this.layer1Web3.eth.Contract(ERC20ABI as any, tokenAddress);
+    let token = new this.layer1Web3.eth.Contract(ERC20ABI as AbiItem[], tokenAddress);
     let foreignBridge = await getAddress('foreignBridge', this.layer1Web3);
     return await token.methods.approve(foreignBridge, amount).send({ ...options, from });
   }


### PR DESCRIPTION
This introduces exchange rates API's. Because the math can be very sensitive when dealing with ethereum numbers, especially when you have floating points involved, this API will do the math for you instead of just returning a rate. These rates are a snapshot of the oracles from today (our partners didn't deploy any oracles in sokol, so we have manual feeds that emulate the structure of our partner's contracts--Chainlink and DIA). I did a test of all the rates and they look totally sane. (DAI is just a hair more valuable than USD--you'll notice when you start getting the value of more than 100 DAI)