### PR TITLE
catch and reject web3/json-rpc errors in l1 -> l2 bridge

### DIFF
--- a/packages/cardpay-sdk/sdk/token-bridge-foreign-side.ts
+++ b/packages/cardpay-sdk/sdk/token-bridge-foreign-side.ts
@@ -39,6 +39,9 @@ export default class TokenBridgeForeignSide implements ITokenBridgeForeignSide {
           } catch (e) {
             reject(e);
           }
+        })
+        .on('error', (error: Error) => {
+          reject(error);
         });
     });
   }
@@ -65,6 +68,9 @@ export default class TokenBridgeForeignSide implements ITokenBridgeForeignSide {
           } catch (e) {
             reject(e);
           }
+        })
+        .on('error', (error: Error) => {
+          reject(error);
         });
     });
   }


### PR DESCRIPTION
Directly reject errors that originate from `Contract.send` calls in `TokenBridgeForeignSide`. From web3's [docs](https://web3js.readthedocs.io/en/v1.2.11/web3-eth-contract.html#methods-mymethod-send) about the error event:

> "error" returns error: Error: Fired if an error occurs during sending. If the transaction was rejected by the network with a receipt, the receipt will be available as a property on the error object.

Necessary to catch user rejections of transaction requests and other errors to display helpful messages on the unlock and deposit UI.