### PR TITLE
Enhancement/check and cancel workflows via workflow card check method

### DIFF
--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -11,7 +11,6 @@ import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { action } from '@ember/object';
 import { WorkflowPostable } from '@cardstack/web-client/models/workflow/workflow-postable';
 import { BN } from 'bn.js';
-import { toWei } from 'web3-utils';
 import { faceValueOptions } from './workflow-config';
 
 class IssuePrepaidCardWorkflow extends Workflow {
@@ -63,11 +62,21 @@ class IssuePrepaidCardWorkflow extends Workflow {
               Math.min(...faceValueOptions)
             );
 
-            return !!layer2Network.defaultTokenBalance?.gte(
+            let sufficientFunds = !!layer2Network.defaultTokenBalance?.gte(
               new BN(daiMinValue)
             );
+
+            if (sufficientFunds) {
+              return {
+                success: true,
+              };
+            } else {
+              return {
+                success: false,
+                reason: 'INSUFFICIENT_FUNDS',
+              };
+            }
           },
-          failureReason: 'INSUFFICIENT_FUNDS',
         }),
       ],
       completedDetail: 'xDai chain wallet connected',

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -58,12 +58,13 @@ class IssuePrepaidCardWorkflow extends Workflow {
               'service:layer2-network'
             ) as Layer2Network;
 
-            // TODO: replace this with usage of ExchangeRate.convertFromSpend
-            // this will be async
-            let daiMinValue = `${Math.min(...faceValueOptions) / 100}`;
+            let daiMinValue = await layer2Network.convertFromSpend(
+              'DAI',
+              Math.min(...faceValueOptions)
+            );
 
             return !!layer2Network.defaultTokenBalance?.gte(
-              new BN(toWei(daiMinValue))
+              new BN(daiMinValue)
             );
           },
           failureReason: 'INSUFFICIENT_FUNDS',

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -10,6 +10,9 @@ import NetworkAwareWorkflowMessage from '@cardstack/web-client/components/workfl
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { action } from '@ember/object';
 import { WorkflowPostable } from '@cardstack/web-client/models/workflow/workflow-postable';
+import { BN } from 'bn.js';
+import { toWei } from 'web3-utils';
+import { faceValueOptions } from './workflow-config';
 
 class IssuePrepaidCardWorkflow extends Workflow {
   name = 'Prepaid Card Issuance';
@@ -50,6 +53,20 @@ class IssuePrepaidCardWorkflow extends Workflow {
         new WorkflowCard({
           author: cardbot,
           componentName: 'card-pay/layer-two-connect-card',
+          check: async () => {
+            let layer2Network = this.owner.lookup(
+              'service:layer2-network'
+            ) as Layer2Network;
+
+            // TODO: replace this with usage of ExchangeRate.convertFromSpend
+            // this will be async
+            let daiMinValue = `${Math.min(...faceValueOptions) / 100}`;
+
+            return !!layer2Network.defaultTokenBalance?.gte(
+              new BN(toWei(daiMinValue))
+            );
+          },
+          failureReason: 'INSUFFICIENT_FUNDS',
         }),
       ],
       completedDetail: 'xDai chain wallet connected',

--- a/packages/web-client/app/models/workflow/workflow-card.ts
+++ b/packages/web-client/app/models/workflow/workflow-card.ts
@@ -2,16 +2,26 @@ import { action } from '@ember/object';
 import { Participant, WorkflowPostable } from './workflow-postable';
 import WorkflowSession from './workflow-session';
 
+type SuccessCheckResult = {
+  success: true;
+};
+type FailureCheckResult = {
+  success: false;
+  reason: string;
+};
+type CheckResult = SuccessCheckResult | FailureCheckResult;
+
 interface WorkflowCardOptions {
   author: Participant;
   componentName: string; // this should eventually become a card reference
   includeIf: () => boolean;
-  check?: () => Promise<boolean>;
-  failureReason: string;
+  check(): Promise<CheckResult>;
 }
 
 export class WorkflowCard extends WorkflowPostable {
   componentName: string;
+  check?: () => Promise<CheckResult>;
+
   constructor(options: Partial<WorkflowCardOptions>) {
     super(options.author!, options.includeIf);
     this.componentName = options.componentName!;
@@ -20,27 +30,26 @@ export class WorkflowCard extends WorkflowPostable {
         this.isComplete = false;
       }
     };
-    if (options.check && !options.failureReason) {
-      throw new Error(
-        'If providing the check option in a WorkflowCard, you should also be providing a failureReason'
-      );
-    }
-    this.check = options.check ?? (async () => true);
-    this.failureReason = options.failureReason;
+    this.check = options.check;
   }
   get session(): WorkflowSession | undefined {
     return this.workflow?.session;
   }
 
   @action onComplete() {
-    this.check!().then((successful) => {
-      if (successful) {
-        this.workflow?.emit('visible-postables-changed');
-        this.isComplete = true;
-      } else {
-        this.workflow?.cancel(this.failureReason);
-      }
-    });
+    if (this.check) {
+      this.check().then((checkResult) => {
+        if (checkResult.success) {
+          this.workflow?.emit('visible-postables-changed');
+          this.isComplete = true;
+        } else {
+          this.workflow?.cancel(checkResult.reason);
+        }
+      });
+    } else {
+      this.workflow?.emit('visible-postables-changed');
+      this.isComplete = true;
+    }
   }
   @action onIncomplete() {
     this.workflow?.resetTo(this);

--- a/packages/web-client/app/models/workflow/workflow-postable.ts
+++ b/packages/web-client/app/models/workflow/workflow-postable.ts
@@ -20,5 +20,7 @@ export class WorkflowPostable {
     this.includeIf = includeIf;
   }
   includeIf: (() => boolean) | undefined;
+  check: (() => Promise<boolean>) | undefined;
   reset: (() => void) | undefined;
+  failureReason: string | undefined;
 }

--- a/packages/web-client/app/models/workflow/workflow-postable.ts
+++ b/packages/web-client/app/models/workflow/workflow-postable.ts
@@ -20,7 +20,6 @@ export class WorkflowPostable {
     this.includeIf = includeIf;
   }
   includeIf: (() => boolean) | undefined;
-  check: (() => Promise<boolean>) | undefined;
   reset: (() => void) | undefined;
   failureReason: string | undefined;
 }

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -62,6 +62,10 @@ export default class Layer2Network extends Service {
     return this.strategy.updateUsdConverters(symbolsToUpdate);
   }
 
+  async convertFromSpend(symbol: ConvertibleSymbol, amount: number) {
+    return await this.strategy.convertFromSpend(symbol, amount);
+  }
+
   disconnect() {
     return this.strategy.disconnect();
   }

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -9,7 +9,12 @@ import WalletConnectProvider from '@walletconnect/web3-provider';
 import { task } from 'ember-concurrency-decorators';
 
 import { SimpleEmitter, UnbindEventListener } from '../events';
-import { ConvertibleSymbol, ConversionFunction, NetworkSymbol } from '../token';
+import {
+  ConvertibleSymbol,
+  ConversionFunction,
+  NetworkSymbol,
+  TokenContractInfo,
+} from '../token';
 import WalletInfo from '../wallet-info';
 import CustomStorageWalletConnect from '../wc-connector';
 import { ChainAddress, Layer2Web3Strategy, TransactionHash } from './types';
@@ -33,7 +38,8 @@ export default abstract class Layer2ChainWeb3Strategy
   networkSymbol: NetworkSymbol;
   provider: WalletConnectProvider | undefined;
   simpleEmitter = new SimpleEmitter();
-
+  defaultTokenSymbol: ConvertibleSymbol = 'DAI';
+  defaultTokenContractAddress?: string;
   web3: Web3 = new Web3();
   #exchangeRateApi!: IExchangeRate;
   #safesApi!: ISafes;
@@ -55,7 +61,11 @@ export default abstract class Layer2ChainWeb3Strategy
     this.chainId = networkIds[networkSymbol];
     this.networkSymbol = networkSymbol;
     this.walletInfo = new WalletInfo([], this.chainId);
-
+    let defaultTokenContractInfo = this.getTokenContractInfo(
+      this.defaultTokenSymbol,
+      networkSymbol
+    );
+    this.defaultTokenContractAddress = defaultTokenContractInfo.address;
     this.initialize();
   }
 
@@ -114,6 +124,13 @@ export default abstract class Layer2ChainWeb3Strategy
     this.#exchangeRateApi = await getSDK('ExchangeRate', this.web3);
     this.#safesApi = await getSDK('Safes', this.web3);
     this.updateWalletInfo(this.connector.accounts, this.connector.chainId);
+  }
+
+  private getTokenContractInfo(
+    symbol: ConvertibleSymbol,
+    network: NetworkSymbol
+  ): TokenContractInfo {
+    return new TokenContractInfo(symbol, network);
   }
 
   async updateWalletInfo(accounts: string[], chainId: number) {
@@ -208,13 +225,13 @@ export default abstract class Layer2ChainWeb3Strategy
 
       depot = depotSafes[depotSafes.length - 1] ?? null;
       if (depot) {
-        let daiBalance = depot.tokens.find(
-          (tokenInfo) => tokenInfo.token.symbol === 'DAI'
+        let defaultBalance = depot.tokens.find(
+          (tokenInfo) => tokenInfo.token.symbol === this.defaultTokenSymbol
         )?.balance;
         let cardBalance = depot.tokens.find(
           (tokenInfo) => tokenInfo.token.symbol === 'CARD'
         )?.balance;
-        this.defaultTokenBalance = new BN(daiBalance ?? '0');
+        this.defaultTokenBalance = new BN(defaultBalance ?? '0');
         this.cardBalance = new BN(cardBalance ?? '0');
       } else {
         this.defaultTokenBalance = new BN('0');
@@ -224,6 +241,25 @@ export default abstract class Layer2ChainWeb3Strategy
 
     this.depotSafe = depot;
     return;
+  }
+
+  async convertFromSpend(symbol: ConvertibleSymbol, amount: number) {
+    let address: string | undefined;
+    if (symbol === this.defaultTokenSymbol) {
+      address = this.defaultTokenContractAddress;
+    } else {
+      let tokenContractInfo = this.getTokenContractInfo(
+        symbol,
+        this.networkSymbol
+      );
+      address = tokenContractInfo.address;
+    }
+
+    if (!address) {
+      return '0';
+    }
+
+    return await this.#exchangeRateApi.convertFromSpend(address, amount);
   }
 
   async disconnect(): Promise<void> {

--- a/packages/web-client/app/utils/web3-strategies/test-layer2.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer2.ts
@@ -7,7 +7,7 @@ import {
 } from '@cardstack/web-client/utils/token';
 import RSVP, { defer } from 'rsvp';
 import BN from 'bn.js';
-import { fromWei } from 'web3-utils';
+import { fromWei, toWei } from 'web3-utils';
 import { TransactionReceipt } from 'web3-core';
 import { DepotSafe } from '@cardstack/cardpay-sdk/sdk/safes';
 import {
@@ -91,6 +91,10 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
     return this.waitForAccountDeferred.promise;
   }
 
+  async convertFromSpend(symbol: ConvertibleSymbol, amount: number) {
+    return await this.test__simulateConvertFromSpend(symbol, amount);
+  }
+
   test__lastSymbolsToUpdate: ConvertibleSymbol[] = [];
   test__simulatedExchangeRate: number = 0.2;
   test__updateUsdConvertersDeferred: RSVP.Deferred<void> | undefined;
@@ -126,5 +130,14 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
       return;
     }
     this.depotSafe = null;
+  }
+
+  test__simulateConvertFromSpend(symbol: ConvertibleSymbol, amount: number) {
+    let spendToDaiSimRate = 0.01;
+    if (symbol === 'DAI') {
+      return toWei(`${amount * spendToDaiSimRate}`);
+    } else {
+      return '0';
+    }
   }
 }

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -50,6 +50,7 @@ export interface Layer2Web3Strategy extends Web3Strategy {
   ): Promise<TransactionReceipt>;
   fetchDepotTask(): Promise<DepotSafe | null>;
   refreshBalances(): void;
+  convertFromSpend(symbol: ConvertibleSymbol, amount: number): Promise<string>;
 }
 
 export type TransactionHash = string;

--- a/packages/web-client/tests/unit/models/workflow-test.ts
+++ b/packages/web-client/tests/unit/models/workflow-test.ts
@@ -138,6 +138,16 @@ module('Unit | Workflow model', function (hooks) {
     workflow.milestones = [exampleMilestone];
     workflow.cancel('TEST');
     assert.equal(workflow.isCanceled, true);
+    assert.equal(workflow.cancelationReason, 'TEST');
+  });
+
+  test('Workflow cannot be canceled twice', function (assert) {
+    let workflow = new ConcreteWorkflow({});
+    workflow.milestones = [exampleMilestone];
+    workflow.cancel('FIRST');
+    workflow.cancel('SECOND');
+    assert.equal(workflow.isCanceled, true);
+    assert.equal(workflow.cancelationReason, 'FIRST');
   });
 
   test('Completed workflow is not canceled when workflow.cancel is called', function (assert) {

--- a/packages/web-client/tests/unit/models/workflow/workflow-card-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/workflow-card-test.ts
@@ -50,9 +50,11 @@ module('Unit | WorkflowCard model', function (hooks) {
     let subject = new WorkflowCard({
       author: participant,
       componentName: 'foo/bar',
-      failureReason: 'TEST',
       async check() {
-        return false;
+        return {
+          success: false,
+          reason: 'TEST',
+        };
       },
     });
 

--- a/packages/web-client/tests/unit/models/workflow/workflow-card-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/workflow-card-test.ts
@@ -6,6 +6,8 @@ import {
 } from '@cardstack/web-client/models/workflow/workflow-postable';
 import { WorkflowCard } from '@cardstack/web-client/models/workflow/workflow-card';
 import { Workflow } from '@cardstack/web-client/models/workflow';
+import { settled } from '@ember/test-helpers';
+import { Milestone } from '@cardstack/web-client/models/workflow/milestone';
 
 module('Unit | WorkflowCard model', function (hooks) {
   setupTest(hooks);
@@ -34,13 +36,43 @@ module('Unit | WorkflowCard model', function (hooks) {
     assert.equal(subject.isComplete, false);
   });
 
-  test('when onComplete is called, isComplete is set to true', function (assert) {
+  test('when onComplete is called, isComplete is set to true', async function (assert) {
     let subject = new WorkflowCard({
       author: participant,
       componentName: 'foo/bar',
     });
     subject.onComplete();
+    await settled();
     assert.equal(subject.isComplete, true);
+  });
+
+  test("when onComplete is called, the card's check method is called and the card's workflow is canceled", async function (assert) {
+    let subject = new WorkflowCard({
+      author: participant,
+      componentName: 'foo/bar',
+      failureReason: 'TEST',
+      async check() {
+        return false;
+      },
+    });
+
+    class StubWorkflow extends Workflow {
+      milestones = [
+        new Milestone({
+          title: 'mock. should not be completed',
+          postables: [subject],
+          completedDetail: 'This should never be seen',
+        }),
+      ];
+    }
+    let wf = new StubWorkflow(this.owner);
+    subject.setWorkflow(wf);
+
+    subject.onComplete();
+    await settled();
+    assert.equal(subject.isComplete, false);
+    assert.equal(wf.isCanceled, true);
+    assert.equal(wf.cancelationReason, 'TEST');
   });
 
   test('when onIncomplete is called, workflow is called', function (assert) {


### PR DESCRIPTION
This aims to fix issues identified in #1764. Adds `check` and `failureReason` to `WorkflowCard`. `check` is a callback that should return `Promise<boolean>`, `failureReason` is a string that becomes the workflow's `cancelationReason` if `check` returns `false`. `check` is called within the `WorkflowCard`'s `onComplete` method, and cancels the workflow using the `failureReason` provided if the check fails. 

Rationale:
- Adding `check` to a `WorkflowCard` means we can control cancelations to occur at set points in the workflow more easily (as opposed to adding checking to the workflow, which would mean we need to keep track of the visibility of different postables within the workflow)
- We make the `check` callback in `onComplete` because all of the actions required to be taken in the card are assumed to be done (unlikely to be racing async calls).
- We prevent the `WorkflowCard` from completing if the check fails because completing a card starts showing subsequent postables.
- `check` is asynchronous because we don't know whether the workflow will have all information for a check ready at the point of the check. This can be made synchronous if we assume that all information required for a check will be made available in local state at the time of a check, however I feel like this is hard to guarantee.

Issues:
- as @backspace has mentioned, there probably needs to be a more dynamic way to provide the context of failure. This context would need to be accessed and used for informative cancelation messages

Other todos if this method works out:
- Cherry pick / extract and adjust way of getting previous postable and accompanying changes in #1764 to new PR