### PR TITLE
Fix/db does not connect

### DIFF
--- a/packages/hub/services/database-manager.ts
+++ b/packages/hub/services/database-manager.ts
@@ -11,8 +11,8 @@ export default class DatabaseManager {
   async getClient() {
     if (!this.client) {
       this.client = new Client(this.dbConfig.url as string);
+      await this.client.connect();
       if (this.dbConfig.useTransactionalRollbacks) {
-        await this.client.connect();
         await this.client.query('START TRANSACTION');
       }
     }
@@ -22,8 +22,8 @@ export default class DatabaseManager {
   async teardown() {
     if (this.dbConfig.useTransactionalRollbacks) {
       await this.client?.query('ROLLBACK');
-      await this.client?.end();
     }
+    await this.client?.end();
   }
 }
 


### PR DESCRIPTION
Fixes an issue in #1701 where we never resolve queries to `/api/prepaid-card-color-schemes` and `/api/prepaid-card-patterns` outside tests. This is because `useTransactionalRollbacks` isn't true for default config and we never do `client.connect()`.

If this is merged, we should remove `db.connect()`  from `seed-db.ts` in #1701.