### PR TITLE
fix type of networkIds constant

### DIFF
--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -1,5 +1,6 @@
 import Web3 from 'web3';
 import invert from 'lodash/invert';
+import mapValues from 'lodash/mapValues';
 import { networkName } from './utils/general-utils';
 
 const INFURA_PROJECT_ID = 'dfb8cbe2e916420a9dbcc1d1f5828406';
@@ -85,7 +86,14 @@ export const networks: { [networkId: number]: string } = Object.freeze({
   77: 'sokol',
   100: 'xdai',
 });
-export const networkIds = (Object.freeze(invert({ ...networks })) as unknown) as { [networkName: string]: number };
+
+// invert the networks object, so { '1': 'mainnet', ... } becomes { mainnet: '1', ... }
+// then map over the values, so that { mainnet: '1', ... } has its values casted as numbers: { mainnet: 1, ... }
+export const networkIds = (Object.freeze(
+  mapValues(invert({ ...networks }), (networkIdString: string) => Number(networkIdString))
+) as unknown) as {
+  [networkName: string]: number;
+};
 
 export function getConstantByNetwork(name: ConstantKeys, network: string): string {
   let value = constants[network][name];


### PR DESCRIPTION
Noticed when working on detecting "incorrect" networks that I was getting strings where numbers were expected for chain id. This casts network id lookup values to numbers to match the provided type.