### PR TITLE
Fix/walletconnect transaction never resolves

### DIFF
--- a/packages/cardpay-cli/package.json
+++ b/packages/cardpay-cli/package.json
@@ -23,9 +23,9 @@
     "esm": "^3.2.25",
     "node-fetch": "^2.6.1",
     "parity-hdwallet-provider": "^1.3.0-fork.2",
-    "web3": "1.3.2",
-    "web3-core": "1.3.2",
-    "web3-utils": "1.3.2",
+    "web3": "^1.3.5",
+    "web3-core": "^1.3.5",
+    "web3-utils": "1.3.5",
     "yargs": "^16.2.0"
   },
   "config": {

--- a/packages/cardpay-sdk/package.json
+++ b/packages/cardpay-sdk/package.json
@@ -20,12 +20,12 @@
     "ethereumjs-wallet": "^1.0.1",
     "lodash": "^4.17.21",
     "semver": "^7.3.5",
-    "web3": "1.3.2",
-    "web3-core": "1.3.2",
-    "web3-eth": "1.3.2",
-    "web3-eth-contract": "1.3.2",
+    "web3": "^1.3.5",
+    "web3-core": "^1.3.5",
+    "web3-eth": "^1.3.5",
+    "web3-eth-contract": "^1.3.5",
     "web3-provider-engine": "^16.0.1",
-    "web3-utils": "1.3.2"
+    "web3-utils": "^1.3.5"
   },
   "homepage": "https://github.com/cardstack/cardstack",
   "license": "MIT",

--- a/packages/cardpay-sdk/sdk/utils/general-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/general-utils.ts
@@ -24,7 +24,7 @@ export function waitUntilTransactionMined(web3: Web3, txnHash: string): Promise<
       let receipt = await web3.eth.getTransactionReceipt(txnHash);
       if (!receipt) {
         setTimeout(function () {
-          transactionReceiptAsync(txnHash, resolve, reject);
+          return transactionReceiptAsync(txnHash, resolve, reject);
         }, POLL_INTERVAL);
       } else {
         resolve(receipt);

--- a/packages/cardpay-sdk/sdk/utils/general-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/general-utils.ts
@@ -14,7 +14,11 @@ export async function networkName(web3: Web3): Promise<string> {
   return name;
 }
 
-export function waitUntilTransactionMined(web3: Web3, txnHash: string, duration = 30000): Promise<TransactionReceipt> {
+export function waitUntilTransactionMined(
+  web3: Web3,
+  txnHash: string,
+  duration = 60 * 5 * 1000
+): Promise<TransactionReceipt> {
   let endTime = Number(new Date()) + duration;
 
   let transactionReceiptAsync = async function (

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -126,9 +126,9 @@
     "qunit-dom": "^1.6.0",
     "stream-browserify": "^3.0.0",
     "stylelint-config-standard": "^22.0.0",
-    "web3": "1.3.2",
-    "web3-eth-contract": "1.3.2",
-    "web3-utils": "1.3.2",
+    "web3": "^1.3.5",
+    "web3-eth-contract": "^1.3.5",
+    "web3-utils": "^1.3.5",
     "webpack": "^5.0.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22273,6 +22273,11 @@ underscore.string@^3.2.2, underscore.string@~3.3.4:
     sprintf-js "^1.0.3"
     util-deprecate "^1.0.2"
 
+underscore@1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
+  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
+
 underscore@1.9.1, underscore@>=1.8.3:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
@@ -22750,16 +22755,6 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-web3-bzz@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-bzz/-/web3-bzz-1.3.2.tgz#144b850fc4c685df555c9fa44219056fe77f6204"
-  integrity sha512-rciwsXK1kTTjx50lcCKOFDSV4EOEHkhvRTIFun+dvyQiW3pcbqap1ENzxnlGxlG6M4O+SPOxxWILh0rMEi4tDA==
-  dependencies:
-    "@types/node" "^12.12.6"
-    got "9.6.0"
-    swarm-js "^0.1.40"
-    underscore "1.9.1"
-
 web3-bzz@1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/web3-bzz/-/web3-bzz-1.3.5.tgz#f181a1319d9f867f4183b147e7aebd21aecff4a0"
@@ -22770,15 +22765,6 @@ web3-bzz@1.3.5:
     swarm-js "^0.1.40"
     underscore "1.9.1"
 
-web3-core-helpers@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.3.2.tgz#5a18f70b7063be3fa29130481091fa8200fdf57c"
-  integrity sha512-puZze35eApfZVR0PPTMMjwmJ0uFAxXK8KDZ6xwO6Yp+ktSN5U3ruehYDLbJ8HuxGFXcdHCXxrodVKW3FCviT+Q==
-  dependencies:
-    underscore "1.9.1"
-    web3-eth-iban "1.3.2"
-    web3-utils "1.3.2"
-
 web3-core-helpers@1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.3.5.tgz#9f0ff7ed40befb9f691986e66fd94c828c7b1b13"
@@ -22788,17 +22774,14 @@ web3-core-helpers@1.3.5:
     web3-eth-iban "1.3.5"
     web3-utils "1.3.5"
 
-web3-core-method@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-core-method/-/web3-core-method-1.3.2.tgz#c049dcb4a05130b961aed6e291a9b5215890849f"
-  integrity sha512-cjNhNxEIrGd2E6lCNWvYSd5s282dgCIt5hjchrae1T88x84WF5mxLjqMDDFF3z1LvZBs1rAc11m0JBu/QtMlLQ==
+web3-core-helpers@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.3.6.tgz#c478246a9abe4e5456acf42657dac2f7c330be74"
+  integrity sha512-nhtjA2ZbkppjlxTSwG0Ttu6FcPkVu1rCN5IFAOVpF/L0SEt+jy+O5l90+cjDq0jAYvlBwUwnbh2mR9hwDEJCNA==
   dependencies:
-    "@ethersproject/transactions" "^5.0.0-beta.135"
-    underscore "1.9.1"
-    web3-core-helpers "1.3.2"
-    web3-core-promievent "1.3.2"
-    web3-core-subscriptions "1.3.2"
-    web3-utils "1.3.2"
+    underscore "1.12.1"
+    web3-eth-iban "1.3.6"
+    web3-utils "1.3.6"
 
 web3-core-method@1.3.5:
   version "1.3.5"
@@ -22812,12 +22795,17 @@ web3-core-method@1.3.5:
     web3-core-subscriptions "1.3.5"
     web3-utils "1.3.5"
 
-web3-core-promievent@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.3.2.tgz#48dcedc3bcca4ea7ed15980a62713890452f544d"
-  integrity sha512-fR7jUAFtvqAwmWdWMlDDeYSqR/6oKAUSmnhHeJcvLYGPmKUTHLNxEbupZVOqI1F1TJmLq99t5Nq45HBJqmAU8A==
+web3-core-method@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-core-method/-/web3-core-method-1.3.6.tgz#4b0334edd94b03dfec729d113c69a4eb6ebc68ae"
+  integrity sha512-RyegqVGxn0cyYW5yzAwkPlsSEynkdPiegd7RxgB4ak1eKk2Cv1q2x4C7D2sZjeeCEF+q6fOkVmo2OZNqS2iQxg==
   dependencies:
-    eventemitter3 "4.0.4"
+    "@ethersproject/transactions" "^5.0.0-beta.135"
+    underscore "1.12.1"
+    web3-core-helpers "1.3.6"
+    web3-core-promievent "1.3.6"
+    web3-core-subscriptions "1.3.6"
+    web3-utils "1.3.6"
 
 web3-core-promievent@1.3.5:
   version "1.3.5"
@@ -22826,17 +22814,12 @@ web3-core-promievent@1.3.5:
   dependencies:
     eventemitter3 "4.0.4"
 
-web3-core-requestmanager@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-core-requestmanager/-/web3-core-requestmanager-1.3.2.tgz#5f8177570edb245898eda13b0e23b9dcc7520e94"
-  integrity sha512-VYZbWA98vYXxnlP5xEpYo03CTr+tjUWqRT0VGsEUAlH617Wank3TPyEo8ASU5O41t7Sh1p/mWY55QzXAF5lLaA==
+web3-core-promievent@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.3.6.tgz#6c27dc79de8f71b74f5d17acaf9aaf593d3cb0c9"
+  integrity sha512-Z+QzfyYDTXD5wJmZO5wwnRO8bAAHEItT1XNSPVb4J1CToV/I/SbF7CuF8Uzh2jns0Cm1109o666H7StFFvzVKw==
   dependencies:
-    underscore "1.9.1"
-    util "^0.12.0"
-    web3-core-helpers "1.3.2"
-    web3-providers-http "1.3.2"
-    web3-providers-ipc "1.3.2"
-    web3-providers-ws "1.3.2"
+    eventemitter3 "4.0.4"
 
 web3-core-requestmanager@1.3.5:
   version "1.3.5"
@@ -22850,14 +22833,17 @@ web3-core-requestmanager@1.3.5:
     web3-providers-ipc "1.3.5"
     web3-providers-ws "1.3.5"
 
-web3-core-subscriptions@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.3.2.tgz#5f649d2bfe8c50a760e80a0013d319b3318f94cd"
-  integrity sha512-gDLaDYCpt6zPU4cmQeJKHj7zbsv/dFoNSrj2wQzlBQetxGxyqmd4akf+PwqIE1zRybld/EZaWPEdOF65sA+2Kg==
+web3-core-requestmanager@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-core-requestmanager/-/web3-core-requestmanager-1.3.6.tgz#4fea269fe913fd4fca464b4f7c65cb94857b5b2a"
+  integrity sha512-2rIaeuqeo7QN1Eex7aXP0ZqeteJEPWXYFS/M3r3LXMiV8R4STQBKE+//dnHJXoo2ctzEB5cgd+7NaJM8S3gPyA==
   dependencies:
-    eventemitter3 "4.0.4"
-    underscore "1.9.1"
-    web3-core-helpers "1.3.2"
+    underscore "1.12.1"
+    util "^0.12.0"
+    web3-core-helpers "1.3.6"
+    web3-providers-http "1.3.6"
+    web3-providers-ipc "1.3.6"
+    web3-providers-ws "1.3.6"
 
 web3-core-subscriptions@1.3.5:
   version "1.3.5"
@@ -22868,20 +22854,16 @@ web3-core-subscriptions@1.3.5:
     underscore "1.9.1"
     web3-core-helpers "1.3.5"
 
-web3-core@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-core/-/web3-core-1.3.2.tgz#e5042c62cfb6148c0140f971d83b96cf3cbfd680"
-  integrity sha512-nWObgrGdTRqtX3cCsTV0gO110Cq5UFb0c/G4s7CdG8tYKSjRdiMfm3YRBGCcyySGWbxMvnyMROt9xrg1Vy4f0g==
+web3-core-subscriptions@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.3.6.tgz#ee24e7974d1d72ff6c992c599deba4ef9b308415"
+  integrity sha512-wi9Z9X5X75OKvxAg42GGIf81ttbNR2TxzkAsp1g+nnp5K8mBwgZvXrIsDuj7Z7gx72Y45mWJADCWjk/2vqNu8g==
   dependencies:
-    "@types/bn.js" "^4.11.5"
-    "@types/node" "^12.12.6"
-    bignumber.js "^9.0.0"
-    web3-core-helpers "1.3.2"
-    web3-core-method "1.3.2"
-    web3-core-requestmanager "1.3.2"
-    web3-utils "1.3.2"
+    eventemitter3 "4.0.4"
+    underscore "1.12.1"
+    web3-core-helpers "1.3.6"
 
-web3-core@1.3.5:
+web3-core@1.3.5, web3-core@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/web3-core/-/web3-core-1.3.5.tgz#1e9335e6c4549dac09aaa07157242ebd6d097226"
   integrity sha512-VQjTvnGTqJwDwjKEHSApea3RmgtFGLDSJ6bqrOyHROYNyTyKYjFQ/drG9zs3rjDkND9mgh8foI1ty37Qua3QCQ==
@@ -22894,14 +22876,18 @@ web3-core@1.3.5:
     web3-core-requestmanager "1.3.5"
     web3-utils "1.3.5"
 
-web3-eth-abi@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.3.2.tgz#f9cd49dbbc83b181cd2eaa2ce7cd3b94336c30cf"
-  integrity sha512-9W+cvvK2Ek47rn4y4Xv76coUsZoqJL6X/WYLmwLuHS1arPFcpHzui0/KHgCb9g7OuDpd1BQNk28nm5Hr2y+fsw==
+web3-core@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-core/-/web3-core-1.3.6.tgz#a6a761d1ff2f3ee462b8dab679229d2f8e267504"
+  integrity sha512-gkLDM4T1Sc0T+HZIwxrNrwPg0IfWI0oABSglP2X5ZbBAYVUeEATA0o92LWV8BeF+okvKXLK1Fek/p6axwM/h3Q==
   dependencies:
-    "@ethersproject/abi" "5.0.7"
-    underscore "1.9.1"
-    web3-utils "1.3.2"
+    "@types/bn.js" "^4.11.5"
+    "@types/node" "^12.12.6"
+    bignumber.js "^9.0.0"
+    web3-core-helpers "1.3.6"
+    web3-core-method "1.3.6"
+    web3-core-requestmanager "1.3.6"
+    web3-utils "1.3.6"
 
 web3-eth-abi@1.3.5:
   version "1.3.5"
@@ -22912,22 +22898,14 @@ web3-eth-abi@1.3.5:
     underscore "1.9.1"
     web3-utils "1.3.5"
 
-web3-eth-accounts@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-eth-accounts/-/web3-eth-accounts-1.3.2.tgz#81b9cbb66f537950ce0edd97ec7240406e4f64a8"
-  integrity sha512-UIVg75e6bQYw54oOGlSV9OSkebIP00EPmpA59Jhj0uczJwM0BJkAxGAX9zfCOrKh98DcETLla9TEQjIM1mvlMg==
+web3-eth-abi@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.3.6.tgz#4272ca48d817aa651bbf97b269f5ff10abc2b8a9"
+  integrity sha512-Or5cRnZu6WzgScpmbkvC6bfNxR26hqiKK4i8sMPFeTUABQcb/FU3pBj7huBLYbp9dH+P5W79D2MqwbWwjj9DoQ==
   dependencies:
-    crypto-browserify "3.12.0"
-    eth-lib "0.2.8"
-    ethereumjs-common "^1.3.2"
-    ethereumjs-tx "^2.1.1"
-    scrypt-js "^3.0.1"
-    underscore "1.9.1"
-    uuid "3.3.2"
-    web3-core "1.3.2"
-    web3-core-helpers "1.3.2"
-    web3-core-method "1.3.2"
-    web3-utils "1.3.2"
+    "@ethersproject/abi" "5.0.7"
+    underscore "1.12.1"
+    web3-utils "1.3.6"
 
 web3-eth-accounts@1.3.5:
   version "1.3.5"
@@ -22946,22 +22924,24 @@ web3-eth-accounts@1.3.5:
     web3-core-method "1.3.5"
     web3-utils "1.3.5"
 
-web3-eth-contract@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.3.2.tgz#935dfeb3ba697512060e9d5702e511df0888dff8"
-  integrity sha512-RQ0bVtFPsm2/ZyPkAjDFa2JvAbuCGsnj7QJiilPYV8ICSG18u+8KDC2n6h0K5eweAJp25ma6nF/fugimPGnQLw==
+web3-eth-accounts@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-eth-accounts/-/web3-eth-accounts-1.3.6.tgz#f9fcb50b28ee58090ab292a10d996155caa2b474"
+  integrity sha512-Ilr0hG6ONbCdSlVKffasCmNwftD5HsNpwyQASevocIQwHdTlvlwO0tb3oGYuajbKOaDzNTwXfz25bttAEoFCGA==
   dependencies:
-    "@types/bn.js" "^4.11.5"
-    underscore "1.9.1"
-    web3-core "1.3.2"
-    web3-core-helpers "1.3.2"
-    web3-core-method "1.3.2"
-    web3-core-promievent "1.3.2"
-    web3-core-subscriptions "1.3.2"
-    web3-eth-abi "1.3.2"
-    web3-utils "1.3.2"
+    crypto-browserify "3.12.0"
+    eth-lib "0.2.8"
+    ethereumjs-common "^1.3.2"
+    ethereumjs-tx "^2.1.1"
+    scrypt-js "^3.0.1"
+    underscore "1.12.1"
+    uuid "3.3.2"
+    web3-core "1.3.6"
+    web3-core-helpers "1.3.6"
+    web3-core-method "1.3.6"
+    web3-utils "1.3.6"
 
-web3-eth-contract@1.3.5:
+web3-eth-contract@1.3.5, web3-eth-contract@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.3.5.tgz#b41ecf8612b379c4fb1c614e950135717aa8f919"
   integrity sha512-WfGVeQquN3D7Qm+KEIN9EI7yrm/fL2V9Y4+YhDWiKA/ns1pX1LYcEWojTOnBXCnPF3tcvoKKL+KBxXg1iKm38A==
@@ -22976,20 +22956,20 @@ web3-eth-contract@1.3.5:
     web3-eth-abi "1.3.5"
     web3-utils "1.3.5"
 
-web3-eth-ens@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-eth-ens/-/web3-eth-ens-1.3.2.tgz#b14968a3eba28a3f2e371e6988d1bbd7c5f37b88"
-  integrity sha512-WSg21o1qj5FY21ZHQ0YmMK7NLtQ+UIMqPvIMSl5VKZO7sDnyRTNiUFrJtsv9ck4WVvBOE8ETqbbm9GOlHxuzuA==
+web3-eth-contract@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.3.6.tgz#cccf4d32dc56917fb6923e778498a9ba2a5ba866"
+  integrity sha512-8gDaRrLF2HCg+YEZN1ov0zN35vmtPnGf3h1DxmJQK5Wm2lRMLomz9rsWsuvig3UJMHqZAQKD7tOl3ocJocQsmA==
   dependencies:
-    content-hash "^2.5.2"
-    eth-ens-namehash "2.0.8"
-    underscore "1.9.1"
-    web3-core "1.3.2"
-    web3-core-helpers "1.3.2"
-    web3-core-promievent "1.3.2"
-    web3-eth-abi "1.3.2"
-    web3-eth-contract "1.3.2"
-    web3-utils "1.3.2"
+    "@types/bn.js" "^4.11.5"
+    underscore "1.12.1"
+    web3-core "1.3.6"
+    web3-core-helpers "1.3.6"
+    web3-core-method "1.3.6"
+    web3-core-promievent "1.3.6"
+    web3-core-subscriptions "1.3.6"
+    web3-eth-abi "1.3.6"
+    web3-utils "1.3.6"
 
 web3-eth-ens@1.3.5:
   version "1.3.5"
@@ -23006,13 +22986,20 @@ web3-eth-ens@1.3.5:
     web3-eth-contract "1.3.5"
     web3-utils "1.3.5"
 
-web3-eth-iban@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.3.2.tgz#5fc72f62230de7ae746bdc5281f67e2c6ee8e3a0"
-  integrity sha512-w00aAK7lPlKKhBtC72hJGmCnuH/Uf87HoH77+1XH4wrLCxvry7ChZoQ1g+88Qu8bNnSMdDcSDxLVsvHGwZJp3Q==
+web3-eth-ens@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-eth-ens/-/web3-eth-ens-1.3.6.tgz#0d28c5d4ea7b4462ef6c077545a77956a6cdf175"
+  integrity sha512-n27HNj7lpSkRxTgSx+Zo7cmKAgyg2ElFilaFlUu/X2CNH23lXfcPm2bWssivH9z0ndhg0OyR4AYFZqPaqDHkJA==
   dependencies:
-    bn.js "^4.11.9"
-    web3-utils "1.3.2"
+    content-hash "^2.5.2"
+    eth-ens-namehash "2.0.8"
+    underscore "1.12.1"
+    web3-core "1.3.6"
+    web3-core-helpers "1.3.6"
+    web3-core-promievent "1.3.6"
+    web3-eth-abi "1.3.6"
+    web3-eth-contract "1.3.6"
+    web3-utils "1.3.6"
 
 web3-eth-iban@1.3.5:
   version "1.3.5"
@@ -23022,17 +23009,13 @@ web3-eth-iban@1.3.5:
     bn.js "^4.11.9"
     web3-utils "1.3.5"
 
-web3-eth-personal@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-eth-personal/-/web3-eth-personal-1.3.2.tgz#737c05e4fd7c115764884019974850685a216aa5"
-  integrity sha512-gpMUEwho+RkR6EunHEsxm66HarXfGav9meC2D4xOkedxBOniog/TyGG8ntwN0AKRqXcX9Cv8NzndMfGcMzCXNw==
+web3-eth-iban@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.3.6.tgz#0d6ba21fe78f190af8919e9cd5453882457209e0"
+  integrity sha512-nfMQaaLA/zsg5W4Oy/EJQbs8rSs1vBAX6b/35xzjYoutXlpHMQadujDx2RerTKhSHqFXSJeQAfE+2f6mdhYkRQ==
   dependencies:
-    "@types/node" "^12.12.6"
-    web3-core "1.3.2"
-    web3-core-helpers "1.3.2"
-    web3-core-method "1.3.2"
-    web3-net "1.3.2"
-    web3-utils "1.3.2"
+    bn.js "^4.11.9"
+    web3-utils "1.3.6"
 
 web3-eth-personal@1.3.5:
   version "1.3.5"
@@ -23046,24 +23029,17 @@ web3-eth-personal@1.3.5:
     web3-net "1.3.5"
     web3-utils "1.3.5"
 
-web3-eth@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-eth/-/web3-eth-1.3.2.tgz#46520b9edb4a258bb7a67f6d1bbd4358e8ea79db"
-  integrity sha512-zGhPsDB9Jn+kx3l8ddZ86q4btRBivoLOj+EvUqxTAg0ZQ9g2/FPnsnNXlaYEZx/fjwHXcOB+h/biyNlylL+HnQ==
+web3-eth-personal@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-eth-personal/-/web3-eth-personal-1.3.6.tgz#226137916754c498f0284f22c55924c87a2efcf0"
+  integrity sha512-pOHU0+/h1RFRYoh1ehYBehRbcKWP4OSzd4F7mDljhHngv6W8ewMHrAN8O1ol9uysN2MuCdRE19qkRg5eNgvzFQ==
   dependencies:
-    underscore "1.9.1"
-    web3-core "1.3.2"
-    web3-core-helpers "1.3.2"
-    web3-core-method "1.3.2"
-    web3-core-subscriptions "1.3.2"
-    web3-eth-abi "1.3.2"
-    web3-eth-accounts "1.3.2"
-    web3-eth-contract "1.3.2"
-    web3-eth-ens "1.3.2"
-    web3-eth-iban "1.3.2"
-    web3-eth-personal "1.3.2"
-    web3-net "1.3.2"
-    web3-utils "1.3.2"
+    "@types/node" "^12.12.6"
+    web3-core "1.3.6"
+    web3-core-helpers "1.3.6"
+    web3-core-method "1.3.6"
+    web3-net "1.3.6"
+    web3-utils "1.3.6"
 
 web3-eth@1.3.5:
   version "1.3.5"
@@ -23084,14 +23060,24 @@ web3-eth@1.3.5:
     web3-net "1.3.5"
     web3-utils "1.3.5"
 
-web3-net@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.3.2.tgz#c347e58fa090868ed914fa513bfaf768d420e7f4"
-  integrity sha512-3aYio5ZJKy+mrw3S9G1Qyxk0k6NYM3gFYfRuEVoV99g2R2YpVLm/uU4j8XgwA0uayWU67bddVzw74n5w7sKkpw==
+web3-eth@^1.3.5:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-eth/-/web3-eth-1.3.6.tgz#2c650893d540a7a0eb1365dd5b2dca24ac919b7c"
+  integrity sha512-9+rnywRRpyX3C4hfsAQXPQh6vHh9XzQkgLxo3gyeXfbhbShUoq2gFVuy42vsRs//6JlsKdyZS7Z3hHPHz2wreA==
   dependencies:
-    web3-core "1.3.2"
-    web3-core-method "1.3.2"
-    web3-utils "1.3.2"
+    underscore "1.12.1"
+    web3-core "1.3.6"
+    web3-core-helpers "1.3.6"
+    web3-core-method "1.3.6"
+    web3-core-subscriptions "1.3.6"
+    web3-eth-abi "1.3.6"
+    web3-eth-accounts "1.3.6"
+    web3-eth-contract "1.3.6"
+    web3-eth-ens "1.3.6"
+    web3-eth-iban "1.3.6"
+    web3-eth-personal "1.3.6"
+    web3-net "1.3.6"
+    web3-utils "1.3.6"
 
 web3-net@1.3.5:
   version "1.3.5"
@@ -23101,6 +23087,15 @@ web3-net@1.3.5:
     web3-core "1.3.5"
     web3-core-method "1.3.5"
     web3-utils "1.3.5"
+
+web3-net@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.3.6.tgz#a56492e2227475e38db29394f8bac305a2446e41"
+  integrity sha512-KhzU3wMQY/YYjyMiQzbaLPt2kut88Ncx2iqjy3nw28vRux3gVX0WOCk9EL/KVJBiAA/fK7VklTXvgy9dZnnipw==
+  dependencies:
+    web3-core "1.3.6"
+    web3-core-method "1.3.6"
+    web3-utils "1.3.6"
 
 web3-provider-engine@16.0.1, web3-provider-engine@^16.0.1:
   version "16.0.1"
@@ -23130,14 +23125,6 @@ web3-provider-engine@16.0.1, web3-provider-engine@^16.0.1:
     xhr "^2.2.0"
     xtend "^4.0.1"
 
-web3-providers-http@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.3.2.tgz#1d9e22109bcf48db5d33e34d49fa6f81f75a0b1f"
-  integrity sha512-r0e92BqC4BswzZeAQYTp0+kMPTc4DIhwC7+TNFVD1LnzWeiHUZk0nui7JF4kKllMOJSjvJRQvoLS/2DBtb3Acw==
-  dependencies:
-    web3-core-helpers "1.3.2"
-    xhr2-cookies "1.1.0"
-
 web3-providers-http@1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.3.5.tgz#cdada6fb342e08fd75aea249fceb6eee467beffc"
@@ -23146,14 +23133,13 @@ web3-providers-http@1.3.5:
     web3-core-helpers "1.3.5"
     xhr2-cookies "1.1.0"
 
-web3-providers-ipc@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-providers-ipc/-/web3-providers-ipc-1.3.2.tgz#3e0a9136ab81d4da0a60cbb490543a1c6a6c96ec"
-  integrity sha512-MjTW/EEFAWbiVPXYk5ZLyJCvgiaGhTbQY1UNvbGuPnAI5OYKW6BsZYi3J9nx8/drwO7dszJueRbjF9TnzJDKHw==
+web3-providers-http@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.3.6.tgz#36e8724a7424d52827819d53fd75dbf31f5422c2"
+  integrity sha512-OQkT32O1A06dISIdazpGLveZcOXhEo5cEX6QyiSQkiPk/cjzDrXMw4SKZOGQbbS1+0Vjizm1Hrp7O8Vp2D1M5Q==
   dependencies:
-    oboe "2.1.5"
-    underscore "1.9.1"
-    web3-core-helpers "1.3.2"
+    web3-core-helpers "1.3.6"
+    xhr2-cookies "1.1.0"
 
 web3-providers-ipc@1.3.5:
   version "1.3.5"
@@ -23164,15 +23150,14 @@ web3-providers-ipc@1.3.5:
     underscore "1.9.1"
     web3-core-helpers "1.3.5"
 
-web3-providers-ws@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.3.2.tgz#3bfe35a22f3fc77c3ab4ec69a29bb8efdbc6acc2"
-  integrity sha512-I55BFSc6Q5BoB9q99IxZaPlZQQV3e/lHO3oj9GvSi+E+sTYIb6ccGawkKRInWh1i//R6zN6FptCCyOfAPT5B+g==
+web3-providers-ipc@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-providers-ipc/-/web3-providers-ipc-1.3.6.tgz#cef8d12c1ebb47adce5ebf597f553c623362cb4a"
+  integrity sha512-+TVsSd2sSVvVgHG4s6FXwwYPPT91boKKcRuEFXqEfAbUC5t52XOgmyc2LNiD9LzPhed65FbV4LqICpeYGUvSwA==
   dependencies:
-    eventemitter3 "4.0.4"
-    underscore "1.9.1"
-    web3-core-helpers "1.3.2"
-    websocket "^1.0.32"
+    oboe "2.1.5"
+    underscore "1.12.1"
+    web3-core-helpers "1.3.6"
 
 web3-providers-ws@1.3.5:
   version "1.3.5"
@@ -23184,15 +23169,15 @@ web3-providers-ws@1.3.5:
     web3-core-helpers "1.3.5"
     websocket "^1.0.32"
 
-web3-shh@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-shh/-/web3-shh-1.3.2.tgz#7c86c7b532c1e76f8197d33d74d1c5e38170ea11"
-  integrity sha512-aEgL6ryUxvdxaAl0Uz0QyBvKS4a88wsRWmacGtI8RFR3eUEzTbAb8jZ7sd5UuUxqP6Q/Wmt6/+bc4FqxSaF5xA==
+web3-providers-ws@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.3.6.tgz#e1df617bc89d66165abdf2191da0014c505bfaac"
+  integrity sha512-bk7MnJf5or0Re2zKyhR3L3CjGululLCHXx4vlbc/drnaTARUVvi559OI5uLytc/1k5HKUUyENAxLvetz2G1dnQ==
   dependencies:
-    web3-core "1.3.2"
-    web3-core-method "1.3.2"
-    web3-core-subscriptions "1.3.2"
-    web3-net "1.3.2"
+    eventemitter3 "4.0.4"
+    underscore "1.12.1"
+    web3-core-helpers "1.3.6"
+    websocket "^1.0.32"
 
 web3-shh@1.3.5:
   version "1.3.5"
@@ -23204,21 +23189,7 @@ web3-shh@1.3.5:
     web3-core-subscriptions "1.3.5"
     web3-net "1.3.5"
 
-web3-utils@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.3.2.tgz#3f6ac95704ba41f60062fd283e629015f5d359a9"
-  integrity sha512-00jr14EH/dYLjHqkt7l5VAj27IhRsn+I4b2OHvGXGG+8PT/HQTf3IxoYknHRE09kh+TmrTAT3mPurX/Q6+RVng==
-  dependencies:
-    bn.js "^4.11.9"
-    eth-lib "0.2.8"
-    ethereum-bloom-filters "^1.0.6"
-    ethjs-unit "0.1.6"
-    number-to-bn "1.7.0"
-    randombytes "^2.1.0"
-    underscore "1.9.1"
-    utf8 "3.0.0"
-
-web3-utils@1.3.5:
+web3-utils@1.3.5, web3-utils@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.3.5.tgz#14ee2ff1a7a226867698d6eaffd21aa97aed422e"
   integrity sha512-5apMRm8ElYjI/92GHqijmaLC+s+d5lgjpjHft+rJSs/dsnX8I8tQreqev0dmU+wzU+2EEe4Sx9a/OwGWHhQv3A==
@@ -23232,7 +23203,21 @@ web3-utils@1.3.5:
     underscore "1.9.1"
     utf8 "3.0.0"
 
-web3@*:
+web3-utils@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.3.6.tgz#390bc9fa3a7179746963cfaca55bb80ac4d8dc10"
+  integrity sha512-hHatFaQpkQgjGVER17gNx8u1qMyaXFZtM0y0XLGH1bzsjMPlkMPLRcYOrZ00rOPfTEuYFOdrpGOqZXVmGrMZRg==
+  dependencies:
+    bn.js "^4.11.9"
+    eth-lib "0.2.8"
+    ethereum-bloom-filters "^1.0.6"
+    ethjs-unit "0.1.6"
+    number-to-bn "1.7.0"
+    randombytes "^2.1.0"
+    underscore "1.12.1"
+    utf8 "3.0.0"
+
+web3@*, web3@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/web3/-/web3-1.3.5.tgz#ef4c3a2241fdd74f2f7794e839f30bc6f9814e46"
   integrity sha512-UyQW/MT5EIGBrXPCh/FDIaD7RtJTn5/rJUNw2FOglp0qoXnCQHNKvntiR1ylztk05fYxIF6UgsC76IrazlKJjw==
@@ -23244,19 +23229,6 @@ web3@*:
     web3-net "1.3.5"
     web3-shh "1.3.5"
     web3-utils "1.3.5"
-
-web3@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/web3/-/web3-1.3.2.tgz#066fbd8831356dbade25fddec3534ec14288b06b"
-  integrity sha512-zZA8mymny6G+/eyISbaQ9fMQ6SsZOObX1ZUgqpnttNluuwc+oLjModjh+XiIC1OqU8WSwoq5HkKatli7sILbNA==
-  dependencies:
-    web3-bzz "1.3.2"
-    web3-core "1.3.2"
-    web3-eth "1.3.2"
-    web3-eth-personal "1.3.2"
-    web3-net "1.3.2"
-    web3-shh "1.3.2"
-    web3-utils "1.3.2"
 
 webidl-conversions@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
CS-1177

Workaround for `web3@1.3.x` not receiving 'confirmation' and 'receipt' events when used with WalletConnect. 

- Wrap contract method calls in TokenBridgeForeignSide in a Promise
- Makes existing polling for receipts timeout after a set duration, defaults to 30 seconds
- Resolves the Promise in TokenBridgeForeignSide if a receipt is successfully retrieved within the duration
- Throws an error if polling is not successful after the duration