### PR TITLE
Transfer safe tokens

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,16 +49,16 @@
       "args": [
         // Kovan CARD Bridge args
         // "bridge",
+        // "10000",
         // "0xd6E34821F508e4247Db359CFceE0cb5e8050972a",
-        // "1000",
         // "--network", "kovan",
         // // Hassan's testing mnemonic feel free to use your own
         // "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
 
-        // Kovan Dai Bridge args
+        // Kovan DAI Bridge args
         "bridge",
         "10",
-        "0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa",
+        "0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa", // Kovan DAI
         "--network", "kovan",
         // Hassan's testing mnemonic feel free to use your own
         "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
@@ -83,15 +83,32 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Cardpay: Transfer Tokens from Safe",
+      "program": "${workspaceFolder}/packages/cardpay-cli/cardpay.js",
+      "console": "integratedTerminal",
+      "env": {},
+      "args": [
+        "safe-transfer-tokens",
+        "0xaE9D292753f05b00E996F6b18E4bAe5CC9e5aa48", // Hassan's depot safe feel free to use your own
+        "0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee", // CARD.CPXD
+        "0xD7182E380b7dFa33C186358De7E1E5d0950fCAE7", // Relay txn sender
+        "100000",
+        "--network", "sokol",
+        // Hassan's testing mnemonic feel free to use your own
+        "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Cardpay: Create Prepaid Card",
       "program": "${workspaceFolder}/packages/cardpay-cli/cardpay.js",
       "console": "integratedTerminal",
       "env": {},
       "args": [
         "prepaidcard-create",
-        // Hassan's depot safe feel free to use your own
-        "0xaE9D292753f05b00E996F6b18E4bAe5CC9e5aa48",
-        "0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1",
+        "0xaE9D292753f05b00E996F6b18E4bAe5CC9e5aa48", // Hassan's depot safe feel free to use your own
+        "0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1", // DAI.CPXD
         "500",
         "--network", "sokol",
         // Hassan's testing mnemonic feel free to use your own
@@ -110,8 +127,7 @@
         // currently creating a merchant is an administrative function--ping
         // hassan to have him create a merchant for you until we get the self-serve fucntionality live
         "0x8B3A993F4f8159A5FcFEe3155a33BD1E9Bd6ABe4", // safe for merchant 0x54b11672e90B38ca52140Ac364EebC5cC07F3d91
-        // Hassan's prepaid card --feel free to use your own
-        "0x6931aDbbefAfFCB0E1F3a4EbA95A5017386c9752",
+        "0x6931aDbbefAfFCB0E1F3a4EbA95A5017386c9752", // Hassan's prepaid card --feel free to use your own
         "100",
         "--network", "sokol",
         // Hassan's testing mnemonic feel free to use your own
@@ -127,7 +143,7 @@
       "env": {},
       "args": [
         "price-for-face-value",
-        "0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1",
+        "0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1", // DAI.CPXD
         "10000",
         "--network", "sokol",
         // Hassan's testing mnemonic feel free to use your own
@@ -143,7 +159,7 @@
       "env": {},
       "args": [
         "new-prepaidcard-gas-fee",
-        "0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1",
+        "0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1", // DAI.CPXD
         "--network", "sokol",
         // Hassan's testing mnemonic feel free to use your own
         "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"

--- a/packages/cardpay-cli/README.md
+++ b/packages/cardpay-cli/README.md
@@ -125,7 +125,7 @@ ARGUMENTS
 
 ## `yarn cardpay safe-transfer-tokens [SAFE_ADDRESS] [TOKEN_ADDRESS] [RECIPIENT] [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC]`
 
-Transfer tokens from a safe to an arbitrary recipient. The token amount specified is *not* in units of `wei`.
+Transfer tokens from a safe to an arbitrary recipient. The token amount specified is *not* in units of `wei`. Note that the gas will be paid with the token you are transferring so there must be enough token balance in teh safe to cover both the transferred amount of tokens and gas.
 
 ```
 USAGE

--- a/packages/cardpay-cli/README.md
+++ b/packages/cardpay-cli/README.md
@@ -13,6 +13,7 @@ CLI tool for basic actions in Cardpay
   - [`yarn cardpay pay-merchant <MERCHANT_SAFE> <PREPAID_CARD> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-pay-merchant-merchant_safe-prepaid_card-amount---networknetwork---mnemonicmnemonic)
   - [`yarn cardpay new-prepaidcard-gas-fee <TOKEN_ADDRESS> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-new-prepaidcard-gas-fee-token_address---networknetwork---mnemonicmnemonic)
   - [`yarn cardpay safes-view [ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-safes-view-address---networknetwork---mnemonicmnemonic)
+  - [`yarn cardpay safe-transfer-tokens [TOKEN_ADDRESS] [RECIPIENT] [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-safe-transfer-tokens-token_address-recipient-amount---networknetwork---mnemonicmnemonic)
   - [`yarn cardpay usd-price <TOKEN> [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-usd-price-token-amount---networknetwork---mnemonicmnemonic)
   - [`yarn cardpay eth-price <TOKEN> [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-eth-price-token-amount---networknetwork---mnemonicmnemonic)
   - [`yarn cardpay price-oracle-updated-at <TOKEN> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-price-oracle-updated-at-token---networknetwork---mnemonicmnemonic)
@@ -118,6 +119,23 @@ USAGE
 
 ARGUMENTS
   ADDRESS   (Optional) an address of an owner whose safes you wish to view (defaults to the wallet's default account)
+  NETWORK   The network to use ("sokol" or "xdai")
+  MNEMONIC  (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+```
+
+## `yarn cardpay safe-transfer-tokens [SAFE_ADDRESS] [TOKEN_ADDRESS] [RECIPIENT] [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC]`
+
+Transfer tokens from a safe to an arbitrary recipient. The token amount specified is *not* in units of `wei`.
+
+```
+USAGE
+  $ yarn cardpay safes-view [ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC]
+
+ARGUMENTS
+  SAFE_ADDRESS     The address of the safe that is sending the tokens
+  TOKEN_ADDRESS    The token address of the tokens to transfer from the safe
+  RECIPIENT        The token recipient's address
+  AMOUNT           The amount of tokens to transfer (*not* in units of `wei`).
   NETWORK   The network to use ("sokol" or "xdai")
   MNEMONIC  (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
 ```

--- a/packages/cardpay-cli/safe.ts
+++ b/packages/cardpay-cli/safe.ts
@@ -1,8 +1,10 @@
 import Web3 from 'web3';
-import { Safes } from '@cardstack/cardpay-sdk';
+import { Safes, Assets, getConstant } from '@cardstack/cardpay-sdk';
 import { getWeb3 } from './utils';
 
-export default async function (network: string, mnemonic: string, address?: string): Promise<void> {
+const { toWei } = Web3.utils;
+
+export async function viewSafes(network: string, mnemonic: string, address?: string): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
 
   let safesApi = new Safes(web3);
@@ -30,4 +32,25 @@ export default async function (network: string, mnemonic: string, address?: stri
 
     console.log('\n');
   });
+}
+
+export async function transferTokens(
+  network: string,
+  mnemonic: string,
+  safe: string,
+  token: string,
+  recipient: string,
+  amount: number
+): Promise<void> {
+  let web3 = await getWeb3(network, mnemonic);
+  let weiAmount = toWei(String(amount));
+
+  let safes = new Safes(web3);
+  let assets = new Assets(web3);
+  let { symbol } = await assets.getTokenInfo(token);
+
+  console.log(`transferring ${amount} ${symbol} from safe ${safe} to ${recipient}`);
+  let result = await safes.sendTokens(safe, token, recipient, weiAmount);
+  let blockExplorer = await getConstant('blockExplorer', web3);
+  console.log(`Transaction hash: ${blockExplorer}/tx/${result.ethereumTx.txHash}/token-transfers`);
 }

--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -12,6 +12,7 @@ This is a package that provides an SDK to use the Cardpay protocol.
   - [`TokenBridgeHomeSide.waitForBridgingCompleted`](#tokenbridgehomesidewaitforbridgingcompleted)
 - [`Safes`](#safes)
   - [`Safes.view`](#safesview)
+  - [`Safes.sendTokens`](#safessendtokens)
 - [`PrepaidCard`](#prepaidcard)
   - [`PrepaidCard.create`](#prepaidcardcreate)
   - [`PrepaidCard.priceForFaceValue`](#prepaidcardpriceforfacevalue)
@@ -148,6 +149,62 @@ interface PrepaidCardSafe extends BaseSafe {
 Which can be called like this:
 ```js
 let safeDetails = await safes.view();
+```
+
+### `Safes.sendTokens`
+This call is used to send tokens from a gnosis safe to an arbitrary address in the layer 2 network.
+
+This method is invoked with the following parameters:
+- the address of the gnosis safe
+- the address of the token contract
+- the address of the recipient
+- the amount of tokens to send as a string in units of `wei`
+- optionally the address of a safe owner. If no address is supplied, then the default account in your web3 provider's wallet will be used.
+
+```js
+let cardCpxd = await getAddress('cardCpxd', web3);
+let result = await safes.sendTokens(
+  depotSafeAddress,
+  cardCpxd,
+  relayTxnFunderAddress
+  [10000000000000000000000]
+);
+```
+This method returns a promise for a gnosis relay transaction object that has the following shape:
+```ts
+interface RelayTransaction {
+  to: string;
+  ethereumTx: {
+    txHash: string;
+    to: string;
+    data: string;
+    blockNumber: string;
+    blockTimestamp: string;
+    created: string;
+    modified: string;
+    gasUsed: string;
+    status: number;
+    transactionIndex: number;
+    gas: string;
+    gasPrice: string;
+    nonce: string;
+    value: string;
+    from: string;
+  };
+  value: number;
+  data: string;
+  timestamp: string;
+  operation: string;
+  safeTxGas: number;
+  dataGas: number;
+  gasPrice: number;
+  gasToken: string;
+  refundReceiver: string;
+  nonce: number;
+  safeTxHash: string;
+  txHash: string;
+  transactionHash: string;
+}
 ```
 
 ## `PrepaidCard`

--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -152,7 +152,7 @@ let safeDetails = await safes.view();
 ```
 
 ### `Safes.sendTokens`
-This call is used to send tokens from a gnosis safe to an arbitrary address in the layer 2 network.
+This call is used to send tokens from a gnosis safe to an arbitrary address in the layer 2 network. Note that the gas will be paid with the token you are transferring so there must be enough token balance in teh safe to cover both the transferred amount of tokens and gas.
 
 This method is invoked with the following parameters:
 - the address of the gnosis safe

--- a/packages/cardpay-sdk/sdk/assets.ts
+++ b/packages/cardpay-sdk/sdk/assets.ts
@@ -3,18 +3,27 @@ import { AbiItem } from 'web3-utils';
 import Web3 from 'web3';
 
 export default class Assets {
-  constructor(private layer2Web3: Web3) {}
+  constructor(private web3: Web3) {}
 
   async getNativeTokenBalance(userAddress?: string): Promise<string> {
-    let address = userAddress || (await this.layer2Web3.eth.getAccounts())[0];
+    let address = userAddress ?? (await this.web3.eth.getAccounts())[0];
 
-    return this.layer2Web3.eth.getBalance(address);
+    return this.web3.eth.getBalance(address);
   }
 
-  async getBalanceForToken(tokenAddress: string, userAddress?: string): Promise<string> {
-    let address = userAddress || (await this.layer2Web3.eth.getAccounts())[0];
-    const tokenContract = new this.layer2Web3.eth.Contract(ERC20ABI as AbiItem[], tokenAddress);
+  async getBalanceForToken(tokenAddress: string, tokenHolderAddress?: string): Promise<string> {
+    let address = tokenHolderAddress ?? (await this.web3.eth.getAccounts())[0];
+    const tokenContract = new this.web3.eth.Contract(ERC20ABI as AbiItem[], tokenAddress);
 
     return tokenContract.methods.balanceOf(address).call();
+  }
+
+  async getTokenInfo(tokenAddress: string): Promise<{ decimals: number; name: string; symbol: string }> {
+    const tokenContract = new this.web3.eth.Contract(ERC20ABI as AbiItem[], tokenAddress);
+    return {
+      decimals: Number(await tokenContract.methods.decimals().call()),
+      name: await tokenContract.methods.name().call(),
+      symbol: await tokenContract.methods.symbol().call(),
+    };
   }
 }

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -23,7 +23,7 @@ const SOKOL = {
   name: 'Sokol',
   rpcNode: 'https://sokol.stack.cards',
   rpcWssNode: 'https://sokol-wss.stack.cards',
-  relayServiceURL: 'https://relay-staging.stack.cards/api',
+  relayServiceURL: 'http://localhost:8000/api', //'https://relay-staging.stack.cards/api',
   transactionServiceURL: 'https://transactions-staging.stack.cards/api',
 };
 const KOVAN = {

--- a/packages/cardpay-sdk/sdk/safes.ts
+++ b/packages/cardpay-sdk/sdk/safes.ts
@@ -4,10 +4,15 @@ import Web3 from 'web3';
 import PrepaidCardManagerABI from '../contracts/abi/prepaid-card-manager';
 import RevenuePoolABI from '../contracts/abi/revenue-pool';
 import BridgeUtilsABI from '../contracts/abi/bridge-utils';
+import ERC20ABI from '../contracts/abi/erc-20';
 import { AbiItem } from 'web3-utils';
 import { getAddress } from '../contracts/addresses';
 import { getConstant, ZERO_ADDRESS } from './constants';
 import ExchangeRate from './exchange-rate';
+import { ContractOptions } from 'web3-eth-contract';
+import { GnosisExecTx, sign, gasEstimate, executeTransaction } from './utils';
+import BN from 'bn.js';
+const { toBN, fromWei } = Web3.utils;
 
 export type Safe = DepotSafe | PrepaidCardSafe | MerchantSafe | ExternalSafe;
 interface BaseSafe {
@@ -106,5 +111,66 @@ export default class Safes {
         };
       })
     );
+  }
+
+  async sendTokens(
+    safeAddress: string,
+    tokenAddress: string,
+    recipient: string,
+    amount: string,
+    options?: ContractOptions
+  ): Promise<GnosisExecTx> {
+    let from = options?.from ?? (await this.layer2Web3.eth.getAccounts())[0];
+    let token = new this.layer2Web3.eth.Contract(ERC20ABI as AbiItem[], tokenAddress);
+    let safeBalance = new BN(await token.methods.balanceOf(safeAddress).call());
+    if (safeBalance.lt(new BN(amount))) {
+      throw new Error(
+        `Safe does not have enough balance to transfer tokens. The token ${tokenAddress} balance of safe ${safeAddress} is ${fromWei(
+          safeAddress.toString()
+        )}, amount to transfer ${fromWei(amount)}`
+      );
+    }
+    let payload = await this.transferTokenPayload(tokenAddress, recipient, amount);
+    let estimate = await gasEstimate(this.layer2Web3, safeAddress, tokenAddress, '0', payload, 0, tokenAddress);
+    if (estimate.lastUsedNonce == null) {
+      estimate.lastUsedNonce = -1;
+    }
+    let signatures = await sign(
+      this.layer2Web3,
+      tokenAddress,
+      0,
+      payload,
+      0,
+      estimate.safeTxGas,
+      estimate.dataGas,
+      estimate.gasPrice,
+      estimate.gasToken,
+      ZERO_ADDRESS,
+      toBN(estimate.lastUsedNonce + 1),
+      from,
+      safeAddress
+    );
+    let result = await executeTransaction(
+      this.layer2Web3,
+      safeAddress,
+      tokenAddress,
+      0,
+      payload,
+      0,
+      estimate.safeTxGas,
+      estimate.dataGas,
+      estimate.gasPrice,
+      toBN(estimate.lastUsedNonce + 1).toString(),
+      signatures,
+      estimate.gasToken,
+      ZERO_ADDRESS
+    );
+    return result;
+  }
+
+  private async transferTokenPayload(tokenAddress: string, recipient: string, amount: string): Promise<string> {
+    let token = new this.layer2Web3.eth.Contract(ERC20ABI as AbiItem[], tokenAddress);
+
+    return token.methods.transfer(recipient, amount).encodeABI();
   }
 }

--- a/packages/cardpay-sdk/sdk/utils.ts
+++ b/packages/cardpay-sdk/sdk/utils.ts
@@ -2,6 +2,7 @@ import Web3 from 'web3';
 import { TransactionReceipt } from 'web3-core';
 import { networks } from './constants';
 import { Contract, EventData, PastEventOptions } from 'web3-eth-contract';
+import { getConstant } from './constants.js';
 
 export async function networkName(web3: Web3): Promise<string> {
   let id = await web3.eth.net.getId();
@@ -13,6 +14,58 @@ export async function networkName(web3: Web3): Promise<string> {
 }
 
 const POLL_INTERVAL = 500;
+
+export interface Estimate {
+  safeTxGas: string;
+  baseGas: string;
+  dataGas: string;
+  operationalGas: string;
+  gasPrice: string;
+  lastUsedNonce: number | undefined;
+  gasToken: string;
+  refundReceiver: string;
+}
+export interface RelayTransaction {
+  to: string;
+  ethereumTx: {
+    txHash: string;
+    to: string;
+    data: string;
+    blockNumber: string;
+    blockTimestamp: string;
+    created: string;
+    modified: string;
+    gasUsed: string;
+    status: number;
+    transactionIndex: number;
+    gas: string;
+    gasPrice: string;
+    nonce: string;
+    value: string;
+    from: string;
+  };
+}
+export interface GnosisExecTx extends RelayTransaction {
+  value: number;
+  nonce: number;
+  data: string;
+  timestamp: string;
+  operation: string;
+  safeTxGas: number;
+  dataGas: number;
+  gasPrice: number;
+  gasToken: string;
+  refundReceiver: string;
+  safeTxHash: string;
+  txHash: string;
+  transactionHash: string;
+}
+
+export interface Signature {
+  v: number;
+  r: string;
+  s: string | 0;
+}
 
 export function waitUntilTransactionMined(web3: Web3, txnHash: string): Promise<TransactionReceipt> {
   let transactionReceiptAsync = async function (
@@ -61,4 +114,179 @@ export function waitForEvent(contract: Contract, eventName: string, opts: PastEv
   return new Promise(function (resolve, reject) {
     eventDataAsync(resolve, reject);
   });
+}
+
+export async function gasEstimate(
+  web3: Web3,
+  from: string,
+  to: string,
+  value: string,
+  data: string,
+  operation: number,
+  gasToken: string
+): Promise<Estimate> {
+  let relayServiceURL = await getConstant('relayServiceURL', web3);
+  let url = `${relayServiceURL}/v2/safes/${from}/transactions/estimate/`;
+  let options = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json', //eslint-disable-line @typescript-eslint/naming-convention
+    },
+    body: JSON.stringify({
+      to,
+      value,
+      data,
+      operation,
+      gasToken,
+    }),
+  };
+  let response = await fetch(url, options);
+  if (!response?.ok) {
+    throw new Error(await response.text());
+  }
+  return await response.json();
+}
+
+export async function sign(
+  web3: Web3,
+  to: string,
+  value: number,
+  data: any,
+  operation: number,
+  txGasEstimate: string,
+  baseGasEstimate: string,
+  gasPrice: string,
+  txGasToken: string,
+  refundReceiver: string,
+  nonce: any,
+  owner: string,
+  gnosisSafeAddress: string
+): Promise<Signature[]> {
+  const typedData = {
+    types: {
+      //eslint-disable-next-line @typescript-eslint/naming-convention
+      EIP712Domain: [{ type: 'address', name: 'verifyingContract' }],
+      // "SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)"
+      //eslint-disable-next-line @typescript-eslint/naming-convention
+      SafeTx: [
+        { type: 'address', name: 'to' },
+        { type: 'uint256', name: 'value' },
+        { type: 'bytes', name: 'data' },
+        { type: 'uint8', name: 'operation' },
+        { type: 'uint256', name: 'safeTxGas' },
+        { type: 'uint256', name: 'baseGas' },
+        { type: 'uint256', name: 'gasPrice' },
+        { type: 'address', name: 'gasToken' },
+        { type: 'address', name: 'refundReceiver' },
+        { type: 'uint256', name: 'nonce' },
+      ],
+    },
+    domain: {
+      verifyingContract: gnosisSafeAddress,
+    },
+    primaryType: 'SafeTx',
+    message: {
+      to: to,
+      value: value,
+      data: data,
+      operation: operation,
+      safeTxGas: txGasEstimate,
+      baseGas: baseGasEstimate,
+      gasPrice: gasPrice,
+      gasToken: txGasToken,
+      refundReceiver: refundReceiver,
+      nonce: nonce.toNumber(),
+    },
+  };
+  const signatureBytes = [];
+  signatureBytes.push(await signTypedData(web3, owner, typedData));
+
+  return signatureBytes;
+}
+
+export async function executeTransaction(
+  web3: Web3,
+  from: string,
+  to: string,
+  value: number,
+  data: any,
+  operation: number,
+  safeTxGas: string,
+  dataGas: string,
+  gasPrice: string,
+  nonce: string,
+  signatures: any,
+  gasToken: string,
+  refundReceiver: string
+): Promise<GnosisExecTx> {
+  let relayServiceURL = await getConstant('relayServiceURL', web3);
+  const url = `${relayServiceURL}/v1/safes/${from}/transactions/`;
+  const options = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json', //eslint-disable-line @typescript-eslint/naming-convention
+    },
+    body: JSON.stringify({
+      to,
+      value,
+      data,
+      operation,
+      safeTxGas,
+      baseGas: dataGas,
+      dataGas,
+      gasPrice,
+      nonce,
+      signatures,
+      gasToken,
+      refundReceiver,
+    }),
+  };
+  let response = await fetch(url, options);
+  if (!response?.ok) {
+    throw new Error(await response.text());
+  }
+  return response.json();
+}
+
+async function signTypedData(web3: Web3, account: string, data: any): Promise<Signature> {
+  let result: string = await new Promise((resolve, reject) => {
+    let provider = web3.currentProvider;
+    if (typeof provider === 'string') {
+      throw new Error(`The provider ${web3.currentProvider} is not supported`);
+    }
+    if (provider == null) {
+      throw new Error('No provider configured');
+    }
+    //@ts-ignore TS is complaining that provider might be undefined--but the
+    //check above should prevent that from ever happening
+    provider.send(
+      {
+        jsonrpc: '2.0',
+        method: 'eth_signTypedData',
+        params: [account, data],
+        id: new Date().getTime(),
+      },
+      (err, response) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve(response?.result);
+      }
+    );
+  });
+  const sig = result.replace('0x', '');
+  const sigV = parseInt(sig.slice(-2), 16);
+  const sigR = Web3.utils.toBN('0x' + sig.slice(0, 64)).toString();
+  const sigS = Web3.utils.toBN('0x' + sig.slice(64, 128)).toString();
+
+  // Metamask with ledger returns v = 01, this is not valid for ethereum
+  // For ethereum valid V is 27 or 28
+  // In case V = 0 or 01 we add it to 27 and then add 4
+  // Adding 4 is required to make signature valid for safe contracts:
+  // https://gnosis-safe.readthedocs.io/en/latest/contracts/signatures.html#eth-sign-signature
+  return {
+    v: sigV,
+    r: sigR,
+    s: sigS,
+  };
 }

--- a/packages/cardpay-sdk/sdk/utils.ts
+++ b/packages/cardpay-sdk/sdk/utils.ts
@@ -1,3 +1,5 @@
+/*global fetch */
+
 import Web3 from 'web3';
 import { TransactionReceipt } from 'web3-core';
 import { networks } from './constants';


### PR DESCRIPTION
This SDK and CLI command is used to transfer tokens from a safe to an arbitrary address. We will use this to load CARD.CPXD into the relay gas payer so that this account can air drop CARD.CPXD on new prepaid cards. (and perhaps other administrative functions)