### PR TITLE
Display token conversions of spend amounts on FaceValue selection card

### DIFF
--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
@@ -30,7 +30,7 @@
             @symbol="SPEND"
             @balance={{this.selectedFaceValue.spendAmount}}
             @usdBalance={{spend-to-usd this.selectedFaceValue.spendAmount}}
-            @text={{concat this.selectedFaceValue.tokenAmount " " this.fundingTokenSymbol "*"}}
+            @text={{concat "≈ " this.selectedFaceValue.approxTokenAmount " " this.fundingTokenSymbol "*"}}
             data-test-face-value-display
           />
         </CardPay::LabeledValue>
@@ -38,11 +38,11 @@
         <div class="face-value-card__options">
           {{#each this.options as |option|}}
             <CardPay::IssuePrepaidCardWorkflow::FaceValue::Option
-              @disabled={{lt this.balanceFromBN (spend-to-usd option.spendAmount)}}
+              @disabled={{option.isOptionDisabled}}
               @checked={{eq option.spendAmount this.selectedFaceValue.spendAmount}}
               @spendFaceValue={{option.spendAmount}}
               @usdAmount={{spend-to-usd option.spendAmount}}
-              @tokenAmount={{option.tokenAmount}}
+              @approxTokenAmount={{option.approxTokenAmount}}
               @tokenSymbol={{this.fundingTokenSymbol}}
               @onInput={{fn this.chooseFaceValue option}}
             />

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
@@ -28,22 +28,23 @@
             @icon="spend"
             @sign="§"
             @symbol="SPEND"
-            @balance={{this.selectedFaceValue}}
-            @usdBalance={{spend-to-usd this.selectedFaceValue}}
-            @text={{concat "≈ " (spend-to-usd this.selectedFaceValue) " " this.fundingTokenSymbol "*"}}
+            @balance={{this.selectedFaceValue.spendAmount}}
+            @usdBalance={{spend-to-usd this.selectedFaceValue.spendAmount}}
+            @text={{concat this.selectedFaceValue.tokenAmount " " this.fundingTokenSymbol "*"}}
             data-test-face-value-display
           />
         </CardPay::LabeledValue>
       {{else}}
         <div class="face-value-card__options">
-          {{#each this.faceValueOptions as |amount|}}
+          {{#each this.options as |option|}}
             <CardPay::IssuePrepaidCardWorkflow::FaceValue::Option
-              @disabled={{lt this.balanceFromBN (spend-to-usd amount)}}
-              @checked={{eq amount this.selectedFaceValue}}
-              @spendFaceValue={{amount}}
-              @usdAmount={{spend-to-usd amount}}
-              @approxDaiAmount={{spend-to-usd amount}}
-              @onInput={{fn this.chooseFaceValue amount}}
+              @disabled={{lt this.balanceFromBN (spend-to-usd option.spendAmount)}}
+              @checked={{eq option.spendAmount this.selectedFaceValue.spendAmount}}
+              @spendFaceValue={{option.spendAmount}}
+              @usdAmount={{spend-to-usd option.spendAmount}}
+              @tokenAmount={{option.tokenAmount}}
+              @tokenSymbol={{this.fundingTokenSymbol}}
+              @onInput={{fn this.chooseFaceValue option}}
             />
           {{/each}}
         </div>

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.ts
@@ -24,7 +24,7 @@ class FaceValueCard extends Component<WorkflowCardComponentArgs> {
   faceValueOptions = faceValueOptions;
   spendToUsdRate = spendToUsdRate;
 
-  @service('layer2-network') declare layer2Network: Layer2Network;
+  @service declare layer2Network: Layer2Network;
   @reads('args.workflowSession.state.prepaidFundingToken')
   declare fundingTokenSymbol: TokenSymbol;
   @tracked selectedFaceValue?: FaceValue;

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/option/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/option/index.hbs
@@ -25,7 +25,7 @@
       ${{@usdAmount}} USD
     </div>
     <div class="face-value-option__conversion">
-      ≈ {{@approxDaiAmount}} DAI.CPXD*
+      {{@tokenAmount}} {{@tokenSymbol}}*
     </div>
   </div>
 </label>

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/option/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/option/index.hbs
@@ -25,7 +25,7 @@
       ${{@usdAmount}} USD
     </div>
     <div class="face-value-option__conversion">
-      {{@tokenAmount}} {{@tokenSymbol}}*
+      ≈ {{@approxTokenAmount}} {{@tokenSymbol}}*
     </div>
   </div>
 </label>

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -62,6 +62,10 @@ export default class Layer2Network extends Service {
     return this.strategy.updateUsdConverters(symbolsToUpdate);
   }
 
+  async convertFromSpend(symbol: ConvertibleSymbol, amount: number) {
+    return await this.strategy.convertFromSpend(symbol, amount);
+  }
+
   disconnect() {
     return this.strategy.disconnect();
   }

--- a/packages/web-client/app/utils/web3-strategies/test-layer2.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer2.ts
@@ -7,7 +7,7 @@ import {
 } from '@cardstack/web-client/utils/token';
 import RSVP, { defer } from 'rsvp';
 import BN from 'bn.js';
-import { fromWei } from 'web3-utils';
+import { fromWei, toWei } from 'web3-utils';
 import { TransactionReceipt } from 'web3-core';
 import { DepotSafe } from '@cardstack/cardpay-sdk/sdk/safes';
 import {
@@ -91,6 +91,10 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
     return this.waitForAccountDeferred.promise;
   }
 
+  async convertFromSpend(symbol: ConvertibleSymbol, amount: number) {
+    return await this.test__simulateConvertFromSpend(symbol, amount);
+  }
+
   test__lastSymbolsToUpdate: ConvertibleSymbol[] = [];
   test__simulatedExchangeRate: number = 0.2;
   test__updateUsdConvertersDeferred: RSVP.Deferred<void> | undefined;
@@ -126,5 +130,14 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
       return;
     }
     this.depotSafe = null;
+  }
+
+  test__simulateConvertFromSpend(symbol: ConvertibleSymbol, amount: number) {
+    let spendToDaiSimRate = 0.01;
+    if (symbol === 'DAI') {
+      return toWei(`${amount * spendToDaiSimRate}`);
+    } else {
+      return '0';
+    }
   }
 }

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -50,6 +50,7 @@ export interface Layer2Web3Strategy extends Web3Strategy {
   ): Promise<TransactionReceipt>;
   fetchDepotTask(): Promise<DepotSafe | null>;
   refreshBalances(): void;
+  convertFromSpend(symbol: ConvertibleSymbol, amount: number): Promise<string>;
 }
 
 export type TransactionHash = string;

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -50,7 +50,7 @@ export interface Layer2Web3Strategy extends Web3Strategy {
   ): Promise<TransactionReceipt>;
   fetchDepotTask(): Promise<DepotSafe | null>;
   refreshBalances(): void;
-  convertFromSpend(symbol: ConvertibleSymbol, amount: number): Promise<string>;
+  convertFromSpend(symbol: ConvertibleSymbol, amount: number): Promise<any>;
 }
 
 export type TransactionHash = string;

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -247,7 +247,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
     assert.dom('[data-test-face-value-option="50000"]').containsText('500 USD');
     assert
       .dom('[data-test-face-value-option="50000"]')
-      .containsText('500.00 DAI.CPXD');
+      .containsText('≈ 500 DAI.CPXD');
     assert.dom('[data-test-face-value-option="10000"] input').isNotDisabled();
     assert.dom('[data-test-face-value-option="5000"] input').isNotDisabled();
     await click('[data-test-face-value-option="5000"]');
@@ -280,9 +280,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
 
     assert.dom('[data-test-face-value-display]').containsText('10000 SPEND');
     assert.dom('[data-test-face-value-display]').containsText('100 USD');
-    assert
-      .dom('[data-test-face-value-display]')
-      .containsText('100.00 DAI.CPXD');
+    assert.dom('[data-test-face-value-display]').containsText('≈ 100 DAI.CPXD');
 
     await waitFor(milestoneCompletedSel(2));
     assert.dom(milestoneCompletedSel(2)).containsText('Face value chosen');

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -247,7 +247,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
     assert.dom('[data-test-face-value-option="50000"]').containsText('500 USD');
     assert
       .dom('[data-test-face-value-option="50000"]')
-      .containsText('≈ 500 DAI.CPXD');
+      .containsText('500.00 DAI.CPXD');
     assert.dom('[data-test-face-value-option="10000"] input').isNotDisabled();
     assert.dom('[data-test-face-value-option="5000"] input').isNotDisabled();
     await click('[data-test-face-value-option="5000"]');
@@ -280,7 +280,9 @@ module('Acceptance | issue prepaid card', function (hooks) {
 
     assert.dom('[data-test-face-value-display]').containsText('10000 SPEND');
     assert.dom('[data-test-face-value-display]').containsText('100 USD');
-    assert.dom('[data-test-face-value-display]').containsText('≈ 100 DAI.CPXD');
+    assert
+      .dom('[data-test-face-value-display]')
+      .containsText('100.00 DAI.CPXD');
 
     await waitFor(milestoneCompletedSel(2));
     assert.dom(milestoneCompletedSel(2)).containsText('Face value chosen');


### PR DESCRIPTION
Fixes cs-1178

- Convert spend to token via layer2-chain strategy, which has access to the exchange rate sdk
- Adjust the face value options on the template to display approximate token amounts
- Disable option if user balance is less than the actual converted token amount
