### PR TITLE
Enhancement/wallet connection close button

### DIFF
--- a/packages/web-client/app/components/card-pay/layer-connect-modal/index.css
+++ b/packages/web-client/app/components/card-pay/layer-connect-modal/index.css
@@ -33,28 +33,28 @@
   }
 }
 
-.layer-connect-modal__close-button-container {
-  display: flex; 
-  justify-content: flex-end; 
-  padding-top: var(--boxel-sp-sm);
-  padding-right: var(--boxel-sp-sm);
+.layer-connect-modal__card {
+  position: relative;
+  padding-top: calc(var(--boxel-sp-sm) + 0.75rem);
+  outline-color: transparent;
+  outline-style: solid;
 }
 
 .layer-connect-modal__close-button  {
-  padding: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 1;
+  padding: var(--boxel-sp-sm);
+  height: calc(var(--boxel-sp-sm) * 2 + 0.75rem);
+  width: calc(var(--boxel-sp-sm) * 2 + 0.75rem);
+  line-height: 0;
+
   background: transparent;
   border: none;
-  height: 0.75rem;
-  width: 0.75rem;
-  line-height: 0;
   cursor: pointer;
 
   --icon-color: var(--boxel-dark);
-}
-
-.layer-connect-modal__card {
-  outline-color: transparent;
-  outline-style: solid;
 }
 
 .layer-connect-modal__wrapped-card {

--- a/packages/web-client/app/components/card-pay/layer-connect-modal/index.css
+++ b/packages/web-client/app/components/card-pay/layer-connect-modal/index.css
@@ -33,13 +33,26 @@
   }
 }
 
-.layer-connect-modal__card:focus {
-  outline-color: transparent;
-  outline-offset: -5px;
-  box-shadow: 0 0 0 2px var(--boxel-blue);
+.layer-connect-modal__close-button-container {
+  display: flex; 
+  justify-content: flex-end; 
+  padding-top: var(--boxel-sp-sm);
+  padding-right: var(--boxel-sp-sm);
 }
 
-.layer-connect-modal__card:focus:not(:focus-visible) {
+.layer-connect-modal__close-button  {
+  padding: 0;
+  background: transparent;
+  border: none;
+  height: 0.75rem;
+  width: 0.75rem;
+  line-height: 0;
+  cursor: pointer;
+
+  --icon-color: var(--boxel-dark);
+}
+
+.layer-connect-modal__wrapped-card {
   box-shadow: none;
 }
 

--- a/packages/web-client/app/components/card-pay/layer-connect-modal/index.css
+++ b/packages/web-client/app/components/card-pay/layer-connect-modal/index.css
@@ -52,6 +52,11 @@
   --icon-color: var(--boxel-dark);
 }
 
+.layer-connect-modal__card {
+  outline-color: transparent;
+  outline-style: solid;
+}
+
 .layer-connect-modal__wrapped-card {
   box-shadow: none;
 }

--- a/packages/web-client/app/components/card-pay/layer-connect-modal/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-connect-modal/index.hbs
@@ -5,7 +5,36 @@
   data-test-layer-connect-modal={{@name}}
 >
   <div class="layer-connect-modal__scroll-wrapper">
-    <Boxel::CardContainer class="layer-connect-modal__card">
+    <Boxel::CardContainer 
+      class="layer-connect-modal__card" 
+      tabindex="-1"
+      {{!-- 
+        Focus is trapped within this element, with the element as the initial focus 
+        outside clicks are allowed to trigger @onClose
+
+        This should ideally be replaced with a selector for the primary/first action
+        in the modal. However, the programmatic focus it introduces does not match
+        :focus-visible. This behaviour means the user doesn't know what is being focused.
+        Forcing the user to press Tab will create focus that does match :focus-visible
+        and hence show a ring.
+
+        Also, there is no distinguishing state for focused radio buttons - leading to the same 
+        problem of the user not knowing what is being focused, if we try to select the radio
+        button for layer one as the initial focus.
+
+        Some reading, if you are up for a slight headache:
+        - https://github.com/WICG/focus-visible/issues/88
+        - https://github.com/w3c/csswg-drafts/issues/5885
+      --}}
+      {{focus-trap
+        isActive=@isOpen
+        focusTrapOptions=(hash 
+          allowOutsideClick=true 
+          clickOutsideDeactivates=true
+          initialFocus=".layer-connect-modal__card"
+        )
+      }}
+    >
       <div class="layer-connect-modal__close-button-container">
         <button
           class="layer-connect-modal__close-button"
@@ -22,8 +51,6 @@
           @onConnect={{@onClose}}
           @onDisconnect={{@onClose}}
           @suppressHeader={{true}}
-          {{did-insert this.focus}}
-          data-test-layer-one-connect-modal-card
         />
       {{else}}
         <CardPay::LayerTwoConnectCard
@@ -32,8 +59,6 @@
           @includeExplanations={{true}}
           @onConnect={{@onClose}}
           @onDisconnect={{@onClose}}
-          {{did-insert this.focus}}
-          data-test-layer-two-connect-modal-card
         />
       {{/if}}
     </Boxel::CardContainer>

--- a/packages/web-client/app/components/card-pay/layer-connect-modal/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-connect-modal/index.hbs
@@ -35,16 +35,14 @@
         )
       }}
     >
-      <div class="layer-connect-modal__close-button-container">
-        <button
-          class="layer-connect-modal__close-button"
-          type="button"
-          aria-label="Close"
-          {{on "click" @onClose}}
-        >
-          {{svg-jar "close" width="100%" height="100%" aria-hidden=true}}
-        </button>
-      </div>
+      <button
+        class="layer-connect-modal__close-button"
+        type="button"
+        aria-label="Close"
+        {{on "click" @onClose}}
+      >
+        {{svg-jar "close" width="100%" height="100%" aria-hidden=true}}
+      </button>
       {{#if (eq @name "layer1")}}
         <CardPay::LayerOneConnectCard
           class="layer-connect-modal__wrapped-card"

--- a/packages/web-client/app/components/card-pay/layer-connect-modal/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-connect-modal/index.hbs
@@ -5,27 +5,37 @@
   data-test-layer-connect-modal={{@name}}
 >
   <div class="layer-connect-modal__scroll-wrapper">
-    {{#if (eq @name "layer1")}}
-      <CardPay::LayerOneConnectCard
-        class="layer-connect-modal__card"
-        @onConnect={{@onClose}}
-        @onDisconnect={{@onClose}}
-        @suppressHeader={{true}}
-        @suppressConnectingCard={{true}}
-        tabindex="0"
-        {{did-insert this.focus}}
-        data-test-layer-one-connect-modal-card
-      />
-    {{else}}
-      <CardPay::LayerTwoConnectCard
-        @suppressHeader={{true}}
-        @includeExplanations={{true}}
-        @onConnect={{@onClose}}
-        @onDisconnect={{@onClose}}
-        tabindex="0"
-        {{did-insert this.focus}}
-        data-test-layer-two-connect-modal-card
-      />
-    {{/if}}
+    <Boxel::CardContainer class="layer-connect-modal__card">
+      <div class="layer-connect-modal__close-button-container">
+        <button
+          class="layer-connect-modal__close-button"
+          type="button"
+          aria-label="Close"
+          {{on "click" @onClose}}
+        >
+          {{svg-jar "close" width="100%" height="100%" aria-hidden=true}}
+        </button>
+      </div>
+      {{#if (eq @name "layer1")}}
+        <CardPay::LayerOneConnectCard
+          class="layer-connect-modal__wrapped-card"
+          @onConnect={{@onClose}}
+          @onDisconnect={{@onClose}}
+          @suppressHeader={{true}}
+          {{did-insert this.focus}}
+          data-test-layer-one-connect-modal-card
+        />
+      {{else}}
+        <CardPay::LayerTwoConnectCard
+          class="layer-connect-modal__wrapped-card"
+          @suppressHeader={{true}}
+          @includeExplanations={{true}}
+          @onConnect={{@onClose}}
+          @onDisconnect={{@onClose}}
+          {{did-insert this.focus}}
+          data-test-layer-two-connect-modal-card
+        />
+      {{/if}}
+    </Boxel::CardContainer>
   </div>
 </Boxel::Modal>

--- a/packages/web-client/app/components/card-pay/layer-connect-modal/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-connect-modal/index.ts
@@ -4,7 +4,6 @@ import Layer2Network from '../../../services/layer2-network';
 import { inject as service } from '@ember/service';
 import { taskFor } from 'ember-concurrency-ts';
 import { task } from 'ember-concurrency-decorators';
-import { action } from '@ember/object';
 
 interface CardPayLayerConnectModalComponentArgs {
   name: string | null;
@@ -26,9 +25,6 @@ class CardPayLayerConnectModalComponent extends Component<CardPayLayerConnectMod
       yield this.layer2Network.waitForAccount;
     }
     this.args.onClose();
-  }
-  @action focus(element: HTMLElement): void {
-    element.focus();
   }
 }
 

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
@@ -29,7 +29,14 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
   @service declare layer1Network: Layer1Network;
   @reads('layer1Network.hasAccount') declare hasAccount: boolean;
   @tracked isWaitingForConnection = false;
-  @tracked radioWalletProviderId = '';
+  /*
+     Set a starting wallet provider for the focus trap library in the modal
+     - focus trapping requires checking what the next tabbable element is
+     - radios with their roving tabindex confuse tabbable, so they cannot be the last focusable element
+       , otherwise focus leaves the page
+     - selecting a radio makes the connect button enabled and focusable.
+   */
+  @tracked radioWalletProviderId = 'metamask';
 
   constructor(
     owner: unknown,

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -91,6 +91,7 @@
     "ember-data": "~3.25.0",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.4",
+    "ember-focus-trap": "^0.6.0",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-page-title": "^6.2.1",

--- a/packages/web-client/tests/acceptance/connect-wallet-test.ts
+++ b/packages/web-client/tests/acceptance/connect-wallet-test.ts
@@ -25,7 +25,6 @@ module('Acceptance | Connect Wallet', function (hooks) {
     );
     let layer1Service = this.owner.lookup('service:layer1-network')
       .strategy as Layer1TestWeb3Strategy;
-    assert.dom('[data-test-layer-one-connect-modal-card]').isFocused();
     await click('[data-test-wallet-option="metamask"]');
     await click(
       '[data-test-mainnnet-connection-action-container] [data-test-boxel-button]'
@@ -57,7 +56,6 @@ module('Acceptance | Connect Wallet', function (hooks) {
     await click(
       '[data-test-card-pay-layer-2-connect] [data-test-card-pay-connect-button]'
     );
-    assert.dom('[data-test-layer-two-connect-modal-card]').isFocused();
 
     let layer2Service = this.owner.lookup('service:layer2-network')
       .strategy as Layer2TestWeb3Strategy;

--- a/packages/web-client/tests/integration/components/layer-one-connect-card-test.ts
+++ b/packages/web-client/tests/integration/components/layer-one-connect-card-test.ts
@@ -37,18 +37,6 @@ module('Integration | Component | layer-one-connect-card', function (hooks) {
     assert.dom(HEADER_SELECTOR).containsText('Metamask');
   });
 
-  test('The connect button should be disabled before a provider is selected and enabled after', async function (assert) {
-    await render(hbs`
-        <CardPay::LayerOneConnectCard/>
-      `);
-
-    assert.dom(CONNECT_BUTTON_SELECTOR).isDisabled();
-
-    await click('[data-test-wallet-option="metamask"]');
-
-    assert.dom(CONNECT_BUTTON_SELECTOR).isEnabled();
-  });
-
   test('It should be able to move between default (unconnected), loading, and connected states', async function (assert) {
     let layer1Service = this.owner.lookup('service:layer1-network')
       .strategy as Layer1TestWeb3Strategy;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9129,6 +9129,16 @@ ember-fetch@^8.0.4:
     node-fetch "^2.6.1"
     whatwg-fetch "^3.4.0"
 
+ember-focus-trap@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/ember-focus-trap/-/ember-focus-trap-0.6.0.tgz#49312309926835cec7bfc2e516dfa47f7821211d"
+  integrity sha512-LuEv0BNMLspTkW4c2KsAkWLwr3s5ZLlpGS6JN8YazFmYaILWvoyp82AFqgMKLjQJrONx9TpqpCqpW308KE7s4w==
+  dependencies:
+    ember-auto-import "^1.11.2"
+    ember-cli-babel "^7.26.3"
+    ember-modifier-manager-polyfill "^1.2.0"
+    focus-trap "^6.4.0"
+
 ember-getowner-polyfill@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"
@@ -11005,6 +11015,13 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+focus-trap@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.4.0.tgz#e9951484fddf933d9b9b0e95b499f9420f6a54d6"
+  integrity sha512-RpH291GjfNhy1ek+Iwe00oCaqJN0sBaB+S/v7BpCIldf39IslPI7657nOZ6HwgoEHpjCmUJoAY+Mfgrm0rohvQ==
+  dependencies:
+    tabbable "^5.2.0"
 
 follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.3"
@@ -17910,6 +17927,11 @@ sync-disk-cache@^2.0.0:
     mkdirp "^0.5.0"
     rimraf "^3.0.0"
     username-sync "^1.0.2"
+
+tabbable@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.0.tgz#4fba60991d8bb89d06e5d9455c92b453acf88fb2"
+  integrity sha512-0uyt8wbP0P3T4rrsfYg/5Rg3cIJ8Shl1RJ54QMqYxm1TLdWqJD1u6+RQjr2Lor3wmfT7JRHkirIwy99ydBsyPg==
 
 table@^6.0.4:
   version "6.0.7"


### PR DESCRIPTION
CS-714

Added a close button to the wallet connection modal(s) by somewhat hackily wrapping it in yet another card container. 

When the close button was added, realised that there was a problem with focus trapping. We were programmatically focusing the modal when someone opened it, which made sense because otherwise someone could accidentally change something in the background of the page without realising. However, it's still possible for someone to tab into the background without realising.

Added a focus trap library to handle this behaviour and prevent focus from leaving the modal via tabbing. There are caveats to this:
- Programmatic focus may not show the focus ring because it does not match the  `:focus-visible` selector we use to only show keyboard-triggered focus and ignore mouse-triggered focus. When a modal opens, you generally want the first actionable element to be selected, and have its focus styles visible, but it's not immediately clear how to do this programmatically with `focus-visible`. See discussions on focus behaviour in:
        - https://github.com/WICG/focus-visible/issues/88
        - https://github.com/w3c/csswg-drafts/issues/5885
- The library itself does not seem to like an unselected radio as the last focusable element within a trap. This might have to do with roving tabindex - the library (tabbable) will try to select only a checked radio. To avoid this issue, I set the starting selected value of the radio to metamask, providing a checked radio, and an enabled button after it.