### PR TITLE
web: Add prepaid listing refresh after creation

### DIFF
--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -114,6 +114,9 @@ export default class Layer2Network
       customizationDid,
       options
     );
+
+    taskFor(this.viewSafes).perform(this.walletInfo.firstAddress!);
+
     return address;
   }
 

--- a/packages/web-client/app/utils/web3-strategies/test-layer2.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer2.ts
@@ -271,6 +271,9 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
       ...options,
     };
     request?.onTxHash?.('exampleTxHash');
+
+    this.test__simulateAccountSafes(walletAddress, [prepaidCardSafe]);
+
     return request?.deferred.resolve(prepaidCardSafe);
   }
 

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -105,6 +105,27 @@ module('Acceptance | issue prepaid card', function (hooks) {
       defaultToken: SLIGHTLY_LESS_THAN_MAX_VALUE,
       card: new BN('250000000000000000000'),
     });
+
+    layer2Service.test__simulateAccountSafes(layer2AccountAddress, [
+      {
+        type: 'prepaid-card',
+        createdAt: Date.now() / 1000,
+
+        address: '0x123400000000000000000000000000000000abcd',
+
+        tokens: [],
+        owners: [layer2AccountAddress],
+
+        issuingToken: '0xTOKEN',
+        spendFaceValue: 2324,
+        prepaidCardOwner: layer2AccountAddress,
+        hasBeenUsed: false,
+        issuer: layer2AccountAddress,
+        reloadable: false,
+        transferrable: false,
+      },
+    ]);
+
     let depotAddress = '0xB236ca8DbAB0644ffCD32518eBF4924ba8666666';
     let testDepot = {
       address: depotAddress,
@@ -135,6 +156,8 @@ module('Acceptance | issue prepaid card', function (hooks) {
       .isVisible();
 
     await settled();
+
+    assert.dom('[data-test-prepaid-cards-count]').containsText('1');
 
     assert
       .dom(milestoneCompletedSel(0))
@@ -490,6 +513,8 @@ module('Acceptance | issue prepaid card', function (hooks) {
       )} [data-test-issue-prepaid-card-next-step="dashboard"]`
     );
     assert.dom('[data-test-workflow-thread]').doesNotExist();
+
+    assert.dom('[data-test-prepaid-cards-count]').containsText('2');
   });
 
   // test('Initiating workflow with layer 2 wallet already connected', async function (assert) {


### PR DESCRIPTION
To reproduce the SDK behaviour where `Safe.viewSafes` will return a new `PrepaidCard.create`,
this makes the test strategy store the newly-created `PrepaidCardSafe` in the same map that
`test__simulateAccountSafes` uses.

Here it is in action:

![screencast 2021-07-30 10-26-45](https://user-images.githubusercontent.com/43280/127699666-2ba34a81-cbe3-4dae-b33c-99608a88603a.gif)
