### PR TITLE
L2 can connect after clicking 'cancel' in wallet

### DIFF
--- a/packages/web-client/app/components/styled-qr-code/index.hbs
+++ b/packages/web-client/app/components/styled-qr-code/index.hbs
@@ -1,1 +1,1 @@
-<div {{did-insert this.generateQrCode}} class="styled-qr-code"></div>
+<div {{did-insert this.generateQrCode}} {{did-update this.updateQrCode @data}} class="styled-qr-code"></div>

--- a/packages/web-client/app/components/styled-qr-code/index.ts
+++ b/packages/web-client/app/components/styled-qr-code/index.ts
@@ -30,9 +30,10 @@ class StyledQrCodeComponent extends Component<StyledQrCodeComponentArgs> {
   @reads('args.dotType', 'square') declare dotType: DotType;
   @reads('args.margin', 0) declare margin: number;
   @reads('args.imageMargin', 0) declare imageMargin: number;
+  qrCode: any;
 
-  @action generateQrCode(element: HTMLElement) {
-    let qrOptions = {
+  get qrOptions() {
+    return {
       width: this.size,
       height: this.size,
       margin: this.margin,
@@ -59,8 +60,15 @@ class StyledQrCodeComponent extends Component<StyledQrCodeComponentArgs> {
         hideBackgroundDots: false,
       },
     };
-    const qrCode = new QRCodeStyling(qrOptions);
-    qrCode.append(element);
+  }
+
+  @action generateQrCode(element: HTMLElement) {
+    this.qrCode = new QRCodeStyling(this.qrOptions);
+    this.qrCode.append(element);
+  }
+
+  @action updateQrCode() {
+    this.qrCode.update(this.qrOptions);
   }
 }
 

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -147,11 +147,16 @@ export default abstract class Layer2ChainWeb3Strategy
       this.clearWalletInfo();
       this.walletConnectUri = undefined;
       this.simpleEmitter.emit('disconnect');
-      setTimeout(() => {
-        console.log('initializing');
-        this.initialize();
-      }, 1000);
     }
+
+    // we always want to re-generate the uri, because the 'disconnect' event from WalletConnect
+    // covers clicking the 'cancel' button in the wallet/mobile app
+    // if we don't re-generate the uri, then users might be stuck with the old one that cannot
+    // scan/fails silently
+    setTimeout(() => {
+      console.log('initializing');
+      this.initialize();
+    }, 500);
   }
 
   get isConnected(): boolean {


### PR DESCRIPTION
CS-1174

Fixes the issue @habdelra was facing with being unable to connect after canceling. This seems like a potentially very confusing issue for users. 

The core issue is not having a new URI generated, and if generated, not updated in the QR code, so when WalletConnect sends us a 'disconnect' event (odd that it's a disconnect event that happens when users click 'cancel' before connection, but it works!), we:
- generate a new uri
- make qr code rebuild in response to uri change

And users should be able to use the QR code to connect.