### PR TITLE
Add page titles for each route

### DIFF
--- a/packages/web-client/app/templates/application.hbs
+++ b/packages/web-client/app/templates/application.hbs
@@ -1,3 +1,3 @@
-{{page-title "@cardstack/web-client"}}
+{{page-title "Cardstack"}}
 
 {{outlet}}

--- a/packages/web-client/app/templates/card-pay.hbs
+++ b/packages/web-client/app/templates/card-pay.hbs
@@ -1,3 +1,5 @@
+{{page-title "Card Pay" replace=true}}
+
 <Boxel::Dashboard @darkTheme={{true}} class="card-pay" data-test-card-pay>
   <:header>
     <CardPay::Header

--- a/packages/web-client/app/templates/card-pay/balances.hbs
+++ b/packages/web-client/app/templates/card-pay/balances.hbs
@@ -1,3 +1,5 @@
+{{page-title "Card Balances"}}
+
 <section class="card-pay-dashboard__section" role="tabpanel" aria-labelledby="card-pay.balances">
   <CardPay::DashboardPanel @panel={{@model.panel}}>
     {{#each @model.panel.sections as |section|}}

--- a/packages/web-client/app/templates/card-pay/merchant-services.hbs
+++ b/packages/web-client/app/templates/card-pay/merchant-services.hbs
@@ -1,3 +1,5 @@
+{{page-title "Merchant Services"}}
+
 <section class="card-pay-dashboard__section" role="tabpanel" aria-labelledby="card-pay.merchant-services">
   <CardPay::DashboardPanel @panel={{@model.panel}}>
     {{#each @model.panel.sections as |section|}}

--- a/packages/web-client/app/templates/card-pay/token-suppliers.hbs
+++ b/packages/web-client/app/templates/card-pay/token-suppliers.hbs
@@ -1,3 +1,5 @@
+{{page-title "Token Suppliers"}}
+
 <section class="card-pay-dashboard__section" role="tabpanel" aria-labelledby="card-pay.token-suppliers">
   <CardPay::DashboardPanel @panel={{@model.panel}}>
     {{#each @model.panel.sections as |section|}}

--- a/packages/web-client/config/environment.js
+++ b/packages/web-client/config/environment.js
@@ -30,6 +30,9 @@ module.exports = function (environment) {
         tracesSampleRate: 1.0,
       },
     },
+    pageTitle: {
+      separator: ' · ',
+    },
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build


### PR DESCRIPTION
Page title defaults to Cardstack.

Card Pay page titles follow the tabs, omitting "Cardstack" from the title. These seem pretty long already!
- Card Balances · Card Pay
- Token Suppliers · Card Pay
- Merchant Services · Card Pay