### PR TITLE
Fix test date parsing strings in Safari

### DIFF
--- a/packages/web-client/tests/integration/components/workflow-thread-test.ts
+++ b/packages/web-client/tests/integration/components/workflow-thread-test.ts
@@ -60,10 +60,13 @@ module('Integration | Component | workflow-thread', function (hooks) {
       }),
     ];
     workflow.epilogue.postables = [postable4];
-    postable1.timestamp = new Date(Date.parse('2021-05-20T00:00:00'));
-    postable2.timestamp = new Date(Date.parse('2021-05-20T00:00:00'));
-    postable3.timestamp = new Date(Date.parse('2021-05-21T00:00:00'));
-    postable4.timestamp = new Date(Date.parse('2021-05-21T00:00:00'));
+
+    // new Date(year, monthIndex, day, hour, minute, second)
+    postable1.timestamp = new Date(2021, 4, 20, 0, 0, 0);
+    postable2.timestamp = new Date(2021, 4, 20, 0, 0, 0);
+    postable3.timestamp = new Date(2021, 4, 21, 0, 0, 0);
+    postable4.timestamp = new Date(2021, 4, 21, 0, 0, 0);
+
     this.set('workflow', workflow);
     workflow.attachWorkflow();
     await render(hbs`

--- a/packages/web-client/tests/integration/components/workflow-thread-test.ts
+++ b/packages/web-client/tests/integration/components/workflow-thread-test.ts
@@ -60,11 +60,10 @@ module('Integration | Component | workflow-thread', function (hooks) {
       }),
     ];
     workflow.epilogue.postables = [postable4];
-    // Date.parse below is returning NaN on Safari
-    postable1.timestamp = new Date(Date.parse('2021-05-20 00:00:00'));
-    postable2.timestamp = new Date(Date.parse('2021-05-20 00:00:00'));
-    postable3.timestamp = new Date(Date.parse('2021-05-21 00:00:00'));
-    postable4.timestamp = new Date(Date.parse('2021-05-21 00:00:00'));
+    postable1.timestamp = new Date(Date.parse('2021-05-20T00:00:00'));
+    postable2.timestamp = new Date(Date.parse('2021-05-20T00:00:00'));
+    postable3.timestamp = new Date(Date.parse('2021-05-21T00:00:00'));
+    postable4.timestamp = new Date(Date.parse('2021-05-21T00:00:00'));
     this.set('workflow', workflow);
     workflow.attachWorkflow();
     await render(hbs`


### PR DESCRIPTION
The test was failing in Safari but succeeds with this change.

![2021-07-06 13-30-10-date-parse](https://user-images.githubusercontent.com/43280/124650044-e417f700-de5e-11eb-8693-e0e7bcd90699.png)
![2021-07-06 13-32-03-date-parse](https://user-images.githubusercontent.com/43280/124650049-e4b08d80-de5e-11eb-90cc-8a07444ee5fa.png)
