### PR TITLE
Upgrade Boxel to 0.7.2

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/next-steps/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/next-steps/index.css
@@ -1,5 +1,0 @@
-.card-pay-deposit-button-container {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--boxel-sp);
-}

--- a/packages/web-client/app/components/card-pay/deposit-workflow/next-steps/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/next-steps/index.hbs
@@ -1,20 +1,18 @@
 <Boxel::NextStepsBox>
-  <div class="card-pay-deposit-button-container">
-    <Boxel::Button 
-      @size="base" 
-      @kind="primary" 
-      {{on "click" this.openNewDepositWorkflow}} 
-      data-test-deposit-next-step="new-deposit"
-    >
-      Make Another Deposit
-    </Boxel::Button>
-    <Boxel::Button 
-      @size="base" 
-      @kind="secondary-dark" 
-      {{on "click" this.returnToDashboard}} 
-      data-test-deposit-next-step="dashboard"
-    >
-      Return to Dashboard
-    </Boxel::Button>
-  </div>
+  <Boxel::Button 
+    @size="base" 
+    @kind="primary" 
+    {{on "click" this.openNewDepositWorkflow}} 
+    data-test-deposit-next-step="new-deposit"
+  >
+    Make Another Deposit
+  </Boxel::Button>
+  <Boxel::Button 
+    @size="base" 
+    @kind="secondary-dark" 
+    {{on "click" this.returnToDashboard}} 
+    data-test-deposit-next-step="dashboard"
+  >
+    Return to Dashboard
+  </Boxel::Button>
 </Boxel::NextStepsBox>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.hbs
@@ -23,7 +23,7 @@
       {{#if @balanceInUsd}}
         ≈ $ {{@balanceInUsd}} USD
       {{else}}
-        <LoadingIndicator class="card-pay-token-balance-view__loading-indicator"/>
+        <Boxel::LoadingIndicator class="card-pay-token-balance-view__loading-indicator"/>
       {{/if}}
     </span>
   </div>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.css
@@ -100,11 +100,6 @@
   margin-right: var(--boxel-sp-xs);
 }
 
-.deposit-card__loading-indicator {
-  width: var(--boxel-sp);
-  height: var(--boxel-sp);
-}
-
 .deposit-card__text-sm {
   color: var(--boxel-purple-500);
   font: var(--boxel-font-sm);

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
@@ -84,7 +84,7 @@
                       </div>
                     {{/if}}
                   {{else}}
-                    <LoadingIndicator class="deposit-card__loading-indicator" />
+                    <Boxel::LoadingIndicator/>
                   {{/if}}
                 </div>
               </div>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.hbs
@@ -25,7 +25,7 @@
       {{#if @balanceInUsd}}
         ≈ $ {{@balanceInUsd}} USD
       {{else}}
-        <LoadingIndicator class="token-option__loading-indicator"/>
+        <Boxel::LoadingIndicator class="token-option__loading-indicator"/>
       {{/if}}
     </div>
   </div>

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/next-steps/index.css
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/next-steps/index.css
@@ -1,5 +1,0 @@
-.card-pay-issue-prepaid-card-button-container {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--boxel-sp);
-}

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/next-steps/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/next-steps/index.hbs
@@ -1,20 +1,18 @@
 <Boxel::NextStepsBox>
-  <div class="card-pay-issue-prepaid-card-button-container">
-    <Boxel::Button 
-      @size="base" 
-      @kind="primary" 
-      {{on "click" this.openNewIssuanceWorkflow}} 
-      data-test-issue-prepaid-card-next-step="new-issuance"
-    >
-      Make Another Deposit
-    </Boxel::Button>
-    <Boxel::Button 
-      @size="base" 
-      @kind="secondary-dark" 
-      {{on "click" this.returnToDashboard}} 
-      data-test-issue-prepaid-card-next-step="dashboard"
-    >
-      Return to Dashboard
-    </Boxel::Button>
-  </div>
+  <Boxel::Button 
+    @size="base" 
+    @kind="primary" 
+    {{on "click" this.openNewIssuanceWorkflow}} 
+    data-test-issue-prepaid-card-next-step="new-issuance"
+  >
+    Make Another Deposit
+  </Boxel::Button>
+  <Boxel::Button 
+    @size="base" 
+    @kind="secondary-dark" 
+    {{on "click" this.returnToDashboard}} 
+    data-test-issue-prepaid-card-next-step="dashboard"
+  >
+    Return to Dashboard
+  </Boxel::Button>
 </Boxel::NextStepsBox>

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.css
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.css
@@ -78,9 +78,7 @@
 }
 
 .layer-one-connect-card__loading-indicator {
-  --icon-color: var(--boxel-light);
-
-  width: 1.25rem;
-  height: 1.25rem;
   margin-right: var(--boxel-sp-xs);
+  flex-grow: 0;
+  flex-shrink: 0;
 }

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
@@ -65,7 +65,10 @@
     </:disabled>
     <:in-progress as |i|>
       <i.ActionStatusArea class="layer-one-connect-card__logo" @icon={{concat this.radioWalletProviderId "-logo"}} style={{css-var status-icon-size="2.5rem"}}>
-        <LoadingIndicator class="layer-one-connect-card__loading-indicator" />
+        <Boxel::LoadingIndicator 
+          class="layer-one-connect-card__loading-indicator" 
+          @color="var(--boxel-light)"
+        />
         Waiting for you to connect Card Pay with your mainnet wallet...
       </i.ActionStatusArea>
       <i.CancelButton {{on "click" this.cancelConnection}}>

--- a/packages/web-client/app/components/loading-indicator/index.css
+++ b/packages/web-client/app/components/loading-indicator/index.css
@@ -1,7 +1,0 @@
-.loading-indicator {
-  animation: spin 6000ms linear infinite;
-}
-
-@keyframes spin {
-  to {transform:rotate(360deg);}
-}

--- a/packages/web-client/app/components/loading-indicator/index.hbs
+++ b/packages/web-client/app/components/loading-indicator/index.hbs
@@ -1,3 +1,0 @@
-<div class="loading-indicator" ...attributes>
-  {{svg-jar "loading-indicator"}}
-</div>

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -22,7 +22,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
-    "@cardstack/boxel": "^0.7.1",
+    "@cardstack/boxel": "^0.7.2",
     "@cardstack/cardpay-sdk": "0.19.10",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,10 +933,10 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@cardstack/boxel@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@cardstack/boxel/-/boxel-0.7.1.tgz#baa64e56708e5090821eda02df68a337a2701615"
-  integrity sha512-wgRq7zz6QH/zT6jUVZC6qGjPTJl4A7qgU21TZ4jCAr6URaUnjXVXC1W1b9oHmFAYU9Cry2AydePgBHN4mpMH6Q==
+"@cardstack/boxel@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@cardstack/boxel/-/boxel-0.7.2.tgz#ce8c1650dafa583882145424c12326e377ee661d"
+  integrity sha512-IT000z75EU2YlFUc66y7CGl25zWpxxf6UTcQkjqrvc0XGssL3GM960yN0P2t6mJ+yq4TDInsd6hNoWEwpto2/A==
   dependencies:
     broccoli-concat "^4.2.4"
     broccoli-funnel "^3.0.3"
@@ -9264,7 +9264,7 @@ ember-page-title@^6.2.1:
   dependencies:
     ember-cli-babel "^7.22.1"
 
-ember-power-select-typeahead@alexspeller/ember-power-select-typeahead#6d279fb:
+"ember-power-select-typeahead@github:alexspeller/ember-power-select-typeahead#6d279fb":
   version "0.8.0"
   resolved "https://codeload.github.com/alexspeller/ember-power-select-typeahead/tar.gz/6d279fb9e6a640282a2dc887fe06f1d09a062148"
   dependencies:


### PR DESCRIPTION
Fixes issue with static loading indicator on buttons, and allows use of NextStepsBox without having to add a containing element that applies a cluster layout.