### PR TITLE
Use strings when referring to token amount in cli

### DIFF
--- a/packages/cardpay-cli/README.md
+++ b/packages/cardpay-cli/README.md
@@ -16,7 +16,7 @@ CLI tool for basic actions in Cardpay
   - [`yarn cardpay prepaidcard-transfer <PREPAID_CARD> <NEW_OWNER> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-prepaidcard-transfer-prepaid_card-new_owner---networknetwork---mnemonicmnemonic---walletconnect)
   - [`yarn cardpay price-for-face-value <TOKEN_ADDRESS> <SPEND_FACE_VALUE> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-price-for-face-value-token_address-spend_face_value---networknetwork---mnemonicmnemonic---walletconnect)
   - [`yarn cardpay register-merchant <PREPAID_CARD> <INFO_DID> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-register-merchant-prepaid_card-info_did---networknetwork---mnemonicmnemonic---walletconnect)
-  - [`yarn cardpay pay-merchant <MERCHANT_SAFE> <PREPAID_CARD> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-pay-merchant-merchant_safe-prepaid_card-amount---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`yarn cardpay pay-merchant <MERCHANT_SAFE> <PREPAID_CARD> <SPEND_AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-pay-merchant-merchant_safe-prepaid_card-amount---networknetwork---mnemonicmnemonic---walletconnect)
   - [`yarn cardpay revenue-balances <MERCHANT_SAFE> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-revenue-balances-merchant_safe---networknetwork---mnemonicmnemonic---walletconnect)
   - [`yarn cardpay claim-revenue <MERCHANT_SAFE> <TOKEN_ADDRESS> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-claim-revenue-merchant_safe-token_address-amount---networknetwork---mnemonicmnemonic---walletconnect)
   - [`yarn cardpay new-prepaidcard-gas-fee <TOKEN_ADDRESS> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#yarn-cardpay-new-prepaidcard-gas-fee-token_address---networknetwork---mnemonicmnemonic---walletconnect)
@@ -196,17 +196,17 @@ ARGUMENTS
   WALLET_CONNECT    (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
 
-## `yarn cardpay pay-merchant <MERCHANT_SAFE> <PREPAID_CARD> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
+## `yarn cardpay pay-merchant <MERCHANT_SAFE> <PREPAID_CARD> <SPEND_AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 Pay a merchant from a prepaid card. The amount of tokens to send to the merchant in units of SPEND.
 
 ```
 USAGE
-  $ yarn cardpay pay-merchant <MERCHANT_SAFE> <PREPAID_CARD> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
+  $ yarn cardpay pay-merchant <MERCHANT_SAFE> <PREPAID_CARD> <SPEND_AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
   MERCHANT_SAFE     The address of the merchant's safe who will receive the payment
   PREPAID_CARD      The address of the prepaid card that is being used to pay the merchant
-  AMOUNT            The amount to send to the merchant in units of SPEND
+  SPEND_AMOUNT      The amount to send to the merchant in units of SPEND
   NETWORK           The network to use ("sokol" or "xdai")
   MNEMONIC          (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
   WALLET_CONNECT    (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet

--- a/packages/cardpay-cli/bridge.ts
+++ b/packages/cardpay-cli/bridge.ts
@@ -9,10 +9,10 @@ export async function bridgeToLayer1(
   safeAddress: string,
   tokenAddress: string,
   receiverAddress: string,
-  amount: number,
+  amount: string,
   mnemonic?: string
 ): Promise<void> {
-  const amountInWei = toWei(amount.toString()).toString();
+  const amountInWei = toWei(amount);
 
   let web3 = await getWeb3(network, mnemonic);
   let tokenBridge = await getSDK('TokenBridgeHomeSide', web3);
@@ -66,12 +66,12 @@ export async function claimLayer1BridgedTokens(
 
 export async function bridgeToLayer2(
   network: string,
-  amount: number,
+  amount: string,
   receiverAddress: string | undefined,
   tokenAddress: string,
   mnemonic?: string
 ): Promise<void> {
-  const amountInWei = toWei(amount.toString()).toString();
+  const amountInWei = toWei(amount);
 
   let web3 = await getWeb3(network, mnemonic);
   let tokenBridge = await getSDK('TokenBridgeForeignSide', web3);

--- a/packages/cardpay-cli/exchange-rate.ts
+++ b/packages/cardpay-cli/exchange-rate.ts
@@ -3,28 +3,18 @@ import { getWeb3 } from './utils';
 import { getSDK } from '@cardstack/cardpay-sdk';
 const { toWei, fromWei } = Web3.utils;
 
-export async function usdPrice(
-  network: string,
-  token: string,
-  amount: number | undefined,
-  mnemonic?: string
-): Promise<void> {
-  amount = amount ?? 1;
+export async function usdPrice(network: string, token: string, amount?: string, mnemonic?: string): Promise<void> {
+  amount = amount ?? '1';
   let web3 = await getWeb3(network, mnemonic);
-  let amountInWei = toWei(amount.toString());
+  let amountInWei = toWei(amount);
   let exchangeRate = await getSDK('ExchangeRate', web3);
   let usdPrice = await exchangeRate.getUSDPrice(token, amountInWei);
   console.log(`USD value: $${usdPrice.toFixed(2)} USD`);
 }
-export async function ethPrice(
-  network: string,
-  token: string,
-  amount: number | undefined,
-  mnemonic?: string
-): Promise<void> {
-  amount = amount ?? 1;
+export async function ethPrice(network: string, token: string, amount?: string, mnemonic?: string): Promise<void> {
+  amount = amount ?? '1';
   let web3 = await getWeb3(network, mnemonic);
-  let amountInWei = toWei(amount.toString());
+  let amountInWei = toWei(amount);
   let exchangeRate = await getSDK('ExchangeRate', web3);
   let ethWeiPrice = await exchangeRate.getETHPrice(token, amountInWei);
   console.log(`ETH value: ${fromWei(ethWeiPrice)} ETH`);

--- a/packages/cardpay-cli/index.ts
+++ b/packages/cardpay-cli/index.ts
@@ -59,7 +59,8 @@ interface Options {
   mnemonic: string;
   walletConnect: boolean;
   tokenAddress?: string;
-  amount?: number;
+  amount?: string;
+  spendAmount?: number;
   fromBlock?: number;
   address?: string;
   token?: string;
@@ -85,6 +86,7 @@ let {
   walletConnect,
   tokenAddress,
   amount,
+  spendAmount,
   address,
   token,
   newOwner,
@@ -108,7 +110,7 @@ let {
   .usage('Usage: $0 <command> [options]')
   .command('bridge-to-l2 <amount> <tokenAddress> [receiver]', 'Bridge tokens to the layer 2 network', (yargs) => {
     yargs.positional('amount', {
-      type: 'number',
+      type: 'string',
       description: 'Amount of tokens you would like bridged (*not* in units of wei)',
     });
     yargs.positional('tokenAddress', {
@@ -145,7 +147,7 @@ let {
         description: 'The layer 2 safe to bridge the tokens from',
       });
       yargs.positional('amount', {
-        type: 'number',
+        type: 'string',
         description: 'Amount of tokens you would like bridged (*not* in units of wei)',
       });
       yargs.positional('tokenAddress', {
@@ -229,7 +231,7 @@ let {
         description: "The token recipient's address",
       });
       yargs.positional('amount', {
-        type: 'number',
+        type: 'string',
         description: 'The amount of tokens to transfer (not in units of wei)',
       });
       command = 'safeTransferTokens';
@@ -324,21 +326,25 @@ let {
       command = 'registerMerchant';
     }
   )
-  .command('pay-merchant <merchantSafe> <prepaidCard> <amount>', 'Pay a merchant from a prepaid card.', (yargs) => {
-    yargs.positional('merchantSafe', {
-      type: 'string',
-      description: "The address of the merchant's safe who will receive the payment",
-    });
-    yargs.positional('prepaidCard', {
-      type: 'string',
-      description: 'The address of the prepaid card that is being used to pay the merchant',
-    });
-    yargs.positional('amount', {
-      type: 'number',
-      description: 'The amount to send to the merchant in units of SPEND',
-    });
-    command = 'payMerchant';
-  })
+  .command(
+    'pay-merchant <merchantSafe> <prepaidCard> <spendAmount>',
+    'Pay a merchant from a prepaid card.',
+    (yargs) => {
+      yargs.positional('merchantSafe', {
+        type: 'string',
+        description: "The address of the merchant's safe who will receive the payment",
+      });
+      yargs.positional('prepaidCard', {
+        type: 'string',
+        description: 'The address of the prepaid card that is being used to pay the merchant',
+      });
+      yargs.positional('spendAmount', {
+        type: 'number',
+        description: 'The amount to send to the merchant in units of SPEND',
+      });
+      command = 'payMerchant';
+    }
+  )
   .command(
     'revenue-balances <merchantSafe>',
     'View token balances of unclaimed revenue in the revenue pool for a merchant',
@@ -363,7 +369,7 @@ let {
         description: 'The address of the tokens that are being claimed as revenue',
       });
       yargs.positional('amount', {
-        type: 'number',
+        type: 'string',
         description: 'The amount of tokens that are being claimed as revenue (*not* in units of wei)',
       });
       command = 'claimRevenue';
@@ -404,7 +410,7 @@ let {
         description: 'The token symbol (without the .CPXD suffix)',
       });
       yargs.positional('amount', {
-        type: 'number',
+        type: 'string',
         default: 1,
         description: 'The amount of the specified token (*not* in units of wei)',
       });
@@ -420,7 +426,7 @@ let {
         description: 'The token symbol (without the .CPXD suffix)',
       });
       yargs.positional('amount', {
-        type: 'number',
+        type: 'string',
         default: 1,
         description: 'The amount of the specified token (*not* in units of wei)',
       });
@@ -594,11 +600,11 @@ if (!command) {
       await registerMerchant(network, prepaidCard, infoDID || undefined, mnemonic);
       break;
     case 'payMerchant':
-      if (merchantSafe == null || prepaidCard == null || amount == null) {
-        showHelpAndExit('merchantSafe, prepaidCard, and amount are required values');
+      if (merchantSafe == null || prepaidCard == null || spendAmount == null) {
+        showHelpAndExit('merchantSafe, prepaidCard, and spendAmount are required values');
         return;
       }
-      await payMerchant(network, merchantSafe, prepaidCard, amount, mnemonic);
+      await payMerchant(network, merchantSafe, prepaidCard, spendAmount, mnemonic);
       break;
     case 'revenueBalances':
       if (merchantSafe == null) {

--- a/packages/cardpay-cli/prepaid-card.ts
+++ b/packages/cardpay-cli/prepaid-card.ts
@@ -90,7 +90,7 @@ export async function payMerchant(
   network: string,
   merchantSafe: string,
   prepaidCardAddress: string,
-  amount: number,
+  spendAmount: number,
   mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
@@ -98,8 +98,8 @@ export async function payMerchant(
   let blockExplorer = await getConstant('blockExplorer', web3);
 
   console.log(
-    `Paying merchant safe address ${merchantSafe} the amount §${amount} SPEND from prepaid card address ${prepaidCardAddress}...`
+    `Paying merchant safe address ${merchantSafe} the amount §${spendAmount} SPEND from prepaid card address ${prepaidCardAddress}...`
   );
-  let result = await prepaidCard.payMerchant(merchantSafe, prepaidCardAddress, amount);
+  let result = await prepaidCard.payMerchant(merchantSafe, prepaidCardAddress, spendAmount);
   console.log(`Transaction hash: ${blockExplorer}/tx/${result?.ethereumTx.txHash}/token-transfers`);
 }

--- a/packages/cardpay-cli/revenue-pool.ts
+++ b/packages/cardpay-cli/revenue-pool.ts
@@ -34,14 +34,14 @@ export async function claimRevenue(
   network: string,
   merchantSafeAddress: string,
   tokenAddress: string,
-  amount: number,
+  amount: string,
   mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let revenuePool = await getSDK('RevenuePool', web3);
   let assets = await getSDK('Assets', web3);
   let { symbol } = await assets.getTokenInfo(tokenAddress);
-  let weiAmount = toWei(String(amount));
+  let weiAmount = toWei(amount);
   console.log(`Claiming ${amount} ${symbol} in revenue for merchant safe ${merchantSafeAddress}`);
 
   let result = await revenuePool.claim(merchantSafeAddress, tokenAddress, weiAmount);

--- a/packages/cardpay-cli/safe.ts
+++ b/packages/cardpay-cli/safe.ts
@@ -69,11 +69,11 @@ export async function transferTokens(
   safe: string,
   token: string,
   recipient: string,
-  amount: number,
+  amount: string,
   mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let weiAmount = toWei(String(amount));
+  let weiAmount = toWei(amount);
 
   let safes = await getSDK('Safes', web3);
   let assets = await getSDK('Assets', web3);


### PR DESCRIPTION
Noticed when testing things out with the cli just now that yargs was converting amount inputs to numbers and token amounts sometimes lost precision. To prevent this, changed the type of `amount` inputs from 'number' to 'string'. Also changed an existing `amount` argument (in `pay-merchant`) that referred to spend to `spendAmount`.