### PR TITLE
typescript eslint overrides

### DIFF
--- a/packages/web-client/.eslintrc.js
+++ b/packages/web-client/.eslintrc.js
@@ -19,11 +19,16 @@ module.exports = {
   env: {
     browser: true,
   },
-  rules: {
-    'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error'],
-  },
   overrides: [
+    // typescript-specific
+    {
+      files: ['*.ts'],
+      rules: {
+        'no-undef': 'off',
+        'no-unused-vars': 'off',
+        '@typescript-eslint/no-unused-vars': ['error'],
+      },
+    },
     // node files
     {
       files: [


### PR DESCRIPTION
- no-undef is off, because typescript should cover this
- this is strongly recommended by typescript-eslint https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors