### PR TITLE
Fix/network aware messages

### DIFF
--- a/packages/web-client/app/helpers/is-network-initialized.ts
+++ b/packages/web-client/app/helpers/is-network-initialized.ts
@@ -8,6 +8,8 @@ export default class IsNetworkInitializedHelper extends Helper {
   @service declare layer2Network: Layer2Network;
 
   compute() {
-    return !this.layer1Network.isInitializing;
+    return (
+      !this.layer1Network.isInitializing && !this.layer2Network.isInitializing
+    );
   }
 }

--- a/packages/web-client/app/helpers/is-network-initialized.ts
+++ b/packages/web-client/app/helpers/is-network-initialized.ts
@@ -1,0 +1,13 @@
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+import Layer1Network from '../services/layer1-network';
+import Layer2Network from '../services/layer2-network';
+
+export default class IsNetworkInitializedHelper extends Helper {
+  @service declare layer1Network: Layer1Network;
+  @service declare layer2Network: Layer2Network;
+
+  compute() {
+    return !this.layer1Network.isInitializing;
+  }
+}

--- a/packages/web-client/app/services/layer1-network.ts
+++ b/packages/web-client/app/services/layer1-network.ts
@@ -27,6 +27,7 @@ export default class Layer1Network
   implements Emitter<Layer1ChainEvent> {
   strategy!: Layer1Web3Strategy;
   simpleEmitter = new SimpleEmitter();
+  @reads('strategy.isInitializing') declare isInitializing: boolean;
   @reads('strategy.isConnected', false) isConnected!: boolean;
   @reads('strategy.walletConnectUri') walletConnectUri: string | undefined;
   @reads('strategy.walletInfo', new WalletInfo([], -1)) walletInfo!: WalletInfo;

--- a/packages/web-client/app/templates/card-pay/balances.hbs
+++ b/packages/web-client/app/templates/card-pay/balances.hbs
@@ -32,5 +32,7 @@
   @isOpen={{eq this.flow 'issue-prepaid-card'}}
   @onClose={{set this "flow" null}}
 >
+{{#if (is-network-initialized)}}
   <CardPay::IssuePrepaidCardWorkflow />
+{{/if}}
 </Boxel::Modal>

--- a/packages/web-client/app/templates/card-pay/token-suppliers.hbs
+++ b/packages/web-client/app/templates/card-pay/token-suppliers.hbs
@@ -25,10 +25,12 @@
   @isOpen={{or (eq this.flow 'deposit') (eq this.flow 'withdrawal')}}
   @onClose={{set this "flow" null}}
 >
+{{#if (is-network-initialized)}}
   {{#if (eq this.flow 'deposit')}}
     <CardPay::DepositWorkflow />
   {{/if}}
   {{#if (eq this.flow 'withdrawal')}}
     <CardPay::WithdrawalWorkflow />
   {{/if}}
+{{/if}}
 </Boxel::Modal>

--- a/packages/web-client/app/utils/web3-strategies/test-layer1.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer1.ts
@@ -23,6 +23,7 @@ interface ClaimBridgedTokensRequest {
 
 export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
   chainId = -1;
+  @tracked isInitializing = false;
   @tracked currentProviderId: string | undefined;
   @tracked walletConnectUri: string | undefined;
   @tracked walletInfo: WalletInfo = new WalletInfo([], -1);

--- a/packages/web-client/app/utils/web3-strategies/test-layer2.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer2.ts
@@ -23,6 +23,7 @@ import {
   UnbindEventListener,
   SimpleEmitter,
 } from '@cardstack/web-client/utils/events';
+import { task, TaskGenerator } from 'ember-concurrency';
 
 interface IssuePrepaidCardRequest {
   deferred: RSVP.Deferred<PrepaidCardSafe>;
@@ -49,6 +50,7 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
   @tracked defaultTokenBalance: BN | undefined;
   @tracked cardBalance: BN | undefined;
   @tracked depotSafe: DepotSafe | null = null;
+  @tracked isInitializing = false;
   issuePrepaidCardRequests: Map<number, IssuePrepaidCardRequest> = new Map();
 
   // property to test whether the refreshBalances method is called
@@ -56,7 +58,10 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
   // this is only a mock property
   @tracked balancesRefreshed = false;
 
-  async initialize() {}
+  @task *initializeTask(): TaskGenerator<void> {
+    yield '';
+    return;
+  }
 
   disconnect(): Promise<void> {
     this.test__simulateAccountsChanged([]);

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -36,6 +36,7 @@ export interface ClaimBridgedTokensOptions {
 export interface Layer1Web3Strategy
   extends Web3Strategy,
     Emitter<Layer1ChainEvent> {
+  isInitializing: boolean;
   isConnected: boolean;
   currentProviderId: string | undefined;
   defaultTokenBalance: BN | undefined;

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -9,6 +9,7 @@ import {
 } from '@cardstack/web-client/utils/token';
 import { Emitter } from '../events';
 import { BridgeValidationResult } from '@cardstack/cardpay-sdk/sdk/token-bridge-home-side';
+import { TaskGenerator } from 'ember-concurrency';
 
 export type Layer1ChainEvent =
   | 'disconnect'
@@ -61,12 +62,13 @@ export interface Layer1Web3Strategy
 export interface Layer2Web3Strategy
   extends Web3Strategy,
     Emitter<Layer2ChainEvent> {
+  isInitializing: boolean;
   isConnected: boolean;
   defaultTokenBalance: BN | undefined;
   cardBalance: BN | undefined;
   depotSafe: DepotSafe | null;
   walletConnectUri: string | undefined;
-  initialize(): Promise<void>;
+  initializeTask(): TaskGenerator<void>;
   updateUsdConverters(
     symbolsToUpdate: ConvertibleSymbol[]
   ): Promise<Record<ConvertibleSymbol, ConversionFunction>>;


### PR DESCRIPTION
This PR fixes CS-1107. We delay rendering of workflows until both layer 1 and layer 2 have either completed reconnection, or identified that they don't need to reconnect, ensuring that the correct messages are displayed each time.

This does raise design questions, as discussed with @lukemelia yesterday - what should we show during while the networks are reconnecting? I've left this to address in a separate PR.