### PR TITLE
explicitly reject errors when polling for receipt

### DIFF
--- a/packages/cardpay-sdk/sdk/token-bridge-foreign-side.ts
+++ b/packages/cardpay-sdk/sdk/token-bridge-foreign-side.ts
@@ -29,12 +29,16 @@ export default class TokenBridgeForeignSide implements ITokenBridgeForeignSide {
     let token = new this.layer1Web3.eth.Contract(ERC20ABI as AbiItem[], tokenAddress);
     let foreignBridge = await getAddress('foreignBridge', this.layer1Web3);
 
-    return await new Promise((resolve) => {
+    return await new Promise((resolve, reject) => {
       token.methods
         .approve(foreignBridge, amount)
         .send({ ...options, from })
         .on('transactionHash', async (txnHash: string) => {
-          resolve(await waitUntilTransactionMined(this.layer1Web3, txnHash));
+          try {
+            resolve(await waitUntilTransactionMined(this.layer1Web3, txnHash));
+          } catch (e) {
+            reject(e);
+          }
         });
     });
   }
@@ -51,12 +55,16 @@ export default class TokenBridgeForeignSide implements ITokenBridgeForeignSide {
       await getAddress('foreignBridge', this.layer1Web3)
     );
 
-    return await new Promise((resolve) => {
+    return await new Promise((resolve, reject) => {
       foreignBridge.methods
         .relayTokens(tokenAddress, recipientAddress, amount)
         .send({ ...options, from })
         .on('transactionHash', async (txnHash: string) => {
-          resolve(await waitUntilTransactionMined(this.layer1Web3, txnHash));
+          try {
+            resolve(await waitUntilTransactionMined(this.layer1Web3, txnHash));
+          } catch (e) {
+            reject(e);
+          }
         });
     });
   }


### PR DESCRIPTION
The `transactionHash` event callback is called in a `setTimeout` (probably because web3 is also polling?) so `Promise.catch` does not work without explicitly rejecting the promise, and using `TokenBridgeForeignSide.unlockTokens` and `TokenBridgeForeignSide.relayTokens` will result in uncaught errors in Promises, if any happen. This is fixed by explicitly catching then rejecting the error.