### PR TITLE
Prep for production deployment

### DIFF
--- a/packages/web-client/config/deploy.js
+++ b/packages/web-client/config/deploy.js
@@ -57,12 +57,17 @@ module.exports = function (deployTarget) {
     ENV.cloudfront.distribution = 'E330O30QIWNDYA';
   }
 
-  // if (deployTarget === 'production') {
-  //   ENV.build.environment = 'production';
-  //   ENV.s3Assets.bucket = ENV.s3Pages.bucket = 'web-client-prod';
-  //   ENV.s3Assets.region = ENV.s3Pages.region = 'us-east-1';
-  //   ENV.cloudfront.distribution = 'TBD';
-  // }
+  if (deployTarget === 'production') {
+    ENV.build.environment = 'production';
+    ENV.s3Assets.bucket = ENV.s3Pages.bucket = 'app-assets-cardstack';
+    ENV.cloudfront.region = ENV.s3Assets.region = ENV.s3Pages.region =
+      'us-east-1';
+    ENV.cloudfront.accessKeyId = ENV.s3Assets.accessKeyId = ENV.s3Pages.accessKeyId =
+      process.env.EMBER_DEPLOY_AWS_ACCESS_KEY;
+    ENV.cloudfront.secretAccessKey = ENV.s3Assets.secretAccessKey = ENV.s3Pages.secretAccessKey =
+      process.env.EMBER_DEPLOY_AWS_ACCESS_SECRET;
+    ENV.cloudfront.distribution = 'E3VPNGI7F1WEW8';
+  }
 
   // Note: if you need to build some configuration asynchronously, you can return
   // a promise that resolves with the ENV object instead of returning the

--- a/packages/web-client/config/environment.js
+++ b/packages/web-client/config/environment.js
@@ -2,6 +2,7 @@
 
 const infuraIdsByTarget = {
   staging: '558ee533522a468e9d421d818e06fadb', // this infura id is specific to https://app-staging.stack.cards/
+  production: '5d6efa6b750b45459184cd11dd2c8697', // this infura id is specific to https://app.cardstack.com/
 };
 
 // eslint-disable-next-line no-undef

--- a/waypoint.prod.hcl
+++ b/waypoint.prod.hcl
@@ -1,0 +1,44 @@
+project = "cardstack"
+
+# Labels can be specified for organizational purposes.
+# labels = { "foo" = "bar" }
+
+app "hub" {
+    path = "./packages/hub"
+
+    build {
+        use "pack" {}
+
+        registry {
+            use "aws-ecr" {
+                region     = "us-east-1"
+                repository = "hub"
+                tag        = "latest"
+            }
+        }
+    }
+
+    deploy {
+        use "aws-ecs" {
+            region = "us-east-1"
+            memory = "512"
+            cluster = "hub-prod"
+            count = 2
+            subnets = ["subnet-0c22641bd41cbdd1e", "subnet-01d36d7bcd0334fc0"]
+            task_role_name = "hub-prod-hub_ecr_task"
+            alb {
+                listener_arn = "arn:aws:elasticloadbalancing:us-east-1:120317779495:listener/app/hub-prod/52cb41649112bec8/1ce6522a7998b3b4"
+            }
+        }
+
+        hook {
+            when    = "before"
+            command = ["./packages/hub/bin/purge-services.sh", "hub-prod", "waypoint-hub"] # need this to purge old ecs services
+        }
+
+        hook {
+            when    = "after"
+            command = ["./packages/hub/bin/fix-listener.sh"] # need this until https://github.com/hashicorp/waypoint/issues/1568
+        }
+    }
+}


### PR DESCRIPTION
@pcjun97 and I will be creating a manual github workflow to deploy hub and web-client to prod.

The following environment variables should be set for the web-client deployment

          EMBER_DEPLOY_AWS_ACCESS_KEY: ${{ secrets.PROD_EMBER_DEPLOY_AWS_ACCESS_KEY }}
          EMBER_DEPLOY_AWS_ACCESS_SECRET: ${{ secrets.PROD_EMBER_DEPLOY_AWS_ACCESS_SECRET }}
          HUB_URL: https://hub.cardstack.com
          LAYER_1_CHAIN: 'keth' // set to "eth" when ready to go to real money
          LAYER_2_CHAIN: 'sokol' // set to "xdai" when ready to go to real money

The following environment variables should be set for the hub via waypoint:

           NODE_ENV=production

