### PR TITLE
replace no-unused-vars with typescript variant

### DIFF
--- a/packages/web-client/.eslintrc.js
+++ b/packages/web-client/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
       legacyDecorators: true,
     },
   },
-  plugins: ['ember'],
+  plugins: ['ember', '@typescript-eslint'],
   extends: [
     'eslint:recommended',
     'plugin:ember/recommended',
@@ -19,7 +19,10 @@ module.exports = {
   env: {
     browser: true,
   },
-  rules: {},
+  rules: {
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ['error'],
+  },
   overrides: [
     // node files
     {

--- a/packages/web-client/app/services/layer1-network.ts
+++ b/packages/web-client/app/services/layer1-network.ts
@@ -91,7 +91,6 @@ export default class Layer1Network extends Service {
 
 // DO NOT DELETE: this is how TypeScript knows how to look up your services.
 declare module '@ember/service' {
-  // eslint-disable-next-line no-unused-vars
   interface Registry {
     'layer1-network': Layer1Network;
   }

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -27,7 +27,7 @@ export default class Layer2Network extends Service {
   @reads('strategy.waitForAccount') waitForAccount!: Promise<void>;
   @reads('strategy.chainName') chainName!: string;
   @reads('strategy.usdConverters') usdConverters!: {
-    [symbol: string]: (amountInWei: string) => number; // eslint-disable-line no-unused-vars
+    [symbol: string]: (amountInWei: string) => number;
   };
   @reads('strategy.defaultTokenBalance') defaultTokenBalance: BN | undefined;
 
@@ -90,7 +90,6 @@ export default class Layer2Network extends Service {
 
 // DO NOT DELETE: this is how TypeScript knows how to look up your services.
 declare module '@ember/service' {
-  // eslint-disable-next-line no-unused-vars
   interface Registry {
     'layer2-network': Layer2Network;
   }

--- a/packages/web-client/app/services/token-to-usd.ts
+++ b/packages/web-client/app/services/token-to-usd.ts
@@ -97,7 +97,6 @@ export default class TokenToUsd extends Service {
 
 // DO NOT DELETE: this is how TypeScript knows how to look up your services.
 declare module '@ember/service' {
-  // eslint-disable-next-line no-unused-vars
   interface Registry {
     'token-to-usd': TokenToUsd;
   }

--- a/packages/web-client/app/utils/events.ts
+++ b/packages/web-client/app/utils/events.ts
@@ -2,7 +2,7 @@
 export type UnbindEventListener = () => void;
 
 export interface Emitter {
-  on(event: string, cb: Function): UnbindEventListener; // eslint-disable-line no-unused-vars
+  on(event: string, cb: Function): UnbindEventListener;
 }
 
 /**
@@ -39,7 +39,6 @@ export interface Emitter {
  *
  * // DO NOT DELETE: this is how TypeScript knows how to look up your services.
  * declare module '@ember/service' {
- *   // eslint-disable-next-line no-unused-vars
  *   interface Registry {
  *     'resized-target': ResizedTarget;
  *   }

--- a/packages/web-client/app/utils/token.ts
+++ b/packages/web-client/app/utils/token.ts
@@ -14,7 +14,6 @@ export type TokenSymbol =
 export type NetworkSymbol = 'kovan' | 'sokol' | 'mainnet' | 'xdai';
 
 // conversion
-// eslint-disable-next-line no-unused-vars
 export type ConversionFunction = (amountInWei: string) => number;
 export const convertibleSymbols: ConvertibleSymbol[] = ['DAI', 'CARD'];
 

--- a/packages/web-client/app/utils/wallet-info.ts
+++ b/packages/web-client/app/utils/wallet-info.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 class WalletAccount {
   constructor(
     readonly address: string,

--- a/packages/web-client/app/utils/web3-strategies/test-layer1.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer1.ts
@@ -33,7 +33,7 @@ export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
   #unlockDeferred: RSVP.Deferred<TransactionReceipt> | undefined;
   #depositDeferred: RSVP.Deferred<TransactionReceipt> | undefined;
 
-  // eslint-disable-next-line no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   connect(_walletProvider: WalletProvider): Promise<void> {
     return this.waitForAccount;
   }
@@ -52,17 +52,14 @@ export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
     this.disconnect();
   }
 
-  // eslint-disable-next-line no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   approve(_amountInWei: BN, _token: string) {
     this.#unlockDeferred = RSVP.defer();
     return this.#unlockDeferred.promise;
   }
 
-  relayTokens(
-    _token: string, // eslint-disable-line no-unused-vars
-    _destinationAddress: string, // eslint-disable-line no-unused-vars
-    _amountInWei: BN // eslint-disable-line no-unused-vars
-  ) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  relayTokens(_token: string, _destinationAddress: string, _amountInWei: BN) {
     this.#depositDeferred = RSVP.defer();
     return this.#depositDeferred.promise;
   }

--- a/packages/web-client/app/utils/web3-strategies/test-layer2.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer2.ts
@@ -44,20 +44,17 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
     return Promise.resolve(new BN('0'));
   }
 
-  // eslint-disable-next-line no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   fetchDepot(_owner: ChainAddress): Promise<DepotSafe | null> {
     return Promise.resolve(this.depot);
   }
 
-  awaitBridged(
-    _fromBlock: BN, // eslint-disable-line no-unused-vars
-    _receiver: string // eslint-disable-line no-unused-vars
-  ): Promise<TransactionReceipt> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  awaitBridged(_fromBlock: BN, _receiver: string): Promise<TransactionReceipt> {
     this.bridgingDeferred = defer<TransactionReceipt>();
     return this.bridgingDeferred.promise as Promise<TransactionReceipt>;
   }
 
-  // eslint-disable-next-line no-unused-vars
   async updateUsdConverters(symbolsToUpdate: ConvertibleSymbol[]) {
     this.test__lastSymbolsToUpdate = symbolsToUpdate;
     let result = {} as Record<ConvertibleSymbol, ConversionFunction>;

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import { WalletProvider } from '../wallet-providers';
 import BN from 'bn.js';
 import { TransactionReceipt } from 'web3-core';

--- a/packages/web-client/tests/integration/components/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/transaction-amount-test.ts
@@ -25,12 +25,10 @@ module('Integration | Component | transaction-amount', function (hooks) {
 
   const hijackApprove = (
     service: Layer1TestWeb3Strategy,
-    fn: (_amountInWei: BN) => void // eslint-disable-line no-unused-vars
+    fn: (_amountInWei: BN) => void
   ) => {
-    service.approve = function approve(
-      _amountInWei: BN, // eslint-disable-line no-unused-vars
-      _token: string // eslint-disable-line no-unused-vars
-    ) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    service.approve = function approve(_amountInWei: BN, _token: string) {
       fn(_amountInWei);
       let resolved = defer() as RSVP.Deferred<TransactionReceipt>;
       resolved.resolve();

--- a/packages/web-client/types/@cardstack/web-client/index.d.ts
+++ b/packages/web-client/types/@cardstack/web-client/index.d.ts
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 
 declare global {
-  // eslint-disable-next-line no-unused-vars
   interface Array<T> extends Ember.ArrayPrototypeExtensions<T> {}
   // interface Function extends Ember.FunctionPrototypeExtensions {}
 }


### PR DESCRIPTION
This is so type (especially function) declarations don't need the `// eslint-disable no-unused-vars`