### PR TITLE
removed "sender" from token swap

### DIFF
--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -8,8 +8,7 @@ type Account @entity {
   createdMerchants: [MerchantCreation]!            @derivedFrom(field: "merchant")
   receivedPrepaidCards: [PrepaidCardTransfer]!     @derivedFrom(field: "to")
   sentPrepaidCards: [PrepaidCardTransfer]!         @derivedFrom(field: "from")
-  sentTokenSwaps: [TokenSwap]!                     @derivedFrom(field: "sender") # generally the "sender" and "to" addresses for token swaps are the same, but they have the ability to be different
-  receivedTokenSwaps: [TokenSwap]!                 @derivedFrom(field: "to")
+  tokenSwaps: [TokenSwap]!                         @derivedFrom(field: "to")
   tokens: [TokenHolder]!                           @derivedFrom(field: "account")
   transactions: [EOATransaction]!                  @derivedFrom(field: "account")
 }
@@ -176,7 +175,6 @@ type TokenSwap @entity {
   transaction: Transaction!
   timestamp: BigInt!
   tokenPair: TokenPair!
-  sender: Account!
   to: Account!
   token0AmountIn: BigInt!
   token0AmountOut: BigInt!

--- a/packages/cardpay-subgraph/src/mappings/gnosis-safe.ts
+++ b/packages/cardpay-subgraph/src/mappings/gnosis-safe.ts
@@ -25,7 +25,6 @@ export function handleExecutionSuccess(event: ExecutionSuccess): void {
   let bytes = event.transaction.input.toHex();
   let methodHash = methodHashFromEncodedHex(bytes);
 
-  // TODO handle all the PrepaidCardMethod's functions too
   if (methodHash == encodeMethodSignature(EXEC_TRANSACTION)) {
     let safeTxEntity = new SafeTransaction(txnHash + '-' + event.logIndex.toString());
     safeTxEntity.safe = safeAddress;

--- a/packages/cardpay-subgraph/src/mappings/token-pair.ts
+++ b/packages/cardpay-subgraph/src/mappings/token-pair.ts
@@ -3,14 +3,7 @@ import { makeEOATransaction, makeEOATransactionForSafe, toChecksumAddress } from
 import { Safe, TokenSwap } from '../../generated/schema';
 
 export function handleSwap(event: SwapEvent): void {
-  let sender = toChecksumAddress(event.params.sender);
   let to = toChecksumAddress(event.params.to);
-  let senderSafe = Safe.load(sender);
-  if (senderSafe != null) {
-    makeEOATransactionForSafe(event, senderSafe as Safe);
-  } else {
-    makeEOATransaction(event, sender);
-  }
   let toSafe = Safe.load(to);
   if (toSafe != null) {
     makeEOATransactionForSafe(event, toSafe as Safe);
@@ -24,7 +17,6 @@ export function handleSwap(event: SwapEvent): void {
   swapEntity.transaction = txnHash;
   swapEntity.timestamp = event.block.timestamp;
   swapEntity.tokenPair = pair;
-  swapEntity.sender = sender;
   swapEntity.to = to;
   swapEntity.token0AmountIn = event.params.amount0In;
   swapEntity.token0AmountOut = event.params.amount0Out;

--- a/packages/cardpay-subgraph/src/utils.ts
+++ b/packages/cardpay-subgraph/src/utils.ts
@@ -12,6 +12,7 @@ import {
   PrepaidCardPayment,
   Token,
   Safe,
+  Account,
 } from '../generated/schema';
 import { GnosisSafe } from '../generated/Gnosis/GnosisSafe';
 
@@ -35,6 +36,9 @@ export function makeTransaction(event: ethereum.Event): void {
 
 export function makeEOATransaction(event: ethereum.Event, address: string): void {
   makeTransaction(event);
+  let accountEntity = new Account(address);
+  accountEntity.save();
+
   let txnHash = event.transaction.hash.toHex();
   let entity = new EOATransaction(txnHash + '-' + address);
   entity.transaction = txnHash;


### PR DESCRIPTION
this is too low level of a detail to track and ultimately probably just confusing to clients