### PR TITLE
register dummy component in test directly

### DIFF
--- a/packages/web-client/app/components/dummy-test/index.hbs
+++ b/packages/web-client/app/components/dummy-test/index.hbs
@@ -1,1 +1,0 @@
-This is a component used as to test the workflow thread.

--- a/packages/web-client/tests/integration/components/workflow-thread-test.ts
+++ b/packages/web-client/tests/integration/components/workflow-thread-test.ts
@@ -194,6 +194,13 @@ module('Integration | Component | workflow-thread', function (hooks) {
   });
 
   test('A workflow can be rolled back', async function (assert) {
+    this.owner.register(
+      'template:components/dummy-test',
+      hbs`
+        <div>Just a dummy component so we don't have to depend on existing components for this test</div>
+        `
+    );
+
     let workflow = new ConcreteWorkflow(this.owner);
     let message = () =>
       new WorkflowMessage({


### PR DESCRIPTION
Register a dummy test component in a test directly instead of adding a template that is otherwise unused. Thanks @backspace!