### PR TITLE
Added blue node deploy and sync status tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,12 +45,6 @@
   "scripts": {
     "clean": "git clean -x -f --exclude=packages/web-client/.env",
     "compile": "yarn codegen:subgraph-sokol && tsc --build ./tsconfig.json",
-    "deploy:boxel": "cd ./packages/boxel && ember deploy production --verbose",
-    "deploy:boxel:preview": "cd ./packages/boxel && ember deploy s3-preview --verbose",
-    "deploy:web-client:staging": "cd ./packages/web-client && ember deploy staging --verbose",
-    "deploy:web-client:production": "cd ./packages/web-client && ember deploy production --verbose",
-    "deploy:subgraph-local": "cd ./packages/cardpay-subgraph && yarn deploy-local",
-    "deploy:subgraph-sokol-green": "cd ./packages/cardpay-subgraph && yarn deploy-sokol-green",
     "prepare": "npm run compile",
     "codegen:subgraph-sokol": "cd ./packages/cardpay-subgraph && yarn codegen-sokol",
     "build:subgraph": "cd ./packages/cardpay-subgraph && yarn build",
@@ -72,7 +66,16 @@
     "test:hub": "cd packages/hub && PACKAGE=hub NODE_ENV=test mocha ../../packages/test-support/bin/run.js --timeout 60000",
     "test:hub:preparedb": "cd packages/hub && node ./bin/setup-test-db.js",
     "test:web-client": "cd packages/web-client && ember test",
-    "test:web-client:serve": "cd packages/web-client && ember test --serve --no-launch"
+    "test:web-client:serve": "cd packages/web-client && ember test --serve --no-launch",
+    "deploy:boxel": "cd ./packages/boxel && ember deploy production --verbose",
+    "deploy:boxel:preview": "cd ./packages/boxel && ember deploy s3-preview --verbose",
+    "deploy:web-client:staging": "cd ./packages/web-client && ember deploy staging --verbose",
+    "deploy:web-client:production": "cd ./packages/web-client && ember deploy production --verbose",
+    "deploy:subgraph-local": "cd ./packages/cardpay-subgraph && yarn deploy-local",
+    "deploy:subgraph-sokol-green": "cd ./packages/cardpay-subgraph && yarn deploy-sokol-green",
+    "deploy:subgraph-sokol-blue": "cd ./packages/cardpay-subgraph && yarn deploy-sokol-blue",
+    "status:subgraph-sokol-green": "cd ./packages/cardpay-subgraph && yarn green-status",
+    "status:subgraph-sokol-blue": "cd ./packages/cardpay-subgraph && yarn blue-status"
   },
   "resolutions": {
     "ember-test-selectors": "^5.0.0"

--- a/packages/cardpay-subgraph/README.md
+++ b/packages/cardpay-subgraph/README.md
@@ -67,7 +67,21 @@ $ graph auth https://api.thegraph.com/deploy/ <The Graph access token>
 After you have performed this authorization you will not need to perform this again for subsequent deployments.
 
 ### Deployment
-To deploy the subgraph to The Graph, just run the following in the `@cardstack/cardpay-subgraph`:
+To deploy the subgraph to both The Graph and one of our hosted graph nodes, run either the following in the `@cardstack/cardpay-subgraph`:
 ```
-yarn deploy-sokol
+yarn deploy-sokol-green
+```
+which deploys to our green node and The Graph, or
+```
+yarn deploy-sokol-blue
+```
+which deploys to our blue node and The Graph
+
+To check the sync status of either node, run:
+```
+yarn green-status
+```
+or
+```
+yarn blue-status
 ```

--- a/packages/cardpay-subgraph/lib/sync-status-entrypoint.ts
+++ b/packages/cardpay-subgraph/lib/sync-status-entrypoint.ts
@@ -1,0 +1,5 @@
+/* global module, require */
+/* eslint no-process-exit: "off",  @typescript-eslint/no-var-requires: "off", @typescript-eslint/no-require-imports: "off", */
+// @ts-ignore not actually redefining block-scoped var
+const esmRequire = require('esm')(module, { cjs: true });
+module.exports = esmRequire('./sync-status');

--- a/packages/cardpay-subgraph/lib/sync-status.ts
+++ b/packages/cardpay-subgraph/lib/sync-status.ts
@@ -1,0 +1,65 @@
+import fetch from 'node-fetch';
+
+// @ts-ignore polyfilling fetch
+global.fetch = fetch;
+
+const USAGE = `node sync-status <green | blue>`;
+const nodes: { [node: string]: string } = {
+  green: 'https://graph-staging-green.stack.cards/subgraphs/name/habdelra/cardpay-sokol',
+  blue: 'https://graph-staging-blue.stack.cards/subgraphs/name/habdelra/cardpay-sokol',
+};
+
+let node = process.argv[2];
+if (!node) {
+  console.error(`please specify the node to query
+${USAGE}`);
+  process.exit(1);
+}
+
+(async () => {
+  let status = await syncQuery(node);
+  if (status == null) {
+    console.log(`The ${node} node has not started syncing`);
+  } else {
+    console.log(
+      `The ${node} node has synced to block number ${status.blockHeight} and has ${
+        status.hasIndexingErrors ? 'encountered' : 'no'
+      } indexing errors`
+    );
+  }
+  process.exit(0);
+})().catch((err) => console.error(err));
+
+async function syncQuery(node: string): Promise<{ blockHeight: number; hasIndexingErrors: boolean } | undefined> {
+  let subgraphURL = nodes[node];
+  if (!subgraphURL) {
+    throw new Error(`invalid node: ${node}`);
+  }
+  let response = await fetch(subgraphURL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json', // eslint-disable-line @typescript-eslint/naming-convention
+      Accept: 'application/json', // eslint-disable-line @typescript-eslint/naming-convention
+    },
+    body: JSON.stringify({
+      query: `
+      {
+        _meta {
+          hasIndexingErrors
+          block {
+            number
+          }
+        }
+      }`,
+      variables: {},
+    }),
+  });
+
+  let meta = (await response.json()).data?._meta;
+  let hasIndexingErrors = meta?.hasIndexingErrors;
+  let blockHeight = meta?.block?.number;
+  if (hasIndexingErrors != null && blockHeight != null) {
+    return { hasIndexingErrors, blockHeight };
+  }
+  return;
+}

--- a/packages/cardpay-subgraph/package.json
+++ b/packages/cardpay-subgraph/package.json
@@ -6,13 +6,19 @@
     "codegen-sokol": "node ./etc/pre-codegen-entrypoint.js poa-sokol && graph codegen && node ./etc/pre-tsc-build-entrypoint.js",
     "build": "graph build",
     "deploy-sokol-green": "yarn deploy-thegraph-sokol && yarn deploy-cardstack-sokol-green",
+    "deploy-sokol-blue": "yarn deploy-thegraph-sokol && yarn deploy-cardstack-sokol-blue",
     "deploy-thegraph-sokol": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ habdelra/cardpay-sokol",
     "create-cardstack-sokol-green": "graph create --node https://admin-graph-staging-green.stack.cards/ habdelra/cardpay-sokol",
     "remove-cardstack-sokol-green": "graph remove --node https://admin-graph-staging-green.stack.cards/ habdelra/cardpay-sokol",
     "deploy-cardstack-sokol-green": "graph deploy --node https://admin-graph-staging-green.stack.cards/ --ipfs https://ipfs-graph-staging-green.stack.cards habdelra/cardpay-sokol",
+    "create-cardstack-sokol-blue": "graph create --node https://admin-graph-staging-blue.stack.cards/ habdelra/cardpay-sokol",
+    "remove-cardstack-sokol-blue": "graph remove --node https://admin-graph-staging-blue.stack.cards/ habdelra/cardpay-sokol",
+    "deploy-cardstack-sokol-blue": "graph deploy --node https://admin-graph-staging-blue.stack.cards/ --ipfs https://ipfs-graph-staging-blue.stack.cards habdelra/cardpay-sokol",
     "create-local": "graph create --node http://localhost:8020/ habdelra/cardpay-sokol",
     "remove-local": "graph remove --node http://localhost:8020/ habdelra/cardpay-sokol",
-    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 habdelra/cardpay-sokol"
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 habdelra/cardpay-sokol",
+    "green-status": "node ./lib/sync-status-entrypoint.js green",
+    "blue-status": "node ./lib/sync-status-entrypoint.js blue"
   },
   "devDependencies": {
     "@cardstack/cardpay-sdk": "0.19.34",
@@ -20,7 +26,8 @@
     "@graphprotocol/graph-ts": "graphprotocol/graph-ts#56adb62d9e4233c6fc6c38bc0519a8a566afdd9e",
     "@protofire/subgraph-toolkit": "0.1.2",
     "esm": "^3.2.25",
-    "fs-extra": "^10.0.0"
+    "fs-extra": "^10.0.0",
+    "node-fetch": "^2.6.1"
   },
   "private": true,
   "workspaces": {


### PR DESCRIPTION
Adds the blue node deploy (for the green/blue deploy strategy) for our hosted subgraph as well as a tool to check the sync status for either node so that you know when a node is ready to be switched over to live.