### PR TITLE
Hub: Fix structure of generated JSON:API document

### DIFF
--- a/packages/hub/services/serializers/prepaid-card-color-scheme-serializer.ts
+++ b/packages/hub/services/serializers/prepaid-card-color-scheme-serializer.ts
@@ -10,7 +10,7 @@ interface PrepaidCardColorScheme {
 }
 interface JSONAPIDocument {
   data: any;
-  includes?: any[];
+  included?: any[];
 }
 
 export default class PrepaidCardColorSchemeSerializer {

--- a/packages/hub/services/serializers/prepaid-card-customization-serializer.ts
+++ b/packages/hub/services/serializers/prepaid-card-customization-serializer.ts
@@ -16,7 +16,7 @@ interface PrepaidCardCustomizationSerializationOptions {
 }
 interface JSONAPIDocument {
   data: any;
-  includes?: any[];
+  included?: any[];
 }
 type PrepaidCardCustomizationRelationship = 'colorScheme' | 'pattern';
 
@@ -69,12 +69,12 @@ export default class PrepaidCardCustomizationSerializer {
       data,
     } as JSONAPIDocument;
     if (options.include?.includes('colorScheme')) {
-      result.includes = result.includes || [];
-      result.includes.push(await this.prepaidCardColorSchemeSerializer.serialize(content.colorSchemeId));
+      result.included = result.included || [];
+      result.included.push((await this.prepaidCardColorSchemeSerializer.serialize(content.colorSchemeId)).data);
     }
     if (options.include?.includes('pattern')) {
-      result.includes = result.includes || [];
-      result.includes.push(await this.prepaidCardPatternSerializer.serialize(content.patternId));
+      result.included = result.included || [];
+      result.included.push((await this.prepaidCardPatternSerializer.serialize(content.patternId)).data);
     }
     return result;
   }

--- a/packages/hub/services/serializers/prepaid-card-pattern-serializer.ts
+++ b/packages/hub/services/serializers/prepaid-card-pattern-serializer.ts
@@ -8,7 +8,7 @@ interface PrepaidCardPattern {
 }
 interface JSONAPIDocument {
   data: any;
-  includes?: any[];
+  included?: any[];
 }
 
 export default class PrepaidCardPatternSerializer {


### PR DESCRIPTION
The container for sideloaded data is called `included`
and its members shouldn’t have a `data` wrapper.

I couldn’t find tests for this but I exercised it locally and it generated [this card customisation document](https://storage.cardstack.com/prepaid-card-customization/x2UAQqoZaTTWGPqqSHi5Ls.json) that has the expected structure.

The `(await …).data` approach could be called hackish, I see that Mirage has the idea of a [“primary resource”](https://github.com/miragejs/miragejs/blob/b965b8a058523dac0d6ab4792826887154e25368/lib/serializer.js#L389) probably for this reason, could be something to adapt.