### PR TITLE
make dashboard component more flexible

### DIFF
--- a/packages/boxel/addon/components/boxel/dashboard/index.css
+++ b/packages/boxel/addon/components/boxel/dashboard/index.css
@@ -4,6 +4,7 @@
   --boxel-dashboard-left-edge-width: 5rem; /* 80px */
 
   position: relative;
+  min-height: 100%;
   display: grid;
   grid-template-rows: auto 1fr;
   background-color: var(--boxel-dashboard-background-color);
@@ -11,11 +12,6 @@
   font: var(--boxel-font);
   letter-spacing: var(--boxel-lsp-lg);
   z-index: 0;
-}
-
-.boxel-dashboard__body-container {
-  overflow: auto;
-  min-height: 50vh;
 }
 
 .boxel-dashboard--with-left-edge {


### PR DESCRIPTION
- handle case for dashboards with too little content (when height of content does not fill parent container, body named block can fill all available height by setting height:100%)
- also remove the dashboard body container overflow