### PR TITLE
use postgres setup from hub workflow in main ci

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -8,7 +8,27 @@ jobs:
   test:
     name: Build & Lint & Test
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+          -v /var/run/postgresql/:/var/run/postgresql
+
     steps:
+    - name: Create database
+      run: sudo -u postgres createdb hub_test
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
@@ -22,6 +42,7 @@ jobs:
           ${{ runner.os }}-yarn-
     - run: yarn global add lerna
     - run: yarn --prefer-offline
+    - run: yarn test:hub:preparedb
     - run: yarn lint
     - run: yarn test
 


### PR DESCRIPTION
Tests for the hub are failing at the moment:

```
2 failing

  1) GET /api/prepaid-card-color-schemes
       "before each" hook for "responds with 200 and available color schemes":
     Error: connect ECONNREFUSED 127.0.0.1:5432
      at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1146:16)

  2) GET /api/prepaid-card-patterns
       "before each" hook for "responds with 200 and available header patterns":
     Error: connect ECONNREFUSED 127.0.0.1:5432
      at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1146:16)
```

This adds db setup to our main CI to see if it fixes these tests.