### PR TITLE
set web client and boxel test ports to different values

### DIFF
--- a/packages/boxel/.ember-cli.js
+++ b/packages/boxel/.ember-cli.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 'use strict';
 
-process.env.EMBER_VERSION = "OCTANE";
+process.env.EMBER_VERSION = 'OCTANE';
 
 const { setEdition } = require('@ember/edition-utils');
 
@@ -14,5 +14,6 @@ module.exports = {
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
-  "disableAnalytics": false
-}
+  testPort: 7356,
+  disableAnalytics: false,
+};

--- a/packages/web-client/.ember-cli
+++ b/packages/web-client/.ember-cli
@@ -5,5 +5,6 @@
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
+  "testPort": 7357,
   "disableAnalytics": false
 }


### PR DESCRIPTION
This is so that running `yarn test` in the monorepo root will not fail because Boxel and Web Client both want to use port 7357. We could in addition (or as an alternative?) run tests in series, not parallel. I've found that running 2 ember test instances simultaneously can be very taxing on my laptop.