### PR TITLE
Refresh layer 1 balances after relaying tokens

### DIFF
--- a/packages/web-client/app/services/layer1-network.ts
+++ b/packages/web-client/app/services/layer1-network.ts
@@ -76,6 +76,7 @@ export default class Layer1Network extends Service {
       destinationAddress,
       amount
     );
+    yield this.strategy.refreshBalances();
     return txnReceipt;
   }
 

--- a/packages/web-client/app/utils/web3-strategies/ethereum.ts
+++ b/packages/web-client/app/utils/web3-strategies/ethereum.ts
@@ -51,6 +51,8 @@ export default class EthereumWeb3Strategy implements Layer1Web3Strategy {
     throw new Error('Method not implemented.');
   }
 
+  refreshBalances() {}
+
   blockExplorerUrl(txnHash: TransactionHash) {
     return `${getConstantByNetwork('blockExplorer', 'mainnet')}/tx/${txnHash}`;
   }

--- a/packages/web-client/app/utils/web3-strategies/test-layer1.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer1.ts
@@ -19,6 +19,11 @@ export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
   @tracked walletInfo: WalletInfo = new WalletInfo([], -1);
   simpleEmitter = new SimpleEmitter();
 
+  // property to test whether the refreshBalances method is called
+  // to test if balances are refreshed after relaying tokens
+  // this is only a mock property
+  @tracked balancesRefreshed = false;
+
   // Balances are settable in this test implementation
   @tracked defaultTokenBalance: BN | undefined;
   @tracked daiBalance: BN | undefined;
@@ -60,6 +65,10 @@ export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
   ) {
     this.#depositDeferred = RSVP.defer();
     return this.#depositDeferred.promise;
+  }
+
+  refreshBalances() {
+    this.balancesRefreshed = true;
   }
 
   blockExplorerUrl(txnHash: TransactionHash): string {

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -19,10 +19,11 @@ export interface Web3Strategy {
 export interface Layer1Web3Strategy extends Web3Strategy {
   on(event: string, cb: Function): UnbindEventListener;
   isConnected: boolean;
-  defaultTokenBalance: BN | undefined;
   currentProviderId: string | undefined;
+  defaultTokenBalance: BN | undefined;
   daiBalance: BN | undefined;
   cardBalance: BN | undefined;
+  refreshBalances(): void;
   connect(walletProvider: WalletProvider): Promise<void>;
   waitForAccount: Promise<void>;
   approve(amountInWei: BN, token: string): Promise<TransactionReceipt>;

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -189,6 +189,9 @@ module('Acceptance | deposit', function (hooks) {
     assert
       .dom(`${post} [data-test-unlock-button]`)
       .isEnabled('Unlock button is enabled once amount has been entered');
+
+    // make sure that our property to test if balances are refreshed is not true yet
+    layer1Service.balancesRefreshed = false;
     await click(`${post} [data-test-unlock-button]`);
 
     // // MetaMask pops up and user approves the transaction. There is a spinner
@@ -226,6 +229,11 @@ module('Acceptance | deposit', function (hooks) {
 
     layer1Service.test__simulateDeposit();
     await settled();
+
+    assert.ok(
+      layer1Service.balancesRefreshed,
+      'Balances should be refreshed after relaying tokens'
+    );
 
     assert
       .dom(`${post} [data-test-deposit-button]`)


### PR DESCRIPTION
CS-851

Refresh layer 1 balances after relaying tokens. This updates all displayed balances in the workflow that made the request to relay tokens. 