### PR TITLE
Cardstack support references/links in error messages lead to discord

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -53,8 +53,8 @@
       {{/unless}}
     </div>
     {{#if this.errorMessage}}
-      <CardPay::ErrorMessage>
-        {{this.errorMessage}} Please try again if you want to continue with this workflow, or contact Cardstack support.
+      <CardPay::ErrorMessage as |supportURL|>
+        {{this.errorMessage}} Please try again if you want to continue with this workflow, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
       </CardPay::ErrorMessage>
     {{/if}}
     <div class="transaction-amount__footnote">

--- a/packages/web-client/app/components/card-pay/error-message/index.hbs
+++ b/packages/web-client/app/components/card-pay/error-message/index.hbs
@@ -1,3 +1,3 @@
 <div class="cardstack-error-message" ...attributes>
-  {{yield}}
+  {{yield this.supportURL}}
 </div>

--- a/packages/web-client/app/components/card-pay/error-message/index.ts
+++ b/packages/web-client/app/components/card-pay/error-message/index.ts
@@ -1,0 +1,6 @@
+import Component from '@glimmer/component';
+import config from '@cardstack/web-client/config/environment';
+
+export default class CardPayErrorMessageComponent extends Component {
+  supportURL = config.urls.discordBetaChannelLink;
+}

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
@@ -69,15 +69,15 @@
       </CardPay::FieldStack>
     </div>
     {{#if this.error}}
-      <CardPay::ErrorMessage data-test-issue-prepaid-card-error-message>
+      <CardPay::ErrorMessage data-test-issue-prepaid-card-error-message as |supportURL|>
         {{#if (eq this.error.message "INSUFFICIENT_FUNDS")}}
           {{!-- TODO: This should be accompanied by canceling the workflow --}}
           Looks like there's no balance in your {{network-display-info "layer2" "fullName"}} wallet to fund your selected prepaid card. Before you can continue, please add funds to your {{network-display-info "layer2" "fullName"}} wallet by bridging some tokens from your {{network-display-info "layer1" "fullName"}} wallet.
           {{!-- TODO: "The balance required to create your desired prepaid card is ${}" --}}
         {{else if (eq this.error.message "TIMEOUT")}}
-          There was a problem creating your prepaid card. Please contact <a href="mailto:support@cardstack.com" target="_blank" rel="noopener noreferrer">Cardstack support</a> to find out the status of your transaction.
+          There was a problem creating your prepaid card. Please contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a> to find out the status of your transaction.
         {{else}}
-           There was a problem creating your prepaid card. Please try again if you want to continue with this workflow, or contact Cardstack support.
+          There was a problem creating your prepaid card. Please try again if you want to continue with this workflow, or contact  <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
         {{/if}}
         </CardPay::ErrorMessage>
     {{/if}}

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.hbs
@@ -19,7 +19,9 @@
       />
     </div>
     {{#if this.errorMessage}}
-      <CardPay::ErrorMessage>{{this.errorMessage}}</CardPay::ErrorMessage>
+      <CardPay::ErrorMessage as |supportURL|>
+        {{this.errorMessage}} Please try again if you want to continue with this workflow, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
+      </CardPay::ErrorMessage>
     {{/if}}
     <div class="token-claim__footnote">
       * The actual value depends on the current exchange rate and is determined at the time of authorization.

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.ts
@@ -91,8 +91,7 @@ class CardPayWithdrawalWorkflowTokenClaimComponent extends Component<WorkflowCar
     } catch (e) {
       console.error(e);
       this.errorMessage = `There was a problem with claiming your tokens. This may be due
-      to a network issue, or perhaps you canceled the request in your wallet. Please try
-      again if you want to continue with this workflow, or contact Cardstack support.`;
+      to a network issue, or perhaps you canceled the request in your wallet.`;
     } finally {
       this.isConfirming = false;
     }

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
@@ -52,8 +52,8 @@
       {{/unless}}
     </div>
     {{#if this.errorMessage}}
-      <CardPay::ErrorMessage>
-        {{this.errorMessage}} Please try again if you want to continue with this workflow, or contact Cardstack support.
+      <CardPay::ErrorMessage as |supportURL|>
+        {{this.errorMessage}} Please try again if you want to continue with this workflow, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
       </CardPay::ErrorMessage>
     {{/if}}
     <div class="withdrawal-transaction-amount__footnote" data-test-approximate-value-footnote>

--- a/packages/web-client/app/components/workflow-thread/index.ts
+++ b/packages/web-client/app/components/workflow-thread/index.ts
@@ -10,9 +10,6 @@ interface WorkflowThreadArgs {
   workflow: Workflow;
 }
 
-const TESTNET_FAUCET_CHANNEL_URL =
-  'https://discord.com/channels/584043165066199050/867588838524190762';
-
 export default class WorkflowThread extends Component<WorkflowThreadArgs> {
   threadEl: HTMLElement | undefined;
   workflow = new AnimatedWorkflow(this.args.workflow);
@@ -75,7 +72,7 @@ export default class WorkflowThread extends Component<WorkflowThreadArgs> {
   }
 
   @action openDiscord() {
-    window.open(TESTNET_FAUCET_CHANNEL_URL, '_blank');
+    window.open(config.urls.discordBetaChannelLink, '_blank');
   }
 
   get lastMilestonePostable() {

--- a/packages/web-client/app/config/environment.d.ts
+++ b/packages/web-client/app/config/environment.d.ts
@@ -8,6 +8,7 @@ interface ChainsOptions {
 interface UrlsOptions {
   appStoreLink: string | undefined;
   googlePlayLink: string | undefined;
+  discordBetaChannelLink: string | undefined;
 }
 
 /**

--- a/packages/web-client/config/environment.js
+++ b/packages/web-client/config/environment.js
@@ -40,6 +40,8 @@ module.exports = function (environment) {
     urls: {
       appStoreLink: undefined,
       googlePlayStoreLink: undefined,
+      discordBetaChannelLink:
+        'https://discord.com/channels/584043165066199050/867588838524190762',
     },
     threadAnimationInterval: 1000,
     'ember-cli-mirage': {


### PR DESCRIPTION
Since we're using discord as the main source of help in beta, the links that previously started an email to Cardstack support should instead open the discord beta user channel. 