### PR TITLE
web: Add balance refresh after prepaid issuance

### DIFF
--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/confirmation/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/confirmation/index.ts
@@ -1,11 +1,16 @@
 import Component from '@glimmer/component';
 import { next } from '@ember/runloop';
+import { inject as service } from '@ember/service';
 import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import Layer2Network from '@cardstack/web-client/services/layer2-network';
 
 export default class CardPayDepositWorkflowConfirmationComponent extends Component<WorkflowCardComponentArgs> {
+  @service declare layer2Network: Layer2Network;
+
   constructor(owner: unknown, args: WorkflowCardComponentArgs) {
     super(owner, args);
     next(this, () => {
+      this.layer2Network.refreshBalances();
       this.args.onComplete?.();
     });
   }

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -409,6 +409,8 @@ module('Acceptance | issue prepaid card', function (hooks) {
       );
     });
 
+    layer2Service.balancesRefreshed = false;
+
     // // preview card
     await click(
       `${postableSel(
@@ -481,6 +483,8 @@ module('Acceptance | issue prepaid card', function (hooks) {
     assert
       .dom(`${epiloguePostableSel(3)} [data-test-balance="DAI.CPXD"]`)
       .containsText('150.0');
+
+    assert.ok(layer2Service.balancesRefreshed);
 
     await waitFor(epiloguePostableSel(4));
 


### PR DESCRIPTION
Local screenshots from before and after issuance with this change:

<img width="606" alt="before-@cardstack:web-client 2021-07-26 17-00-39" src="https://user-images.githubusercontent.com/43280/127059327-fae0964a-e668-4834-8145-49036e03196c.png">

<img width="610" alt="after-@cardstack:web-client 2021-07-26 17-06-17" src="https://user-images.githubusercontent.com/43280/127059330-afeae146-b90d-40e9-a593-bfff6ceedf57.png">

This brings the prepaid card issuance workflow in line with the others, though I wonder whether it would be preferable to “freeze” the balance shown in the opening card with the value before the workflow has completed, as it seems strange that it changes when the operation has been completed. But that’s a UX concern outside the scope of this fix, as certainly one would expect the balance shown after the confirmation to be the new lower number.