### PR TITLE
make prepaid card gradients more in sync with design

### DIFF
--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.ts
@@ -26,10 +26,14 @@ export default class LayoutCustomizationCard extends Component<LayoutCustomizati
     '#efefef',
     '#393642',
     '#c3fc33',
-    'linear-gradient(49.27deg, #ff5050 0%, #ac00ff 100%)',
-    'linear-gradient(49.27deg, #03c4bf 0%, #3689d2 30%, #ac00ff 100%)',
-    'linear-gradient(49.27deg, #c3fc33 0%, #0069f9 100%)',
-    'linear-gradient(49.27deg, #ac00ff 0%, #ffd800 100%)',
+    // gradients generated in https://codepen.io/aierie/pen/qBryBoy?editors=0010
+    // the codepen assumes that you are only generating gradients with two colors and is hardcoded
+    // if gradient style changes, this should be modified to make sure that angle and starting point is correct
+    // to use this, copy the svg code for a swatch's gradient and paste it in the codepen's input
+    'linear-gradient(139.27deg, #ff5050 16%, #ac00ff 100%)',
+    'linear-gradient(139.27deg, #03c4bf 16%, #ac00ff 100%)',
+    'linear-gradient(139.27deg, #c3fc33 16%, #0069f9 100%)',
+    'linear-gradient(139.27deg, #ac00ff 16%, #ffd800 100%)',
     'transparent',
   ].map((color) =>
     color === 'transparent'


### PR DESCRIPTION
# Design
![image](https://user-images.githubusercontent.com/39579264/121178856-8f01b900-c891-11eb-8081-868d8b5ae63d.png)

# Before fix
![image](https://user-images.githubusercontent.com/39579264/121178965-b35d9580-c891-11eb-99a7-2efd54529b18.png)

# After fix
![image](https://user-images.githubusercontent.com/39579264/121178797-7c877f80-c891-11eb-9841-3ebfa30922a2.png)

Generate gradients in:
https://codepen.io/aierie/pen/qBryBoy?editors=0010

This assumes two stops, first stop at 16% and second at 100%, and an angle of 139.27deg.