### PR TITLE
make boxel dashboard header scroll with content

### DIFF
--- a/packages/boxel/addon/components/boxel/dashboard/index.css
+++ b/packages/boxel/addon/components/boxel/dashboard/index.css
@@ -6,18 +6,11 @@
   position: relative;
   display: grid;
   grid-template-rows: auto 1fr;
-  height: 100%;
   background-color: var(--boxel-dashboard-background-color);
   color: var(--boxel-dashboard-color);
   font: var(--boxel-font);
   letter-spacing: var(--boxel-lsp-lg);
   z-index: 0;
-}
-
-.boxel-dashboard__sticky-header-container {
-  position: sticky;
-  top: 0;
-  z-index: 1;
 }
 
 .boxel-dashboard__body-container {

--- a/packages/boxel/addon/components/boxel/dashboard/index.hbs
+++ b/packages/boxel/addon/components/boxel/dashboard/index.hbs
@@ -12,7 +12,7 @@
     </div>
   {{/if}}
 
-  <div class="boxel-dashboard__sticky-header-container">
+  <div class="boxel-dashboard__header-container">
     {{yield to="header"}}
   </div>
 


### PR DESCRIPTION
CS-1348

Done by uncapping the height of the dashboard and removing `position: sticky`, at request of design for usability purposes.