### PR TITLE
Fix bn.js import path (part of Typescript fixes)

### DIFF
--- a/packages/web-client/app/utils/token.ts
+++ b/packages/web-client/app/utils/token.ts
@@ -3,7 +3,7 @@ import { ERC20ABI } from '@cardstack/cardpay-sdk/index.js';
 import { getAddressByNetwork, AddressKeys } from '@cardstack/cardpay-sdk';
 import { ChainAddress } from './web3-strategies/types';
 import { NetworkSymbol } from './web3-strategies/types';
-import BN from 'web3-core/node_modules/@types/bn.js';
+import BN from 'bn.js';
 
 // symbols
 export type ConvertibleSymbol = 'DAI' | 'CARD';


### PR DESCRIPTION
The main part of the web-client typescript fixes were committed directly to main by mistake https://github.com/cardstack/cardstack/commit/8d8f812662973fca7939a2bb4a83021aabac7fca