### PR TITLE
Enhancement/workflow cancelation on render

### DIFF
--- a/packages/web-client/app/components/card-pay/layer-two-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-two-connect-card/index.hbs
@@ -1,4 +1,5 @@
 <ActionCardContainer
+  {{did-insert @onRender}}
   @suppressHeader={{@suppressHeader}}
   @header={{concat "Wallet - " this.layer2Network.chainName}}
   @isComplete={{@isComplete}}

--- a/packages/web-client/app/components/card-pay/layer-two-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-two-connect-card/index.hbs
@@ -1,5 +1,5 @@
 <ActionCardContainer
-  {{did-insert @onRender}}
+  {{did-insert (optional @onRender)}}
   @suppressHeader={{@suppressHeader}}
   @header={{concat "Wallet - " this.layer2Network.chainName}}
   @isComplete={{@isComplete}}

--- a/packages/web-client/app/components/workflow-thread/postable/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/postable/index.hbs
@@ -43,6 +43,7 @@
         onComplete=(optional @postable.onComplete)
         onIncomplete=(optional @postable.onIncomplete)
         isComplete=@postable.isComplete
+        onRender=(optional @postable.onRender)
       }}
     </div>
   </Boxel::ThreadMessage>

--- a/packages/web-client/app/models/workflow/workflow-card.ts
+++ b/packages/web-client/app/models/workflow/workflow-card.ts
@@ -6,12 +6,13 @@ interface WorkflowCardOptions {
   author: Participant;
   componentName: string; // this should eventually become a card reference
   includeIf: () => boolean;
+  onRender?: () => void;
 }
 
 export class WorkflowCard extends WorkflowPostable {
   componentName: string;
   constructor(options: Partial<WorkflowCardOptions>) {
-    super(options.author!, options.includeIf);
+    super(options.author!, options.includeIf, options.onRender);
     this.componentName = options.componentName!;
     this.reset = () => {
       if (this.isComplete) {

--- a/packages/web-client/app/models/workflow/workflow-postable.ts
+++ b/packages/web-client/app/models/workflow/workflow-postable.ts
@@ -14,11 +14,14 @@ export class WorkflowPostable {
   @tracked isComplete: boolean = false;
   constructor(
     author: Participant,
-    includeIf: (() => boolean) | undefined = undefined
+    includeIf: (() => boolean) | undefined = undefined,
+    onRender: (() => void) | undefined = undefined
   ) {
     this.author = author;
     this.includeIf = includeIf;
+    this.onRender = onRender;
   }
   includeIf: (() => boolean) | undefined;
+  onRender: (() => void) | undefined;
   reset: (() => void) | undefined;
 }


### PR DESCRIPTION
Competing implementation (vs #1742, #1764) of prepaid card workflow cancelation when there isn't enough DAI to create a prepaid card.

- Adds an optional `onRender` callback to postables
- `onRender` hook is called by the layer 2 connect card to cancel the workflow if funds are insufficient