### PR TITLE
Use refactored AccountDisplay component

### DIFF
--- a/packages/web-client/app/components/card-pay/account-display/index.css
+++ b/packages/web-client/app/components/card-pay/account-display/index.css
@@ -1,56 +1,61 @@
 .account-display {
+  --icon-alignment: flex-start;
+  --icon-size: var(--boxel-icon-lg);
+  --name-font-size: var(--boxel-font-size);
+  --name-line-height: calc(22 / 16);
+  --address-font-size: var(--boxel-font-size);
+  --address-line-height: calc(22 / 16);
+
   display: flex;
   align-items: center;
   flex-wrap: nowrap;
 }
 
 .account-display__icon {
-  align-self: flex-start;
+  align-self: var(--icon-alignment);
   flex-shrink: 0;
-  width: 2.5rem;
-  height: 2.5rem;
+  width: var(--icon-size);
+  height: var(--icon-size);
   margin-right: var(--boxel-sp-xs);
 }
 
-.account-display__icon-sm {
-  flex-shrink: 0;
-  width: 1.25rem;
-  height: 1.25rem;
-  margin-right: var(--boxel-sp-xs);
+.account-display__icon--sm {
+  --icon-alignment: unset;
+  --icon-size: var(--boxel-icon-sm);
 }
 
 .account-display__name {
-  font: 600 var(--boxel-font);
-  letter-spacing: var(--boxel-lsp-xs);
-}
-
-.account-display__name-sm {
-  font: 600 var(--boxel-font-sm);
-  letter-spacing: var(--boxel-lsp-xs);
-}
-
-.account-display__name-lg {
-  font-size: 1.25rem;
   font-weight: 600;
-  line-height: calc(27 / 20);
+  font-size: var(--name-font-size);
+  line-height: var(--name-line-height);
   letter-spacing: var(--boxel-lsp-xs);
+}
+
+.account-display__name--sm {
+  --name-font-size: var(--boxel-font-size-sm);
+  --name-line-height: calc(18 / 13);
+}
+
+.account-display__name--lg {
+  --name-font-size: 1.25rem;
+  --name-line-height: calc(27 / 20);
 }
 
 .account-display__address {
   color: var(--boxel-purple-500);
   font-family: var(--boxel-monospace-font-family);
-  font-size: var(--boxel-font-size);
-  line-height: calc(22 / 16);
+  font-size: var(--address-font-size);
+  line-height: var(--address-line-height);
   letter-spacing: var(--boxel-lsp-sm);
   word-break: break-all;
 }
 
-.account-display__address-sm {
-  font-size: var(--boxel-font-size-sm);
-  line-height: calc(18 / 13);
+.account-display__address--sm {
+  --address-font-size: var(--boxel-font-size-sm);
+  --address-line-height: calc(18 / 13);
 }
 
-.account-display__address-wrapped {
+.account-display__address--wrapped {
   max-width: 22ch;
 }
 

--- a/packages/web-client/app/components/card-pay/account-display/index.css
+++ b/packages/web-client/app/components/card-pay/account-display/index.css
@@ -26,7 +26,7 @@
 
 .account-display__name-sm {
   font: 600 var(--boxel-font-sm);
-  letter-spacing: var(--boxel-lsp-sm);
+  letter-spacing: var(--boxel-lsp-xs);
 }
 
 .account-display__name-lg {
@@ -41,7 +41,7 @@
   font-family: var(--boxel-monospace-font-family);
   font-size: var(--boxel-font-size);
   line-height: calc(22 / 16);
-  letter-spacing: 0.02em;
+  letter-spacing: var(--boxel-lsp-sm);
   word-break: break-all;
 }
 

--- a/packages/web-client/app/components/card-pay/account-display/index.css
+++ b/packages/web-client/app/components/card-pay/account-display/index.css
@@ -39,27 +39,24 @@
 .account-display__text {
   color: var(--boxel-purple-500);
   font: var(--boxel-font);
-  letter-spacing: 0.02em;
+  letter-spacing: var(--boxel-lsp);
 }
 
 .account-display__text-sm {
   color: var(--boxel-purple-500);
   font: var(--boxel-font-sm);
-  letter-spacing: 0.02em;
-}
-
-.account-display__text--outer {
-  color: var(--boxel-purple-400);
-  letter-spacing: var(--boxel-lsp-sm);
+  letter-spacing: var(--boxel-lsp);
 }
 
 .account-display__address {
   font-family: var(--boxel-monospace-font-family);
   word-break: break-all;
+  letter-spacing: 0.02em;
 }
 
 .account-display__address-wrapped {
   font-family: var(--boxel-monospace-font-family);
   word-break: break-all;
   max-width: 22ch;
+  letter-spacing: 0.02em;
 }

--- a/packages/web-client/app/components/card-pay/account-display/index.css
+++ b/packages/web-client/app/components/card-pay/account-display/index.css
@@ -19,44 +19,43 @@
   margin-right: var(--boxel-sp-xs);
 }
 
-.account-display__title {
+.account-display__name {
   font: 600 var(--boxel-font);
   letter-spacing: var(--boxel-lsp-xs);
 }
 
-.account-display__title-sm {
+.account-display__name-sm {
   font: 600 var(--boxel-font-sm);
   letter-spacing: var(--boxel-lsp-sm);
 }
 
-.account-display__title-lg {
+.account-display__name-lg {
   font-size: 1.25rem;
   font-weight: 600;
   line-height: calc(27 / 20);
   letter-spacing: var(--boxel-lsp-xs);
 }
 
-.account-display__text {
-  color: var(--boxel-purple-500);
-  font: var(--boxel-font);
-  letter-spacing: var(--boxel-lsp);
-}
-
-.account-display__text-sm {
-  color: var(--boxel-purple-500);
-  font: var(--boxel-font-sm);
-  letter-spacing: var(--boxel-lsp);
-}
-
 .account-display__address {
+  color: var(--boxel-purple-500);
   font-family: var(--boxel-monospace-font-family);
-  word-break: break-all;
+  font-size: var(--boxel-font-size);
+  line-height: calc(22 / 16);
   letter-spacing: 0.02em;
+  word-break: break-all;
+}
+
+.account-display__address-sm {
+  font-size: var(--boxel-font-size-sm);
+  line-height: calc(18 / 13);
 }
 
 .account-display__address-wrapped {
-  font-family: var(--boxel-monospace-font-family);
-  word-break: break-all;
   max-width: 22ch;
-  letter-spacing: 0.02em;
+}
+
+.account-display__text {
+  color: var(--boxel-purple-500);
+  font: var(--boxel-font-sm);
+  letter-spacing: var(--boxel-lsp-xs);
 }

--- a/packages/web-client/app/components/card-pay/account-display/index.hbs
+++ b/packages/web-client/app/components/card-pay/account-display/index.hbs
@@ -1,66 +1,66 @@
 <div class="account-display" ...attributes>
-  {{#if @balance}}
-    {{#if @isComplete}}
-      {{svg-jar @icon class="account-display__icon" role="presentation"}}
-      <div>
-        <div class="account-display__title-lg" data-test-account-title>
-          {{format-token-amount @balance}} {{uppercase @symbol}}
-        </div>
-      </div>
-    {{else}}
+  {{#if (eq @size "small")}}
+    {{#if @icon}}
       {{svg-jar @icon class="account-display__icon-sm" role="presentation"}}
-      <div>
-        <div class="account-display__title-sm" data-test-account-title>{{uppercase @symbol}}</div>
-        <div class="account-display__text-sm" data-test-account-balance>
-          {{format-token-amount @balance}} {{uppercase @symbol}}
-        </div>
-      </div>
     {{/if}}
-  {{else}}
-    {{#if @isComplete}}
-      {{#if @inner}}
-        {{svg-jar @icon class="account-display__icon" role="presentation"}}
-        <div>
-          <div class="account-display__title-lg" data-test-account-title>{{@title}}</div>
-          <div class="account-display__text account-display__address-wrapped" data-test-account-address>
+    <div>
+      <div class="account-display__title-sm" data-test-account-title>{{@title}}</div>
+      {{#if (or @address @text)}}
+        <div class={{cn "account-display__text-sm" account-display__address=@address}}
+          data-test-account-address={{@address}}
+          data-test-account-text={{@text}}
+        >
+          {{#if @address}}
             {{@address}}
-          </div>
-        </div>
-      {{else}}
-        {{svg-jar @icon class="account-display__icon-sm" role="presentation"}}
-        <div>
-          <div class="account-display__title-sm" data-test-account-title>{{@title}}</div>
-          <div class="account-display__text-sm account-display__address account-display__text--outer" data-test-account-address>
-            {{truncate-middle @address}}
-          </div>
+          {{else if @text}}
+            {{@text}}
+          {{else}}
+            <Boxel::LoadingIndicator />
+          {{/if}}
         </div>
       {{/if}}
-    {{else}}
-      {{#if @inner}}
-        {{svg-jar @icon class="account-display__icon" role="presentation"}}
-        <div>
-          <div class="account-display__title" data-test-account-title>{{@title}}</div>
-          <div class="account-display__text account-display__address" data-test-account-address>
-            {{#if @address}}
-              {{@address}}
-            {{else}}
-              <Boxel::LoadingIndicator />
-            {{/if}}
-          </div>
-        </div>
-      {{else}}
-        {{svg-jar @icon class="account-display__icon" role="presentation"}}
-        <div>
-          <div class="account-display__title" data-test-account-title>{{@title}}</div>
-          <div class="account-display__text account-display__address account-display__text--outer" data-test-account-address>
-            {{#if @address}}
-              {{@address}}
-            {{else}}
-              <Boxel::LoadingIndicator />
-            {{/if}}
-          </div>
-        </div>
-      {{/if}}
+    </div>
+  {{else if (eq @size "large")}}
+    {{#if @icon}}
+      {{svg-jar @icon class="account-display__icon" role="presentation"}}
     {{/if}}
+    <div>
+      <div class="account-display__title-lg" data-test-account-title>{{@title}}</div>
+      {{#if (or @address @text)}}
+        <div class={{cn "account-display__text" account-display__text-sm=@text account-display__address-wrapped=@address}}
+          data-test-account-address={{@address}}
+          data-test-account-text={{@text}}
+        >
+          {{#if @address}}
+            {{@address}}
+          {{else if @text}}
+            {{@text}}
+          {{else}}
+            <Boxel::LoadingIndicator />
+          {{/if}}
+        </div>
+      {{/if}}
+    </div>
+  {{else}}
+    {{#if @icon}}
+      {{svg-jar @icon class="account-display__icon" role="presentation"}}
+    {{/if}}
+    <div>
+      <div class="account-display__title" data-test-account-title>{{@title}}</div>
+      {{#if (or @address @text)}}
+        <div class={{cn "account-display__text" account-display__address=@address}}
+          data-test-account-address={{@address}}
+          data-test-account-text={{@text}}
+        >
+          {{#if @address}}
+            {{@address}}
+          {{else if @text}}
+            {{@text}}
+          {{else}}
+            <Boxel::LoadingIndicator />
+          {{/if}}
+        </div>
+      {{/if}}
+    </div>
   {{/if}}
 </div>

--- a/packages/web-client/app/components/card-pay/account-display/index.hbs
+++ b/packages/web-client/app/components/card-pay/account-display/index.hbs
@@ -29,7 +29,7 @@
         </div>
       {{/if}}
       {{#if @text}}
-        <div class="account-display__text-sm" data-test-account-text>
+        <div class="account-display__text" data-test-account-text>
           {{@text}}
         </div>
       {{/if}}

--- a/packages/web-client/app/components/card-pay/account-display/index.hbs
+++ b/packages/web-client/app/components/card-pay/account-display/index.hbs
@@ -1,14 +1,14 @@
 {{#let (eq @size "small") (eq @size "large") as |isSmall isLarge|}}
   <div class="account-display" ...attributes>
     {{#if @icon}}
-      {{svg-jar @icon class=(if isSmall "account-display__icon-sm" "account-display__icon") role="presentation"}}
+      {{svg-jar @icon class=(cn "account-display__icon" account-display__icon--sm=isSmall) role="presentation"}}
     {{/if}}
     <div>
       {{#if @name}}
         <div class={{cn
-          account-display__name=(not (or isSmall isLarge))
-          account-display__name-sm=isSmall
-          account-display__name-lg=isLarge
+          "account-display__name"
+          account-display__name--sm=isSmall
+          account-display__name--lg=isLarge
         }} data-test-account-name>
           {{@name}}
         </div>
@@ -16,8 +16,8 @@
       {{#if @address}}
         <div class={{cn
           "account-display__address"
-          account-display__address-sm=isSmall
-          account-display__address-wrapped=(or @wrapped isLarge)
+          account-display__address--sm=isSmall
+          account-display__address--wrapped=(or @wrapped isLarge)
         }}
           data-test-account-address
         >

--- a/packages/web-client/app/components/card-pay/account-display/index.hbs
+++ b/packages/web-client/app/components/card-pay/account-display/index.hbs
@@ -1,66 +1,52 @@
-<div class="account-display" ...attributes>
-  {{#if (eq @size "small")}}
+{{#let (eq @size "small") (eq @size "large") as |isSmall isLarge|}}
+  <div class="account-display" ...attributes>
     {{#if @icon}}
-      {{svg-jar @icon class="account-display__icon-sm" role="presentation"}}
+      {{svg-jar @icon class=(if isSmall "account-display__icon-sm" "account-display__icon") role="presentation"}}
     {{/if}}
     <div>
-      <div class="account-display__title-sm" data-test-account-title>{{@title}}</div>
-      {{#if (or @address @text)}}
-        <div class={{cn "account-display__text-sm" account-display__address=@address}}
-          data-test-account-address={{@address}}
-          data-test-account-text={{@text}}
+      {{#if @label}}
+        <div class="account-display__text-sm">{{@label}}</div>
+      {{/if}}
+      {{#if @title}}
+        <div class={{cn
+          account-display__title=(not (or isSmall isLarge))
+          account-display__title-sm=isSmall
+          account-display__title-lg=isLarge
+        }} data-test-account-title>
+          {{@title}}
+        </div>
+      {{/if}}
+      {{#if @address}}
+        <div class={{cn
+          "account-display__text"
+          account-display__text-sm=isSmall
+          account-display__address=@address
+          account-display__address-wrapped=(and @address isLarge)
+        }}
+          data-test-account-address
         >
-          {{#if @address}}
-            {{@address}}
-          {{else if @text}}
-            {{@text}}
-          {{else}}
+          {{#if (eq @address "isLoading")}}
             <Boxel::LoadingIndicator />
+          {{else}}
+            {{@address}}
           {{/if}}
         </div>
       {{/if}}
-    </div>
-  {{else if (eq @size "large")}}
-    {{#if @icon}}
-      {{svg-jar @icon class="account-display__icon" role="presentation"}}
-    {{/if}}
-    <div>
-      <div class="account-display__title-lg" data-test-account-title>{{@title}}</div>
-      {{#if (or @address @text)}}
-        <div class={{cn "account-display__text" account-display__text-sm=@text account-display__address-wrapped=@address}}
-          data-test-account-address={{@address}}
-          data-test-account-text={{@text}}
-        >
-          {{#if @address}}
-            {{@address}}
-          {{else if @text}}
-            {{@text}}
-          {{else}}
-            <Boxel::LoadingIndicator />
-          {{/if}}
+      {{#if @balance}}
+        <div class={{if isLarge "account-display__title-lg" "account-display__text-sm"}} data-test-account-balance>
+          {{@balance}} {{@symbol}}
+        </div>
+      {{/if}}
+      {{#if @usdBalance}}
+        <div class="account-display__text-sm" data-test-account-usd-balance>
+          ${{@usdBalance}} USD
+        </div>
+      {{/if}}
+      {{#if @text}}
+        <div class="account-display__text-sm" data-test-account-text>
+          {{@text}}
         </div>
       {{/if}}
     </div>
-  {{else}}
-    {{#if @icon}}
-      {{svg-jar @icon class="account-display__icon" role="presentation"}}
-    {{/if}}
-    <div>
-      <div class="account-display__title" data-test-account-title>{{@title}}</div>
-      {{#if (or @address @text)}}
-        <div class={{cn "account-display__text" account-display__address=@address}}
-          data-test-account-address={{@address}}
-          data-test-account-text={{@text}}
-        >
-          {{#if @address}}
-            {{@address}}
-          {{else if @text}}
-            {{@text}}
-          {{else}}
-            <Boxel::LoadingIndicator />
-          {{/if}}
-        </div>
-      {{/if}}
-    </div>
-  {{/if}}
-</div>
+  </div>
+{{/let}}

--- a/packages/web-client/app/components/card-pay/account-display/index.hbs
+++ b/packages/web-client/app/components/card-pay/account-display/index.hbs
@@ -21,7 +21,7 @@
           "account-display__text"
           account-display__text-sm=isSmall
           account-display__address=@address
-          account-display__address-wrapped=(and @address isLarge)
+          account-display__address-wrapped=(or @wrapped (and @address isLarge))
         }}
           data-test-account-address
         >

--- a/packages/web-client/app/components/card-pay/account-display/index.hbs
+++ b/packages/web-client/app/components/card-pay/account-display/index.hbs
@@ -4,24 +4,20 @@
       {{svg-jar @icon class=(if isSmall "account-display__icon-sm" "account-display__icon") role="presentation"}}
     {{/if}}
     <div>
-      {{#if @label}}
-        <div class="account-display__text-sm">{{@label}}</div>
-      {{/if}}
-      {{#if @title}}
+      {{#if @name}}
         <div class={{cn
-          account-display__title=(not (or isSmall isLarge))
-          account-display__title-sm=isSmall
-          account-display__title-lg=isLarge
-        }} data-test-account-title>
-          {{@title}}
+          account-display__name=(not (or isSmall isLarge))
+          account-display__name-sm=isSmall
+          account-display__name-lg=isLarge
+        }} data-test-account-name>
+          {{@name}}
         </div>
       {{/if}}
       {{#if @address}}
         <div class={{cn
-          "account-display__text"
-          account-display__text-sm=isSmall
-          account-display__address=@address
-          account-display__address-wrapped=(or @wrapped (and @address isLarge))
+          "account-display__address"
+          account-display__address-sm=isSmall
+          account-display__address-wrapped=(or @wrapped isLarge)
         }}
           data-test-account-address
         >
@@ -30,16 +26,6 @@
           {{else}}
             {{@address}}
           {{/if}}
-        </div>
-      {{/if}}
-      {{#if @balance}}
-        <div class={{if isLarge "account-display__title-lg" "account-display__text-sm"}} data-test-account-balance>
-          {{@balance}} {{@symbol}}
-        </div>
-      {{/if}}
-      {{#if @usdBalance}}
-        <div class="account-display__text-sm" data-test-account-usd-balance>
-          ${{@usdBalance}} USD
         </div>
       {{/if}}
       {{#if @text}}

--- a/packages/web-client/app/components/card-pay/balance-display/index.css
+++ b/packages/web-client/app/components/card-pay/balance-display/index.css
@@ -53,7 +53,3 @@
   line-height: calc(27 / 20);
   letter-spacing: var(--boxel-lsp-xs);
 }
-
-
-
-

--- a/packages/web-client/app/components/card-pay/balance-display/index.css
+++ b/packages/web-client/app/components/card-pay/balance-display/index.css
@@ -44,7 +44,7 @@
 
 .balance-display__name-sm {
   font: 600 var(--boxel-font-sm);
-  letter-spacing: var(--boxel-lsp-sm);
+  letter-spacing: var(--boxel-lsp-xs);
 }
 
 .balance-display__name-lg {

--- a/packages/web-client/app/components/card-pay/balance-display/index.css
+++ b/packages/web-client/app/components/card-pay/balance-display/index.css
@@ -1,55 +1,68 @@
 .balance-display {
+  --icon-alignment: center;
+  --icon-size: var(--boxel-icon-sm);
+  --name-font-size: var(--boxel-font-size);
+  --name-line-height: calc(22 / 16);
+  --balance-font-size: var(--boxel-font-size);
+  --balance-line-height: calc(22 / 16);
+
   display: flex;
   align-items: center;
   flex-wrap: nowrap;
 }
 
-.balance-display__icon-lg {
-  align-self: flex-start;
-  flex-shrink: 0;
-  width: 2.5rem;
-  height: 2.5rem;
-  margin-right: var(--boxel-sp-xs);
-}
-
 .balance-display__icon {
+  align-self: var(--icon-alignment);
   flex-shrink: 0;
-  width: 1.25rem;
-  height: 1.25rem;
+  width: var(--icon-size);
+  height: var(--icon-size);
   margin-right: var(--boxel-sp-xs);
 }
 
-.balance-display__text {
-  font: var(--boxel-font);
-  letter-spacing: var(--boxel-lsp-xs);
-}
-
-.balance-display__text-lg {
-  font-size: 1.25rem;
-  font-weight: 600;
-  line-height: calc(27 / 20);
-  letter-spacing: var(--boxel-lsp-xs);
-}
-
-.balance-display__text-sm {
-  color: var(--boxel-purple-500);
-  font: var(--boxel-font-sm);
-  letter-spacing: var(--boxel-lsp-xs);
+.balance-display__icon--lg {
+  --icon-alignment: flex-start;
+  --icon-size: var(--boxel-icon-lg);
 }
 
 .balance-display__name {
-  font: 600 var(--boxel-font);
-  letter-spacing: var(--boxel-lsp-xs);
-}
-
-.balance-display__name-sm {
-  font: 600 var(--boxel-font-sm);
-  letter-spacing: var(--boxel-lsp-xs);
-}
-
-.balance-display__name-lg {
-  font-size: 1.25rem;
   font-weight: 600;
-  line-height: calc(27 / 20);
+  font-size: var(--name-font-size);
+  line-height: var(--name-line-height);
+  letter-spacing: var(--boxel-lsp-xs);
+}
+
+.balance-display__name--sm {
+  --name-font-size: var(--boxel-font-size-sm);
+  --name-line-height: calc(18 / 13);
+}
+
+.balance-display__name--lg {
+  --name-font-size: 1.25rem;
+  --name-line-height: calc(27 / 20);
+}
+
+.balance-display__balance {
+  font-size: var(--balance-font-size);
+  line-height: var(--balance-line-height);
+  letter-spacing: var(--boxel-lsp-xs);
+}
+
+.balance-display__balance--lg {
+  --balance-font-size: 1.25rem;
+  --balance-line-height: calc(27 / 20);
+
+  font-weight: 600;
+}
+
+.balance-display__balance--sm {
+  --balance-font-size: var(--boxel-font-size-sm);
+  --balance-line-height: calc(18 / 13);
+
+  color: var(--boxel-purple-500);
+}
+
+.balance-display__text {
+  color: var(--boxel-purple-500);
+  font: var(--boxel-font-sm);
   letter-spacing: var(--boxel-lsp-xs);
 }

--- a/packages/web-client/app/components/card-pay/balance-display/index.css
+++ b/packages/web-client/app/components/card-pay/balance-display/index.css
@@ -1,0 +1,59 @@
+.balance-display {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+}
+
+.balance-display__icon-lg {
+  align-self: flex-start;
+  flex-shrink: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  margin-right: var(--boxel-sp-xs);
+}
+
+.balance-display__icon {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-right: var(--boxel-sp-xs);
+}
+
+.balance-display__text {
+  font: var(--boxel-font);
+  letter-spacing: var(--boxel-lsp-xs);
+}
+
+.balance-display__text-lg {
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: calc(27 / 20);
+  letter-spacing: var(--boxel-lsp-xs);
+}
+
+.balance-display__text-sm {
+  color: var(--boxel-purple-500);
+  font: var(--boxel-font-sm);
+  letter-spacing: var(--boxel-lsp-xs);
+}
+
+.balance-display__name {
+  font: 600 var(--boxel-font);
+  letter-spacing: var(--boxel-lsp-xs);
+}
+
+.balance-display__name-sm {
+  font: 600 var(--boxel-font-sm);
+  letter-spacing: var(--boxel-lsp-sm);
+}
+
+.balance-display__name-lg {
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: calc(27 / 20);
+  letter-spacing: var(--boxel-lsp-xs);
+}
+
+
+
+

--- a/packages/web-client/app/components/card-pay/balance-display/index.hbs
+++ b/packages/web-client/app/components/card-pay/balance-display/index.hbs
@@ -21,13 +21,13 @@
           balance-display__text-lg=isLarge
           balance-display__text-sm=isSmall
         }} data-test-balance-display-amount>
-          {{@balance}} {{@symbol}}
+          {{format-token-amount @balance}} {{@symbol}}
         </div>
-      {{/if}}
-      {{#if @usdBalance}}
-        <div class="balance-display__text-sm" data-test-balance-display-usd-amount>
-          ${{@usdBalance}} USD
-        </div>
+        {{#if @displayUsdBalance}}
+          <div class="balance-display__text-sm" data-test-balance-display-usd-amount>
+            ${{token-to-usd @symbol @balance}} USD
+          </div>
+        {{/if}}
       {{/if}}
       {{#if @text}}
         <div class="balance-display__text-sm" data-test-balance-display-text>

--- a/packages/web-client/app/components/card-pay/balance-display/index.hbs
+++ b/packages/web-client/app/components/card-pay/balance-display/index.hbs
@@ -1,15 +1,12 @@
 {{#let (eq @size "small") (eq @size "large") as |isSmall isLarge|}}
   <div class="balance-display" ...attributes>
     {{#if @icon}}
-      {{svg-jar @icon class=(if isLarge "balance-display__icon-lg" "balance-display__icon") role="presentation"}}
+      {{svg-jar @icon class=(cn "balance-display__icon" balance-display__icon--lg=isLarge) role="presentation"}}
     {{/if}}
     <div>
-      {{#if @label}}
-        <div class="balance-display__text-sm">{{@label}}</div>
-      {{/if}}
       {{#if @name}}
         <div
-          class={{if isSmall "balance-display__name-sm" "balance-display__name"}}
+          class={{cn "balance-display__name" balance-display__name--sm=isSmall}}
           data-test-balance-display-name
         >
           {{@name}}
@@ -17,20 +14,20 @@
       {{/if}}
       {{#if @balance}}
         <div class={{cn
-          balance-display__text=(not (or isSmall isLarge))
-          balance-display__text-lg=isLarge
-          balance-display__text-sm=isSmall
+          "balance-display__balance"
+          balance-display__balance--lg=isLarge
+          balance-display__balance--sm=isSmall
         }} data-test-balance-display-amount>
           {{format-token-amount @balance}} {{@symbol}}
         </div>
         {{#if @displayUsdBalance}}
-          <div class="balance-display__text-sm" data-test-balance-display-usd-amount>
+          <div class="balance-display__text" data-test-balance-display-usd-amount>
             ${{token-to-usd @symbol @balance}} USD
           </div>
         {{/if}}
       {{/if}}
       {{#if @text}}
-        <div class="balance-display__text-sm" data-test-balance-display-text>
+        <div class="balance-display__text" data-test-balance-display-text>
           {{@text}}
         </div>
       {{/if}}

--- a/packages/web-client/app/components/card-pay/balance-display/index.hbs
+++ b/packages/web-client/app/components/card-pay/balance-display/index.hbs
@@ -1,0 +1,39 @@
+{{#let (eq @size "small") (eq @size "large") as |isSmall isLarge|}}
+  <div class="balance-display" ...attributes>
+    {{#if @icon}}
+      {{svg-jar @icon class=(if isLarge "balance-display__icon-lg" "balance-display__icon") role="presentation"}}
+    {{/if}}
+    <div>
+      {{#if @label}}
+        <div class="balance-display__text-sm">{{@label}}</div>
+      {{/if}}
+      {{#if @name}}
+        <div
+          class={{if isSmall "balance-display__name-sm" "balance-display__name"}}
+          data-test-balance-display-name
+        >
+          {{@name}}
+        </div>
+      {{/if}}
+      {{#if @balance}}
+        <div class={{cn
+          balance-display__text=(not (or isSmall isLarge))
+          balance-display__text-lg=isLarge
+          balance-display__text-sm=isSmall
+        }} data-test-balance-display-amount>
+          {{@balance}} {{@symbol}}
+        </div>
+      {{/if}}
+      {{#if @usdBalance}}
+        <div class="balance-display__text-sm" data-test-balance-display-usd-amount>
+          ${{@usdBalance}} USD
+        </div>
+      {{/if}}
+      {{#if @text}}
+        <div class="balance-display__text-sm" data-test-balance-display-text>
+          {{@text}}
+        </div>
+      {{/if}}
+    </div>
+  </div>
+{{/let}}

--- a/packages/web-client/app/components/card-pay/balances-list/balance/index.css
+++ b/packages/web-client/app/components/card-pay/balances-list/balance/index.css
@@ -9,7 +9,7 @@
 }
 
 .card-pay-balances-list-balance__small-icon {
-  width: 1.25rem;
-  height: 1.25rem;
-  margin-right: 0.5rem;
+  width: var(--boxel-icon-sm);
+  height: var(--boxel-icon-sm);
+  margin-right: var(--boxel-sp-xxs);
 }

--- a/packages/web-client/app/components/card-pay/balances-list/index.css
+++ b/packages/web-client/app/components/card-pay/balances-list/index.css
@@ -1,6 +1,4 @@
 .card-pay-balances-list {
-  font-size: 1rem;
-  line-height: var(--field-text-line-height);
   padding-left: 0;
   margin: 0;
 }

--- a/packages/web-client/app/components/card-pay/deposit-workflow/confirmation/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/confirmation/index.css
@@ -42,30 +42,11 @@
 .card-pay-confirmation__transaction-amount {
   grid-area: amount;
   align-self: center;
-  display: flex;
-  align-items: center;
   grid-row: 1 / -1;
-}
-
-.card-pay-confirmation__transaction-token-icon {
-  align-self: flex-start;
-  flex-shrink: 0;
-  width: 2.5rem;
-  height: 2.5rem;
-  object-fit: contain;
-  margin-right: var(--boxel-sp-sm);
-}
-
-.card-pay-confirmation__transaction-balance {
-  font: 600 1.25rem/calc(27 / 20) var(--boxel-font-family);
-  letter-spacing: var(--boxel-lsp-xs);
 }
 
 .card-pay-confirmation__transaction-wallet {
   grid-area: wallet;
-  font-size: var(--boxel-font-size-sm);
-  font-weight: 600;
-  letter-spacing: var(--boxel-lsp-sm);
 }
 
 .card-pay-confirmation__transaction-preposition {
@@ -73,18 +54,7 @@
   margin-bottom: var(--boxel-sp-sm);
   font-size: var(--boxel-font-size-sm);
   color: var(--boxel-purple-400);
-  letter-spacing: 0.025em;
-}
-
-.card-pay-confirmation__transaction-address {
-  grid-area: details;
-  font-family: var(--boxel-monospace-font-family);
-  font-size: var(--boxel-font-size-sm);
-  line-height: 1.125rem;
-  letter-spacing: var(--boxel-lsp-sm);
-  color: var(--boxel-purple-500);
-  max-width: 23ch;
-  word-break: break-all;
+  letter-spacing: var(--boxel-lsp);
 }
 
 .card-pay-confirmation__transaction-depot {
@@ -137,34 +107,4 @@
 /* 2 selectors because of specificity */
 .card-pay-confirmation__bridge-inner-button.boxel-button {
   --boxel-button-color: var(--boxel-light-300);
-}
-
-.card-pay-confirmation__entity-details {
-  display: flex;
-  align-items: center;
-}
-
-.card-pay-confirmation__entity-icon {
-  width: 1.25rem;
-  height: 1.25rem;
-  margin-right: var(--boxel-sp-xs);
-}
-
-.card-pay-confirmation__entity-text {
-  font: 600 var(--boxel-font-sm);
-  letter-spacing: var(--boxel-lsp-xs);
-}
-
-.card-pay-confirmation__entity-address {
-  font-family: var(--boxel-monospace-font-family);
-  font-size: var(--boxel-font-size-sm);
-  line-height: 1.125rem;
-  letter-spacing: var(--boxel-lsp-sm);
-  color: var(--boxel-purple-500);
-}
-
-.card-pay-confirmation__new-depot-message {
-  color: var(--boxel-purple-500);
-  font: var(--boxel-font-sm);
-  letter-spacing: var(--boxel-lsp-xs);
 }

--- a/packages/web-client/app/components/card-pay/deposit-workflow/confirmation/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/confirmation/index.hbs
@@ -12,7 +12,7 @@
         </Boxel::Button>
       </div>
       <div class="card-pay-confirmation__transaction">
-        <CardPay::AccountDisplay
+        <CardPay::BalanceDisplay
           class="card-pay-confirmation__transaction-amount"
           @size="large"
           @icon={{this.depositedToken.icon}}
@@ -25,7 +25,7 @@
         <CardPay::AccountDisplay
           class="card-pay-confirmation__transaction-wallet"
           @size="small"
-          @title={{concat this.layer2Network.chainName " wallet"}}
+          @name={{concat this.layer2Network.chainName " wallet"}}
           @address={{this.layer1Network.walletInfo.firstAddress}}
           @wrapped={{true}}
         />
@@ -66,7 +66,7 @@
         </Boxel::Button>
       </div>
       <div class="card-pay-confirmation__transaction">
-        <CardPay::AccountDisplay
+        <CardPay::BalanceDisplay
           class="card-pay-confirmation__transaction-amount"
           @size="large"
           @icon={{this.depositedToken.icon}}
@@ -79,14 +79,14 @@
         <CardPay::AccountDisplay
           class="card-pay-confirmation__transaction-wallet"
           @size="small"
-          @title={{concat this.layer2Network.chainName " wallet"}}
+          @name={{concat this.layer2Network.chainName " wallet"}}
         />
         <CardPay::NestedItems class="card-pay-confirmation__transaction-depot">
           <:outer>
             <CardPay::AccountDisplay
               @size="small"
               @icon="avatar-default"
-              @title="Account 1"
+              @name="Account 1"
               @address={{truncate-middle this.layer2Network.walletInfo.firstAddress}}
               data-test-deposit-confirmation-account-address
             />
@@ -95,7 +95,7 @@
             <CardPay::AccountDisplay
               @size="small"
               @icon="depot"
-              @title="DEPOT:"
+              @name="DEPOT:"
               @address={{truncate-middle this.depotAddress}}
               @text={{unless this.depotAddress "New Depot"}}
               data-test-deposit-confirmation-depot-address

--- a/packages/web-client/app/components/card-pay/deposit-workflow/confirmation/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/confirmation/index.hbs
@@ -12,21 +12,23 @@
         </Boxel::Button>
       </div>
       <div class="card-pay-confirmation__transaction">
-        <div class="card-pay-confirmation__transaction-amount">
-          {{svg-jar this.depositedToken.icon class="card-pay-confirmation__transaction-token-icon"}}
-          <div class="card-pay-confirmation__transaction-balance">
-            {{format-token-amount this.depositedAmount}} {{this.depositedToken.symbol}}
-          </div>
-        </div>
+        <CardPay::AccountDisplay
+          class="card-pay-confirmation__transaction-amount"
+          @size="large"
+          @icon={{this.depositedToken.icon}}
+          @balance={{format-token-amount this.depositedAmount}}
+          @symbol={{this.depositedToken.symbol}}
+        />
         <div class="card-pay-confirmation__transaction-preposition">
           from
         </div>
-        <div class="card-pay-confirmation__transaction-wallet">
-          {{this.layer1Network.chainName}} wallet
-        </div>
-        <div class="card-pay-confirmation__transaction-address">
-          {{this.layer1Network.walletInfo.firstAddress}}
-        </div>
+        <CardPay::AccountDisplay
+          class="card-pay-confirmation__transaction-wallet"
+          @size="small"
+          @title={{concat this.layer2Network.chainName " wallet"}}
+          @address={{this.layer1Network.walletInfo.firstAddress}}
+          @wrapped={{true}}
+        />
       </div>
     </Boxel::CardContainer>
     {{svg-jar "arrow" class="card-pay-confirmation__down-arrow"}}
@@ -64,52 +66,40 @@
         </Boxel::Button>
       </div>
       <div class="card-pay-confirmation__transaction">
-        <div class="card-pay-confirmation__transaction-amount">
-          {{svg-jar this.depositedToken.icon class="card-pay-confirmation__transaction-token-icon"}}
-          <div class="card-pay-confirmation__transaction-balance">
-            {{format-token-amount this.depositedAmount}} {{this.depositedToken.symbol}}.CPXD
-          </div>
-        </div>
+        <CardPay::AccountDisplay
+          class="card-pay-confirmation__transaction-amount"
+          @size="large"
+          @icon={{this.depositedToken.icon}}
+          @balance={{format-token-amount this.depositedAmount}}
+          @symbol={{concat this.depositedToken.symbol ".CPXD"}}
+        />
         <div class="card-pay-confirmation__transaction-preposition">
           in
         </div>
-        <div class="card-pay-confirmation__transaction-wallet">
-          {{this.layer2Network.chainName}} wallet
-        </div>
+        <CardPay::AccountDisplay
+          class="card-pay-confirmation__transaction-wallet"
+          @size="small"
+          @title={{concat this.layer2Network.chainName " wallet"}}
+        />
         <CardPay::NestedItems class="card-pay-confirmation__transaction-depot">
           <:outer>
-            <div class="card-pay-confirmation__entity-details">
-              {{svg-jar "avatar-default" width="20" height="20" class="card-pay-confirmation__entity-icon" role="presentation"}}
-              <div>
-                <div class="card-pay-confirmation__entity-text">Account 1</div>
-                <div class="card-pay-confirmation__entity-address" data-test-deposit-confirmation-account-address>
-                  {{truncate-middle this.layer2Network.walletInfo.firstAddress}}
-                </div>
-              </div>
-            </div>
+            <CardPay::AccountDisplay
+              @size="small"
+              @icon="avatar-default"
+              @title="Account 1"
+              @address={{truncate-middle this.layer2Network.walletInfo.firstAddress}}
+              data-test-deposit-confirmation-account-address
+            />
           </:outer>
           <:inner>
-            <div class="card-pay-confirmation__entity-details">
-              {{svg-jar "depot" class="card-pay-confirmation__entity-icon" role="presentation"}}
-              <div>
-                <div class="card-pay-confirmation__entity-text">DEPOT:</div>
-                <div class="card-pay-confirmation__entity-address" data-test-deposit-confirmation-depot-address>
-                  {{#if this.depotAddress}}
-                    {{truncate-middle this.depotAddress}}
-                  {{else}}
-                    {{!--
-                      This depot is fetched earlier in the workflow.
-                      If it isn't present and we got this far, it's because the
-                      user created a new repo. That's why we don't show a loading indicator here.
-                      This might change in the future if we fetch the depot address in this component
-                    --}}
-                    <div class="card-pay-confirmation__new-depot-message">
-                      New Depot
-                    </div>
-                  {{/if}}
-                </div>
-              </div>
-            </div>
+            <CardPay::AccountDisplay
+              @size="small"
+              @icon="depot"
+              @title="DEPOT:"
+              @address={{truncate-middle this.depotAddress}}
+              @text={{unless this.depotAddress "New Depot"}}
+              data-test-deposit-confirmation-depot-address
+            />
           </:inner>
         </CardPay::NestedItems>
       </div>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/confirmation/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/confirmation/index.hbs
@@ -16,7 +16,7 @@
           class="card-pay-confirmation__transaction-amount"
           @size="large"
           @icon={{this.depositedToken.icon}}
-          @balance={{format-token-amount this.depositedAmount}}
+          @balance={{this.depositedAmount}}
           @symbol={{this.depositedToken.symbol}}
         />
         <div class="card-pay-confirmation__transaction-preposition">
@@ -70,7 +70,7 @@
           class="card-pay-confirmation__transaction-amount"
           @size="large"
           @icon={{this.depositedToken.icon}}
-          @balance={{format-token-amount this.depositedAmount}}
+          @balance={{this.depositedAmount}}
           @symbol={{concat this.depositedToken.symbol ".CPXD"}}
         />
         <div class="card-pay-confirmation__transaction-preposition">

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.css
@@ -1,7 +1,7 @@
 /* details - summary container styles */
 .balance-view {
   --details-summary-height: 3.125rem; /* 50px */
-  --details-open-height: 11rem; /* ~180px */
+  --details-open-height: 10rem;       /* 160px */
 
   position: relative;
   border: 1px solid var(--boxel-light-400);
@@ -21,14 +21,16 @@
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 0 var(--boxel-sp);
   height: var(--details-summary-height);
   padding: var(--boxel-sp-xxs) calc(var(--boxel-sp) + 3rem) var(--boxel-sp-xxs) var(--boxel-sp);
   font: 600 var(--boxel-font-sm);
   letter-spacing: var(--boxel-lsp-xs);
-  transition:
-    padding var(--boxel-transition),
-    font var(--boxel-transition);
+}
+
+.balance-view__summary::marker,
+.balance-view__summary::-webkit-details-marker {
+  display: none;
+  content: '';
 }
 
 .balance-view__summary:focus {
@@ -36,32 +38,23 @@
   outline-offset: -5px;
 }
 
-.balance-view__summary--memorialized {
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: center;
+.balance-view[open] .balance-view__summary {
+  height: var(--boxel-sp);
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 .balance-view__summary-balance {
+  margin-left: var(--boxel-sp);
   letter-spacing: var(--boxel-lsp);
 }
 
-.balance-view__summary--memorialized .balance-view__summary-balance {
-  color: var(--boxel-purple-500);
-  font: var(--boxel-font-sm);
-}
-
-.balance-view[open] .balance-view__summary {
-  height: auto;
-  padding: var(--boxel-sp-xl) var(--boxel-sp-lg) 0;
-  font: 600 var(--boxel-font);
-}
-
 .balance-view__details {
-  padding: 0 var(--boxel-sp-lg) var(--boxel-sp-xl);
+  padding: 0 var(--boxel-sp);
+  margin-bottom: var(--boxel-sp-lg);
 }
 
-.balance-view[open] .balance-view__summary-balance {
+.balance-view[open] .balance-view__summary-content {
   display: none;
 }
 
@@ -92,48 +85,4 @@
 
 .balance-view[open] .balance-view__marker-icon {
   transform: rotate(-90deg);
-}
-
-/* balance display styles */
-.balance-view__address {
-  color: var(--boxel-purple-500);
-  font-family: var(--boxel-monospace-font-family);
-  font-size: var(--boxel-font-size);
-  line-height: calc(22 / 16);
-  letter-spacing: 0;
-  word-break: break-all;
-}
-
-.balance-view__token {
-  display: flex;
-  align-items: center;
-  color: var(--boxel-dark);
-}
-
-.balance-view__token-icon {
-  align-self: flex-start;
-  flex-shrink: 0;
-  width: 2.5rem;
-  height: 2.5rem;
-  object-fit: contain;
-  margin-right: var(--boxel-sp-sm);
-}
-
-.balance-view__token-balance {
-  font-weight: 600;
-  font-size: 1.25rem;
-  line-height: calc(27 / 20);
-  letter-spacing: var(--boxel-lsp-xs);
-}
-
-.balance-view__usd-balance {
-  color: var(--boxel-purple-400);
-  font: var(--boxel-font-sm);
-  letter-spacing: var(--boxel-lsp-xs);
-}
-
-.balance-view__loading-indicator {
-  flex-shrink: 0;
-  width: 1.25rem;
-  height: 1.25rem;
 }

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.css
@@ -1,7 +1,7 @@
 /* details - summary container styles */
 .balance-view {
   --details-summary-height: 3.125rem; /* 50px */
-  --details-open-height: 10rem;       /* 160px */
+  --details-open-height: 11rem;
 
   position: relative;
   border: 1px solid var(--boxel-light-400);
@@ -22,7 +22,7 @@
   display: flex;
   align-items: center;
   height: var(--details-summary-height);
-  padding: var(--boxel-sp-xxs) calc(var(--boxel-sp) + 3rem) var(--boxel-sp-xxs) var(--boxel-sp);
+  padding: 0 calc(var(--boxel-sp) + 3rem) 0 var(--boxel-sp);
   font: 600 var(--boxel-font-sm);
   letter-spacing: var(--boxel-lsp-xs);
 }
@@ -39,7 +39,7 @@
 }
 
 .balance-view[open] .balance-view__summary {
-  height: var(--boxel-sp);
+  height: var(--boxel-sp-xl);
   padding-top: 0;
   padding-bottom: 0;
 }
@@ -50,8 +50,7 @@
 }
 
 .balance-view__details {
-  padding: 0 var(--boxel-sp);
-  margin-bottom: var(--boxel-sp-lg);
+  padding: 0 var(--boxel-sp-lg);
 }
 
 .balance-view[open] .balance-view__summary-content {

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.hbs
@@ -1,35 +1,38 @@
 <details class="balance-view" ...attributes>
-  <summary class={{cn "balance-view__summary" balance-view__summary--memorialized=@isComplete}}>
-    <div>{{@wallet}} wallet</div>
-    <div class="balance-view__summary-balance" data-test-source-token={{@tokenSymbol}}>
-      {{@balance}} {{@tokenSymbol}}
-    </div>
+  <summary class="balance-view__summary">
+    {{#if @isComplete}}
+      <CardPay::AccountDisplay
+        class="balance-view__summary-content"
+        @size="small"
+        @title={{concat @wallet " wallet"}}
+        @text={{concat @balance " " @tokenSymbol}}
+        data-test-source-token={{@tokenSymbol}}
+      />
+    {{else}}
+      <div class="balance-view__summary-content">
+        {{@wallet}} wallet
+        <span class="balance-view__summary-balance" data-test-source-token={{@tokenSymbol}}>{{@balance}} {{@tokenSymbol}}</span>
+      </div>
+    {{/if}}
     <div class="balance-view__marker">
       {{svg-jar "caret-right" class="balance-view__marker-icon" role="presentation"}}
     </div>
   </summary>
   <CardPay::NestedItems class="balance-view__details">
     <:outer>
-      <div class="balance-view__address">
-        {{@address}}
-      </div>
+      <CardPay::AccountDisplay
+        @title={{concat @wallet " wallet"}}
+        @address={{@address}}
+        data-test-source-token={{@tokenSymbol}}
+      />
     </:outer>
     <:inner>
-      <div class="balance-view__token">
-        {{svg-jar @tokenIcon class="balance-view__token-icon" role="presentation" width="40" height="40"}}
-        <div>
-          <div class="balance-view__token-balance">
-            {{@balance}} {{@tokenSymbol}}
-          </div>
-          {{#if @balanceInUsd}}
-            <div class="balance-view__usd-balance">
-              ≈ $ {{@balanceInUsd}} USD
-            </div>
-          {{else}}
-            <Boxel::LoadingIndicator class="balance-view__loading-indicator" />
-          {{/if}}
-        </div>
-      </div>
+      <CardPay::AccountDisplay
+        @size="large"
+        @icon={{@tokenIcon}}
+        @title={{concat @balance " " @tokenSymbol}}
+        @text={{if @balanceInUsd (concat "$ " @balanceInUsd " USD")}}
+      />
     </:inner>
   </CardPay::NestedItems>
 </details>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.hbs
@@ -5,7 +5,8 @@
         class="balance-view__summary-content"
         @size="small"
         @title={{concat @wallet " wallet"}}
-        @text={{concat @balance " " @tokenSymbol}}
+        @balance={{@balance}}
+        @symbol={{@tokenSymbol}}
         data-test-source-token={{@tokenSymbol}}
       />
     {{else}}
@@ -30,8 +31,9 @@
       <CardPay::AccountDisplay
         @size="large"
         @icon={{@tokenIcon}}
-        @title={{concat @balance " " @tokenSymbol}}
-        @text={{if @balanceInUsd (concat "$ " @balanceInUsd " USD")}}
+        @balance={{@balance}}
+        @symbol={{@tokenSymbol}}
+        @usdBalance={{@balanceInUsd}}
       />
     </:inner>
   </CardPay::NestedItems>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.hbs
@@ -12,7 +12,9 @@
     {{else}}
       <div class="balance-view__summary-content">
         {{@wallet}} wallet
-        <span class="balance-view__summary-balance" data-test-source-token={{@tokenSymbol}}>{{@balance}} {{@tokenSymbol}}</span>
+        <span class="balance-view__summary-balance" data-test-source-token={{@tokenSymbol}}>
+          {{format-token-amount @balance}} {{@tokenSymbol}}
+        </span>
       </div>
     {{/if}}
     <div class="balance-view__marker">

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.hbs
@@ -33,7 +33,7 @@
         @icon={{@tokenIcon}}
         @balance={{@balance}}
         @symbol={{@tokenSymbol}}
-        @usdBalance={{@balanceInUsd}}
+        @displayUsdBalance={{true}}
       />
     </:inner>
   </CardPay::NestedItems>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/balance-view/index.hbs
@@ -1,10 +1,10 @@
 <details class="balance-view" ...attributes>
   <summary class="balance-view__summary">
     {{#if @isComplete}}
-      <CardPay::AccountDisplay
+      <CardPay::BalanceDisplay
         class="balance-view__summary-content"
         @size="small"
-        @title={{concat @wallet " wallet"}}
+        @name={{concat @wallet " wallet"}}
         @balance={{@balance}}
         @symbol={{@tokenSymbol}}
         data-test-source-token={{@tokenSymbol}}
@@ -22,13 +22,13 @@
   <CardPay::NestedItems class="balance-view__details">
     <:outer>
       <CardPay::AccountDisplay
-        @title={{concat @wallet " wallet"}}
+        @name={{concat @wallet " wallet"}}
         @address={{@address}}
         data-test-source-token={{@tokenSymbol}}
       />
     </:outer>
     <:inner>
-      <CardPay::AccountDisplay
+      <CardPay::BalanceDisplay
         @size="large"
         @icon={{@tokenIcon}}
         @balance={{@balance}}

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.css
@@ -82,36 +82,18 @@
 /* token balance display styles */
 .transaction-amount__token {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  color: var(--boxel-dark);
-
-  /* bordered display box */
   justify-content: center;
   padding: var(--boxel-sp-xl) var(--boxel-sp);
   border: 1px solid var(--boxel-light-400);
   border-radius: var(--boxel-border-radius);
 }
 
-.transaction-amount__token-icon {
-  align-self: flex-start;
-  flex-shrink: 0;
-  width: 2.5rem;
-  height: 2.5rem;
-  object-fit: contain;
-  margin-right: var(--boxel-sp-sm);
-}
-
-.transaction-amount__token-balance {
-  font-weight: 600;
-  font-size: 1.25rem;
-  line-height: calc(27 / 20);
-  letter-spacing: var(--boxel-lsp-xs);
-  margin-top: var(--boxel-sp-xxs);
-}
-
 .transaction-amount__usd-balance {
+  margin-top: var(--boxel-sp-xxxs);
+  margin-left: var(--boxel-sp-xxl);
   color: var(--boxel-purple-500);
   font: var(--boxel-font-sm);
   letter-spacing: var(--boxel-lsp-xs);
-  margin-top: var(--boxel-sp-xs);
 }

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.css
@@ -83,18 +83,11 @@
 .transaction-amount__token {
   display: flex;
   align-items: center;
+  color: var(--boxel-dark);
+
+  /* bordered display box */
   justify-content: center;
   padding: var(--boxel-sp-xl) var(--boxel-sp);
   border: 1px solid var(--boxel-light-400);
   border-radius: var(--boxel-border-radius);
-}
-
-.transaction-amount__token > div > :first-child {
-  height: 2.5rem;
-  display: flex;
-  align-items: center;
-}
-
-.transaction-amount__token > div > :last-child {
-  text-align: center;
 }

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.css
@@ -82,10 +82,19 @@
 /* token balance display styles */
 .transaction-amount__token {
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
   padding: var(--boxel-sp-xl) var(--boxel-sp);
   border: 1px solid var(--boxel-light-400);
   border-radius: var(--boxel-border-radius);
+}
+
+.transaction-amount__token > div > :first-child {
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+}
+
+.transaction-amount__token > div > :last-child {
+  text-align: center;
 }

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.css
@@ -89,11 +89,3 @@
   border: 1px solid var(--boxel-light-400);
   border-radius: var(--boxel-border-radius);
 }
-
-.transaction-amount__usd-balance {
-  margin-top: var(--boxel-sp-xxxs);
-  margin-left: var(--boxel-sp-xxl);
-  color: var(--boxel-purple-500);
-  font: var(--boxel-font-sm);
-  letter-spacing: var(--boxel-lsp-xs);
-}

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -15,7 +15,7 @@
           @tokenSymbol={{this.currentTokenSymbol}}
           @tokenIcon={{this.currentTokenDetails.icon}}
           @address={{this.layer1Network.walletInfo.firstAddress}}
-          @balance={{format-token-amount this.currentTokenBalance}}
+          @balance={{this.currentTokenBalance}}
           @balanceInUsd={{token-to-usd this.currentTokenSymbol this.currentTokenBalance}}
           @isComplete={{@isComplete}}
         />
@@ -29,9 +29,9 @@
             class="transaction-amount__token"
             @size="large"
             @icon={{this.currentTokenDetails.icon}}
-            @balance={{format-token-amount this.amountAsBigNumber}}
+            @balance={{this.amountAsBigNumber}}
             @symbol={{this.currentTokenSymbol}}
-            @usdBalance={{token-to-usd this.currentTokenSymbol this.amountAsBigNumber}}
+            @displayUsdBalance={{true}}
             data-test-deposit-amount-entered
           />
         </Boxel::Field>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -25,17 +25,22 @@
           class="transaction-amount__field"
           @label="Amount to deposit:"
         >
-          <div class="transaction-amount__token">
-            <CardPay::AccountDisplay
-              @size="large"
-              @icon={{this.currentTokenDetails.icon}}
-              @title={{concat (format-token-amount this.amountAsBigNumber) " " this.currentTokenSymbol}}
-              data-test-deposit-amount-entered
-            />
-            <div class="transaction-amount__usd-balance">
-              $ {{token-to-usd this.currentTokenSymbol this.amountAsBigNumber}} USD
-            </div>
-          </div>
+          <CardPay::NestedItems @noBorder={{true}} class="transaction-amount__token">
+            <:outer>
+              <CardPay::AccountDisplay
+                @size="large"
+                @icon={{this.currentTokenDetails.icon}}
+                @balance={{format-token-amount this.amountAsBigNumber}}
+                @symbol={{this.currentTokenSymbol}}
+                data-test-deposit-amount-entered
+              />
+            </:outer>
+            <:inner>
+              <CardPay::AccountDisplay
+                @usdBalance={{token-to-usd this.currentTokenSymbol this.amountAsBigNumber}}
+              />
+            </:inner>
+          </CardPay::NestedItems>
         </Boxel::Field>
       {{else}}
         <Boxel::Field
@@ -63,7 +68,7 @@
         </div>
         </Boxel::Field>
         <Boxel::Field @label="Approximate value">
-          $ {{token-to-usd this.currentTokenSymbol this.amountAsBigNumber}} USD
+          ${{token-to-usd this.currentTokenSymbol this.amountAsBigNumber}} USD
         </Boxel::Field>
       {{/if}}
     </div>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -25,22 +25,15 @@
           class="transaction-amount__field"
           @label="Amount to deposit:"
         >
-          <CardPay::NestedItems @noBorder={{true}} class="transaction-amount__token">
-            <:outer>
-              <CardPay::AccountDisplay
-                @size="large"
-                @icon={{this.currentTokenDetails.icon}}
-                @balance={{format-token-amount this.amountAsBigNumber}}
-                @symbol={{this.currentTokenSymbol}}
-                data-test-deposit-amount-entered
-              />
-            </:outer>
-            <:inner>
-              <CardPay::AccountDisplay
-                @usdBalance={{token-to-usd this.currentTokenSymbol this.amountAsBigNumber}}
-              />
-            </:inner>
-          </CardPay::NestedItems>
+          <CardPay::BalanceDisplay
+            class="transaction-amount__token"
+            @size="large"
+            @icon={{this.currentTokenDetails.icon}}
+            @balance={{format-token-amount this.amountAsBigNumber}}
+            @symbol={{this.currentTokenSymbol}}
+            @usdBalance={{token-to-usd this.currentTokenSymbol this.amountAsBigNumber}}
+            data-test-deposit-amount-entered
+          />
         </Boxel::Field>
       {{else}}
         <Boxel::Field

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -26,14 +26,14 @@
           @label="Amount to deposit:"
         >
           <div class="transaction-amount__token">
-            {{svg-jar this.currentTokenDetails.icon class="transaction-amount__token-icon" role="presentation" width="40" height="40"}}
-            <div>
-              <div class="transaction-amount__token-balance" data-test-deposit-amount-entered>
-                {{this.amount}} {{this.currentTokenSymbol}}
-              </div>
-              <div class="transaction-amount__usd-balance">
-                ≈ $ {{token-to-usd this.currentTokenSymbol this.amountAsBigNumber}} USD
-              </div>
+            <CardPay::AccountDisplay
+              @size="large"
+              @icon={{this.currentTokenDetails.icon}}
+              @title={{concat (format-token-amount this.amountAsBigNumber) " " this.currentTokenSymbol}}
+              data-test-deposit-amount-entered
+            />
+            <div class="transaction-amount__usd-balance">
+              $ {{token-to-usd this.currentTokenSymbol this.amountAsBigNumber}} USD
             </div>
           </div>
         </Boxel::Field>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.css
@@ -3,43 +3,6 @@
   row-gap: 0;
 }
 
-.transaction-setup__title {
-  font: 600 var(--boxel-font);
-  letter-spacing: var(--boxel-lsp-xs);
-}
-
-.transaction-setup__title-sm {
-  font: 600 var(--boxel-font-sm);
-  letter-spacing: var(--boxel-lsp-xs);
-}
-
-.transaction-setup__title-lg {
-  font-size: 1.25rem;
-  font-weight: 600;
-  line-height: calc(27 / 20);
-  letter-spacing: var(--boxel-lsp-xs);
-}
-
-.transaction-setup__address {
-  color: var(--boxel-purple-500);
-  font-family: var(--boxel-monospace-font-family);
-  font-size: var(--boxel-font-size);
-  line-height: calc(22 / 16);
-  letter-spacing: 0.02em;
-  word-break: break-all;
-}
-
-.transaction-setup__address-sm {
-  color: var(--boxel-purple-400);
-  font-family: var(--boxel-monospace-font-family);
-  font-size: var(--boxel-font-size-sm);
-  line-height: calc(18 / 13);
-}
-
-.transaction-setup__address--wrapped {
-  max-width: 22ch;
-}
-
 .transaction-setup__field-info {
   grid-column: 2;
 }
@@ -52,34 +15,6 @@
   margin-top: var(--boxel-sp);
 }
 
-.transaction-setup__icon-group {
-  display: flex;
-  align-items: center;
-}
-
-.transaction-setup__icon-group-sm {
-  display: flex;
-  align-items: center;
+.transaction-setup__account {
   margin-top: var(--boxel-sp-xs);
-}
-
-.transaction-setup__icon {
-  align-self: flex-start;
-  width: 2.5rem;
-  height: 2.5rem;
-  object-fit: contain;
-  margin-right: var(--boxel-sp-sm);
-}
-
-.transaction-setup__icon-sm {
-  width: 1.25rem;
-  height: 1.25rem;
-  object-fit: contain;
-  margin-right: var(--boxel-sp-xs);
-}
-
-.transaction-setup__text-sm {
-  color: var(--boxel-purple-500);
-  font: var(--boxel-font-sm);
-  letter-spacing: var(--boxel-lsp-xs);
 }

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
@@ -19,8 +19,9 @@
               <CardPay::AccountDisplay
                 @size="large"
                 @icon={{this.selectedToken.icon}}
-                @title={{concat (format-token-amount this.selectedTokenBalance) " " this.selectedToken.symbol}}
-                @text={{concat "$ " (token-to-usd this.selectedToken.symbol this.selectedTokenBalance) " USD"}}
+                @balance={{format-token-amount this.selectedTokenBalance}}
+                @symbol={{this.selectedToken.symbol}}
+                @usdBalance={{token-to-usd this.selectedToken.symbol this.selectedTokenBalance}}
                 data-test-deposit-transaction-setup-from-balance={{this.selectedToken.symbol}}
               />
             </:inner>
@@ -69,7 +70,7 @@
               @size={{if @isComplete "large"}}
               @icon="depot"
               @title="DEPOT:"
-              @address={{if this.layer2Network.depotSafe this.layer2Network.depotSafe.address}}
+              @address={{if this.layer2Network.isFetchingDepot "isLoading" this.layer2Network.depotSafe.address}}
               @text={{unless this.layer2Network.depotSafe "New Depot"}}
               data-test-deposit-transaction-setup-depot-address
             />
@@ -84,9 +85,7 @@
     data-test-deposit-transaction-setup
   >
     <:default as |d|>
-      <d.ActionButton
-        {{on "click" this.toggleComplete}}
-      >
+      <d.ActionButton {{on "click" this.toggleComplete}}>
         Continue
       </d.ActionButton>
     </:default>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
@@ -19,9 +19,9 @@
               <CardPay::BalanceDisplay
                 @size="large"
                 @icon={{this.selectedToken.icon}}
-                @balance={{format-token-amount this.selectedTokenBalance}}
+                @balance={{this.selectedTokenBalance}}
                 @symbol={{this.selectedToken.symbol}}
-                @usdBalance={{token-to-usd this.selectedToken.symbol this.selectedTokenBalance}}
+                @displayUsdBalance={{true}}
                 data-test-deposit-transaction-setup-from-balance={{this.selectedToken.symbol}}
               />
             </:inner>
@@ -38,11 +38,8 @@
                 <CardPay::DepositWorkflow::TransactionSetup::TokenOption
                   @checked={{eq @workflowSession.state.depositSourceToken token.symbol}}
                   @onInput={{fn this.chooseSource token.symbol}}
-                  @balance={{format-token-amount balance}}
-                  @balanceInUsd={{token-to-usd token.symbol balance}}
-                  @tokenSymbol={{token.symbol}}
-                  @tokenDescription={{token.description}}
-                  @tokenIcon={{token.icon}}
+                  @balance={{balance}}
+                  @token={{token}}
                   data-test-deposit-transaction-setup-from-option={{token.symbol}}
                 />
               {{/let}}

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
@@ -38,8 +38,11 @@
                 <CardPay::DepositWorkflow::TransactionSetup::TokenOption
                   @checked={{eq @workflowSession.state.depositSourceToken token.symbol}}
                   @onInput={{fn this.chooseSource token.symbol}}
-                  @balance={{balance}}
-                  @token={{token}}
+                  @balance={{format-token-amount balance}}
+                  @balanceInUsd={{token-to-usd token.symbol balance}}
+                  @tokenSymbol={{token.symbol}}
+                  @tokenDescription={{token.description}}
+                  @tokenIcon={{token.icon}}
                   data-test-deposit-transaction-setup-from-option={{token.symbol}}
                 />
               {{/let}}

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
@@ -21,7 +21,7 @@
                 @icon={{this.selectedToken.icon}}
                 @title={{concat (format-token-amount this.selectedTokenBalance) " " this.selectedToken.symbol}}
                 @text={{concat "$ " (token-to-usd this.selectedToken.symbol this.selectedTokenBalance) " USD"}}
-                data-test-option-view-only
+                data-test-deposit-transaction-setup-from-balance={{this.selectedToken.symbol}}
               />
             </:inner>
           </CardPay::NestedItems>
@@ -42,6 +42,7 @@
                   @tokenSymbol={{token.symbol}}
                   @tokenDescription={{token.description}}
                   @tokenIcon={{token.icon}}
+                  data-test-deposit-transaction-setup-from-option={{token.symbol}}
                 />
               {{/let}}
             {{/each}}

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
@@ -9,28 +9,28 @@
         {{#if @isComplete}}
           <CardPay::NestedItems>
             <:outer>
-              <div class="transaction-setup__title">{{this.layer1Network.chainName}} wallet</div>
-              <div class="transaction-setup__address" data-test-deposit-transaction-setup-from-address>{{this.layer1Network.walletInfo.firstAddress}}</div>
+              <CardPay::AccountDisplay
+                @title={{concat this.layer1Network.chainName " wallet"}}
+                @address={{this.layer1Network.walletInfo.firstAddress}}
+                data-test-deposit-transaction-setup-from-address
+              />
             </:outer>
             <:inner>
-              <div class="transaction-setup__icon-group" data-test-option-view-only>
-                {{svg-jar this.selectedToken.icon class="transaction-setup__icon" role="presentation" width="40" height="40"}}
-                <div>
-                  <div class={{if @isComplete "transaction-setup__title-lg" "transaction-setup__title"}} data-test-balance-view-only={{this.selectedToken.symbol}}>
-                    {{format-token-amount this.selectedTokenBalance}} {{uppercase this.selectedToken.symbol}}
-                  </div>
-                  <div class="transaction-setup__text-sm" data-test-usd-balance-view-only={{this.selectedToken.symbol}}>
-                    ≈ $ {{token-to-usd this.selectedToken.symbol this.selectedTokenBalance}} USD
-                  </div>
-                </div>
-              </div>
+              <CardPay::AccountDisplay
+                @size="large"
+                @icon={{this.selectedToken.icon}}
+                @title={{concat (format-token-amount this.selectedTokenBalance) " " this.selectedToken.symbol}}
+                @text={{concat "$ " (token-to-usd this.selectedToken.symbol this.selectedTokenBalance) " USD"}}
+                data-test-option-view-only
+              />
             </:inner>
           </CardPay::NestedItems>
         {{else}}
-          <div>
-            <div class="transaction-setup__title">{{this.layer1Network.chainName}} wallet</div>
-            <div class="transaction-setup__address" data-test-deposit-transaction-setup-from-address>{{this.layer1Network.walletInfo.firstAddress}}</div>
-          </div>
+          <CardPay::AccountDisplay
+            @title={{concat this.layer1Network.chainName " wallet"}}
+            @address={{this.layer1Network.walletInfo.firstAddress}}
+            data-test-deposit-transaction-setup-from-address
+          />
           <div class="transaction-setup__field-info transaction-setup__radio-buttons">
             {{#each this.tokens as |token|}}
               {{#let (if (eq token.symbol 'CARD') this.layer1Network.cardBalance this.layer1Network.daiBalance) as |balance|}}
@@ -51,39 +51,29 @@
     </ActionCardContainer::Section>
     <ActionCardContainer::Section @title="Receive tokens">
       <CardPay::LabeledValue @label="In:" class="transaction-setup__field">
-        <div class="transaction-setup__title">{{this.layer2Network.chainName}} wallet</div>
-          <CardPay::NestedItems class="transaction-setup__field-info">
-            <:outer>
-              <div class="transaction-setup__icon-group-sm">
-                {{svg-jar "avatar-default" width="20" height="20" class="transaction-setup__icon-sm" role="presentation"}}
-                <div>
-                  <div class="transaction-setup__title-sm">Account 1</div>
-                  <div class="transaction-setup__address-sm" data-test-deposit-transaction-setup-to-address>
-                    {{truncate-middle this.layer2Network.walletInfo.firstAddress}}
-                  </div>
-                </div>
-              </div>
-            </:outer>
-            <:inner>
-              <div class="transaction-setup__icon-group">
-                {{svg-jar "depot" width="40" height="40" class="transaction-setup__icon" role="presentation"}}
-                <div>
-                  <div class={{if @isComplete "transaction-setup__title-lg" "transaction-setup__title"}}>DEPOT:</div>
-                  {{#if this.layer2Network.isFetchingDepot}}
-                    <Boxel::LoadingIndicator/>
-                  {{else if this.layer2Network.depotSafe}}
-                    <div class={{cn "transaction-setup__address" transaction-setup__address--wrapped=@isComplete}} data-test-deposit-transaction-setup-depot-address>
-                      {{this.layer2Network.depotSafe.address}}
-                    </div>
-                  {{else}}
-                    <div class="transaction-setup__text-sm" data-test-deposit-transaction-setup-depot-address>
-                      New Depot
-                    </div>
-                  {{/if}}
-                </div>
-              </div>
-            </:inner>
-          </CardPay::NestedItems>
+        <CardPay::AccountDisplay @title={{concat this.layer2Network.chainName " wallet"}} />
+        <CardPay::NestedItems class="transaction-setup__field-info">
+          <:outer>
+            <CardPay::AccountDisplay
+              class="transaction-setup__account"
+              @size="small"
+              @icon="avatar-default"
+              @title="Account 1"
+              @address={{truncate-middle this.layer2Network.walletInfo.firstAddress}}
+              data-test-deposit-transaction-setup-to-address
+            />
+          </:outer>
+          <:inner>
+            <CardPay::AccountDisplay
+              @size={{if @isComplete "large"}}
+              @icon="depot"
+              @title="DEPOT:"
+              @address={{if this.layer2Network.depotSafe this.layer2Network.depotSafe.address}}
+              @text={{unless this.layer2Network.depotSafe "New Depot"}}
+              data-test-deposit-transaction-setup-depot-address
+            />
+          </:inner>
+        </CardPay::NestedItems>
       </CardPay::LabeledValue>
     </ActionCardContainer::Section>
   </ActionCardContainer::Section>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
@@ -10,13 +10,13 @@
           <CardPay::NestedItems>
             <:outer>
               <CardPay::AccountDisplay
-                @title={{concat this.layer1Network.chainName " wallet"}}
+                @name={{concat this.layer1Network.chainName " wallet"}}
                 @address={{this.layer1Network.walletInfo.firstAddress}}
                 data-test-deposit-transaction-setup-from-address
               />
             </:outer>
             <:inner>
-              <CardPay::AccountDisplay
+              <CardPay::BalanceDisplay
                 @size="large"
                 @icon={{this.selectedToken.icon}}
                 @balance={{format-token-amount this.selectedTokenBalance}}
@@ -28,7 +28,7 @@
           </CardPay::NestedItems>
         {{else}}
           <CardPay::AccountDisplay
-            @title={{concat this.layer1Network.chainName " wallet"}}
+            @name={{concat this.layer1Network.chainName " wallet"}}
             @address={{this.layer1Network.walletInfo.firstAddress}}
             data-test-deposit-transaction-setup-from-address
           />
@@ -53,14 +53,14 @@
     </ActionCardContainer::Section>
     <ActionCardContainer::Section @title="Receive tokens">
       <CardPay::LabeledValue @label="In:" class="transaction-setup__field">
-        <CardPay::AccountDisplay @title={{concat this.layer2Network.chainName " wallet"}} />
+        <CardPay::AccountDisplay @name={{concat this.layer2Network.chainName " wallet"}} />
         <CardPay::NestedItems class="transaction-setup__field-info">
           <:outer>
             <CardPay::AccountDisplay
               class="transaction-setup__account"
               @size="small"
               @icon="avatar-default"
-              @title="Account 1"
+              @name="Account 1"
               @address={{truncate-middle this.layer2Network.walletInfo.firstAddress}}
               data-test-deposit-transaction-setup-to-address
             />
@@ -69,7 +69,7 @@
             <CardPay::AccountDisplay
               @size={{if @isComplete "large"}}
               @icon="depot"
-              @title="DEPOT:"
+              @name="DEPOT:"
               @address={{if this.layer2Network.isFetchingDepot "isLoading" this.layer2Network.depotSafe.address}}
               @text={{unless this.layer2Network.depotSafe "New Depot"}}
               data-test-deposit-transaction-setup-depot-address

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.hbs
@@ -6,17 +6,12 @@
     @checked={{@checked}}
     {{on "input" @onInput}}
   />
-  <div class="token-option__currency">
-    {{svg-jar @tokenIcon class="token-option__icon" role="presentation" width="40" height="40"}}
-    <div>
-      <div class="token-option__title" data-test-option={{@tokenSymbol}}>
-        {{@tokenSymbol}}
-      </div>
-      <div class="token-option__desc">
-        {{@tokenDescription}}
-      </div>
-    </div>
-  </div>
+  <CardPay::AccountDisplay
+    @icon={{@tokenIcon}}
+    @title={{@tokenSymbol}}
+    @text={{@tokenDescription}}
+    data-test-option={{@tokenSymbol}}
+  />
   <div>
     <div class="token-option__balance-header">Balance</div>
     <div class="token-option__balance" data-test-balance={{@tokenSymbol}}>
@@ -24,7 +19,7 @@
     </div>
     <div class="token-option__usd-balance" data-test-usd-balance={{@tokenSymbol}}>
       {{#if @balanceInUsd}}
-        ≈ $ {{@balanceInUsd}} USD
+        ${{@balanceInUsd}} USD
       {{else}}
         <Boxel::LoadingIndicator class="token-option__loading-indicator"/>
       {{/if}}

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.hbs
@@ -1,4 +1,8 @@
-<label class={{cn "token-option" token-option--checked=@checked}} ...attributes>
+<label
+  class={{cn "token-option" token-option--checked=@checked}}
+  data-test-option={{@tokenSymbol}}
+  ...attributes
+>
   <Input
     name="deposit-token"
     class={{cn "token-option__input" token-option__input--checked=@checked}}
@@ -6,23 +10,16 @@
     @checked={{@checked}}
     {{on "input" @onInput}}
   />
-  <CardPay::AccountDisplay
+  <CardPay::BalanceDisplay
+    @size="large"
     @icon={{@tokenIcon}}
-    @title={{@tokenSymbol}}
+    @name={{@tokenSymbol}}
     @text={{@tokenDescription}}
-    data-test-option={{@tokenSymbol}}
   />
-  <div>
-    <div class="token-option__balance-header">Balance</div>
-    <div class="token-option__balance" data-test-balance={{@tokenSymbol}}>
-      {{@balance}} {{@tokenSymbol}}
-    </div>
-    <div class="token-option__usd-balance" data-test-usd-balance={{@tokenSymbol}}>
-      {{#if @balanceInUsd}}
-        ${{@balanceInUsd}} USD
-      {{else}}
-        <Boxel::LoadingIndicator class="token-option__loading-indicator"/>
-      {{/if}}
-    </div>
-  </div>
+  <CardPay::BalanceDisplay
+    @label="Balance"
+    @balance={{@balance}}
+    @symbol={{@tokenSymbol}}
+    @usdBalance={{@balanceInUsd}}
+  />
 </label>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.hbs
@@ -1,8 +1,4 @@
-<label
-  class={{cn "token-option" token-option--checked=@checked}}
-  data-test-option={{@token.symbol}}
-  ...attributes
->
+<label class={{cn "token-option" token-option--checked=@checked}} ...attributes>
   <Input
     name="deposit-token"
     class={{cn "token-option__input" token-option__input--checked=@checked}}
@@ -10,17 +6,28 @@
     @checked={{@checked}}
     {{on "input" @onInput}}
   />
-  <CardPay::BalanceDisplay
-    @size="large"
-    @icon={{@token.icon}}
-    @name={{@token.symbol}}
-    @text={{@token.description}}
-  />
-  <CardPay::BalanceDisplay
-    @label="Balance"
-    @balance={{@balance}}
-    @symbol={{@token.symbol}}
-    @displayUsdBalance={{true}}
-    data-test-balance={{@token.symbol}}
-  />
+  <div class="token-option__currency">
+    {{svg-jar @tokenIcon class="token-option__icon" role="presentation" width="40" height="40"}}
+    <div>
+      <div class="token-option__title" data-test-option={{@tokenSymbol}}>
+        {{@tokenSymbol}}
+      </div>
+      <div class="token-option__desc">
+        {{@tokenDescription}}
+      </div>
+    </div>
+  </div>
+  <div>
+    <div class="token-option__balance-header">Balance</div>
+    <div class="token-option__balance" data-test-balance={{@tokenSymbol}}>
+      {{@balance}} {{@tokenSymbol}}
+    </div>
+    <div class="token-option__usd-balance" data-test-usd-balance={{@tokenSymbol}}>
+      {{#if @balanceInUsd}}
+        ${{@balanceInUsd}} USD
+      {{else}}
+        <Boxel::LoadingIndicator class="token-option__loading-indicator"/>
+      {{/if}}
+    </div>
+  </div>
 </label>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.hbs
@@ -1,6 +1,6 @@
 <label
   class={{cn "token-option" token-option--checked=@checked}}
-  data-test-option={{@tokenSymbol}}
+  data-test-option={{@token.symbol}}
   ...attributes
 >
   <Input
@@ -12,14 +12,15 @@
   />
   <CardPay::BalanceDisplay
     @size="large"
-    @icon={{@tokenIcon}}
-    @name={{@tokenSymbol}}
-    @text={{@tokenDescription}}
+    @icon={{@token.icon}}
+    @name={{@token.symbol}}
+    @text={{@token.description}}
   />
   <CardPay::BalanceDisplay
     @label="Balance"
     @balance={{@balance}}
-    @symbol={{@tokenSymbol}}
-    @usdBalance={{@balanceInUsd}}
+    @symbol={{@token.symbol}}
+    @displayUsdBalance={{true}}
+    data-test-balance={{@token.symbol}}
   />
 </label>

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
@@ -9,17 +9,16 @@
           <:outer>
             {{!-- TODO: display account avatar and name if available --}}
             <CardPay::AccountDisplay
-              @isComplete={{true}}
+              @size="small"
               @icon="avatar-default"
               @title="Account 1"
-              @address={{this.layer2Network.walletInfo.firstAddress}}
+              @address={{truncate-middle this.layer2Network.walletInfo.firstAddress}}
               data-test-funding-source-account
             />
           </:outer>
           <:inner>
             <CardPay::AccountDisplay
-              @isComplete={{@isComplete}}
-              @inner={{true}}
+              @size={{if @isComplete "large"}}
               @icon="depot"
               @title="DEPOT:"
               @address={{this.depotAddress}}
@@ -38,20 +37,19 @@
         >
           <:outer>
             <CardPay::AccountDisplay
-              @isComplete={{@isComplete}}
+              @size={{if @isComplete "small"}}
               @icon="depot"
               @title="DEPOT:"
-              @address={{this.depotAddress}}
+              @address={{if @isComplete (truncate-middle this.depotAddress) this.depotAddress}}
               data-test-funding-source-depot-outer
             />
           </:outer>
           <:inner>
             {{#if @isComplete}}
               <CardPay::AccountDisplay
-                @isComplete={{@isComplete}}
+                @size="large"
                 @icon={{this.selectedToken.icon}}
-                @balance={{this.selectedToken.balance}}
-                @symbol={{this.selectedToken.symbol}}
+                @title={{concat (format-token-amount this.selectedToken.balance) " " this.selectedToken.symbol}}
                 data-test-funding-source-token
               />
             {{else}}
@@ -67,10 +65,10 @@
                 as |token|>
                   <CardPay::AccountDisplay
                     class={{cn "funding-source__dropdown-option" (if (eq token.symbol this.selectedToken.symbol) "funding-source__dropdown-option--selected")}}
-                    @isComplete={{@isComplete}}
+                    @size="small"
                     @icon={{token.icon}}
-                    @balance={{token.balance}}
-                    @symbol={{token.symbol}}
+                    @title={{token.symbol}}
+                    @text={{concat (format-token-amount token.balance) " " token.symbol}}
                     data-test-funding-source-token-option={{token.symbol}}
                   />
                 </PowerSelect>

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
@@ -68,7 +68,7 @@
                     class={{cn "funding-source__dropdown-option" (if (eq token.symbol this.selectedToken.symbol) "funding-source__dropdown-option--selected")}}
                     @size="small"
                     @icon={{token.icon}}
-                    @title={{token.symbol}}
+                    @name={{token.symbol}}
                     @balance={{token.balance}}
                     @symbol={{token.symbol}}
                     data-test-funding-source-token-option={{token.symbol}}

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
@@ -11,7 +11,7 @@
             <CardPay::AccountDisplay
               @size="small"
               @icon="avatar-default"
-              @title="Account 1"
+              @name="Account 1"
               @address={{truncate-middle this.layer2Network.walletInfo.firstAddress}}
               data-test-funding-source-account
             />
@@ -20,7 +20,7 @@
             <CardPay::AccountDisplay
               @size={{if @isComplete "large"}}
               @icon="depot"
-              @title="DEPOT:"
+              @name="DEPOT:"
               @address={{this.depotAddress}}
               data-test-funding-source-depot-inner
             />
@@ -39,14 +39,14 @@
             <CardPay::AccountDisplay
               @size={{if @isComplete "small"}}
               @icon="depot"
-              @title="DEPOT:"
+              @name="DEPOT:"
               @address={{if @isComplete (truncate-middle this.depotAddress) this.depotAddress}}
               data-test-funding-source-depot-outer
             />
           </:outer>
           <:inner>
             {{#if @isComplete}}
-              <CardPay::AccountDisplay
+              <CardPay::BalanceDisplay
                 @size="large"
                 @icon={{this.selectedToken.icon}}
                 @balance={{format-token-amount this.selectedToken.balance}}
@@ -64,7 +64,7 @@
                   @verticalPosition="below"
                   data-test-funding-source-dropdown={{this.selectedToken.symbol}}
                 as |token|>
-                  <CardPay::AccountDisplay
+                  <CardPay::BalanceDisplay
                     class={{cn "funding-source__dropdown-option" (if (eq token.symbol this.selectedToken.symbol) "funding-source__dropdown-option--selected")}}
                     @size="small"
                     @icon={{token.icon}}

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
@@ -49,7 +49,8 @@
               <CardPay::AccountDisplay
                 @size="large"
                 @icon={{this.selectedToken.icon}}
-                @title={{concat (format-token-amount this.selectedToken.balance) " " this.selectedToken.symbol}}
+                @balance={{format-token-amount this.selectedToken.balance}}
+                @symbol={{this.selectedToken.symbol}}
                 data-test-funding-source-token
               />
             {{else}}
@@ -68,7 +69,8 @@
                     @size="small"
                     @icon={{token.icon}}
                     @title={{token.symbol}}
-                    @text={{concat (format-token-amount token.balance) " " token.symbol}}
+                    @balance={{format-token-amount token.balance}}
+                    @symbol={{token.symbol}}
                     data-test-funding-source-token-option={{token.symbol}}
                   />
                 </PowerSelect>

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
@@ -49,7 +49,7 @@
               <CardPay::BalanceDisplay
                 @size="large"
                 @icon={{this.selectedToken.icon}}
-                @balance={{format-token-amount this.selectedToken.balance}}
+                @balance={{this.selectedToken.balance}}
                 @symbol={{this.selectedToken.symbol}}
                 data-test-funding-source-token
               />
@@ -69,7 +69,7 @@
                     @size="small"
                     @icon={{token.icon}}
                     @title={{token.symbol}}
-                    @balance={{format-token-amount token.balance}}
+                    @balance={{token.balance}}
                     @symbol={{token.symbol}}
                     data-test-funding-source-token-option={{token.symbol}}
                   />

--- a/packages/web-client/app/components/card-pay/labeled-value/index.css
+++ b/packages/web-client/app/components/card-pay/labeled-value/index.css
@@ -1,18 +1,15 @@
 .card-pay-labeled-value {
   --boxel-field-label-width: minmax(4rem, 25%);
-  --field-text-line-height: 1.375rem;
 
   align-items: start;
 }
 
-/* vertically aligning centers of the label text and the content text using line height */
 .card-pay-labeled-value__label {
-  line-height: var(--field-text-line-height);
+  margin-top: 2px;
 }
 
 .card-pay-labeled-value__contents {
-  font-size: var(--boxel-font-size);
-  line-height: var(--field-text-line-height);
+  font: var(--boxel-font);
   letter-spacing: var(--boxel-lsp-sm);
 }
 
@@ -34,9 +31,9 @@
 
 /* utility class used for small icons - currency, and the check mark */
 .card-pay-labeled-value__small-icon {
-  width: 1.25rem;
-  height: 1.25rem;
-  margin-right: 0.5rem;
+  width: var(--boxel-icon-sm);
+  height: var(--boxel-icon-sm);
+  margin-right: var(--boxel-sp-xxs);
 }
 
 .card-pay-labeled-value--vertical {

--- a/packages/web-client/app/components/card-pay/labeled-value/index.hbs
+++ b/packages/web-client/app/components/card-pay/labeled-value/index.hbs
@@ -1,8 +1,8 @@
 {{#if @vertical}}
-  <div class={{cn
-    "card-pay-labeled-value"
-    "card-pay-labeled-value--vertical"
-    card-pay-labeled-value--address=@isAddress
+  <div class={{cn 
+    "card-pay-labeled-value" 
+    "card-pay-labeled-value--vertical" 
+    card-pay-labeled-value--address=@isAddress 
     card-pay-labeled-value--has-icon=@icon
     card-pay-labeled-value--has-block=(has-block)
   }}

--- a/packages/web-client/app/components/card-pay/labeled-value/index.hbs
+++ b/packages/web-client/app/components/card-pay/labeled-value/index.hbs
@@ -1,8 +1,8 @@
 {{#if @vertical}}
-  <div class={{cn 
-    "card-pay-labeled-value" 
-    "card-pay-labeled-value--vertical" 
-    card-pay-labeled-value--address=@isAddress 
+  <div class={{cn
+    "card-pay-labeled-value"
+    "card-pay-labeled-value--vertical"
+    card-pay-labeled-value--address=@isAddress
     card-pay-labeled-value--has-icon=@icon
     card-pay-labeled-value--has-block=(has-block)
   }}

--- a/packages/web-client/app/components/card-pay/layer-two-connect-card/index.css
+++ b/packages/web-client/app/components/card-pay/layer-two-connect-card/index.css
@@ -81,3 +81,8 @@
 .layer-two-connect-card__loading-qr > span {
   margin: auto;
 }
+
+.layer-two-connect-card__account-display svg {
+  width: var(--boxel-icon-sm);
+  height: var(--boxel-icon-sm);
+}

--- a/packages/web-client/app/components/card-pay/layer-two-connect-card/index.css
+++ b/packages/web-client/app/components/card-pay/layer-two-connect-card/index.css
@@ -82,7 +82,6 @@
   margin: auto;
 }
 
-.layer-two-connect-card__account-display svg {
-  width: var(--boxel-icon-sm);
-  height: var(--boxel-icon-sm);
+.layer-two-connect-card__account-display {
+  --icon-size: var(--boxel-icon-sm);
 }

--- a/packages/web-client/app/components/card-pay/layer-two-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-two-connect-card/index.hbs
@@ -21,11 +21,15 @@
           @label="Network"
           @value={{this.layer2Network.chainName}}
         />
-        <CardPay::LabeledValue
-          @label="Address"
-          @value={{this.layer2Network.walletInfo.firstAddress}}
-          @isAddress={{true}}
-        />
+        <CardPay::LabeledValue @label="Account">
+          <CardPay::AccountDisplay
+            class="layer-two-connect-card__account-display"
+            @icon="avatar-default"
+            @name="Account 1"
+            @address={{this.layer2Network.walletInfo.firstAddress}}
+            @wrapped={{true}}
+          />
+        </CardPay::LabeledValue>
         <CardPay::LabeledValue @label="Depot balance" data-test-balance-container>
           {{#if this.layer2Network.isFetchingDepot}}
             <Boxel::LoadingIndicator data-test-balance-container-loading/>

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -142,12 +142,12 @@ module('Acceptance | deposit', function (hooks) {
 
     // transaction-setup card
     await waitFor(`${post} [data-test-balance="DAI"]`);
-    assert.dom(`${post} [data-test-balance="DAI"]`).containsText('250.50 DAI');
-    assert.dom(`${post} [data-test-balance="DAI"]`).containsText('$50.10');
+    assert.dom(`${post} [data-test-balance="DAI"]`).containsText('250.50');
+    assert.dom(`${post} [data-test-usd-balance="DAI"]`).containsText('50.10');
+    assert.dom(`${post} [data-test-balance="CARD"]`).containsText('10000.00');
     assert
-      .dom(`${post} [data-test-balance="CARD"]`)
-      .containsText('10000.00 CARD');
-    assert.dom(`${post} [data-test-balance="CARD"]`).containsText('$2000.00');
+      .dom(`${post} [data-test-usd-balance="CARD"]`)
+      .containsText('2000.00');
     assert
       .dom(
         `${post} [data-test-deposit-transaction-setup-from-address] [data-test-account-address]`

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -142,12 +142,12 @@ module('Acceptance | deposit', function (hooks) {
 
     // transaction-setup card
     await waitFor(`${post} [data-test-balance="DAI"]`);
-    assert.dom(`${post} [data-test-balance="DAI"]`).containsText('250.50');
-    assert.dom(`${post} [data-test-usd-balance="DAI"]`).containsText('50.10');
-    assert.dom(`${post} [data-test-balance="CARD"]`).containsText('10000.00');
+    assert.dom(`${post} [data-test-balance="DAI"]`).containsText('250.50 DAI');
+    assert.dom(`${post} [data-test-balance="DAI"]`).containsText('$50.10');
     assert
-      .dom(`${post} [data-test-usd-balance="CARD"]`)
-      .containsText('2000.00');
+      .dom(`${post} [data-test-balance="CARD"]`)
+      .containsText('10000.00 CARD');
+    assert.dom(`${post} [data-test-balance="CARD"]`).containsText('$2000.00');
     assert
       .dom(
         `${post} [data-test-deposit-transaction-setup-from-address] [data-test-account-address]`
@@ -218,7 +218,8 @@ module('Acceptance | deposit', function (hooks) {
     assert
       .dom('[data-test-deposit-amount-input]')
       .doesNotExist('Input field is no longer available when unlocking');
-    assert.dom('[data-test-deposit-amount-entered]').hasText('250.00 DAI');
+
+    assert.dom('[data-test-deposit-amount-entered]').containsText('250.00 DAI');
 
     layer1Service.test__simulateUnlock();
     await settled();

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -166,7 +166,9 @@ module('Acceptance | deposit', function (hooks) {
     assert
       .dom('[data-test-deposit-transaction-setup-is-complete]')
       .doesNotExist();
-    assert.dom(`${post} [data-test-option-view-only]`).doesNotExist();
+    assert
+      .dom(`${post} [data-test-deposit-transaction-setup-from-option]`)
+      .exists({ count: 2 });
     assert
       .dom('[data-test-deposit-transaction-setup] [data-test-boxel-button]')
       .isDisabled();
@@ -176,13 +178,17 @@ module('Acceptance | deposit', function (hooks) {
     );
     // transaction-setup card (memorialized)
     assert.dom(`${post} [data-test-option]`).doesNotExist();
-    assert.dom(`${post} [data-test-option-view-only]`).exists({ count: 1 });
+    assert
+      .dom(`${post} [data-test-deposit-transaction-setup-from-option]`)
+      .doesNotExist();
     assert
       .dom('[data-test-deposit-transaction-setup] [data-test-boxel-button]')
       .isNotDisabled();
     assert.dom('[data-test-deposit-transaction-setup-is-complete]').exists();
     assert
-      .dom(`${post} [data-test-balance-view-only="DAI"]`)
+      .dom(
+        `${post} [data-test-deposit-transaction-setup-from-balance="DAI"] [data-test-account-title]`
+      )
       .containsText('250.50');
     // transaction-amount card
     assert
@@ -212,7 +218,7 @@ module('Acceptance | deposit', function (hooks) {
     assert
       .dom('[data-test-deposit-amount-input]')
       .doesNotExist('Input field is no longer available when unlocking');
-    assert.dom('[data-test-deposit-amount-entered]').hasText('250 DAI');
+    assert.dom('[data-test-deposit-amount-entered]').hasText('250.00 DAI');
 
     layer1Service.test__simulateUnlock();
     await settled();

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -187,7 +187,7 @@ module('Acceptance | deposit', function (hooks) {
     assert.dom('[data-test-deposit-transaction-setup-is-complete]').exists();
     assert
       .dom(
-        `${post} [data-test-deposit-transaction-setup-from-balance="DAI"] [data-test-account-balance]`
+        `${post} [data-test-deposit-transaction-setup-from-balance="DAI"] [data-test-balance-display-amount]`
       )
       .containsText('250.50');
     // transaction-amount card

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -187,7 +187,7 @@ module('Acceptance | deposit', function (hooks) {
     assert.dom('[data-test-deposit-transaction-setup-is-complete]').exists();
     assert
       .dom(
-        `${post} [data-test-deposit-transaction-setup-from-balance="DAI"] [data-test-account-title]`
+        `${post} [data-test-deposit-transaction-setup-from-balance="DAI"] [data-test-account-balance]`
       )
       .containsText('250.50');
     // transaction-amount card

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -149,13 +149,19 @@ module('Acceptance | deposit', function (hooks) {
       .dom(`${post} [data-test-usd-balance="CARD"]`)
       .containsText('2000.00');
     assert
-      .dom(`${post} [data-test-deposit-transaction-setup-from-address]`)
+      .dom(
+        `${post} [data-test-deposit-transaction-setup-from-address] [data-test-account-address]`
+      )
       .hasText(layer1AccountAddress);
     assert
-      .dom(`${post} [data-test-deposit-transaction-setup-to-address]`)
+      .dom(
+        `${post} [data-test-deposit-transaction-setup-to-address] [data-test-account-address]`
+      )
       .hasText('0x1826...6E44');
     assert
-      .dom(`${post} [data-test-deposit-transaction-setup-depot-address]`)
+      .dom(
+        `${post} [data-test-deposit-transaction-setup-depot-address] [data-test-account-text]`
+      )
       .hasText('New Depot');
     assert
       .dom('[data-test-deposit-transaction-setup-is-complete]')

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -196,7 +196,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
     assert.dom('[data-test-funding-source-dropdown="DAI.CPXD"]').exists();
     assert
       .dom(
-        '[data-test-funding-source-dropdown="DAI.CPXD"] [data-test-account-balance]'
+        '[data-test-funding-source-dropdown="DAI.CPXD"] [data-test-balance-display-amount]'
       )
       .containsText('250.00 DAI');
 
@@ -207,7 +207,9 @@ module('Acceptance | issue prepaid card', function (hooks) {
       `${post} [data-test-boxel-action-chin] [data-test-boxel-button]`
     );
     assert
-      .dom('[data-test-funding-source-token] [data-test-account-balance]')
+      .dom(
+        '[data-test-funding-source-token] [data-test-balance-display-amount]'
+      )
       .containsText('500.00 CARD');
 
     await click(
@@ -221,7 +223,9 @@ module('Acceptance | issue prepaid card', function (hooks) {
 
     assert.dom('[data-test-funding-source-dropdown="DAI.CPXD"]').doesNotExist();
     assert
-      .dom('[data-test-funding-source-token] [data-test-account-balance]')
+      .dom(
+        '[data-test-funding-source-token] [data-test-balance-display-amount]'
+      )
       .containsText('250.00 DAI');
 
     assert

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -196,7 +196,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
     assert.dom('[data-test-funding-source-dropdown="DAI.CPXD"]').exists();
     assert
       .dom(
-        '[data-test-funding-source-dropdown="DAI.CPXD"] [data-test-account-balance]'
+        '[data-test-funding-source-dropdown="DAI.CPXD"] [data-test-account-text]'
       )
       .containsText('250.00 DAI');
 

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -196,7 +196,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
     assert.dom('[data-test-funding-source-dropdown="DAI.CPXD"]').exists();
     assert
       .dom(
-        '[data-test-funding-source-dropdown="DAI.CPXD"] [data-test-account-text]'
+        '[data-test-funding-source-dropdown="DAI.CPXD"] [data-test-account-balance]'
       )
       .containsText('250.00 DAI');
 
@@ -207,7 +207,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
       `${post} [data-test-boxel-action-chin] [data-test-boxel-button]`
     );
     assert
-      .dom('[data-test-funding-source-token] [data-test-account-title]')
+      .dom('[data-test-funding-source-token] [data-test-account-balance]')
       .containsText('500.00 CARD');
 
     await click(
@@ -221,7 +221,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
 
     assert.dom('[data-test-funding-source-dropdown="DAI.CPXD"]').doesNotExist();
     assert
-      .dom('[data-test-funding-source-token] [data-test-account-title]')
+      .dom('[data-test-funding-source-token] [data-test-account-balance]')
       .containsText('250.00 DAI');
 
     assert


### PR DESCRIPTION
Use the `AccountDisplay` and `BalanceDisplay` components

Here are some examples:

## BalanceDisplay component:
With `size="large"`, `icon`, `balance`, and `symbol` args:
<img width="251" alt="lg-icon-balance-symbol" src="https://user-images.githubusercontent.com/16160806/122440118-42417080-cf6a-11eb-87bb-4c16bd752066.png">

With `size="large"`, `icon`, `balance`, `symbol` and `displayUsdBalance=true` args:
<img width="145" alt="lg-icon-balance-usdbalance" src="https://user-images.githubusercontent.com/16160806/122440137-49687e80-cf6a-11eb-9858-5bd1ff5d0f2a.png">

With `size="small"`, `icon`, `name`, `balance`, `symbol`:
<img width="150" alt="sm-icon-title-balance-symbol" src="https://user-images.githubusercontent.com/16160806/122440629-be3bb880-cf6a-11eb-899e-b77a8722989a.png">


## AccountDisplay component:
With `size="large"`, `icon`, `name` and `text` args:
<img width="165" alt="lg-title-text" src="https://user-images.githubusercontent.com/16160806/122440037-2dfd7380-cf6a-11eb-8268-f0202c292414.png">

With `size="large"`, `icon`, `name`, and `address` args:
<img width="285" alt="lg-icon-title-address" src="https://user-images.githubusercontent.com/16160806/122440245-600ed580-cf6a-11eb-96e9-277aab2ed297.png">

With `icon`, `name`, and `text` args:
<img width="148" alt="def-title-text-depot" src="https://user-images.githubusercontent.com/16160806/122439984-2047ee00-cf6a-11eb-8819-6cc2651d6dca.png">

With `name` and `address` args:
<img width="475" alt="def-title-address" src="https://user-images.githubusercontent.com/16160806/122439373-9ac43e00-cf69-11eb-939b-0260180625a5.png">

With `icon`, `name`, and `address` args:
<img width="478" alt="def-icon-title-address" src="https://user-images.githubusercontent.com/16160806/122439426-a3b50f80-cf69-11eb-841b-af9853416454.png">

With `size="small"`, `name`, `address`, and `wrapped`:
<img width="191" alt="sm-title-address-wrapped" src="https://user-images.githubusercontent.com/16160806/122441831-f1cb1280-cf6b-11eb-8bf9-b068d0c32586.png">

With `size="small"`, `icon`, `name`, `address`:
<img width="182" alt="sm-icon-title-address" src="https://user-images.githubusercontent.com/16160806/122441009-1d99c880-cf6b-11eb-93e5-618d6f2823ff.png">