### PR TITLE
Add withdrawal tx confirmation card

### DIFF
--- a/packages/web-client/app/components/card-pay/balance-display/index.hbs
+++ b/packages/web-client/app/components/card-pay/balance-display/index.hbs
@@ -4,6 +4,9 @@
       {{svg-jar @icon class=(cn "balance-display__icon" balance-display__icon--lg=isLarge) role="presentation"}}
     {{/if}}
     <div>
+      {{#if @label}}
+        <div class="balance-display__text">{{@label}}</div>
+      {{/if}}
       {{#if @name}}
         <div
           class={{cn "balance-display__name" balance-display__name--sm=isSmall}}

--- a/packages/web-client/app/components/card-pay/balance-view-banner/index.css
+++ b/packages/web-client/app/components/card-pay/balance-view-banner/index.css
@@ -1,6 +1,6 @@
 .balance-view-banner {
   --details-summary-height: 3.75rem; /* 60px */
-  --details-open-height: 12rem;
+  --details-open-height: 13rem;
   --details-padding-right: calc(var(--boxel-sp) + 3rem);
 
   position: relative;
@@ -104,9 +104,4 @@
   color: var(--boxel-purple-500);
   font: var(--boxel-font-sm);
   letter-spacing: var(--boxel-lsp);
-}
-
-.balance-view-banner__details-token {
-  margin-top: var(--boxel-sp-xs);
-  margin-left: var(--boxel-sp-lg);
 }

--- a/packages/web-client/app/components/card-pay/balance-view-banner/index.hbs
+++ b/packages/web-client/app/components/card-pay/balance-view-banner/index.hbs
@@ -28,14 +28,16 @@
         @address={{@depotAddress}}
         data-test-balance-view-depot-address
       />
+    </:inner>
+    <:innermost>
       <CardPay::BalanceDisplay
-        class="balance-view-banner__details-token"
+        @label="Available Balance"
         @size="large"
         @icon={{@token.icon}}
         @balance={{@balance}}
         @symbol={{@token.symbol}}
         data-test-balance-view-token-amount
       />
-    </:inner>
+    </:innermost>
   </CardPay::NestedItems>
 </details>

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
@@ -13,7 +13,7 @@
         </span>
       </p>
       <CardPay::LabeledValue @vertical={{true}} @label="Funding From:">
-        <CardPay::IssuePrepaidCardWorkflow::FaceValue::BalanceView
+        <CardPay::BalanceViewBanner
           @walletAddress={{this.layer2Network.walletInfo.firstAddress}}
           @depotAddress={{this.layer2Network.depotSafe.address}}
           @token={{this.fundingToken}}

--- a/packages/web-client/app/components/card-pay/nested-items/index.css
+++ b/packages/web-client/app/components/card-pay/nested-items/index.css
@@ -1,17 +1,19 @@
 .card-pay-nested-items__inner {
   margin-top: var(--boxel-sp-xxxs);
   margin-left: var(--boxel-sp-xl);
-  padding-top: calc(var(--boxel-sp) - var(--boxel-sp-xxxs));
-  padding-left: var(--boxel-sp-sm);
-  border-left: 1px solid var(--boxel-purple-300);
-}
-
-.card-pay-nested-items__inner--no-border {
-  padding-top: 0;
-  padding-left: 0;
-  border-left: none;
 }
 
 .card-pay-nested-items__inner--no-indent {
   margin-left: 0;
+}
+
+.card-pay-nested-items__inner-content {
+  padding-top: calc(var(--boxel-sp) - var(--boxel-sp-xxxs));
+  padding-left: var(--boxel-sp-xs);
+  border-left: 1px solid var(--boxel-purple-300);
+}
+
+.card-pay-nested-items__innermost {
+  margin-top: var(--boxel-sp-xxxs);
+  margin-left: var(--boxel-sp-xxl);
 }

--- a/packages/web-client/app/components/card-pay/nested-items/index.hbs
+++ b/packages/web-client/app/components/card-pay/nested-items/index.hbs
@@ -4,9 +4,18 @@
   </div>
   <div class={{cn
     "card-pay-nested-items__inner"
-    card-pay-nested-items__inner--no-border=@noBorder
     card-pay-nested-items__inner--no-indent=@noIndent
   }}>
-    {{yield to="inner"}}
+    <div class={{unless @noBorder "card-pay-nested-items__inner-content"}}>
+      {{yield to="inner"}}
+    </div>
+
+    {{#if (has-block "innermost")}}
+      <div class="card-pay-nested-items__innermost">
+        <div class={{unless @noBorder "card-pay-nested-items__inner-content"}}>
+          {{yield to="innermost"}}
+        </div>
+      </div>
+    {{/if}}
   </div>
 </div>

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-approval/index.css
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-approval/index.css
@@ -1,0 +1,26 @@
+.withdrawal-transaction-approval__amount-display {
+  display: flex;
+  align-items: center;
+  width: 100%;
+
+  /* bordered display box */
+  justify-content: center;
+  padding: var(--boxel-sp-xl) var(--boxel-sp);
+  border: 1px solid var(--boxel-light-400);
+  border-radius: var(--boxel-border-radius);
+}
+
+.withdrawal-transaction-approval__footnote {
+  display: block;
+  color: var(--boxel-purple-400);
+  font: var(--boxel-font-xs);
+  letter-spacing: var(--boxel-lsp-lg);
+}
+
+.withdrawal-transaction-approval__loading-indicator {
+  margin-right: var(--boxel-sp-xs);
+}
+
+.withdrawal-transaction-approval__loading-message {
+  max-width: 20rem;
+}

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-approval/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-approval/index.hbs
@@ -1,19 +1,61 @@
 <ActionCardContainer
-  @header="Withdrawal"
+  @header="Confirmation"
   @isComplete={{@isComplete}}
   data-test-withdrawal-transaction-approval-is-complete={{@isComplete}}
 >
-  <ActionCardContainer::Section>
+  <ActionCardContainer::Section @title="Confirm the withdrawal details">
+    <CardPay::LabeledValue @vertical={{true}}  @label="Funding From:">
+      <CardPay::BalanceViewBanner
+        @walletAddress={{truncate-middle this.layer2Network.walletInfo.firstAddress}}
+        @depotAddress={{truncate-middle this.depotAddress}}
+        @token={{this.withdrawalToken}}
+        @balance={{format-token-amount this.tokenBalance}}
+        data-test-withdrawal-tx-approval-balance
+      />
+    </CardPay::LabeledValue>
+    <CardPay::LabeledValue @vertical={{true}} @label="Amount to Withdraw:">
+      <CardPay::BalanceDisplay
+        class="withdrawal-transaction-approval__amount-display"
+        @size="large"
+        @icon={{this.withdrawalToken.icon}}
+        @symbol={{this.tokenSymbol}}
+        @balance={{format-token-amount this.withdrawalAmount}}
+        @text={{concat "$" (token-to-usd this.convertibleSymbol this.withdrawalAmount) " USD*"}}
+        data-test-withdrawal-tx-approval-amount
+      />
+    </CardPay::LabeledValue>
+    <small class="withdrawal-transaction-approval__footnote">
+      * The actual value depends on the current exchange rate and is determined at the time of authorization.
+    </small>
   </ActionCardContainer::Section>
   <Boxel::ActionChin
-    @state={{if @isComplete "memorialized" "default"}}
+    @state={{this.state}}
+    @disabled={{or @frozen this.isDisabled}}
     data-test-withdrawal-transaction-approval
   >
     <:default as |d|>
-      <d.ActionButton {{on "click" this.toggleComplete}}>
+      <d.ActionButton {{on "click" this.save}}>
         Confirm
       </d.ActionButton>
     </:default>
+    <:in-progress as |i|>
+      <i.ActionStatusArea @icon="card-wallet-app-icon" style={{css-var status-icon-size="2.5rem"}}>
+        <Boxel::LoadingIndicator
+          class="withdrawal-transaction-approval__loading-indicator"
+          @color="var(--boxel-light)"
+        />
+        <div class="withdrawal-transaction-approval__loading-message">
+          You will receive a confirmation request from the Card Wallet app in a few moments…
+        </div>
+      </i.ActionStatusArea>
+      <i.InfoArea>
+        Only visible to you
+      </i.InfoArea>
+    </:in-progress>
+    <:memorialized as |m|>
+      <m.ActionStatusArea>
+        Confirmed
+      </m.ActionStatusArea>
+    </:memorialized>
   </Boxel::ActionChin>
-
 </ActionCardContainer>

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-approval/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-approval/index.ts
@@ -1,17 +1,84 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { toBN } from 'web3-utils';
+import Layer2Network from '@cardstack/web-client/services/layer2-network';
+import {
+  ConvertibleSymbol,
+  TokenDisplayInfo,
+  TokenSymbol,
+} from '@cardstack/web-client/utils/token';
 import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
 
 class CardPayWithdrawalWorkflowChooseBalanceComponent extends Component<WorkflowCardComponentArgs> {
-  constructor(owner: unknown, args: WorkflowCardComponentArgs) {
-    super(owner, args);
+  defaultTokenSymbol: TokenSymbol = 'DAI.CPXD';
+  cardTokenSymbol: TokenSymbol = 'CARD.CPXD';
+  @service declare layer2Network: Layer2Network;
+  @tracked tokenSymbol: TokenSymbol =
+    this.args.workflowSession.state.withdrawalToken ?? this.defaultTokenSymbol;
+  @tracked isConfirmed = false;
+
+  get withdrawalToken() {
+    return new TokenDisplayInfo(this.tokenSymbol);
   }
 
-  @action toggleComplete() {
-    if (this.args.isComplete) {
-      this.args.onIncomplete?.();
+  get convertibleSymbol(): ConvertibleSymbol {
+    if (this.tokenSymbol === this.cardTokenSymbol) {
+      return 'CARD';
     } else {
+      return 'DAI';
+    }
+  }
+
+  get tokenBalance() {
+    if (this.tokenSymbol === this.defaultTokenSymbol) {
+      return this.layer2Network.defaultTokenBalance ?? toBN('0');
+    } else if (this.tokenSymbol === this.cardTokenSymbol) {
+      return this.layer2Network.cardBalance ?? toBN('0');
+    }
+    return toBN('0');
+  }
+
+  get withdrawalAmount() {
+    // TODO: Replace with the amount selected in previous card
+    return this.tokenBalance;
+  }
+
+  get depotAddress() {
+    return this.layer2Network.depotSafe?.address || undefined;
+  }
+
+  get isDisabled() {
+    return (
+      !this.depotAddress ||
+      !this.withdrawalAmount ||
+      this.withdrawalAmount.isZero() ||
+      this.isConfirmed
+    );
+  }
+
+  get state() {
+    if (this.args.isComplete) {
+      return 'memorialized';
+    } else if (this.isConfirmed) {
+      return 'in-progress';
+    } else {
+      return 'default';
+    }
+  }
+
+  @action save() {
+    if (this.isDisabled) {
+      return;
+    }
+    // TODO: Need to get confirm action result from Card Wallet
+    this.isConfirmed = true; // mock result
+
+    if (this.isConfirmed) {
       this.args.onComplete?.();
+    } else {
+      this.args.onIncomplete?.();
     }
   }
 }

--- a/packages/web-client/tests/acceptance/withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-test.ts
@@ -195,11 +195,65 @@ module('Acceptance | withdrawal', function (hooks) {
     post = postableSel(3, 1);
     // // transaction-approval card
     await waitFor(`${post} [data-test-withdrawal-transaction-approval]`);
+    assert
+      .dom(
+        `[data-test-withdrawal-tx-approval-balance] [data-test-balance-view-summary]`
+      )
+      .containsText('0x1826...6E44');
+    assert
+      .dom(
+        `[data-test-withdrawal-tx-approval-balance] [data-test-balance-view-summary]`
+      )
+      .containsText('250.00 DAI.CPXD');
+    await click(
+      `[data-test-withdrawal-tx-approval-balance] [data-test-balance-view-summary]`
+    );
+    assert
+      .dom(
+        `[data-test-withdrawal-tx-approval-balance] [data-test-balance-view-account-address]`
+      )
+      .containsText('0x1826...6E44');
+    assert
+      .dom(
+        `[data-test-withdrawal-tx-approval-balance] [data-test-balance-view-depot-address]`
+      )
+      .containsText('0xB236...6666');
+    assert
+      .dom(
+        `[data-test-withdrawal-tx-approval-balance] [data-test-balance-display-amount]`
+      )
+      .containsText('250.00 DAI.CPXD');
+
+    // TODO: replace the amounts below with the user-chosen amount
+    assert
+      .dom('[data-test-withdrawal-tx-approval-amount]')
+      .containsText('250.00 DAI.CPXD');
+    assert
+      .dom('[data-test-withdrawal-tx-approval-amount]')
+      .containsText('50.00 USD');
+
     await click(
       `${post} [data-test-withdrawal-transaction-approval] [data-test-boxel-button]`
     );
-    // TODO: simulate approval and bridge success
+    // TODO: simulate approval
+    assert
+      .dom('[data-test-withdrawal-transaction-approval-is-complete]')
+      .exists();
+    assert
+      .dom(
+        `${post} [data-test-withdrawal-transaction-approval] [data-test-boxel-button]`
+      )
+      .doesNotExist();
+    assert
+      .dom('[data-test-withdrawal-transaction-approval]')
+      .containsText('Confirmed');
+
     assert.dom(milestoneCompletedSel(3)).containsText('Transaction confirmed');
+
+    // // transaction-status step card
+    // TODO: simulate bridge success
+
+    // // transaction-summary card
     assert
       .dom(epiloguePostableSel(0))
       .containsText('You have successfully withdrawn tokens');


### PR DESCRIPTION
- Add transaction approval card
- Extract `CardPay::BalanceViewBanner` component
- Update NestedItems component to include a third level
- Style fixes in expanded view of the banner component
- Update tests

We will need to revisit this component:
- When the withdrawal amount set in the previous card is available. We need to replace the current withdrawal amount with the user selected amount.
- Need to request confirmation from Card Wallet app

<img width="738" alt="confirm-default" src="https://user-images.githubusercontent.com/16160806/124842997-efeae280-df5e-11eb-9bb8-0a8d531630c2.png">
<img width="745" alt="confirm-expanded" src="https://user-images.githubusercontent.com/16160806/124997576-e02fd480-e018-11eb-9358-b144d35deb39.png">
<img width="715" alt="confirm-memorialized" src="https://user-images.githubusercontent.com/16160806/124842998-f1b4a600-df5e-11eb-9d03-346e0bfdbbe9.png">