### PR TITLE
use wallet connect to sign txns in the CLI

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -95,7 +95,7 @@
         "safes-view",
         "--network", "sokol",
         // Hassan's testing mnemonic feel free to use your own
-        "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
+        // "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
         // Hassan's testing merchant mnemonic: 0x54b11672e90B38ca52140Ac364EebC5cC07F3d91
         // "--mnemonic", "sign crawl student excite mouse young narrow essence soul brick life slush"
       ]
@@ -133,7 +133,7 @@
         "1000",
         "--network", "sokol",
         // Hassan's testing mnemonic feel free to use your own
-        "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
+        // "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
       ]
     },
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -95,7 +95,7 @@
         "safes-view",
         "--network", "sokol",
         // Hassan's testing mnemonic feel free to use your own
-        // "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
+        "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
         // Hassan's testing merchant mnemonic: 0x54b11672e90B38ca52140Ac364EebC5cC07F3d91
         // "--mnemonic", "sign crawl student excite mouse young narrow essence soul brick life slush"
       ]
@@ -133,7 +133,7 @@
         "1000",
         "--network", "sokol",
         // Hassan's testing mnemonic feel free to use your own
-        // "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
+        "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
       ]
     },
     {

--- a/packages/cardpay-cli/README.md
+++ b/packages/cardpay-cli/README.md
@@ -6,33 +6,32 @@ CLI tool for basic actions in Cardpay
 
 # Commands
 - [Commands](#commands)
-  - [`yarn cardpay bridge <AMOUNT> <TOKEN_ADDRESS> [RECEIVER] --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-bridge-amount-token_address-receiver---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay await-bridged <FROM_BLOCK> [RECIPIENT] --network=_NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-await-bridged-from_block-recipient---network_network---mnemonicmnemonic)
-  - [`yarn cardpay prepaidcard-create <SAFE_ADDRESS> <TOKEN_ADDRESS> <CUSTOMIZATION_DID> <FACE_VALUES..> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-prepaidcard-create-safe_address-token_address-customization_did-face_values---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay price-for-face-value <TOKEN_ADDRESS> <SPEND_FACE_VALUE> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-price-for-face-value-token_address-spend_face_value---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay register-merchant <PREPAID_CARD> <INFO_DID> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-register-merchant-prepaid_card-info_did---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay pay-merchant <MERCHANT_SAFE> <PREPAID_CARD> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-pay-merchant-merchant_safe-prepaid_card-amount---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay revenue-balances <MERCHANT_SAFE> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-revenue-balances-merchant_safe---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay claim-revenue <MERCHANT_SAFE> <TOKEN_ADDRESS> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-claim-revenue-merchant_safe-token_address-amount---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay new-prepaidcard-gas-fee <TOKEN_ADDRESS> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-new-prepaidcard-gas-fee-token_address---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay safes-view [ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-safes-view-address---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay safe-transfer-tokens [SAFE_ADDRESS] [TOKEN_ADDRESS] [RECIPIENT] [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-safe-transfer-tokens-safe_address-token_address-recipient-amount---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay set-supplier-info-did [SAFE_ADDRESS] [INFO_DID] [TOKEN_ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-set-supplier-info-did-safe_address-info_did-token_address---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay usd-price <TOKEN> [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-usd-price-token-amount---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay eth-price <TOKEN> [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-eth-price-token-amount---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay price-oracle-updated-at <TOKEN> --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-price-oracle-updated-at-token---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay view-token-balance [TOKEN_ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-view-token-balance-token_address---networknetwork---mnemonicmnemonic)
-  - [`yarn cardpay hub-auth [HUB_ROOT_URL] --network=NETWORK [--mnemonic=MNEMONIC]`](#yarn-cardpay-hub-auth-hub_root_url---networknetwork---mnemonicmnemonic)
-  (#yarn-cardpay-hub-auth-hub_root_url---networknetwork---mnemonicmnemonic)
+  - [`yarn cardpay bridge <AMOUNT> <TOKEN_ADDRESS> [RECEIVER] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-bridge-amount-token_address-receiver---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay await-bridged <FROM_BLOCK> [RECIPIENT] --network=_NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-await-bridged-from_block-recipient---network_network---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay prepaidcard-create <SAFE_ADDRESS> <TOKEN_ADDRESS> <CUSTOMIZATION_DID> <FACE_VALUES..> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-prepaidcard-create-safe_address-token_address-customization_did-face_values---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay price-for-face-value <TOKEN_ADDRESS> <SPEND_FACE_VALUE> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-price-for-face-value-token_address-spend_face_value---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay register-merchant <PREPAID_CARD> <INFO_DID> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-register-merchant-prepaid_card-info_did---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay pay-merchant <MERCHANT_SAFE> <PREPAID_CARD> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-pay-merchant-merchant_safe-prepaid_card-amount---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay revenue-balances <MERCHANT_SAFE> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-revenue-balances-merchant_safe---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay claim-revenue <MERCHANT_SAFE> <TOKEN_ADDRESS> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-claim-revenue-merchant_safe-token_address-amount---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay new-prepaidcard-gas-fee <TOKEN_ADDRESS> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-new-prepaidcard-gas-fee-token_address---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay safes-view [ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-safes-view-address---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay safe-transfer-tokens [SAFE_ADDRESS] [TOKEN_ADDRESS] [RECIPIENT] [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-safe-transfer-tokens-safe_address-token_address-recipient-amount---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay set-supplier-info-did [SAFE_ADDRESS] [INFO_DID] [TOKEN_ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-set-supplier-info-did-safe_address-info_did-token_address---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay usd-price <TOKEN> [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-usd-price-token-amount---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay eth-price <TOKEN> [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-eth-price-token-amount---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay price-oracle-updated-at <TOKEN> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-price-oracle-updated-at-token---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay view-token-balance [TOKEN_ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-view-token-balance-token_address---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay hub-auth [HUB_ROOT_URL] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-hub-auth-hub_root_url---networknetwork---mnemonicmnemonic---walletconnect)
 
 
-## `yarn cardpay bridge <AMOUNT> <TOKEN_ADDRESS> [RECEIVER] --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay bridge <AMOUNT> <TOKEN_ADDRESS> [RECEIVER] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 
 Bridge tokens from L1 wallet to L2 safe
 
 ```
 USAGE
-  $ yarn cardpay bridge <amount> <tokenAddress> [receiver] --network=NETWORK [--mnemonic=MNEMONIC]
+  $ yarn cardpay bridge <amount> <tokenAddress> [receiver] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
   AMOUNT          Amount in ether you would like bridged
@@ -40,30 +39,32 @@ ARGUMENTS
   RECEIVER        Layer 2 address to be owner of L2 safe, defaults to same as L1 address
   NETWORK         The Layer 1 network to use ("kovan" or "mainnet")
   MNEMONIC        (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT  (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
 
-## `yarn cardpay await-bridged <FROM_BLOCK> [RECIPIENT] --network=_NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay await-bridged <FROM_BLOCK> [RECIPIENT] --network=_NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 
 Wait for token bridging to complete on L2
 
 ```
 USAGE
-  $ yarn cardpay await-bridged <fromBlock> [recipient] --network=NETWORK [--mnemonic=MNEMONIC]
+  $ yarn cardpay await-bridged <fromBlock> [recipient] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
   FROM_BLOCK      Layer 2 block height before bridging was initiated
   RECIPIENT       Layer 2 address that is the owner of the bridged tokens, defaults to wallet address
   NETWORK         The Layer 2 network to use ("sokol" or "xdai")
   MNEMONIC        (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT  (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
 
-## `yarn cardpay prepaidcard-create <SAFE_ADDRESS> <TOKEN_ADDRESS> <CUSTOMIZATION_DID> <FACE_VALUES..> --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay prepaidcard-create <SAFE_ADDRESS> <TOKEN_ADDRESS> <CUSTOMIZATION_DID> <FACE_VALUES..> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 
 Create a prepaid card using DAI CPXD tokens
 
 ```
 USAGE
-  $ yarn cardpay prepaidcard-create <SAFE_ADDRESS> <TOKEN_ADDRESS> <CUSTOMIZATION_DID> <FACE_VALUES..> --network=NETWORK [--mnemonic=MNEMONIC]
+  $ yarn cardpay prepaidcard-create <SAFE_ADDRESS> <TOKEN_ADDRESS> <CUSTOMIZATION_DID> <FACE_VALUES..> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
   FACE_VALUES       A list of face values (separated by spaces) in units of § SPEND to create
@@ -72,42 +73,45 @@ ARGUMENTS
   TOKEN_ADDRESS     The token address of the token to use to pay for the prepaid cards
   NETWORK           The network to use ("sokol" or "xdai")
   MNEMONIC          (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT    (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
 
-## `yarn cardpay price-for-face-value <TOKEN_ADDRESS> <SPEND_FACE_VALUE> --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay price-for-face-value <TOKEN_ADDRESS> <SPEND_FACE_VALUE> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 Get the price in the units of the specified token to achieve a prepaid card with the specified face value in SPEND. This takes into account the exchange rate for the specified token as well as the gas fee that is charged for creating a new prepaid card.
 
 ```
 USAGE
-  $ yarn cardpay price-for-face-value <TOKEN_ADDRESS> <SPEND_FACE_VALUE> --network=NETWORK [--mnemonic=MNEMONIC]
+  $ yarn cardpay price-for-face-value <TOKEN_ADDRESS> <SPEND_FACE_VALUE> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
   TOKEN_ADDRESS      The token address of the token that will be used to pay for the prepaid card
   SPEND_FACE_VALUE   The desired face value in SPEND for the prepaid card
   NETWORK            The network to use ("sokol" or "xdai")
   MNEMONIC           (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT     (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
 
-## `yarn cardpay register-merchant <PREPAID_CARD> <INFO_DID> --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay register-merchant <PREPAID_CARD> <INFO_DID> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 Register a new merchant from a prepaid card. The prepaid card will be used to pay the merchant registration fee.
 
 ```
 USAGE
-  $ yarn cardpay register-merchant <PREPAID_CARD> --network=NETWORK [--mnemonic=MNEMONIC]
+  $ yarn cardpay register-merchant <PREPAID_CARD> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
   PREPAID_CARD      The address of the prepaid card that is being used to pay the merchant registration fee
   INFO_DID          The DID string that can be resolved to a DID document representing the merchant's information
   NETWORK           The network to use ("sokol" or "xdai")
   MNEMONIC          (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT    (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
 
-## `yarn cardpay pay-merchant <MERCHANT_SAFE> <PREPAID_CARD> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay pay-merchant <MERCHANT_SAFE> <PREPAID_CARD> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 Pay a merchant from a prepaid card. The amount of tokens to send to the merchant in units of SPEND.
 
 ```
 USAGE
-  $ yarn cardpay pay-merchant <MERCHANT_SAFE> <PREPAID_CARD> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC]
+  $ yarn cardpay pay-merchant <MERCHANT_SAFE> <PREPAID_CARD> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
   MERCHANT_SAFE     The address of the merchant's safe who will receive the payment
@@ -115,27 +119,29 @@ ARGUMENTS
   AMOUNT            The amount to send to the merchant in units of SPEND
   NETWORK           The network to use ("sokol" or "xdai")
   MNEMONIC          (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT    (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
 
-## `yarn cardpay revenue-balances <MERCHANT_SAFE> --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay revenue-balances <MERCHANT_SAFE> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 View token balances of unclaimed revenue in the revenue pool for a merchant.
 
 ```
 USAGE
-  $ yarn cardpay revenue-balances <MERCHANT_SAFE> --network=NETWORK [--mnemonic=MNEMONIC]
+  $ yarn cardpay revenue-balances <MERCHANT_SAFE> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
   MERCHANT_SAFE     The address of the merchant's safe whose revenue balances are to be viewed
   NETWORK           The network to use ("sokol" or "xdai")
   MNEMONIC          (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT    (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
 
-## `yarn cardpay claim-revenue <MERCHANT_SAFE> <TOKEN_ADDRESS> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay claim-revenue <MERCHANT_SAFE> <TOKEN_ADDRESS> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 Claim merchant revenue earned from prepaid card payments.
 
 ```
 USAGE
-  $ yarn cardpay claim-revenue <MERCHANT_SAFE> <TOKEN_ADDRESS> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC]
+  $ yarn cardpay claim-revenue <MERCHANT_SAFE> <TOKEN_ADDRESS> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
   MERCHANT_SAFE     The address of the merchant's safe whose revenue balance is being claimed
@@ -143,35 +149,38 @@ ARGUMENTS
   AMOUNT            The amount of tokens that are being claimed as revenue (*not* in units of `wei`)
   NETWORK           The network to use ("sokol" or "xdai")
   MNEMONIC          (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT    (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
 
-## `yarn cardpay new-prepaidcard-gas-fee <TOKEN_ADDRESS> --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay new-prepaidcard-gas-fee <TOKEN_ADDRESS> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 Get the gas fee in the units of the specified token for creating a new prepaid card.
 
 ```
 USAGE
-  $ yarn cardpay new-prepaidcard-gas-fee <TOKEN_ADDRESS> --network=NETWORK [--mnemonic=MNEMONIC]
+  $ yarn cardpay new-prepaidcard-gas-fee <TOKEN_ADDRESS> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
   TOKEN_ADDRESS      The token address of the token that will be used to pay for the prepaid card
   NETWORK            The network to use ("sokol" or "xdai")
   MNEMONIC           (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT     (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
-## `yarn cardpay safes-view [ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay safes-view [ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 
 View safes that your wallet is the owner of
 
 ```
 USAGE
-  $ yarn cardpay safes-view [ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC]
+  $ yarn cardpay safes-view [ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
-  ADDRESS   (Optional) an address of an owner whose safes you wish to view (defaults to the wallet's default account)
-  NETWORK   The network to use ("sokol" or "xdai")
-  MNEMONIC  (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  ADDRESS         (Optional) an address of an owner whose safes you wish to view (defaults to the wallet's default account)
+  NETWORK         The network to use ("sokol" or "xdai")
+  MNEMONIC        (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT  (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
 
-## `yarn cardpay safe-transfer-tokens [SAFE_ADDRESS] [TOKEN_ADDRESS] [RECIPIENT] [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay safe-transfer-tokens [SAFE_ADDRESS] [TOKEN_ADDRESS] [RECIPIENT] [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 
 Transfer tokens from a safe to an arbitrary recipient. The token amount specified is *not* in units of `wei`. Note that the gas will be paid with the token you are transferring so there must be enough token balance in teh safe to cover both the transferred amount of tokens and gas.
 
@@ -184,87 +193,94 @@ ARGUMENTS
   TOKEN_ADDRESS    The token address of the tokens to transfer from the safe
   RECIPIENT        The token recipient's address
   AMOUNT           The amount of tokens to transfer (*not* in units of `wei`).
-  NETWORK   The network to use ("sokol" or "xdai")
-  MNEMONIC  (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  NETWORK          The network to use ("sokol" or "xdai")
+  MNEMONIC         (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT   (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
 
-## `yarn cardpay set-supplier-info-did [SAFE_ADDRESS] [INFO_DID] [TOKEN_ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay set-supplier-info-did [SAFE_ADDRESS] [INFO_DID] [TOKEN_ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 
 This allows a supplier to customize their appearance within the cardpay ecosystem by letting them set an info DID, that when used with a DID resolver can retrieve supplier info, such as their name, logo, URL, etc.
 
 ```
 USAGE
-  $ yarn cardpay set-supplier-info-did [SAFE_ADDRESS] [INFO_DID] [TOKEN_ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC]
+  $ yarn cardpay set-supplier-info-did [SAFE_ADDRESS] [INFO_DID] [TOKEN_ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
   SAFE_ADDRESS     The supplier's depot safe address (the safe that was assigned to the supplier when they bridged tokens into L2)
   INFO_DID         The DID string that can be resolved to a DID document representing the supplier's information
   TOKEN_ADDRESS    The token address that you want to use to pay for gas for this transaction. This should be an address of a token in the depot safe.
-  NETWORK   The network to use ("sokol" or "xdai")
-  MNEMONIC  (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  NETWORK          The network to use ("sokol" or "xdai")
+  MNEMONIC         (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT   (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
 
-## `yarn cardpay usd-price <TOKEN> [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay usd-price <TOKEN> [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 Get the USD value for the specified token name in the specified amount. This returns a floating point number in units of USD.
 ```
 USAGE
-  $ yarn cardpay usd-price <TOKEN> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC]
+  $ yarn cardpay usd-price <TOKEN> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
-  TOKEN     The token symbol (without the .CPXD suffix)
-  AMOUNT    (Optional) The amount of the specified token (not in units of wei).
-  NETWORK   The network to use ("sokol" or "xdai")
-  MNEMONIC  (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  TOKEN           The token symbol (without the .CPXD suffix)
+  AMOUNT          (Optional) The amount of the specified token (not in units of wei).
+  NETWORK         The network to use ("sokol" or "xdai")
+  MNEMONIC        (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT  (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
 
-## `yarn cardpay eth-price <TOKEN> [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay eth-price <TOKEN> [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 Get the ETH value for the specified token name in the specified amount (in units `ether`).
 ```
 USAGE
-  $ yarn cardpay eth-price <TOKEN> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC]
+  $ yarn cardpay eth-price <TOKEN> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
-  TOKEN     The token symbol (without the .CPXD suffix)
-  AMOUNT    The amount of the specified token (not in units of wei)
-  AMOUNT    (Optional) The amount of the specified token (not in units of wei).
-  NETWORK   The network to use ("sokol" or "xdai")
-  MNEMONIC  (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  TOKEN           The token symbol (without the .CPXD suffix)
+  AMOUNT          The amount of the specified token (not in units of wei)
+  AMOUNT          (Optional) The amount of the specified token (not in units of wei).
+  NETWORK         The network to use ("sokol" or "xdai")
+  MNEMONIC        (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT  (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
 
-## `yarn cardpay price-oracle-updated-at <TOKEN> --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay price-oracle-updated-at <TOKEN> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 This returns the date that the oracle was last updated for the specified token.
 
 ```
 USAGE
-  $ yarn cardpay price-oracle-updated-at <TOKEN> --network=NETWORK [--mnemonic=MNEMONIC]
+  $ yarn cardpay price-oracle-updated-at <TOKEN> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
-  TOKEN     The token symbol (without the .CPXD suffix)
-  NETWORK   The network to use ("sokol" or "xdai")
-  MNEMONIC  (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  TOKEN           The token symbol (without the .CPXD suffix)
+  NETWORK         The network to use ("sokol" or "xdai")
+  MNEMONIC        (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT  (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
 
-## `yarn cardpay view-token-balance [TOKEN_ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay view-token-balance [TOKEN_ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 This returns the token balance for the given wallet.
 
 ```
 USAGE
-  $ yarn cardpay view-token-balance [TOKEN_ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC]
+  $ yarn cardpay view-token-balance [TOKEN_ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
   TOKEN_ADDRESS     The address of the token to get the balance of. Defaults to native token for network
   NETWORK           The network to use ("kovan", "mainnet", "sokol", "xdai")
   MNEMONIC          (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT    (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
-## `yarn cardpay hub-auth [HUB_ROOT_URL] --network=NETWORK [--mnemonic=MNEMONIC]`
+## `yarn cardpay hub-auth [HUB_ROOT_URL] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 This returns the token balance for the given wallet.
 
 ```
 USAGE
-  $ yarn cardpay hub-auth [HUB_ROOT_URL] --network=NETWORK [--mnemonic=MNEMONIC]
+  $ yarn cardpay hub-auth [HUB_ROOT_URL] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
   HUB_ROOT_URL      The root URL of the hub instance to authenticate to, e.g. "https://hub.cardstack.com"
   NETWORK           The network to use ("sokol", "xdai")
   MNEMONIC          (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT    (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```

--- a/packages/cardpay-cli/assets.ts
+++ b/packages/cardpay-cli/assets.ts
@@ -2,7 +2,11 @@ import { getConstantByNetwork, getSDK, ERC20ABI } from '@cardstack/cardpay-sdk';
 import { AbiItem } from 'web3-utils';
 import { getWeb3 } from './utils';
 
-export const viewTokenBalance = async (network: string, mnemonic: string, tokenAddress?: string): Promise<void> => {
+export const viewTokenBalance = async (
+  network: string,
+  tokenAddress: string | undefined,
+  mnemonic?: string
+): Promise<void> => {
   let web3 = await getWeb3(network, mnemonic);
   let assets = await getSDK('Assets', web3);
 

--- a/packages/cardpay-cli/await-bridged.ts
+++ b/packages/cardpay-cli/await-bridged.ts
@@ -3,9 +3,9 @@ import { getWeb3 } from './utils';
 
 export default async function (
   network: string,
-  mnemonic: string,
   fromBlock: number,
-  recipient?: string
+  recipient: string | undefined,
+  mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let tokenBridge = await getSDK('TokenBridgeHomeSide', web3);

--- a/packages/cardpay-cli/bridge.ts
+++ b/packages/cardpay-cli/bridge.ts
@@ -6,10 +6,10 @@ const { toWei } = Web3.utils;
 
 export default async function (
   network: string,
-  mnemonic: string,
   amount: number,
-  receiverAddress?: string,
-  tokenAddress?: string
+  receiverAddress: string | undefined,
+  tokenAddress: string | undefined,
+  mnemonic?: string
 ): Promise<void> {
   const amountInWei = toWei(amount.toString()).toString();
 

--- a/packages/cardpay-cli/exchange-rate.ts
+++ b/packages/cardpay-cli/exchange-rate.ts
@@ -3,21 +3,33 @@ import { getWeb3 } from './utils';
 import { getSDK } from '@cardstack/cardpay-sdk';
 const { toWei, fromWei } = Web3.utils;
 
-export async function usdPrice(network: string, mnemonic: string, token: string, amount = 1): Promise<void> {
+export async function usdPrice(
+  network: string,
+  token: string,
+  amount: number | undefined,
+  mnemonic?: string
+): Promise<void> {
+  amount = amount ?? 1;
   let web3 = await getWeb3(network, mnemonic);
   let amountInWei = toWei(amount.toString());
   let exchangeRate = await getSDK('ExchangeRate', web3);
   let usdPrice = await exchangeRate.getUSDPrice(token, amountInWei);
   console.log(`USD value: $${usdPrice.toFixed(2)} USD`);
 }
-export async function ethPrice(network: string, mnemonic: string, token: string, amount = 1): Promise<void> {
+export async function ethPrice(
+  network: string,
+  token: string,
+  amount: number | undefined,
+  mnemonic?: string
+): Promise<void> {
+  amount = amount ?? 1;
   let web3 = await getWeb3(network, mnemonic);
   let amountInWei = toWei(amount.toString());
   let exchangeRate = await getSDK('ExchangeRate', web3);
   let ethWeiPrice = await exchangeRate.getETHPrice(token, amountInWei);
   console.log(`ETH value: ${fromWei(ethWeiPrice)} ETH`);
 }
-export async function priceOracleUpdatedAt(network: string, mnemonic: string, token: string): Promise<void> {
+export async function priceOracleUpdatedAt(network: string, token: string, mnemonic?: string): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let exchangeRate = await getSDK('ExchangeRate', web3);
   let date = await exchangeRate.getUpdatedAt(token);

--- a/packages/cardpay-cli/hub-auth.ts
+++ b/packages/cardpay-cli/hub-auth.ts
@@ -1,7 +1,7 @@
 import { getWeb3 } from './utils';
 import { getSDK } from '@cardstack/cardpay-sdk';
 
-export const hubAuth = async (hubRootUrl: string, network: string, mnemonic: string): Promise<void> => {
+export const hubAuth = async (hubRootUrl: string, network: string, mnemonic?: string): Promise<void> => {
   let web3 = await getWeb3(network, mnemonic);
   let authToken = await (await getSDK('HubAuth', web3, hubRootUrl)).authenticate();
   console.log(`Authentication token: ${authToken}`);

--- a/packages/cardpay-cli/index.ts
+++ b/packages/cardpay-cli/index.ts
@@ -37,6 +37,7 @@ let command: Commands | undefined;
 interface Options {
   network: string;
   mnemonic: string;
+  walletConnect: boolean;
   tokenAddress?: string;
   amount?: number;
   fromBlock?: number;
@@ -53,9 +54,10 @@ interface Options {
   hubRootUrl?: string;
   faceValues?: number[];
 }
-const {
+let {
   network,
   mnemonic = process.env.MNEMONIC_PHRASE,
+  walletConnect,
   tokenAddress,
   amount,
   address,
@@ -342,19 +344,27 @@ const {
       type: 'string',
       description: 'Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE',
     },
+    walletConnect: {
+      alias: 'w',
+      type: 'boolean',
+      description: 'A flag to indicate that wallet connect should be used for the wallet',
+    },
   })
   .demandOption(['network'], `'network' must be specified.`)
   .demandCommand(1, 'Please specify a command')
   .help().argv as Options;
 
-// if (!mnemonic) {
-//   yargs.showHelp(() =>
-//     console.log(
-//       'No mnemonic is defined, either specify the mnemonic as a positional arg or pass it in using the MNEMONIC_PHRASE env var'
-//     )
-//   );
-//   process.exit(1);
-// }
+if (!mnemonic && !walletConnect) {
+  yargs.showHelp(() =>
+    console.log(
+      'Wallet is not specified. Either specify that wallet connect should be used for the wallet, or specify the mnemonic as a positional arg, or pass the mnemonic in using the MNEMONIC_PHRASE env var'
+    )
+  );
+  process.exit(1);
+}
+if (walletConnect) {
+  mnemonic = undefined;
+}
 
 if (!command) {
   throw new Error('missing command--should never get here');

--- a/packages/cardpay-cli/index.ts
+++ b/packages/cardpay-cli/index.ts
@@ -347,14 +347,14 @@ const {
   .demandCommand(1, 'Please specify a command')
   .help().argv as Options;
 
-if (!mnemonic) {
-  yargs.showHelp(() =>
-    console.log(
-      'No mnemonic is defined, either specify the mnemonic as a positional arg or pass it in using the MNEMONIC_PHRASE env var'
-    )
-  );
-  process.exit(1);
-}
+// if (!mnemonic) {
+//   yargs.showHelp(() =>
+//     console.log(
+//       'No mnemonic is defined, either specify the mnemonic as a positional arg or pass it in using the MNEMONIC_PHRASE env var'
+//     )
+//   );
+//   process.exit(1);
+// }
 
 if (!command) {
   throw new Error('missing command--should never get here');
@@ -367,104 +367,104 @@ if (!command) {
         showHelpAndExit('amount is a required value');
         return;
       }
-      await bridge(network, mnemonic, amount, receiver, tokenAddress);
+      await bridge(network, amount, receiver, tokenAddress, mnemonic);
       break;
     case 'awaitBridged':
       if (fromBlock == null) {
         showHelpAndExit('fromBlock is a required value');
         return;
       }
-      await awaitBridged(network, mnemonic, fromBlock, recipient);
+      await awaitBridged(network, fromBlock, recipient, mnemonic);
       break;
     case 'safesView':
-      await viewSafes(network, mnemonic, address);
+      await viewSafes(network, address, mnemonic);
       break;
     case 'safeTransferTokens':
       if (safeAddress == null || recipient == null || token == null || amount == null) {
         showHelpAndExit('safeAddress, token, recipient, and amount are required values');
         return;
       }
-      await transferTokens(network, mnemonic, safeAddress, token, recipient, amount);
+      await transferTokens(network, safeAddress, token, recipient, amount, mnemonic);
       break;
     case 'setSupplierInfoDID':
       if (safeAddress == null || token == null || infoDID == null) {
         showHelpAndExit('safeAddress, token, and infoDID are required values');
         return;
       }
-      await setSupplierInfoDID(network, mnemonic, safeAddress, infoDID, token);
+      await setSupplierInfoDID(network, safeAddress, infoDID, token, mnemonic);
       break;
     case 'prepaidCardCreate':
       if (tokenAddress == null || safeAddress == null || faceValues == null) {
         showHelpAndExit('tokenAddress, safeAddress, and amounts are required values');
         return;
       }
-      await createPrepaidCard(network, mnemonic, safeAddress, faceValues, tokenAddress, customizationDID || undefined);
+      await createPrepaidCard(network, safeAddress, faceValues, tokenAddress, customizationDID || undefined, mnemonic);
       break;
     case 'registerMerchant':
       if (prepaidCard == null) {
         showHelpAndExit('prepaidCard is a required value');
         return;
       }
-      await registerMerchant(network, mnemonic, prepaidCard, infoDID || undefined);
+      await registerMerchant(network, prepaidCard, infoDID || undefined, mnemonic);
       break;
     case 'payMerchant':
       if (merchantSafe == null || prepaidCard == null || amount == null) {
         showHelpAndExit('merchantSafe, prepaidCard, and amount are required values');
         return;
       }
-      await payMerchant(network, mnemonic, merchantSafe, prepaidCard, amount);
+      await payMerchant(network, merchantSafe, prepaidCard, amount, mnemonic);
       break;
     case 'revenueBalances':
       if (merchantSafe == null) {
         showHelpAndExit('merchantSafe is a required value');
         return;
       }
-      await revenueBalances(network, mnemonic, merchantSafe);
+      await revenueBalances(network, merchantSafe, mnemonic);
       break;
     case 'claimRevenue':
       if (merchantSafe == null || tokenAddress == null || amount == null) {
         showHelpAndExit('merchantSafe, tokenAddress, and amount are required values');
         return;
       }
-      await claimRevenue(network, mnemonic, merchantSafe, tokenAddress, amount);
+      await claimRevenue(network, merchantSafe, tokenAddress, amount, mnemonic);
       break;
     case 'usdPrice':
       if (token == null || amount == null) {
         showHelpAndExit('token and amount are required values');
         return;
       }
-      await usdPrice(network, mnemonic, token, amount);
+      await usdPrice(network, token, amount, mnemonic);
       break;
     case 'ethPrice':
       if (token == null || amount == null) {
         showHelpAndExit('token and amount are required values');
         return;
       }
-      await ethPrice(network, mnemonic, token, amount);
+      await ethPrice(network, token, amount, mnemonic);
       break;
     case 'priceOracleUpdatedAt':
       if (token == null) {
         showHelpAndExit('tokenAddress is a required value');
         return;
       }
-      await priceOracleUpdatedAt(network, mnemonic, token);
+      await priceOracleUpdatedAt(network, token, mnemonic);
       break;
     case 'viewTokenBalance':
-      await viewTokenBalance(network, mnemonic, tokenAddress);
+      await viewTokenBalance(network, tokenAddress, mnemonic);
       break;
     case 'priceForFaceValue':
       if (tokenAddress == null || spendFaceValue == null) {
         showHelpAndExit('tokenAddress and spendFaceValue are required values');
         return;
       }
-      await priceForFaceValue(network, mnemonic, tokenAddress, spendFaceValue);
+      await priceForFaceValue(network, tokenAddress, spendFaceValue, mnemonic);
       break;
     case 'gasFee':
       if (tokenAddress == null) {
         showHelpAndExit('token is a required value');
         return;
       }
-      await gasFee(network, mnemonic, tokenAddress);
+      await gasFee(network, tokenAddress, mnemonic);
       break;
     case 'hubAuth':
       if (hubRootUrl == null) {

--- a/packages/cardpay-cli/package.json
+++ b/packages/cardpay-cli/package.json
@@ -24,6 +24,7 @@
     "node-fetch": "^2.6.1",
     "parity-hdwallet-provider": "^1.3.0-fork.2",
     "web3": "^1.3.5",
+    "web3-core": "^1.3.5",
     "web3-utils": "1.3.5",
     "yargs": "^16.2.0"
   },

--- a/packages/cardpay-cli/package.json
+++ b/packages/cardpay-cli/package.json
@@ -19,6 +19,7 @@
     "@types/bn.js": "^5.1.0",
     "@types/lodash": "^4.14.168",
     "@types/web3-provider-engine": "^14.0.0",
+    "@walletconnect/web3-provider": "^1.4.0",
     "esm": "^3.2.25",
     "node-fetch": "^2.6.1",
     "parity-hdwallet-provider": "^1.3.0-fork.2",

--- a/packages/cardpay-cli/prepaid-card.ts
+++ b/packages/cardpay-cli/prepaid-card.ts
@@ -6,9 +6,9 @@ const { fromWei } = Web3.utils;
 
 export async function priceForFaceValue(
   network: string,
-  mnemonic: string,
   tokenAddress: string,
-  spendFaceValue: number
+  spendFaceValue: number,
+  mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let prepaidCard = await getSDK('PrepaidCard', web3);
@@ -18,7 +18,7 @@ export async function priceForFaceValue(
   );
 }
 
-export async function gasFee(network: string, mnemonic: string, tokenAddress: string): Promise<void> {
+export async function gasFee(network: string, tokenAddress: string, mnemonic?: string): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let prepaidCard = await getSDK('PrepaidCard', web3);
   let weiAmount = await prepaidCard.gasFee(tokenAddress);
@@ -27,11 +27,11 @@ export async function gasFee(network: string, mnemonic: string, tokenAddress: st
 
 export async function createPrepaidCard(
   network: string,
-  mnemonic: string,
   safe: string,
   faceValues: number[],
   tokenAddress: string,
-  customizationDID?: string
+  customizationDID: string | undefined,
+  mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
 
@@ -47,10 +47,10 @@ export async function createPrepaidCard(
 
 export async function payMerchant(
   network: string,
-  mnemonic: string,
   merchantSafe: string,
   prepaidCardAddress: string,
-  amount: number
+  amount: number,
+  mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let prepaidCard = await getSDK('PrepaidCard', web3);

--- a/packages/cardpay-cli/revenue-pool.ts
+++ b/packages/cardpay-cli/revenue-pool.ts
@@ -4,9 +4,9 @@ import { getWeb3 } from './utils';
 
 export async function registerMerchant(
   network: string,
-  mnemonic: string,
   prepaidCardAddress: string,
-  infoDID?: string
+  infoDID: string | undefined,
+  mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let revenuePool = await getSDK('RevenuePool', web3);
@@ -20,7 +20,7 @@ export async function registerMerchant(
   console.log(`Transaction hash: ${blockExplorer}/tx/${gnosisTxn?.ethereumTx.txHash}/token-transfers`);
 }
 
-export async function revenueBalances(network: string, mnemonic: string, merchantSafeAddress: string): Promise<void> {
+export async function revenueBalances(network: string, merchantSafeAddress: string, mnemonic?: string): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let revenuePool = await getSDK('RevenuePool', web3);
   let balanceInfo = await revenuePool.balances(merchantSafeAddress);
@@ -32,10 +32,10 @@ export async function revenueBalances(network: string, mnemonic: string, merchan
 
 export async function claimRevenue(
   network: string,
-  mnemonic: string,
   merchantSafeAddress: string,
   tokenAddress: string,
-  amount: number
+  amount: number,
+  mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let revenuePool = await getSDK('RevenuePool', web3);

--- a/packages/cardpay-cli/safe.ts
+++ b/packages/cardpay-cli/safe.ts
@@ -4,7 +4,7 @@ import { getWeb3 } from './utils';
 
 const { toWei } = Web3.utils;
 
-export async function viewSafes(network: string, mnemonic: string, address?: string): Promise<void> {
+export async function viewSafes(network: string, address: string | undefined, mnemonic?: string): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
 
   let safesApi = await getSDK('Safes', web3);
@@ -46,11 +46,11 @@ export async function viewSafes(network: string, mnemonic: string, address?: str
 
 export async function transferTokens(
   network: string,
-  mnemonic: string,
   safe: string,
   token: string,
   recipient: string,
-  amount: number
+  amount: number,
+  mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let weiAmount = toWei(String(amount));
@@ -67,10 +67,10 @@ export async function transferTokens(
 
 export async function setSupplierInfoDID(
   network: string,
-  mnemonic: string,
   safe: string,
   infoDID: string,
-  gasToken: string
+  gasToken: string,
+  mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let safes = await getSDK('Safes', web3);

--- a/packages/cardpay-cli/utils.ts
+++ b/packages/cardpay-cli/utils.ts
@@ -1,15 +1,54 @@
 import HDWalletProvider from 'parity-hdwallet-provider';
 import Web3 from 'web3';
-import { HttpProvider, getConstant, networkIds } from '@cardstack/cardpay-sdk';
+import { AbstractProvider } from 'web3-core';
+import { HttpProvider, getConstant, networkIds, getConstantByNetwork } from '@cardstack/cardpay-sdk';
+import WalletConnectProvider from '@walletconnect/web3-provider';
+// import { IWalletConnectOptions, IPushServerOptions } from '@walletconnect/types';
+// import * as cryptoLib from '@walletconnect/iso-crypto';
 
-export async function getWeb3(network: string, mnemonic: string): Promise<Web3> {
-  return new Web3(
-    new HDWalletProvider({
-      chainId: networkIds[network],
-      mnemonic: {
-        phrase: mnemonic,
+// import Connector from '@walletconnect/core';
+// import SessionStorage from '@walletconnect/core/dist/cjs/storage';
+const BRIDGE = 'https://safe-walletconnect.gnosis.io/';
+
+export async function getWeb3(network: string, mnemonic?: string): Promise<Web3> {
+  if (mnemonic) {
+    return new Web3(
+      new HDWalletProvider({
+        chainId: networkIds[network],
+        mnemonic: {
+          phrase: mnemonic,
+        },
+        providerOrUrl: new HttpProvider(await getConstant('rpcNode', network)),
+      })
+    );
+  } else {
+    let provider = new WalletConnectProvider({
+      rpc: {
+        [networkIds[network]]: getConstantByNetwork('rpcNode', network),
       },
-      providerOrUrl: new HttpProvider(await getConstant('rpcNode', network)),
-    })
-  );
+      bridge: BRIDGE,
+    });
+    provider.sendAsync = provider.send;
+    await provider.enable();
+    return new Web3((provider as unknown) as AbstractProvider);
+  }
 }
+
+// Hassan: I don't think we need this, but just leaving it here in case--as the web-client does actually use this
+
+// based on https://github.com/WalletConnect/walletconnect-monorepo/blob/1d2828fe63c97e4c0a72eea0150e2f65b819152d/packages/clients/client/src/index.ts
+// class CustomStorageWalletConnect extends Connector {
+//   constructor(connectorOpts: IWalletConnectOptions, chainId: string | number, pushServerOpts?: IPushServerOptions) {
+//     if (!chainId) {
+//       throw new Error('chainId is required to set custom session storage for parallel connections in WalletConnect');
+//     }
+//     const storage = new SessionStorage();
+//     storage.storageId = `wallet-connect-chain-${chainId}`;
+//     super({
+//       cryptoLib,
+//       connectorOpts,
+//       pushServerOpts,
+//       sessionStorage: storage,
+//     });
+//   }
+// }

--- a/packages/cardpay-cli/utils.ts
+++ b/packages/cardpay-cli/utils.ts
@@ -23,12 +23,17 @@ export async function getWeb3(network: string, mnemonic?: string): Promise<Web3>
     );
   } else {
     let provider = new WalletConnectProvider({
+      clientMeta: {
+        description: '',
+        url: 'http://localhost:3000',
+        icons: [],
+        name: 'Cardstack',
+      },
       rpc: {
         [networkIds[network]]: getConstantByNetwork('rpcNode', network),
       },
       bridge: BRIDGE,
     });
-    provider.sendAsync = provider.send;
     await provider.enable();
     return new Web3((provider as unknown) as AbstractProvider);
   }

--- a/packages/cardpay-cli/utils.ts
+++ b/packages/cardpay-cli/utils.ts
@@ -3,11 +3,7 @@ import Web3 from 'web3';
 import { AbstractProvider } from 'web3-core';
 import { HttpProvider, getConstant, networkIds, getConstantByNetwork } from '@cardstack/cardpay-sdk';
 import WalletConnectProvider from '@walletconnect/web3-provider';
-// import { IWalletConnectOptions, IPushServerOptions } from '@walletconnect/types';
-// import * as cryptoLib from '@walletconnect/iso-crypto';
 
-// import Connector from '@walletconnect/core';
-// import SessionStorage from '@walletconnect/core/dist/cjs/storage';
 const BRIDGE = 'https://safe-walletconnect.gnosis.io/';
 
 export async function getWeb3(network: string, mnemonic?: string): Promise<Web3> {
@@ -38,22 +34,3 @@ export async function getWeb3(network: string, mnemonic?: string): Promise<Web3>
     return new Web3((provider as unknown) as AbstractProvider);
   }
 }
-
-// Hassan: I don't think we need this, but just leaving it here in case--as the web-client does actually use this
-
-// based on https://github.com/WalletConnect/walletconnect-monorepo/blob/1d2828fe63c97e4c0a72eea0150e2f65b819152d/packages/clients/client/src/index.ts
-// class CustomStorageWalletConnect extends Connector {
-//   constructor(connectorOpts: IWalletConnectOptions, chainId: string | number, pushServerOpts?: IPushServerOptions) {
-//     if (!chainId) {
-//       throw new Error('chainId is required to set custom session storage for parallel connections in WalletConnect');
-//     }
-//     const storage = new SessionStorage();
-//     storage.storageId = `wallet-connect-chain-${chainId}`;
-//     super({
-//       cryptoLib,
-//       connectorOpts,
-//       pushServerOpts,
-//       sessionStorage: storage,
-//     });
-//   }
-// }

--- a/packages/cardpay-sdk/package.json
+++ b/packages/cardpay-sdk/package.json
@@ -22,7 +22,7 @@
     "semver": "^7.3.5",
     "web3": "^1.3.5",
     "web3-core": "^1.3.5",
-    "web3-eth": "^1.3.6",
+    "web3-eth": "^1.3.5",
     "web3-eth-contract": "^1.3.5",
     "web3-provider-engine": "^16.0.1",
     "web3-utils": "^1.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23060,7 +23060,7 @@ web3-eth@1.3.5:
     web3-net "1.3.5"
     web3-utils "1.3.5"
 
-web3-eth@^1.3.6:
+web3-eth@^1.3.5:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/web3-eth/-/web3-eth-1.3.6.tgz#2c650893d540a7a0eb1365dd5b2dca24ac919b7c"
   integrity sha512-9+rnywRRpyX3C4hfsAQXPQh6vHh9XzQkgLxo3gyeXfbhbShUoq2gFVuy42vsRs//6JlsKdyZS7Z3hHPHz2wreA==


### PR DESCRIPTION
This is an enhancement to the CLI that allows us to use the card wallet mobile app to sign txn in the CLI. This facilitates an alternate way to perform cardpay SDK commands from the web-client to help narrow down issues as well as to allow the card wallet team to work ahead of the web-client team in terms of their signing work.