### PR TITLE
check whether account is null as part of checking for bridging success

### DIFF
--- a/packages/cardpay-sdk/sdk/token-bridge-home-side.ts
+++ b/packages/cardpay-sdk/sdk/token-bridge-home-side.ts
@@ -187,7 +187,7 @@ export default class TokenBridgeHomeSide implements ITokenBridgeHomeSide {
         await new Promise<void>((res) => setTimeout(() => res(), POLL_INTERVAL));
       }
       queryResults = await query(this.layer2Web3, bridgedTokensQuery, { account: recipientAddress, fromBlock });
-      receivedBridgedTokens = queryResults.data.account.depots[0]?.receivedBridgedTokens ?? [];
+      receivedBridgedTokens = queryResults.data.account?.depots[0]?.receivedBridgedTokens ?? [];
     } while (receivedBridgedTokens.length === 0 && Date.now() < start + TIMEOUT);
 
     if (receivedBridgedTokens.length === 0) {


### PR DESCRIPTION
Account may be null when polling if it is the user's first time bridging.

Your switching to the subgraph seems to fix CS-1094 (tokens not showing up after deposit in new depot if refetching balances happens too soon) as well, just noticed while working on this. Thanks!