### PR TITLE
Enhancement/workflow cancelations

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/index.hbs
@@ -35,3 +35,13 @@
     </Boxel::ExpandableBanner>
   </:before-content>
 </WorkflowThread>
+<Listener
+  @emitter={{this.layer1Network}}
+  @event="disconnect"
+  @action={{this.cancelWorkflow}}
+/>
+<Listener
+  @emitter={{this.layer2Network}}
+  @event="disconnect"
+  @action={{this.cancelWorkflow}}
+/>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -66,7 +66,7 @@
       {{/if}}
     </div>
   </ActionCardContainer::Section>
-  <Boxel::ActionChin @stepNumber={{1}} @state={{this.unlockCtaState}} @disabled={{this.unlockCtaDisabled}}>
+  <Boxel::ActionChin @stepNumber={{1}} @state={{this.unlockCtaState}} @disabled={{or @frozen this.unlockCtaDisabled}}>
     <:default as |a|>
       <a.ActionButton data-test-unlock-button {{on "click" this.unlock}}>
         Unlock
@@ -90,7 +90,7 @@
       {{/if}}
     </:memorialized>
   </Boxel::ActionChin>
-  <Boxel::ActionChin @stepNumber={{2}} @state={{this.depositCtaState}} @disabled={{this.depositCtaDisabled}}>
+  <Boxel::ActionChin @stepNumber={{2}} @state={{this.depositCtaState}} @disabled={{or @frozen this.depositCtaDisabled}}>
     <:default as |a|>
       <a.ActionButton  {{on "click" this.deposit}} data-test-deposit-button>
         Deposit

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -66,17 +66,12 @@
       {{/if}}
     </div>
   </ActionCardContainer::Section>
-  <Boxel::ActionChin @stepNumber={{1}} @state={{this.unlockCtaState}}>
+  <Boxel::ActionChin @stepNumber={{1}} @state={{this.unlockCtaState}} @disabled={{this.unlockCtaDisabled}}>
     <:default as |a|>
       <a.ActionButton data-test-unlock-button {{on "click" this.unlock}}>
         Unlock
       </a.ActionButton>
     </:default>
-    <:disabled as |d|>
-      <d.ActionButton data-test-unlock-button>
-        Unlock
-      </d.ActionButton>
-    </:disabled>
     <:in-progress as |i|>
       <i.ActionButton data-test-unlock-button>
         Unlocking
@@ -95,7 +90,7 @@
       {{/if}}
     </:memorialized>
   </Boxel::ActionChin>
-  <Boxel::ActionChin @stepNumber={{2}} @state={{this.depositCtaState}}>
+  <Boxel::ActionChin @stepNumber={{2}} @state={{this.depositCtaState}} @disabled={{this.depositCtaDisabled}}>
     <:default as |a|>
       <a.ActionButton  {{on "click" this.deposit}} data-test-deposit-button>
         Deposit

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
@@ -59,23 +59,25 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<CardPay
       return 'memorialized';
     } else if (this.isUnlocking) {
       return 'in-progress';
-    } else if (this.isValidAmount) {
-      return 'default';
     } else {
-      return 'disabled';
+      return 'default';
     }
+  }
+  get unlockCtaDisabled() {
+    return !this.isUnlocked && !this.isValidAmount;
   }
 
   get depositCtaState() {
-    if (!this.isUnlocked || (!this.hasDeposited && !this.isValidAmount)) {
-      return 'disabled';
-    } else if (this.isDepositing) {
+    if (this.isDepositing) {
       return 'in-progress';
     } else if (this.hasDeposited) {
       return 'memorialized';
     } else {
       return 'default';
     }
+  }
+  get depositCtaDisabled() {
+    return !this.isUnlocked;
   }
 
   get amountAsBigNumber(): BN {

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
@@ -93,6 +93,7 @@
   </ActionCardContainer::Section>
   <Boxel::ActionChin
     @state={{if @isComplete "memorialized" "default"}}
+    @disabled={{@frozen}}
     data-test-deposit-transaction-setup
   >
     <:default as |d|>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/workflow-canceled-cta/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/workflow-canceled-cta/index.hbs
@@ -1,0 +1,5 @@
+<Boxel::NextStepsBox @title="Workflow canceled" data-test-deposit-workflow-canceled-cta>
+    <Boxel::Button @kind="secondary-dark" {{on "click" this.openNewDepositWorkflow}} data-test-deposit-workflow-canceled-restart>
+        Start Again
+    </Boxel::Button>
+</Boxel::NextStepsBox>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/workflow-canceled-cta/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/workflow-canceled-cta/index.ts
@@ -1,0 +1,19 @@
+/* eslint-disable ember/no-empty-glimmer-component-classes */
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import RouterService from '@ember/routing/router-service';
+import { next } from '@ember/runloop';
+
+class CardPayDepositWorkflowCanceledComponent extends Component {
+  @service declare router: RouterService;
+
+  @action async openNewDepositWorkflow() {
+    await this.router.transitionTo({ queryParams: { flow: null } });
+    next(this, () => {
+      this.router.transitionTo({ queryParams: { flow: 'deposit' } });
+    });
+  }
+}
+
+export default CardPayDepositWorkflowCanceledComponent;

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
@@ -5,6 +5,7 @@
 >
   <Boxel::ActionChin
     @state={{if @isComplete "memorialized" "default"}}
+    @disabled={{@frozen}}
     data-test-layout-customization
   >
     <:default as |d|>

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
@@ -5,6 +5,7 @@
 >
   <Boxel::ActionChin
     @state={{if @isComplete "memorialized" "default"}}
+    @disabled={{@frozen}}
     data-test-layout-customization
   >
     <:default as |d|>

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.hbs
@@ -29,6 +29,7 @@
 </ActionCardContainer::Section>
   <Boxel::ActionChin
     @state={{this.ctaState}}
+    @disabled={{this.ctaDisabled}}
     data-test-layout-customization
   >
     <:default as |a|>
@@ -38,13 +39,6 @@
         Save layout
       </a.ActionButton>
     </:default>
-    <:disabled as |d|>
-      <d.ActionButton
-        {{on "click" this.save}}
-      >
-        Save layout
-      </d.ActionButton>
-    </:disabled>
     <:memorialized as |m|>
       <m.ActionButton
         {{on "click" this.edit}}

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.hbs
@@ -29,7 +29,7 @@
 </ActionCardContainer::Section>
   <Boxel::ActionChin
     @state={{this.ctaState}}
-    @disabled={{this.ctaDisabled}}
+    @disabled={{or @frozen this.ctaDisabled}}
     data-test-layout-customization
   >
     <:default as |a|>

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.ts
@@ -58,11 +58,11 @@ export default class LayoutCustomizationCard extends Component<LayoutCustomizati
       return 'memorialized';
     }
 
-    if (this.issuerName) {
-      return 'default';
-    }
+    return 'default';
+  }
 
-    return 'disabled';
+  get ctaDisabled() {
+    return !this.issuerName;
   }
 
   @action updateHeaderBackground(item: any) {

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
@@ -5,6 +5,7 @@
 >
   <Boxel::ActionChin
     @state={{if @isComplete "memorialized" "default"}}
+    @disabled={{@frozen}}
     data-test-layout-customization
   >
     <:default as |d|>

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
@@ -63,7 +63,7 @@
       />
     </ActionCardContainer::Section>
   {{/if}}
-  <Boxel::ActionChin @state={{this.ctaState}} @disabled={{this.ctaDisabled}}>
+  <Boxel::ActionChin @state={{this.ctaState}} @disabled={{or @frozen this.ctaDisabled}}>
     <:default as |a|>
       <a.ActionButton {{on "click" this.connect}} data-test-mainnet-connect-button>
         Connect Wallet

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
@@ -63,17 +63,12 @@
       />
     </ActionCardContainer::Section>
   {{/if}}
-  <Boxel::ActionChin @state={{this.ctaState}}>
+  <Boxel::ActionChin @state={{this.ctaState}} @disabled={{this.ctaDisabled}}>
     <:default as |a|>
       <a.ActionButton {{on "click" this.connect}} data-test-mainnet-connect-button>
         Connect Wallet
       </a.ActionButton>
     </:default>
-    <:disabled as |d|>
-      <d.ActionButton data-test-mainnet-connect-button>
-        Connect Wallet
-      </d.ActionButton>
-    </:disabled>
     <:in-progress as |i|>
       <i.ActionStatusArea class="layer-one-connect-card__in-progress-logo" @icon={{concat this.radioWalletProviderId "-logo"}} style={{css-var status-icon-size="2.5rem"}}>
         <Boxel::LoadingIndicator

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
@@ -67,11 +67,12 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
       return 'memorialized';
     } else if (this.isWaitingForConnection) {
       return 'in-progress';
-    } else if (!this.radioWalletProviderId) {
-      return 'disabled';
     } else {
       return 'default';
     }
+  }
+  get ctaDisabled() {
+    return !this.isConnected && !this.radioWalletProviderId;
   }
 
   get balancesToShow() {

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
@@ -113,7 +113,6 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
 
   @action onDisconnect() {
     this.args.onDisconnect?.();
-    this.args.onIncomplete?.();
   }
 
   @task *connectWalletTask() {

--- a/packages/web-client/app/components/card-pay/layer-two-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-two-connect-card/index.hbs
@@ -43,7 +43,7 @@
         />
       </CardPay::FieldStack>
     </ActionCardContainer::Section>
-    <Boxel::ActionChin @state='memorialized'>
+    <Boxel::ActionChin @state='memorialized' @disabled={{@frozen}}>
       <:memorialized as |m|>
         <m.ActionButton {{on "click" this.disconnect}} data-test-layer-2-wallet-disconnect-button>
           Disconnect Wallet

--- a/packages/web-client/app/components/card-pay/layer-two-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-two-connect-card/index.ts
@@ -17,7 +17,6 @@ import { action } from '@ember/object';
 
 interface CardPayLayerTwoConnectCardComponentArgs {
   onComplete: (() => void) | undefined;
-  onIncomplete: (() => void) | undefined;
   onConnect: (() => void) | undefined;
   onDisconnect: (() => void) | undefined;
   isComplete: boolean;
@@ -69,7 +68,6 @@ class CardPayLayerTwoConnectCardComponent extends Component<CardPayLayerTwoConne
 
   @action onDisconnect() {
     this.args.onDisconnect?.();
-    this.args.onIncomplete?.();
     taskFor(this.connectWalletTask).perform();
   }
 

--- a/packages/web-client/app/components/workflow-thread/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/index.hbs
@@ -10,7 +10,7 @@
       {{#each milestone.visiblePostables as |postable j|}}
         <WorkflowThread::Postable
           @postable={{postable}}
-          @postables={{milestone.visiblePostables}}
+          @previous={{object-at milestone.visiblePostables (dec j)}}
           @index={{j}}
           data-test-milestone={{i}}
         />
@@ -29,10 +29,19 @@
       {{#each @workflow.epilogue.visiblePostables as |postable j|}}
         <WorkflowThread::Postable
           @postable={{postable}}
-          @postables={{@workflow.epilogue.visiblePostables}}
+          @previous={{object-at @workflow.epilogue.visiblePostables (dec j)}}
           @index={{j}}
           data-test-epilogue
         />
+      {{/each}}
+    {{else if @workflow.isCanceled}}
+      {{#each @workflow.cancelationMessages.visiblePostables as |postable j|}}
+         <WorkflowThread::Postable
+           @postable={{postable}}
+           @previous={{if (eq j 0) this.lastMilestonePostable (object-at @workflow.cancelationMessages.visiblePostables (dec j))}}
+           @index={{j}}
+           data-test-cancelation
+         />
       {{/each}}
     {{/if}}
     <div data-thread-end></div>

--- a/packages/web-client/app/components/workflow-thread/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/index.hbs
@@ -37,6 +37,7 @@
     {{else if @workflow.isCanceled}}
       {{#each @workflow.cancelationMessages.visiblePostables as |postable j|}}
          <WorkflowThread::Postable
+           {{did-insert this.scrollToEnd}}
            @postable={{postable}}
            @previous={{if (eq j 0) this.lastMilestonePostable (object-at @workflow.cancelationMessages.visiblePostables (dec j))}}
            @index={{j}}

--- a/packages/web-client/app/components/workflow-thread/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/index.hbs
@@ -11,6 +11,7 @@
         <WorkflowThread::Postable
           @postable={{postable}}
           @previous={{object-at milestone.visiblePostables (dec j)}}
+          @frozen={{or @workflow.isComplete @workflow.isCanceled}}
           @index={{j}}
           data-test-milestone={{i}}
         />

--- a/packages/web-client/app/components/workflow-thread/index.ts
+++ b/packages/web-client/app/components/workflow-thread/index.ts
@@ -1,7 +1,12 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { Workflow } from '@cardstack/web-client/models/workflow';
 
-export default class WorkflowThread extends Component {
+interface WorkflowThreadArgs {
+  workflow: Workflow;
+}
+
+export default class WorkflowThread extends Component<WorkflowThreadArgs> {
   threadEl: HTMLElement | undefined;
   @action focus(element: HTMLElement): void {
     this.threadEl = element;
@@ -15,5 +20,14 @@ export default class WorkflowThread extends Component {
     let targetEl =
       milestoneEl || this.threadEl?.querySelector('[data-thread-end]');
     targetEl?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+  }
+
+  get lastMilestonePostable() {
+    let milestones = this.args.workflow.visibleMilestones;
+    let postablesInLastMilestone = milestones[
+      milestones.length - 1
+    ].peekAtVisiblePostables();
+
+    return postablesInLastMilestone[postablesInLastMilestone.length - 1];
   }
 }

--- a/packages/web-client/app/components/workflow-thread/index.ts
+++ b/packages/web-client/app/components/workflow-thread/index.ts
@@ -22,6 +22,12 @@ export default class WorkflowThread extends Component<WorkflowThreadArgs> {
     targetEl?.scrollIntoView({ block: 'end', behavior: 'smooth' });
   }
 
+  @action scrollToEnd() {
+    this.threadEl
+      ?.querySelector('[data-thread-end]')
+      ?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+  }
+
   get lastMilestonePostable() {
     let milestones = this.args.workflow.visibleMilestones;
     let postablesInLastMilestone = milestones[

--- a/packages/web-client/app/components/workflow-thread/postable/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/postable/index.hbs
@@ -36,6 +36,7 @@
       {{component
         @postable.componentName
         workflowSession=@postable.session
+        frozen=@frozen
         onComplete=(optional @postable.onComplete)
         onIncomplete=(optional @postable.onIncomplete)
         isComplete=@postable.isComplete

--- a/packages/web-client/app/components/workflow-thread/postable/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/postable/index.hbs
@@ -4,14 +4,13 @@
     data-test-date-divider
   />
 {{/if}}
-
 {{#if @postable.message}}
   <Boxel::ThreadMessage
     @datetime={{@postable.timestamp}}
     @imgURL={{@postable.author.imgURL}}
     @name={{@postable.author.name}}
     @hideName={{true}}
-    @hideMeta={{postable-meta-hidden @postable previous=(object-at @postables (dec @index))}}
+    @hideMeta={{postable-meta-hidden @postable previous=@previous}}
     data-test-postable={{@index}}
     ...attributes
   >
@@ -26,7 +25,7 @@
     @imgURL={{@postable.author.imgURL}}
     @name={{@postable.author.name}}
     @hideName={{true}}
-    @hideMeta={{postable-meta-hidden @postable previous=(object-at @postables (dec @index))}}
+    @hideMeta={{postable-meta-hidden @postable previous=@previous}}
     data-test-postable={{@index}}
     ...attributes
   >

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -22,7 +22,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
-    "@cardstack/boxel": "^0.7.3",
+    "@cardstack/boxel": "^0.7.5",
     "@cardstack/cardpay-sdk": "0.19.12",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -316,6 +316,20 @@ module('Acceptance | deposit', function (hooks) {
       .dom(`${epiloguePostableSel(3)} [data-test-balance="CARD"]`)
       .containsText('10000.00');
 
+    let milestoneCtaButtonCount = Array.from(
+      document.querySelectorAll(
+        '[data-test-milestone] [data-test-boxel-action-chin] button[data-test-boxel-button]'
+      )
+    ).length;
+    assert
+      .dom(
+        '[data-test-milestone] [data-test-boxel-action-chin] button[data-test-boxel-button]:disabled'
+      )
+      .exists(
+        { count: milestoneCtaButtonCount },
+        'All cta buttons in milestones should be disabled'
+      );
+
     assert
       .dom(
         `${epiloguePostableSel(4)} [data-test-deposit-next-step="dashboard"]`
@@ -540,6 +554,22 @@ module('Acceptance | deposit', function (hooks) {
       .dom(`${postableSel(0, 4)} [data-test-mainnet-disconnect-button]`)
       .containsText('Disconnect Wallet');
     await click(`${postableSel(0, 4)} [data-test-mainnet-disconnect-button]`);
+
+    // test that all cta buttons are disabled
+    let milestoneCtaButtonCount = Array.from(
+      document.querySelectorAll(
+        '[data-test-milestone] [data-test-boxel-action-chin] button[data-test-boxel-button]'
+      )
+    ).length;
+    assert
+      .dom(
+        '[data-test-milestone] [data-test-boxel-action-chin] button[data-test-boxel-button]:disabled'
+      )
+      .exists(
+        { count: milestoneCtaButtonCount },
+        'All cta buttons in milestones should be disabled'
+      );
+
     assert
       .dom(cancelationPostableSel(0))
       .containsText(
@@ -604,6 +634,21 @@ module('Acceptance | deposit', function (hooks) {
     layer1Service.test__simulateDisconnectFromWallet();
 
     await waitFor('[data-test-deposit-workflow-canceled-cta]');
+
+    // test that all cta buttons are disabled
+    let milestoneCtaButtonCount = Array.from(
+      document.querySelectorAll(
+        '[data-test-milestone] [data-test-boxel-action-chin] button[data-test-boxel-button]'
+      )
+    ).length;
+    assert
+      .dom(
+        '[data-test-milestone] [data-test-boxel-action-chin] button[data-test-boxel-button]:disabled'
+      )
+      .exists(
+        { count: milestoneCtaButtonCount },
+        'All cta buttons in milestones should be disabled'
+      );
 
     assert
       .dom(cancelationPostableSel(0))
@@ -675,12 +720,27 @@ module('Acceptance | deposit', function (hooks) {
       `[data-test-layer-2-wallet-card] [data-test-layer-2-wallet-disconnect-button]`
     );
 
+    // test that all cta buttons are disabled
+    let milestoneCtaButtonCount = Array.from(
+      document.querySelectorAll(
+        '[data-test-milestone] [data-test-boxel-action-chin] button[data-test-boxel-button]'
+      )
+    ).length;
+    assert
+      .dom(
+        '[data-test-milestone] [data-test-boxel-action-chin] button[data-test-boxel-button]:disabled'
+      )
+      .exists(
+        { count: milestoneCtaButtonCount },
+        'All cta buttons in milestones should be disabled'
+      );
     assert
       .dom(cancelationPostableSel(0))
       .containsText(
         'It looks like your xDai chain wallet has been disconnected. If you still want to deposit funds, please start again by connecting your wallet.'
       );
     assert.dom(cancelationPostableSel(1)).containsText('Workflow canceled');
+
     assert.dom('[data-test-deposit-workflow-canceled-restart]').exists();
   });
 
@@ -745,6 +805,20 @@ module('Acceptance | deposit', function (hooks) {
     layer2Service.test__simulateDisconnectFromWallet();
 
     await waitFor('[data-test-deposit-workflow-canceled-cta]');
+    // test that all cta buttons are disabled
+    let milestoneCtaButtonCount = Array.from(
+      document.querySelectorAll(
+        '[data-test-milestone] [data-test-boxel-action-chin] button[data-test-boxel-button]'
+      )
+    ).length;
+    assert
+      .dom(
+        '[data-test-milestone] [data-test-boxel-action-chin] button[data-test-boxel-button]:disabled'
+      )
+      .exists(
+        { count: milestoneCtaButtonCount },
+        'All cta buttons in milestones should be disabled'
+      );
     assert
       .dom(cancelationPostableSel(0))
       .containsText(

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -26,6 +26,10 @@ function milestoneCompletedSel(milestoneIndex: number): string {
   return `[data-test-milestone-completed][data-test-milestone="${milestoneIndex}"]`;
 }
 
+function cancelationPostableSel(postableIndex: number) {
+  return `[data-test-cancelation][data-test-postable="${postableIndex}"]`;
+}
+
 module('Acceptance | deposit', function (hooks) {
   setupApplicationTest(hooks);
 
@@ -481,7 +485,7 @@ module('Acceptance | deposit', function (hooks) {
       .containsText('choose the asset you would like to deposit');
   });
 
-  test('Disconnecting Layer 1 after proceeding beyond it', async function (assert) {
+  test('Disconnecting Layer 1 from within the workflow', async function (assert) {
     let layer1Service = this.owner.lookup('service:layer1-network')
       .strategy as Layer1TestWeb3Strategy;
     let layer1AccountAddress = '0xaCD5f5534B756b856ae3B2CAcF54B3321dd6654Fb6';
@@ -537,10 +541,12 @@ module('Acceptance | deposit', function (hooks) {
       .containsText('Disconnect Wallet');
     await click(`${postableSel(0, 4)} [data-test-mainnet-disconnect-button]`);
     assert
-      .dom(postableSel(0, 4))
-      .containsText('Connect your L1 test chain wallet');
-    assert.dom(milestoneCompletedSel(1)).doesNotExist();
-    assert.dom(milestoneCompletedSel(0)).doesNotExist();
+      .dom(cancelationPostableSel(0))
+      .containsText(
+        'It looks like your mainnet wallet has been disconnected. If you still want to deposit funds, please start again by connecting your wallet.'
+      );
+    assert.dom(cancelationPostableSel(1)).containsText('Workflow canceled');
+    assert.dom('[data-test-deposit-workflow-canceled-restart]').exists();
   });
 
   test('Disconnecting Layer 1 from outside the current tab (mobile wallet / other tabs)', async function (assert) {
@@ -597,17 +603,18 @@ module('Acceptance | deposit', function (hooks) {
 
     layer1Service.test__simulateDisconnectFromWallet();
 
-    await waitUntil(() =>
-      document
-        .querySelector(postableSel(0, 4))
-        ?.textContent?.includes('Connect your L1 test chain wallet')
-    );
+    await waitFor('[data-test-deposit-workflow-canceled-cta]');
 
-    assert.dom(milestoneCompletedSel(1)).doesNotExist();
-    assert.dom(milestoneCompletedSel(0)).doesNotExist();
+    assert
+      .dom(cancelationPostableSel(0))
+      .containsText(
+        'It looks like your mainnet wallet has been disconnected. If you still want to deposit funds, please start again by connecting your wallet.'
+      );
+    assert.dom(cancelationPostableSel(1)).containsText('Workflow canceled');
+    assert.dom('[data-test-deposit-workflow-canceled-restart]').exists();
   });
 
-  test('Disconnecting Layer 2 after proceeding beyond it', async function (assert) {
+  test('Disconnecting Layer 2 from within the workflow', async function (assert) {
     let layer1Service = this.owner.lookup('service:layer1-network')
       .strategy as Layer1TestWeb3Strategy;
     let layer1AccountAddress = '0xaCD5f5534B756b856ae3B2CAcF54B3321dd6654Fb6';
@@ -667,10 +674,14 @@ module('Acceptance | deposit', function (hooks) {
     await click(
       `[data-test-layer-2-wallet-card] [data-test-layer-2-wallet-disconnect-button]`
     );
+
     assert
-      .dom('[data-test-layer-2-wallet-card]')
-      .containsText('Install the Card Wallet app on your mobile phone');
-    assert.dom(milestoneCompletedSel(1)).doesNotExist();
+      .dom(cancelationPostableSel(0))
+      .containsText(
+        'It looks like your xDai chain wallet has been disconnected. If you still want to deposit funds, please start again by connecting your wallet.'
+      );
+    assert.dom(cancelationPostableSel(1)).containsText('Workflow canceled');
+    assert.dom('[data-test-deposit-workflow-canceled-restart]').exists();
   });
 
   test('Disconnecting Layer 2 from outside the current tab (mobile wallet / other tabs)', async function (assert) {
@@ -733,14 +744,13 @@ module('Acceptance | deposit', function (hooks) {
 
     layer2Service.test__simulateDisconnectFromWallet();
 
-    await waitUntil(() =>
-      document
-        .querySelector('[data-test-layer-2-wallet-card]')
-        ?.textContent?.includes(
-          'Install the Card Wallet app on your mobile phone'
-        )
-    );
-
-    assert.dom(milestoneCompletedSel(1)).doesNotExist();
+    await waitFor('[data-test-deposit-workflow-canceled-cta]');
+    assert
+      .dom(cancelationPostableSel(0))
+      .containsText(
+        'It looks like your xDai chain wallet has been disconnected. If you still want to deposit funds, please start again by connecting your wallet.'
+      );
+    assert.dom(cancelationPostableSel(1)).containsText('Workflow canceled');
+    assert.dom('[data-test-deposit-workflow-canceled-restart]').exists();
   });
 });

--- a/packages/web-client/tests/unit/models/workflow-test.ts
+++ b/packages/web-client/tests/unit/models/workflow-test.ts
@@ -47,6 +47,15 @@ module('Unit | Workflow model', function (hooks) {
     assert.strictEqual(workflow, exampleMessage.workflow);
   });
 
+  test('attachWorkflow sets workflow on cancelationMessages', function (assert) {
+    let workflow = new ConcreteWorkflow({});
+    workflow.milestones = [exampleMilestone];
+    workflow.cancelationMessages = new PostableCollection([exampleMessage]);
+    assert.ok(!exampleMessage.workflow);
+    workflow.attachWorkflow();
+    assert.strictEqual(workflow, exampleMessage.workflow);
+  });
+
   test('completedMilestoneCount returns count of milestones with isComplete true', function (assert) {
     let workflow = new ConcreteWorkflow({});
     let milestone2Postable = new WorkflowPostable({ name: 'cardbot' });
@@ -115,6 +124,30 @@ module('Unit | Workflow model', function (hooks) {
     let workflow = new ConcreteWorkflow({});
     workflow.milestones = [exampleMilestone];
     assert.equal(workflow.progressStatus, 'Workflow started');
+  });
+
+  test('progressStatus returns "Workflow canceled" when workflow is canceled', function (assert) {
+    let workflow = new ConcreteWorkflow({});
+    workflow.milestones = [exampleMilestone];
+    workflow.cancel();
+    assert.equal(workflow.progressStatus, 'Workflow canceled');
+  });
+
+  test('Incomplete workflow is canceled when workflow.cancel is called', function (assert) {
+    let workflow = new ConcreteWorkflow({});
+    workflow.milestones = [exampleMilestone];
+    workflow.cancel();
+    assert.equal(workflow.isCanceled, true);
+  });
+
+  test('Completed workflow is not canceled when workflow.cancel is called', function (assert) {
+    let workflow = new ConcreteWorkflow({});
+    workflow.milestones = [exampleMilestone];
+    examplePostable.isComplete = true;
+
+    assert.ok(workflow.isComplete, 'Completing workflow before canceling');
+    workflow.cancel();
+    assert.ok(!workflow.isCanceled);
   });
 
   test('Workflow.resetTo resets each milestone and its epilogue correctly', function (assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,10 +933,10 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@cardstack/boxel@^0.7.4":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@cardstack/boxel/-/boxel-0.7.4.tgz#d4bd966cf3388cf5ab7d405fe5731371bc0b5342"
-  integrity sha512-1JJwqRO3ttK91iN7ibIgf5j0WVVfjvcUoZN5mCbXG549pXjiuKhuByUvVrB50RWYMDHmtSLPKfq9uCWFZIetBA==
+"@cardstack/boxel@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@cardstack/boxel/-/boxel-0.7.5.tgz#838e48349cc696f965b805a25745bfed04e439c0"
+  integrity sha512-jshb7fN0UfhMYQf9rmlvle1CHDfbiKw+6kqrK+LpE08Q86wcBue8D98nozut46l2ytUy8e+h2vS3ZWJ5qkExgg==
   dependencies:
     broccoli-concat "^4.2.4"
     broccoli-funnel "^3.0.3"
@@ -967,7 +967,7 @@
     ember-set-body-class "^1.0.2"
     ember-svg-jar "^2.2.3"
     ember-table "^2.2.3"
-    ember-test-selectors "^2.1.0"
+    ember-test-selectors "^5.0.0"
     ember-truth-helpers "^3.0.0"
     file-loader "^6.2.0"
     macro-decorators "^0.1.2"
@@ -8395,6 +8395,39 @@ ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cl
     rimraf "^3.0.1"
     semver "^5.5.0"
 
+ember-cli-babel@^7.26.4:
+  version "7.26.6"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
+  integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
+  dependencies:
+    "@babel/core" "^7.12.0"
+    "@babel/helper-compilation-targets" "^7.12.0"
+    "@babel/plugin-proposal-class-properties" "^7.13.0"
+    "@babel/plugin-proposal-decorators" "^7.13.5"
+    "@babel/plugin-transform-modules-amd" "^7.13.0"
+    "@babel/plugin-transform-runtime" "^7.13.9"
+    "@babel/plugin-transform-typescript" "^7.13.0"
+    "@babel/polyfill" "^7.11.5"
+    "@babel/preset-env" "^7.12.0"
+    "@babel/runtime" "7.12.18"
+    amd-name-resolver "^1.3.1"
+    babel-plugin-debug-macros "^0.3.4"
+    babel-plugin-ember-data-packages-polyfill "^0.1.2"
+    babel-plugin-ember-modules-api-polyfill "^3.5.0"
+    babel-plugin-module-resolver "^3.2.0"
+    broccoli-babel-transpiler "^7.8.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.2"
+    broccoli-source "^2.1.2"
+    clone "^2.1.2"
+    ember-cli-babel-plugin-helpers "^1.1.1"
+    ember-cli-version-checker "^4.1.0"
+    ensure-posix-path "^1.0.2"
+    fixturify-project "^1.10.0"
+    resolve-package-path "^3.1.0"
+    rimraf "^3.0.1"
+    semver "^5.5.0"
+
 ember-cli-babel@~7.24.0:
   version "7.24.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.24.0.tgz#d58670d0f214c63a46f44f86e7c407799d77fc45"
@@ -9524,6 +9557,15 @@ ember-test-selectors@^2.1.0:
   dependencies:
     ember-cli-babel "^6.8.2"
     ember-cli-version-checker "^3.1.2"
+
+ember-test-selectors@^5.0.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/ember-test-selectors/-/ember-test-selectors-5.3.0.tgz#1dee515e43e7beb7b7083a2fee2cdf808bf9de26"
+  integrity sha512-B9kkCTO39l+XXcp6eRnfZWHeeL3Ffxdux8chXHSwmAPYCc50KI8VW7mr1uy2ZcUMNP/o0sk7VrpA6x3lBkSvWQ==
+  dependencies:
+    calculate-cache-key-for-tree "^2.0.0"
+    ember-cli-babel "^7.26.4"
+    ember-cli-version-checker "^5.1.2"
 
 ember-text-measurer@^0.6.0:
   version "0.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,10 +933,10 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@cardstack/boxel@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@cardstack/boxel/-/boxel-0.7.3.tgz#ad4c87c70290fb46d910ff706a65d7cc236bcac2"
-  integrity sha512-LqtCRic9xOhLJxRmSb1muLFlliG9oARiDyI0yg7T5I3Lr8cgWvQytHf5JJeLHvItaocjFOWf/Ox/xf+6TD9G7Q==
+"@cardstack/boxel@^0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@cardstack/boxel/-/boxel-0.7.4.tgz#d4bd966cf3388cf5ab7d405fe5731371bc0b5342"
+  integrity sha512-1JJwqRO3ttK91iN7ibIgf5j0WVVfjvcUoZN5mCbXG549pXjiuKhuByUvVrB50RWYMDHmtSLPKfq9uCWFZIetBA==
   dependencies:
     broccoli-concat "^4.2.4"
     broccoli-funnel "^3.0.3"


### PR DESCRIPTION
Attempt to implement CS-859. Adds the `cancelation` and `isCanceled` property to workflows.

- `cancelation` is a `PostableCollection` that will be shown at the end of the current thread if `isCanceled` is true.
- A workflow being complete (`isComplete` is true) precludes it from being canceled
- Workflows are expected to be cancelled by their `WorkflowComponent`s - eg. `DepositWorkflowComponent` and `IssuePrepaidCardWorkflowComponent`
- Removed rolling back of thread in response to layer 1 and layer 2 disconnection

Also made some changes to the way we pass data to postables in order to support comparisons between postables in different `PostableCollection`s.

After implementing cancelation, will implement a way to freeze a workflow to prevent inputs/changes after cancelation in this PR (issue in CS-867).

Looking for some feedback on whether this way of cancelling a workflow seems ok.