### PR TITLE
add minPrecision to format-token-amount

### DIFF
--- a/packages/web-client/app/helpers/format-token-amount.ts
+++ b/packages/web-client/app/helpers/format-token-amount.ts
@@ -4,18 +4,47 @@ import TextFormattingService from '../services/text-formatting';
 import BN from 'bn.js';
 import { fromWei } from 'web3-utils';
 
-type FormatTokenAmountHelperParams = [BN];
+type FormatTokenAmountHelperParams = [BN, number];
 
 class FormatTokenAmountHelper extends Helper {
   @service declare textFormatting: TextFormattingService;
-  compute([amountInSmallestUnit]: FormatTokenAmountHelperParams /*, hash*/) {
+  compute(
+    [
+      amountInSmallestUnit,
+      minPrecision,
+    ]: FormatTokenAmountHelperParams /*, hash*/
+  ) {
     if (amountInSmallestUnit == null) {
       return null;
     }
-    let result = fromWei(amountInSmallestUnit).toString();
-    if (!result.includes('.')) {
-      result = `${result}.0`;
+
+    // fallback to the reasonable default of 2
+    // assume that non-numbers and numbers < 0 are mistakes
+    if (
+      minPrecision === undefined ||
+      minPrecision === null ||
+      isNaN(minPrecision) ||
+      minPrecision < 0
+    ) {
+      minPrecision = 2;
     }
+    let result = fromWei(amountInSmallestUnit).toString();
+
+    if (minPrecision === 0) {
+      return result;
+    }
+
+    if (!result.includes('.')) {
+      result += '.';
+      result = result.padEnd(minPrecision + result.length, '0');
+    } else {
+      let floatingDecimals = result.split('.')[1]?.length;
+      if (floatingDecimals < minPrecision) {
+        let difference = minPrecision - floatingDecimals;
+        result = result.padEnd(difference + result.length, '0');
+      }
+    }
+
     return result;
   }
 }

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -79,8 +79,8 @@ module('Acceptance | deposit', function (hooks) {
 
     await waitFor(`${post} [data-test-balance="ETH"]`);
     assert.dom(`${post} [data-test-balance="ETH"]`).containsText('2.1411');
-    assert.dom(`${post} [data-test-balance="DAI"]`).containsText('250.5');
-    assert.dom(`${post} [data-test-balance="CARD"]`).containsText('10000.0');
+    assert.dom(`${post} [data-test-balance="DAI"]`).containsText('250.50');
+    assert.dom(`${post} [data-test-balance="CARD"]`).containsText('10000.00');
 
     await waitFor(milestoneCompletedSel(0));
     assert
@@ -118,7 +118,7 @@ module('Acceptance | deposit', function (hooks) {
     await waitFor(`${postableSel(1, 2)} [data-test-balance="XDAI"]`);
     assert
       .dom(`${postableSel(1, 2)} [data-test-balance="XDAI"]`)
-      .containsText('0.0');
+      .containsText('0.00');
     await waitUntil(
       () => !document.querySelector('[data-test-wallet-connect-qr-code]')
     );
@@ -140,9 +140,9 @@ module('Acceptance | deposit', function (hooks) {
 
     // transaction-setup card
     await waitFor(`${post} [data-test-balance="DAI"]`);
-    assert.dom(`${post} [data-test-balance="DAI"]`).containsText('250.5');
+    assert.dom(`${post} [data-test-balance="DAI"]`).containsText('250.50');
     assert.dom(`${post} [data-test-usd-balance="DAI"]`).containsText('50.10');
-    assert.dom(`${post} [data-test-balance="CARD"]`).containsText('10000.0');
+    assert.dom(`${post} [data-test-balance="CARD"]`).containsText('10000.00');
     assert
       .dom(`${post} [data-test-usd-balance="CARD"]`)
       .containsText('2000.00');
@@ -175,7 +175,7 @@ module('Acceptance | deposit', function (hooks) {
     assert.dom('[data-test-deposit-transaction-setup-is-complete]').exists();
     assert
       .dom(`${post} [data-test-balance-view-only="DAI"]`)
-      .containsText('250.5');
+      .containsText('250.50');
     // transaction-amount card
     assert
       .dom(postableSel(2, 2))
@@ -282,7 +282,7 @@ module('Acceptance | deposit', function (hooks) {
     assert
       .dom(epiloguePostableSel(1))
       .containsText('Minted from CARD Protocol on L2 test chain');
-    assert.dom(epiloguePostableSel(1)).containsText('250.0 DAI.CPXD');
+    assert.dom(epiloguePostableSel(1)).containsText('250.00 DAI.CPXD');
 
     await waitFor(epiloguePostableSel(2));
 
@@ -304,10 +304,10 @@ module('Acceptance | deposit', function (hooks) {
       .containsText('2.1411');
     assert
       .dom(`${epiloguePostableSel(3)} [data-test-balance="DAI"]`)
-      .containsText('0.5');
+      .containsText('0.50');
     assert
       .dom(`${epiloguePostableSel(3)} [data-test-balance="CARD"]`)
-      .containsText('10000.0');
+      .containsText('10000.00');
 
     assert
       .dom(

--- a/packages/web-client/tests/integration/helpers/format-token-amount-test.ts
+++ b/packages/web-client/tests/integration/helpers/format-token-amount-test.ts
@@ -1,0 +1,70 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { toWei, toBN } from 'web3-utils';
+
+module('Integration | Helper | format-token-amount', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('It should return a precise value up to 18 decimals', async function (assert) {
+    this.set('inputValue', toBN('123456789123456789'));
+    await render(hbs`{{format-token-amount this.inputValue}}`);
+    assert.dom(this.element).hasText('0.123456789123456789');
+  });
+
+  test('It should add zeros to fulfil the required precision', async function (assert) {
+    this.set('inputValue', toWei(toBN('1')));
+    this.set('minPrecision', 1);
+    await render(
+      hbs`{{format-token-amount this.inputValue this.minPrecision}}`
+    );
+    assert.dom(this.element).hasText('1.0');
+
+    this.set('minPrecision', 2);
+    assert.dom(this.element).hasText('1.00');
+  });
+
+  test('It should respect existing non-zero floating decimals when adding zeros', async function (assert) {
+    // 1.1
+    this.set('inputValue', toWei(toBN('11')).div(toBN('10')));
+    this.set('minPrecision', 3);
+    await render(
+      hbs`{{format-token-amount this.inputValue this.minPrecision}}`
+    );
+    assert.dom(this.element).hasText('1.100');
+
+    // 1.11
+    this.set('inputValue', toWei(toBN('111')).div(toBN('100')));
+    assert.dom(this.element).hasText('1.110');
+  });
+
+  test('It should have a minPrecision of 2 by default', async function (assert) {
+    this.set('inputValue', toWei(toBN('1')));
+    await render(hbs`{{format-token-amount this.inputValue}}`);
+
+    assert.dom(this.element).hasText('1.00');
+  });
+
+  test('It should have a minPrecision of 2 if an invalid minPrecision is provided', async function (assert) {
+    this.set('inputValue', toWei(toBN('1')));
+    this.set('minPrecision', 'beep');
+    await render(
+      hbs`{{format-token-amount this.inputValue this.minPrecision}}`
+    );
+
+    assert.dom(this.element).hasText('1.00');
+
+    this.set('minPrecision', -30);
+    assert.dom(this.element).hasText('1.00');
+  });
+
+  test('It should not add floating zeros if minPrecision is 0', async function (assert) {
+    this.set('inputValue', toWei(toBN('1')));
+    this.set('minPrecision', 0);
+    await render(
+      hbs`{{format-token-amount this.inputValue this.minPrecision}}`
+    );
+    assert.dom(this.element).hasText('1');
+  });
+});


### PR DESCRIPTION
CS-847

By default, make sure that formatted token amounts have 2 floating decimal places 