### PR TITLE
Add underscore-prefix exclusion on unused vars

### DIFF
--- a/packages/web-client/.eslintrc.js
+++ b/packages/web-client/.eslintrc.js
@@ -26,7 +26,10 @@ module.exports = {
       rules: {
         'no-undef': 'off',
         'no-unused-vars': 'off',
-        '@typescript-eslint/no-unused-vars': ['error'],
+        '@typescript-eslint/no-unused-vars': [
+          'error',
+          { argsIgnorePattern: '^_' },
+        ],
       },
     },
     // node files

--- a/packages/web-client/app/utils/web3-strategies/test-layer1.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer1.ts
@@ -34,7 +34,6 @@ export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
 
   bridgingDeferred!: RSVP.Deferred<TransactionReceipt>;
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   connect(_walletProvider: WalletProvider): Promise<void> {
     return this.waitForAccount;
   }
@@ -53,13 +52,11 @@ export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
     this.disconnect();
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   approve(_amountInWei: BN, _token: string) {
     this.#unlockDeferred = RSVP.defer();
     return this.#unlockDeferred.promise;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   relayTokens(_token: string, _destinationAddress: string, _amountInWei: BN) {
     this.#depositDeferred = RSVP.defer();
     return this.#depositDeferred.promise;
@@ -149,7 +146,6 @@ export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   awaitBridged(_fromBlock: BN, _receiver: string): Promise<TransactionReceipt> {
     this.bridgingDeferred = defer<TransactionReceipt>();
     return this.bridgingDeferred.promise as Promise<TransactionReceipt>;

--- a/packages/web-client/app/utils/web3-strategies/test-layer2.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer2.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { tracked } from '@glimmer/tracking';
 import WalletInfo from '../wallet-info';
 import { Layer2Web3Strategy, TransactionHash } from './types';
@@ -68,7 +67,6 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
     return Promise.resolve(this.depotSafe);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   awaitBridgedToLayer2(
     _fromBlock: BN,
     _receiver: string
@@ -132,7 +130,6 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
   async issuePrepaidCard(
     _safeAddress: string,
     faceValue: number,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _customizationDID: string
   ): Promise<String> {
     let deferred: RSVP.Deferred<String> = defer();


### PR DESCRIPTION
This saves us having to manually disable linting for
no-unused-vars when following the convention that variables
starting with an underscore are unused.