### PR TITLE
Handle user rejection of withdrawal prompt

### DIFF
--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
@@ -51,9 +51,13 @@
         </CardPay::LabeledValue>
       {{/unless}}
     </div>
-    {{#if this.errorMessage}}
-      <CardPay::ErrorMessage as |supportURL|>
-        {{this.errorMessage}} Please try again if you want to continue with this workflow, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
+    {{#if this.error}}
+      <CardPay::ErrorMessage data-test-withdrawal-transaction-amount-error as |supportURL|>
+        {{#if (eq this.error.message "USER_REJECTION")}}
+          It looks like you have canceled the request in your wallet. Please try again if you want to continue with this workflow.
+        {{else}}
+          There was a problem initiating the withdrawal of your tokens from {{network-display-info "layer2" "fullName"}}. Please try again, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
+        {{/if}}
       </CardPay::ErrorMessage>
     {{/if}}
     <div class="withdrawal-transaction-amount__footnote" data-test-approximate-value-footnote>
@@ -67,7 +71,7 @@
   >
     <:default as |d|>
       <d.ActionButton {{on "click" this.withdraw}}>
-        Withdraw
+        {{if this.error "Try Again" "Withdraw"}}
       </d.ActionButton>
     </:default>
     <:in-progress as |i|>


### PR DESCRIPTION
CS-1316

So it turns out the more granular error messages (insufficient funds, timeout, etc) do not appear until the relayTokens function is called, which is after this card in the status card. So here I'm handling the user rejection of confirmation prompt and have a default error message for anything else. 

I have updated the UI so that if there's an error, the card is not stuck in the in-progress state and goes back to the default state with a Try Again button.

Any input under 0.5 DAI fails, however, so I'm wondering if our minimum for input validation should be 0.5 and above instead of greater than 0? The only error message returned is from the gas estimation function, something like `Error: { exception: CannotEstimateGas: 0x0 }` which turns out to be a sort of generic message, not just for insufficient balance. I'm also not sure if 0.5 is always the minimum, I wonder if this fluctuates.