### PR TITLE
Enhancement/prepaid card preview UI

### DIFF
--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
@@ -94,7 +94,7 @@
         {{on "click" this.issuePrepaidCard}}
         data-test-issue-prepaid-card-button
       >
-        {{if this.hasTriedCreatingPrepaidCard "Retry" "Create"}}
+        {{if this.hasTriedCreatingPrepaidCard "Try Again" "Create"}}
       </d.ActionButton>
     </:default>
     <:in-progress as |i|>

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
@@ -80,7 +80,7 @@
         {{else if (eq this.error.message "USER_REJECTION")}}
           It looks like you have canceled the request in your wallet. Please try again if you want to continue with this workflow.
         {{else}}
-          There was a problem creating your prepaid card. Please try again if you want to continue with this workflow, or contact  <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
+          There was a problem creating your prepaid card. This may be due to a network issue, or perhaps you canceled the request in your wallet. Please try again if you want to continue with this workflow, or contact  <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
         {{/if}}
         </CardPay::ErrorMessage>
     {{/if}}

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
@@ -94,7 +94,7 @@
         {{on "click" this.issuePrepaidCard}}
         data-test-issue-prepaid-card-button
       >
-        Continue
+        {{if this.hasTriedCreatingPrepaidCard "Retry" "Create"}}
       </d.ActionButton>
     </:default>
     <:in-progress as |i|>

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
@@ -99,6 +99,10 @@ export default class CardPayPrepaidCardWorkflowPreviewComponent extends Componen
     }
   }
 
+  get hasTriedCreatingPrepaidCard() {
+    return taskFor(this.issueTask).performCount > 0;
+  }
+
   get txViewerUrl() {
     return this.txHash && this.layer2Network.blockExplorerUrl(this.txHash);
   }

--- a/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
@@ -88,7 +88,7 @@ module(
         await waitFor('[data-test-issue-prepaid-card-error-message]');
         assert
           .dom('[data-test-issue-prepaid-card-button]')
-          .containsText('Retry');
+          .containsText('Try Again');
       });
       test('It shows the correct error message for a user rejection', async function (assert) {
         sinon

--- a/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
@@ -74,6 +74,22 @@ module(
     });
 
     module('Test the sdk prepaid card creation calls', async function () {
+      test('It shows the correct text in the creation button in the beginning and after errors', async function (assert) {
+        sinon
+          .stub(layer2Service, 'issuePrepaidCard')
+          .throws(new Error('An arbitrary error'));
+
+        assert
+          .dom('[data-test-issue-prepaid-card-button]')
+          .containsText('Create');
+
+        await click('[data-test-issue-prepaid-card-button]');
+
+        await waitFor('[data-test-issue-prepaid-card-error-message]');
+        assert
+          .dom('[data-test-issue-prepaid-card-button]')
+          .containsText('Retry');
+      });
       test('It shows the correct error message for a user rejection', async function (assert) {
         sinon
           .stub(layer2Service, 'issuePrepaidCard')

--- a/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
@@ -19,7 +19,7 @@ const TIMEOUT_ERROR_MESSAGE =
   'There was a problem creating your prepaid card. Please contact Cardstack support to find out the status of your transaction.';
 const INSUFFICIENT_FUNDS_ERROR_MESSAGE = `Looks like there's no balance in your ${c.layer2.fullName} wallet to fund your selected prepaid card. Before you can continue, please add funds to your ${c.layer2.fullName} wallet by bridging some tokens from your ${c.layer1.fullName} wallet.`;
 const DEFAULT_ERROR_MESSAGE =
-  'There was a problem creating your prepaid card. Please try again if you want to continue with this workflow, or contact Cardstack support.';
+  'There was a problem creating your prepaid card. This may be due to a network issue, or perhaps you canceled the request in your wallet. Please try again if you want to continue with this workflow, or contact Cardstack support.';
 
 interface Context extends MirageTestContext {}
 


### PR DESCRIPTION
CS-1413

Updated prepaid card creation button text to read Create (previously Continue), and Retry after unsuccessful tries. Default error text is also updated.

![Updated default state of the prepaid card creation card](https://user-images.githubusercontent.com/39579264/127659289-03014098-9aec-4533-8711-52c9c3900327.png)

![Updated error state of the prepaid card creation card](https://user-images.githubusercontent.com/39579264/127660322-59e0ed6c-619c-4590-948b-0b8693dbbec4.png)