### PR TITLE
Use a more suitable message for disconnections

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/index.ts
@@ -154,33 +154,19 @@ class DepositWorkflow extends Workflow {
     new NetworkAwareWorkflowMessage({
       author: cardbot,
       message:
-        'It looks like your wallets have been disconnected. If you still want to deposit funds, please start again by connecting your wallets.',
+        'It looks like your wallet(s) got disconnected. If you still want to deposit funds, please start again by connecting your wallet(s).',
       includeIf() {
         let message = this as NetworkAwareWorkflowMessage;
-        return !message.hasLayer1Account && !message.hasLayer2Account;
-      },
-    }),
-    new NetworkAwareWorkflowMessage({
-      author: cardbot,
-      message:
-        'It looks like your mainnet wallet has been disconnected. If you still want to deposit funds, please start again by connecting your wallet.',
-      includeIf() {
-        let message = this as NetworkAwareWorkflowMessage;
-        return !message.hasLayer1Account && message.hasLayer2Account;
-      },
-    }),
-    new NetworkAwareWorkflowMessage({
-      author: cardbot,
-      message:
-        'It looks like your xDai chain wallet has been disconnected. If you still want to deposit funds, please start again by connecting your wallet.',
-      includeIf() {
-        let message = this as NetworkAwareWorkflowMessage;
-        return message.hasLayer1Account && !message.hasLayer2Account;
+        return !message.hasLayer1Account || !message.hasLayer2Account;
       },
     }),
     new WorkflowCard({
       author: cardbot,
       componentName: 'card-pay/deposit-workflow/workflow-canceled-cta',
+      includeIf() {
+        let message = this as NetworkAwareWorkflowMessage;
+        return !message.hasLayer1Account || !message.hasLayer2Account;
+      },
     }),
   ]);
 

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -573,7 +573,7 @@ module('Acceptance | deposit', function (hooks) {
     assert
       .dom(cancelationPostableSel(0))
       .containsText(
-        'It looks like your mainnet wallet has been disconnected. If you still want to deposit funds, please start again by connecting your wallet.'
+        'It looks like your wallet(s) got disconnected. If you still want to deposit funds, please start again by connecting your wallet(s).'
       );
     assert.dom(cancelationPostableSel(1)).containsText('Workflow canceled');
     assert.dom('[data-test-deposit-workflow-canceled-restart]').exists();
@@ -653,7 +653,7 @@ module('Acceptance | deposit', function (hooks) {
     assert
       .dom(cancelationPostableSel(0))
       .containsText(
-        'It looks like your mainnet wallet has been disconnected. If you still want to deposit funds, please start again by connecting your wallet.'
+        'It looks like your wallet(s) got disconnected. If you still want to deposit funds, please start again by connecting your wallet(s).'
       );
     assert.dom(cancelationPostableSel(1)).containsText('Workflow canceled');
     assert.dom('[data-test-deposit-workflow-canceled-restart]').exists();
@@ -737,7 +737,7 @@ module('Acceptance | deposit', function (hooks) {
     assert
       .dom(cancelationPostableSel(0))
       .containsText(
-        'It looks like your xDai chain wallet has been disconnected. If you still want to deposit funds, please start again by connecting your wallet.'
+        'It looks like your wallet(s) got disconnected. If you still want to deposit funds, please start again by connecting your wallet(s).'
       );
     assert.dom(cancelationPostableSel(1)).containsText('Workflow canceled');
 
@@ -822,7 +822,7 @@ module('Acceptance | deposit', function (hooks) {
     assert
       .dom(cancelationPostableSel(0))
       .containsText(
-        'It looks like your xDai chain wallet has been disconnected. If you still want to deposit funds, please start again by connecting your wallet.'
+        'It looks like your wallet(s) got disconnected. If you still want to deposit funds, please start again by connecting your wallet(s).'
       );
     assert.dom(cancelationPostableSel(1)).containsText('Workflow canceled');
     assert.dom('[data-test-deposit-workflow-canceled-restart]').exists();


### PR DESCRIPTION
As per design feedback, uses a more generic way to tell users that a workflow is canceled because of disconnection.

### Problem
Cancelation messages may not provide an accurate picture of events. Since the messages shown are selected via `includeIf`, they never change after the first event that causes a workflow cancelation. Future changes are not reflected.

### Example
We have three different messages for different scenarios:
- Message A: Layer 1 disconnected
- Message B: Layer 2 disconnected
- Message C: Both layer 1 and layer 2 disconnected

If a user disconnects from Layer 1, they are shown message A. If the user disconnects from layer 2 after this, the message shown is still Message A, not message C.

### Edit
A second, related problem is we base the messages on whether wallets are disconnected, not whether there was a disconnect event. This means that if you start the workflow with only Layer 1 connected, then disconnect Layer 1, we show you the message for having both Layer 1 and Layer 2 disconnected.

This is solvable. We can keep track of disconnect events (as opposed to connected state) in the workflow session and choose messages based on that. However, it seems like it is a lot of trouble for little return.