### PR TITLE
be more lenient with subgraph errors and use more recent start block

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,7 +57,7 @@
 
         // Kovan DAI Bridge args
         "bridge",
-        "10",
+        "30",
         "0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa", // Kovan DAI
         "--network", "kovan",
         // Hassan's testing mnemonic feel free to use your own
@@ -127,7 +127,7 @@
         "0xeAA4965f22D66aAd04FAC81212155442F3e5326a", // Hassan's depot safe feel free to use your own
         "0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1", // DAI.CPXD
         "did:cardstack:56d6fc54-d399-443b-8778-d7e4512d3a49",
-        "500",
+        "100",
         "--network", "sokol",
         // Hassan's testing mnemonic feel free to use your own
         "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"

--- a/packages/cardpay-subgraph/package.json
+++ b/packages/cardpay-subgraph/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "codegen": "node ./etc/pre-codegen-entrypoint.js poa-sokol && graph codegen && node ./etc/pre-tsc-build-entrypoint.js",
     "build": "graph build",
-    "deploy-sokol": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ habdelra/cardpay-sokol",
+    "deploy-sokol": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ habdelra/cardpay-sokol-ver-0_5_6",
     "create-local-sokol": "graph create --node http://localhost:8020/ habdelra/cardpay-sokol",
     "remove-local-sokol": "graph remove --node http://localhost:8020/ habdelra/cardpay-sokol",
     "deploy-local-sokol": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 habdelra/cardpay-sokol"

--- a/packages/cardpay-subgraph/src/mappings/prepaid-card.ts
+++ b/packages/cardpay-subgraph/src/mappings/prepaid-card.ts
@@ -1,8 +1,11 @@
 import { CreatePrepaidCard, PrepaidCardManager } from '../../generated/PrepaidCard/PrepaidCardManager';
 import { Account, PrepaidCard, PrepaidCardCreation } from '../../generated/schema';
 import { assertTransactionExists, toChecksumAddress } from '../utils';
+import { log } from '@graphprotocol/graph-ts';
 
 export function handleCreatePrepaidCard(event: CreatePrepaidCard): void {
+  let prepaidCard = toChecksumAddress(event.params.card);
+  log.info('indexing new prepaid card {}', [prepaidCard]);
   assertTransactionExists(event);
   let issuer = toChecksumAddress(event.params.issuer);
   let accountEntity = new Account(issuer);
@@ -11,8 +14,8 @@ export function handleCreatePrepaidCard(event: CreatePrepaidCard): void {
   let prepaidCardMgr = PrepaidCardManager.bind(event.address);
   let cardInfo = prepaidCardMgr.cardDetails(event.params.card);
   let reloadable = cardInfo.value4;
-  let prepaidCard = toChecksumAddress(event.params.card);
   let issuingToken = toChecksumAddress(event.params.token);
+
   let prepaidCardEntity = new PrepaidCard(prepaidCard);
   prepaidCardEntity.safe = prepaidCard;
   prepaidCardEntity.customizationDID = event.params.customizationDID;

--- a/packages/cardpay-subgraph/src/mappings/revenue-pool.ts
+++ b/packages/cardpay-subgraph/src/mappings/revenue-pool.ts
@@ -14,6 +14,7 @@ import {
   PrepaidCard,
 } from '../../generated/schema';
 import { assertTransactionExists, toChecksumAddress } from '../utils';
+import { log } from '@graphprotocol/graph-ts';
 
 export function handleMerchantPayment(event: MerchantPaymentEvent): void {
   assertTransactionExists(event);
@@ -28,12 +29,9 @@ export function handleMerchantPayment(event: MerchantPaymentEvent): void {
     prepaidCardEntity.issuingTokenBalance = prepaidCardEntity.issuingTokenBalance - event.params.issuingTokenAmount;
     prepaidCardEntity.save();
   } else {
-    assert(
-      false,
-      'Error while processing merchant payment txn ' +
-        txnHash +
-        ', PrepaidCard entity does not exist for prepaid card ' +
-        prepaidCard
+    log.warning(
+      'Cannot process merchant payment txn {}: PrepaidCard entity does not exist for prepaid card {}. This is likely due to the subgraph having a startBlock that is higher than the block the prepaid card was created in.',
+      [txnHash, prepaidCard]
     );
     return;
   }

--- a/packages/cardpay-subgraph/src/mappings/spend.ts
+++ b/packages/cardpay-subgraph/src/mappings/spend.ts
@@ -1,6 +1,7 @@
 import { Mint as MintEvent } from '../../generated/Spend/Spend';
 import { SpendAccumulation, MerchantSafe } from '../../generated/schema';
 import { assertTransactionExists, toChecksumAddress } from '../utils';
+import { log } from '@graphprotocol/graph-ts';
 
 export function handleMint(event: MintEvent): void {
   assertTransactionExists(event);
@@ -13,12 +14,9 @@ export function handleMint(event: MintEvent): void {
     merchantSafeEntity.spendBalance = merchantSafeEntity.spendBalance + event.params.amount;
     merchantSafeEntity.save();
   } else {
-    assert(
-      false,
-      'Error while processing spend minting txn ' +
-        txnHash +
-        ', MerchantSafe entity does not exist for address ' +
-        merchantSafe
+    log.warning(
+      'Cannot process spend minting txn {}: MerchantSafe entity does not exist for safe address {}. This is likely due to the subgraph having a startBlock that is higher than the block the merchant safe was created in.',
+      [txnHash, merchantSafe]
     );
     return;
   }

--- a/packages/cardpay-subgraph/subgraph-template.yaml
+++ b/packages/cardpay-subgraph/subgraph-template.yaml
@@ -36,16 +36,16 @@ dataSources:
     source:
       address: "{PREPAID_CARD_MANAGER_ADDRESS}"
       abi: PrepaidCardManager
-      startBlock: 20030732 # this is the block when gnosis safes were first added to sokol. we'll need to look this up for xDai
+      startBlock: 21372398 # v0.5.6 version of protocol
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
       language: wasm/assemblyscript
       entities:
-        - Safe
         - PrepaidCard
-        - Depot
+        - PrepaidCardCreation
         - Transaction
+        - Account
       abis:
         - name: PrepaidCardManager
           file: ./abis/PrepaidCardManager.json
@@ -60,17 +60,18 @@ dataSources:
     source:
       address: "{REVENUE_POOL_ADDRESS}"
       abi: RevenuePool
-      startBlock: 20030732 # this is the block when gnosis safes were first added to sokol. we'll need to look this up for xDai
+      startBlock: 21372398 # v0.5.6 version of protocol
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
       language: wasm/assemblyscript
       entities:
-        - Safe
-        - PrepaidCard
-        - MerchantSafe
         - Transaction
         - PrepaidCardPayment
+        - MerchantFeePayment
+        - Account
+        - MerchantSafe
+        - MerchantCreation
       abis:
         - name: RevenuePool
           file: ./abis/RevenuePool.json
@@ -89,14 +90,14 @@ dataSources:
     source:
       address: "{SPEND_ADDRESS}"
       abi: Spend
-      startBlock: 20030732 # this is the block when gnosis safes were first added to sokol. we'll need to look this up for xDai
+      startBlock: 21372398 # v0.5.6 version of protocol
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
       language: wasm/assemblyscript
       entities:
-        - SpendAccumulation
         - Transaction
+        - SpendAccumulation
       abis:
         - name: Spend
           file: ./abis/Spend.json
@@ -111,7 +112,7 @@ dataSources:
     source:
       address: "{BRIDGE_UTILS_ADDRESS}"
       abi: BridgeUtils
-      startBlock: 20030732 # this is the block when gnosis safes were first added to sokol. we'll need to look this up for xDai
+      startBlock: 21372398 # v0.5.6 version of protocol
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -136,15 +137,17 @@ dataSources:
     source:
       address: "{HOME_TOKEN_BRIDGE_ADDRESS}"
       abi: HomeMultiAMBErc20ToErc677
-      startBlock: 20030732 # this is the block when gnosis safes were first added to sokol. we'll need to look this up for xDai
+      startBlock: 21372398 # v0.5.6 version of protocol
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
       language: wasm/assemblyscript
       entities:
-        - Safe
+        - Account
         - Depot
         - Transaction
+        - SupplierInfoDIDUpdate
+        - BridgeEvent
       abis:
         - name: HomeMultiAMBErc20ToErc677
           file: ./abis/HomeMultiAMBErc20ToErc677.json
@@ -160,14 +163,15 @@ dataSources:
     source:
       address: "0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B"
       abi: GnosisProxyFactory
-      startBlock: 20030732 # this is the block when gnosis safes were first added to sokol. we'll need to look this up for xDai
+      startBlock: 21372398 # v0.5.6 version of protocol
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
       language: wasm/assemblyscript
       entities:
         - Safe
-        - Transaction
+        - Account
+        - SafeOwner
       abis:
         - name: GnosisProxyFactory
           file: ./abis/GnosisProxyFactory.json


### PR DESCRIPTION
it looks like `assert` failures (which is the closest thing to throwing an exception in assembly script) during indexing will actually halt *all* indexing, not just the current event you are dealing with. Stopped using `assert` since we don't want to break all of indexing when we see an event we don't understand. Also advanced the start block for indexing to the latest version of the contracts so that we can skip over old events that are fashioned oddly compared to the current event shapes