### PR TITLE
move into the hub package for yarn start hub

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "lint:hbs": "cd packages/web-client && ember-template-lint .",
     "lint:hbs:web-client": "cd packages/web-client && ember-template-lint .",
     "start": "WAIT_ON_TIMEOUT=600000 start-server-and-test 'yarn start:web-client' http://localhost:4200 'yarn start:hub'",
-    "start:hub": "./packages/hub/bin/server.ts",
+    "start:hub": "cd ./packages/hub && node ./bin/server.ts",
     "console:hub": "node --experimental-repl-await ./packages/hub/bin/console.ts",
     "start:web-client": "cd packages/web-client && ember serve",
     "test": "npm-run-all --aggregate-output --continue-on-error --parallel test:*",


### PR DESCRIPTION
Right now, we have to `cd packages/hub && node ./bin/server` in order to have the db config available to the `config` package, `yarn start` doesn't work. See: https://github.com/lorenwest/node-config/issues/225

To reproduce, try `yarn start` and performing a request to `/api/prepaid-card-color-schemes`:
```
await (await fetch("http://localhost:3000/api/prepaid-card-color-schemes", {
  method: "GET",
  headers: {
    Accept: "application/vnd.api+json",
  },
})).json()
```

This makes it easier to do `yarn start` from the root folder and still have access to db config.

Alternatively, we could move the config up to the root directory? (Yet to try). 
There is an option to configure the config directory via an environment variable, but this didn't work properly when I tried it.