### PR TITLE
Fix/metamask incorrect chain

### DIFF
--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -159,10 +159,6 @@ class MetaMaskConnectionManager extends ConnectionManager {
       return;
     }
 
-    // remove all listeners that previous instances of metamask connections have added
-    // otherwise disconnecting and reconnecting might cause "duplicate" event listeners
-    provider.removeAllListeners();
-
     provider.on('accountsChanged', (accounts: string[]) => {
       if (!accounts.length) {
         this.onDisconnect();
@@ -230,6 +226,14 @@ class MetaMaskConnectionManager extends ConnectionManager {
       ConnectionManager.removeProviderFromStorage(this.chainId);
       return;
     }
+  }
+
+  // eslint-disable-next-line ember/classic-decorator-hooks
+  destroy() {
+    super.destroy();
+    // remove all listeners that previous instances of metamask connections have added
+    // otherwise disconnecting and reconnecting might cause "duplicate" event listeners
+    this.provider?.removeAllListeners();
   }
 }
 

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -227,7 +227,7 @@ class MetaMaskConnectionManager extends ConnectionManager {
       this.onConnect(accounts);
     } else {
       // if we didn't find accounts, then the stored provider key is not useful, delete it
-      window.localStorage.removeItem(GET_PROVIDER_STORAGE_KEY(this.chainId));
+      ConnectionManager.removeProviderFromStorage(this.chainId);
       return;
     }
   }

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -46,7 +46,6 @@ export abstract class ConnectionManager
   protected simpleEmitter: SimpleEmitter;
   protected broadcastChannel: BroadcastChannel;
   protected provider: any;
-  protected connected = false;
   abstract providerId: WalletProviderId;
 
   constructor(options: ConnectionManagerOptions) {
@@ -110,15 +109,6 @@ export abstract class ConnectionManager
   }
 
   onDisconnect(broadcast = true) {
-    // NOTE: if the ConnectionManager thinks that it's disconnected and Layer1Chain thinks
-    // that it's connected, this can result in never being able to disconnect
-    // The problem here is that WalletConnect gives you two disconnect events when you disconnect
-    // from the Dapp
-    // and one when you disconnect from the wallet
-    if (!this.connected) {
-      return;
-    }
-    this.connected = false;
     ConnectionManager.removeProviderFromStorage(this.chainId);
     if (broadcast)
       this.broadcastChannel.postMessage(
@@ -129,7 +119,6 @@ export abstract class ConnectionManager
   }
 
   onConnect(accounts: string[]) {
-    this.connected = true;
     ConnectionManager.addProviderToStorage(this.chainId, this.providerId);
     this.emit('connected', accounts);
   }

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -131,9 +131,9 @@ export default abstract class Layer1ChainWeb3Strategy
 
   private onDisconnect() {
     if (this.isConnected) {
-      this.cleanupConnectionState();
       this.simpleEmitter.emit('disconnect');
     }
+    this.cleanupConnectionState();
     this.#waitForAccountDeferred = defer();
   }
 

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -127,6 +127,7 @@ export default abstract class Layer1ChainWeb3Strategy
     this.connectionManager = undefined;
     this.web3 = undefined;
     this.currentProviderId = '';
+    this.#waitForAccountDeferred = defer();
   }
 
   private onDisconnect() {
@@ -134,7 +135,6 @@ export default abstract class Layer1ChainWeb3Strategy
       this.simpleEmitter.emit('disconnect');
     }
     this.cleanupConnectionState();
-    this.#waitForAccountDeferred = defer();
   }
 
   get waitForAccount(): Promise<void> {
@@ -157,7 +157,6 @@ export default abstract class Layer1ChainWeb3Strategy
       this.defaultTokenBalance = undefined;
       this.cardBalance = undefined;
       this.daiBalance = undefined;
-      this.#waitForAccountDeferred = defer();
     }
   }
 


### PR DESCRIPTION
Focus of this PR is to not allow MetaMask to connect with the wrong chain undetected upon initial connection. As dApp-side disconnection from MetaMask is a faux-disconnection, we need to manually check for this within the connect and reconnect methods, the `accountsChanged` event listener is not a reliable place to do this.

Also made disconnections more reliable by removing a check to prevent emitting doubled-up disconnect events (WalletConnect emits one for its local disconnection and another for the wallet-side disconnection). Responsibility to decide whether or not a disconnection is relevant to communicate to the UI rests completely with layer 1 chain as of https://github.com/cardstack/cardstack/pull/1814/commits/f9419c492b774b78bbd513ea2fea6148c5be789a, we always clear connection state upon disconnect.