### PR TITLE
ember-cli-dotenv only runs in development

### DIFF
--- a/packages/web-client/config/dotenv.js
+++ b/packages/web-client/config/dotenv.js
@@ -4,8 +4,9 @@
 
 const path = require('path');
 
-module.exports = function (/* env */) {
+module.exports = function (env) {
   return {
+    enabled: env === 'development',
     clientAllowedKeys: [],
     fastbootAllowedKeys: [],
     failOnMissingKey: false,


### PR DESCRIPTION
Use provided API to turn off for any environment besides development.

https://github.com/fivetanley/ember-cli-dotenv#environment-specific-use