### PR TITLE
Add amount card for withdrawal workflow

### DIFF
--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.css
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.css
@@ -1,0 +1,98 @@
+.withdrawal-transaction-amount {
+  --tx-amount-banner-height: 3.125rem; /* 50px */
+  --tx-amount-input-height: 3.75rem; /* 60px */
+}
+
+.withdrawal-transaction-amount__input-section > * + * {
+  margin-top: var(--boxel-sp-lg);
+}
+
+.withdrawal-transaction-amount__input-container {
+  --input-currency-icon-size: 2.5rem;
+  --input-currency-text-width: 5ch;
+  --input-currency-icon-space: var(--boxel-sp-xs);
+  --input-currency-text-space: var(--boxel-sp-sm);
+
+  position: relative;
+}
+
+.withdrawal-transaction-amount__input-token-balance {
+  font-family: var(--boxel-font-family);
+  font-size: 1.25rem;
+  line-height: calc(27 / 20);
+  letter-spacing: var(--boxel-lsp-xs);
+}
+
+.withdrawal-transaction-amount__input {
+  height: var(--tx-amount-input-height);
+  padding-left: calc(var(--input-currency-icon-size) + var(--input-currency-icon-space) * 2);
+  padding-right: calc(var(--input-currency-text-width) + var(--input-currency-text-space) * 2);
+  font: inherit;
+  letter-spacing: inherit;
+}
+
+.withdrawal-transaction-amount__currency-icon {
+  position: absolute;
+  width: var(--input-currency-icon-size);
+  height: var(--tx-amount-input-height);
+  left: var(--input-currency-icon-space);
+  top: 0;
+  user-select: none;
+}
+
+.withdrawal-transaction-amount__currency-text {
+  position: absolute;
+  height: var(--tx-amount-input-height);
+  display: flex;
+  align-items: center;
+  right: var(--input-currency-text-space);
+  top: 0;
+  user-select: none;
+}
+
+.withdrawal-transaction-amount__banner-field-label {
+  align-self: flex-start;
+  display: flex;
+  align-items: center;
+  height: var(--tx-amount-banner-height);
+}
+
+.withdrawal-transaction-amount__input-field-label {
+  align-self: flex-start;
+  display: flex;
+  align-items: center;
+  height: var(--tx-amount-input-height);
+}
+
+/* unlocking, unlocked, memorialized states */
+.withdrawal-transaction-amount--data-entered .withdrawal-transaction-amount__input-section > * + * {
+  margin-top: var(--boxel-sp);
+}
+
+.withdrawal-transaction-amount--data-entered .withdrawal-transaction-amount__field {
+  grid-template-columns: 1fr;
+  row-gap: var(--boxel-sp-xxs);
+}
+
+.withdrawal-transaction-amount--data-entered .withdrawal-transaction-amount__banner-field-label {
+  height: unset;
+}
+
+/* token balance display styles */
+.withdrawal-transaction-amount__token {
+  display: flex;
+  align-items: center;
+  color: var(--boxel-dark);
+
+  /* bordered display box */
+  justify-content: center;
+  padding: var(--boxel-sp-xl) var(--boxel-sp);
+  border: 1px solid var(--boxel-light-400);
+  border-radius: var(--boxel-border-radius);
+}
+
+.withdrawal-transaction-amount__footnote {
+  margin-top: var(--boxel-sp-xxl);
+  font: var(--boxel-font-xs);
+  color: var(--boxel-purple-400);
+}

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
@@ -1,24 +1,92 @@
 <ActionCardContainer
+  class={{cn "withdrawal-transaction-amount" withdrawal-transaction-amount--data-entered=this.isAmountSet}}
   @header="Withdrawal"
   @isComplete={{@isComplete}}
-  data-test-withdrawal-transaction-amount-is-complete={{@isComplete}}
 >
-  <ActionCardContainer::Section>
+  <ActionCardContainer::Section @title="Choose a withdrawal amount" @dataTestId="withdrawal-transaction-amount">
+    <div class="withdrawal-transaction-amount__input-section">
+      <Boxel::Field
+        class="withdrawal-transaction-amount__field"
+        @label="Funding From"
+        @labelClass="withdrawal-transaction-amount__banner-field-label"
+      >
+        <CardPay::BalanceViewBanner
+          @walletAddress={{this.layer2Network.walletInfo.firstAddress}}
+          @depotAddress={{this.layer2Network.depotSafe.address}}
+          @token={{this.currentTokenDetails}}
+          @balance={{format-token-amount this.currentTokenBalance}}
+        />
+      </Boxel::Field>
+      {{#if this.isAmountSet}}
+        <Boxel::Field
+          class="withdrawal-transaction-amount__field"
+          @label="Amount to withdraw"
+          data-test-amount-label
+        >
+          <CardPay::BalanceDisplay
+            class="withdrawal-transaction-amount__token"
+            @size="large"
+            @icon={{this.currentTokenDetails.icon}}
+            @balance={{format-token-amount this.amountAsBigNumber}}
+            @symbol={{this.currentTokenSymbol}}
+            @usdBalance={{token-to-usd this.tokenSymbolForConversion this.amountAsBigNumber}}
+            @usdFootnote={{true}}
+            data-test-amount-entered
+          />
+        </Boxel::Field>
+      {{else}}
+        <Boxel::Field
+          @label="Amount to withdraw"
+          @fieldMode="edit"
+          class="withdrawal-transaction-amount__field"
+          @labelClass="withdrawal-transaction-amount__input-field-label"
+          data-test-amount-label
+        >
+        <div class="withdrawal-transaction-amount__input-container withdrawal-transaction-amount__input-token-balance">
+          {{svg-jar this.currentTokenDetails.icon class="withdrawal-transaction-amount__currency-icon" role="presentation"}}
+          <Boxel::Input
+            class="withdrawal-transaction-amount__input"
+            @id="withdrawal-amount-input"
+            @value={{this.amount}}
+            @required={{true}}
+            @onInput={{this.onInputAmount}}
+            placeholder="0.00"
+            autocomplete="off"
+            inputmode="decimal"
+            data-test-amount-input
+          />
+          <div class="withdrawal-transaction-amount__currency-text">
+            {{this.currentTokenSymbol}}
+          </div>
+        </div>
+        </Boxel::Field>
+        <Boxel::Field @label="Approximate value*" data-test-approximate-value-label>
+          ${{token-to-usd this.tokenSymbolForConversion this.amountAsBigNumber}} USD
+        </Boxel::Field>
+      {{/if}}
+    </div>
+    <div class="withdrawal-transaction-amount__footnote" data-test-approximate-value-footnote>
+      * The actual value depends on the current exchange rate and is determined at the time of authorization.
+    </div>
   </ActionCardContainer::Section>
   <Boxel::ActionChin
-    @state={{if @isComplete "memorialized" "default"}}
+    @state={{this.setAmountCtaState}} @disabled={{this.setAmountCtaDisabled}}
     data-test-withdrawal-transaction-amount
   >
     <:default as |d|>
-      <d.ActionButton {{on "click" this.toggleComplete}}>
+      <d.ActionButton {{on "click" this.toggleAmountSet}}>
         Set Amount
       </d.ActionButton>
     </:default>
+    <:disabled as |d|>
+      <d.ActionButton>
+        Set Amount
+      </d.ActionButton>
+    </:disabled>
     <:memorialized as |m|>
-      <m.ActionButton {{on "click" this.toggleComplete}}>
+      <m.ActionButton {{on "click" this.toggleAmountSet}}>
         Edit
       </m.ActionButton>
     </:memorialized>
   </Boxel::ActionChin>
-
 </ActionCardContainer>

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
@@ -29,8 +29,7 @@
             @icon={{this.currentTokenDetails.icon}}
             @balance={{format-token-amount this.amountAsBigNumber}}
             @symbol={{this.currentTokenSymbol}}
-            @usdBalance={{token-to-usd this.tokenSymbolForConversion this.amountAsBigNumber}}
-            @usdFootnote={{true}}
+            @text={{concat "$" (token-to-usd this.tokenSymbolForConversion this.amountAsBigNumber) " USD*"}}
             data-test-amount-entered
           />
         </Boxel::Field>

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
@@ -1,19 +1,100 @@
-import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import Layer2Network from '@cardstack/web-client/services/layer2-network';
+import { inject as service } from '@ember/service';
+import BN from 'web3-core/node_modules/@types/bn.js';
+import { toBN, toWei } from 'web3-utils';
+import {
+  BridgedTokenSymbol,
+  TokenDisplayInfo,
+  TokenSymbol,
+  getUnbridgedSymbol,
+} from '@cardstack/web-client/utils/token';
 import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
 
-class CardPayWithdrawalWorkflowChooseBalanceComponent extends Component<WorkflowCardComponentArgs> {
-  constructor(owner: unknown, args: WorkflowCardComponentArgs) {
-    super(owner, args);
+class CardPayWithdrawalWorkflowTransactionAmountComponent extends Component<WorkflowCardComponentArgs> {
+  @tracked amount = '';
+  @tracked isAmountSet = false;
+  @service declare layer2Network: Layer2Network;
+
+  // assumption is this is always set by cards before it. It should be defined by the time
+  // it gets to this part of the workflow
+  get currentTokenSymbol(): TokenSymbol {
+    return this.args.workflowSession.state.withdrawalToken;
   }
 
-  @action toggleComplete() {
-    if (this.args.isComplete) {
+  get tokenSymbolForConversion(): TokenSymbol {
+    return getUnbridgedSymbol(this.currentTokenSymbol as BridgedTokenSymbol);
+  }
+
+  get currentTokenDetails(): TokenDisplayInfo | undefined {
+    if (this.currentTokenSymbol) {
+      return new TokenDisplayInfo(this.currentTokenSymbol);
+    } else {
+      return undefined;
+    }
+  }
+
+  get currentTokenBalance(): BN {
+    let balance;
+    if (this.currentTokenSymbol === 'DAI.CPXD') {
+      balance = this.layer2Network.defaultTokenBalance;
+    } else if (this.currentTokenSymbol === 'CARD.CPXD') {
+      balance = this.layer2Network.cardBalance;
+    }
+    return balance || toBN(0);
+  }
+
+  get setAmountCtaState() {
+    if (this.isAmountSet) {
+      return 'memorialized';
+    } else {
+      return 'default';
+    }
+  }
+
+  get setAmountCtaDisabled() {
+    return !this.isAmountSet && !this.isValidAmount;
+  }
+
+  get amountAsBigNumber(): BN {
+    const regex = /^\d*(\.\d{0,18})?$/gm;
+    if (!this.amount || !regex.test(this.amount)) {
+      return toBN(0);
+    }
+    return toBN(toWei(this.amount));
+  }
+
+  get isValidAmount() {
+    if (!this.amount) return false;
+    return (
+      !this.amountAsBigNumber.lte(toBN(0)) &&
+      this.amountAsBigNumber.lte(this.currentTokenBalance)
+    );
+  }
+
+  @action onInputAmount(str: string) {
+    if (!isNaN(+str)) {
+      this.amount = str.trim();
+    } else {
+      this.amount = this.amount; // eslint-disable-line no-self-assign
+    }
+  }
+
+  @action toggleAmountSet() {
+    if (this.isAmountSet) {
+      this.isAmountSet = false;
       this.args.onIncomplete?.();
     } else {
+      this.args.workflowSession.update(
+        'withdrawnAmount',
+        this.amountAsBigNumber.toString()
+      );
       this.args.onComplete?.();
+      this.isAmountSet = true;
     }
   }
 }
 
-export default CardPayWithdrawalWorkflowChooseBalanceComponent;
+export default CardPayWithdrawalWorkflowTransactionAmountComponent;

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-approval/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-approval/index.ts
@@ -41,8 +41,7 @@ class CardPayWithdrawalWorkflowChooseBalanceComponent extends Component<Workflow
   }
 
   get withdrawalAmount() {
-    // TODO: Replace with the amount selected in previous card
-    return this.tokenBalance;
+    return toBN(this.args.workflowSession.state.withdrawnAmount);
   }
 
   get depotAddress() {

--- a/packages/web-client/app/utils/token.ts
+++ b/packages/web-client/app/utils/token.ts
@@ -43,6 +43,16 @@ const contractNames: Record<NetworkSymbol, Record<BridgeableSymbol, string>> = {
   },
 };
 
+export function getUnbridgedSymbol(
+  bridgedSymbol: BridgedTokenSymbol
+): BridgeableSymbol {
+  if (bridgedSymbol === 'DAI.CPXD') {
+    return 'DAI';
+  } else {
+    return 'CARD';
+  }
+}
+
 export class TokenContractInfo {
   symbol: BridgeableSymbol;
   address: ChainAddress;

--- a/packages/web-client/tests/acceptance/withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-test.ts
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import {
   click,
   currentURL,
+  fillIn,
   settled,
   visit,
   waitFor,
@@ -175,19 +176,48 @@ module('Acceptance | withdrawal', function (hooks) {
       .dom(postableSel(2, 2))
       .containsText('How much would you like to withdraw from your balance?');
     post = postableSel(2, 3);
-    // assert.dom(`${post} [data-test-source-token="DAI.CPXD"]`).exists();
-    // assert
-    //   .dom(`${post} [data-test-withdrawal-transaction-amount] [data-test-boxel-button]`)
-    //   .isDisabled('Set amount button is disabled until amount has been entered');
-    // await fillIn('[data-test-withdrawal-amount-input]', '250');
-    // assert
-    //   .dom(`${post} [data-test-withdrawal-transaction-amount] [data-test-boxel-button]`)
-    //   .isEnabled('Set amount button is enabled once amount has been entered');
+
+    assert
+      .dom(
+        `${post} [data-test-action-card-title="withdrawal-transaction-amount"]`
+      )
+      .containsText('Choose a withdrawal amount');
+
+    assert
+      .dom(`${post} [data-test-balance-display-amount]`)
+      .containsText('250.00 DAI.CPXD');
+
+    assert
+      .dom(
+        `${post} [data-test-withdrawal-transaction-amount] [data-test-boxel-button]`
+      )
+      .isDisabled(
+        'Set amount button is disabled until amount has been entered'
+      );
+    await fillIn('[data-test-amount-input]', '250');
+    assert
+      .dom(
+        `${post} [data-test-withdrawal-transaction-amount] [data-test-boxel-button]`
+      )
+      .isEnabled('Set amount button is enabled once amount has been entered');
     await waitFor(`${post} [data-test-withdrawal-transaction-amount]`);
     await click(
       `${post} [data-test-withdrawal-transaction-amount] [data-test-boxel-button]`
     );
     assert.dom(milestoneCompletedSel(2)).containsText('Withdrawal amount set');
+
+    assert
+      .dom(
+        `${post} [data-test-withdrawal-transaction-amount] [data-test-boxel-button]`
+      )
+      .hasText('Edit');
+
+    await waitFor(`${post} [data-test-balance-display-usd-amount]`);
+
+    assert
+      .dom(`${post} [data-test-amount-entered]`)
+      .containsText('250.00 DAI.CPXD')
+      .containsText('$50.00 USD'); // FIXME add asterisk for footnote
 
     assert
       .dom(postableSel(3, 0))

--- a/packages/web-client/tests/acceptance/withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-test.ts
@@ -3,9 +3,11 @@ import {
   click,
   currentURL,
   fillIn,
+  find,
   settled,
   visit,
   waitFor,
+  waitUntil,
 } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
@@ -212,12 +214,16 @@ module('Acceptance | withdrawal', function (hooks) {
       )
       .hasText('Edit');
 
-    await waitFor(`${post} [data-test-balance-display-usd-amount]`);
+    await waitUntil(function () {
+      return find('[data-test-balance-display-text]')?.textContent?.includes(
+        '50'
+      );
+    });
 
     assert
       .dom(`${post} [data-test-amount-entered]`)
       .containsText('250.00 DAI.CPXD')
-      .containsText('$50.00 USD'); // FIXME add asterisk for footnote
+      .containsText('$50.00 USD*');
 
     assert
       .dom(postableSel(3, 0))

--- a/packages/web-client/tests/acceptance/withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-test.ts
@@ -196,7 +196,7 @@ module('Acceptance | withdrawal', function (hooks) {
       .isDisabled(
         'Set amount button is disabled until amount has been entered'
       );
-    await fillIn('[data-test-amount-input]', '250');
+    await fillIn('[data-test-amount-input]', '200');
     assert
       .dom(
         `${post} [data-test-withdrawal-transaction-amount] [data-test-boxel-button]`
@@ -216,14 +216,14 @@ module('Acceptance | withdrawal', function (hooks) {
 
     await waitUntil(function () {
       return find('[data-test-balance-display-text]')?.textContent?.includes(
-        '50'
+        '40'
       );
     });
 
     assert
       .dom(`${post} [data-test-amount-entered]`)
-      .containsText('250.00 DAI.CPXD')
-      .containsText('$50.00 USD*');
+      .containsText('200.00 DAI.CPXD')
+      .containsText('$40.00 USD*');
 
     assert
       .dom(postableSel(3, 0))
@@ -260,13 +260,12 @@ module('Acceptance | withdrawal', function (hooks) {
       )
       .containsText('250.00 DAI.CPXD');
 
-    // TODO: replace the amounts below with the user-chosen amount
     assert
       .dom('[data-test-withdrawal-tx-approval-amount]')
-      .containsText('250.00 DAI.CPXD');
+      .containsText('200.00 DAI.CPXD');
     assert
       .dom('[data-test-withdrawal-tx-approval-amount]')
-      .containsText('50.00 USD');
+      .containsText('40.00 USD');
 
     await click(
       `${post} [data-test-withdrawal-transaction-approval] [data-test-boxel-button]`


### PR DESCRIPTION
This fills out the amount-setting card for the withdrawal workflow:

![screencast 2021-07-08 14-50-23](https://user-images.githubusercontent.com/43280/124982221-13b03600-dffc-11eb-93a8-1a2296e38a0a.gif)

It’s mostly a copy of `CardPay::DepositWorkflow::TransactionAmount`, but it uses a `Layer2BalanceView` component renamed from `IssuePrepaidCardWorkflow::FaceValue::BalanceView`. There’s an opportunity for future extraction here as the currency input field and accompanying validation could be shared.

One significant caveat: I’ve only exercised this with DAI.CPXD and not CARD.CPXD. See CS 1224 for more.