### PR TITLE
Fix/wallet connection states

### DIFF
--- a/packages/web-client/app/utils/events.ts
+++ b/packages/web-client/app/utils/events.ts
@@ -1,8 +1,8 @@
 // based on https://github.com/ai/nanoevents/blob/main/index.js
 export type UnbindEventListener = () => void;
 
-export interface Emitter {
-  on(event: string, cb: Function): UnbindEventListener;
+export interface Emitter<EmitterEvents = string> {
+  on(event: EmitterEvents, cb: Function): UnbindEventListener;
 }
 
 /**

--- a/packages/web-client/app/utils/wallet-providers.ts
+++ b/packages/web-client/app/utils/wallet-providers.ts
@@ -1,8 +1,9 @@
 import metamaskLogo from '@cardstack/web-client/images/logos/metamask-logo.svg';
 import walletConnectLogo from '@cardstack/web-client/images/logos/wallet-connect-logo.svg';
 
+export type WalletProviderId = 'metamask' | 'wallet-connect';
 export interface WalletProvider {
-  id: string;
+  id: WalletProviderId;
   name: string;
   logo: string;
 }

--- a/packages/web-client/app/utils/wc-connector.ts
+++ b/packages/web-client/app/utils/wc-connector.ts
@@ -7,6 +7,13 @@ import * as cryptoLib from '@walletconnect/iso-crypto';
 import Connector from '@walletconnect/core';
 import SessionStorage from '@walletconnect/core/dist/cjs/storage';
 
+const GET_STORAGE_ID = (chainId: string | number) =>
+  `wallet-connect-chain-${chainId}`;
+
+export function clearWalletConnectStorage(chainId: string | number) {
+  window.localStorage.removeItem(GET_STORAGE_ID(chainId));
+}
+
 // based on https://github.com/WalletConnect/walletconnect-monorepo/blob/1d2828fe63c97e4c0a72eea0150e2f65b819152d/packages/clients/client/src/index.ts
 export default class CustomStorageWalletConnect extends Connector {
   constructor(
@@ -20,7 +27,7 @@ export default class CustomStorageWalletConnect extends Connector {
       );
     }
     const storage = new SessionStorage();
-    storage.storageId = `wallet-connect-chain-${chainId}`;
+    storage.storageId = GET_STORAGE_ID(chainId);
     super({
       cryptoLib,
       connectorOpts,

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -14,73 +14,7 @@ const GET_PROVIDER_STORAGE_KEY = (chainId: string | number) =>
   `cardstack-chain-${chainId}-provider`;
 const WALLET_CONNECT_BRIDGE = 'https://safe-walletconnect.gnosis.io/';
 
-export async function createConnectionManagerFromLocalStorage(
-  web3: Web3,
-  options: ConnectionManagerOptions
-): Promise<ConnectionManager | void> {
-  try {
-    let providerId = ConnectionManager.getProviderIdForChain(options.chainId);
-    if (providerId !== 'wallet-connect' && providerId !== 'metamask') {
-      return;
-    }
-
-    let connectionManager: ConnectionManager = ConnectionManager.create(
-      providerId,
-      options
-    );
-
-    connectionManager.on('connected', options.onConnect);
-    connectionManager.on('disconnected', options.onDisconnect);
-    connectionManager.on('incorrect-chain', options.onIncorrectChain);
-
-    await connectionManager.setup();
-    connectionManager.setWeb3Provider(web3);
-
-    return connectionManager;
-  } catch (e) {
-    console.error('Failed to create connection manager from local storage');
-    console.error(e);
-    return;
-  }
-}
-
-export async function createConnectionManager(
-  providerId: WalletProviderId,
-  web3: Web3,
-  options: ConnectionManagerOptions
-): Promise<ConnectionManager | void> {
-  try {
-    let connectionManager: ConnectionManager = ConnectionManager.create(
-      providerId,
-      options
-    );
-
-    connectionManager.on('connected', options.onConnect);
-    connectionManager.on('disconnected', options.onDisconnect);
-    connectionManager.on('incorrect-chain', options.onIncorrectChain);
-
-    await connectionManager.setup();
-
-    connectionManager.setWeb3Provider(web3);
-
-    return connectionManager;
-  } catch (e) {
-    console.error(`Failed to create connection manager: ${providerId}`);
-    console.error(e);
-    ConnectionManager.removeProviderFromStorage(options.chainId);
-    return;
-  }
-}
-
-interface EventCallbacks {
-  // events here are different from EIP 1193
-  onDisconnect(): void;
-  onConnect(accounts: string[]): void;
-  onIncorrectChain(): void;
-  onError(error: Error): void;
-}
-
-interface ConnectionManagerOptions extends EventCallbacks {
+interface ConnectionManagerOptions {
   chainId: number;
   networkSymbol: NetworkSymbol;
 }

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -50,6 +50,7 @@ export abstract class ConnectionManager
   simpleEmitter: SimpleEmitter;
   broadcastChannel: BroadcastChannel;
   protected provider: any;
+  protected connected = false;
   abstract providerId: WalletProviderId;
 
   constructor(options: ConnectionManagerOptions) {
@@ -113,6 +114,10 @@ export abstract class ConnectionManager
   }
 
   onDisconnect(broadcast = true) {
+    if (!this.connected) {
+      return;
+    }
+    this.connected = false;
     ConnectionManager.removeProviderFromStorage(this.chainId);
     if (broadcast)
       this.broadcastChannel.postMessage(
@@ -123,6 +128,7 @@ export abstract class ConnectionManager
   }
 
   onConnect(accounts: string[]) {
+    this.connected = true;
     ConnectionManager.addProviderToStorage(this.chainId, this.providerId);
     this.emit('connected', accounts);
   }

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -43,8 +43,8 @@ export abstract class ConnectionManager
   implements Emitter<ConnectionManagerEvents> {
   networkSymbol: NetworkSymbol;
   chainId: number;
-  simpleEmitter: SimpleEmitter;
-  broadcastChannel: BroadcastChannel;
+  protected simpleEmitter: SimpleEmitter;
+  protected broadcastChannel: BroadcastChannel;
   protected provider: any;
   protected connected = false;
   abstract providerId: WalletProviderId;

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -1,0 +1,334 @@
+import detectEthereumProvider from '@metamask/detect-provider';
+import Web3 from 'web3';
+import { NetworkSymbol } from '../token';
+import WalletConnectProvider from '@walletconnect/web3-provider';
+import WalletConnectQRCodeModal from '@walletconnect/qrcode-modal';
+import config from '../../config/environment';
+import CustomStorageWalletConnect, {
+  clearWalletConnectStorage,
+} from '../wc-connector';
+import { Emitter, SimpleEmitter } from '../events';
+import { WalletProviderId } from '../wallet-providers';
+
+const GET_PROVIDER_STORAGE_KEY = (chainId: string | number) =>
+  `cardstack-chain-${chainId}-provider`;
+const WALLET_CONNECT_BRIDGE = 'https://safe-walletconnect.gnosis.io/';
+
+export async function createConnectionManagerFromLocalStorage(
+  web3: Web3,
+  options: ConnectionManagerOptions
+): Promise<ConnectionManager | void> {
+  try {
+    let providerId = ConnectionManager.getProviderIdForChain(options.chainId);
+    if (providerId !== 'wallet-connect' && providerId !== 'metamask') {
+      return;
+    }
+
+    let connectionManager: ConnectionManager = ConnectionManager.create(
+      providerId,
+      options
+    );
+
+    connectionManager.on('connected', options.onConnect);
+    connectionManager.on('disconnected', options.onDisconnect);
+    connectionManager.on('incorrect-chain', options.onIncorrectChain);
+
+    await connectionManager.setup();
+    connectionManager.setWeb3Provider(web3);
+
+    return connectionManager;
+  } catch (e) {
+    console.error('Failed to create connection manager from local storage');
+    console.error(e);
+    return;
+  }
+}
+
+export async function createConnectionManager(
+  providerId: WalletProviderId,
+  web3: Web3,
+  options: ConnectionManagerOptions
+): Promise<ConnectionManager | void> {
+  try {
+    let connectionManager: ConnectionManager = ConnectionManager.create(
+      providerId,
+      options
+    );
+
+    connectionManager.on('connected', options.onConnect);
+    connectionManager.on('disconnected', options.onDisconnect);
+    connectionManager.on('incorrect-chain', options.onIncorrectChain);
+
+    await connectionManager.setup();
+
+    connectionManager.setWeb3Provider(web3);
+
+    return connectionManager;
+  } catch (e) {
+    console.error(`Failed to create connection manager: ${providerId}`);
+    console.error(e);
+    ConnectionManager.removeProviderFromStorage(options.chainId);
+    return;
+  }
+}
+
+interface EventCallbacks {
+  // events here are different from EIP 1193
+  onDisconnect(): void;
+  onConnect(accounts: string[]): void;
+  onIncorrectChain(): void;
+  onError(error: Error): void;
+}
+
+interface ConnectionManagerOptions extends EventCallbacks {
+  chainId: number;
+  networkSymbol: NetworkSymbol;
+}
+
+type ConnectionManagerEvents =
+  | 'connected'
+  | 'disconnected'
+  | 'incorrect-chain'
+  | 'error';
+
+export abstract class ConnectionManager
+  implements Emitter<ConnectionManagerEvents> {
+  web3: Web3 | undefined;
+  networkSymbol: NetworkSymbol;
+  chainId: number;
+  simpleEmitter: SimpleEmitter;
+  protected provider: any;
+  abstract providerId: WalletProviderId;
+
+  constructor(options: ConnectionManagerOptions) {
+    this.networkSymbol = options.networkSymbol;
+    this.chainId = options.chainId;
+    this.simpleEmitter = new SimpleEmitter();
+  }
+
+  static create(
+    providerId: WalletProviderId,
+    options: ConnectionManagerOptions
+  ): ConnectionManager {
+    if (providerId === 'metamask') {
+      return new MetaMaskConnectionManager(options);
+    } else if (providerId === 'wallet-connect') {
+      return new WalletConnectConnectionManager(options);
+    } else {
+      throw new Error(`Unrecognised id for connection manager: ${providerId}`);
+    }
+  }
+
+  static getProviderIdForChain(chainId: string | number) {
+    return window.localStorage.getItem(GET_PROVIDER_STORAGE_KEY(chainId));
+  }
+
+  static removeProviderFromStorage(chainId: string | number) {
+    window.localStorage.removeItem(GET_PROVIDER_STORAGE_KEY(chainId));
+  }
+
+  static addProviderToStorage(
+    chainId: string | number,
+    providerId: WalletProviderId
+  ) {
+    window.localStorage.setItem(GET_PROVIDER_STORAGE_KEY(chainId), providerId);
+  }
+
+  on(event: ConnectionManagerEvents, cb: Function) {
+    return this.simpleEmitter.on(event, cb);
+  }
+
+  emit(event: ConnectionManagerEvents, ...args: any[]) {
+    return this.simpleEmitter.emit(event, ...args);
+  }
+
+  onDisconnect() {
+    ConnectionManager.removeProviderFromStorage(this.chainId);
+    this.emit('disconnected');
+  }
+
+  onConnect(accounts: string[]) {
+    ConnectionManager.addProviderToStorage(this.chainId, this.providerId);
+    this.emit('connected', accounts);
+  }
+
+  // maybe should be onError
+  onIncorrectChain() {
+    ConnectionManager.removeProviderFromStorage(this.chainId);
+    this.emit('incorrect-chain');
+  }
+
+  abstract reconnect(): Promise<void>;
+  abstract connect(): Promise<void>;
+  abstract disconnect(): Promise<void>;
+
+  // create provider and setup event listeners here
+  abstract setup(): Promise<any>;
+
+  setWeb3Provider(web3: Web3) {
+    web3.setProvider(this.provider);
+  }
+}
+
+class MetaMaskConnectionManager extends ConnectionManager {
+  providerId = 'metamask' as WalletProviderId;
+
+  async setup() {
+    let provider: any | undefined = await detectEthereumProvider();
+
+    if (!provider) {
+      // TODO: some UI prompt for getting people to setup metamask
+      console.log('Please install MetaMask!');
+      return;
+    }
+
+    if (provider !== window.ethereum) {
+      // TODO: some UI prompt to get people to disconnect their other wallets
+      console.error('Do you have multiple wallets installed?');
+      return;
+    }
+
+    // remove all listeners that previous instances of metamask connections have added
+    // otherwise disconnecting and reconnecting might cause "duplicate" event listeners
+    // it doesn't seem like it should be a problem, but unsure
+    provider.removeAllListeners();
+
+    provider.on('accountsChanged', (accounts: string[]) => {
+      if (!accounts.length) {
+        this.onDisconnect();
+      } else {
+        this.onConnect(accounts);
+      }
+    });
+
+    // Subscribe to chainId change
+    provider.on('chainChanged', (changedChainId: number) => {
+      if (String(changedChainId) !== String(this.chainId)) {
+        console.error('connected to incorrect chain');
+        this.onIncorrectChain();
+      }
+    });
+
+    provider.on('connect', (info: { chainId: number }) => {
+      console.log(info);
+    });
+
+    // Note that this is, following EIP-1193, about connection of the wallet to the
+    // chain, not our dapp to the wallet
+    provider.on('disconnect', (error: { code: number; message: string }) => {
+      console.error(error);
+      this.onDisconnect();
+    });
+
+    this.provider = provider;
+  }
+
+  async connect() {
+    if (!this.provider)
+      throw new Error('Trying to connect before provider is set');
+    let accounts = await this.provider.request({
+      method: 'eth_accounts',
+    });
+    if (accounts.length) {
+      // so we had accounts before, let's just connect to them now
+      // metamask's disconnection is a faux-disconnection - the wallet still thinks
+      // it is connected to the account so it will not fire the connection/account change events
+      this.onConnect(accounts);
+    } else {
+      // otherwise we want to trigger the extension prompt
+      await this.provider.request({
+        method: 'eth_requestAccounts',
+      });
+    }
+    return;
+  }
+
+  // metamask actually doesn't allow you to disconnect via its API
+  // all we do here is fire the disconnect callback
+  async disconnect() {
+    this.onDisconnect();
+    return;
+  }
+
+  // unlike the connect method, here we do not try to open the popup (eth_requestAccounts) if there is no account
+  async reconnect() {
+    let provider: any | undefined = await detectEthereumProvider();
+    let accounts = await provider.request({ method: 'eth_accounts' });
+    if (accounts.length) {
+      // metamask's disconnection is a faux-disconnection - the wallet still thinks
+      // it is connected to the account so it will not fire the connection/account change events
+      this.onConnect(accounts);
+    } else {
+      // if we didn't find accounts, then the stored provider key is not useful, delete it
+      window.localStorage.removeItem(GET_PROVIDER_STORAGE_KEY(this.chainId));
+      return;
+    }
+  }
+}
+
+class WalletConnectConnectionManager extends ConnectionManager {
+  providerId = 'wallet-connect' as WalletProviderId;
+
+  async setup() {
+    let { chainId } = this;
+    // in case we've disconnected, we should clear wallet connect's local storage data as well
+    if (ConnectionManager.getProviderIdForChain(chainId) !== this.providerId) {
+      clearWalletConnectStorage(chainId);
+    }
+    let provider = new WalletConnectProvider({
+      chainId,
+      infuraId: config.infuraId,
+      // based on https://github.com/WalletConnect/walletconnect-monorepo/blob/7aa9a7213e15489fa939e2e020c7102c63efd9c4/packages/providers/web3-provider/src/index.ts#L47-L52
+      connector: new CustomStorageWalletConnect(
+        {
+          bridge: WALLET_CONNECT_BRIDGE,
+          qrcodeModal: WalletConnectQRCodeModal,
+        },
+        chainId
+      ),
+    });
+
+    // Subscribe to accounts change
+    provider.on('accountsChanged', (accounts: string[]) => {
+      if (accounts.length) this.onConnect(accounts);
+    });
+
+    // Subscribe to chainId change
+    provider.on('chainChanged', (changedChainId: number) => {
+      if (String(changedChainId) !== String(chainId)) {
+        console.error('connected to incorrect chain');
+        this.onIncorrectChain();
+      }
+    });
+
+    // TODO: fill this in w connect callback
+    // provider.on('connect', function () {});
+
+    // Subscribe to session disconnection
+    // This is how WalletConnect informs us if we disconnect the Dapp
+    // from the wallet side. Unlike MetaMask, listening to 'accountsChanged'
+    // does not work.
+    provider.on('disconnect', (code: number, reason: string) => {
+      console.log('disconnect from wallet connect', code, reason);
+      // without checking this, the event will fire twice.
+      this.onDisconnect();
+    });
+
+    this.provider = provider;
+
+    return;
+  }
+
+  async connect() {
+    return await this.provider.enable();
+  }
+
+  async disconnect() {
+    await this.provider.disconnect();
+    return;
+  }
+
+  async reconnect() {
+    return await this.provider.enable();
+  }
+}

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -30,6 +30,19 @@ const BROADCAST_CHANNEL_MESSAGES = {
   DISCONNECTED: 'DISCONNECTED',
 } as const;
 
+/**
+ * # ConnectionManager
+ * This class instantiates a web3 provider given a WalletProviderId. It then handles the EIP-1193
+ * events that come from the web3 provider and filters them for events that we want to handle
+ * in the Dapp:
+ *
+ * - connected: A wallet is connected, or the address is changed
+ * - disconnected: A wallet is disconnected
+ * - incorrect-chain: A wallet is connected to the wrong chain
+ *
+ * It handles cross-tab communication and persistence of connection information across refreshes.
+ * This class does not, at the moment, store any state used directly by the UI besides providerId.
+ */
 export abstract class ConnectionManager
   implements Emitter<ConnectionManagerEvents> {
   web3: Web3 | undefined;

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -20,11 +20,7 @@ interface ConnectionManagerOptions {
   networkSymbol: NetworkSymbol;
 }
 
-type ConnectionManagerEvents =
-  | 'connected'
-  | 'disconnected'
-  | 'incorrect-chain'
-  | 'error';
+type ConnectionManagerEvents = 'connected' | 'disconnected' | 'incorrect-chain';
 
 const BROADCAST_CHANNEL_MESSAGES = {
   DISCONNECTED: 'DISCONNECTED',

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -123,7 +123,7 @@ export abstract class ConnectionManager
       this.broadcastChannel.postMessage(
         BROADCAST_CHANNEL_MESSAGES.DISCONNECTED
       );
-    // disconnect will destroy this object so it has to be last
+    // the layer1-chain will destroy the instance of ConnectionManager so we emit as the last item
     this.emit('disconnected');
   }
 
@@ -133,7 +133,6 @@ export abstract class ConnectionManager
     this.emit('connected', accounts);
   }
 
-  // maybe should be onError
   onIncorrectChain() {
     ConnectionManager.removeProviderFromStorage(this.chainId);
     this.emit('incorrect-chain');
@@ -172,7 +171,6 @@ class MetaMaskConnectionManager extends ConnectionManager {
 
     // remove all listeners that previous instances of metamask connections have added
     // otherwise disconnecting and reconnecting might cause "duplicate" event listeners
-    // it doesn't seem like it should be a problem, but unsure
     provider.removeAllListeners();
 
     provider.on('accountsChanged', (accounts: string[]) => {

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -185,10 +185,6 @@ class MetaMaskConnectionManager extends ConnectionManager {
       }
     });
 
-    provider.on('connect', (info: { chainId: number }) => {
-      console.log(info);
-    });
-
     // Note that this is, following EIP-1193, about connection of the wallet to the
     // chain, not our dapp to the wallet
     provider.on('disconnect', (error: { code: number; message: string }) => {
@@ -277,9 +273,6 @@ class WalletConnectConnectionManager extends ConnectionManager {
         this.onIncorrectChain();
       }
     });
-
-    // TODO: fill this in w connect callback
-    // provider.on('connect', function () {});
 
     // Subscribe to session disconnection
     // This is how WalletConnect informs us if we disconnect the Dapp

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -296,6 +296,9 @@ class WalletConnectConnectionManager extends ConnectionManager {
   }
 
   async reconnect() {
+    // if the qr code modal ever pops up when the application is loading, it's time to revisit this code
+    // this typically should not open the modal if CustomStorageWalletConnect is initialized with a
+    // valid session from localStorage
     return await this.provider.enable();
   }
 }

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -1,6 +1,6 @@
 import detectEthereumProvider from '@metamask/detect-provider';
 import Web3 from 'web3';
-import { NetworkSymbol } from '../token';
+import { NetworkSymbol } from './types';
 import WalletConnectProvider from '@walletconnect/web3-provider';
 import WalletConnectQRCodeModal from '@walletconnect/qrcode-modal';
 import config from '../../config/environment';

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -245,6 +245,9 @@ class WalletConnectConnectionManager extends ConnectionManager {
   async setup(web3: Web3) {
     let { chainId } = this;
     // in case we've disconnected, we should clear wallet connect's local storage data as well
+    // As per https://github.com/WalletConnect/walletconnect-monorepo/issues/258 there is no way
+    // for us to tell if this is valid before we connect, but we don't want to connect to something
+    // if we have disconnected from it in the first place (since we cleared our local storage identification of provider)
     if (ConnectionManager.getProviderIdForChain(chainId) !== this.providerId) {
       clearWalletConnectStorage(chainId);
     }
@@ -280,7 +283,6 @@ class WalletConnectConnectionManager extends ConnectionManager {
     // does not work.
     provider.on('disconnect', (code: number, reason: string) => {
       console.log('disconnect from wallet connect', code, reason);
-      // without checking this, the event will fire twice.
       this.onDisconnect(false);
     });
 

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -110,6 +110,11 @@ export abstract class ConnectionManager
   }
 
   onDisconnect(broadcast = true) {
+    // NOTE: if the ConnectionManager thinks that it's disconnected and Layer1Chain thinks
+    // that it's connected, this can result in never being able to disconnect
+    // The problem here is that WalletConnect gives you two disconnect events when you disconnect
+    // from the Dapp
+    // and one when you disconnect from the wallet
     if (!this.connected) {
       return;
     }

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -135,18 +135,14 @@ export default abstract class Layer1ChainWeb3Strategy
 
   private onDisconnect() {
     if (this.isConnected) {
-      this.clearLocalConnectionState();
+      this.clearWalletInfo();
+      this.connectionManager = undefined;
+      this.web3 = undefined;
+      this.currentProviderId = '';
       this.simpleEmitter.emit('disconnect');
       this.broadcastChannel.postMessage('disconnected');
     }
     this.#waitForAccountDeferred = defer();
-  }
-
-  private clearLocalConnectionState() {
-    this.clearWalletInfo();
-    this.connectionManager = undefined;
-    this.web3 = undefined;
-    this.currentProviderId = '';
   }
 
   get waitForAccount(): Promise<void> {

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -60,6 +60,9 @@ export default abstract class Layer1ChainWeb3Strategy
         }
       );
 
+      // these events might need unbinding in the future. For now, since we create a new instance
+      // of ConnectionManager each time we connect, and destroy it when we disconnect, not keeping
+      // references to the returned UnbindEventListener function
       connectionManager.on('connected', this.onConnect.bind(this));
       connectionManager.on('disconnected', this.onDisconnect.bind(this));
       connectionManager.on('incorrect-chain', this.disconnect.bind(this));
@@ -74,7 +77,6 @@ export default abstract class Layer1ChainWeb3Strategy
         await connectionManager.reconnect(); // use the reconnect method because of edge cases
       }
     } catch (e) {
-      // clean up if anything goes wrong.
       this.disconnect();
       ConnectionManager.removeProviderFromStorage(this.chainId);
     }

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -35,12 +35,14 @@ export default abstract class Layer1ChainWeb3Strategy
   chainId: number;
   networkSymbol: Layer1NetworkSymbol;
   web3 = new Web3();
-  provider: any | undefined;
   broadcastChannel: BroadcastChannel;
-  simpleEmitter = new SimpleEmitter();
   cardTokenContract: Contract;
   daiTokenContract: Contract;
   bridgeableTokens: TokenContractInfo[];
+  simpleEmitter = new SimpleEmitter();
+
+  // changes with connection state
+  provider: any | undefined;
   #waitForAccountDeferred = defer<void>();
   @tracked currentProviderId: string | undefined;
   @tracked defaultTokenBalance: BN | undefined;

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -67,9 +67,7 @@ export default abstract class Layer1ChainWeb3Strategy
       connectionManager.on('disconnected', this.onDisconnect.bind(this));
       connectionManager.on('incorrect-chain', this.disconnect.bind(this));
 
-      await connectionManager.setup();
-
-      connectionManager.setWeb3Provider(web3);
+      await connectionManager.setup(web3);
 
       if (connectionManager) {
         this.web3 = web3;
@@ -95,8 +93,9 @@ export default abstract class Layer1ChainWeb3Strategy
       connectionManager.on('connected', this.onConnect.bind(this));
       connectionManager.on('disconnected', this.onDisconnect.bind(this));
       connectionManager.on('incorrect-chain', this.disconnect.bind(this));
-      await connectionManager.setup();
-      connectionManager.setWeb3Provider(web3);
+
+      await connectionManager.setup(web3);
+
       this.web3 = web3;
       this.connectionManager = connectionManager;
       await connectionManager.connect();

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -5,7 +5,7 @@ import Web3 from 'web3';
 import { TransactionReceipt } from 'web3-core';
 import { Contract } from 'web3-eth-contract';
 
-import { SimpleEmitter, UnbindEventListener } from '../events';
+import { Emitter, SimpleEmitter, UnbindEventListener } from '../events';
 import { BridgeableSymbol, TokenContractInfo } from '../token';
 import WalletInfo from '../wallet-info';
 import { WalletProvider } from '../wallet-providers';
@@ -22,7 +22,7 @@ import {
 import { ConnectionManager } from './layer-1-connection-manager';
 
 export default abstract class Layer1ChainWeb3Strategy
-  implements Layer1Web3Strategy {
+  implements Layer1Web3Strategy, Emitter<'disconnect'> {
   chainId: number;
   networkSymbol: Layer1NetworkSymbol;
   simpleEmitter = new SimpleEmitter();

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -104,7 +104,6 @@ export default abstract class Layer1ChainWeb3Strategy
       );
       console.error(e);
       ConnectionManager.removeProviderFromStorage(this.chainId);
-      return;
     }
   }
 

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -19,12 +19,10 @@ import {
   getSDK,
   networkIds,
 } from '@cardstack/cardpay-sdk';
-import { networkDisplayInfo } from './network-display-info';
 import { ConnectionManager } from './layer-1-connection-manager';
 
 export default abstract class Layer1ChainWeb3Strategy
   implements Layer1Web3Strategy {
-  private chainName: string;
   chainId: number;
   networkSymbol: Layer1NetworkSymbol;
   simpleEmitter = new SimpleEmitter();
@@ -40,7 +38,6 @@ export default abstract class Layer1ChainWeb3Strategy
   @tracked walletInfo: WalletInfo;
 
   constructor(networkSymbol: Layer1NetworkSymbol) {
-    this.chainName = networkDisplayInfo[networkSymbol].fullName;
     this.chainId = networkIds[networkSymbol];
     this.walletInfo = new WalletInfo([], this.chainId);
     this.networkSymbol = networkSymbol;

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -124,6 +124,7 @@ export default abstract class Layer1ChainWeb3Strategy
   private onDisconnect() {
     if (this.isConnected) {
       this.clearWalletInfo();
+      this.connectionManager?.destroy();
       this.connectionManager = undefined;
       this.web3 = undefined;
       this.currentProviderId = '';

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -37,7 +37,6 @@ export default abstract class Layer1ChainWeb3Strategy
   web3 = new Web3();
   provider: any | undefined;
   broadcastChannel: BroadcastChannel;
-  walletConnectUri: string | undefined;
   simpleEmitter = new SimpleEmitter();
   cardTokenContract: Contract;
   daiTokenContract: Contract;

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -75,7 +75,11 @@ export default abstract class Layer1ChainWeb3Strategy
         await connectionManager.reconnect(); // use the reconnect method because of edge cases
       }
     } catch (e) {
-      this.disconnect();
+      this.clearWalletInfo();
+      this.connectionManager?.destroy();
+      this.connectionManager = undefined;
+      this.web3 = undefined;
+      this.currentProviderId = '';
       ConnectionManager.removeProviderFromStorage(this.chainId);
     }
   }
@@ -104,6 +108,11 @@ export default abstract class Layer1ChainWeb3Strategy
         `Failed to create connection manager: ${walletProvider.id}`
       );
       console.error(e);
+      this.clearWalletInfo();
+      this.connectionManager?.destroy();
+      this.connectionManager = undefined;
+      this.web3 = undefined;
+      this.currentProviderId = '';
       ConnectionManager.removeProviderFromStorage(this.chainId);
     }
   }

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -163,6 +163,9 @@ export default abstract class Layer1ChainWeb3Strategy
       this.refreshBalances();
       this.#waitForAccountDeferred.resolve();
     } else {
+      this.defaultTokenBalance = undefined;
+      this.cardBalance = undefined;
+      this.daiBalance = undefined;
       this.#waitForAccountDeferred = defer();
     }
   }

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -5,16 +5,11 @@ import BN from 'bn.js';
 import Web3 from 'web3';
 import { TransactionReceipt } from 'web3-core';
 import { Contract } from 'web3-eth-contract';
-import detectEthereumProvider from '@metamask/detect-provider';
-import WalletConnectProvider from '@walletconnect/web3-provider';
-import WalletConnectQRCodeModal from '@walletconnect/qrcode-modal';
 
-import config from '../../config/environment';
 import { SimpleEmitter, UnbindEventListener } from '../events';
 import { BridgeableSymbol, TokenContractInfo } from '../token';
 import WalletInfo from '../wallet-info';
 import { WalletProvider } from '../wallet-providers';
-import CustomStorageWalletConnect from '../wc-connector';
 import {
   Layer1Web3Strategy,
   TransactionHash,
@@ -26,23 +21,24 @@ import {
   networkIds,
 } from '@cardstack/cardpay-sdk';
 import { networkDisplayInfo } from './network-display-info';
-
-const WALLET_CONNECT_BRIDGE = 'https://safe-walletconnect.gnosis.io/';
+import {
+  createConnectionManagerFromLocalStorage,
+  createConnectionManager,
+  ConnectionManager,
+} from './layer-1-connection-manager';
 
 export default abstract class Layer1ChainWeb3Strategy
   implements Layer1Web3Strategy {
   private chainName: string;
   chainId: number;
   networkSymbol: Layer1NetworkSymbol;
-  web3 = new Web3();
   broadcastChannel: BroadcastChannel;
-  cardTokenContract: Contract;
-  daiTokenContract: Contract;
-  bridgeableTokens: TokenContractInfo[];
   simpleEmitter = new SimpleEmitter();
 
   // changes with connection state
   #waitForAccountDeferred = defer<void>();
+  web3: Web3 | undefined;
+  connectionManager: ConnectionManager | undefined;
   @tracked currentProviderId: string | undefined;
   @tracked defaultTokenBalance: BN | undefined;
   @tracked daiBalance: BN | undefined;
@@ -54,21 +50,6 @@ export default abstract class Layer1ChainWeb3Strategy
     this.chainId = networkIds[networkSymbol];
     this.walletInfo = new WalletInfo([], this.chainId);
     this.networkSymbol = networkSymbol;
-    let cardTokenContractInfo = this.getTokenContractInfo(
-      'CARD',
-      networkSymbol
-    );
-    let daiTokenContractInfo = this.getTokenContractInfo('DAI', networkSymbol);
-
-    this.cardTokenContract = new this.web3.eth.Contract(
-      cardTokenContractInfo.abi,
-      cardTokenContractInfo.address
-    );
-    this.daiTokenContract = new this.web3.eth.Contract(
-      daiTokenContractInfo.abi,
-      daiTokenContractInfo.address
-    );
-    this.bridgeableTokens = [cardTokenContractInfo, daiTokenContractInfo];
 
     // the broadcast channel is really for metamask disconnections
     // since metamask doesn't allow you to disconnect from the dapp side
@@ -83,34 +64,84 @@ export default abstract class Layer1ChainWeb3Strategy
   }
 
   async initialize() {
-    const previousProviderId = window.localStorage.getItem(
-      this.providerStorageKey
-    );
     try {
-      if (previousProviderId === 'metamask') {
-        // ping because the disconnect event does not seem to be a reliable way to tell whether there's actually a connection
-        // if the user hasn't sent a request after they disconnected at the wallet side,
-        // the app might not know that it's disconnected and end up popping up metamask
-        let provider: any | undefined = await detectEthereumProvider();
-        let accounts = await provider.request({ method: 'eth_accounts' });
-        if (!accounts.length) {
-          window.localStorage.removeItem(this.providerStorageKey);
-          return;
-        }
-      }
+      let web3 = new Web3();
+      // add necessary init options here
+      let connectionManager = await createConnectionManagerFromLocalStorage(
+        web3,
+        this.connectionManagerOptions
+      );
 
-      await this.connect({ id: previousProviderId } as WalletProvider);
+      if (connectionManager) {
+        this.web3 = web3;
+        this.connectionManager = connectionManager;
+        await connectionManager.reconnect(); // use the reconnect method because of edge cases
+      } else {
+        this.clearLocalConnectionState();
+      }
     } catch (e) {
       // clean up if anything goes wrong.
+      this.disconnect();
+      // probably extraneous, but in case the thing that went wrong prevents the onDisconnect callback
+      // from being called, we clear the local state anyway
       this.clearLocalConnectionState();
     }
   }
 
-  private getTokenContractInfo(
-    symbol: BridgeableSymbol,
-    network: Layer1NetworkSymbol
-  ): TokenContractInfo {
-    return new TokenContractInfo(symbol, network);
+  async connect(walletProvider: WalletProvider): Promise<void> {
+    let web3 = new Web3();
+    let connectionManager = await createConnectionManager(
+      walletProvider.id,
+      web3,
+      this.connectionManagerOptions
+    );
+    if (connectionManager) {
+      this.web3 = web3;
+      this.connectionManager = connectionManager;
+      await connectionManager.connect();
+    }
+  }
+
+  get connectionManagerOptions() {
+    let bound = {
+      onDisconnect: this.onDisconnect.bind(this),
+      onConnect: this.onConnect.bind(this),
+      disconnect: this.disconnect.bind(this),
+    };
+    return {
+      onDisconnect: bound.onDisconnect,
+      onConnect: bound.onConnect,
+      onIncorrectChain: bound.disconnect,
+      onError: bound.disconnect,
+      networkSymbol: this.networkSymbol,
+      chainId: this.chainId,
+    };
+  }
+
+  async onConnect(accounts: string[]) {
+    this.updateWalletInfo(accounts, this.chainId);
+    this.currentProviderId = this.connectionManager?.providerId;
+    this.#waitForAccountDeferred.resolve();
+  }
+
+  async disconnect(): Promise<void> {
+    return this.connectionManager?.disconnect();
+  }
+
+  private onDisconnect() {
+    if (this.isConnected) {
+      this.clearLocalConnectionState();
+      this.simpleEmitter.emit('disconnect');
+      this.broadcastChannel.postMessage('disconnected');
+    }
+    this.#waitForAccountDeferred = defer();
+  }
+
+  private clearLocalConnectionState() {
+    this.clearWalletInfo();
+    this.connectionManager = undefined;
+    this.web3 = undefined;
+    this.currentProviderId = '';
   }
 
   get waitForAccount(): Promise<void> {
@@ -125,11 +156,32 @@ export default abstract class Layer1ChainWeb3Strategy
     return this.simpleEmitter.on(event, cb);
   }
 
+  private updateWalletInfo(accounts: string[], chainId: number) {
+    this.walletInfo = new WalletInfo(accounts, chainId);
+    if (accounts.length > 0) {
+      this.refreshBalances();
+      this.#waitForAccountDeferred.resolve();
+    } else {
+      this.#waitForAccountDeferred = defer();
+    }
+  }
+
+  private clearWalletInfo() {
+    this.updateWalletInfo([], -1);
+  }
+
+  contractForToken(symbol: BridgeableSymbol) {
+    if (!this.web3)
+      throw new Error('Cannot get contract for bridgeable tokens without web3');
+    let { address, abi } = new TokenContractInfo(symbol, this.networkSymbol);
+    return new this.web3.eth.Contract(abi, address);
+  }
+
   async refreshBalances() {
     let balances = await Promise.all<string>([
       this.getDefaultTokenBalance(),
-      this.getErc20Balance(this.daiTokenContract),
-      this.getErc20Balance(this.cardTokenContract),
+      this.getErc20Balance(this.contractForToken('DAI')),
+      this.getErc20Balance(this.contractForToken('CARD')),
     ]);
     let [defaultTokenBalance, daiBalance, cardBalance] = balances;
     this.defaultTokenBalance = new BN(defaultTokenBalance);
@@ -142,6 +194,7 @@ export default abstract class Layer1ChainWeb3Strategy
   }
 
   private async getDefaultTokenBalance() {
+    if (!this.web3) throw new Error('Cannot get token balances without web3');
     if (this.walletInfo.firstAddress)
       return await this.web3.eth.getBalance(
         this.walletInfo.firstAddress,
@@ -150,198 +203,30 @@ export default abstract class Layer1ChainWeb3Strategy
     else return 0;
   }
 
-  async connect(walletProvider: WalletProvider): Promise<void> {
-    if (walletProvider.id === 'metamask') {
-      let provider = await this.setupMetamask();
-      if (!provider) {
-        return;
-      }
-      this.web3.setProvider(provider);
-      let accounts = await provider.request({
-        method: 'eth_requestAccounts',
-      });
-      this.updateWalletInfo(accounts, this.chainId);
-      this.currentProviderId = walletProvider.id;
-      window.localStorage.setItem(this.providerStorageKey, walletProvider.id);
-    } else if (walletProvider.id === 'wallet-connect') {
-      let provider = this.setupWalletConnect();
-      this.web3.setProvider(provider);
-      await provider.enable();
-      if (!this.isConnected) {
-        return;
-      }
-      let accounts = await this.web3.eth.getAccounts();
-      this.updateWalletInfo(accounts, this.chainId);
-      this.currentProviderId = walletProvider.id;
-      window.localStorage.setItem(this.providerStorageKey, walletProvider.id);
-    }
-  }
-
-  private get providerStorageKey(): string {
-    return `cardstack-chain-${this.chainId}-provider`;
-  }
-
-  private updateWalletInfo(accounts: string[], chainId: number) {
-    this.walletInfo = new WalletInfo(accounts, chainId);
-    if (accounts.length > 0) {
-      this.refreshBalances();
-      this.#waitForAccountDeferred.resolve();
-    } else {
-      this.#waitForAccountDeferred = defer();
-    }
-  }
-
-  private async setupMetamask() {
-    let provider: any | undefined = await detectEthereumProvider();
-    if (!provider) {
-      // TODO: some UI prompt for getting people to setup metamask
-      console.log('Please install MetaMask!');
-      return;
-    }
-
-    if (provider !== window.ethereum) {
-      // TODO: some UI prompt to get people to disconnect their other wallets
-      console.error('Do you have multiple wallets installed?');
-      return;
-    }
-
-    provider.on('accountsChanged', (accounts: string[]) => {
-      if (!accounts.length) {
-        this.onDisconnect();
-      } else {
-        this.updateWalletInfo(accounts, this.chainId);
-      }
-    });
-
-    // Subscribe to chainId change
-    provider.on('chainChanged', (chainId: number) => {
-      console.log('Layer1 MM chainChanged', chainId);
-    });
-
-    // Subscribe to provider connection
-    provider.on('connect', (info: { chainId: number }) => {
-      console.log(info);
-    });
-
-    // Subscribe to provider disconnection
-    // MetaMask doesn't use disconnect the same way WalletConnect does
-    // If you disconnect via the wallet, the 'accountsChanged' event is where
-    // the Dapp is notified. Disconnect is for other unforeseen stuff
-    provider.on('disconnect', (error: { code: number; message: string }) => {
-      console.log(error);
-      this.onDisconnect();
-    });
-
-    return provider;
-  }
-
-  private onDisconnect() {
-    if (this.isConnected) {
-      this.clearLocalConnectionState();
-      this.simpleEmitter.emit('disconnect');
-      this.broadcastChannel.postMessage('disconnected');
-    }
-  }
-
-  private clearLocalConnectionState() {
-    this.clearWalletInfo();
-    this.web3.setProvider(undefined);
-    this.currentProviderId = '';
-    window.localStorage.removeItem(this.providerStorageKey);
-  }
-
-  private clearWalletInfo() {
-    this.updateWalletInfo([], -1);
-  }
-
-  async disconnect(): Promise<void> {
-    // re: disconnecting from metamask
-    // There is a solution in https://github.com/MetaMask/metamask-extension/issues/8990
-    // that just makes the site think that the wallet isn't connected
-    // It actually still is, you can see this when you open the wallet
-    // The metamask team believes you should be disconnecting via the extension
-    // and has not exposed any way to do this from a dapp
-    if (this.currentProviderId === 'wallet-connect') {
-      // typescript is unhappy with this but it's actually the walletconnect provider that we gave in the connect method
-      await (this.web3.currentProvider as any).disconnect();
-    } else {
-      this.onDisconnect();
-    }
-  }
-
-  private setupWalletConnect(): any {
-    let { chainId } = this;
-    let provider = new WalletConnectProvider({
-      chainId,
-      infuraId: config.infuraId,
-      // based on https://github.com/WalletConnect/walletconnect-monorepo/blob/7aa9a7213e15489fa939e2e020c7102c63efd9c4/packages/providers/web3-provider/src/index.ts#L47-L52
-      connector: new CustomStorageWalletConnect(
-        {
-          bridge: WALLET_CONNECT_BRIDGE,
-          qrcodeModal: WalletConnectQRCodeModal,
-        },
-        chainId
-      ),
-    });
-
-    // Subscribe to accounts change
-    provider.on('accountsChanged', (accounts: string[]) => {
-      if (accounts.length) this.updateWalletInfo(accounts, chainId);
-    });
-
-    // Subscribe to chainId change
-    let strategy = this;
-    provider.on('chainChanged', (changedChainId: number) => {
-      if (String(changedChainId) !== String(chainId)) {
-        console.log(
-          `Layer1 WC chainChanged to ${changedChainId}. Disconnecting`
-        );
-        strategy.disconnect();
-      }
-    });
-
-    // Subscribe to session disconnection
-    // This is how WalletConnect informs us if we disconnect the Dapp
-    // from the wallet side. Unlike MetaMask, listening to 'accountsChanged'
-    // does not work.
-    provider.on('disconnect', (code: number, reason: string) => {
-      console.log('disconnect', code, reason);
-      // without checking this, the event will fire twice.
-      this.onDisconnect();
-    });
-
-    return provider;
-  }
-
   async approve(
     amountInWei: BN,
-    tokenSymbol: string
+    tokenSymbol: BridgeableSymbol
   ): Promise<TransactionReceipt> {
+    if (!this.web3) throw new Error('Cannot unlock tokens without web3');
     let tokenBridge = await getSDK('TokenBridgeForeignSide', this.web3);
-    let token = this.getTokenBySymbol(tokenSymbol);
-    return tokenBridge.unlockTokens(token.address, amountInWei.toString());
-  }
-
-  async relayTokens(
-    tokenSymbol: string,
-    receiverAddress: string,
-    amountInWei: BN
-  ): Promise<TransactionReceipt> {
-    let tokenBridge = await getSDK('TokenBridgeForeignSide', this.web3);
-    let token = this.getTokenBySymbol(tokenSymbol);
-    return tokenBridge.relayTokens(
-      token.address,
-      receiverAddress,
+    return tokenBridge.unlockTokens(
+      new TokenContractInfo(tokenSymbol, this.networkSymbol).address,
       amountInWei.toString()
     );
   }
 
-  private getTokenBySymbol(symbol: string): TokenContractInfo {
-    let token = this.bridgeableTokens.findBy('symbol', symbol);
-    if (!token) {
-      throw new Error(`Expected to find bridgeable token for symbol ${symbol}`);
-    }
-    return token!;
+  async relayTokens(
+    tokenSymbol: BridgeableSymbol,
+    receiverAddress: string,
+    amountInWei: BN
+  ): Promise<TransactionReceipt> {
+    if (!this.web3) throw new Error('Cannot relay tokens without web3');
+    let tokenBridge = await getSDK('TokenBridgeForeignSide', this.web3);
+    return tokenBridge.relayTokens(
+      new TokenContractInfo(tokenSymbol, this.networkSymbol).address,
+      receiverAddress,
+      amountInWei.toString()
+    );
   }
 
   blockExplorerUrl(txnHash: TransactionHash): string {

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -8,7 +8,7 @@ import { IConnector } from '@walletconnect/types';
 import WalletConnectProvider from '@walletconnect/web3-provider';
 import { task } from 'ember-concurrency-decorators';
 
-import { SimpleEmitter, UnbindEventListener } from '../events';
+import { Emitter, SimpleEmitter, UnbindEventListener } from '../events';
 import {
   ConvertibleSymbol,
   ConversionFunction,
@@ -39,7 +39,7 @@ import { networkDisplayInfo } from './network-display-info';
 const BRIDGE = 'https://safe-walletconnect.gnosis.io/';
 
 export default abstract class Layer2ChainWeb3Strategy
-  implements Layer2Web3Strategy {
+  implements Layer2Web3Strategy, Emitter<'disconnect'> {
   private chainName: string;
   chainId: number;
   networkSymbol: Layer2NetworkSymbol;

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -10,7 +10,6 @@ import { Emitter } from '@cardstack/web-client/utils/events';
 
 export interface Web3Strategy extends Emitter {
   isConnected: boolean;
-  walletConnectUri: string | undefined;
   disconnect(): Promise<void>;
 }
 
@@ -38,6 +37,7 @@ export interface Layer2Web3Strategy extends Web3Strategy {
   defaultTokenBalance: BN | undefined;
   cardBalance: BN | undefined;
   depotSafe: DepotSafe | null;
+  walletConnectUri: string | undefined;
   updateUsdConverters(
     symbolsToUpdate: ConvertibleSymbol[]
   ): Promise<Record<ConvertibleSymbol, ConversionFunction>>;

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -7,8 +7,7 @@ import {
   ConversionFunction,
 } from '@cardstack/web-client/utils/token';
 import { Emitter } from '@cardstack/web-client/utils/events';
-
-export interface Web3Strategy extends Emitter {
+export interface Web3Strategy extends Emitter<'disconnect'> {
   isConnected: boolean;
   disconnect(): Promise<void>;
 }


### PR DESCRIPTION
Extract providers and related event handling for layer 1 into their own class, and expose an API with callbacks centered around connection events we care about and that the Dapp's logic deals with - account changes (connection, disconnection), errors, and connecting to an incorrect chain. This PR as is should fix CS-1179 and sets up for CS-1088.

The API is intentionally very specific at the moment, the only callbacks that are in use at the moment (`onConnect`, `onDisconnect`, `onIncorrectChain`) are the events that we are concerned about and want to handle in the Dapp logic. There is a "standard" for Ethereum events (https://github.com/ethereum/EIPs/issues/2319), but I'm unsure about adoption, and WalletConnect and MetaMask seem to be using these events in ways fairly different from each other. I felt it was better to use specific callbacks to ensure we are handling the events we want, and keep the complexity out of `layer1-chain`.