### PR TITLE
prepaid card creation checks if the user has enough balance for gas + transaction

### DIFF
--- a/packages/cardpay-sdk/sdk/prepaid-card/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card/base.ts
@@ -370,6 +370,17 @@ export default class PrepaidCard {
 
     let payload = await this.getCreateCardPayload(from, tokenAddress, amounts, faceValues, customizationDID);
     let estimate = await gasEstimate(this.layer2Web3, safeAddress, tokenAddress, '0', payload, 0, tokenAddress);
+    let gasCost = new BN(estimate.dataGas).add(new BN(estimate.baseGas)).mul(new BN(estimate.gasPrice));
+
+    if (balance.lt(totalWeiAmount.add(gasCost))) {
+      throw new Error(
+        `Safe does not have enough balance to make prepaid card(s). The issuing token ${tokenAddress} balance of the safe ${safeAddress} is ${fromWei(
+          balance
+        )}, the total amount necessary to create prepaid cards is ${fromWei(
+          totalWeiAmount
+        )} ${symbol}, the gas cost is ${fromWei(gasCost)} ${symbol}`
+      );
+    }
 
     if (estimate.lastUsedNonce == null) {
       estimate.lastUsedNonce = -1;


### PR DESCRIPTION
Copies the approach used in `Safe.sendTokens` to check if there is enough gas to create a prepaid card.

https://github.com/cardstack/cardstack/blob/d33919aaac7f36dfd887ea969ee3ee42f78180af/packages/cardpay-sdk/sdk/safes/base.ts#L164-L181