### PR TITLE
Fix/clear hub auth

### DIFF
--- a/packages/web-client/app/services/card-customization.ts
+++ b/packages/web-client/app/services/card-customization.ts
@@ -190,6 +190,27 @@ export default class CardCustomization extends Service {
       }
     );
     let customization = yield response.json();
+    if (customization.errors) {
+      if (
+        customization.errors.length === 1 &&
+        Number(customization.errors[0].status) === 401 &&
+        customization.errors[0].title === 'No valid auth token'
+      ) {
+        console.error(
+          'Failed to store prepaid card customization due to invalid auth token'
+        );
+        this.hubAuthentication.authToken = null;
+        throw new Error('No valid auth token');
+      } else {
+        // TODO: this should be changed to a form that communicates the errors
+        console.error(
+          'Failed to store prepaid card customization, got errors:',
+          customization.errors
+        );
+        throw new Error('Failed to store prepaid card customizations');
+      }
+    }
+
     return {
       did: customization.data.attributes.did,
     };

--- a/packages/web-client/app/services/layer1-network.ts
+++ b/packages/web-client/app/services/layer1-network.ts
@@ -11,13 +11,17 @@ import { WalletProvider } from '../utils/wallet-providers';
 import { TransactionReceipt } from 'web3-core';
 import BN from 'bn.js';
 import {
+  Emitter,
   SimpleEmitter,
   UnbindEventListener,
 } from '@cardstack/web-client/utils/events';
 import { action } from '@ember/object';
 import { TaskGenerator } from 'ember-concurrency';
 
-export default class Layer1Network extends Service {
+type Layer1NetworkEvent = 'disconnect';
+export default class Layer1Network
+  extends Service
+  implements Emitter<Layer1NetworkEvent> {
   strategy!: Layer1Web3Strategy;
   simpleEmitter = new SimpleEmitter();
   @reads('strategy.isConnected', false) isConnected!: boolean;
@@ -58,7 +62,7 @@ export default class Layer1Network extends Service {
     this.simpleEmitter.emit('disconnect');
   }
 
-  on(event: string, cb: Function): UnbindEventListener {
+  on(event: Layer1NetworkEvent, cb: Function): UnbindEventListener {
     return this.simpleEmitter.on(event, cb);
   }
 

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -1,5 +1,6 @@
 import Service from '@ember/service';
 import config from '../config/environment';
+import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency-decorators';
 import { Layer2Web3Strategy } from '../utils/web3-strategies/types';
 import Layer2TestWeb3Strategy from '../utils/web3-strategies/test-layer2';
@@ -19,11 +20,13 @@ import {
   UnbindEventListener,
 } from '@cardstack/web-client/utils/events';
 import { action } from '@ember/object';
+import HubAuthentication from '@cardstack/web-client/services/hub-authentication';
 
 type Layer2NetworkEvent = 'disconnect';
 export default class Layer2Network
   extends Service
   implements Emitter<Layer2NetworkEvent> {
+  @service declare hubAuthentication: HubAuthentication;
   strategy!: Layer2Web3Strategy;
   simpleEmitter = new SimpleEmitter();
   @reads('strategy.isConnected', false) isConnected!: boolean;
@@ -88,6 +91,7 @@ export default class Layer2Network
   }
 
   @action onDisconnect() {
+    this.hubAuthentication.authToken = null;
     this.simpleEmitter.emit('disconnect');
   }
 

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -14,12 +14,16 @@ import {
   ConversionFunction,
 } from '@cardstack/web-client/utils/token';
 import {
+  Emitter,
   SimpleEmitter,
   UnbindEventListener,
 } from '@cardstack/web-client/utils/events';
 import { action } from '@ember/object';
 
-export default class Layer2Network extends Service {
+type Layer2NetworkEvent = 'disconnect';
+export default class Layer2Network
+  extends Service
+  implements Emitter<Layer2NetworkEvent> {
   strategy!: Layer2Web3Strategy;
   simpleEmitter = new SimpleEmitter();
   @reads('strategy.isConnected', false) isConnected!: boolean;
@@ -87,7 +91,7 @@ export default class Layer2Network extends Service {
     this.simpleEmitter.emit('disconnect');
   }
 
-  on(event: string, cb: Function): UnbindEventListener {
+  on(event: Layer2NetworkEvent, cb: Function): UnbindEventListener {
     return this.simpleEmitter.on(event, cb);
   }
 

--- a/packages/web-client/tests/unit/services/layer2-network-test.ts
+++ b/packages/web-client/tests/unit/services/layer2-network-test.ts
@@ -9,4 +9,13 @@ module('Unit | Service | Layer2Network', function (hooks) {
     let service = this.owner.lookup('service:layer2-network');
     assert.ok(service);
   });
+
+  test('it clears the auth token when onDisconnect is called', function (assert) {
+    let hubAuthentication = this.owner.lookup('service:hub-authentication');
+    hubAuthentication.authToken = 'something';
+    assert.equal(hubAuthentication.authToken, 'something');
+    let layer2Network = this.owner.lookup('service:layer2-network');
+    layer2Network.onDisconnect();
+    assert.equal(hubAuthentication.authToken, null);
+  });
 });


### PR DESCRIPTION
CS-1239

Remove the auth token from local storage when a user disconnects, or when the prepaid card customization saving fails due to an invalid auth token. I think using customized errors which hold codes and communicative messages could be useful, do people have any thoughts about how to do this?

Edit: Noticed that the case where we have multiple errors is returned is for invalid prepaid card customization attributes, seems straightforward enough to pass the error information up to the calling component so it can show error messages as a first step. To follow up with UI in [task 1240](https://linear.app/cardstack/issue/CS-1240/add-ui-for-errors-to-prepaid-card-preview-card)