### PR TITLE
Fix exchange rate inflated number values

### DIFF
--- a/packages/cardpay-sdk/sdk/exchange-rate.ts
+++ b/packages/cardpay-sdk/sdk/exchange-rate.ts
@@ -44,6 +44,6 @@ export default class ExchangeRate {
 // the decimal point. After this operation, the number should be safely in JS's
 // territory.
 function safeFloatConvert(rawAmount: BN, decimals: number): number {
-  let amountStr = rawAmount.toString();
+  let amountStr = rawAmount.toString().padStart(decimals, '0');
   return Number(`${amountStr.slice(0, -1 * decimals)}.${amountStr.slice(-1 * decimals)}`);
 }


### PR DESCRIPTION
Account for amountStr < 8 chars when converting to string-float. 

Inflated:
```
let decimals = 8;
let amountStr = '15'

//.15
console.log(`${amountStr.slice(0, -1 * decimals)}.${amountStr.slice(-1 * decimals)}`); 
```

Expected
```
let decimals = 8;
let amountStr = '15'.padStart(decimals, 0);

// .00000015
console.log(`${amountStr.slice(0, -1 * decimals)}.${amountStr.slice(-1 * decimals)}`);
```
