### PR TITLE
web: Add deposit transaction-viewing URL when available

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -71,6 +71,13 @@
       <i.ActionButton data-test-unlock-button>
         Unlocking
       </i.ActionButton>
+      {{#if this.unlockTxnViewerUrl}}
+        <i.InfoArea>
+          <Boxel::Button @as="anchor" @kind="secondary-dark" @size="extra-small" @href={{this.unlockTxnViewerUrl}} target="_blank" rel="noopener" data-test-unlock-etherscan-button>
+            View on Etherscan
+          </Boxel::Button>
+        </i.InfoArea>
+      {{/if}}
     </:in-progress>
     <:memorialized as |m|>
       <m.ActionStatusArea data-test-unlock-success-message>
@@ -78,7 +85,7 @@
       </m.ActionStatusArea>
       {{#if this.unlockTxnViewerUrl}}
       <m.InfoArea>
-        <Boxel::Button @as="anchor" @size="extra-small" @href={{this.unlockTxnViewerUrl}} target="_blank" rel="noopener">
+        <Boxel::Button @as="anchor" @size="extra-small" @href={{this.unlockTxnViewerUrl}} target="_blank" rel="noopener" data-test-unlock-etherscan-button>
           View on Etherscan
         </Boxel::Button>
       </m.InfoArea>
@@ -100,6 +107,13 @@
       <i.ActionButton data-test-deposit-button>
         Depositing
       </i.ActionButton>
+      {{#if this.depositTxnViewerUrl}}
+        <i.InfoArea>
+          <Boxel::Button @as="anchor" @kind="secondary-dark" @size="extra-small" @href={{this.depositTxnViewerUrl}} target="_blank" rel="noopener" data-test-deposit-etherscan-button>
+            View on Etherscan
+          </Boxel::Button>
+        </i.InfoArea>
+      {{/if}}
     </:in-progress>
     <:memorialized as |m|>
       <m.ActionStatusArea data-test-deposit-success-message>
@@ -107,7 +121,7 @@
       </m.ActionStatusArea>
       {{#if this.depositTxnViewerUrl}}
       <m.InfoArea>
-        <Boxel::Button @as="anchor" @size="extra-small" @href={{this.depositTxnViewerUrl}} target="_blank" rel="noopener">
+        <Boxel::Button @as="anchor" @size="extra-small" @href={{this.depositTxnViewerUrl}} target="_blank" rel="noopener" data-test-deposit-etherscan-button>
           View on Etherscan
         </Boxel::Button>
       </m.InfoArea>

--- a/packages/web-client/app/services/layer1-network.ts
+++ b/packages/web-client/app/services/layer1-network.ts
@@ -4,6 +4,7 @@ import {
   ClaimBridgedTokensOptions,
   Layer1ChainEvent,
   Layer1Web3Strategy,
+  TransactionHash,
 } from '../utils/web3-strategies/types';
 import Layer1TestWeb3Strategy from '../utils/web3-strategies/test-layer1';
 import EthWeb3Strategy from '../utils/web3-strategies/ethereum';
@@ -83,21 +84,26 @@ export default class Layer1Network
 
   @task *approve(
     amount: BN,
-    tokenSymbol: string
+    tokenSymbol: string,
+    onTxHash: (txHash: TransactionHash) => void
   ): TaskGenerator<TransactionReceipt> {
-    let txnReceipt = yield this.strategy.approve(amount, tokenSymbol);
+    let txnReceipt = yield this.strategy.approve(amount, tokenSymbol, {
+      onTxHash,
+    });
     return txnReceipt;
   }
 
   @task *relayTokens(
     tokenSymbol: string,
     destinationAddress: string,
-    amount: BN
+    amount: BN,
+    onTxHash: (txHash: TransactionHash) => void
   ): TaskGenerator<TransactionReceipt> {
     let txnReceipt = yield this.strategy.relayTokens(
       tokenSymbol,
       destinationAddress,
-      amount
+      amount,
+      { onTxHash }
     );
     yield this.strategy.refreshBalances();
     return txnReceipt;

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -10,11 +10,13 @@ import { BridgeableSymbol, TokenContractInfo } from '../token';
 import WalletInfo from '../wallet-info';
 import { WalletProvider } from '../wallet-providers';
 import {
+  ApproveOptions,
   Layer1ChainEvent,
   Layer1Web3Strategy,
   TransactionHash,
   Layer1NetworkSymbol,
   ClaimBridgedTokensOptions,
+  RelayTokensOptions,
 } from './types';
 import {
   BridgeValidationResult,
@@ -246,27 +248,31 @@ export default abstract class Layer1ChainWeb3Strategy
 
   async approve(
     amountInWei: BN,
-    tokenSymbol: BridgeableSymbol
+    tokenSymbol: BridgeableSymbol,
+    { onTxHash }: ApproveOptions
   ): Promise<TransactionReceipt> {
     if (!this.web3) throw new Error('Cannot unlock tokens without web3');
     let tokenBridge = await getSDK('TokenBridgeForeignSide', this.web3);
     return tokenBridge.unlockTokens(
       new TokenContractInfo(tokenSymbol, this.networkSymbol).address,
-      amountInWei.toString()
+      amountInWei.toString(),
+      onTxHash
     );
   }
 
   async relayTokens(
     tokenSymbol: BridgeableSymbol,
     receiverAddress: string,
-    amountInWei: BN
+    amountInWei: BN,
+    { onTxHash }: RelayTokensOptions
   ): Promise<TransactionReceipt> {
     if (!this.web3) throw new Error('Cannot relay tokens without web3');
     let tokenBridge = await getSDK('TokenBridgeForeignSide', this.web3);
     return tokenBridge.relayTokens(
       new TokenContractInfo(tokenSymbol, this.networkSymbol).address,
       receiverAddress,
-      amountInWei.toString()
+      amountInWei.toString(),
+      onTxHash
     );
   }
 

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -30,6 +30,14 @@ export interface Web3Strategy {
   bridgeExplorerUrl(txnHash: TransactionHash): string;
 }
 
+export interface ApproveOptions {
+  onTxHash?(txHash: TransactionHash): void;
+}
+
+export interface RelayTokensOptions {
+  onTxHash?(txHash: TransactionHash): void;
+}
+
 export interface IssuePrepaidCardOptions {
   onTxHash?(txHash: TransactionHash): void;
 }
@@ -50,11 +58,16 @@ export interface Layer1Web3Strategy
   refreshBalances(): void;
   connect(walletProvider: WalletProvider): Promise<void>;
   waitForAccount: Promise<void>;
-  approve(amountInWei: BN, token: string): Promise<TransactionReceipt>;
+  approve(
+    amountInWei: BN,
+    token: string,
+    options?: ApproveOptions
+  ): Promise<TransactionReceipt>;
   relayTokens(
     token: ChainAddress,
     destinationAddress: ChainAddress,
-    amountInWei: BN
+    amountInWei: BN,
+    options?: RelayTokensOptions
   ): Promise<TransactionReceipt>;
   blockExplorerUrl(txnHash: TransactionHash): string;
   claimBridgedTokens(

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -187,6 +187,13 @@ module('Acceptance | deposit', function (hooks) {
 
     assert.dom('[data-test-deposit-amount-entered]').containsText('250.00 DAI');
 
+    assert.dom(`${post} [data-test-unlock-etherscan-button]`).doesNotExist();
+
+    layer1Service.test__simulateUnlockTxHash();
+    await settled();
+
+    assert.dom(`${post} [data-test-unlock-etherscan-button]`).exists();
+
     layer1Service.test__simulateUnlock();
     await settled();
 
@@ -207,6 +214,13 @@ module('Acceptance | deposit', function (hooks) {
     assert
       .dom(`${post} [data-test-deposit-button]`)
       .hasClass('boxel-button--loading');
+
+    assert.dom(`${post} [data-test-deposit-etherscan-button]`).doesNotExist();
+
+    layer1Service.test__simulateDepositTxHash();
+    await settled();
+
+    assert.dom(`${post} [data-test-deposit-etherscan-button]`).exists();
 
     layer1Service.test__simulateDeposit();
     await settled();

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
@@ -94,7 +94,7 @@ module(
       await click('[data-test-unlock-button]');
 
       assert.ok(
-        approveSpy.calledOnceWith(new BN(daiToSendInWei), 'DAI'),
+        approveSpy.calledWith(new BN(daiToSendInWei), 'DAI'),
         'The amount that the approve call is made with matches the amount shown in the UI'
       );
     });


### PR DESCRIPTION
Here it is with manual pauses, as it can otherwise be too fast to catch:

![screencast 2021-08-03 13-06-18](https://user-images.githubusercontent.com/43280/128082106-5608ffb6-0273-4cd4-a247-b8083d2d4a92.gif)

Code to produce a pause for manual testing:

![image](https://user-images.githubusercontent.com/43280/127723782-9e33f476-8b2c-4b55-9aa5-d97a7c3c6563.png)