### PR TITLE
Fix/tests wait for animations

### DIFF
--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -127,7 +127,9 @@ module('Acceptance | deposit', function (hooks) {
         '[data-test-card-pay-layer-2-connect] [data-test-card-pay-connect-button]'
       )
       .hasText('0x1826...6E44');
-    await waitFor(milestoneCompletedSel(1));
+
+    await settled();
+
     assert
       .dom(milestoneCompletedSel(1))
       .containsText('xDai chain wallet connected');
@@ -428,7 +430,9 @@ module('Acceptance | deposit', function (hooks) {
         '[data-test-card-pay-layer-2-connect] [data-test-card-pay-connect-button]'
       )
       .hasText('0x1826...6E44');
-    await waitFor(milestoneCompletedSel(1));
+
+    await settled();
+
     assert
       .dom(milestoneCompletedSel(1))
       .containsText('xDai chain wallet connected');

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -96,7 +96,9 @@ module('Acceptance | issue prepaid card', function (hooks) {
         '[data-test-card-pay-layer-2-connect] [data-test-card-pay-connect-button]'
       )
       .hasText('0x1826...6E44');
-    await waitFor(milestoneCompletedSel(0));
+
+    await settled();
+
     assert
       .dom(milestoneCompletedSel(0))
       .containsText('xDai chain wallet connected');


### PR DESCRIPTION
### Overview
Since we have animations, the tests need the `settled` helper to wait for animations to complete so that the expected elements are in the DOM. This usually replaces `await waitFor(some-milestone-selector)`, because there was a card that was completed via a mock method (eg. `test__simulateAccountsChanged`) before that. `waitFor` doesn't wait for our test waiters, but `settled` does.

There are some cases where we don't replace this. The reason is, right before these, `await click(selector)` is called and this calls `settled` internally. 

### About waitFor and settled
waitFor: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#waitfor

> Used to wait for a particular selector to appear in the DOM. Due to the fact that it **does not wait for general settledness**, this is quite useful for testing interim DOM states (e.g. loading states, pending promises, etc).

settled: https://github.com/emberjs/ember-test-helpers/blob/master/API.md#settled

> Returns a promise that resolves when in a settled state (see isSettled for a definition of "settled state").

More about settledness: https://github.com/emberjs/ember-test-waiters#general-design

### Where and how test waiters start and stop in our code
Test waiters start when a card is completed, hence pausing assertions if `await settled()` is called in our test, until the test waiter is stopped.

This change starts at `WorkflowCard.onComplete`. An event is emitted by the `Workflow` that contains the newly completed card, and received in the `AnimatedWorkflow`, which starts the test waiter and pauses assertions.

https://github.com/cardstack/cardstack/blob/e3ab86bf62c9729e84ba3d355dccc891c764126e/packages/web-client/app/models/workflow/workflow-card.ts#L26-L29

https://github.com/cardstack/cardstack/blob/e3ab86bf62c9729e84ba3d355dccc891c764126e/packages/web-client/app/models/animated-workflow.ts#L141-L144

And when we reach an incomplete card, we stop the test waiter, resuming assertions:

https://github.com/cardstack/cardstack/blob/e3ab86bf62c9729e84ba3d355dccc891c764126e/packages/web-client/app/models/animated-workflow.ts#L178-L180

We also stop the test waiters when all messages in a workflow's `epilogue` or `cancelationMessages` are shown, but this usually does not matter for our tests:

https://github.com/cardstack/cardstack/blob/e3ab86bf62c9729e84ba3d355dccc891c764126e/packages/web-client/app/models/animated-workflow.ts#L167-L176
