### PR TITLE
web: Update prepaid issuance to use new SDK response

### DIFF
--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
@@ -54,16 +54,19 @@ export default class CardPayDepositWorkflowPreviewComponent extends Component<Ca
         patternId: workflowSession.state.pattern.id,
       });
 
-      let address = yield taskFor(this.layer2Network.issuePrepaidCard).perform(
-        this.faceValue,
-        customization.did,
-        {
-          onTxHash: (txHash: TransactionHash) => {
-            this.txHash = txHash;
-          },
-        }
+      let prepaidCardSafe = yield taskFor(
+        this.layer2Network.issuePrepaidCard
+      ).perform(this.faceValue, customization.did, {
+        onTxHash: (txHash: TransactionHash) => {
+          this.txHash = txHash;
+        },
+      });
+
+      this.args.workflowSession.update(
+        'prepaidCardAddress',
+        prepaidCardSafe.address
       );
-      this.args.workflowSession.update('prepaidCardAddress', address);
+
       this.args.onComplete();
     } catch (e) {
       let insufficientFunds = e.message.startsWith(

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -35,6 +35,7 @@ import {
   IExchangeRate,
   IHubAuth,
   ISafes,
+  PrepaidCardSafe,
 } from '@cardstack/cardpay-sdk';
 import { taskFor } from 'ember-concurrency-ts';
 import config from '../../config/environment';
@@ -188,7 +189,7 @@ export default abstract class Layer2ChainWeb3Strategy
     amount: number,
     customizationDid: string,
     options: IssuePrepaidCardOptions
-  ): Promise<ChainAddress> {
+  ): Promise<PrepaidCardSafe> {
     const PrepaidCard = await getSDK('PrepaidCard', this.web3);
 
     const result = await PrepaidCard.create(
@@ -200,7 +201,7 @@ export default abstract class Layer2ChainWeb3Strategy
       options.onTxHash
     );
 
-    return result.prepaidCardAddresses[0];
+    return result.prepaidCards[0];
   }
 
   // unlike layer 1 with metamask, there is no necessity for cross-tab communication

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -1,7 +1,7 @@
 import { WalletProvider } from '../wallet-providers';
 import BN from 'bn.js';
 import { TransactionReceipt } from 'web3-core';
-import { DepotSafe } from '@cardstack/cardpay-sdk/sdk/safes';
+import { DepotSafe, PrepaidCardSafe } from '@cardstack/cardpay-sdk/sdk/safes';
 import {
   ConvertibleSymbol,
   ConversionFunction,
@@ -90,7 +90,7 @@ export interface Layer2Web3Strategy
     amount: number,
     customizationDid: string,
     options?: IssuePrepaidCardOptions
-  ): Promise<ChainAddress>;
+  ): Promise<PrepaidCardSafe>;
   fetchDepotTask(): Promise<DepotSafe | null>;
   refreshBalances(): void;
   convertFromSpend(symbol: ConvertibleSymbol, amount: number): Promise<any>;

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -430,6 +430,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
     await timeout(250);
     layer2Service.test__simulateIssuePrepaidCardForAmount(
       10000,
+      layer2AccountAddress,
       '0xaeFbA62A2B3e90FD131209CC94480E722704E1F8'
     );
 


### PR DESCRIPTION
This fixes the issue prepaid card workflow for the SDK’s
updated PrepaidCard.create interface, which as of #1878
returns a PrepaidCardSafe instead of just the address
of the prepaid card. This is something I requested for
#1855 and it’ll be used more thoroughly there, but this
is a minimal interim change to handle the new return type.

I’ve used this locally to issue a new prepaid card:

![image](https://user-images.githubusercontent.com/43280/127020241-b3937e20-2fae-432b-a622-1fcf8a9486b8.png)