### PR TITLE
User rejection identification

### DIFF
--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
@@ -76,6 +76,8 @@
           {{!-- TODO: "The balance required to create your desired prepaid card is ${}" --}}
         {{else if (eq this.error.message "TIMEOUT")}}
           There was a problem creating your prepaid card. Please contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a> to find out the status of your transaction.
+        {{else if (eq this.error.message "USER_REJECTION")}}
+          It looks like you have canceled the request in your wallet. Please try again if you want to continue with this workflow.
         {{else}}
           There was a problem creating your prepaid card. Please try again if you want to continue with this workflow, or contact  <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
         {{/if}}

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
@@ -12,6 +12,7 @@ import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { TransactionHash } from '@cardstack/web-client/utils/web3-strategies/types';
+import { isLayer2UserRejectionError } from '@cardstack/web-client/utils/is-user-rejection-error';
 
 // http://ember-concurrency.com/docs/typescript
 // infer whether we should treat the return of a yield statement as a promise
@@ -81,6 +82,8 @@ export default class CardPayDepositWorkflowPreviewComponent extends Component<Ca
         throw new Error('INSUFFICIENT_FUNDS');
       } else if (tookTooLong) {
         throw new Error('TIMEOUT');
+      } else if (isLayer2UserRejectionError(e)) {
+        throw new Error('USER_REJECTION');
       } else {
         // Basically, for pretty much everything we want to make the user retry or seek support
         throw e;

--- a/packages/web-client/app/utils/is-user-rejection-error.ts
+++ b/packages/web-client/app/utils/is-user-rejection-error.ts
@@ -1,0 +1,7 @@
+// this code is dependent on CardWallet providing the appropriate error message
+export function isLayer2UserRejectionError(error: {
+  message: string;
+  code?: number;
+}) {
+  return error.message === 'User rejected request';
+}


### PR DESCRIPTION
CS-1319

- Adds a utility that checks if an error's message matches the user rejection error message.
- Uses the utility in the prepaid card preview card (to be used in the withdrawal flow as well)

This code is dependent on CardWallet returning the correct error message. As such, we will not be able to use this for other wallets connected via WalletConnect on Layer 1.