### PR TITLE
Update deposit source card and cover no-balance edge-case

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
@@ -19,9 +19,9 @@
               <CardPay::BalanceDisplay
                 @size="large"
                 @icon={{this.selectedToken.icon}}
-                @balance={{format-token-amount this.selectedTokenBalance}}
+                @balance={{format-token-amount this.selectedToken.balance}}
                 @symbol={{this.selectedToken.symbol}}
-                @usdBalance={{token-to-usd this.selectedToken.symbol this.selectedTokenBalance}}
+                @usdBalance={{token-to-usd this.selectedToken.symbol this.selectedToken.balance}}
                 data-test-deposit-transaction-setup-from-balance={{this.selectedToken.symbol}}
               />
             </:inner>
@@ -34,18 +34,15 @@
           />
           <div class="transaction-setup__field-info transaction-setup__radio-buttons">
             {{#each this.tokens as |token|}}
-              {{#let (if (eq token.symbol 'CARD') this.layer1Network.cardBalance this.layer1Network.daiBalance) as |balance|}}
-                <CardPay::DepositWorkflow::TransactionSetup::TokenOption
-                  @checked={{eq @workflowSession.state.depositSourceToken token.symbol}}
-                  @onInput={{fn this.chooseSource token.symbol}}
-                  @balance={{format-token-amount balance}}
-                  @balanceInUsd={{token-to-usd token.symbol balance}}
-                  @tokenSymbol={{token.symbol}}
-                  @tokenDescription={{token.description}}
-                  @tokenIcon={{token.icon}}
-                  data-test-deposit-transaction-setup-from-option={{token.symbol}}
-                />
-              {{/let}}
+              <CardPay::DepositWorkflow::TransactionSetup::TokenOption
+                @checked={{unless this.noTokenBalance (eq this.selectedToken.symbol token.symbol)}}
+                @onInput={{fn this.chooseSource token}}
+                @balance={{format-token-amount token.balance}}
+                @balanceInUsd={{token-to-usd token.symbol token.balance}}
+                @token={{token}}
+                @disabled={{eq (format-token-amount token.balance) "0.00"}}
+                data-test-deposit-transaction-setup-from-option={{token.symbol}}
+              />
             {{/each}}
           </div>
         {{/if}}
@@ -53,7 +50,7 @@
     </ActionCardContainer::Section>
     <ActionCardContainer::Section @title="Receive tokens">
       <CardPay::LabeledValue @label="In:" class="transaction-setup__field">
-        <CardPay::AccountDisplay @name={{concat (network-display-info "layer2" "fullName") " wallet"}} />
+        <CardPay::AccountDisplay @name={{concat (network-display-info "layer2" "fullName") " wallet"}} data-test-deposit-transaction-setup-to-wallet />
         <CardPay::NestedItems class="transaction-setup__field-info">
           <:outer>
             <CardPay::AccountDisplay
@@ -76,19 +73,27 @@
         </CardPay::NestedItems>
       </CardPay::LabeledValue>
     </ActionCardContainer::Section>
+    {{#if this.noTokenBalance}}
+      <CardPay::ErrorMessage data-test-deposit-transaction-setup-validation as |supportURL|>
+        You need DAI or CARD tokens to continue with this workflow.
+        <a href={{supportURL}} target="_blank" rel="noopener noreferrer">
+          Please request test tokens from Cardstack Discord.
+        </a>
+      </CardPay::ErrorMessage>
+    {{/if}}
   </ActionCardContainer::Section>
   <Boxel::ActionChin
     @state={{if @isComplete "memorialized" "default"}}
-    @disabled={{or @frozen (not @workflowSession.state.depositSourceToken)}}
+    @disabled={{or @frozen this.isCtaDisabled}}
     data-test-deposit-transaction-setup
   >
     <:default as |d|>
-      <d.ActionButton {{on "click" this.toggleComplete}}>
+      <d.ActionButton {{on "click" this.save}}>
         Continue
       </d.ActionButton>
     </:default>
     <:memorialized as |m|>
-      <m.ActionButton {{on "click" this.toggleComplete}}>
+      <m.ActionButton {{on "click" @onIncomplete}}>
         Edit
       </m.ActionButton>
     </:memorialized>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.css
@@ -9,15 +9,19 @@
   transition: box-shadow var(--boxel-transition);
 }
 
-.token-option:hover {
+.token-option:hover:not(.token-option--disabled) {
   box-shadow: 0 0 0 1px var(--boxel-dark);
 }
 
-.token-option--checked,
-.token-option:focus,
-.token-option:focus-within {
+.token-option--checked:not(.token-option--disabled),
+.token-option:focus:not(.token-option--disabled),
+.token-option:focus-within:not(.token-option--disabled) {
   box-shadow: 0 0 0 2px var(--boxel-highlight);
   outline: 1px solid transparent;
+}
+
+.token-option--disabled > * {
+  opacity: 0.5;
 }
 
 .token-option__input {
@@ -36,7 +40,11 @@
   border-width: 3px;
 }
 
-.token-option__input:focus {
+.token-option__input:disabled {
+  border-color: var(--boxel-purple-300);
+}
+
+.token-option__input:focus:not(:disabled) {
   outline: 1px solid transparent;
 }
 

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/token-option/index.hbs
@@ -1,28 +1,29 @@
-<label class={{cn "token-option" token-option--checked=@checked}} ...attributes>
+<label class={{cn "token-option" token-option--checked=@checked token-option--disabled=@disabled}} ...attributes>
   <Input
     name="deposit-token"
     class={{cn "token-option__input" token-option__input--checked=@checked}}
     @type="radio"
     @checked={{@checked}}
+    disabled={{@disabled}}
     {{on "input" @onInput}}
   />
   <div class="token-option__currency">
-    {{svg-jar @tokenIcon class="token-option__icon" role="presentation" width="40" height="40"}}
+    {{svg-jar @token.icon class="token-option__icon" role="presentation" width="40" height="40"}}
     <div>
-      <div class="token-option__title" data-test-option={{@tokenSymbol}}>
-        {{@tokenSymbol}}
+      <div class="token-option__title" data-test-option={{@token.symbol}}>
+        {{@token.symbol}}
       </div>
       <div class="token-option__desc">
-        {{@tokenDescription}}
+        {{@token.description}}
       </div>
     </div>
   </div>
   <div>
     <div class="token-option__balance-header">Balance</div>
-    <div class="token-option__balance" data-test-balance={{@tokenSymbol}}>
-      {{@balance}} {{@tokenSymbol}}
+    <div class="token-option__balance" data-test-balance={{@token.symbol}}>
+      {{@balance}} {{@token.symbol}}
     </div>
-    <div class="token-option__usd-balance" data-test-usd-balance={{@tokenSymbol}}>
+    <div class="token-option__usd-balance" data-test-usd-balance={{@token.symbol}}>
       {{#if @balanceInUsd}}
         ${{@balanceInUsd}} USD
       {{else}}

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/choose-balance/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/choose-balance/index.ts
@@ -71,8 +71,8 @@ class CardPayWithdrawalWorkflowChooseBalanceComponent extends Component<Workflow
         'withdrawalToken',
         this.selectedToken.symbol
       );
+      this.args.onComplete?.();
     }
-    this.args.onComplete?.();
   }
 }
 

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -147,54 +147,15 @@ module('Acceptance | deposit', function (hooks) {
 
     // transaction-setup card
     await waitFor(`${post} [data-test-balance="DAI"]`);
-    assert.dom(`${post} [data-test-balance="DAI"]`).containsText('250.50');
-    assert.dom(`${post} [data-test-usd-balance="DAI"]`).containsText('50.10');
-    assert.dom(`${post} [data-test-balance="CARD"]`).containsText('10000.00');
-    assert
-      .dom(`${post} [data-test-usd-balance="CARD"]`)
-      .containsText('2000.00');
-    assert
-      .dom(
-        `${post} [data-test-deposit-transaction-setup-from-address] [data-test-account-address]`
-      )
-      .hasText(layer1AccountAddress);
-    assert
-      .dom(
-        `${post} [data-test-deposit-transaction-setup-to-address] [data-test-account-address]`
-      )
-      .hasText('0x1826...6E44');
-    assert
-      .dom(
-        `${post} [data-test-deposit-transaction-setup-depot-address] [data-test-account-text]`
-      )
-      .hasText('New Depot');
-    assert
-      .dom('[data-test-deposit-transaction-setup-is-complete]')
-      .doesNotExist();
-    assert
-      .dom(`${post} [data-test-deposit-transaction-setup-from-option]`)
-      .exists({ count: 2 });
-    assert
-      .dom('[data-test-deposit-transaction-setup] [data-test-boxel-button]')
-      .isDisabled();
-    await click(`${post} [data-test-option="DAI"]`);
     await click(
       `${post} [data-test-deposit-transaction-setup] [data-test-boxel-button]`
     );
-    // transaction-setup card (memorialized)
-    assert.dom(`${post} [data-test-option]`).doesNotExist();
-    assert
-      .dom(`${post} [data-test-deposit-transaction-setup-from-option]`)
-      .doesNotExist();
-    assert
-      .dom('[data-test-deposit-transaction-setup] [data-test-boxel-button]')
-      .isNotDisabled();
-    assert.dom('[data-test-deposit-transaction-setup-is-complete]').exists();
     assert
       .dom(
         `${post} [data-test-deposit-transaction-setup-from-balance="DAI"] [data-test-balance-display-amount]`
       )
-      .containsText('250.50');
+      .hasText('250.50 DAI');
+
     // transaction-amount card
     assert
       .dom(postableSel(2, 2))

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-setup-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-setup-test.ts
@@ -1,0 +1,359 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
+import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
+import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
+import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
+import BN from 'bn.js';
+
+module(
+  'Integration | Component | card-pay/deposit-workflow/transaction-setup',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      let layer2Service = this.owner.lookup('service:layer2-network');
+      let layer2Strategy = layer2Service.strategy as Layer2TestWeb3Strategy;
+
+      // Simulate being connected on layer 2 -- prereq to converting to USD
+      let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
+      layer2Strategy.test__simulateAccountsChanged([layer2AccountAddress]);
+    });
+
+    test('incomplete card displays the correct data', async function (assert) {
+      const session = new WorkflowSession();
+      const layer1AccountAddress =
+        '0xaCD5f5534B756b856ae3B2CAcF54B3321dd6654Fb6';
+      const layer1Service = this.owner.lookup('service:layer1-network')
+        .strategy as Layer1TestWeb3Strategy;
+
+      layer1Service.test__simulateAccountsChanged(
+        [layer1AccountAddress],
+        'metamask'
+      );
+      layer1Service.test__simulateBalances({
+        defaultToken: new BN('2141100000000000000'),
+        dai: new BN('250500000000000000000'),
+        card: new BN('10000000000000000000000'),
+      });
+
+      this.setProperties({
+        session,
+      });
+
+      await render(hbs`
+          <CardPay::DepositWorkflow::TransactionSetup
+            @workflowSession={{this.session}}
+            @onComplete={{noop}}
+            @onIncomplete={{noop}}
+          />
+        `);
+
+      assert
+        .dom('[data-test-deposit-transaction-setup-is-complete]')
+        .doesNotExist();
+      assert
+        .dom(`[data-test-deposit-transaction-setup-from-option]`)
+        .exists({ count: 2 });
+      assert
+        .dom(
+          `[data-test-deposit-transaction-setup-from-address] [data-test-account-name]`
+        )
+        .hasText(`${c.layer1.fullName} wallet`);
+      assert
+        .dom(
+          `[data-test-deposit-transaction-setup-from-address] [data-test-account-address]`
+        )
+        .hasText(layer1AccountAddress);
+      assert.dom(`[data-test-balance="DAI"]`).hasText('250.50 DAI');
+      assert.dom(`[data-test-usd-balance="DAI"]`).hasText('$50.10 USD');
+      assert.dom(`[data-test-balance="CARD"]`).hasText('10000.00 CARD');
+      assert.dom(`[data-test-usd-balance="CARD"]`).hasText('$2000.00 USD');
+      assert
+        .dom(`[data-test-deposit-transaction-setup-to-wallet]`)
+        .hasText(`${c.layer2.fullName} wallet`);
+      assert
+        .dom(
+          `[data-test-deposit-transaction-setup-to-address] [data-test-account-address]`
+        )
+        .hasText('0x1826...6E44');
+      assert
+        .dom(
+          `[data-test-deposit-transaction-setup-depot-address] [data-test-account-text]`
+        )
+        .hasText('New Depot');
+    });
+
+    test('completed card displays the correct data', async function (assert) {
+      const session = new WorkflowSession();
+      const layer1AccountAddress =
+        '0xaCD5f5534B756b856ae3B2CAcF54B3321dd6654Fb6';
+      const layer1Service = this.owner.lookup('service:layer1-network')
+        .strategy as Layer1TestWeb3Strategy;
+
+      layer1Service.test__simulateAccountsChanged(
+        [layer1AccountAddress],
+        'metamask'
+      );
+      layer1Service.test__simulateBalances({
+        defaultToken: new BN('2141100000000000000'),
+        dai: new BN('250500000000000000000'),
+        card: new BN('10000000000000000000000'),
+      });
+
+      session.update('depositSourceToken', 'DAI');
+
+      this.setProperties({
+        session,
+        isComplete: true,
+      });
+
+      await render(hbs`
+          <CardPay::DepositWorkflow::TransactionSetup
+            @workflowSession={{this.session}}
+            @isComplete={{this.isComplete}}
+            @onComplete={{noop}}
+            @onIncomplete={{noop}}
+          />
+        `);
+
+      assert.dom('[data-test-deposit-transaction-setup-is-complete]').exists();
+      assert
+        .dom(`[data-test-deposit-transaction-setup-from-option]`)
+        .doesNotExist();
+      assert
+        .dom(
+          `[data-test-deposit-transaction-setup-from-address] [data-test-account-name]`
+        )
+        .hasText(`${c.layer1.fullName} wallet`);
+      assert
+        .dom(
+          `[data-test-deposit-transaction-setup-from-address] [data-test-account-address]`
+        )
+        .hasText(layer1AccountAddress);
+      assert
+        .dom(
+          '[data-test-deposit-transaction-setup-from-balance="DAI"] [data-test-balance-display-amount]'
+        )
+        .hasText('250.50 DAI');
+      assert
+        .dom(
+          '[data-test-deposit-transaction-setup-from-balance="DAI"] [data-test-balance-display-usd-amount]'
+        )
+        .hasText('$50.10 USD');
+      assert
+        .dom(`[data-test-deposit-transaction-setup-to-wallet]`)
+        .hasText(`${c.layer2.fullName} wallet`);
+      assert
+        .dom(
+          `[data-test-deposit-transaction-setup-to-address] [data-test-account-address]`
+        )
+        .hasText('0x1826...6E44');
+      assert
+        .dom(
+          `[data-test-deposit-transaction-setup-depot-address] [data-test-account-text]`
+        )
+        .hasText('New Depot');
+    });
+
+    test('interacting with the card', async function (assert) {
+      const session = new WorkflowSession();
+      const layer1Service = this.owner.lookup('service:layer1-network')
+        .strategy as Layer1TestWeb3Strategy;
+
+      layer1Service.test__simulateBalances({
+        defaultToken: new BN('2141100000000000000'),
+        dai: new BN('250500000000000000000'),
+        card: new BN('10000000000000000000000'),
+      });
+
+      this.setProperties({
+        onComplete: () => {
+          this.set('isComplete', true);
+        },
+        onIncomplete: () => {
+          this.set('isComplete', false);
+        },
+        isComplete: false,
+        session,
+      });
+
+      await render(hbs`
+          <CardPay::DepositWorkflow::TransactionSetup
+            @workflowSession={{this.session}}
+            @isComplete={{this.isComplete}}
+            @onComplete={{this.onComplete}}
+            @onIncomplete={{this.onIncomplete}}
+          />
+        `);
+
+      assert
+        .dom('[data-test-deposit-transaction-setup-is-complete]')
+        .doesNotExist();
+      assert
+        .dom(`[data-test-deposit-transaction-setup-from-option="DAI"]`)
+        .hasClass('token-option--checked');
+      assert
+        .dom(`[data-test-deposit-transaction-setup-from-option="CARD"]`)
+        .doesNotHaveClass('token-option--checked');
+      assert
+        .dom('[data-test-deposit-transaction-setup] [data-test-boxel-button]')
+        .hasText('Continue');
+      assert
+        .dom('[data-test-deposit-transaction-setup] [data-test-boxel-button]')
+        .isNotDisabled();
+
+      await click(
+        `[data-test-deposit-transaction-setup] [data-test-boxel-button]`
+      );
+      assert
+        .dom('[data-test-deposit-transaction-setup-from-balance="DAI"]')
+        .containsText('250.50 DAI');
+      assert
+        .dom('[data-test-deposit-transaction-setup-from-balance="CARD"]')
+        .doesNotExist();
+
+      await click(
+        `[data-test-deposit-transaction-setup] [data-test-boxel-button]`
+      );
+      assert
+        .dom('[data-test-deposit-transaction-setup-is-complete]')
+        .doesNotExist();
+      assert
+        .dom(`[data-test-deposit-transaction-setup-from-option]`)
+        .exists({ count: 2 });
+
+      await click(`[data-test-deposit-transaction-setup-from-option="CARD"]`);
+      assert
+        .dom(`[data-test-deposit-transaction-setup-from-option="CARD"]`)
+        .hasClass('token-option--checked');
+      assert
+        .dom(`[data-test-deposit-transaction-setup-from-option="DAI"]`)
+        .doesNotHaveClass('token-option--checked');
+
+      await click(
+        `[data-test-deposit-transaction-setup] [data-test-boxel-button]`
+      );
+      assert
+        .dom('[data-test-deposit-transaction-setup-from-balance="CARD"]')
+        .containsText('10000.00 CARD');
+      assert
+        .dom('[data-test-deposit-transaction-setup-from-balance="DAI"]')
+        .doesNotExist();
+    });
+
+    test('it displays validation message if user has 0 card and dai balances', async function (assert) {
+      const session = new WorkflowSession();
+      const layer1Service = this.owner.lookup('service:layer1-network')
+        .strategy as Layer1TestWeb3Strategy;
+      layer1Service.test__simulateBalances({
+        defaultToken: new BN('2141100000000000000'),
+        dai: new BN('0'),
+        card: new BN('0'),
+      });
+
+      this.setProperties({
+        session,
+      });
+
+      await render(hbs`
+          <CardPay::DepositWorkflow::TransactionSetup
+            @workflowSession={{this.session}}
+            @onComplete={{noop}}
+            @onIncomplete={{noop}}
+          />
+        `);
+
+      assert
+        .dom('[data-test-deposit-transaction-setup-from-option="DAI"] input')
+        .isDisabled();
+      assert
+        .dom('[data-test-deposit-transaction-setup-from-option="CARD"] input')
+        .isDisabled();
+      assert
+        .dom('[data-test-deposit-transaction-setup-validation]')
+        .containsText('You need DAI or CARD tokens');
+      assert
+        .dom('[data-test-deposit-transaction-setup] [data-test-boxel-button]')
+        .isDisabled();
+    });
+
+    test('it displays validation message if funds are undefined and 0', async function (assert) {
+      const session = new WorkflowSession();
+      const layer1Service = this.owner.lookup('service:layer1-network')
+        .strategy as Layer1TestWeb3Strategy;
+
+      layer1Service.test__simulateBalances({
+        defaultToken: undefined,
+        dai: undefined,
+        card: new BN('0'),
+      });
+
+      this.setProperties({
+        session,
+      });
+
+      await render(hbs`
+          <CardPay::DepositWorkflow::TransactionSetup
+            @workflowSession={{this.session}}
+            @onComplete={{noop}}
+            @onIncomplete={{noop}}
+          />
+        `);
+
+      assert
+        .dom('[data-test-deposit-transaction-setup-from-option="DAI"] input')
+        .isDisabled();
+      assert
+        .dom('[data-test-deposit-transaction-setup-from-option="CARD"] input')
+        .isDisabled();
+      assert.dom('[data-test-deposit-transaction-setup-validation]').exists();
+      assert
+        .dom('[data-test-deposit-transaction-setup] [data-test-boxel-button]')
+        .isDisabled();
+    });
+
+    test('it disables radio option with undefined balance', async function (assert) {
+      const session = new WorkflowSession();
+      const layer1Service = this.owner.lookup('service:layer1-network')
+        .strategy as Layer1TestWeb3Strategy;
+      layer1Service.test__simulateBalances({
+        defaultToken: new BN('2141100000000000000'),
+        dai: undefined,
+        card: new BN('10000000000000000000000'),
+      });
+
+      this.setProperties({
+        session,
+      });
+
+      await render(hbs`
+          <CardPay::DepositWorkflow::TransactionSetup
+            @workflowSession={{this.session}}
+            @onComplete={{noop}}
+            @onIncomplete={{noop}}
+          />
+        `);
+      assert
+        .dom('[data-test-deposit-transaction-setup-from-option="DAI"] input')
+        .isDisabled();
+      assert
+        .dom('[data-test-deposit-transaction-setup-from-option="DAI"]')
+        .doesNotHaveClass('token-option--checked');
+      assert
+        .dom('[data-test-deposit-transaction-setup-from-option="CARD"] input')
+        .isNotDisabled();
+      assert
+        .dom('[data-test-deposit-transaction-setup-from-option="CARD"]')
+        .hasClass('token-option--checked');
+      assert
+        .dom('[data-test-deposit-transaction-setup-validation]')
+        .doesNotExist();
+      assert
+        .dom('[data-test-deposit-transaction-setup] [data-test-boxel-button]')
+        .isNotDisabled();
+    });
+  }
+);


### PR DESCRIPTION
- Disable radio option if balance is 0 or undefined
- If neither option is selectable, disable CTA and display validation message (The wording for the message might change)
- CSS for disabled radio options
- Preselect DAI option if user has DAI balance
- Preselect CARD option if user has no DAI but has CARD balance
