### PR TITLE
Remove pointer events for hero image

### DIFF
--- a/packages/web-client/app/components/card-pay/dashboard-panel/index.css
+++ b/packages/web-client/app/components/card-pay/dashboard-panel/index.css
@@ -98,4 +98,5 @@
   background-position: top right;
   background-repeat: no-repeat;
   background-size: contain;
+  pointer-events: none;
 }


### PR DESCRIPTION
This addresses a case where the hero could partially or
completely cover the navigation buttons, making them
unreachable with the cursor.