### PR TITLE
Enhancement/misc UI ux

### DIFF
--- a/packages/web-client/app/components/card-pay/header/connection-button/index.hbs
+++ b/packages/web-client/app/components/card-pay/header/connection-button/index.hbs
@@ -13,6 +13,7 @@
 >
   {{#if @isInitializing}}
     {{!-- just show the spinner --}}
+    <span class="boxel-sr-only">Reconnecting to {{@chainName}}</span>
   {{else if @isConnected}}
     {{truncate-middle @address}}
   {{else}}

--- a/packages/web-client/app/css/card-pay/balances.css
+++ b/packages/web-client/app/css/card-pay/balances.css
@@ -41,7 +41,7 @@
 
 .card-pay-dashboard__balances-cards {
   display: grid;
-  gap: var(--boxel-sp);
+  gap: var(--boxel-sp-xl) var(--boxel-sp);
   grid-template-columns: repeat(auto-fill, 22.75rem);
   margin-top: var(--boxel-sp);
 }


### PR DESCRIPTION
Adds the fix for the Hermann grid illusion as discussed in the design meeting, and screenreader-only text for initializing wallet connection buttons.

The vertical gap will probably need to be smaller for mobile, but I think we can cross that bridge when we get to it!

![image](https://user-images.githubusercontent.com/39579264/128530486-6a9c5c10-c9bd-4cf0-a36f-011f319acf27.png)
