### PR TITLE
web: Add prepaid card issuer name truncation

### DIFF
--- a/packages/web-client/app/components/card-pay/prepaid-card/index.css
+++ b/packages/web-client/app/components/card-pay/prepaid-card/index.css
@@ -72,6 +72,10 @@
 .prepaid-card__name {
   font: var(--boxel-font-sm);
   font-weight: 700;
+  max-width: 10rem;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow-x: hidden;
 }
 
 .prepaid-card__address {

--- a/packages/web-client/app/components/card-pay/prepaid-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/prepaid-card/index.hbs
@@ -17,7 +17,9 @@
   <header class="prepaid-card__header">
     <div>
       <div>Issued by</div>
-      <div class="prepaid-card__name" data-test-prepaid-card-issuer-name>{{or @issuerName "Enter name"}}</div>
+      {{#let (or @issuerName "Enter name") as |name|}}
+        <div class="prepaid-card__name" title={{name}} data-test-prepaid-card-issuer-name>{{name}}</div>
+      {{/let}}
     </div>
     <div class="prepaid-card__meta">
       <div class="prepaid-card__type">PREPAID CARD</div>


### PR DESCRIPTION
This also adds a `title` attribute to the element so the full name can still be seen:

![screencast 2021-08-04 12-36-26](https://user-images.githubusercontent.com/43280/128244338-db505c04-8de4-4205-a2fd-63755016b818.gif)