### PR TITLE
use exchangeRateOf from exchange contract

### DIFF
--- a/packages/cardpay-sdk/sdk/revenue-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/revenue-pool/base.ts
@@ -2,6 +2,7 @@ import Web3 from 'web3';
 import { AbiItem } from 'web3-utils';
 import { Contract, ContractOptions } from 'web3-eth-contract';
 import RevenuePoolABI from '../../contracts/abi/v0.6.0/revenue-pool';
+import ExchangeABI from '../../contracts/abi/v0.6.0/exchange';
 import ERC20ABI from '../../contracts/abi/erc-20';
 import { getAddress } from '../../contracts/addresses';
 import {
@@ -39,11 +40,11 @@ export default class RevenuePool {
   }
 
   async currentTokenUSDRate(tokenAddress: string): Promise<string> {
-    let revenuePool = new this.layer2Web3.eth.Contract(
-      RevenuePoolABI as AbiItem[],
-      await getAddress('revenuePool', this.layer2Web3)
+    let exchange = new this.layer2Web3.eth.Contract(
+      ExchangeABI as AbiItem[],
+      await getAddress('exchange', this.layer2Web3)
     );
-    let { price } = await revenuePool.methods.exchangeRateOf(tokenAddress).call();
+    let { price } = await exchange.methods.exchangeRateOf(tokenAddress).call();
     return price;
   }
 

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -11,7 +11,7 @@
   "description": "Stock API server for the Cardstack tech stack.",
   "dependencies": {
     "@cardstack/logger": "^0.2.1",
-    "@cardstack/did-resolver": "0.19.18",
+    "@cardstack/did-resolver": "0.19.19",
     "@types/fs-extra": "^9.0.11",
     "@types/koa": "^2.13.1",
     "@types/koa-route": "^3.2.4",


### PR DESCRIPTION
Found issue when registering merchant. 

```
Paying merchant registration fee in the amount of §1000 SPEND from prepaid card address 0x4C949d3258F74e5f3A5a2C2234FB7c76D07af0eb...
TypeError: revenuePool.methods.exchangeRateOf is not a function
    at RevenuePool.currentTokenUSDRate (/Users/tintinthong/Documents/GitHub/cardstack/packages/cardpay-sdk/sdk/revenue-pool/base.js:22:51)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async RevenuePool.registerMerchant (/Users/tintinthong/Documents/GitHub/cardstack/packages/cardpay-sdk/sdk/revenue-pool/base.js:70:28)
    at async registerMerchant (/Users/tintinthong/Documents/GitHub/cardstack/packages/cardpay-cli/revenue-pool.js:10:46)
    at async /Users/tintinthong/Documents/GitHub/cardstack/packages/cardpay-cli/index.js:284:13
```

I think this is because you moved `exchangeRateOf` into out of revenue contract.