### PR TITLE
make typings for uuid part of published pkg for did-resolver

### DIFF
--- a/packages/did-resolver/package.json
+++ b/packages/did-resolver/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
+    "@types/uuid": "^8.3.0",
     "did-resolver": "^3.1.0",
     "js-sha3": "^0.8.0",
     "lodash": "^4.17.21",
@@ -18,7 +19,6 @@
     "@cardstack/test-support": "0.19.20",
     "@types/chai": "^4.2.15",
     "@types/lodash": "^4.14.169",
-    "@types/uuid": "^8.3.0",
     "chai": "^4.3.4",
     "fast-check": "^1.26.0"
   },


### PR DESCRIPTION
move @types/uuid to dependencies instead of devDeps, because did-resolver is a published package and npm publish gets mad without this