### PR TITLE
web: Add wallet navigation sidebar

### DIFF
--- a/packages/web-client/app/controllers/card-pay.ts
+++ b/packages/web-client/app/controllers/card-pay.ts
@@ -5,6 +5,7 @@ import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { tracked } from '@glimmer/tracking';
 import { currentNetworkDisplayInfo as c } from '../utils/web3-strategies/network-display-info';
+import { taskFor } from 'ember-concurrency-ts';
 
 interface ChainChangeModalOptions {
   title: string;
@@ -95,5 +96,11 @@ export default class CardPayController extends Controller {
 
   @action transitionTo(routeName: string) {
     this.transitionToRoute(routeName);
+  }
+
+  get prepaidCards() {
+    return taskFor(
+      this.layer2Network.viewSafes
+    ).lastSuccessful?.value?.filterBy('type', 'prepaid-card');
   }
 }

--- a/packages/web-client/app/controllers/card-pay.ts
+++ b/packages/web-client/app/controllers/card-pay.ts
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
 import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { tracked } from '@glimmer/tracking';
@@ -95,5 +96,51 @@ export default class CardPayController extends Controller {
 
   @action transitionTo(routeName: string) {
     this.transitionToRoute(routeName);
+  }
+
+  get sidebarSections() {
+    return [
+      {
+        title: 'Card Balances',
+        icon: 'tab-icon-card',
+        links: [
+          {
+            route: 'card-pay.balances',
+            title: 'Prepaid Cards',
+            content: pluralize(
+              this.layer2Network.prepaidCards?.length || 0,
+              'Card'
+            ),
+          },
+          {
+            route: 'boom',
+            title: 'Reward Cards',
+            content: '0 Cards',
+          },
+        ],
+      },
+      {
+        title: 'Merchant Services',
+        icon: 'tab-icon-merchant',
+        links: [
+          {
+            route: 'card-pay.merchant-services',
+            title: 'Merchant Name',
+            content: '0x1234...abcd',
+          },
+        ],
+      },
+      {
+        title: 'Token Suppliers',
+        icon: 'tab-icon-token',
+        links: [
+          {
+            route: 'card-pay.token-suppliers',
+            title: 'Depot X',
+            content: '0x1234....abcd',
+          },
+        ],
+      },
+    ];
   }
 }

--- a/packages/web-client/app/controllers/card-pay.ts
+++ b/packages/web-client/app/controllers/card-pay.ts
@@ -5,7 +5,6 @@ import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { tracked } from '@glimmer/tracking';
 import { currentNetworkDisplayInfo as c } from '../utils/web3-strategies/network-display-info';
-import { taskFor } from 'ember-concurrency-ts';
 
 interface ChainChangeModalOptions {
   title: string;
@@ -96,11 +95,5 @@ export default class CardPayController extends Controller {
 
   @action transitionTo(routeName: string) {
     this.transitionToRoute(routeName);
-  }
-
-  get prepaidCards() {
-    return taskFor(
-      this.layer2Network.viewSafes
-    ).lastSuccessful?.value?.filterBy('type', 'prepaid-card');
   }
 }

--- a/packages/web-client/app/controllers/card-pay/balances.ts
+++ b/packages/web-client/app/controllers/card-pay/balances.ts
@@ -2,19 +2,12 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
-import { taskFor } from 'ember-concurrency-ts';
 
 class CardPayBalancesController extends Controller {
   @service declare layer2Network: Layer2Network;
 
   queryParams = ['flow'];
   @tracked flow: 'deposit' | null = null;
-
-  get prepaidCards() {
-    return taskFor(
-      this.layer2Network.viewSafes
-    ).lastSuccessful?.value?.filterBy('type', 'prepaid-card');
-  }
 }
 
 export default CardPayBalancesController;

--- a/packages/web-client/app/css/card-pay.css
+++ b/packages/web-client/app/css/card-pay.css
@@ -57,22 +57,6 @@
   border-radius: var(--boxel-border-radius);
 }
 
-.card-pay-dashboard__sidebar-link.active {
-  background: var(--boxel-cyan);
-  color: var(--boxel-dark);
-}
-
 .card-pay-dashboard__sidebar-link .card-pay-dashboard__sidebar-link-header {
   font-weight: 600;
-}
-
-.card-pay-dashboard__sidebar-link .card-pay-dashboard__sidebar-link-icon {
-  opacity: 0;
-  margin-right: var(--boxel-sp);
-}
-
-.card-pay-dashboard__sidebar-link.active .card-pay-dashboard__sidebar-link-icon {
-  opacity: 1;
-
-  --icon-color: #000;
 }

--- a/packages/web-client/app/css/card-pay.css
+++ b/packages/web-client/app/css/card-pay.css
@@ -34,10 +34,14 @@
   min-width: 16rem;
 }
 
+.card-pay-dashboard__sidebar-account {
+  padding-bottom: var(--boxel-sp);
+  border-bottom: 1px solid #5f5d71;
+}
+
 .card-pay-dashboard__sidebar-section-header {
   display: flex;
   align-items: center;
-  border-top: 1px solid #5f5d71;
   padding-top: var(--boxel-sp);
   text-transform: uppercase;
   font: 600 var(--boxel-font-xs);

--- a/packages/web-client/app/css/card-pay.css
+++ b/packages/web-client/app/css/card-pay.css
@@ -34,6 +34,22 @@
   min-width: 16rem;
 }
 
+.card-pay-dashboard__sidebar-section-header {
+  display: flex;
+  align-items: center;
+  border-top: 1px solid #5f5d71;
+  padding-top: var(--boxel-sp);
+  text-transform: uppercase;
+  font: 600 var(--boxel-font-xs);
+  letter-spacing: var(--boxel-lsp-xxl);
+}
+
+.card-pay-dashboard__sidebar-section-icon {
+  margin-right: var(--boxel-sp-xs);
+
+  --icon-color: var(--boxel-light);
+}
+
 .card-pay-dashboard__sidebar-link {
   display: flex;
   align-items: flex-start;

--- a/packages/web-client/app/css/card-pay.css
+++ b/packages/web-client/app/css/card-pay.css
@@ -24,3 +24,39 @@
   padding: var(--boxel-sp-lg) 0;
   overflow-y: auto;
 }
+
+.card-pay-dashboard__body {
+  display: flex;
+}
+
+.card-pay-dashboard__sidebar {
+  padding: var(--boxel-sp-xxl) 0 0 var(--boxel-sp-xl);
+  min-width: 16rem;
+}
+
+.card-pay-dashboard__sidebar-link {
+  display: flex;
+  align-items: flex-start;
+  padding: var(--boxel-sp-sm);
+  border-radius: var(--boxel-border-radius);
+}
+
+.card-pay-dashboard__sidebar-link.active {
+  background: var(--boxel-cyan);
+  color: var(--boxel-dark);
+}
+
+.card-pay-dashboard__sidebar-link .card-pay-dashboard__sidebar-link-header {
+  font-weight: 600;
+}
+
+.card-pay-dashboard__sidebar-link .card-pay-dashboard__sidebar-link-icon {
+  opacity: 0;
+  margin-right: var(--boxel-sp);
+}
+
+.card-pay-dashboard__sidebar-link.active .card-pay-dashboard__sidebar-link-icon {
+  opacity: 1;
+
+  --icon-color: #000;
+}

--- a/packages/web-client/app/routes/card-pay.ts
+++ b/packages/web-client/app/routes/card-pay.ts
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+import '../css/card-pay.css';
+
+export default class CardPayRoute extends Route {}

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -99,6 +99,13 @@ export default class Layer2Network
     return yield this.strategy.viewSafes(account);
   }
 
+  get prepaidCards() {
+    return taskFor(this.viewSafes).lastSuccessful?.value?.filterBy(
+      'type',
+      'prepaid-card'
+    );
+  }
+
   @task *issuePrepaidCard(
     faceValue: number,
     customizationDid: string,

--- a/packages/web-client/app/templates/card-pay.hbs
+++ b/packages/web-client/app/templates/card-pay.hbs
@@ -32,7 +32,7 @@
             My Account: {{truncate-middle this.layer2Network.walletInfo.firstAddress}}
           </SidebarSection>
 
-          {{#if this.prepaidCards}}
+          {{#if this.layer2Network.prepaidCards}}
             <SidebarSection>
               <LinkTo class="card-pay-dashboard__sidebar-link" @route="card-pay.balances">
                 {{svg-jar "active-sidebar-link-triangle" class="card-pay-dashboard__sidebar-link-icon" width="15" height="15" role="presentation"}}
@@ -40,7 +40,7 @@
                   <div class="card-pay-dashboard__sidebar-link-header">
                     Prepaid Cards
                   </div>
-                  {{pluralize this.prepaidCards.length "Card"}}
+                  {{pluralize this.layer2Network.prepaidCards.length "Card"}}
                 </div>
               </LinkTo>
             </SidebarSection>

--- a/packages/web-client/app/templates/card-pay.hbs
+++ b/packages/web-client/app/templates/card-pay.hbs
@@ -25,7 +25,31 @@
   </:header>
 
   <:body>
-    {{outlet}}
+    <section class="card-pay-dashboard__body">
+      {{#if this.layer2Network.isConnected}}
+        <Boxel::Sidebar class="card-pay-dashboard__sidebar" data-test-wallet-sidebar as |SidebarSection|>
+          <SidebarSection>
+            My Account: {{truncate-middle this.layer2Network.walletInfo.firstAddress}}
+          </SidebarSection>
+
+          {{#if this.prepaidCards}}
+            <SidebarSection>
+              <LinkTo class="card-pay-dashboard__sidebar-link" @route="card-pay.balances">
+                {{svg-jar "active-sidebar-link-triangle" class="card-pay-dashboard__sidebar-link-icon" width="15" height="15" role="presentation"}}
+                <div>
+                  <div class="card-pay-dashboard__sidebar-link-header">
+                    Prepaid Cards
+                  </div>
+                  {{pluralize this.prepaidCards.length "Card"}}
+                </div>
+              </LinkTo>
+            </SidebarSection>
+          {{/if}}
+        </Boxel::Sidebar>
+      {{/if}}
+
+      {{outlet}}
+    </section>
   </:body>
 </Boxel::Dashboard>
 

--- a/packages/web-client/app/templates/card-pay.hbs
+++ b/packages/web-client/app/templates/card-pay.hbs
@@ -32,23 +32,25 @@
             My Account: {{truncate-middle this.layer2Network.walletInfo.firstAddress}}
           </SidebarSection>
 
-          {{#if this.layer2Network.prepaidCards}}
+          {{#each this.sidebarSections as |section|}}
             <SidebarSection>
               <h4 class="card-pay-dashboard__sidebar-section-header">
-                {{svg-jar "tab-icon-card" class="card-pay-dashboard__sidebar-section-icon" width="18" height="18" role="presentation"}}
-                Card Balances
+                {{svg-jar section.icon class="card-pay-dashboard__sidebar-section-icon" width="18" height="18" role="presentation"}}
+                {{section.title}}
               </h4>
-              <LinkTo class="card-pay-dashboard__sidebar-link" @route="card-pay.balances">
-                {{svg-jar "active-sidebar-link-triangle" class="card-pay-dashboard__sidebar-link-icon" width="15" height="15" role="presentation"}}
-                <div>
-                  <div class="card-pay-dashboard__sidebar-link-header">
-                    Prepaid Cards
+              {{#each section.links as |link|}}
+                <LinkTo class="card-pay-dashboard__sidebar-link" @route={{link.route}}>
+                  {{svg-jar "active-sidebar-link-triangle" class="card-pay-dashboard__sidebar-link-icon" width="15" height="15" role="presentation"}}
+                  <div>
+                    <div class="card-pay-dashboard__sidebar-link-header">
+                      {{link.title}}
+                    </div>
+                    {{link.content}}
                   </div>
-                  {{pluralize this.layer2Network.prepaidCards.length "Card"}}
-                </div>
-              </LinkTo>
+                </LinkTo>
+              {{/each}}
             </SidebarSection>
-          {{/if}}
+          {{/each}}
         </Boxel::Sidebar>
       {{/if}}
 

--- a/packages/web-client/app/templates/card-pay.hbs
+++ b/packages/web-client/app/templates/card-pay.hbs
@@ -34,6 +34,10 @@
 
           {{#if this.layer2Network.prepaidCards}}
             <SidebarSection>
+              <h4 class="card-pay-dashboard__sidebar-section-header">
+                {{svg-jar "tab-icon-card" class="card-pay-dashboard__sidebar-section-icon" width="18" height="18" role="presentation"}}
+                Card Balances
+              </h4>
               <LinkTo class="card-pay-dashboard__sidebar-link" @route="card-pay.balances">
                 {{svg-jar "active-sidebar-link-triangle" class="card-pay-dashboard__sidebar-link-icon" width="15" height="15" role="presentation"}}
                 <div>

--- a/packages/web-client/app/templates/card-pay.hbs
+++ b/packages/web-client/app/templates/card-pay.hbs
@@ -28,7 +28,7 @@
     <section class="card-pay-dashboard__body">
       {{#if this.layer2Network.isConnected}}
         <Boxel::Sidebar class="card-pay-dashboard__sidebar" data-test-wallet-sidebar as |SidebarSection|>
-          <SidebarSection>
+          <SidebarSection class="card-pay-dashboard__sidebar-account">
             My Account: {{truncate-middle this.layer2Network.walletInfo.firstAddress}}
           </SidebarSection>
 

--- a/packages/web-client/app/templates/card-pay.hbs
+++ b/packages/web-client/app/templates/card-pay.hbs
@@ -40,7 +40,6 @@
               </h4>
               {{#each section.links as |link|}}
                 <LinkTo class="card-pay-dashboard__sidebar-link" @route={{link.route}}>
-                  {{svg-jar "active-sidebar-link-triangle" class="card-pay-dashboard__sidebar-link-icon" width="15" height="15" role="presentation"}}
                   <div>
                     <div class="card-pay-dashboard__sidebar-link-header">
                       {{link.title}}

--- a/packages/web-client/app/templates/card-pay/balances.hbs
+++ b/packages/web-client/app/templates/card-pay/balances.hbs
@@ -33,12 +33,12 @@
       <aside class="card-pay-dashboard__balances" data-test-card-balances {{did-insert (perform this.layer2Network.viewSafes this.layer2Network.walletInfo.firstAddress)}}>
         <h3 class="card-pay-dashboard__balances-title">Card Balances</h3>
 
-        {{#if this.prepaidCards}}
+        {{#if this.layer2Network.prepaidCards}}
           <section class="card-pay-dashboard__balances-section">
             <header class="card-pay-dashboard__balances-section-header">
               <h4 class="card-pay-dashboard__balances-section-title">
                 Prepaid Cards
-                <span class="card-pay-dashboard__balances-count" data-test-prepaid-cards-count>{{this.prepaidCards.length}}</span>
+                <span class="card-pay-dashboard__balances-count" data-test-prepaid-cards-count>{{this.layer2Network.prepaidCards.length}}</span>
               </h4>
 
               {{#let @model.panel.sections.lastObject as |section|}}
@@ -59,7 +59,7 @@
             </header>
 
             <section class="card-pay-dashboard__balances-cards">
-              {{#each this.prepaidCards as |prepaidCard|}}
+              {{#each this.layer2Network.prepaidCards as |prepaidCard|}}
                 <CardPay::PrepaidCardSafe @safe={{prepaidCard}} />
               {{/each}}
             </section>

--- a/packages/web-client/public/images/icons/active-sidebar-link-triangle.svg
+++ b/packages/web-client/public/images/icons/active-sidebar-link-triangle.svg
@@ -1,1 +1,0 @@
-<svg height="7.262" viewBox="0 0 6.792 7.262" width="6.792" xmlns="http://www.w3.org/2000/svg"><path d="m9 11.262 4.792-2.631-4.792-2.631z" fill="var(--icon-color, #000)" stroke="var(--icon-color, #000)" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" transform="translate(-8 -5)"/></svg>

--- a/packages/web-client/public/images/icons/active-sidebar-link-triangle.svg
+++ b/packages/web-client/public/images/icons/active-sidebar-link-triangle.svg
@@ -1,0 +1,1 @@
+<svg height="7.262" viewBox="0 0 6.792 7.262" width="6.792" xmlns="http://www.w3.org/2000/svg"><path d="m9 11.262 4.792-2.631-4.792-2.631z" fill="var(--icon-color, #000)" stroke="var(--icon-color, #000)" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" transform="translate(-8 -5)"/></svg>

--- a/packages/web-client/tests/acceptance/wallet-sidebar-test.ts
+++ b/packages/web-client/tests/acceptance/wallet-sidebar-test.ts
@@ -1,0 +1,54 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+import { MirageTestContext } from 'ember-cli-mirage/test-support';
+
+interface Context extends MirageTestContext {}
+
+module('Acceptance | wallet sidebar', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('Sidebar is hidden when wallet is not connected', async function (assert) {
+    await visit('/card-pay');
+
+    assert.dom('[data-test-wallet-sidebar]').doesNotExist();
+  });
+
+  test('Sidebar shows counts and summaries when wallet is connected', async function (this: Context, assert) {
+    let layer2Service = this.owner.lookup('service:layer2-network')
+      .strategy as Layer2TestWeb3Strategy;
+
+    let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
+    layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
+
+    layer2Service.test__simulateAccountSafes(layer2AccountAddress, [
+      {
+        type: 'prepaid-card',
+
+        address: '0x123400000000000000000000000000000000abcd',
+
+        tokens: [],
+        owners: [layer2AccountAddress],
+
+        issuingToken: '0xTOKEN',
+        spendFaceValue: 2324,
+        prepaidCardOwner: layer2AccountAddress,
+        hasBeenUsed: false,
+        issuer: layer2AccountAddress,
+        reloadable: false,
+        transferrable: false,
+      },
+    ]);
+
+    await visit('/card-pay');
+
+    assert
+      .dom('[data-test-wallet-sidebar]')
+      .containsText('0x1826...6E44')
+      .containsText('1 Card');
+  });
+});


### PR DESCRIPTION
This is on hold because it’s almost all placeholders for now, but it shouldn’t be hard to bring back when it’s more useful:

![image](https://user-images.githubusercontent.com/43280/127684662-c64de083-d8a6-4059-8e7c-4407767e4fc0.png)

Some styling updates are still needed etc