### PR TITLE
Use updated card chin with connecting state

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -57,7 +57,7 @@
 
     </div>
   </section>
-  <Boxel::CtaBlock @stepNumber={{1}} @state={{this.unlockCtaState}}>
+  <Boxel::ActionChin @stepNumber={{1}} @state={{this.unlockCtaState}}>
     <:default as |a|>
       <a.ActionButton data-test-unlock-button {{on "click" this.unlock}}>
         Unlock
@@ -85,8 +85,8 @@
       </m.InfoArea>
       {{/if}}
     </:memorialized>
-  </Boxel::CtaBlock>
-  <Boxel::CtaBlock @stepNumber={{2}} @state={{this.depositCtaState}} class={{cn card-pay-transaction-amount__deposited-memorialized-cta=(eq this.depositCtaState 'memorialized')}}>
+  </Boxel::ActionChin>
+  <Boxel::ActionChin @stepNumber={{2}} @state={{this.depositCtaState}} class={{cn card-pay-transaction-amount__deposited-memorialized-cta=(eq this.depositCtaState 'memorialized')}}>
     <:default as |a|>
       <a.ActionButton  {{on "click" this.deposit}} data-test-deposit-button>
         Deposit
@@ -114,5 +114,5 @@
       </m.InfoArea>
       {{/if}}
     </:memorialized>
-  </Boxel::CtaBlock>
+  </Boxel::ActionChin>
 </ActionCardContainer>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.css
@@ -24,88 +24,88 @@
   row-gap: 0;
 }
 
-.deposit-card__field-value {
+.deposit-card__title {
   font: 600 var(--boxel-font);
   letter-spacing: var(--boxel-lsp-xs);
 }
 
-.deposit-card__field-value-sm {
+.deposit-card__title-sm {
   font: 600 var(--boxel-font-sm);
+  letter-spacing: var(--boxel-lsp-xs);
 }
 
-.deposit-card__field-address {
-  color: var(--boxel-purple-400);
+.deposit-card__title-lg {
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: calc(27/20);
+  letter-spacing: var(--boxel-lsp-xs);
+}
+
+.deposit-card__address {
+  color: var(--boxel-purple-500);
   font-family: var(--boxel-monospace-font-family);
   font-size: var(--boxel-font-size);
   line-height: calc(22 / 16);
-  letter-spacing: var(--boxel-lsp-sm);
+  letter-spacing: 0.02em;
   word-break: break-all;
 }
 
-.deposit-card__field-address--view-only {
-  max-width: 23ch;
-}
-
-.deposit-card__field-address-sm {
-  color: var(--boxel-purple-500);
+.deposit-card__address-sm {
+  color: var(--boxel-purple-400);
+  font-family: var(--boxel-monospace-font-family);
   font-size: var(--boxel-font-size-sm);
   line-height: calc(18 / 13);
 }
 
+.deposit-card__address--view-only {
+  max-width: 22ch;
+}
+
 .deposit-card__field-info {
   grid-column: 2;
+}
+
+.deposit-card__radio-buttons {
   margin-top: var(--boxel-sp);
 }
 
-.deposit-card__field-info > * + * {
+.deposit-card__radio-buttons > * + * {
   margin-top: var(--boxel-sp);
 }
 
-.deposit-card__account {
-  display: flex;
-  align-items: center;
-  margin-top: var(--boxel-sp-xxs);
-}
-
-.deposit-card__depot {
+.deposit-card__icon-group {
   display: flex;
   align-items: center;
 }
 
-.deposit-card__field-icon {
+.deposit-card__icon-group-sm {
+  display: flex;
+  align-items: center;
+  margin-top: var(--boxel-sp-xs);
+}
+
+.deposit-card__icon {
   align-self: flex-start;
-  margin-right: var(--boxel-sp-sm);
-}
-
-.deposit-card__field-icon-sm {
-  /* width: 1.25rem;
-  height: 1.25rem; */
-  margin-right: var(--boxel-sp-xs);
-}
-
-.deposit-card__loading-indicator {
-  width: var(--boxel-sp-sm);
-  height: var(--boxel-sp-sm);
-}
-
-.deposit-card__selected-token {
-  display: flex;
-  align-items: center;
-}
-
-.deposit-card__selected-token-icon {
   width: 2.5rem;
   height: 2.5rem;
   object-fit: contain;
   margin-right: var(--boxel-sp-sm);
 }
 
-.deposit-card__selected-token-title {
-  color: var(--boxel-dark);
-  font: 600 var(--boxel-font);
-  letter-spacing: var(--boxel-lsp-xs);
+.deposit-card__icon-sm {
+  align-self: flex-start;
+  width: 1.25rem;
+  height: 1.25rem;
+  object-fit: contain;
+  margin-right: var(--boxel-sp-xs);
 }
-.deposit-card__selected-token-desc {
+
+.deposit-card__loading-indicator {
+  width: var(--boxel-sp);
+  height: var(--boxel-sp);
+}
+
+.deposit-card__text-sm {
   color: var(--boxel-purple-500);
   font: var(--boxel-font-sm);
   letter-spacing: var(--boxel-lsp-xs);

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
@@ -10,20 +10,17 @@
         {{#if @isComplete}}
           <CardPay::NestedItems>
             <:outer>
-              <div>
-                <div class="deposit-card__field-value">{{this.layer1Network.chainName}} wallet</div>
-                <div class="deposit-card__field-address" data-test-deposit-transaction-setup-from-address>{{this.layer1Network.walletInfo.firstAddress}}</div>
-              </div>
+              <div class="deposit-card__title">{{this.layer1Network.chainName}} wallet</div>
+              <div class="deposit-card__address" data-test-deposit-transaction-setup-from-address>{{this.layer1Network.walletInfo.firstAddress}}</div>
             </:outer>
             <:inner>
-              <div class="deposit-card__selected-token" data-test-option-view-only>
-                {{svg-jar this.selectedToken.icon class="deposit-card__selected-token-icon" role="presentation" width="40" height="40"}}
+              <div class="deposit-card__icon-group" data-test-option-view-only>
+                {{svg-jar this.selectedToken.icon class="deposit-card__icon" role="presentation" width="40" height="40"}}
                 <div>
-                  <div class="deposit-card__selected-token-title" data-test-balance-view-only={{this.selectedToken.symbol}}>
+                  <div class={{if @isComplete "deposit-card__title-lg" "deposit-card__title"}} data-test-balance-view-only={{this.selectedToken.symbol}}>
                     {{format-token-amount this.selectedTokenBalance}} {{uppercase this.selectedToken.symbol}}
                   </div>
-                  <div class="deposit-card__selected-token-desc" data-test-usd-balance-view-only={{this.selectedToken.symbol}}>
-                    
+                  <div class="deposit-card__text-sm" data-test-usd-balance-view-only={{this.selectedToken.symbol}}>
                     ≈ $ {{token-to-usd this.selectedToken.symbol this.selectedTokenBalance}} USD
                   </div>
                 </div>
@@ -32,10 +29,10 @@
           </CardPay::NestedItems>
         {{else}}
           <div>
-            <div class="deposit-card__field-value">{{this.layer1Network.chainName}} wallet</div>
-            <div class="deposit-card__field-address" data-test-deposit-transaction-setup-from-address>{{this.layer1Network.walletInfo.firstAddress}}</div>
+            <div class="deposit-card__title">{{this.layer1Network.chainName}} wallet</div>
+            <div class="deposit-card__address" data-test-deposit-transaction-setup-from-address>{{this.layer1Network.walletInfo.firstAddress}}</div>
           </div>
-          <div class="deposit-card__field-info deposit-card__field-info--full-width">
+          <div class="deposit-card__field-info deposit-card__radio-buttons">
             {{#each this.tokens as |token|}}
               {{#let (if (eq token.symbol 'CARD') this.layer1Network.cardBalance this.layer1Network.daiBalance) as |balance|}}
                 <CardPay::DepositWorkflow::TransactionSetup::TokenOption
@@ -56,33 +53,39 @@
     <fieldset class="deposit-card__fieldset">
       <legend class="deposit-card__legend">Receive tokens</legend>
       <CardPay::LabeledValue @label="In:" class="deposit-card__field">
-        <div class="deposit-card__field-value">{{this.layer2Network.chainName}} wallet</div>
+        <div class="deposit-card__title">{{this.layer2Network.chainName}} wallet</div>
           <CardPay::NestedItems class="deposit-card__field-info">
             <:outer>
-              <div class="deposit-card__account">
-                <span class="deposit-card__field-icon deposit-card__field-icon-sm">
+              <div class="deposit-card__icon-group-sm">
+                <span class="deposit-card__icon-sm">
                   {{!-- placeholder for account icon --}}
                 </span>
                 <div>
-                  <div class="deposit-card__field-value deposit-card__field-value-sm">Account</div>
-                  <div class="deposit-card__field-address deposit-card__field-address-sm" data-test-deposit-transaction-setup-to-address>
+                  <div class="deposit-card__title-sm">Account</div>
+                  <div class="deposit-card__address-sm" data-test-deposit-transaction-setup-to-address>
                     {{truncate-middle this.layer2Network.walletInfo.firstAddress 7 4}}
                   </div>
                 </div>
               </div>
             </:outer>
             <:inner>
-              <div class="deposit-card__depot">
-                {{svg-jar "depot" width="40" height="40" class="deposit-card__field-icon" role="presentation"}}
+              <div class="deposit-card__icon-group">
+                {{svg-jar "depot" width="40" height="40" class="deposit-card__icon" role="presentation"}}
                 <div>
-                  <div class="deposit-card__field-value">DEPOT:</div>
-                  <div class={{cn "deposit-card__field-address" "deposit-card__field-address-sm" deposit-card__field-address--view-only=@isComplete}} data-test-deposit-transaction-setup-depot-address>
-                    {{#if this.fetchDepotTask.last.isSuccessful}}
-                      {{or this.fetchDepotTask.last.value.address 'Create a new Depot'}}
+                  <div class={{if @isComplete "deposit-card__title-lg" "deposit-card__title"}}>DEPOT:</div>
+                  {{#if this.fetchDepotTask.last.isSuccessful}}
+                    {{#if this.fetchDepotTask.last.value.address}}
+                      <div class={{cn "deposit-card__address" deposit-card__address--view-only=@isComplete}} data-test-deposit-transaction-setup-depot-address>
+                        {{this.fetchDepotTask.last.value.address}}
+                      </div>
                     {{else}}
-                      <LoadingIndicator class="deposit-card__loading-indicator"/>
+                      <div class="deposit-card__text-sm" data-test-deposit-transaction-setup-depot-address>
+                        New Depot
+                      </div>
                     {{/if}}
-                  </div>
+                  {{else}}
+                    <LoadingIndicator class="deposit-card__loading-indicator" />
+                  {{/if}}
                 </div>
               </div>
             </:inner>
@@ -91,10 +94,24 @@
     </fieldset>
   </section>
   <Boxel::ActionChin
-    @disabled={{not @workflowSession.state.depositSourceToken}}
-    @mode={{if @isComplete "memorialized" "data-entry"}}
-    @buttonText={{if @isComplete "Edit" "Continue"}}
-    @onClickButton={{this.toggleComplete}}
+    @state={{if @isComplete "memorialized" "default"}}
     data-test-deposit-transaction-setup
-  />
+  >
+    <:default as |d|>
+      <d.ActionButton
+        {{on "click" this.toggleComplete}}
+        @disabled={{not @workflowSession.state.depositSourceToken}}
+      >
+        Continue
+      </d.ActionButton>
+    </:default>
+    <:memorialized as |m|>
+      <m.ActionButton
+        {{on "click" this.toggleComplete}}
+        @disabled={{not @workflowSession.state.depositSourceToken}}
+      >
+        Continue
+      </m.ActionButton>
+    </:memorialized>
+  </Boxel::ActionChin>
 </ActionCardContainer>

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.css
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.css
@@ -70,3 +70,17 @@
 .layer-one-connect-card__connection-status {
   --icon-color: var(--boxel-dark);
 }
+
+.layer-one-connect-card__logo > svg:nth-child(1) {
+  padding: 5px;
+  background-color: var(--boxel-light);
+  border-radius: var(--boxel-border-radius);
+}
+
+.layer-one-connect-card__loading-indicator {
+  --icon-color: var(--boxel-light);
+
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-right: var(--boxel-sp-xs);
+}

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
@@ -52,7 +52,7 @@
       />
     {{/if}}
   </section>
-  <Boxel::CtaBlock @state={{this.ctaState}}>
+  <Boxel::ActionChin @state={{this.ctaState}}>
     <:default as |a|>
       <a.ActionButton {{on "click" this.connect}} data-test-mainnet-connect-button>
         Connect Wallet
@@ -64,28 +64,21 @@
       </d.ActionButton>
     </:disabled>
     <:in-progress as |i|>
-      <i.ActionButton data-test-mainnet-connect-button>
-        Connecting
-      </i.ActionButton>
+      <i.ActionStatusArea class="layer-one-connect-card__logo" @icon={{concat this.radioWalletProviderId "-logo"}} style={{css-var status-icon-size="2.5rem"}}>
+        <LoadingIndicator class="layer-one-connect-card__loading-indicator" />
+        Waiting for you to connect Card Pay with your mainnet wallet...
+      </i.ActionStatusArea>
       <i.CancelButton {{on "click" this.cancelConnection}}>
         Cancel
       </i.CancelButton>
+      <i.InfoArea>
+        Only visible to you
+      </i.InfoArea>
     </:in-progress>
     <:memorialized as |m|>
       <m.ActionButton {{on "click" this.disconnect}} data-test-mainnet-disconnect-button>
         Disconnect Wallet
       </m.ActionButton>
     </:memorialized>
-  </Boxel::CtaBlock>
+  </Boxel::ActionChin>
 </ActionCardContainer>
-
-{{#if (and this.isWaitingForConnection (not @suppressConnectingCard))}}
-  <ActionCardContainer class="layer-one-connect-card__connection">
-    <div class="layer-one-connect-card__connection-icons">
-      <img src={{this.cardstackLogo}} alt="" role="presentation" class="layer-one-connect-card__connection-cardstack-logo">
-      <img src={{this.connectionSymbol}} alt="" role="presentation" class="layer-one-connect-card__connection-symbol">
-      <img src={{this.connectedWalletLogo}} alt="" role="presentation" class="layer-one-connect-card__connection-wallet-logo">
-    </div>
-    <div class="layer-one-connect-card__connection-text">Waiting for you to connect Card Pay with your mainnet wallet...</div>
-  </ActionCardContainer>
-{{/if}}

--- a/packages/web-client/app/components/card-pay/layer-one-wallet-provider-selection/index.css
+++ b/packages/web-client/app/components/card-pay/layer-one-wallet-provider-selection/index.css
@@ -73,5 +73,5 @@
 
 .card-pay-layer-one-wallet-provider-selection__item-disabled:not(.card-pay-layer-one-wallet-provider-selection__item--checked) {
   opacity: 0.5;
-  box-shadow: 0 0 0 1px transparent;
+  box-shadow: 0 0 0 1px var(--boxel-light-400);
 }

--- a/packages/web-client/app/components/card-pay/layer-two-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-two-connect-card/index.hbs
@@ -36,13 +36,13 @@
         />
       </CardPay::FieldStack>
     </section>
-    <Boxel::CtaBlock @state='memorialized'>
+    <Boxel::ActionChin @state='memorialized'>
       <:memorialized as |m|>
         <m.ActionButton {{on "click" (perform this.disconnectWalletTask)}} data-test-layer-2-wallet-disconnect-button>
           Disconnect Wallet
         </m.ActionButton>
       </:memorialized>
-    </Boxel::CtaBlock>
+    </Boxel::ActionChin>
   {{else}}
     <div class="layer-two-connect-card__section-one">
       <h2 class="layer-two-connect-card__header">

--- a/packages/web-client/app/components/loading-indicator/index.hbs
+++ b/packages/web-client/app/components/loading-indicator/index.hbs
@@ -1,3 +1,3 @@
 <div class="loading-indicator" ...attributes>
-  {{svg-jar "loading-indicator" width="20" height="20"}}
+  {{svg-jar "loading-indicator"}}
 </div>

--- a/packages/web-client/app/components/loading-indicator/index.hbs
+++ b/packages/web-client/app/components/loading-indicator/index.hbs
@@ -1,3 +1,3 @@
 <div class="loading-indicator" ...attributes>
-  {{svg-jar "loading-indicator"}}
+  {{svg-jar "loading-indicator" width="20" height="20"}}
 </div>

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -22,7 +22,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
-    "@cardstack/boxel": "^0.7.0",
+    "@cardstack/boxel": "^0.7.1",
     "@cardstack/cardpay-sdk": "0.19.8",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -150,7 +150,7 @@ module('Acceptance | deposit', function (hooks) {
       .hasText('0x18261...6E44');
     assert
       .dom(`${post} [data-test-deposit-transaction-setup-depot-address]`)
-      .hasText('Create a new Depot');
+      .hasText('New Depot');
     assert
       .dom('[data-test-deposit-transaction-setup-is-complete]')
       .doesNotExist();
@@ -158,7 +158,6 @@ module('Acceptance | deposit', function (hooks) {
     assert
       .dom('[data-test-deposit-transaction-setup] [data-test-boxel-button]')
       .isDisabled();
-
     await click(`${post} [data-test-option="DAI"]`);
     await click(
       `${post} [data-test-deposit-transaction-setup] [data-test-boxel-button]`

--- a/packages/web-client/tests/integration/components/layer-one-connect-card-test.ts
+++ b/packages/web-client/tests/integration/components/layer-one-connect-card-test.ts
@@ -56,12 +56,13 @@ module('Integration | Component | layer-one-connect-card', function (hooks) {
     await render(hbs`
         <CardPay::LayerOneConnectCard/>
       `);
-
     await click('[data-test-wallet-option="metamask"]');
     await click(CONNECT_BUTTON_SELECTOR);
 
     // the card should not be assuming it is connected to metamask before connection is completed
-    assert.dom(CONNECT_BUTTON_SELECTOR).hasClass(/--loading/);
+    assert
+      .dom('[data-test-boxel-action-chin-action-status-area]')
+      .containsText('Waiting for you to connect');
     assert
       .dom(HEADER_SELECTOR)
       .containsText('Connect your Ethereum mainnet wallet');

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,10 +933,10 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@cardstack/boxel@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@cardstack/boxel/-/boxel-0.7.0.tgz#e34eef7a72328fd66f3da2ca0c47e55b5cc83fc6"
-  integrity sha512-zMdB9uw1MDrcSd3wz+MWW9pNE+5r96ocijO7QeY5DPvk9b2JuKd2XdyYfw2RXte3mAkFVsNRutzakfPmerZ3XA==
+"@cardstack/boxel@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@cardstack/boxel/-/boxel-0.7.1.tgz#baa64e56708e5090821eda02df68a337a2701615"
+  integrity sha512-wgRq7zz6QH/zT6jUVZC6qGjPTJl4A7qgU21TZ4jCAr6URaUnjXVXC1W1b9oHmFAYU9Cry2AydePgBHN4mpMH6Q==
   dependencies:
     broccoli-concat "^4.2.4"
     broccoli-funnel "^3.0.3"


### PR DESCRIPTION
CS-709, CS-719

- Update boxel version
- Use chin
- Update layer-1 connecting state chin
- Fix alignment regression on transaction setup card

**Note:** Cancel button is TBD. Need to check with Gardella when he returns. Leaving the button as is for now.

<img width="731" alt="connecting-chin" src="https://user-images.githubusercontent.com/16160806/118145458-a1481e80-b3db-11eb-98f1-953fdf8d343c.png">