### PR TITLE
Extract amount input validation functions

### DIFF
--- a/packages/web-client/app/components/card-pay/token-amount-input/index.hbs
+++ b/packages/web-client/app/components/card-pay/token-amount-input/index.hbs
@@ -1,0 +1,25 @@
+<Boxel::Field
+  @label={{@label}}
+  @fieldMode="edit"
+  class="amount-input"
+  data-test-amount-label
+>
+  <div class="amount-input__input-container">
+    {{svg-jar this.tokenDetails.icon class="amount-input__currency-icon" role="presentation" data-test-currency-icon-name=this.tokenDetails.icon}}
+    <Boxel::Input
+      class="amount-input__input"
+      @value={{@amount}}
+      @required={{true}}
+      @onInput={{@onInputAmount}}
+      @invalid={{@isInvalid}}
+      @errorMessage={{@errorMessage}}
+      placeholder="0.00"
+      autocomplete="off"
+      inputmode="decimal"
+      data-test-amount-input
+    />
+    <div class="amount-input__currency-text" data-test-amount-input-currency-label>
+      {{@tokenSymbol}}
+    </div>
+  </div>
+</Boxel::Field>

--- a/packages/web-client/app/components/card-pay/token-amount-input/index.ts
+++ b/packages/web-client/app/components/card-pay/token-amount-input/index.ts
@@ -1,0 +1,23 @@
+import Component from '@glimmer/component';
+import {
+  TokenDisplayInfo,
+  TokenSymbol,
+} from '@cardstack/web-client/utils/token';
+
+interface CardPayTokenAmountInputArgs {
+  amount: string;
+  onInputAmount: (value: string, isValid: boolean) => void;
+  tokenSymbol: TokenSymbol;
+  invalid: boolean;
+  errorMessage: string;
+}
+
+export default class CardPayTokenAmountInput extends Component<CardPayTokenAmountInputArgs> {
+  get tokenDetails(): TokenDisplayInfo | undefined {
+    if (this.args.tokenSymbol) {
+      return new TokenDisplayInfo(this.args.tokenSymbol);
+    } else {
+      return undefined;
+    }
+  }
+}

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
@@ -34,12 +34,38 @@
           />
         </Boxel::Field>
       {{else}}
-        <CardPay::AmountInput
+        <Boxel::Field
+          @label="Amount to withdraw"
+          @fieldMode="edit"
+          class="amount-input"
+          data-test-amount-label
+        >
+          <div class="amount-input__input-container">
+            {{svg-jar this.currentTokenDetails.icon class="amount-input__currency-icon" role="presentation" data-test-currency-icon-name=this.currentTokenDetails.icon}}
+            <Boxel::Input
+              class="amount-input__input"
+              @value={{this.amount}}
+              @required={{true}}
+              @onInput={{this.onInputAmount}}
+              @invalid={{this.isInvalid}}
+              @errorMessage={{this.errorMessage}}
+              placeholder="0.00"
+              autocomplete="off"
+              inputmode="decimal"
+              data-test-amount-input
+            />
+            <div class="amount-input__currency-text" data-test-amount-input-currency-label>
+              {{@currentTokenSymbol}}
+            </div>
+          </div>
+        </Boxel::Field>
+
+        {{!-- <CardPay::AmountInput
           @label="Amount to withdraw"
           @tokenSymbol={{this.currentTokenSymbol}}
           @tokenBalance={{this.currentTokenBalance}}
           @onInputAmount={{this.onInputAmount}}
-        />
+        /> --}}
         <Boxel::Field @label="Approximate value*" data-test-approximate-value-label>
           ${{token-to-usd this.tokenSymbolForConversion this.amountAsBigNumber}} USD
         </Boxel::Field>

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
@@ -34,38 +34,15 @@
           />
         </Boxel::Field>
       {{else}}
-        <Boxel::Field
+        <CardPay::TokenAmountInput
           @label="Amount to withdraw"
-          @fieldMode="edit"
-          class="amount-input"
-          data-test-amount-label
-        >
-          <div class="amount-input__input-container">
-            {{svg-jar this.currentTokenDetails.icon class="amount-input__currency-icon" role="presentation" data-test-currency-icon-name=this.currentTokenDetails.icon}}
-            <Boxel::Input
-              class="amount-input__input"
-              @value={{this.amount}}
-              @required={{true}}
-              @onInput={{this.onInputAmount}}
-              @invalid={{this.isInvalid}}
-              @errorMessage={{this.errorMessage}}
-              placeholder="0.00"
-              autocomplete="off"
-              inputmode="decimal"
-              data-test-amount-input
-            />
-            <div class="amount-input__currency-text" data-test-amount-input-currency-label>
-              {{@currentTokenSymbol}}
-            </div>
-          </div>
-        </Boxel::Field>
-
-        {{!-- <CardPay::AmountInput
-          @label="Amount to withdraw"
+          @amount={{this.amount}}
           @tokenSymbol={{this.currentTokenSymbol}}
           @tokenBalance={{this.currentTokenBalance}}
           @onInputAmount={{this.onInputAmount}}
-        /> --}}
+          @isInvalid={{this.isInvalid}}
+          @errorMessage={{this.errorMessage}}
+        />
         <Boxel::Field @label="Approximate value*" data-test-approximate-value-label>
           ${{token-to-usd this.tokenSymbolForConversion this.amountAsBigNumber}} USD
         </Boxel::Field>

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
@@ -65,10 +65,10 @@ class CardPayWithdrawalWorkflowTransactionAmountComponent extends Component<Work
   }
 
   get amountAsBigNumber(): BN {
-    if (this.amountIsValid) {
-      return toBN(toWei(this.amount));
-    } else {
+    if (this.isInvalid || this.amount === '') {
       return toBN(0);
+    } else {
+      return toBN(toWei(this.amount));
     }
   }
 

--- a/packages/web-client/app/utils/validation.ts
+++ b/packages/web-client/app/utils/validation.ts
@@ -1,0 +1,66 @@
+import BN from 'bn.js';
+import { toBN, toWei } from 'web3-utils';
+
+// token input validations that assume string inputs are in wei
+function isInvalidAsNumber(amount: string) {
+  return isNaN(Number(amount));
+}
+
+function failsToCreateBN(amount: string) {
+  try {
+    toBN(toWei(amount));
+  } catch (e) {
+    return true;
+  }
+  return false;
+}
+
+interface TokenInputValidationOptions {
+  min: BN;
+  max?: BN;
+}
+
+let orderedTokenInputValidations: Array<
+  | ((amount: string, options: TokenInputValidationOptions) => string)
+  | ((amount: string) => string)
+> = [
+  (amount: string) => {
+    return amount.trim().length === 0 ? 'You need to enter an amount' : '';
+  },
+  (amount: string) => {
+    return isInvalidAsNumber(amount) ? 'Amount must be a valid number' : '';
+  },
+  (amount: string) => {
+    const regex = /^\d*(\.\d{0,18})?$/;
+    return !regex.test(amount)
+      ? 'Amount must have less than 18 decimal points'
+      : '';
+  },
+  (amount: string) => {
+    return failsToCreateBN(amount) ? 'Amount must be a valid number' : '';
+  },
+  (amount: string, options: TokenInputValidationOptions) => {
+    if (!options.max) return '';
+    return toBN(toWei(amount)).gt(options.max) ? 'Amount is too high' : '';
+  },
+  (amount: string, options: TokenInputValidationOptions) => {
+    return toBN(toWei(amount)).lte(options.min) ? 'Amount is too low' : '';
+  },
+];
+
+export function validateTokenInput(
+  amount: string,
+  options: TokenInputValidationOptions
+) {
+  for (let validation of orderedTokenInputValidations) {
+    let error = validation(amount, options);
+    if (error) {
+      return error;
+    }
+  }
+  return '';
+}
+
+export function shouldUseTokenInput(newAmount: string) {
+  return !isInvalidAsNumber(newAmount);
+}


### PR DESCRIPTION
This is an extension of #1840 as suggested by @Aierie, as a start toward common validation functions that can be used by other cards.

![screencast 2021-07-20 09-01-44-true-function](https://user-images.githubusercontent.com/43280/126328773-57d8a3d6-a0db-41bc-8d6e-e4f0fb698d64.gif)

At least one refinement would be nice: having the USD conversion amount still show even when the number exceeds the balance (or has too many decimals).