### PR TITLE
Transaction-amount card styling update

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.css
@@ -1,70 +1,138 @@
-.card-pay-token-balance-view {
-  display: flex;
-  align-items: start;
-  padding: var(--boxel-sp);
-  box-shadow: 0 0 0 2px var(--boxel-light-400);
+/* details - summary container styles */
+.balance-view {
+  --details-summary-height: 3.125rem; /* 50px */
+  --details-open-height: 11rem; /* ~180px */
+
+  position: relative;
+  border: 1px solid var(--boxel-light-400);
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.35);
   border-radius: var(--boxel-border-radius);
+  height: var(--details-summary-height);
+  overflow: hidden;
+  transition: height var(--boxel-transition);
 }
 
-.card-pay-token-balance-view__currency-details, .card-pay-token-balance-view__balance {
-  flex-shrink: 0;
+.balance-view[open] {
+  height: var(--details-open-height);
+  overflow: auto;
+}
+
+.balance-view__summary {
+  cursor: pointer;
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  gap: 0 var(--boxel-sp);
+  height: var(--details-summary-height);
+  padding: var(--boxel-sp-xxs) calc(var(--boxel-sp) + 3rem) var(--boxel-sp-xxs) var(--boxel-sp);
+  font: 600 var(--boxel-font-sm);
+  letter-spacing: var(--boxel-lsp-xs);
+  transition: padding var(--boxel-transition),
+    font var(--boxel-transition);
 }
 
-.card-pay-token-balance-view__currency-icon {
+.balance-view__summary:focus {
+  outline-color: var(--boxel-highlight);
+  outline-offset: -5px;
+}
+
+.balance-view__summary--memorialized {
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.balance-view__summary-balance {
+  letter-spacing: var(--boxel-lsp);
+}
+
+.balance-view__summary--memorialized .balance-view__summary-balance {
+  color: var(--boxel-purple-500);
+  font: var(--boxel-font-sm);
+}
+
+.balance-view[open] .balance-view__summary {
+  height: auto;
+  padding: var(--boxel-sp-xl) var(--boxel-sp-lg) 0;
+  font: 600 var(--boxel-font);
+}
+
+.balance-view__details {
+  padding: 0 var(--boxel-sp-lg) var(--boxel-sp-xl);
+}
+
+.balance-view[open] .balance-view__summary-balance {
+  display: none;
+}
+
+.balance-view__marker::before {
+  display: block;
+  content: "Show";
+}
+
+.balance-view[open] .balance-view__marker::before {
+  content: "Hide";
+}
+
+.balance-view__marker {
+  position: absolute;
+  right: var(--boxel-sp-sm);
+  top: var(--boxel-sp-sm);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font: var(--boxel-font-sm);
+  letter-spacing: var(--boxel-lsp-sm);
+}
+
+.balance-view__marker-icon {
+  margin-left: var(--boxel-sp-xs);
+  transform: rotate(90deg);
+}
+
+.balance-view[open] .balance-view__marker-icon {
+  transform: rotate(-90deg);
+}
+
+/* balance display styles */
+.balance-view__address {
+  color: var(--boxel-purple-500);
+  font-family: var(--boxel-monospace-font-family);
+  font-size: var(--boxel-font-size);
+  line-height: calc(22 / 16);
+  letter-spacing: 0;
+  word-break: break-all;
+}
+
+.balance-view__token {
+  display: flex;
+  align-items: center;
+  color: var(--boxel-dark);
+}
+
+.balance-view__token-icon {
+  align-self: flex-start;
   flex-shrink: 0;
   width: 2.5rem;
   height: 2.5rem;
   object-fit: contain;
   margin-right: var(--boxel-sp-sm);
-  margin-bottom: auto;
 }
 
-.card-pay-token-balance-view__currency-details-name {
-  font: 600 var(--boxel-font);
-  color: var(--boxel-dark);
+.balance-view__token-balance {
+  font-weight: 600;
+  font-size: 1.25rem;
+  line-height: calc(27 / 20);
+  letter-spacing: var(--boxel-lsp-xs);
 }
 
-.card-pay-token-balance-view__currency-details-description {
-  font: var(--boxel-font-sm);
-  color: var(--boxel-purple-500);
-  margin-bottom: var(--boxel-sp-xxxs);
-}
-
-.card-pay-token-balance-view__currency-details-address {
-  font-family: "Roboto Mono";
-  font-size: var(--boxel-font-size-sm);
-  line-height: 1.125rem;
-  letter-spacing: var(--boxel-lsp-sm);
-  color: var(--boxel-purple-500);
-  max-width: 22ch;
-  word-break: break-all;
-}
-
-.card-pay-token-balance-view__balance {
-  margin-left: auto;
-  margin-top: auto;
-  margin-bottom: auto;
-}
-
-.card-pay-token-balance-view__balance-header {
-  font: var(--boxel-font-sm);
-  color: var(--boxel-purple-500);
-  margin-bottom: var(--boxel-sp-xxxs);
-}
-
-.card-pay-token-balance-view__balance-amount {
-  font: var(--boxel-font);
-  color: var(--boxel-dark);
-}
-
-.card-pay-token-balance-view__balance-equivalent {
-  font: var(--boxel-font-sm);
+.balance-view__usd-balance {
   color: var(--boxel-purple-400);
+  font: var(--boxel-font-sm);
+  letter-spacing: var(--boxel-lsp-xs);
 }
 
-.card-pay-token-balance-view__loading-indicator {
-  width: var(--boxel-sp-sm);
-  height: var(--boxel-sp-sm);
+.balance-view__loading-indicator {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
 }

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.hbs
@@ -1,30 +1,35 @@
-<div class="card-pay-token-balance-view" ...attributes>
-  {{svg-jar @tokenIcon class="card-pay-token-balance-view__currency-icon" role="presentation"}}
-  <div class="card-pay-token-balance-view__currency-details">
-    <span class="card-pay-token-balance-view__currency-details-name" data-test-source-token={{@tokenSymbol}}>
-      {{@tokenSymbol}}
-    </span>
-    <span class="card-pay-token-balance-view__currency-details-description">
-      {{@tokenDescription}}
-    </span>
-    <span class="card-pay-token-balance-view__currency-details-address">
-      {{@address}}
-    </span>
-  </div>
-
-  <div class="card-pay-token-balance-view__balance">
-    <span class="card-pay-token-balance-view__balance-header">
-      Balance
-    </span>
-    <span class="card-pay-token-balance-view__balance-amount">
+<details class="balance-view" ...attributes>
+  <summary class={{cn "balance-view__summary" balance-view__summary--memorialized=@isComplete}}>
+    <div>{{@wallet}} wallet</div>
+    <div class="balance-view__summary-balance" data-test-source-token={{@tokenSymbol}}>
       {{@balance}} {{@tokenSymbol}}
-    </span>
-    <span class="card-pay-token-balance-view__balance-equivalent">
-      {{#if @balanceInUsd}}
-        ≈ $ {{@balanceInUsd}} USD
-      {{else}}
-        <Boxel::LoadingIndicator class="card-pay-token-balance-view__loading-indicator"/>
-      {{/if}}
-    </span>
-  </div>
-</div>
+    </div>
+    <div class="balance-view__marker">
+      {{svg-jar "caret-right" class="balance-view__marker-icon" role="presentation"}}
+    </div>
+  </summary>
+  <CardPay::NestedItems class="balance-view__details">
+    <:outer>
+      <div class="balance-view__address">
+        {{@address}}
+      </div>
+    </:outer>
+    <:inner>
+      <div class="balance-view__token">
+        {{svg-jar @tokenIcon class="balance-view__token-icon" role="presentation" width="40" height="40"}}
+        <div>
+          <div class="balance-view__token-balance">
+            {{@balance}} {{@tokenSymbol}}
+          </div>
+          {{#if @balanceInUsd}}
+            <div class="balance-view__usd-balance">
+              ≈ $ {{@balanceInUsd}} USD
+            </div>
+          {{else}}
+            <Boxel::LoadingIndicator class="balance-view__loading-indicator" />
+          {{/if}}
+        </div>
+      </div>
+    </:inner>
+  </CardPay::NestedItems>
+</details>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.css
@@ -1,53 +1,50 @@
-.card-pay-transaction-amount__body {
-  padding: 0 var(--boxel-sp-lg);
+.transaction-amount__body {
+  --tx-amount-from-label-height: 3.125rem; /* 50px */
+  --tx-amount-input-height: 3.75rem; /* 60px */
+
   display: flex;
   flex-direction: column;
+  margin: 0 auto;
+  padding: var(--boxel-sp-xxl) var(--boxel-sp-lg);
 }
 
-.card-pay-transaction-amount__body-header {
-  padding: var(--boxel-sp-xl) 0;
-  font-size: 1.125rem;
-  font-weight: 600;
+.transaction-amount__body-header {
+  font: 700 1.125rem/calc(24/18) var(--boxel-font-family);
+  letter-spacing: 0;
 }
 
-.card-pay-transaction-amount__input-section {
-  padding-top: var(--boxel-sp-xl);
-  padding-bottom: var(--boxel-sp-xl);
+.transaction-amount__body-header + .transaction-amount__input-section {
+  margin-top: var(--boxel-sp-xxl);
 }
 
-.card-pay-transaction-amount__input-section > * + * {
+.transaction-amount__input-section > * + * {
   margin-top: var(--boxel-sp-lg);
 }
 
-.card-pay-transaction-amount__field {
-  --boxel-field-label-width: minmax(4rem, 25%);
-}
-
-.card-pay-transaction-amount__field-contents {
-  display: flex;
-  align-items: center;
-}
-
-.card-pay-transaction-amount__small-icon {
-  width: 1.25rem;
-  height: 1.25rem;
-  margin-right: 0.5rem;
-}
-
-.card-pay-transaction-amount__amount-field-input-container {
-  --input-currency-icon-size: 1.25rem;
+.transaction-amount__input-container {
+  --input-currency-icon-size: 2.5rem;
   --input-currency-text-width: 5ch;
   --input-currency-icon-space: var(--boxel-sp-xs);
   --input-currency-text-space: var(--boxel-sp-sm);
   position: relative;
 }
 
-.card-pay-transaction-amount__amount-field-input {
-  padding-left: calc(var(--input-currency-icon-size) + var(--input-currency-icon-space) * 2);
-  padding-right: calc(var(--input-currency-text-width) + var(--input-currency-text-space) * 2);
+.transaction-amount__input-token-balance {
+  font-family: var(--boxel-font-family);
+  font-size: 1.25rem;
+  line-height: calc(27 / 20);
+  letter-spacing: var(--boxel-lsp-xs);
 }
 
-.card-pay-transaction-amount__amount-field-currency-icon {
+.transaction-amount__input {
+  height: var(--tx-amount-input-height);
+  padding-left: calc(var(--input-currency-icon-size) + var(--input-currency-icon-space) * 2);
+  padding-right: calc(var(--input-currency-text-width) + var(--input-currency-text-space) * 2);
+  font: inherit;
+  letter-spacing: inherit;
+}
+
+.transaction-amount__currency-icon {
   position: absolute;
   width: var(--input-currency-icon-size);
   height: var(--input-currency-icon-size);
@@ -57,7 +54,7 @@
   user-select: none;
 }
 
-.card-pay-transaction-amount__amount-field-currency-text {
+.transaction-amount__currency-text {
   position: absolute;
   width: var(--input-currency-text-width);
   right: var(--input-currency-text-space);
@@ -67,6 +64,60 @@
   user-select: none;
 }
 
-.card-pay-transaction-amount__deposited-memorialized-cta {
-  border-top: 1px solid var(--boxel-light-600);
+.transaction-amount__from-field-label {
+  align-self: flex-start;
+  display: flex;
+  align-items: center;
+  height: var(--tx-amount-from-label-height);
+}
+
+/* unlocking, unlocked, memorialized states */
+.transaction-amount--data-entered .transaction-amount__input-section > * + * {
+  margin-top: var(--boxel-sp);
+}
+
+.transaction-amount--data-entered .transaction-amount__field {
+  grid-template-columns: 1fr;
+  row-gap: var(--boxel-sp-xxs);
+}
+
+.transaction-amount--data-entered .transaction-amount__from-field-label {
+  height: unset;
+}
+
+/* token balance display styles */
+.transaction-amount__token {
+  display: flex;
+  align-items: center;
+  color: var(--boxel-dark);
+
+  /* bordered display box */
+  justify-content: center;
+  padding: var(--boxel-sp-xl) var(--boxel-sp);
+  border: 1px solid var(--boxel-light-400);
+  border-radius: var(--boxel-border-radius);
+}
+
+.transaction-amount__token-icon {
+  align-self: flex-start;
+  flex-shrink: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  object-fit: contain;
+  margin-right: var(--boxel-sp-sm);
+}
+
+.transaction-amount__token-balance {
+  font-weight: 600;
+  font-size: 1.25rem;
+  line-height: calc(27 / 20);
+  letter-spacing: var(--boxel-lsp-xs);
+  margin-top: var(--boxel-sp-xxs);
+}
+
+.transaction-amount__usd-balance {
+  color: var(--boxel-purple-500);
+  font: var(--boxel-font-sm);
+  letter-spacing: var(--boxel-lsp-xs);
+  margin-top: var(--boxel-sp-xs);
 }

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -1,60 +1,70 @@
 <ActionCardContainer
-  class="card-pay-transaction-amount"
+  class={{cn "transaction-amount" transaction-amount--data-entered=this.isUnlockingOrUnlocked}}
   @header="Deposit Amount"
   @isComplete={{@isComplete}}
 >
-  <section class="card-pay-transaction-amount__body">
-    <header class="card-pay-transaction-amount__body-header">
+  <section class="transaction-amount__body">
+    <header class="transaction-amount__body-header">
       Choose an amount to deposit into the reserve pool
     </header>
-    <CardPay::DepositWorkflow::TransactionAmount::BalanceView
-      @tokenSymbol={{this.currentTokenSymbol}}
-      @tokenIcon={{this.currentTokenDetails.icon}}
-      @tokenDescription={{this.currentTokenDetails.description}}
-      @address={{this.layer1Network.walletInfo.firstAddress}}
-      @balance={{format-token-amount this.currentTokenBalance}}
-      @balanceInUsd={{token-to-usd this.currentTokenSymbol this.currentTokenBalance}}
-    />
-    <div class="card-pay-transaction-amount__input-section">
-      {{#if this.isUnlocked}}
-      <CardPay::LabeledValue
-        @label="Amount to deposit"
-        @icon={{this.currentTokenDetails.icon}}
-        @value={{concat this.amount " " this.currentTokenSymbol}}
-      />
-      {{else}}
+    <div class="transaction-amount__input-section">
       <Boxel::Field
-        @label="Amount to deposit"
-        @fieldMode="edit"
-        class="card-pay-transaction-amount__field"
-        @labelClass="card-pay-transaction-amount__field-label"
+        class="transaction-amount__field"
+        @label="Funding From:"
+        @labelClass="transaction-amount__from-field-label"
       >
-      <div class="card-pay-transaction-amount__amount-field-input-container">
-        {{svg-jar this.currentTokenDetails.icon class="card-pay-transaction-amount__amount-field-currency-icon" role="presentation"}}
-        {{!--
-          .boxel-input is a hack to get the boxel styles.
-          depending on how we plan to handle validation of this input,
-          we may need to change Boxel's input to use a more DDAU pattern
-        --}}
-        <input
-          class="boxel-input card-pay-transaction-amount__amount-field-input"
-          id="deposit-amount-input"
-          value={{this.amount}}
-          {{on "input" this.onInputAmount}}
-          data-test-deposit-amount-input
+        <CardPay::DepositWorkflow::TransactionAmount::BalanceView
+          @wallet={{this.layer1Network.chainName}}
+          @tokenSymbol={{this.currentTokenSymbol}}
+          @tokenIcon={{this.currentTokenDetails.icon}}
+          @address={{this.layer1Network.walletInfo.firstAddress}}
+          @balance={{format-token-amount this.currentTokenBalance}}
+          @balanceInUsd={{token-to-usd this.currentTokenSymbol this.currentTokenBalance}}
+          @isComplete={{@isComplete}}
         />
-        <div class="card-pay-transaction-amount__amount-field-currency-text">
-          {{this.currentTokenSymbol}}
-        </div>
-      </div>
       </Boxel::Field>
+      {{#if this.isUnlockingOrUnlocked}}
+        <Boxel::Field
+          class="transaction-amount__field"
+          @label="Amount to deposit:"
+        >
+          <div class="transaction-amount__token">
+            {{svg-jar this.currentTokenDetails.icon class="transaction-amount__token-icon" role="presentation" width="40" height="40"}}
+            <div>
+              <div class="transaction-amount__token-balance" data-test-deposit-amount-entered>
+                {{this.amount}} {{this.currentTokenSymbol}}
+              </div>
+              <div class="transaction-amount__usd-balance">
+                ≈ $ {{token-to-usd this.currentTokenSymbol this.amountAsBigNumber}} USD
+              </div>
+            </div>
+          </div>
+        </Boxel::Field>
+      {{else}}
+        <Boxel::Field
+          @label="Amount to deposit"
+          @fieldMode="edit"
+          class="transaction-amount__field"
+        >
+        <div class="transaction-amount__input-container transaction-amount__input-token-balance">
+          {{svg-jar this.currentTokenDetails.icon class="transaction-amount__currency-icon" role="presentation"}}
+          {{!-- .boxel-input is a hack to get the boxel styles. --}}
+          <input
+            class="boxel-input transaction-amount__input"
+            id="deposit-amount-input"
+            value={{this.amount}}
+            {{on "input" this.onInputAmount}}
+            data-test-deposit-amount-input
+          />
+          <div class="transaction-amount__currency-text">
+            {{this.currentTokenSymbol}}
+          </div>
+        </div>
+        </Boxel::Field>
+        <Boxel::Field @label="Approximate value">
+          $ {{token-to-usd this.currentTokenSymbol this.amountAsBigNumber}} USD
+        </Boxel::Field>
       {{/if}}
-
-      <CardPay::LabeledValue
-        @label="Approximate value"
-        @value={{concat "$ " (token-to-usd this.currentTokenSymbol this.amountAsBigNumber) " USD"}}
-      />
-
     </div>
   </section>
   <Boxel::ActionChin @stepNumber={{1}} @state={{this.unlockCtaState}}>
@@ -86,7 +96,7 @@
       {{/if}}
     </:memorialized>
   </Boxel::ActionChin>
-  <Boxel::ActionChin @stepNumber={{2}} @state={{this.depositCtaState}} class={{cn card-pay-transaction-amount__deposited-memorialized-cta=(eq this.depositCtaState 'memorialized')}}>
+  <Boxel::ActionChin @stepNumber={{2}} @state={{this.depositCtaState}}>
     <:default as |a|>
       <a.ActionButton  {{on "click" this.deposit}} data-test-deposit-button>
         Deposit

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
@@ -102,6 +102,12 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<CardPay
     );
   }
 
+  get isUnlockingOrUnlocked() {
+    // user has entered the tx amount in the input field and started the unlocking process
+    // once the unlocking process is started, the input can no longer be changed
+    return this.isUnlocking || this.isUnlocked;
+  }
+
   @action onInputAmount(event: InputEvent) {
     const str = (event.target as HTMLInputElement).value;
     if (!isNaN(+str)) {

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -198,6 +198,10 @@ module('Acceptance | deposit', function (hooks) {
     assert
       .dom(`${post} [data-test-unlock-button]`)
       .hasClass('boxel-button--loading');
+    assert
+      .dom('[data-test-deposit-amount-input]')
+      .doesNotExist('Input field is no longer available when unlocking');
+    assert.dom('[data-test-deposit-amount-entered]').hasText('250 DAI');
 
     layer1Service.test__simulateUnlock();
     await settled();
@@ -208,7 +212,9 @@ module('Acceptance | deposit', function (hooks) {
     assert
       .dom(`${post} [data-test-unlock-success-message]`)
       .exists('There should be a success message after unlocking');
-
+    assert
+      .dom('[data-test-deposit-amount-input]')
+      .doesNotExist('Input field is no longer available after unlocking');
     assert
       .dom(`${post} [data-test-deposit-button]`)
       .isEnabled('Deposit is enabled once unlocked');


### PR DESCRIPTION
CS-712

I removed any other refactor, here are the tx-amount-card-only styling changes:

<img width="726" alt="unlock" src="https://user-images.githubusercontent.com/16160806/118698881-ece53880-b7de-11eb-931d-a814460a1197.png">
<img width="725" alt="unlock-expanded" src="https://user-images.githubusercontent.com/16160806/118698904-f1a9ec80-b7de-11eb-95c0-66819664649c.png">
<img width="724" alt="unlocking" src="https://user-images.githubusercontent.com/16160806/118698892-ef479280-b7de-11eb-9a0d-dc369299a9e6.png">
<img width="615" alt="memorialized" src="https://user-images.githubusercontent.com/16160806/118698928-f79fcd80-b7de-11eb-94db-cbe6eef49c40.png">
<img width="611" alt="memorialized-expanded" src="https://user-images.githubusercontent.com/16160806/118698935-f8d0fa80-b7de-11eb-9a9f-53ee49c7d557.png">


