### PR TITLE
updating sokol rpc ws to use POA hosted service

### DIFF
--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -22,7 +22,7 @@ const SOKOL = {
   name: 'Sokol',
   // this needs to be an "archive" node
   rpcNode: 'https://sokol.stack.cards',
-  rpcWssNode: 'https://sokol-wss.stack.cards',
+  rpcWssNode: 'wss://sokol.poa.network/wss',
   relayServiceURL: 'https://relay-staging.stack.cards/api',
   subgraphURL: 'https://graph.stack.cards/subgraphs/name/habdelra/cardpay-sokol',
   tallyServiceURL: 'https://tally-service-staging.stack.cards/api/v1',


### PR DESCRIPTION
In testing the ws RPC with dominic it looks like the card wallet needs to jump on to nethermind ws now--our own is not working (probably because of the sunetting of open ethereum). Eventually all the RPC nodes will come from POA hosted services, this will be the first one to move over.