### PR TITLE
web: Add source map upload for Sentry

### DIFF
--- a/.github/workflows/manual-web-client.yml
+++ b/.github/workflows/manual-web-client.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           ref: ${{ github.event.inputs.ref }}
 
       - uses: volta-cli/action@v1
@@ -53,3 +54,28 @@ jobs:
 
       - name: Deploy
         run: yarn deploy:web-client:${{ github.event.inputs.environment }}
+      - name: Get current lerna version
+        id: lerna-version
+        uses: saulonunesdev/lerna-get-version-action@v1.0.4
+      - name: Create decompressed copies of assets for Sentry
+        shell: bash
+        run: |
+          cd packages/web-client/tmp
+          mkdir -p deploy-dist-uncompressed/assets
+          cd deploy-dist/assets
+          echo *.js *.map | tr ' ' '\n' | xargs -n1 -I{} cp "{}" "../../deploy-dist-uncompressed/assets/{}.br"
+          cd ../../deploy-dist-uncompressed/assets
+          brotli --rm --decompress *.br
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.WEB_CLIENT_SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: cardstack
+          SENTRY_PROJECT: web-client
+        with:
+          environment: ${{ github.event.inputs.environment }}
+          ignore_empty: true
+          ignore_missing: true
+          sourcemaps: packages/web-client/tmp/deploy-dist-uncompressed
+          version: web-client-${{ github.sha }}@${{ steps.lerna-version.outputs.lerna-version }}
+          url_prefix: https://${{ fromJSON('["app-staging.stack.cards", "app.cardstack.com"]')[github.event.inputs.environment != 'staging'] }}

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -155,7 +155,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - uses: volta-cli/action@v1
       - name: Set up yarn cache
         uses: actions/cache@v2
@@ -172,6 +172,31 @@ jobs:
           EMBER_DEPLOY_AWS_ACCESS_KEY: ${{ secrets.STAGING_EMBER_DEPLOY_AWS_ACCESS_KEY }}
           EMBER_DEPLOY_AWS_ACCESS_SECRET: ${{ secrets.STAGING_EMBER_DEPLOY_AWS_ACCESS_SECRET }}
           HUB_URL: https://hub-staging.stack.cards
+      - name: Get current lerna version
+        id: lerna-version
+        uses: saulonunesdev/lerna-get-version-action@v1.0.4
+      - name: Create decompressed copies of assets for Sentry
+        shell: bash
+        run: |
+          cd packages/web-client/tmp
+          mkdir -p deploy-dist-uncompressed/assets
+          cd deploy-dist/assets
+          echo *.js *.map | tr ' ' '\n' | xargs -n1 -I{} cp "{}" "../../deploy-dist-uncompressed/assets/{}.br"
+          cd ../../deploy-dist-uncompressed/assets
+          brotli --rm --decompress *.br
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.WEB_CLIENT_SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: cardstack
+          SENTRY_PROJECT: web-client
+        with:
+          environment: staging
+          ignore_empty: true
+          ignore_missing: true
+          sourcemaps: packages/web-client/tmp/deploy-dist-uncompressed
+          version: web-client-${{ github.sha }}@${{ steps.lerna-version.outputs.lerna-version }}
+          url_prefix: https://app-staging.stack.cards
 
   deploy-boxel:
     name: Deploy boxel to S3 bucket

--- a/packages/web-client/config/environment.js
+++ b/packages/web-client/config/environment.js
@@ -23,7 +23,10 @@ module.exports = function (environment) {
         // debug: true, // uncomment this to get helpful logs about sentry's behavior
         enabled: !!process.env.DEPLOY_TARGET,
         environment: process.env.DEPLOY_TARGET || 'development',
-        release: 'web-client@' + pkg.version,
+        release:
+          `web-client${
+            process.env.GITHUB_SHA ? `-${process.env.GITHUB_SHA}` : ''
+          }@` + pkg.version,
         // Set tracesSampleRate to 1.0 to capture 100%
         // of transactions for performance monitoring.
         // We recommend adjusting this value in production,

--- a/packages/web-client/ember-cli-build.js
+++ b/packages/web-client/ember-cli-build.js
@@ -39,6 +39,7 @@ module.exports = function (defaults) {
     extraPublicTrees: [appComponentsStylesTree],
     packagerOptions: {
       webpackConfig: {
+        devtool: 'source-map',
         resolve: {
           fallback: {
             stream: require.resolve('stream-browserify'),


### PR DESCRIPTION
This updates deployment workflows to include steps to upload source maps to Sentry using the [Sentry Release](https://github.com/marketplace/actions/sentry-release) GitHub Action.

You can see an example release [here](https://sentry.io/organizations/cardstack/releases/web-client-d9cc44f912392094923cf39b55793eb047e21b6c%400.19.49/?project=5879708), with embedded artifacts that include the source maps.

![image](https://user-images.githubusercontent.com/43280/129092421-dd338b68-7e98-4141-903c-2fadb53e0a1e.png)

[Here](https://sentry.io/organizations/cardstack/issues/2566752189/?environment=staging&project=5879708) is a manually-triggered issue from that release:

![image](https://user-images.githubusercontent.com/43280/129092619-525a6d70-71ec-44c5-a303-5dead4359ba5.png)

One unfortunate aspect is that the stacktrace for the application starts off as collapsed, as it is marked “non-app”; I have a thread going with Sentry support about how to address that. So to view the relevant code, you have to expand the first entry:

![image](https://user-images.githubusercontent.com/43280/129092577-31f2b90f-dd05-4e7d-b6e5-2dbb04365b2b.png)

I made the arbitrary choice of this format for a Sentry release name, building on the existing pattern but adding the SHA:

```web-client-${GITHUB_SHA}@${LERNA_VERSION}```

A possible improvement would be to truncate the SHA at 7 characters, which would be less verbose, but the string-manipulation available in GitHub Actions references are minimal, so it might need to look something like [this](https://github.com/winnipegpolicecauseharm/wpch-ghost-theme/blob/3667bd021288956339fd3456d2a15b62c2b8ad61/.github/workflows/destroy-preview.yml#L17).