### PR TITLE
Update to token bridging to layer1

### DIFF
--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { inject as service } from '@ember/service';
 import BN from 'bn.js';
@@ -20,6 +21,7 @@ import {
 } from '@cardstack/web-client/utils/validation';
 
 class CardPayWithdrawalWorkflowTransactionAmountComponent extends Component<WorkflowCardComponentArgs> {
+  @service declare layer1Network: Layer1Network;
   @service declare layer2Network: Layer2Network;
   @tracked amount = '';
   @tracked amountIsValid = false;
@@ -114,6 +116,7 @@ class CardPayWithdrawalWorkflowTransactionAmountComponent extends Component<Work
       return;
     }
     try {
+      let layer1Address = this.layer1Network.walletInfo.firstAddress;
       this.isConfirmed = true;
       let { currentTokenSymbol } = this;
       let withdrawnAmount = this.amountAsBigNumber.toString();
@@ -122,6 +125,7 @@ class CardPayWithdrawalWorkflowTransactionAmountComponent extends Component<Work
 
       let transactionHash = await this.layer2Network.bridgeToLayer1(
         this.layer2Network.depotSafe?.address!,
+        layer1Address!,
         getUnbridgedSymbol(currentTokenSymbol),
         withdrawnAmount
       );

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -155,10 +155,16 @@ export default class Layer2Network
 
   async bridgeToLayer1(
     safeAddress: string,
+    receiverAddress: string,
     tokenSymbol: BridgeableSymbol,
     amount: string
   ): Promise<TransactionHash> {
-    return this.strategy.bridgeToLayer1(safeAddress, tokenSymbol, amount);
+    return this.strategy.bridgeToLayer1(
+      safeAddress,
+      receiverAddress,
+      tokenSymbol,
+      amount
+    );
   }
 
   async awaitBridgedToLayer1(fromBlock: BN, transactionHash: TransactionHash) {

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -272,13 +272,13 @@ export default abstract class Layer2ChainWeb3Strategy
 
   async bridgeToLayer1(
     safeAddress: string,
+    receiverAddress: string,
     tokenSymbol: BridgeableSymbol,
     amountInWei: string
   ): Promise<TransactionHash> {
     let tokenBridge = await getSDK('TokenBridgeHomeSide', this.web3);
     let tokenAddress = new TokenContractInfo(tokenSymbol, this.networkSymbol)!
       .address;
-    let receiverAddress = this.walletInfo.firstAddress!;
 
     let result = await tokenBridge.relayTokens(
       safeAddress,

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -84,6 +84,7 @@ export interface Layer2Web3Strategy
   ): Promise<TransactionReceipt>;
   bridgeToLayer1(
     safeAddress: string,
+    receiverAddress: string,
     tokenSymbol: BridgeableSymbol,
     amountInWei: string
   ): Promise<TransactionHash>;


### PR DESCRIPTION
When withdrawing tokens, I was stuck in the roach motel. The funds were taken from my depot, but I didn't receive them in my Kovan wallet after the claiming step. In Etherscan, my Sokol wallet appeared as the `receiverAddress` instead of my Kovan wallet. When I made the changes in this PR, though, now everything works as expected. I changed the `receiverAddress` to be the Layer1 wallet address instead of Layer2. Does this look right? The existing withdrawal and claiming work for Luke, so ¯\_(ツ)_/¯