### PR TITLE
Remove tokens other than dai from funding options; null case UI fallback

### DIFF
--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
@@ -3,7 +3,7 @@
   @isComplete={{@isComplete}}
 >
   <ActionCardContainer::Section>
-    <ActionCardContainer::Section @title="Choose a balance to fund your prepaid card">
+    <ActionCardContainer::Section @title="Choose a depot and balance to fund your prepaid card">
       <CardPay::LabeledValue @label="DEPOT:" class="funding-source__field">
         <CardPay::NestedItems class="funding-source__field-info">
           <:outer>
@@ -22,71 +22,74 @@
               @icon="depot"
               @name="DEPOT:"
               @address={{this.depotAddress}}
+              @text={{unless this.depotAddress "None"}}
               data-test-funding-source-depot-inner
             />
           </:inner>
         </CardPay::NestedItems>
       </CardPay::LabeledValue>
     </ActionCardContainer::Section>
-    <ActionCardContainer::Section>
-      <CardPay::LabeledValue @label="BALANCE:" class="funding-source__field">
-        <CardPay::NestedItems
-          class="funding-source__field-info"
-          @noBorder={{not @isComplete}}
-          @noIndent={{not @isComplete}}
-        >
-          <:outer>
-            <CardPay::AccountDisplay
-              @size={{if @isComplete "small"}}
-              @icon="depot"
-              @name="DEPOT:"
-              @address={{if @isComplete (truncate-middle this.depotAddress) this.depotAddress}}
-              data-test-funding-source-depot-outer
-            />
-          </:outer>
-          <:inner>
-            {{#if @isComplete}}
-              <CardPay::BalanceDisplay
-                @size="large"
-                @icon={{this.selectedToken.icon}}
-                @balance={{this.selectedToken.balance}}
-                @symbol={{this.selectedToken.symbol}}
-                data-test-funding-source-token
+    {{#if this.depotAddress}}
+      <ActionCardContainer::Section>
+        <CardPay::LabeledValue @label="BALANCE:" class="funding-source__field">
+          <CardPay::NestedItems
+            class="funding-source__field-info"
+            @noBorder={{not @isComplete}}
+            @noIndent={{not @isComplete}}
+          >
+            <:outer>
+              <CardPay::AccountDisplay
+                @size={{if @isComplete "small"}}
+                @icon="depot"
+                @name="DEPOT:"
+                @address={{if @isComplete (truncate-middle this.depotAddress) this.depotAddress}}
+                data-test-funding-source-depot-outer
               />
-            {{else}}
-              <div class="funding-source__nested-dropdown">
-                <PowerSelect
-                  class="funding-source__dropdown"
-                  @options={{this.tokens}}
-                  @selected={{this.selectedToken}}
-                  @onChange={{this.chooseSource}}
-                  @renderInPlace={{true}}
-                  @verticalPosition="below"
-                  data-test-funding-source-dropdown={{this.selectedToken.symbol}}
-                as |token|>
-                  <CardPay::BalanceDisplay
-                    class={{cn "funding-source__dropdown-option" (if (eq token.symbol this.selectedToken.symbol) "funding-source__dropdown-option--selected")}}
-                    @size="small"
-                    @icon={{token.icon}}
-                    @name={{token.symbol}}
-                    @balance={{token.balance}}
-                    @symbol={{token.symbol}}
-                    data-test-funding-source-token-option={{token.symbol}}
-                  />
-                </PowerSelect>
-              </div>
-            {{/if}}
-          </:inner>
-        </CardPay::NestedItems>
-      </CardPay::LabeledValue>
-    </ActionCardContainer::Section>
+            </:outer>
+            <:inner>
+              {{#if @isComplete}}
+                <CardPay::BalanceDisplay
+                  @size="large"
+                  @icon={{this.selectedToken.icon}}
+                  @balance={{this.selectedToken.balance}}
+                  @symbol={{this.selectedToken.symbol}}
+                  data-test-funding-source-token
+                />
+              {{else}}
+                <div class="funding-source__nested-dropdown">
+                  <PowerSelect
+                    class="funding-source__dropdown"
+                    @options={{this.tokens}}
+                    @selected={{this.selectedToken}}
+                    @onChange={{this.chooseSource}}
+                    @renderInPlace={{true}}
+                    @verticalPosition="below"
+                    data-test-funding-source-dropdown={{this.selectedToken.symbol}}
+                  as |token|>
+                    <CardPay::BalanceDisplay
+                      class={{cn "funding-source__dropdown-option" (if (eq token.symbol this.selectedToken.symbol) "funding-source__dropdown-option--selected")}}
+                      @size="small"
+                      @icon={{token.icon}}
+                      @name={{token.symbol}}
+                      @balance={{token.balance}}
+                      @symbol={{token.symbol}}
+                      data-test-funding-source-token-option={{token.symbol}}
+                    />
+                  </PowerSelect>
+                </div>
+              {{/if}}
+            </:inner>
+          </CardPay::NestedItems>
+        </CardPay::LabeledValue>
+      </ActionCardContainer::Section>
+    {{/if}}
   </ActionCardContainer::Section>
   <Boxel::ActionChin
     @state={{if @isComplete "memorialized" "default"}}
-    @disabled={{@frozen}}
+    @disabled={{or @frozen this.isDisabled}}
   >
     <:default as |d|>
-      <d.ActionButton {{on "click" @onComplete}}>
+      <d.ActionButton {{on "click" this.save}}>
         Continue
       </d.ActionButton>
     </:default>

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -76,7 +76,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
         new WorkflowMessage({
           author: cardbot,
           message:
-            'On to the next step: How do you want to fund your prepaid card? Please select a balance from your xDai chain wallet.',
+            'On to the next step: How do you want to fund your prepaid card? Please select a depot and balance from your xDai chain wallet.',
         }),
         new WorkflowCard({
           author: cardbot,

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -79,8 +79,9 @@ module('Acceptance | issue prepaid card', function (hooks) {
       defaultToken: toBN('250000000000000000000'),
       card: toBN('500000000000000000000'),
     });
+    let depotAddress = '0xB236ca8DbAB0644ffCD32518eBF4924ba8666666';
     let testDepot = {
-      address: '0xB236ca8DbAB0644ffCD32518eBF4924ba8666666',
+      address: depotAddress,
       tokens: [
         {
           balance: '250000000000000000000',
@@ -210,42 +211,15 @@ module('Acceptance | issue prepaid card', function (hooks) {
       .hasText('0x1826...6E44');
     assert
       .dom('[data-test-funding-source-depot-outer] [data-test-account-address]')
-      .hasText('0xB236ca8DbAB0644ffCD32518eBF4924ba8666666');
-
-    assert.dom('[data-test-funding-source-dropdown="DAI.CPXD"]').exists();
+      .hasText(depotAddress);
     assert
-      .dom(
-        '[data-test-funding-source-dropdown="DAI.CPXD"] [data-test-balance-display-amount]'
-      )
+      .dom('[data-test-funding-source-dropdown="DAI.CPXD"]')
       .containsText('250.00 DAI');
-
-    await click('[data-test-funding-source-dropdown="DAI.CPXD"] > div');
-
-    await click('[data-test-funding-source-token-option="CARD.CPXD"]');
     await click(
       `${post} [data-test-boxel-action-chin] [data-test-boxel-button]`
     );
-    assert
-      .dom(
-        '[data-test-funding-source-token] [data-test-balance-display-amount]'
-      )
-      .containsText('500.00 CARD');
-
-    await click(
-      `${post} [data-test-boxel-action-chin] [data-test-boxel-button]`
-    );
-    await click('[data-test-funding-source-dropdown="CARD.CPXD"] > div');
-    await click('[data-test-funding-source-token-option="DAI.CPXD"]');
-    await click(
-      `${post} [data-test-boxel-action-chin] [data-test-boxel-button]`
-    );
-
     assert.dom('[data-test-funding-source-dropdown="DAI.CPXD"]').doesNotExist();
-    assert
-      .dom(
-        '[data-test-funding-source-token] [data-test-balance-display-amount]'
-      )
-      .containsText('250.00 DAI');
+    assert.dom('[data-test-funding-source-token]').containsText('250.00 DAI');
 
     assert
       .dom(postableSel(2, 3))


### PR DESCRIPTION
 - Keep only dai as the funding option but keep it an array just in case
 - Do not change workflow state until user clicks Save (resolves the 'state was already set' error)
 - Disable chin if there's no depot or dai balance
 - Make UI look less broken in disabled state