### PR TITLE
Add withdrawal status card

### DIFF
--- a/packages/web-client/app/components/action-card-container/title/index.hbs
+++ b/packages/web-client/app/components/action-card-container/title/index.hbs
@@ -4,7 +4,7 @@
   ...attributes
 >
   {{#if @icon}}
-    {{svg-jar @icon class="action-card__title-icon" width="20" height="20"}}
+    {{svg-jar @icon class="action-card__title-icon" width="20" height="20" data-test-action-card-title-icon-name=@icon}}
   {{/if}}
 
   <div class="action-card__title-content">

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
@@ -136,6 +136,10 @@ class WithdrawalWorkflow extends Workflow {
     }),
     new WorkflowCard({
       author: cardbot,
+      componentName: 'card-pay/withdrawal-workflow/transaction-status',
+    }),
+    new WorkflowCard({
+      author: cardbot,
       componentName: 'card-pay/withdrawal-workflow/transaction-confirmed',
     }),
     new WorkflowMessage({

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-approval/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-approval/index.ts
@@ -80,9 +80,6 @@ class CardPayWithdrawalWorkflowChooseBalanceComponent extends Component<Workflow
       relayTokensTxnReceipt: {
         transactionHash: 'TODO',
       },
-      completedLayer2TransactionReceipt: {
-        transactionHash: 'TODO',
-      },
     });
 
     if (this.isConfirmed) {

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-approval/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-approval/index.ts
@@ -76,6 +76,7 @@ class CardPayWithdrawalWorkflowChooseBalanceComponent extends Component<Workflow
     this.isConfirmed = true; // mock result
 
     this.args.workflowSession.updateMany({
+      layer1BlockHeightBeforeBridging: 1234,
       relayTokensTxnReceipt: {
         transactionHash: 'TODO',
       },

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-approval/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-approval/index.ts
@@ -75,6 +75,15 @@ class CardPayWithdrawalWorkflowChooseBalanceComponent extends Component<Workflow
     // TODO: Need to get confirm action result from Card Wallet
     this.isConfirmed = true; // mock result
 
+    this.args.workflowSession.updateMany({
+      relayTokensTxnReceipt: {
+        transactionHash: 'TODO',
+      },
+      completedLayer2TransactionReceipt: {
+        transactionHash: 'TODO',
+      },
+    });
+
     if (this.isConfirmed) {
       this.args.onComplete?.();
     } else {

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.hbs
@@ -5,6 +5,7 @@
 >
   <ActionCardContainer::Section
     @title={{concat "Bridging tokens to " (network-display-info "layer1" "fullName")}}
+    @icon={{if this.isInProgress "clock" "success-bordered"}}
     @dataTestId="withdrawal-confirmed"
   >
     <Boxel::ProgressSteps

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.hbs
@@ -44,15 +44,4 @@
       </span>
     </Boxel::ProgressSteps>
   </ActionCardContainer::Section>
-  <Boxel::ActionChin
-    @state={{if @isComplete "memorialized" "default"}}
-    data-test-withdrawal-transaction-confirmed
-  >
-    <:default as |d|>
-      <d.ActionButton {{on "click" this.toggleComplete}}>
-        Confirm
-      </d.ActionButton>
-    </:default>
-  </Boxel::ActionChin>
-
 </ActionCardContainer>

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.hbs
@@ -28,14 +28,9 @@
           </Boxel::Button>
         {{/if}}
         {{#if (eq progressStep.index 1)}}
-          <Boxel::Button @as="anchor" @size="extra-small" @href={{this.bridgeExplorerUrl}} target="_blank" rel="noopener" data-test-bridge-explorer-button>
-            View in Bridge Explorer
-          </Boxel::Button>
-        {{/if}}
-        {{#if (eq progressStep.index 2)}}
           {{#if progressStep.completed}}
-            <Boxel::Button @as="anchor" @size="extra-small" @href={{this.withdrawalTxnViewerUrl}} target="_blank" rel="noopener" data-test-etherscan-button>
-              View on Etherscan
+            <Boxel::Button @as="anchor" @size="extra-small" @href={{this.bridgeExplorerUrl}} target="_blank" rel="noopener" data-test-bridge-explorer-button>
+              View in Bridge Explorer
             </Boxel::Button>
           {{else}}
             Processing...

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.hbs
@@ -1,0 +1,58 @@
+<ActionCardContainer
+  @header="Token bridge"
+  @isComplete={{@isComplete}}
+  data-test-withdrawal-transaction-confirmed-is-complete={{@isComplete}}
+>
+  <ActionCardContainer::Section
+    @title={{concat "Bridging tokens to " (network-display-info "layer1" "fullName")}}
+    @dataTestId="withdrawal-confirmed"
+  >
+    <Boxel::ProgressSteps
+      class="transaction-status__steps"
+      @progressSteps={{this.progressSteps}}
+      @completedCount={{this.completedCount}}
+      as |progressStep|
+    >
+      <span
+        class="transaction-status__step-title"
+        data-test-token-bridge-step={{progressStep.index}}
+        data-test-completed={{progressStep.completed}}
+      >
+        {{progressStep.title}}
+      </span>
+
+      <span class="transaction-status__step-status">
+        {{#if (eq progressStep.index 0)}}
+          <Boxel::Button @as="anchor" @size="extra-small" @href={{this.blockscoutUrl}} target="_blank" rel="noopener" data-test-blockscout-button>
+            View on Blockscout
+          </Boxel::Button>
+        {{/if}}
+        {{#if (eq progressStep.index 1)}}
+          <Boxel::Button @as="anchor" @size="extra-small" @href={{this.bridgeExplorerUrl}} target="_blank" rel="noopener" data-test-bridge-explorer-button>
+            View in Bridge Explorer
+          </Boxel::Button>
+        {{/if}}
+        {{#if (eq progressStep.index 2)}}
+          {{#if progressStep.completed}}
+            <Boxel::Button @as="anchor" @size="extra-small" @href={{this.depositTxnViewerUrlFIXME}} target="_blank" rel="noopener" data-test-etherscan-button>
+              View on Etherscan
+            </Boxel::Button>
+          {{else}}
+            Processing...
+          {{/if}}
+        {{/if}}
+      </span>
+    </Boxel::ProgressSteps>
+  </ActionCardContainer::Section>
+  <Boxel::ActionChin
+    @state={{if @isComplete "memorialized" "default"}}
+    data-test-withdrawal-transaction-confirmed
+  >
+    <:default as |d|>
+      <d.ActionButton {{on "click" this.toggleComplete}}>
+        Confirm
+      </d.ActionButton>
+    </:default>
+  </Boxel::ActionChin>
+
+</ActionCardContainer>

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.hbs
@@ -34,7 +34,7 @@
         {{/if}}
         {{#if (eq progressStep.index 2)}}
           {{#if progressStep.completed}}
-            <Boxel::Button @as="anchor" @size="extra-small" @href={{this.depositTxnViewerUrlFIXME}} target="_blank" rel="noopener" data-test-etherscan-button>
+            <Boxel::Button @as="anchor" @size="extra-small" @href={{this.withdrawalTxnViewerUrl}} target="_blank" rel="noopener" data-test-etherscan-button>
               View on Etherscan
             </Boxel::Button>
           {{else}}

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.ts
@@ -64,8 +64,7 @@ class CardPayWithdrawalWorkflowTransactionStatusComponent extends Component<Work
 
   get blockscoutUrl() {
     return this.layer2Network.blockExplorerUrl(
-      this.args.workflowSession.state.completedLayer2TransactionReceipt
-        .transactionHash
+      this.args.workflowSession.state.relayTokensTxnReceipt.transactionHash
     );
   }
 

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.ts
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
@@ -46,14 +45,6 @@ class CardPayWithdrawalWorkflowTransactionStatusComponent extends Component<Work
         title: `Release tokens on ${c.layer1.conversationalName}: ${c.layer2.shortName}`, // FIXME script says "DAI", not "xDai" 🤔
       },
     ];
-  }
-
-  @action toggleComplete() {
-    if (this.args.isComplete) {
-      this.args.onIncomplete?.();
-    } else {
-      this.args.onComplete?.();
-    }
   }
 
   get bridgeExplorerUrl() {

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.ts
@@ -30,6 +30,10 @@ class CardPayWithdrawalWorkflowTransactionStatusComponent extends Component<Work
       });
   }
 
+  get isInProgress() {
+    return !this.args.workflowSession.state.completedLayer1TransactionReceipt;
+  }
+
   get currentTokenSymbol(): BridgedTokenSymbol {
     return this.args.workflowSession.state.withdrawalToken;
   }

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.ts
@@ -1,0 +1,60 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import Layer1Network from '@cardstack/web-client/services/layer1-network';
+import Layer2Network from '@cardstack/web-client/services/layer2-network';
+import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
+import { next } from '@ember/runloop';
+
+class CardPayWithdrawalWorkflowTransactionStatusComponent extends Component<WorkflowCardComponentArgs> {
+  @service declare layer1Network: Layer1Network;
+  @service declare layer2Network: Layer2Network;
+
+  @tracked completedCount = 1;
+
+  constructor(owner: unknown, args: WorkflowCardComponentArgs) {
+    super(owner, args);
+    next(this, () => {
+      this.args.onComplete?.();
+    });
+  }
+
+  get progressSteps() {
+    return [
+      {
+        title: `Withdraw tokens from ${c.layer2.fullName}`,
+      },
+      {
+        title: `Bridge tokens from ${c.layer2.fullName} to ${c.layer1.fullName}`,
+      },
+      {
+        title: `Release tokens on ${c.layer1.conversationalName}: ${c.layer2.shortName}`, // FIXME script says "DAI", not "xDai" 🤔
+      },
+    ];
+  }
+
+  @action toggleComplete() {
+    if (this.args.isComplete) {
+      this.args.onIncomplete?.();
+    } else {
+      this.args.onComplete?.();
+    }
+  }
+
+  get bridgeExplorerUrl() {
+    return this.layer1Network.bridgeExplorerUrl(
+      this.args.workflowSession.state.relayTokensTxnReceipt.transactionHash
+    );
+  }
+
+  get blockscoutUrl() {
+    return this.layer2Network.blockExplorerUrl(
+      this.args.workflowSession.state.completedLayer2TransactionReceipt
+        .transactionHash
+    );
+  }
+}
+
+export default CardPayWithdrawalWorkflowTransactionStatusComponent;

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.ts
@@ -5,6 +5,7 @@ import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow
 import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
+import { BridgedTokenSymbol } from '@cardstack/web-client/utils/token';
 
 import BN from 'bn.js';
 import { TransactionReceipt } from 'web3-core';
@@ -24,9 +25,13 @@ class CardPayWithdrawalWorkflowTransactionStatusComponent extends Component<Work
           'completedLayer1TransactionReceipt',
           transactionReceipt
         );
-        this.completedCount = 3;
+        this.completedCount = 2;
         this.args.onComplete();
       });
+  }
+
+  get currentTokenSymbol(): BridgedTokenSymbol {
+    return this.args.workflowSession.state.withdrawalToken;
   }
 
   get layer1BlockHeightBeforeBridging(): BN | undefined {
@@ -40,9 +45,6 @@ class CardPayWithdrawalWorkflowTransactionStatusComponent extends Component<Work
       },
       {
         title: `Bridge tokens from ${c.layer2.fullName} to ${c.layer1.fullName}`,
-      },
-      {
-        title: `Release tokens on ${c.layer1.conversationalName}: ${c.layer2.shortName}`, // FIXME script says "DAI", not "xDai" 🤔
       },
     ];
   }

--- a/packages/web-client/app/services/layer1-network.ts
+++ b/packages/web-client/app/services/layer1-network.ts
@@ -95,6 +95,10 @@ export default class Layer1Network
   bridgeExplorerUrl(txnHash: string) {
     return txnHash ? this.strategy.bridgeExplorerUrl(txnHash) : undefined;
   }
+
+  async awaitBridged(fromBlock: BN) {
+    return this.strategy.awaitBridged(fromBlock, this.walletInfo.firstAddress!);
+  }
 }
 
 // DO NOT DELETE: this is how TypeScript knows how to look up your services.

--- a/packages/web-client/app/utils/web3-strategies/test-layer1.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer1.ts
@@ -32,6 +32,8 @@ export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
   #unlockDeferred: RSVP.Deferred<TransactionReceipt> | undefined;
   #depositDeferred: RSVP.Deferred<TransactionReceipt> | undefined;
 
+  bridgingDeferred!: RSVP.Deferred<TransactionReceipt>;
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   connect(_walletProvider: WalletProvider): Promise<void> {
     return this.waitForAccount;
@@ -145,6 +147,18 @@ export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
       logsBloom: '',
       events: {},
     });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  awaitBridged(_fromBlock: BN, _receiver: string): Promise<TransactionReceipt> {
+    this.bridgingDeferred = defer<TransactionReceipt>();
+    return this.bridgingDeferred.promise as Promise<TransactionReceipt>;
+  }
+
+  test__simulateBridged(txnHash: TransactionHash) {
+    this.bridgingDeferred.resolve({
+      transactionHash: txnHash,
+    } as TransactionReceipt);
   }
 
   get waitForAccount() {

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -29,6 +29,10 @@ export interface Layer1Web3Strategy extends Web3Strategy {
   ): Promise<TransactionReceipt>;
   blockExplorerUrl(txnHash: TransactionHash): string;
   bridgeExplorerUrl(txnHash: TransactionHash): string;
+  awaitBridged(
+    fromBlock: BN,
+    receiver: ChainAddress
+  ): Promise<TransactionReceipt>;
 }
 
 export interface Layer2Web3Strategy extends Web3Strategy {

--- a/packages/web-client/tests/acceptance/withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-test.ts
@@ -297,6 +297,11 @@ module('Acceptance | withdrawal', function (hooks) {
       .dom(epiloguePostableSel(1))
       .containsText(`Bridging tokens to ${c.layer1.fullName}`);
 
+    layer1Service.test__simulateBridged(
+      '0xabc123abc123abc123e5984131f6b4cc3ac8af14'
+    );
+    await settled();
+
     assert
       .dom(
         '[data-test-withdrawal-transaction-confirmed-from] [data-test-bridge-item-amount]'

--- a/packages/web-client/tests/acceptance/withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-test.ts
@@ -292,6 +292,11 @@ module('Acceptance | withdrawal', function (hooks) {
     assert
       .dom(epiloguePostableSel(0))
       .containsText('You have successfully withdrawn tokens');
+
+    assert
+      .dom(epiloguePostableSel(1))
+      .containsText(`Bridging tokens to ${c.layer1.fullName}`);
+
     assert
       .dom(
         '[data-test-withdrawal-transaction-confirmed-from] [data-test-bridge-item-amount]'
@@ -302,9 +307,11 @@ module('Acceptance | withdrawal', function (hooks) {
         '[data-test-withdrawal-transaction-confirmed-to] [data-test-bridge-item-amount]'
       )
       .containsText('200.00 DAI');
-    await waitFor(epiloguePostableSel(2));
+
+    await waitFor(epiloguePostableSel(3));
+
     assert
-      .dom(epiloguePostableSel(2))
+      .dom(epiloguePostableSel(3))
       .containsText(
         `This is the remaining balance in your ${c.layer2.fullName} wallet`
       );
@@ -312,12 +319,12 @@ module('Acceptance | withdrawal', function (hooks) {
       defaultToken: toBN('2141100000000000000'), // TODO: choose numbers that make sense with the scenario
       card: toBN('10000000000000000000000'), // TODO: choose numbers that make sense with the scenario
     });
-    await waitFor(`${epiloguePostableSel(3)} [data-test-balance="DAI.CPXD"]`);
+    await waitFor(`${epiloguePostableSel(4)} [data-test-balance="DAI.CPXD"]`);
     assert
-      .dom(`${epiloguePostableSel(3)} [data-test-balance="DAI.CPXD"]`)
+      .dom(`${epiloguePostableSel(4)} [data-test-balance="DAI.CPXD"]`)
       .containsText('2.1411');
     assert
-      .dom(`${epiloguePostableSel(3)} [data-test-balance="CARD.CPXD"]`)
+      .dom(`${epiloguePostableSel(4)} [data-test-balance="CARD.CPXD"]`)
       .containsText('10000.00');
     // let milestoneCtaButtonCount = Array.from(
     //   document.querySelectorAll(
@@ -334,11 +341,11 @@ module('Acceptance | withdrawal', function (hooks) {
     //   );
     assert
       .dom(
-        `${epiloguePostableSel(4)} [data-test-withdrawal-next-step="dashboard"]`
+        `${epiloguePostableSel(5)} [data-test-withdrawal-next-step="dashboard"]`
       )
       .exists();
     await click(
-      `${epiloguePostableSel(4)} [data-test-withdrawal-next-step="dashboard"]`
+      `${epiloguePostableSel(5)} [data-test-withdrawal-next-step="dashboard"]`
     );
     assert.dom('[data-test-workflow-thread]').doesNotExist();
   });

--- a/packages/web-client/tests/acceptance/withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-test.ts
@@ -285,13 +285,11 @@ module('Acceptance | withdrawal', function (hooks) {
 
     assert.dom(milestoneCompletedSel(3)).containsText('Transaction confirmed');
 
-    // // transaction-status step card
-    // TODO: simulate bridge success
-
-    // // transaction-summary card
     assert
       .dom(epiloguePostableSel(0))
       .containsText('You have successfully withdrawn tokens');
+
+    // // transaction-status step card
 
     assert
       .dom(epiloguePostableSel(1))
@@ -301,6 +299,8 @@ module('Acceptance | withdrawal', function (hooks) {
       '0xabc123abc123abc123e5984131f6b4cc3ac8af14'
     );
     await settled();
+
+    // // transaction-summary card
 
     assert
       .dom(

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
@@ -45,6 +45,8 @@ module(
     });
 
     test('It renders transaction status and links', async function (assert) {
+      assert.dom('[data-test-action-card-title-icon-name="clock"]').exists();
+
       assert
         .dom(`[data-test-token-bridge-step="0"][data-test-completed]`)
         .containsText(`Withdraw tokens from ${c.layer2.fullName}`);
@@ -69,6 +71,10 @@ module(
       layer1Service.test__simulateBridged('0xbridged');
 
       await settled();
+
+      assert
+        .dom('[data-test-action-card-title-icon-name="success-bordered"]')
+        .exists();
 
       assert
         .dom(`[data-test-token-bridge-step="1"][data-test-completed]`)

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
@@ -18,10 +18,11 @@ module(
     hooks.beforeEach(async function () {
       let workflowSession = new WorkflowSession();
       workflowSession.updateMany({
+        layer1BlockHeightBeforeBridging: 1234,
         relayTokensTxnReceipt: {
           transactionHash: 'relay',
         },
-        layer1BlockHeightBeforeBridging: 1234,
+        withdrawalToken: 'CARD.CPXD',
       });
 
       this.setProperties({
@@ -56,16 +57,7 @@ module(
         .containsText(
           `Bridge tokens from ${c.layer2.fullName} to ${c.layer1.fullName}`
         );
-      assert
-        .dom(`[data-test-bridge-explorer-button]`)
-        .hasAttribute('href', /relay$/);
-
-      assert
-        .dom(`[data-test-token-bridge-step="2"]:not([data-test-completed])`)
-        .containsText(
-          `Release tokens on ${c.layer1.conversationalName}: ${c.layer2.shortName}`
-        );
-      assert.dom(`[data-test-etherscan-button]`).doesNotExist();
+      assert.dom(`[data-test-bridge-explorer-button]`).doesNotExist();
     });
 
     test('It completes when the bridged transaction completes', async function (assert) {
@@ -81,14 +73,9 @@ module(
       assert
         .dom(`[data-test-token-bridge-step="1"][data-test-completed]`)
         .exists();
-
       assert
-        .dom(`[data-test-token-bridge-step="2"][data-test-completed]`)
-        .exists();
-
-      assert
-        .dom(`[data-test-etherscan-button]`)
-        .hasAttribute('href', /bridged$/);
+        .dom(`[data-test-bridge-explorer-button]`)
+        .hasAttribute('href', /relay$/);
 
       assert.ok(onComplete.called);
     });

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
@@ -19,10 +19,7 @@ module(
       let workflowSession = new WorkflowSession();
       workflowSession.updateMany({
         relayTokensTxnReceipt: {
-          transactionHash: 'bridgeexplorer',
-        },
-        completedLayer2TransactionReceipt: {
-          transactionHash: 'blockscout',
+          transactionHash: 'relay',
         },
         layer1BlockHeightBeforeBridging: 1234,
       });
@@ -52,7 +49,7 @@ module(
         .containsText(`Withdraw tokens from ${c.layer2.fullName}`);
       assert
         .dom(`[data-test-blockscout-button]`)
-        .hasAttribute('href', /blockscout$/);
+        .hasAttribute('href', /relay$/);
 
       assert
         .dom(`[data-test-token-bridge-step="1"]:not([data-test-completed])`)
@@ -61,7 +58,7 @@ module(
         );
       assert
         .dom(`[data-test-bridge-explorer-button]`)
-        .hasAttribute('href', /bridgeexplorer$/);
+        .hasAttribute('href', /relay$/);
 
       assert
         .dom(`[data-test-token-bridge-step="2"]:not([data-test-completed])`)
@@ -77,7 +74,7 @@ module(
       let layer1Service = this.owner.lookup('service:layer1-network')
         .strategy as Layer1TestWeb3Strategy;
 
-      layer1Service.test__simulateBridged('0xetherscan');
+      layer1Service.test__simulateBridged('0xbridged');
 
       await settled();
 
@@ -91,7 +88,7 @@ module(
 
       assert
         .dom(`[data-test-etherscan-button]`)
-        .hasAttribute('href', /etherscan$/);
+        .hasAttribute('href', /bridged$/);
 
       assert.ok(onComplete.called);
     });

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
@@ -1,0 +1,68 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
+import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
+
+module(
+  'Integration | Component | card-pay/withdrawal-workflow/transaction-status',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(async function () {
+      let workflowSession = new WorkflowSession();
+      workflowSession.updateMany({
+        relayTokensTxnReceipt: {
+          transactionHash: 'bridgeexplorer',
+        },
+        completedLayer2TransactionReceipt: {
+          transactionHash: 'blockscout',
+        },
+      });
+
+      this.setProperties({
+        onComplete: () => {},
+        onIncomplete: () => {},
+        isComplete: false,
+        frozen: false,
+        workflowSession,
+      });
+
+      await render(hbs`
+        <CardPay::WithdrawalWorkflow::TransactionStatus
+          @onComplete={{this.onComplete}}
+          @isComplete={{this.isComplete}}
+          @onIncomplete={{this.onIncomplete}}
+          @workflowSession={{this.workflowSession}}
+          @frozen={{this.frozen}}
+        />
+      `);
+    });
+
+    test('It renders transaction status and links', async function (assert) {
+      assert
+        .dom(`[data-test-token-bridge-step="0"][data-test-completed]`)
+        .containsText(`Withdraw tokens from ${c.layer2.fullName}`);
+      assert
+        .dom(`[data-test-blockscout-button]`)
+        .hasAttribute('href', /blockscout$/);
+
+      assert
+        .dom(`[data-test-token-bridge-step="1"]:not([data-test-completed])`)
+        .containsText(
+          `Bridge tokens from ${c.layer2.fullName} to ${c.layer1.fullName}`
+        );
+      assert
+        .dom(`[data-test-bridge-explorer-button]`)
+        .hasAttribute('href', /bridgeexplorer$/);
+
+      assert
+        .dom(`[data-test-token-bridge-step="2"]:not([data-test-completed])`)
+        .containsText(
+          `Release tokens on ${c.layer1.conversationalName}: ${c.layer2.shortName}`
+        );
+      assert.dom(`[data-test-etherscan-button]`).doesNotExist();
+    });
+  }
+);


### PR DESCRIPTION
This adds a new withdrawal transaction status card, similar to the deposit workflow’s status card:

![screencast 2021-07-14 17-21-44-two-step](https://user-images.githubusercontent.com/43280/125701435-5822ba20-5480-44be-8948-4350b8fda2c0.gif)

It assumes these properties exist in the workflow session, and for now has inserted placeholder values in the `TransactionApproval` component (and the component test’s workflow session):
* `layer1BlockHeightBeforeBridging`
* `relayTokensTxnReceipt`

It adds `completedLayer1TransactionReceipt` to the workflow session. I see now that #1810 is expecting a `completedLayer2TransactionReceipt` property, it may be that I’m mixed up on this 🤔