### PR TITLE
Add Layer 2 support for bridging tokens from layer 2 to layer 1

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,7 +47,25 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay: Bridge Tokens",
+      "name": "Cardpay: Bridge to Layer 1",
+      "program": "${workspaceFolder}/packages/cardpay-cli/cardpay.js",
+      "console": "integratedTerminal",
+      "env": {},
+      "args": [
+        "bridge-to-l1",
+        "0x00F0FBDEEa1cDEc029Ba6025ca726Fdcf43E9025", // L2 safe address
+        "30",
+        "0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1", // DAI.CPXD
+        "0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13", // L1 receiver
+        "--network", "sokol",
+        // Hassan's testing mnemonic feel free to use your own
+        "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Cardpay: Bridge to Layer 2",
       "program": "${workspaceFolder}/packages/cardpay-cli/cardpay.js",
       "console": "integratedTerminal",
       "env": {},
@@ -61,7 +79,7 @@
         // "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
 
         // Kovan DAI Bridge args
-        "bridge",
+        "bridge-to-l2",
         "30",
         "0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa", // Kovan DAI
         "--network", "kovan",
@@ -126,8 +144,8 @@
         "safe-transfer-tokens",
         "0x00F0FBDEEa1cDEc029Ba6025ca726Fdcf43E9025", // source safe address
         "0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1", // DAI.CPXD
-        "0x797E1f626cB58f909F3c6a1e0783578BD4D0f32f", // destination addrress
-        "500", // amount (in ether units)
+        "0x09FBEDDc5f94fA2713CDa75A68457cA8A4527adf", // destination addrress
+        "100", // amount (in ether units)
         "--network", "sokol",
         // Hassan's testing mnemonic feel free to use your own
         "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
@@ -328,7 +346,7 @@
         // Hassan's testing mnemonic feel free to use your own
         "--mnemonic", "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
       ]
-    }, 
+    },
     {
       "type": "node",
       "request": "launch",

--- a/packages/cardpay-cli/README.md
+++ b/packages/cardpay-cli/README.md
@@ -6,8 +6,9 @@ CLI tool for basic actions in Cardpay
 
 # Commands
 - [Commands](#commands)
-  - [`yarn cardpay bridge <AMOUNT> <TOKEN_ADDRESS> [RECEIVER] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-bridge-amount-token_address-receiver---networknetwork---mnemonicmnemonic---walletconnect)
-  - [`yarn cardpay await-bridged <FROM_BLOCK> [RECIPIENT] --network=_NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-await-bridged-from_block-recipient---network_network---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay bridge-to-l2 <AMOUNT> <TOKEN_ADDRESS> [RECEIVER] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-bridge-to-l2-amount-token_address-receiver---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay await-bridged-to-l2 <FROM_BLOCK> [RECIPIENT] --network=_NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-await-bridged-to-l2-from_block-recipient---network_network---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay bridge-to-l1 <SAFE_ADDRESS> <AMOUNT> <TOKEN_ADDRESS> <RECEIVER> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-bridge-to-l1-safe_address-amount-token_address-receiver---networknetwork---mnemonicmnemonic---walletconnect)
   - [`yarn cardpay prepaidcard-create <SAFE_ADDRESS> <TOKEN_ADDRESS> <CUSTOMIZATION_DID> <FACE_VALUES..> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-prepaidcard-create-safe_address-token_address-customization_did-face_values---networknetwork---mnemonicmnemonic---walletconnect)
   - [`yarn cardpay prepaidcard-split <PREPAID_CARD> <CUSTOMIZATION_DID> <FACE_VALUES..> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-prepaidcard-split-prepaid_card-customization_did-face_values---networknetwork---mnemonicmnemonic---walletconnect)
   - [`yarn cardpay prepaidcard-transfer <PREPAID_CARD> <NEW_OWNER> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-prepaidcard-transfer-prepaid_card-new_owner---networknetwork---mnemonicmnemonic---walletconnect)
@@ -28,34 +29,52 @@ CLI tool for basic actions in Cardpay
   - [`yarn cardpay hub-auth [HUB_ROOT_URL] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-hub-auth-hub_root_url---networknetwork---mnemonicmnemonic---walletconnect)
 
 
-## `yarn cardpay bridge <AMOUNT> <TOKEN_ADDRESS> [RECEIVER] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
+## `yarn cardpay bridge-to-l2 <AMOUNT> <TOKEN_ADDRESS> [RECEIVER] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 
-Bridge tokens from L1 wallet to L2 safe
+Bridge tokens from L1 address to L2 safe
 
 ```
 USAGE
-  $ yarn cardpay bridge <amount> <tokenAddress> [receiver] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
+  $ yarn cardpay bridge-to-l2 <amount> <tokenAddress> [receiver] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
   AMOUNT          Amount in ether you would like bridged
-  TOKEN_ADDRESS   The token address of the token to bridge
+  TOKEN_ADDRESS   The layer 1 token address of the token to bridge
   RECEIVER        Layer 2 address to be owner of L2 safe, defaults to same as L1 address
   NETWORK         The Layer 1 network to use ("kovan" or "mainnet")
   MNEMONIC        (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
   WALLET_CONNECT  (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
 
-## `yarn cardpay await-bridged <FROM_BLOCK> [RECIPIENT] --network=_NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
+## `yarn cardpay await-bridged-to-l2 <FROM_BLOCK> [RECIPIENT] --network=_NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 
 Wait for token bridging to complete on L2
 
 ```
 USAGE
-  $ yarn cardpay await-bridged <fromBlock> [recipient] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
+  $ yarn cardpay await-bridged-to-l2 <fromBlock> [recipient] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
   FROM_BLOCK      Layer 2 block height before bridging was initiated
   RECIPIENT       Layer 2 address that is the owner of the bridged tokens, defaults to wallet address
+  NETWORK         The Layer 2 network to use ("sokol" or "xdai")
+  MNEMONIC        (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
+  WALLET_CONNECT  (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
+```
+
+## `yarn cardpay bridge-to-l1 <SAFE_ADDRESS> <AMOUNT> <TOKEN_ADDRESS> <RECEIVER> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
+
+Bridge tokens from L2 safe to L1 address
+
+```
+USAGE
+  $ yarn cardpay bridge-to-l1 <SAFE_ADDRESS> <AMOUNT> <TOKEN_ADDRESS> <RECEIVER> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
+
+ARGUMENTS
+  SAFE_ADDRESS    The layer 2 safe address to bridge the tokens from
+  AMOUNT          Amount in ether you would like bridged
+  TOKEN_ADDRESS   The layer 2 token address of the token to bridge
+  RECEIVER        Layer 1 address to receive the bridge tokens
   NETWORK         The Layer 2 network to use ("sokol" or "xdai")
   MNEMONIC        (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
   WALLET_CONNECT  (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet

--- a/packages/cardpay-cli/bridge.ts
+++ b/packages/cardpay-cli/bridge.ts
@@ -1,33 +1,59 @@
 import Web3 from 'web3';
 import { getWeb3 } from './utils';
-import { getConstant, getAddress, getSDK } from '@cardstack/cardpay-sdk';
+import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 
 const { toWei } = Web3.utils;
 
-export default async function (
+export async function bridgeToLayer1(
+  network: string,
+  safeAddress: string,
+  tokenAddress: string,
+  receiverAddress: string,
+  amount: number,
+  mnemonic?: string
+): Promise<void> {
+  const amountInWei = toWei(amount.toString()).toString();
+
+  let web3 = await getWeb3(network, mnemonic);
+  let tokenBridge = await getSDK('TokenBridgeHomeSide', web3);
+  let assets = await getSDK('Assets', web3);
+  let { symbol } = await assets.getTokenInfo(tokenAddress);
+  receiverAddress = receiverAddress ?? (await web3.eth.getAccounts())[0];
+
+  let blockExplorer = await getConstant('blockExplorer', web3);
+
+  console.log(`Bridging ${amount} ${symbol} from layer 2 safe ${safeAddress} to layer 1 account ${receiverAddress}...`);
+  let result = await tokenBridge.relayTokens(safeAddress, tokenAddress, receiverAddress, amountInWei);
+  console.log(`Approve transaction hash: ${blockExplorer}/tx/${result.transactionHash}`);
+}
+
+export async function bridgeToLayer2(
   network: string,
   amount: number,
   receiverAddress: string | undefined,
-  tokenAddress: string | undefined,
+  tokenAddress: string,
   mnemonic?: string
 ): Promise<void> {
   const amountInWei = toWei(amount.toString()).toString();
 
   let web3 = await getWeb3(network, mnemonic);
   let tokenBridge = await getSDK('TokenBridgeForeignSide', web3);
-  tokenAddress = tokenAddress ?? (await getAddress('daiToken', web3));
+  let assets = await getSDK('Assets', web3);
+  let { symbol } = await assets.getTokenInfo(tokenAddress);
   receiverAddress = receiverAddress ?? (await web3.eth.getAccounts())[0];
 
   let blockExplorer = await getConstant('blockExplorer', web3);
 
   {
-    console.log('Sending approve transaction request');
+    console.log(`Sending approve transaction request for ${amount} ${symbol}`);
     let result = await tokenBridge.unlockTokens(tokenAddress, amountInWei);
     console.log(`Approve transaction hash: ${blockExplorer}/tx/${result.transactionHash}`);
   }
 
   {
-    console.log('Sending relay tokens transaction request');
+    console.log(
+      `Sending relay tokens transaction request for ${amount} ${symbol} into layer 2 safe owned by ${receiverAddress}`
+    );
     let result = await tokenBridge.relayTokens(tokenAddress, receiverAddress, amountInWei);
     console.log(`Relay tokens transaction hash: ${blockExplorer}/tx/${result.transactionHash}`);
   }

--- a/packages/cardpay-sdk/sdk/token-bridge-home-side.ts
+++ b/packages/cardpay-sdk/sdk/token-bridge-home-side.ts
@@ -1,9 +1,14 @@
 import Web3 from 'web3';
 import { TransactionReceipt } from 'web3-core';
-import { EventData } from 'web3-eth-contract';
+import { ContractOptions, EventData } from 'web3-eth-contract';
 import HomeBridgeABI from '../contracts/abi/home-bridge-mediator';
+import ERC677ABI from '../contracts/abi/erc-677';
 import { getAddress } from '../contracts/addresses';
 import { waitForEvent, waitUntilTransactionMined } from './utils/general-utils';
+import { executeTransaction, gasEstimate, GnosisExecTx } from './utils/safe-utils';
+import { AbiItem, fromWei, toBN } from 'web3-utils';
+import { signSafeTxAsRSV } from './utils/signing-utils';
+import { ZERO_ADDRESS } from './constants';
 
 // The TokenBridge is created between 2 networks, referred to as a Native (or Home) Network and a Foreign network.
 // The Native or Home network has fast and inexpensive operations. All bridge operations to collect validator confirmations are performed on this side of the bridge.
@@ -15,6 +20,73 @@ export interface ITokenBridgeHomeSide {
 
 export default class TokenBridgeHomeSide implements ITokenBridgeHomeSide {
   constructor(private layer2Web3: Web3) {}
+
+  async relayTokens(
+    safeAddress: string,
+    tokenAddress: string,
+    recipientAddress: string,
+    amount: string,
+    options?: ContractOptions
+  ): Promise<GnosisExecTx> {
+    let from = options?.from ?? (await this.layer2Web3.eth.getAccounts())[0];
+    let homeBridgeAddress = await getAddress('homeBridge', this.layer2Web3);
+    let token = new this.layer2Web3.eth.Contract(ERC677ABI as AbiItem[], tokenAddress);
+    let symbol = await token.methods.symbol().call();
+    let safeBalance = toBN(await token.methods.balanceOf(safeAddress).call());
+    if (safeBalance.lt(toBN(amount))) {
+      throw new Error(
+        `Safe does not have enough balance to transfer tokens. The token ${tokenAddress} balance of safe ${safeAddress} is ${fromWei(
+          safeBalance.toString()
+        )} ${symbol}, amount to transfer ${fromWei(amount)} ${symbol}`
+      );
+    }
+
+    let payload = token.methods.transferAndCall(homeBridgeAddress, amount, recipientAddress).encodeABI();
+    let estimate = await gasEstimate(this.layer2Web3, safeAddress, tokenAddress, '0', payload, 0, tokenAddress);
+    let gasCost = toBN(estimate.dataGas).add(toBN(estimate.baseGas)).mul(toBN(estimate.gasPrice));
+    if (safeBalance.lt(toBN(amount).add(gasCost))) {
+      throw new Error(
+        `Safe does not have enough balance to pay for gas when relaying tokens. The token ${tokenAddress} balance of safe ${safeAddress} is ${fromWei(
+          safeBalance.toString()
+        )} ${symbol}, amount to transfer ${fromWei(amount)} ${symbol}, the gas cost is ${fromWei(gasCost)} ${symbol}`
+      );
+    }
+
+    if (estimate.lastUsedNonce == null) {
+      estimate.lastUsedNonce = -1;
+    }
+    let signatures = await signSafeTxAsRSV(
+      this.layer2Web3,
+      tokenAddress,
+      0,
+      payload,
+      0,
+      estimate.safeTxGas,
+      estimate.dataGas,
+      estimate.gasPrice,
+      estimate.gasToken,
+      ZERO_ADDRESS,
+      toBN(estimate.lastUsedNonce + 1),
+      from,
+      safeAddress
+    );
+    let result = await executeTransaction(
+      this.layer2Web3,
+      safeAddress,
+      tokenAddress,
+      0,
+      payload,
+      0,
+      estimate.safeTxGas,
+      estimate.dataGas,
+      estimate.gasPrice,
+      toBN(estimate.lastUsedNonce + 1).toString(),
+      signatures,
+      estimate.gasToken,
+      ZERO_ADDRESS
+    );
+    return result;
+  }
 
   async waitForBridgingCompleted(recipientAddress: string, fromBlock: string): Promise<TransactionReceipt> {
     let homeBridge = new this.layer2Web3.eth.Contract(

--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -2,7 +2,8 @@ type Account @entity {
   id: ID!                                          # address
   safes: [SafeOwner]!                              @derivedFrom(field: "owner")
   depots: [Depot]!                                 @derivedFrom(field: "supplier")
-  receivedBridgedTokens: [BridgeEvent]!            @derivedFrom(field: "supplier")
+  sentBridgedTokens: [BridgeToLayer1Event]!        @derivedFrom(field: "account")
+  receivedBridgedTokens: [BridgeToLayer2Event]!    @derivedFrom(field: "supplier")
   supplierInfoDIDUpdates: [SupplierInfoDIDUpdate]! @derivedFrom(field: "supplier")
   createdPrepaidCards: [PrepaidCardCreation]!      @derivedFrom(field: "issuer")
   splitPrepaidCards: [PrepaidCardSplit]!           @derivedFrom(field: "issuer")
@@ -17,11 +18,10 @@ type Account @entity {
 type Depot @entity {
   id: ID!                                          # safe address
   safe: Safe!
-  # TODO let's not do this, and rather make a DepotCreation entity instead
   createdAt: BigInt!
   supplier: Account!
   infoDid: String
-  receivedBridgedTokens: [BridgeEvent]!            @derivedFrom(field: "depot")
+  receivedBridgedTokens: [BridgeToLayer2Event]!            @derivedFrom(field: "depot")
 }
 
 type PrepaidCard @entity {
@@ -53,7 +53,17 @@ type MerchantSafe @entity {
   merchantRevenue: [MerchantRevenue]!              @derivedFrom(field: "merchantSafe")
 }
 
-type BridgeEvent @entity {
+type BridgeToLayer1Event @entity {
+  id: ID!
+  transaction: Transaction!
+  safe: Safe
+  timestamp: BigInt!
+  account: Account!
+  token: Token!
+  amount: BigInt!
+}
+
+type BridgeToLayer2Event @entity {
   id: ID!
   transaction: Transaction!
   depot: Depot!
@@ -201,14 +211,15 @@ type TokenSwap @entity {
 }
 
 type Safe @entity {
-  id: ID!                          # safe address
-  createdAt: BigInt!               # unix time
-  owners: [SafeOwner]!             @derivedFrom(field: "safe")
-  safeTxns: [SafeTransaction]!     @derivedFrom(field: "safe")
-  depot: Depot                     @derivedFrom(field: "safe")
-  merchant: MerchantSafe           @derivedFrom(field: "safe")
-  prepaidCard: PrepaidCard         @derivedFrom(field: "safe")
-  tokens: [TokenHolder]!           @derivedFrom(field: "safe")
+  id: ID!                                   # safe address
+  createdAt: BigInt!                        # unix time
+  owners: [SafeOwner]!                      @derivedFrom(field: "safe")
+  safeTxns: [SafeTransaction]!              @derivedFrom(field: "safe")
+  depot: Depot                              @derivedFrom(field: "safe")
+  merchant: MerchantSafe                    @derivedFrom(field: "safe")
+  prepaidCard: PrepaidCard                  @derivedFrom(field: "safe")
+  tokens: [TokenHolder]!                    @derivedFrom(field: "safe")
+  sentBridgedTokens: [BridgeToLayer1Event]! @derivedFrom(field: "safe")
 }
 
 type SafeTransaction @entity {
@@ -245,7 +256,8 @@ type Transaction @entity {
   timestamp: BigInt!
   blockNumber: BigInt!
   safeTxns: [SafeTransaction]!                     @derivedFrom(field: "transaction")
-  bridgeEvents: [BridgeEvent]!                     @derivedFrom(field: "transaction")
+  bridgeToLayer1Events: [BridgeToLayer1Event]!     @derivedFrom(field: "transaction")
+  bridgeToLayer2Events: [BridgeToLayer2Event]!     @derivedFrom(field: "transaction")
   supplierInfoDIDUpdates: [SupplierInfoDIDUpdate]! @derivedFrom(field: "transaction")
   prepaidCardCreations: [PrepaidCardCreation]!     @derivedFrom(field: "transaction")
   prepaidCardTransfers: [PrepaidCardTransfer]!     @derivedFrom(field: "transaction")

--- a/packages/cardpay-subgraph/subgraph-template.yaml
+++ b/packages/cardpay-subgraph/subgraph-template.yaml
@@ -341,7 +341,9 @@ dataSources:
           file: ./abis/GnosisSafe.json
       eventHandlers:
         - event: TokensBridgedToSafe(indexed address,indexed address,address,uint256,indexed bytes32)
-          handler: handleTokensBridged
+          handler: handleReceivedBridgedTokens
+        - event: TokensBridgingInitiated(indexed address,indexed address,uint256,indexed bytes32)
+          handler: handleSentBridgedTokens
       file: ./src/mappings/depot.ts
 
   - kind: ethereum/contract


### PR DESCRIPTION
This PR adds all the layer 2 support for bridging tokens from layer 2 to layer 1. This includes SDK, CLI, and subgraph. There is additionally a "claim" mechanism associated for bridging to layer 1 that we will need to incorporate as well. Currently the only way to claim to the layer 1 tokens that have been bridged to L1  is from the AMB monitoring website.