### PR TITLE
Add layers to Boxel's modal

### DIFF
--- a/packages/boxel/addon/components/boxel/modal/index.css
+++ b/packages/boxel/addon/components/boxel/modal/index.css
@@ -9,7 +9,7 @@
   border: none;
   background-color: rgba(0, 0, 0, 0.75);
   text-align: left;
-  z-index: 10;
+  z-index: calc(var(--boxel-modal-z-index) - 1);
 }
 
 .boxel-modal {
@@ -29,7 +29,7 @@
   background: none;
   border: none;
   overflow: hidden;
-  z-index: 15;
+  z-index: var(--boxel-modal-z-index);
   pointer-events: none;
 }
 

--- a/packages/boxel/addon/components/boxel/modal/index.hbs
+++ b/packages/boxel/addon/components/boxel/modal/index.hbs
@@ -1,7 +1,11 @@
 {{#if @isOpen}}
   {{set-body-class "has-modal"}}
   {{on-key "Escape" @onClose event="keydown"}}
-
+<div
+  style={{css-var
+    boxel-modal-z-index=(if (eq @layer "urgent" ) "var(--boxel-layer-modal-urgent)" "var(--boxel-layer-modal-default)")
+  }}
+>
   <button
     type="button"
     {{on "click" @onClose}}
@@ -21,4 +25,5 @@
       {{yield}}
     </div>
   </dialog>
+</div>
 {{/if}}

--- a/packages/boxel/addon/components/boxel/modal/index.hbs
+++ b/packages/boxel/addon/components/boxel/modal/index.hbs
@@ -1,29 +1,29 @@
 {{#if @isOpen}}
   {{set-body-class "has-modal"}}
   {{on-key "Escape" @onClose event="keydown"}}
-<div
-  style={{css-var
-    boxel-modal-z-index=(if (eq @layer "urgent" ) "var(--boxel-layer-modal-urgent)" "var(--boxel-layer-modal-default)")
-  }}
->
-  <button
-    type="button"
-    {{on "click" @onClose}}
-    class="boxel-modal-overlay {{@overlayClass}}"
-    tabindex="-1"
+  <div
+    style={{css-var
+      boxel-modal-z-index=(if (eq @layer "urgent" ) "var(--boxel-layer-modal-urgent)" "var(--boxel-layer-modal-default)")
+    }}
   >
-    <span class="boxel-sr-only">Close modal</span>
-  </button>
+    <button
+      type="button"
+      {{on "click" @onClose}}
+      class="boxel-modal-overlay {{@overlayClass}}"
+      tabindex="-1"
+    >
+      <span class="boxel-sr-only">Close modal</span>
+    </button>
 
-  <dialog
-    class="boxel-modal"
-    open={{@isOpen}}
-    aria-modal="true"
-    ...attributes
-  >
-    <div class="boxel-modal__inner">
-      {{yield}}
-    </div>
-  </dialog>
-</div>
+    <dialog
+      class="boxel-modal"
+      open={{@isOpen}}
+      aria-modal="true"
+      ...attributes
+    >
+      <div class="boxel-modal__inner">
+        {{yield}}
+      </div>
+    </dialog>
+  </div>
 {{/if}}

--- a/packages/boxel/addon/components/boxel/modal/usage.hbs
+++ b/packages/boxel/addon/components/boxel/modal/usage.hbs
@@ -39,6 +39,15 @@
     @onInput={{fn (mut this.isOpen)}}
     @required={{true}}
   />
+  <Args.String
+    @name="layer"
+    @description="Which of Boxel's z-index layers should be used for this modal"
+    @value={{this.layer}}
+    @defaultValue={{"default"}}
+    @options={{array "default" "urgent"}}
+    @onInput={{fn (mut this.layer)}}
+    @optional={{true}}
+  />
   <Args.Action
     @name="onClose"
     @description="Callback when the modal's background overlay is clicked or the escape key is pressed"
@@ -47,4 +56,40 @@
   />
   <Args.Yield @description="The content of the modal. This visually sits directly on the overlay - there is no 'container' rendered by default." />
 </:api>
+</Freestyle::Usage>
+
+
+<Freestyle::Usage
+  @description="Modals have two different layers, urgent and default"
+>
+<:example>
+<Boxel::Button @kind="primary" {{on "click" this.openDefault}}>Open</Boxel::Button>
+<Boxel::Modal
+  @onClose={{this.closeDefault}}
+  @isOpen={{this.isDefaultOpen}}
+>
+  <Boxel::CardContainer class="boxel-modal-usage-container">
+    <h2>Boxel Modal Default Layer</h2>
+    <p>
+      This modal is on the default layer. It should be below the modal on the urgent layer.
+    </p>
+
+    <Boxel::Button {{on "click" this.openUrgent}}>Open an urgent modal</Boxel::Button>
+    <Boxel::Button {{on "click" this.closeDefault}}>Close this</Boxel::Button>
+  </Boxel::CardContainer>
+</Boxel::Modal>
+<Boxel::Modal
+  @onClose={{this.closeUrgent}}
+  @isOpen={{this.isUrgentOpen}}
+>
+  <Boxel::CardContainer class="boxel-modal-usage-container">
+    <h2>Boxel Modal Urgent Layer</h2>
+    <p>
+      This modal is on the urgent layer. It should be above the default layer modal.
+    </p>
+
+    <Boxel::Button {{on "click" this.closeUrgent}}>Close this</Boxel::Button>
+  </Boxel::CardContainer>
+</Boxel::Modal>
+</:example>
 </Freestyle::Usage>

--- a/packages/boxel/addon/components/boxel/modal/usage.ts
+++ b/packages/boxel/addon/components/boxel/modal/usage.ts
@@ -9,9 +9,28 @@ export default class ModalUsage extends Component {
   @tracked offsetLeft = '0px';
   @tracked offsetTop = 'none';
   @tracked maxWidth = '60%';
+  @tracked layer = 'default';
+  @tracked isDefaultOpen = false;
+  @tracked isUrgentOpen = false;
 
   @action
   onClose(): void {
     this.isOpen = false;
+  }
+
+  @action openDefault(): void {
+    this.isDefaultOpen = true;
+  }
+
+  @action closeDefault(): void {
+    this.isDefaultOpen = false;
+  }
+
+  @action openUrgent(): void {
+    this.isUrgentOpen = true;
+  }
+
+  @action closeUrgent(): void {
+    this.isUrgentOpen = false;
   }
 }

--- a/packages/boxel/addon/styles/variables.css
+++ b/packages/boxel/addon/styles/variables.css
@@ -119,6 +119,10 @@
 
   /* Fix: Other colors used in app, potentially not in color palette: */
 
+  /* z-index layers */
+  --boxel-layer-modal-default: 15;
+  --boxel-layer-modal-urgent: 20;
+
   /*
     #A5A5A5
     #C1C1D0

--- a/packages/boxel/addon/styles/variables.css
+++ b/packages/boxel/addon/styles/variables.css
@@ -117,13 +117,11 @@
   --boxel-success-100: var(--boxel-green);
   --boxel-success-200: var(--boxel-teal);
 
-  /* Fix: Other colors used in app, potentially not in color palette: */
-
   /* z-index layers */
   --boxel-layer-modal-default: 15;
   --boxel-layer-modal-urgent: 20;
 
-  /*
+  /* Fix: Other colors used in app, potentially not in color palette:
     #A5A5A5
     #C1C1D0
     #C9C7DD


### PR DESCRIPTION
## Intention
Prepare for implementation of urgent modals:
![image](https://user-images.githubusercontent.com/39579264/126162814-368526a6-82fe-412e-a4df-39c1268d97cd.png)


## Changes
- add two different z-indices to boxel's variables
- use in boxel's modal as a "layer" argument. Intentionally used "layer" instead of "z-index" to make it harder to add new z-indices ad hoc.

## Pics
1 layer:
![image](https://user-images.githubusercontent.com/39579264/126161927-c618e03a-6bef-416a-9528-f1bc0c54934e.png)

2 layers. I don't like that the background where modal overlays overlap is totally dark, but since this is off the happy path, and we can come back to fix this later, not changing the overlay opacity for now:
![image](https://user-images.githubusercontent.com/39579264/126162283-9e1e513a-8735-414b-957a-5a0eddb183b7.png)
