### PR TITLE
Enhancement/workflow cancelations via check

### DIFF
--- a/packages/web-client/app/components/workflow-check/index.ts
+++ b/packages/web-client/app/components/workflow-check/index.ts
@@ -1,0 +1,20 @@
+import Component from '@glimmer/component';
+
+interface WorkflowCheckArgs {
+  onComplete: () => void;
+  check: () => Promise<boolean>;
+  cancel: () => void;
+}
+
+export default class WorkflowCheck extends Component<WorkflowCheckArgs> {
+  constructor(owner: unknown, args: any) {
+    super(owner, args);
+    this.args.check().then((v) => {
+      if (v) {
+        this.args.onComplete();
+      } else {
+        this.args.cancel();
+      }
+    });
+  }
+}

--- a/packages/web-client/app/components/workflow-thread/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/index.hbs
@@ -18,7 +18,6 @@
       {{#each milestone.visiblePostables as |postable j|}}
         <WorkflowThread::Postable
           @postable={{postable}}
-          @previous={{object-at milestone.visiblePostables (dec j)}}
           @frozen={{or this.workflow.isComplete this.workflow.isCanceled}}
           @index={{j}}
           data-test-milestone={{i}}
@@ -39,7 +38,6 @@
       {{#each this.workflow.epilogue.visiblePostables as |postable j|}}
         <WorkflowThread::Postable
           @postable={{postable}}
-          @previous={{object-at this.workflow.epilogue.visiblePostables (dec j)}}
           @index={{j}}
           data-test-epilogue
         />
@@ -49,7 +47,6 @@
          <WorkflowThread::Postable
            {{did-insert this.scrollToEnd}}
            @postable={{postable}}
-           @previous={{if (eq j 0) this.lastMilestonePostable (object-at this.workflow.cancelationMessages.visiblePostables (dec j))}}
            @index={{j}}
            data-test-cancelation
          />

--- a/packages/web-client/app/components/workflow-thread/postable/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/postable/index.hbs
@@ -5,53 +5,55 @@
     @cancel={{@postable.cancel}}
   />
 {{else}}
-  {{#if (is-postable-on-new-day @postable)}}
-    <Boxel::DateDivider
-      @date={{@postable.timestamp}}
-      class="workflow-date-divider-animated"
-      data-test-date-divider
-    />
-  {{/if}}
-  {{#if @postable.message}}
-    <Boxel::ThreadMessage
-      @datetime={{@postable.timestamp}}
-      @imgURL={{@postable.author.imgURL}}
-      @name={{@postable.author.name}}
-      @hideName={{true}}
-      @hideMeta={{postable-meta-hidden @postable previous=@previous}}
-      data-test-postable={{@index}}
-      class="workflow-postable-animated"
-      ...attributes
-    >
-      <div class="workflow-thread-postable__markdown">
-        {{format-workflow-message @postable.message}}
-      </div>
-    </Boxel::ThreadMessage>
-  {{else}}
-    <Boxel::ThreadMessage
-      @fullWidth={{true}}
-      @datetime={{@postable.timestamp}}
-      @imgURL={{@postable.author.imgURL}}
-      @name={{@postable.author.name}}
-      @hideName={{true}}
-      @hideMeta={{postable-meta-hidden @postable previous=@previous}}
-      data-test-postable={{@index}}
-      class="workflow-postable-animated workflow-postable-animated--has-card"
-      ...attributes
-    >
-      <div class={{cn
-        "workflow-thread-postable__card"
-        workflow-thread-postable__card--is-complete=@postable.isComplete
-      }}>
-        {{component
-          @postable.componentName
-          workflowSession=@postable.session
-          frozen=@frozen
-          onComplete=(optional @postable.onComplete)
-          onIncomplete=(optional @postable.onIncomplete)
-          isComplete=@postable.isComplete
-        }}
-      </div>
-    </Boxel::ThreadMessage>
-  {{/if}}
+  {{#let (get-previous-visible-postable @postable) as |previous|}}
+    {{#if (is-postable-on-new-day @postable previous=previous)}}
+      <Boxel::DateDivider
+        @date={{@postable.timestamp}}
+        class="workflow-date-divider-animated"
+        data-test-date-divider
+      />
+    {{/if}}
+    {{#if @postable.message}}
+      <Boxel::ThreadMessage
+        @datetime={{@postable.timestamp}}
+        @imgURL={{@postable.author.imgURL}}
+        @name={{@postable.author.name}}
+        @hideName={{true}}
+        @hideMeta={{postable-meta-hidden @postable previous=previous}}
+        data-test-postable={{@index}}
+        class="workflow-postable-animated"
+        ...attributes
+      >
+        <div class="workflow-thread-postable__markdown">
+          {{format-workflow-message @postable.message}}
+        </div>
+      </Boxel::ThreadMessage>
+    {{else}}
+      <Boxel::ThreadMessage
+        @fullWidth={{true}}
+        @datetime={{@postable.timestamp}}
+        @imgURL={{@postable.author.imgURL}}
+        @name={{@postable.author.name}}
+        @hideName={{true}}
+        @hideMeta={{postable-meta-hidden @postable previous=previous}}
+        data-test-postable={{@index}}
+        class="workflow-postable-animated workflow-postable-animated--has-card"
+        ...attributes
+      >
+        <div class={{cn
+          "workflow-thread-postable__card"
+          workflow-thread-postable__card--is-complete=@postable.isComplete
+        }}>
+          {{component
+            @postable.componentName
+            workflowSession=@postable.session
+            frozen=@frozen
+            onComplete=(optional @postable.onComplete)
+            onIncomplete=(optional @postable.onIncomplete)
+            isComplete=@postable.isComplete
+          }}
+        </div>
+      </Boxel::ThreadMessage>
+    {{/if}}
+  {{/let}}
 {{/if}}

--- a/packages/web-client/app/components/workflow-thread/postable/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/postable/index.hbs
@@ -1,49 +1,57 @@
-{{#if (is-postable-on-new-day @postable)}}
-  <Boxel::DateDivider
-    @date={{@postable.timestamp}}
-    class="workflow-date-divider-animated"
-    data-test-date-divider
+{{#if @postable._isCheck}}
+  <WorkflowCheck
+    @check={{@postable.check}}
+    @onComplete={{@postable.onComplete}}
+    @cancel={{@postable.cancel}}
   />
-{{/if}}
-{{#if @postable.message}}
-  <Boxel::ThreadMessage
-    @datetime={{@postable.timestamp}}
-    @imgURL={{@postable.author.imgURL}}
-    @name={{@postable.author.name}}
-    @hideName={{true}}
-    @hideMeta={{postable-meta-hidden @postable previous=@previous}}
-    data-test-postable={{@index}}
-    class="workflow-postable-animated"
-    ...attributes
-  >
-    <div class="workflow-thread-postable__markdown">
-      {{format-workflow-message @postable.message}}
-    </div>
-  </Boxel::ThreadMessage>
 {{else}}
-  <Boxel::ThreadMessage
-    @fullWidth={{true}}
-    @datetime={{@postable.timestamp}}
-    @imgURL={{@postable.author.imgURL}}
-    @name={{@postable.author.name}}
-    @hideName={{true}}
-    @hideMeta={{postable-meta-hidden @postable previous=@previous}}
-    data-test-postable={{@index}}
-    class="workflow-postable-animated workflow-postable-animated--has-card"
-    ...attributes
-  >
-    <div class={{cn
-      "workflow-thread-postable__card"
-      workflow-thread-postable__card--is-complete=@postable.isComplete
-    }}>
-      {{component
-        @postable.componentName
-        workflowSession=@postable.session
-        frozen=@frozen
-        onComplete=(optional @postable.onComplete)
-        onIncomplete=(optional @postable.onIncomplete)
-        isComplete=@postable.isComplete
-      }}
-    </div>
-  </Boxel::ThreadMessage>
+  {{#if (is-postable-on-new-day @postable)}}
+    <Boxel::DateDivider
+      @date={{@postable.timestamp}}
+      class="workflow-date-divider-animated"
+      data-test-date-divider
+    />
+  {{/if}}
+  {{#if @postable.message}}
+    <Boxel::ThreadMessage
+      @datetime={{@postable.timestamp}}
+      @imgURL={{@postable.author.imgURL}}
+      @name={{@postable.author.name}}
+      @hideName={{true}}
+      @hideMeta={{postable-meta-hidden @postable previous=@previous}}
+      data-test-postable={{@index}}
+      class="workflow-postable-animated"
+      ...attributes
+    >
+      <div class="workflow-thread-postable__markdown">
+        {{format-workflow-message @postable.message}}
+      </div>
+    </Boxel::ThreadMessage>
+  {{else}}
+    <Boxel::ThreadMessage
+      @fullWidth={{true}}
+      @datetime={{@postable.timestamp}}
+      @imgURL={{@postable.author.imgURL}}
+      @name={{@postable.author.name}}
+      @hideName={{true}}
+      @hideMeta={{postable-meta-hidden @postable previous=@previous}}
+      data-test-postable={{@index}}
+      class="workflow-postable-animated workflow-postable-animated--has-card"
+      ...attributes
+    >
+      <div class={{cn
+        "workflow-thread-postable__card"
+        workflow-thread-postable__card--is-complete=@postable.isComplete
+      }}>
+        {{component
+          @postable.componentName
+          workflowSession=@postable.session
+          frozen=@frozen
+          onComplete=(optional @postable.onComplete)
+          onIncomplete=(optional @postable.onIncomplete)
+          isComplete=@postable.isComplete
+        }}
+      </div>
+    </Boxel::ThreadMessage>
+  {{/if}}
 {{/if}}

--- a/packages/web-client/app/helpers/get-previous-visible-postable.ts
+++ b/packages/web-client/app/helpers/get-previous-visible-postable.ts
@@ -1,0 +1,25 @@
+import { helper } from '@ember/component/helper';
+import { WorkflowPostable } from '../models/workflow/workflow-postable';
+
+function getPreviousVisiblePostable([postable]: [WorkflowPostable]) {
+  if (!postable) {
+    return null;
+  }
+
+  let workflowVisiblePostables = postable!.workflow!.peekAtVisiblePostables();
+  let result = null;
+
+  for (let candidate of workflowVisiblePostables) {
+    if (candidate === postable) {
+      return result;
+    }
+
+    if (!(candidate as any)._isCheck) {
+      result = candidate;
+    }
+  }
+
+  return null;
+}
+
+export default helper(getPreviousVisiblePostable);

--- a/packages/web-client/app/helpers/is-postable-on-new-day.ts
+++ b/packages/web-client/app/helpers/is-postable-on-new-day.ts
@@ -1,19 +1,18 @@
 import { helper } from '@ember/component/helper';
 import { WorkflowPostable } from '../models/workflow/workflow-postable';
 
-function isPostableOnNewDay([postable]: [WorkflowPostable]) {
+function isPostableOnNewDay(
+  [postable]: [WorkflowPostable],
+  { previous }: { previous: WorkflowPostable }
+) {
   if (!postable) {
     return false;
   }
 
-  let workflowVisiblePostables = postable!.workflow!.peekAtVisiblePostables();
-
-  let previousPostable =
-    workflowVisiblePostables[workflowVisiblePostables.indexOf(postable) - 1];
-  if (!previousPostable) {
+  if (!previous) {
     return true;
   }
-  let previousDate = previousPostable.timestamp!.getDate();
+  let previousDate = previous.timestamp!.getDate();
   let postableDate = postable.timestamp!.getDate();
   return previousDate !== postableDate;
 }

--- a/packages/web-client/app/helpers/postable-meta-hidden.ts
+++ b/packages/web-client/app/helpers/postable-meta-hidden.ts
@@ -5,7 +5,7 @@ import { WorkflowCard } from '../models/workflow/workflow-card';
 
 function postableMetaHidden(
   [post]: [WorkflowPostable | WorkflowCard],
-  { previous }: WorkflowPostable | WorkflowCard
+  { previous }: { previous: WorkflowPostable }
 ) {
   let isSameGroup = postableMetaIdentical([post, previous]);
 

--- a/packages/web-client/app/models/animated-workflow.ts
+++ b/packages/web-client/app/models/animated-workflow.ts
@@ -11,6 +11,7 @@ import { A } from '@ember/array';
 import { buildWaiter } from '@ember/test-waiters';
 import RSVP, { defer } from 'rsvp';
 import { UnbindEventListener } from '../utils/events';
+import { WorkflowCheck } from './workflow/workflow-check';
 
 let waiter = buildWaiter('thread-animation');
 let token: any = null;
@@ -177,7 +178,8 @@ export default class AnimatedWorkflow {
         this.stopTestWaiter();
       }
 
-      yield rawTimeout(this.interval);
+      if (!(result.postable instanceof WorkflowCheck))
+        yield rawTimeout(this.interval);
     }
   }
 

--- a/packages/web-client/app/models/workflow/workflow-check.ts
+++ b/packages/web-client/app/models/workflow/workflow-check.ts
@@ -1,0 +1,46 @@
+import { action } from '@ember/object';
+import { Participant, WorkflowPostable } from './workflow-postable';
+import WorkflowSession from './workflow-session';
+
+interface WorkflowCheckOptions {
+  author: Participant;
+  componentName: string; // this should eventually become a card reference
+  includeIf: () => boolean;
+  check: () => Promise<boolean>;
+  failureReason: string;
+}
+
+export class WorkflowCheck extends WorkflowPostable {
+  check: () => Promise<boolean>;
+  failureReason: string;
+  _isCheck = true;
+
+  constructor(options: Partial<WorkflowCheckOptions>) {
+    super(options.author!, options.includeIf);
+    if (!options.check || !options.failureReason) {
+      throw new Error(
+        'Workflow check used without providing a callback or failure reason'
+      );
+    }
+    this.reset = () => {
+      if (this.isComplete) {
+        this.isComplete = false;
+      }
+    };
+    this.failureReason = options.failureReason;
+    this.check = options.check;
+  }
+
+  @action cancel() {
+    this.workflow?.cancel(this.failureReason);
+  }
+
+  get session(): WorkflowSession | undefined {
+    return this.workflow?.session;
+  }
+
+  @action onComplete() {
+    this.workflow?.emit('visible-postables-changed');
+    this.isComplete = true;
+  }
+}

--- a/packages/web-client/app/models/workflow/workflow-check.ts
+++ b/packages/web-client/app/models/workflow/workflow-check.ts
@@ -4,7 +4,6 @@ import WorkflowSession from './workflow-session';
 
 interface WorkflowCheckOptions {
   author: Participant;
-  componentName: string; // this should eventually become a card reference
   includeIf: () => boolean;
   check: () => Promise<boolean>;
   failureReason: string;

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -122,10 +122,10 @@ module('Acceptance | issue prepaid card', function (hooks) {
       .containsText('xDai chain wallet connected');
 
     assert
-      .dom(postableSel(1, 0))
+      .dom(postableSel(1, 1))
       .containsText('First, you can choose the look and feel of your card');
 
-    post = postableSel(1, 1);
+    post = postableSel(1, 2);
 
     assert.dom('[data-test-layout-customization-form]').isVisible();
     assert
@@ -425,10 +425,10 @@ module('Acceptance | issue prepaid card', function (hooks) {
       .containsText('xDai chain wallet connected');
 
     assert
-      .dom(postableSel(1, 0))
+      .dom(postableSel(1, 1))
       .containsText('First, you can choose the look and feel of your card');
 
-    post = postableSel(1, 1);
+    post = postableSel(1, 2);
 
     assert.dom('[data-test-layout-customization-form]').isVisible();
     assert
@@ -541,10 +541,10 @@ module('Acceptance | issue prepaid card', function (hooks) {
       .containsText('xDai chain wallet connected');
 
     assert
-      .dom(postableSel(1, 0))
+      .dom(postableSel(1, 1))
       .containsText('First, you can choose the look and feel of your card');
 
-    post = postableSel(1, 1);
+    post = postableSel(1, 2);
 
     assert.dom('[data-test-layout-customization-form]').isVisible();
     assert


### PR DESCRIPTION
Yet another competing implementation of canceling if balance is too low. I think this is probably the cleanest way to do things - even the `onRender` hook can end up racing? with `onComplete` of cards that complete in an asynchronous fashion, but this should avoid that. Tests are passing currently, but will add a test for `WorkflowCheck` model and component prior to merge if this approach seems sensible.

- Adds a `WorkflowCheck` model that extends `WorkflowPostable`. It provides a way to specify in the workflow what you want to check and where you want to check it, and information needed to cancel the workflow if the runtime check fails. 
- Adds a component with the same name. The component does not render anything to the DOM, but calls the check provided by the model above and cancels if it returns false. This is used in place of the conventional "message" rendered by `WorkflowThread::Postable` if the postable is a `WorkflowCheck`.
- Modifies the postable rendering to take `WorkflowCheck` into account when deciding whether or not to show meta and date for a postable.

Note:
- `this` within the context of the callback can probably still trip consumers up, similar to the `onRender` hook in #1758
- Test selectors have to take check into account because this workflow check still advances the index for the `data-test-postable` selector