### PR TITLE
add color style declaration to workflow-thread component

### DIFF
--- a/packages/boxel/addon/components/boxel/thread/index.css
+++ b/packages/boxel/addon/components/boxel/thread/index.css
@@ -4,6 +4,7 @@
   grid-template-rows: auto 1fr;
   height: 100%;
   background-color: var(--boxel-light-300);
+  color: var(--boxel-dark);
   border-radius: var(--boxel-border-radius);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
 }
@@ -12,7 +13,6 @@
   height: 100%;
   display: grid;
   grid-template-columns: 1fr auto;
-  background-color: var(--boxel-light-300);
   overflow: hidden;
 }
 

--- a/packages/web-client/app/components/card-pay/deposit-workflow/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/index.css
@@ -1,7 +1,3 @@
-.deposit-workflow {
-  color: var(--boxel-dark);
-}
-
 /* Expandable banner */
 .deposit-workflow__banner {
   padding-right: var(--boxel-sp);

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.css
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.css
@@ -1,7 +1,3 @@
-.issue-prepaid-card-workflow {
-  color: var(--boxel-dark);
-}
-
 /* TODO: shared styles with deposit-workflow__banner -- extract common component? */
 .issue-prepaid-card-workflow__banner {
   padding-right: var(--boxel-sp);


### PR DESCRIPTION
Adds the color style declaration to the workflow thread component so we don't have to specify it for each workflow we create. Note: The bug in CS-1327 did not happen in Chrome because Chrome's user agent stylesheet was overriding our text color via their custom property `-internal-light-dark`.

EDIT: moved the color declaration to the Boxel component so that the color declaration is where the background declaration is.