### PR TITLE
Display error message for missing issuer; tx amount entry bugfix

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.css
@@ -1,5 +1,5 @@
 .transaction-amount {
-  --tx-amount-from-label-height: 3.125rem; /* 50px */
+  --tx-amount-banner-height: 3.125rem; /* 50px */
   --tx-amount-input-height: 3.75rem; /* 60px */
 }
 
@@ -33,28 +33,36 @@
 .transaction-amount__currency-icon {
   position: absolute;
   width: var(--input-currency-icon-size);
-  height: var(--input-currency-icon-size);
+  height: var(--tx-amount-input-height);
   left: var(--input-currency-icon-space);
-  top: 50%;
-  transform: translateY(-50%);
+  top: 0;
   user-select: none;
 }
 
 .transaction-amount__currency-text {
   position: absolute;
   width: var(--input-currency-text-width);
-  right: var(--input-currency-text-space);
+  height: var(--tx-amount-input-height);
+  display: flex;
+  align-items: center;
+  right: 0;
   text-align: right;
-  top: 50%;
-  transform: translateY(-50%);
+  top: 0;
   user-select: none;
 }
 
-.transaction-amount__from-field-label {
+.transaction-amount__banner-field-label {
   align-self: flex-start;
   display: flex;
   align-items: center;
-  height: var(--tx-amount-from-label-height);
+  height: var(--tx-amount-banner-height);
+}
+
+.transaction-amount__input-field-label {
+  align-self: flex-start;
+  display: flex;
+  align-items: center;
+  height: var(--tx-amount-input-height);
 }
 
 /* unlocking, unlocked, memorialized states */
@@ -67,7 +75,7 @@
   row-gap: var(--boxel-sp-xxs);
 }
 
-.transaction-amount--data-entered .transaction-amount__from-field-label {
+.transaction-amount--data-entered .transaction-amount__banner-field-label {
   height: unset;
 }
 

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.css
@@ -41,12 +41,11 @@
 
 .transaction-amount__currency-text {
   position: absolute;
-  width: var(--input-currency-text-width);
+  max-width: var(--input-currency-text-width);
   height: var(--tx-amount-input-height);
   display: flex;
   align-items: center;
-  right: 0;
-  text-align: right;
+  right: var(--input-currency-text-space);
   top: 0;
   user-select: none;
 }

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -8,7 +8,7 @@
       <Boxel::Field
         class="transaction-amount__field"
         @label="Funding From:"
-        @labelClass="transaction-amount__from-field-label"
+        @labelClass="transaction-amount__banner-field-label"
       >
         <CardPay::DepositWorkflow::TransactionAmount::BalanceView
           @wallet={{this.layer1Network.chainName}}
@@ -42,15 +42,16 @@
           @label="Amount to deposit"
           @fieldMode="edit"
           class="transaction-amount__field"
+          @labelClass="transaction-amount__input-field-label"
         >
         <div class="transaction-amount__input-container transaction-amount__input-token-balance">
           {{svg-jar this.currentTokenDetails.icon class="transaction-amount__currency-icon" role="presentation"}}
-          {{!-- .boxel-input is a hack to get the boxel styles. --}}
-          <input
-            class="boxel-input transaction-amount__input"
-            id="deposit-amount-input"
-            value={{this.amount}}
-            {{on "input" this.onInputAmount}}
+          <Boxel::Input
+            class="transaction-amount__input"
+            @id="deposit-amount-input"
+            @value={{this.amount}}
+            @required={{true}}
+            @onInput={{this.onInputAmount}}
             autocomplete="off"
             inputmode="decimal"
             data-test-deposit-amount-input

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -52,6 +52,7 @@
             @value={{this.amount}}
             @required={{true}}
             @onInput={{this.onInputAmount}}
+            placeholder="0.00"
             autocomplete="off"
             inputmode="decimal"
             data-test-deposit-amount-input

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
@@ -81,7 +81,11 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<CardPay
   }
 
   get amountAsBigNumber(): BN {
-    return toBN(toWei(this.amount || '0'));
+    const regex = /^\d*(\.\d{0,18})?$/gm;
+    if (!this.amount || !regex.test(this.amount)) {
+      return toBN(0);
+    }
+    return toBN(toWei(this.amount));
   }
 
   get isValidAmount() {
@@ -110,10 +114,9 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<CardPay
     return this.isUnlocking || this.isUnlocked;
   }
 
-  @action onInputAmount(event: InputEvent) {
-    const str = (event.target as HTMLInputElement).value;
+  @action onInputAmount(str: string) {
     if (!isNaN(+str)) {
-      this.amount = str;
+      this.amount = str.trim();
     } else {
       this.amount = this.amount; // eslint-disable-line no-self-assign
     }

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
@@ -21,7 +21,7 @@ interface CardPayDepositWorkflowTransactionAmountComponentArgs {
 }
 
 class CardPayDepositWorkflowTransactionAmountComponent extends Component<CardPayDepositWorkflowTransactionAmountComponentArgs> {
-  @tracked amount = '0';
+  @tracked amount = '';
   @tracked isUnlocked = false;
   @tracked isUnlocking = false;
   @tracked unlockTxnReceipt: TransactionReceipt | undefined;

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/form-view/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/form-view/index.hbs
@@ -19,7 +19,15 @@
       @label="Name of Issuer *"
       class="layout-form-view__input-field"
     >
-      <Boxel::Input @value={{@issuerName}} data-test-layout-customization-name-input/>
+      <Boxel::Input
+        @value={{@issuerName}}
+        @required={{true}}
+        @errorMessage={{@nameFieldErrorMessage}}
+        @invalid={{@isNameInvalid}}
+        @onInput={{@onNameInput}}
+        {{on "blur" (pick "target.value" @onNameInput)}}
+        data-test-layout-customization-name-input
+      />
     </Boxel::Field>
     <CardPay::LabeledValue
       @label="Background Color"

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.hbs
@@ -20,6 +20,9 @@
       @updateHeaderBackground={{this.updateHeaderBackground}}
       @headerTheme={{this.headerTheme}}
       @updateHeaderTheme={{this.updateHeaderTheme}}
+      @onNameInput={{this.onNameInput}}
+      @isNameInvalid={{this.isNameInvalid}}
+      @nameFieldErrorMessage={{this.nameFieldErrorMessage}}
     />
   {{/if}}
 

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.ts
@@ -52,6 +52,8 @@ export default class LayoutCustomizationCard extends Component<LayoutCustomizati
   @tracked headerBackground = this.colorOptions[0];
   @tracked headerTheme = this.themeOptions[0];
   @tracked issuerName = '';
+  @tracked nameFieldErrorMessage = '';
+  @tracked isNameInvalid = false;
 
   get ctaState() {
     if (this.args.isComplete) {
@@ -70,6 +72,25 @@ export default class LayoutCustomizationCard extends Component<LayoutCustomizati
   }
   @action updateHeaderTheme(item: any) {
     this.headerTheme = item;
+  }
+
+  @action onNameInput(value: string): void {
+    this.validateName(value);
+    if (this.isNameInvalid) {
+      this.issuerName = '';
+      return;
+    }
+    this.issuerName = value;
+  }
+
+  @action validateName(value: string): void {
+    if (!value) {
+      this.isNameInvalid = true;
+      this.nameFieldErrorMessage = 'This is a required field';
+      return;
+    }
+    this.isNameInvalid = false;
+    this.nameFieldErrorMessage = '';
   }
 
   @action save() {

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -22,7 +22,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
-    "@cardstack/boxel": "^0.7.5",
+    "@cardstack/boxel": "^0.7.10",
     "@cardstack/cardpay-sdk": "0.19.16",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -92,7 +92,22 @@ module('Acceptance | issue prepaid card', function (hooks) {
       .dom(`${post} [data-test-boxel-action-chin] [data-test-boxel-button]`)
       .isDisabled();
 
+    await fillIn('[data-test-layout-customization-name-input]', 'A');
+
+    assert
+      .dom(`${post} [data-test-boxel-action-chin] [data-test-boxel-button]`)
+      .isEnabled();
+
+    await fillIn('[data-test-layout-customization-name-input]', '');
+    assert
+      .dom(`${post} [data-test-boxel-input-error-message]`)
+      .containsText('required');
+    assert
+      .dom(`${post} [data-test-boxel-action-chin] [data-test-boxel-button]`)
+      .isDisabled();
+
     await fillIn('[data-test-layout-customization-name-input]', 'JJ');
+    assert.dom(`${post} [data-test-boxel-input-error-message]`).doesNotExist();
 
     assert
       .dom(`${post} [data-test-boxel-action-chin] [data-test-boxel-button]`)

--- a/packages/web-client/tests/integration/components/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/transaction-amount-test.ts
@@ -147,7 +147,7 @@ module('Integration | Component | transaction-amount', function (hooks) {
           />
         `);
 
-    assert.dom('[data-test-deposit-amount-input]').hasValue('0');
+    assert.dom('[data-test-deposit-amount-input]').hasValue('');
     assert.dom('[data-test-unlock-button]').isDisabled();
 
     await fillIn('[data-test-deposit-amount-input]', invalidDai1);

--- a/packages/web-client/tests/integration/components/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/transaction-amount-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn, click } from '@ember/test-helpers';
+import { render, fillIn, typeIn, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { TransactionReceipt } from 'web3-core';
 import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
@@ -112,5 +112,76 @@ module('Integration | Component | transaction-amount', function (hooks) {
     await click('[data-test-unlock-button]');
 
     assert.equal(weiSentToApprove.toString(), toBN(daiToSendInWei).toString());
+  });
+
+  test('It does not accept invalid values and ignores invalid characters typed in', async function (assert) {
+    const startDaiString = '55.111111111111111111';
+    const validAmount = '2';
+    const invalidDai1 =
+      '4.1111111111111111112'; /* more than 18 decimal places */
+    const invalidDai2 = '1  1'; /* has space */
+    const invalidDai3 = '  1'; /* has space */
+    const invalidDai4 = '12/'; /* invalid char */
+    let startDaiAmount = toWei(startDaiString);
+
+    const session = new WorkflowSession();
+    session.update('depositSourceToken', 'DAI');
+    const layer1Service = this.owner.lookup('service:layer1-network')
+      .strategy as Layer1TestWeb3Strategy;
+
+    layer1Service.test__simulateBalances({
+      defaultToken: toBN('0'),
+      dai: toBN(startDaiAmount),
+      card: toBN('0'),
+    });
+
+    this.setProperties({
+      session,
+    });
+
+    await render(hbs`
+          <CardPay::DepositWorkflow::TransactionAmount
+            @workflowSession={{this.session}}
+            @onComplete={{noop}}
+            @onIncomplete={{noop}}
+          />
+        `);
+
+    assert.dom('[data-test-deposit-amount-input]').hasValue('0');
+    assert.dom('[data-test-unlock-button]').isDisabled();
+
+    await fillIn('[data-test-deposit-amount-input]', invalidDai1);
+    assert.dom('[data-test-deposit-amount-input]').hasValue(invalidDai1);
+    assert.dom('[data-test-unlock-button]').isDisabled();
+
+    await fillIn('[data-test-deposit-amount-input]', validAmount);
+    assert.dom('[data-test-deposit-amount-input]').hasValue(validAmount);
+    assert.dom('[data-test-unlock-button]').isNotDisabled();
+
+    await fillIn('[data-test-deposit-amount-input]', invalidDai2);
+    assert.dom('[data-test-deposit-amount-input]').hasValue(validAmount);
+    assert.dom('[data-test-unlock-button]').isNotDisabled();
+
+    await fillIn('[data-test-deposit-amount-input]', '');
+    assert.dom('[data-test-deposit-amount-input]').hasValue('');
+    assert.dom('[data-test-unlock-button]').isDisabled();
+
+    await typeIn('[data-test-deposit-amount-input]', invalidDai2);
+    assert.dom('[data-test-deposit-amount-input]').hasValue('11');
+    assert.dom('[data-test-unlock-button]').isNotDisabled();
+
+    await fillIn('[data-test-deposit-amount-input]', '');
+    await typeIn('[data-test-deposit-amount-input]', invalidDai3);
+    assert.dom('[data-test-deposit-amount-input]').hasValue('1');
+    assert.dom('[data-test-unlock-button]').isNotDisabled();
+
+    await fillIn('[data-test-deposit-amount-input]', '');
+    await typeIn('[data-test-deposit-amount-input]', invalidDai4);
+    assert.dom('[data-test-deposit-amount-input]').hasValue('12');
+    assert.dom('[data-test-unlock-button]').isNotDisabled();
+
+    await fillIn('[data-test-deposit-amount-input]', startDaiString);
+    assert.dom('[data-test-deposit-amount-input]').hasValue(startDaiString);
+    assert.dom('[data-test-unlock-button]').isNotDisabled();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,10 +933,10 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@cardstack/boxel@^0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@cardstack/boxel/-/boxel-0.7.5.tgz#838e48349cc696f965b805a25745bfed04e439c0"
-  integrity sha512-jshb7fN0UfhMYQf9rmlvle1CHDfbiKw+6kqrK+LpE08Q86wcBue8D98nozut46l2ytUy8e+h2vS3ZWJ5qkExgg==
+"@cardstack/boxel@^0.7.10":
+  version "0.7.10"
+  resolved "https://registry.yarnpkg.com/@cardstack/boxel/-/boxel-0.7.10.tgz#075a757eb4f355e41a33f775a04735f3a337b437"
+  integrity sha512-S90iQHatrCrFjuA04gan2xBKRam/oQxGaasdTJ7LoDlwV+ocHcvsnMoqOyUe9QBFNut2KVqdHQbZwnfFL5M6Tg==
   dependencies:
     broccoli-concat "^4.2.4"
     broccoli-funnel "^3.0.3"
@@ -969,6 +969,7 @@
     ember-table "^2.2.3"
     ember-test-selectors "^5.0.0"
     ember-truth-helpers "^3.0.0"
+    ember-unique-id-helper-polyfill "^0.1.0"
     file-loader "^6.2.0"
     macro-decorators "^0.1.2"
     qunit "^2.14.0"
@@ -9581,6 +9582,14 @@ ember-text-measurer@^0.6.0:
   integrity sha512-hPKG9QqruAELh0li5xaiLZtr88ioWYxWCXisAWHWE0qCP4a2hgtuMzKUPpiTCkltvKjuqpzTZCU4VhQ+IlRmew==
   dependencies:
     ember-cli-babel "^7.22.1"
+
+ember-unique-id-helper-polyfill@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-unique-id-helper-polyfill/-/ember-unique-id-helper-polyfill-0.1.0.tgz#372f1272cd45dd3ee960a20a4945918264ff1bd3"
+  integrity sha512-qACD+lzMCOXRBJnJdA3tM1bHEKziVga2hhZGpTToLL8QlPj67+lwCaz+j6HBBA/Yw1yavVogO+NUwR8Q1iMKow==
+  dependencies:
+    ember-cli-babel "^7.23.0"
+    ember-cli-htmlbars "^5.3.1"
 
 ember-useragent@^0.6.0:
   version "0.6.1"


### PR DESCRIPTION
CS-897
- Update boxel version
- Display required field error message on input or on blur for the Issuer Name field in Layout Customization card

CS-942
- Bugfix for invalid transaction amount entry into the input field (was causing uncaught error which stopped workflow from continuing)

<img width="662" alt="req" src="https://user-images.githubusercontent.com/16160806/120562344-35eade80-c3d4-11eb-9f9c-f74e813f443e.png">

To do:
- [x] Move `ember-unique-id-helper-polyfill` dependency in boxel from devDependencies to dependencies, and remove it from here
- [x] Tests
- [x] Check for invalid entry for issuer name field --> seems like only blank entry is invalid?