### PR TITLE
pass callback to yargs warning about mnemonic

### DIFF
--- a/packages/cardpay-cli/index.ts
+++ b/packages/cardpay-cli/index.ts
@@ -348,8 +348,10 @@ const {
   .help().argv as Options;
 
 if (!mnemonic) {
-  yargs.showHelp(
-    'No mnemonic is defined, either specify the mnemonic as a positional arg or pass it in using the MNEMONIC_PHRASE env var'
+  yargs.showHelp(() =>
+    console.log(
+      'No mnemonic is defined, either specify the mnemonic as a positional arg or pass it in using the MNEMONIC_PHRASE env var'
+    )
   );
   process.exit(1);
 }


### PR DESCRIPTION
When there is no mnemonic provided, `yargs.showHelp` throws this error:

```
/Users/b/Documents/Cardstack/Code/cardstack/node_modules/yargs/build/index.cjs:1
TypeError: emit is not a function
    at Object.self.showHelp (/Users/b/Documents/Cardstack/Code/cardstack/node_modules/yargs/build/index.cjs:1100:9)
    at Object.Yargs.self.showHelp (/Users/b/Documents/Cardstack/Code/cardstack/node_modules/yargs/build/index.cjs:2495:17)
```

This fixes it so it shows the desired message.

https://yargs.js.org/docs/#api-reference-showhelpconsolelevel-printcallback