### PR TITLE
Add “older messages” docked footer

### DIFF
--- a/packages/web-client/app/components/dummy-tall/index.hbs
+++ b/packages/web-client/app/components/dummy-tall/index.hbs
@@ -1,3 +1,0 @@
-{{!-- template-lint-disable no-inline-styles --}}
-<div style="height: 10000px">This is a tall component used to test the workflow thread.</div>
-It is done.

--- a/packages/web-client/app/components/dummy-tall/index.hbs
+++ b/packages/web-client/app/components/dummy-tall/index.hbs
@@ -1,0 +1,3 @@
+{{!-- template-lint-disable no-inline-styles --}}
+<div style="height: 10000px">This is a tall component used to test the workflow thread.</div>
+It is done.

--- a/packages/web-client/app/components/workflow-thread/index.css
+++ b/packages/web-client/app/components/workflow-thread/index.css
@@ -20,3 +20,19 @@
 .workflow-thread:focus:not(:focus-visible) {
   box-shadow: 0 1px 3px rgb(0 0 0 / 15%);
 }
+
+/* FIXME better name, to extract maybe? */
+.workflow-thread__older {
+  position: fixed;
+  bottom: 0;
+  background: var(--boxel-purple-500);
+  margin-left: calc(var(--boxel-sp) * -1);
+  margin-right: var(--boxel-sp);
+  width: calc(43.75rem + var(--boxel-sp) * 2);
+  color: var(--boxel-light);
+  border-radius: var(--boxel-border-radius) var(--boxel-border-radius) 0 0;
+}
+
+.workflow-thread__older .label {
+  padding: var(--boxel-sp-xxxs) var(--boxel-sp-sm);
+}

--- a/packages/web-client/app/components/workflow-thread/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/index.hbs
@@ -60,6 +60,7 @@
     {{#unless this.threadEndVisible}}
       <div class="workflow-thread__older" data-test-older>
         <div class="label">You’re looking at older messages</div>
+        <button {{on "click" this.scrollToEnd}} type="button" data-test-jump-to-latest>Jump to latest</button>
       </div>
     {{/unless}}
   </:content>

--- a/packages/web-client/app/components/workflow-thread/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/index.hbs
@@ -55,7 +55,13 @@
          />
       {{/each}}
     {{/if}}
-    <div data-thread-end></div>
+    <div data-thread-end {{did-insert this.setupInViewport}}></div>
+
+    {{#unless this.threadEndVisible}}
+      <div class="workflow-thread__older" data-test-older>
+        <div class="label">You’re looking at older messages</div>
+      </div>
+    {{/unless}}
   </:content>
   <:sidebar as |SidebarSection|>
     <SidebarSection>

--- a/packages/web-client/app/components/workflow-thread/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/index.hbs
@@ -58,10 +58,10 @@
     <div data-thread-end {{did-insert this.setupInViewport}}></div>
 
     {{#unless this.threadEndVisible}}
-      <div class="workflow-thread__older" data-test-older>
+      <footer class="workflow-thread__older" data-test-older>
         <div class="label">You’re looking at older messages</div>
         <button {{on "click" this.scrollToEnd}} type="button" data-test-jump-to-latest>Jump to latest</button>
-      </div>
+      </footer>
     {{/unless}}
   </:content>
   <:sidebar as |SidebarSection|>

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -100,6 +100,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.4",
     "ember-focus-trap": "^0.6.0",
+    "ember-in-viewport": "^3.10.2",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-page-title": "^6.2.1",

--- a/packages/web-client/tests/integration/components/workflow-thread-test.ts
+++ b/packages/web-client/tests/integration/components/workflow-thread-test.ts
@@ -1,6 +1,13 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { find, render, settled, waitFor, waitUntil } from '@ember/test-helpers';
+import {
+  find,
+  click,
+  render,
+  settled,
+  waitFor,
+  waitUntil,
+} from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { Workflow } from '@cardstack/web-client/models/workflow';
 import { Milestone } from '@cardstack/web-client/models/workflow/milestone';
@@ -291,12 +298,26 @@ module('Integration | Component | workflow-thread', function (hooks) {
     assert.dom('[data-test-older]').doesNotExist();
 
     // FIXME better way to address scroll container? There are two 🤔
-    find('.boxel-thread__scroll-wrapper')?.scrollTo(0, 0);
+    const scrollWrapper = find('.boxel-thread__scroll-wrapper');
+    scrollWrapper?.scrollTo(0, 0);
 
     await waitUntil(() => {
       return find('[data-test-older]');
     });
 
     assert.dom('[data-test-older]').exists();
+
+    await click('[data-test-jump-to-latest]');
+    await waitUntil(() => {
+      return find('[data-test-older]') === null;
+    });
+
+    assert.dom('[data-test-older]').doesNotExist();
+    // FIXME works in development, but off by 44 in tests?
+    // assert.equal(
+    //   scrollWrapper?.clientHeight,
+    //   scrollWrapper?.scrollHeight - scrollWrapper?.scrollTop,
+    //   'scroll wrapper is scrolled to the bottom'
+    // );
   });
 });

--- a/packages/web-client/tests/integration/components/workflow-thread-test.ts
+++ b/packages/web-client/tests/integration/components/workflow-thread-test.ts
@@ -247,6 +247,14 @@ module('Integration | Component | workflow-thread', function (hooks) {
   });
 
   test('a docked footer message shows when more messages are hidden below', async function (assert) {
+    this.owner.register(
+      'template:components/dummy-tall',
+      hbs`
+        {{!-- template-lint-disable no-inline-styles --}}
+        <div style="height: 10000px">A very tall component</div>
+        It is done.`
+    );
+
     let workflow = new ConcreteWorkflow(this.owner);
     let message = () =>
       new WorkflowMessage({
@@ -256,7 +264,7 @@ module('Integration | Component | workflow-thread', function (hooks) {
 
     let target = new WorkflowCard({
       author: { name: 'cardbot' },
-      componentName: 'dummy-tall', // FIXME any way to register component for this test only?
+      componentName: 'dummy-tall',
     });
     target.isComplete = true;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10253,6 +10253,18 @@ ember-in-element-polyfill@^1.0.1:
     ember-cli-htmlbars "^5.3.1"
     ember-cli-version-checker "^5.1.2"
 
+ember-in-viewport@^3.10.2:
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/ember-in-viewport/-/ember-in-viewport-3.10.2.tgz#78ad3d42ba94354fd05e7adb7a701da351041556"
+  integrity sha512-mOLqknUm+OjPqyYq9BO+h9RIcI3dhebPpfd8jM90/GXVv7jLNz1szq5nk0K0yZT861kY+dEjGLqLGqo1J4pSDQ==
+  dependencies:
+    ember-auto-import "^1.11.2"
+    ember-cli-babel "^7.26.3"
+    ember-modifier "^2.1.0"
+    fast-deep-equal "^2.0.1"
+    intersection-observer-admin "~0.3.2"
+    raf-pool "~0.1.4"
+
 "ember-inflector@^2.0.0 || ^3.0.0 || ^4.0.0":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-4.0.2.tgz#4494f1a5f61c1aca7702d59d54024cc92211d8ec"
@@ -11847,6 +11859,11 @@ fast-check@^1.26.0:
   dependencies:
     pure-rand "^2.0.0"
     tslib "^2.0.0"
+
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
 fast-deep-equal@^3.1.1:
   version "3.1.1"
@@ -13698,6 +13715,11 @@ interpret@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
+
+intersection-observer-admin@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/intersection-observer-admin/-/intersection-observer-admin-0.3.2.tgz#0b6e95ce7272a383e8bbdd47f9ff48de9eab9919"
+  integrity sha512-kJEcF9iVRuI4thXiJd28UzFDgvFHBNUgwkKA4F0bPMmRdzc+1Eq7/J13n2gSgfZ5tsVxb+wJOV7k3DXcsc7D6Q==
 
 invariant@^2.2.2:
   version "2.2.4"
@@ -18660,6 +18682,11 @@ qunit@^2.14.0, qunit@^2.14.1:
     js-reporters "1.2.3"
     node-watch "0.7.1"
     tiny-glob "0.2.8"
+
+raf-pool@~0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/raf-pool/-/raf-pool-0.1.4.tgz#6b9f75ea1903c16e162ffe8c76688f5a625bc2cd"
+  integrity sha512-BBPamTVuSprPq7CUmgxc+ycbsYUtUYnQtJYEfMHXMaostPaNpQzipLfSa/rwjmlgjBPiD7G+I+8W340sLOPu6g==
 
 ramda@^0.24.1:
   version "0.24.1"


### PR DESCRIPTION
This has a way to go and will probably have a followup PR to address the “15 new messages” use case.

One notable TODO is that I was unable to get `ember-in-viewport`’s `in-viewport` modifier working, specifically the `onExit` was never firing. This is using `did-insert` and the service instead, which is less elegant, hopefully I can get the modifier working somehow.