### PR TITLE
Make dashboard panel CTAs align with each other

### DIFF
--- a/packages/web-client/app/components/card-pay/dashboard-panel/index.css
+++ b/packages/web-client/app/components/card-pay/dashboard-panel/index.css
@@ -115,7 +115,6 @@
 .dashboard-panel__header {
   grid-column: 1 / -1;
   max-width: 30rem;
-  z-index: 1;
 }
 
 .dashboard-panel__header-title {
@@ -140,6 +139,11 @@
   background-repeat: no-repeat;
   background-size: contain;
   pointer-events: none;
+  z-index: 0;
+}
+
+.dashboard-panel > *:not(.dashboard-panel__hero) {
+  z-index: 1;
 }
 
 @media screen and (max-width: 1000px) {

--- a/packages/web-client/app/components/card-pay/dashboard-panel/section/index.css
+++ b/packages/web-client/app/components/card-pay/dashboard-panel/section/index.css
@@ -3,6 +3,10 @@
   letter-spacing: var(--boxel-lsp-sm);
   display: flex;
   flex-flow: column nowrap;
+  justify-content: space-between;
+}
+
+.dashboard-panel-section--bottom-aligned {
   justify-content: flex-end;
 }
 
@@ -80,6 +84,7 @@
 
   .dashboard-panel-section__disclaimer {
     position: absolute;
+    bottom: 0;
     transform: translateY(calc(var(--boxel-sp) + 100%));
   }
 }

--- a/packages/web-client/app/components/card-pay/dashboard-panel/section/index.css
+++ b/packages/web-client/app/components/card-pay/dashboard-panel/section/index.css
@@ -1,8 +1,6 @@
 .dashboard-panel-section {
+  position: relative;
   letter-spacing: var(--boxel-lsp-sm);
-}
-
-.dashboard-panel-section--bottom-aligned {
   display: flex;
   flex-flow: column nowrap;
   justify-content: flex-end;
@@ -49,9 +47,8 @@
   margin-top: var(--boxel-sp-xxl);
 }
 
-.dashboard-panel-section small {
+.dashboard-panel-section__disclaimer {
   display: block;
-  margin-top: var(--boxel-sp);
   font-size: var(--boxel-font-size-xs);
   line-height: 1.8;
   letter-spacing: var(--boxel-lsp);
@@ -63,12 +60,26 @@
     border-top: 1px solid var(--border-color);
     padding-top: var(--spacing);
   }
+
+  .dashboard-panel-section__disclaimer {
+    position: relative;
+    margin-top: var(--boxel-sp);
+  }
 }
 
 @media screen and (min-width: 801px) {
+  .dashboard-panel-section--has-disclaimer {
+    margin-bottom: 8ex; /* add fixed-height margin at the bottom to leave space for the disclaimer */
+  }
+
   .dashboard-panel-section:nth-child(even) {
     border-left: 1px solid var(--border-color);
     margin-left: var(--spacing);
     padding-left: var(--spacing);
+  }
+
+  .dashboard-panel-section__disclaimer {
+    position: absolute;
+    transform: translateY(calc(var(--boxel-sp) + 100%));
   }
 }

--- a/packages/web-client/app/components/card-pay/dashboard-panel/section/index.hbs
+++ b/packages/web-client/app/components/card-pay/dashboard-panel/section/index.hbs
@@ -1,4 +1,4 @@
-<section class={{cn "dashboard-panel-section" dashboard-panel-section--bottom-aligned=(not @section.title)}} ...attributes>
+<section class={{cn "dashboard-panel-section" dashboard-panel-section--has-disclaimer=(has-block "disclaimer")}} ...attributes>
   {{#if @section.icon}}
     {{svg-jar @section.icon alt="" role="presentation"}}
   {{/if}}
@@ -16,7 +16,7 @@
   {{yield to="cta"}}
 
   {{#if (has-block "disclaimer")}}
-    <small>
+    <small class="dashboard-panel-section__disclaimer">
       {{yield to="disclaimer"}}
     </small>
   {{/if}}

--- a/packages/web-client/app/components/card-pay/dashboard-panel/section/index.hbs
+++ b/packages/web-client/app/components/card-pay/dashboard-panel/section/index.hbs
@@ -13,5 +13,11 @@
     </ul>
   {{/if}}
 
-  {{yield}}
+  {{yield to="cta"}}
+
+  {{#if (has-block "disclaimer")}}
+    <small>
+      {{yield to="disclaimer"}}
+    </small>
+  {{/if}}
 </section>

--- a/packages/web-client/app/components/card-pay/dashboard-panel/section/index.hbs
+++ b/packages/web-client/app/components/card-pay/dashboard-panel/section/index.hbs
@@ -1,17 +1,19 @@
-<section class={{cn "dashboard-panel-section" dashboard-panel-section--has-disclaimer=(has-block "disclaimer")}} ...attributes>
-  {{#if @section.icon}}
-    {{svg-jar @section.icon alt="" role="presentation"}}
-  {{/if}}
-  <h3 class="dashboard-panel-section__title">{{@section.title}}</h3>
-  <p class="dashboard-panel-section__desc">{{@section.description}}</p>
+<section class={{cn "dashboard-panel-section" dashboard-panel-section--bottom-aligned=(not @section.title) dashboard-panel-section--has-disclaimer=(has-block "disclaimer")}} ...attributes>
+  <div class="dashboard-panel-section__body">
+    {{#if @section.icon}}
+      {{svg-jar @section.icon alt="" role="presentation"}}
+    {{/if}}
+    <h3 class="dashboard-panel-section__title">{{@section.title}}</h3>
+    <p class="dashboard-panel-section__desc">{{@section.description}}</p>
 
-  {{#if @section.bullets}}
-    <ul class="dashboard-panel-section__list">
-      {{#each @section.bullets as |bullet|}}
-        <li class="dashboard-panel-section__list-item">{{bullet}}</li>
-      {{/each}}
-    </ul>
-  {{/if}}
+    {{#if @section.bullets}}
+      <ul class="dashboard-panel-section__list">
+        {{#each @section.bullets as |bullet|}}
+          <li class="dashboard-panel-section__list-item">{{bullet}}</li>
+        {{/each}}
+      </ul>
+    {{/if}}
+  </div>
 
   {{yield to="cta"}}
 

--- a/packages/web-client/app/templates/card-pay/balances.hbs
+++ b/packages/web-client/app/templates/card-pay/balances.hbs
@@ -2,22 +2,24 @@
   <CardPay::DashboardPanel @panel={{@model.panel}}>
     {{#each @model.panel.sections as |section|}}
       <CardPay::DashboardPanel::Section @section={{section}}>
-        <Boxel::Button
-          {{on "click" (set this "flow" section.workflow)}}
-          @kind="primary"
-          @size="touch"
-          @disabled={{section.isCtaDisabled}}
-          data-test-workflow-button={{section.workflow}}
-        >
-          {{section.cta}}
-        </Boxel::Button>
-        {{#if (eq section.workflow 'issue-prepaid-card')}}
-          <small>
+        <:cta>
+          <Boxel::Button
+            {{on "click" (set this "flow" section.workflow)}}
+            @kind="primary"
+            @size="touch"
+            @disabled={{section.isCtaDisabled}}
+            data-test-workflow-button={{section.workflow}}
+          >
+            {{section.cta}}
+          </Boxel::Button>
+        </:cta>
+        <:disclaimer>
+          {{#if (eq section.workflow 'issue-prepaid-card')}}
             This is possible if you have a balance of DAI.CPXD in your {{network-display-info "layer2" "fullName"}} wallet.
             (You can <LinkTo @route="card-pay.token-suppliers">deposit DAI</LinkTo>
             from your {{network-display-info "layer1" "conversationalName"}} wallet to get a balance of DAI.CPXD in your {{network-display-info "layer2" "fullName"}} wallet.)
-          </small>
-        {{/if}}
+          {{/if}}
+        </:disclaimer>
       </CardPay::DashboardPanel::Section>
     {{/each}}
   </CardPay::DashboardPanel>

--- a/packages/web-client/app/templates/card-pay/merchant-services.hbs
+++ b/packages/web-client/app/templates/card-pay/merchant-services.hbs
@@ -2,20 +2,22 @@
   <CardPay::DashboardPanel @panel={{@model.panel}}>
     {{#each @model.panel.sections as |section|}}
       <CardPay::DashboardPanel::Section @section={{section}}>
-        <Boxel::Button
-          {{on "click" (set this "flow" section.workflow)}}
-          @kind="primary"
-          @size="touch"
-          @disabled={{section.isCtaDisabled}}
-          data-test-workflow-button={{section.workflow}}
-        >
-          {{section.cta}}
-        </Boxel::Button>
-        {{#if (eq section.workflow 'request-payment')}}
-          <small>
+        <:cta>
+          <Boxel::Button
+            {{on "click" (set this "flow" section.workflow)}}
+            @kind="primary"
+            @size="touch"
+            @disabled={{section.isCtaDisabled}}
+            data-test-workflow-button={{section.workflow}}
+          >
+            {{section.cta}}
+          </Boxel::Button>
+        </:cta>
+        <:disclaimer>
+          {{#if (eq section.workflow 'request-payment')}}
             This is possible once you have connected your {{network-display-info "layer2" "fullName"}} wallet and created a merchant.
-          </small>
-        {{/if}}
+          {{/if}}
+        </:disclaimer>
       </CardPay::DashboardPanel::Section>
     {{/each}}
   </CardPay::DashboardPanel>

--- a/packages/web-client/app/templates/card-pay/token-suppliers.hbs
+++ b/packages/web-client/app/templates/card-pay/token-suppliers.hbs
@@ -2,15 +2,17 @@
   <CardPay::DashboardPanel @panel={{@model.panel}}>
     {{#each @model.panel.sections as |section|}}
       <CardPay::DashboardPanel::Section @section={{section}}>
-        <Boxel::Button
-          {{on "click" (set this "flow" section.workflow)}}
-          @kind="primary"
-          @size="touch"
-          @disabled={{section.isCtaDisabled}}
-          data-test-workflow-button={{section.workflow}}
-        >
-          {{section.cta}}
-        </Boxel::Button>
+        <:cta>
+          <Boxel::Button
+            {{on "click" (set this "flow" section.workflow)}}
+            @kind="primary"
+            @size="touch"
+            @disabled={{section.isCtaDisabled}}
+            data-test-workflow-button={{section.workflow}}
+          >
+            {{section.cta}}
+          </Boxel::Button>
+        </:cta>
       </CardPay::DashboardPanel::Section>
     {{/each}}
   </CardPay::DashboardPanel>


### PR DESCRIPTION
# Screen width > 1152 (our max width for this panel right now, based on root font size)
## Before
![image](https://user-images.githubusercontent.com/39579264/127022073-1ace0f20-5625-46cd-8e40-653b943ec448.png)

## After
![image](https://user-images.githubusercontent.com/39579264/127022193-020f1bde-87cc-4d9d-8514-2e123e01cc8b.png)

# Screen width = 801 (media query for vertical orientation + related styling at 800)
## Before
![image](https://user-images.githubusercontent.com/39579264/127022308-39a20140-efa2-4fdf-a5c5-2a6693b187b7.png)

## After
![image](https://user-images.githubusercontent.com/39579264/127021078-f81e0f0b-c3a8-4545-8c3f-7ec5e1934a82.png)

# Screen width = 600
## Before
![image](https://user-images.githubusercontent.com/39579264/127022379-32d804b1-baf2-4021-8a29-c104bba0c257.png)

## After
![image](https://user-images.githubusercontent.com/39579264/127021156-39334c4c-cbac-4417-bc9d-a6eb40bbcd2b.png)
