### PR TITLE
add error message to token bridge/transaction status card

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.hbs
@@ -36,7 +36,7 @@
             <Boxel::Button @as="anchor" @size="extra-small" @href={{this.blockscoutUrl}} target="_blank" rel="noopener" data-test-blockscout-button>
               View on Blockscout
             </Boxel::Button>
-          {{else if this.errored }}
+          {{else if this.errored}}
             Failed
           {{else}}
             Processing...

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.hbs
@@ -36,11 +36,18 @@
             <Boxel::Button @as="anchor" @size="extra-small" @href={{this.blockscoutUrl}} target="_blank" rel="noopener" data-test-blockscout-button>
               View on Blockscout
             </Boxel::Button>
+          {{else if this.errored }}
+            Failed
           {{else}}
             Processing...
           {{/if}}
         {{/if}}
       </span>
     </Boxel::ProgressSteps>
+    {{#if this.errored}}
+      <CardPay::ErrorMessage as |supportURL|>
+        There was a problem completing the bridging of your tokens to {{network-display-info "layer2" "fullName"}}. Please contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a> so that we can investigate and resolve this issue for you.
+      </CardPay::ErrorMessage>
+    {{/if}}
   </ActionCardContainer::Section>
 </ActionCardContainer>


### PR DESCRIPTION
CS-896

This error message is to be shown when minting of tokens fails, would be good to have specific UI for a failed progress step, but we can probably leave that for later. If this is ok, will do the same for the withdrawal flow.

![image](https://user-images.githubusercontent.com/39579264/127989178-136019a8-52f9-438f-8648-f435b6695903.png)
