### PR TITLE
Fix reroute to balances tab and workflow button locations

### DIFF
--- a/packages/web-client/app/router.ts
+++ b/packages/web-client/app/router.ts
@@ -8,7 +8,6 @@ export default class Router extends EmberRouter {
 
 Router.map(function () {
   this.route('card-pay', function () {
-    this.route('connect');
     this.route('balances');
     this.route('merchant-services');
     this.route('reward-programs');

--- a/packages/web-client/app/routes/card-pay/index.ts
+++ b/packages/web-client/app/routes/card-pay/index.ts
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
-import '../css/card-pay.css';
+import '../../css/card-pay.css';
 
-export default class CardPayRoute extends Route {
+export default class CardPayIndexRoute extends Route {
   beforeModel(/* transition */) {
     this.transitionTo('card-pay.balances');
   }

--- a/packages/web-client/app/templates/card-pay/balances.hbs
+++ b/packages/web-client/app/templates/card-pay/balances.hbs
@@ -3,15 +3,15 @@
     Card Balances
   </h2>
 
-  <Boxel::Button @kind="primary" {{on "click" (set this "flow" 'deposit')}} data-test-deposit-workflow-button>
-    Deposit
+  <Boxel::Button @kind="primary" {{on "click" (set this "flow" 'issue-prepaid-card')}} data-test-issue-prepaid-card-workflow-button>
+    Issue a Prepaid Card
   </Boxel::Button>
 </section>
 
 <Boxel::Modal
   style={{css-var boxel-modal-max-width="65rem"}} {{!-- ~1040px --}}
-  @isOpen={{eq this.flow 'deposit'}}
+  @isOpen={{eq this.flow 'issue-prepaid-card'}}
   @onClose={{set this "flow" null}}
 >
-  <CardPay::DepositWorkflow />
+  <CardPay::IssuePrepaidCardWorkflow />
 </Boxel::Modal>

--- a/packages/web-client/app/templates/card-pay/token-suppliers.hbs
+++ b/packages/web-client/app/templates/card-pay/token-suppliers.hbs
@@ -3,15 +3,15 @@
     Token Suppliers
   </h2>
 
-  <Boxel::Button @kind="primary" {{on "click" (set this "flow" 'issue-prepaid-card')}} data-test-issue-prepaid-card-workflow-button>
-    Issue Prepaid Card
+  <Boxel::Button @kind="primary" {{on "click" (set this "flow" 'deposit')}} data-test-deposit-workflow-button>
+    Deposit Tokens
   </Boxel::Button>
 </section>
 
 <Boxel::Modal
   style={{css-var boxel-modal-max-width="65rem"}} {{!-- ~1040px --}}
-  @isOpen={{eq this.flow 'issue-prepaid-card'}}
+  @isOpen={{eq this.flow 'deposit'}}
   @onClose={{set this "flow" null}}
 >
-  <CardPay::IssuePrepaidCardWorkflow />
+  <CardPay::DepositWorkflow />
 </Boxel::Modal>

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -30,13 +30,8 @@ module('Acceptance | deposit', function (hooks) {
   setupApplicationTest(hooks);
 
   test('Initiating workflow without wallet connections', async function (assert) {
-    await visit('/');
-    assert.equal(currentURL(), '/');
-    await click('[data-test-cardstack-org-link="card-pay"]');
-    assert.equal(currentURL(), '/card-pay/balances');
-
-    await click('[data-test-card-pay-header-tab][href="/card-pay/balances"]');
-
+    await visit('/card-pay/token-suppliers');
+    assert.equal(currentURL(), '/card-pay/token-suppliers');
     await click('[data-test-deposit-workflow-button]');
 
     let post = postableSel(0, 0);
@@ -321,9 +316,7 @@ module('Acceptance | deposit', function (hooks) {
   });
 
   test('Initiating workflow with layer 1 wallet already connected', async function (assert) {
-    await visit('/');
-    await click('[data-test-cardstack-org-link="card-pay"]');
-
+    await visit('/card-pay/token-suppliers');
     await click(
       '[data-test-card-pay-layer-1-connect] [data-test-card-pay-connect-button]'
     );
@@ -346,7 +339,6 @@ module('Acceptance | deposit', function (hooks) {
       .hasText('0xaCD5f...4Fb6');
     assert.dom('[data-test-layer-connect-modal="layer1"]').doesNotExist();
 
-    await click('[data-test-card-pay-header-tab][href="/card-pay/balances"]');
     await click('[data-test-deposit-workflow-button]');
 
     let post = postableSel(0, 0);
@@ -418,9 +410,7 @@ module('Acceptance | deposit', function (hooks) {
   });
 
   test('Initiating workflow with layer 2 wallet already connected', async function (assert) {
-    await visit('/');
-    await click('[data-test-cardstack-org-link="card-pay"]');
-
+    await visit('/card-pay/token-suppliers');
     await click(
       '[data-test-card-pay-layer-2-connect] [data-test-card-pay-connect-button]'
     );
@@ -445,7 +435,6 @@ module('Acceptance | deposit', function (hooks) {
       .hasText('0x18261...6E44');
     assert.dom('[data-test-layer-connect-modal="layer2"]').doesNotExist();
 
-    await click('[data-test-card-pay-header-tab][href="/card-pay/balances"]');
     await click('[data-test-deposit-workflow-button]');
     await click(`${postableSel(0, 3)} [data-test-wallet-option="metamask"]`);
     await click(
@@ -505,7 +494,7 @@ module('Acceptance | deposit', function (hooks) {
       defaultToken: toBN('142200000000000000'),
     });
 
-    await visit('/card-pay/balances');
+    await visit('/card-pay/token-suppliers');
     await click('[data-test-deposit-workflow-button]');
 
     let post = postableSel(0, 0);
@@ -567,7 +556,7 @@ module('Acceptance | deposit', function (hooks) {
       defaultToken: toBN('142200000000000000'),
     });
 
-    await visit('/card-pay/balances');
+    await visit('/card-pay/token-suppliers');
     await click('[data-test-deposit-workflow-button]');
 
     let post = postableSel(0, 0);
@@ -631,7 +620,7 @@ module('Acceptance | deposit', function (hooks) {
       defaultToken: toBN('142200000000000000'),
     });
 
-    await visit('/card-pay/balances');
+    await visit('/card-pay/token-suppliers');
     await click('[data-test-deposit-workflow-button]');
 
     let post = postableSel(0, 0);
@@ -697,7 +686,7 @@ module('Acceptance | deposit', function (hooks) {
       defaultToken: toBN('142200000000000000'),
     });
 
-    await visit('/card-pay/balances');
+    await visit('/card-pay/token-suppliers');
     await click('[data-test-deposit-workflow-button]');
 
     let post = postableSel(0, 0);

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -28,11 +28,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
 
   test('Initiating workflow without wallet connections', async function (assert) {
     await visit('/card-pay');
-    await click(
-      '[data-test-card-pay-header-tab][href="/card-pay/token-suppliers"]'
-    );
-    assert.equal(currentURL(), '/card-pay/token-suppliers');
-
+    assert.equal(currentURL(), '/card-pay/balances');
     await click('[data-test-issue-prepaid-card-workflow-button]');
 
     let post = postableSel(0, 0);


### PR DESCRIPTION
CS-910

- Fix reroute to balances tab (only reroute from /card-pay to /card-pay/balances)
- Swap workflow buttons ("Deposit Tokens" is on Token Suppliers tab, and "Issue a Prepaid Card" is on Balances tab)