### PR TITLE
Add Sentry to hub server and worker

### DIFF
--- a/packages/hub/config/custom-environment-variables.json
+++ b/packages/hub/config/custom-environment-variables.json
@@ -12,5 +12,9 @@
   "db": {
     "url": "DATABASE_URL"
   },
+  "sentry": {
+    "dsn": "HUB_SENTRY_DSN",
+    "environment": "HUB_ENVIRONMENT"
+  },
   "serverSecret": "SERVER_SECRET"
 }

--- a/packages/hub/config/default.json
+++ b/packages/hub/config/default.json
@@ -21,5 +21,10 @@
     "migration-filename-format": "utc",
     "ignore-pattern": "README.md|.*\\.ts|.*\\.js\\.map"
   },
-  "serverSecret": null
+  "serverSecret": null,
+  "sentry": {
+    "dsn": null,
+    "enabled": false,
+    "environment": null
+  }
 }

--- a/packages/hub/config/production.json
+++ b/packages/hub/config/production.json
@@ -1,5 +1,8 @@
 {
   "aws": {
     "accountId": "120317779495"
+  },
+  "sentry": {
+    "enabled": true
   }
 }

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -15,6 +15,7 @@
     "@cardstack/did-resolver": "0.19.44",
     "@cardstack/logger": "^0.2.1",
     "@graphile/logger": "^0.2.0",
+    "@sentry/node": "^6.10.0",
     "@types/fs-extra": "^9.0.11",
     "@types/koa": "^2.13.1",
     "@types/koa-route": "^3.2.4",

--- a/packages/hub/routes/boom.ts
+++ b/packages/hub/routes/boom.ts
@@ -1,0 +1,45 @@
+import Koa from 'koa';
+import { inject } from '../di/dependency-injection';
+import { AuthenticationUtils } from '../utils/authentication';
+import packageJson from '../package.json';
+import autoBind from 'auto-bind';
+import * as Sentry from '@sentry/node';
+
+export default class BoomRoute {
+  authenticationUtils: AuthenticationUtils = inject('authentication-utils', { as: 'authenticationUtils' });
+  constructor() {
+    autoBind(this);
+  }
+
+  get(ctx: Koa.Context) {
+    if (ctx.state.userAddress) {
+      Sentry.setUser({
+        userAddress: ctx.state.userAddress,
+      });
+    } else {
+      Sentry.setUser({
+        userAddress: null,
+      });
+    }
+    ctx.status = 500;
+    ctx.body = {
+      errors: [
+        {
+          meta: {
+            version: packageJson.version,
+          },
+          status: '500',
+          title: 'This endpoint fails intentionally',
+        },
+      ],
+    };
+    ctx.type = 'application/vnd.api+json';
+    throw new Error('Boom route fails intentionally');
+  }
+}
+
+declare module '@cardstack/hub/di/dependency-injection' {
+  interface KnownServices {
+    'boom-route': BoomRoute;
+  }
+}

--- a/packages/hub/services/jsonapi-middleware.ts
+++ b/packages/hub/services/jsonapi-middleware.ts
@@ -7,6 +7,7 @@ import KoaBody from 'koa-body';
 import { Memoize } from 'typescript-memoize';
 import { CardstackError } from '../utils/error';
 import { SessionContext } from './authentication-middleware';
+import BoomRoute from '../routes/boom';
 import SessionRoute from '../routes/session';
 import PrepaidCardColorSchemesRoute from '../routes/prepaid-card-color-schemes';
 import PrepaidCardPatternsRoute from '../routes/prepaid-card-patterns';
@@ -17,6 +18,7 @@ const API_PREFIX = '/api';
 const apiPrefixPattern = new RegExp(`^${API_PREFIX}/(.*)`);
 
 export default class JSONAPIMiddleware {
+  boomRoute: BoomRoute = inject('boom-route', { as: 'boomRoute' });
   sessionRoute: SessionRoute = inject('session-route', { as: 'sessionRoute' });
   prepaidCardColorSchemesRoute: PrepaidCardColorSchemesRoute = inject('prepaid-card-color-schemes-route', {
     as: 'prepaidCardColorSchemesRoute',
@@ -55,11 +57,18 @@ export default class JSONAPIMiddleware {
         throw new CardstackError(`error while parsing body: ${error.message}`, { status: 400 });
       },
     });
-    let { prepaidCardColorSchemesRoute, prepaidCardPatternsRoute, prepaidCardCustomizationsRoute, sessionRoute } = this;
+    let {
+      boomRoute,
+      prepaidCardColorSchemesRoute,
+      prepaidCardPatternsRoute,
+      prepaidCardCustomizationsRoute,
+      sessionRoute,
+    } = this;
 
     return compose([
       CardstackError.withJsonErrorHandling,
       body,
+      route.get('/boom', boomRoute.get),
       route.get('/session', sessionRoute.get),
       route.post('/session', sessionRoute.post),
       route.get('/prepaid-card-color-schemes', prepaidCardColorSchemesRoute.get),

--- a/packages/hub/services/jsonapi-middleware.ts
+++ b/packages/hub/services/jsonapi-middleware.ts
@@ -40,7 +40,7 @@ export default class JSONAPIMiddleware {
       if (this.isJSONAPI(ctxt)) {
         return this.jsonHandlers(ctxt, next);
       } else {
-        throw new CardstackError(`not implemented`);
+        throw new CardstackError(`Only JSON-API requests are supported at this endpoint`);
       }
     };
   }

--- a/packages/hub/tasks/boom.ts
+++ b/packages/hub/tasks/boom.ts
@@ -1,0 +1,5 @@
+import { Helpers } from 'graphile-worker';
+
+export default async (_payload: any, _helpers: Helpers) => {
+  throw new Error('Boom! Job with intentional failure has thrown this error.');
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4265,6 +4265,21 @@
     "@sentry/types" "6.10.0"
     tslib "^1.9.3"
 
+"@sentry/node@^6.10.0":
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.10.0.tgz#d91a6877f3447d7349a7f343a1fcadc319002c09"
+  integrity sha512-buGmOjsTnxebHSfa3r/rhpjDk8xmrILG4xslTgV1C2JpbUtf96QnYNNydfsfAGcZrLWO0gid/wigxsx1fdXT8A==
+  dependencies:
+    "@sentry/core" "6.10.0"
+    "@sentry/hub" "6.10.0"
+    "@sentry/tracing" "6.10.0"
+    "@sentry/types" "6.10.0"
+    "@sentry/utils" "6.10.0"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
 "@sentry/tracing@6.10.0":
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.10.0.tgz#8dcdc28cccfad976540a3c801acb6914b9c0802e"
@@ -9717,6 +9732,11 @@ cookie@0.4.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
+cookie@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
 cookiejar@^2.1.1, cookiejar@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
@@ -11508,7 +11528,7 @@ ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-ve
     resolve "^1.3.3"
     semver "^5.3.0"
 
-ember-cli-version-checker@^3.0.0, ember-cli-version-checker@^3.0.1, ember-cli-version-checker@^3.1.2, ember-cli-version-checker@^3.1.3:
+ember-cli-version-checker@^3.0.0, ember-cli-version-checker@^3.0.1, ember-cli-version-checker@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz#7c9b4f5ff30fdebcd480b1c06c4de43bb51c522c"
   integrity sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==
@@ -12462,15 +12482,7 @@ ember-template-recast@^5.0.1:
     tmp "^0.2.1"
     workerpool "^6.0.3"
 
-ember-test-selectors@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ember-test-selectors/-/ember-test-selectors-2.1.0.tgz#faebdf06702aaa0bc510d55eb721ce54d2e85793"
-  integrity sha512-c5HmvefmeABH8hg380TSNZiE9VAK1CBeXWrgyXy+IXHtsew4lZHHw7GnqCAqsakxwvmaMARbAKY9KfSAE91s1g==
-  dependencies:
-    ember-cli-babel "^6.8.2"
-    ember-cli-version-checker "^3.1.2"
-
-ember-test-selectors@^5.0.0:
+ember-test-selectors@^2.1.0, ember-test-selectors@^5.0.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/ember-test-selectors/-/ember-test-selectors-5.3.0.tgz#1dee515e43e7beb7b7083a2fee2cdf808bf9de26"
   integrity sha512-B9kkCTO39l+XXcp6eRnfZWHeeL3Ffxdux8chXHSwmAPYCc50KI8VW7mr1uy2ZcUMNP/o0sk7VrpA6x3lBkSvWQ==
@@ -17766,6 +17778,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
 
 ltgt@~2.2.0:
   version "2.2.1"


### PR DESCRIPTION
I have verified errors are sent to Sentry for worker and server errors by enabling on development and triggering intentional failures. I have also set up HUB_SENTRY_DSN and HUB_ENVIRONMENT env vars on staging and production via waypoint.