### PR TITLE
disable completed or canceled workflows via a wrapping fieldset

### DIFF
--- a/packages/web-client/app/components/workflow-thread/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/index.hbs
@@ -6,25 +6,27 @@
     {{#if (has-block 'before-content')}}
       {{yield to='before-content'}}
     {{/if}}
-    {{#each @workflow.visibleMilestones as |milestone i|}}
-      {{#each milestone.visiblePostables as |postable j|}}
-        <WorkflowThread::Postable
-          @postable={{postable}}
-          @previous={{object-at milestone.visiblePostables (dec j)}}
-          @index={{j}}
-          data-test-milestone={{i}}
-        />
+    <WorkflowThread::Wrapper @frozen={{or @workflow.isComplete @workflow.isCanceled}}>
+      {{#each @workflow.visibleMilestones as |milestone i|}}
+        {{#each milestone.visiblePostables as |postable j|}}
+          <WorkflowThread::Postable
+            @postable={{postable}}
+            @previous={{object-at milestone.visiblePostables (dec j)}}
+            @index={{j}}
+            data-test-milestone={{i}}
+          />
+        {{/each}}
+        {{#if milestone.isComplete}}
+          <Boxel::MilestoneBanner
+            @title={{milestone.completedDetail}}
+            @status={{if (eq i (dec @workflow.milestones.length)) "Workflow completed" "Milestone reached"}}
+            data-milestone={{i}}
+            data-test-milestone-completed
+            data-test-milestone={{i}}
+          />
+        {{/if}}
       {{/each}}
-      {{#if milestone.isComplete}}
-        <Boxel::MilestoneBanner
-          @title={{milestone.completedDetail}}
-          @status={{if (eq i (dec @workflow.milestones.length)) "Workflow completed" "Milestone reached"}}
-          data-milestone={{i}}
-          data-test-milestone-completed
-          data-test-milestone={{i}}
-        />
-      {{/if}}
-    {{/each}}
+    </WorkflowThread::Wrapper>
     {{#if @workflow.isComplete}}
       {{#each @workflow.epilogue.visiblePostables as |postable j|}}
         <WorkflowThread::Postable

--- a/packages/web-client/app/components/workflow-thread/wrapper/index.css
+++ b/packages/web-client/app/components/workflow-thread/wrapper/index.css
@@ -1,0 +1,8 @@
+/* essentially reset fieldset */
+.workflow-thread__disabled-wrapper-fieldset {
+  border: 0;
+  padding: 0.01em 0 0 0;
+  margin: 0;
+  min-width: 0;
+  position: relative;
+}

--- a/packages/web-client/app/components/workflow-thread/wrapper/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/wrapper/index.hbs
@@ -1,0 +1,6 @@
+<fieldset class="boxel-thread__content workflow-thread__disabled-wrapper-fieldset" disabled={{@frozen}}>
+    <legend class="boxel-sr-only">
+        {{if @frozen "This workflow is disabled as it is complete or canceled." "This workflow is currently active"}}
+    </legend>
+    {{yield}}
+</fieldset>


### PR DESCRIPTION
Disable the workflow via a wrapping fieldset. This is a quick solution that disables all input elements within cards. This relies on us using proper html inputs and button elements, however it provides an opportunity to apply the appropriate styling and behaviour to all contained inputs if they use the `:disabled` pseudo-class to apply disabled styles. 

Some issues:
1. Things that require special handling will include non-semantic inputs and interactable items, plus QRCodes.
2. It's easy enough to remove the `disabled` html attribute and continue interacting with the input elements.  Since we don't know if this allows abuses, we should use this together with #1659.
3. This messes up screen readers. 
4. Radio inputs lack good disabled states at the moment.