### PR TITLE
Load gas revisit

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -215,7 +215,7 @@
         "0x00F0FBDEEa1cDEc029Ba6025ca726Fdcf43E9025", // Hassan's depot safe feel free to use your own
         "0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1", // DAI.CPXD
         "",
-        "1000",
+        "500",
         "--network",
         "sokol",
         // Hassan's testing mnemonic feel free to use your own

--- a/packages/cardpay-sdk/sdk/prepaid-card/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card/base.ts
@@ -22,7 +22,7 @@ import {
   getSendPayload,
   executeSend,
 } from '../utils/safe-utils';
-import { waitUntilBlock, waitUntilTransactionMined } from '../utils/general-utils';
+import { waitUntilTransactionMined } from '../utils/general-utils';
 import { signSafeTxAsRSV, Signature, signSafeTxAsBytes } from '../utils/signing-utils';
 import { PrepaidCardSafe } from '../safes';
 
@@ -487,10 +487,7 @@ export default class PrepaidCard {
     createPrepaidCardTxnHash: string,
     onTxnHash?: (txnHash: string) => void
   ): Promise<void> {
-    let receipt = await waitUntilTransactionMined(this.layer2Web3, createPrepaidCardTxnHash);
-    // wait 2 block confirmations to ensure blocks have propagated to relay server
-    await waitUntilBlock(this.layer2Web3, receipt.blockNumber + 2);
-
+    await waitUntilTransactionMined(this.layer2Web3, createPrepaidCardTxnHash);
     let relayServiceURL = await getConstant('relayServiceURL', this.layer2Web3);
     let url = `${relayServiceURL}/v1/prepaid-card/${prepaidCardAddress}/load-gas/`;
     let options = {


### PR DESCRIPTION
backed out the block confirmation wait. the loading gas was a slightly different issue. Specifically it was an issue around how filters are managed in the RPC node. based on teh guidance here, using middleware for filters instead https://github.com/ethereum/web3.py/issues/551