### PR TITLE
Fixes CS-1434 and CS-1433 onTxnHash callback and MerchantSafe response

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -56,7 +56,7 @@
       "args": [
         "bridge-to-l1",
         "0x00F0FBDEEa1cDEc029Ba6025ca726Fdcf43E9025", // L2 safe address
-        "11",
+        "10",
         "0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1", // DAI.CPXD
         "0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13", // L1 receiver
         "--network",
@@ -84,7 +84,7 @@
 
         // Kovan DAI Bridge args
         "bridge-to-l2",
-        "30",
+        "10",
         "0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa", // Kovan DAI
         "--network",
         "kovan",
@@ -120,8 +120,8 @@
       "env": {},
       "args": [
         "await-bridged-to-l1",
-        "21668783", // from block
-        "0xcd7eae7310f944e1b34dcb07c6fe5b891ff0ac5574760fb0d88818a1aa134a7c", // txn hash
+        "22144982", // from block
+        "0x7ccf62e3f83186c695a4a6e54febff97856eef99be8c5a26aaad8bb58f2e99ae", // txn hash
         "--network",
         "sokol",
         // Hassan's testing mnemonic feel free to use your own
@@ -138,11 +138,11 @@
       "env": {},
       "args": [
         "claim-tokens-bridged-to-l1",
-        "0x00050000249bfc2f3cc8d68f6b6bf7230ea0a8ed853de7310000000000000a13", // messageId
+        "0x00050000249bfc2f3cc8d68f6b6bf7230ea0a8ed853de7310000000000000abb", // messageId
         // encodedData
-        "0x00050000249bfc2f3cc8d68f6b6bf7230ea0a8ed853de7310000000000000a1316a80598dd2f143cfbf091638ce3fb02c9135528366b4cc64d30849568af65522de3a68ea6cc78ce001e84800101004d2a125e4cfb0000000000000000000000004f96fe3b7a6cf9725f59d353f723c1bdb64ca6aa0000000000000000000000002f58630ca445ab1a6de2bb9892aa2e1d60876c1300000000000000000000000000000000000000000000000098a7d9b8314c0000",
+        "0x00050000249bfc2f3cc8d68f6b6bf7230ea0a8ed853de7310000000000000abb16a80598dd2f143cfbf091638ce3fb02c9135528366b4cc64d30849568af65522de3a68ea6cc78ce001e84800101004d2a125e4cfb0000000000000000000000004f96fe3b7a6cf9725f59d353f723c1bdb64ca6aa0000000000000000000000002f58630ca445ab1a6de2bb9892aa2e1d60876c130000000000000000000000000000000000000000000000008ac7230489e80000",
         // signatures (add each signature as a separate command line arg)
-        "0x059bab6897002710374f9c1a2ca2130b115b8a73cccac30f841048574c54cff80d2d4df266fcc2d73a660ac17bc3a89fde4af8f103490739d979da40e5146cfe1c",
+        "0x6cf76b8f7abc547f6fe6e4eff5cfbc82d9ee90e399a29de5f861c9b46b108a8f3b2da2c4736617d15a424e4ee02c6d5274f94c3c29a170ce6a9a42bcd90482511b",
         "--network",
         "kovan",
         // Hassan's testing mnemonic feel free to use your own
@@ -232,9 +232,8 @@
       "env": {},
       "args": [
         "prepaidcard-split",
-        "0x2952bC69739c9534d09525ccCa33950F311CbE88", // prepaid card address
-        "did:split-test-07-19-21-B", // customization DID
-        "300", // face values
+        "0xe732F27E31e8e0A17c5069Af7cDF277bA7E6Eff5", // prepaid card address
+        "", // customization DID
         "100", // face values
         "100", // face values
         "--network",
@@ -253,7 +252,7 @@
       "env": {},
       "args": [
         "prepaidcard-transfer",
-        "0xf68168d127cb307706493a3345FAce4593039440", // prepaid card address
+        "0x494C18D80C822f81129bBdaF0bfa70D7E1387F9F", // prepaid card address
         "0xb21851B00bd13C008f703A21DFDd292b28A736b3", // new owner
         "--network",
         "sokol",
@@ -290,7 +289,7 @@
       "args": [
         "pay-merchant",
         "0x3e6C2b2c3a842b6492F9F43349D77A40568e3d7E", // safe for Hassan's merchant (whose address the correlates with the mnemenoic 0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13)
-        "0x2952bC69739c9534d09525ccCa33950F311CbE88", // Hassan's prepaid card --feel free to use your own
+        "0x673Fd582FED2CD8201d58552B912F0D1DaA37bB2", // Hassan's prepaid card --feel free to use your own
         "200",
         "--network",
         "sokol",
@@ -327,7 +326,7 @@
         "claim-revenue",
         "0x3e6C2b2c3a842b6492F9F43349D77A40568e3d7E", // safe for Hassan's merchant (whose address the correlates with the mnemenoic 0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13)
         "0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1", // DAI.CPXD
-        "0.5",
+        "5",
         "--network",
         "sokol",
         // Hassan's testing mnemonic feel free to use your own

--- a/packages/cardpay-cli/bridge.ts
+++ b/packages/cardpay-cli/bridge.ts
@@ -83,16 +83,20 @@ export async function bridgeToLayer2(
 
   {
     console.log(`Sending approve transaction request for ${amount} ${symbol}`);
-    let result = await tokenBridge.unlockTokens(tokenAddress, amountInWei);
-    console.log(`Approve transaction hash: ${blockExplorer}/tx/${result.transactionHash}`);
+    await tokenBridge.unlockTokens(tokenAddress, amountInWei, (txnHash) =>
+      console.log(`Approve transaction hash: ${blockExplorer}/tx/${txnHash}`)
+    );
+    console.log('completed approval');
   }
 
   {
     console.log(
       `Sending relay tokens transaction request for ${amount} ${symbol} into layer 2 safe owned by ${receiverAddress}`
     );
-    let result = await tokenBridge.relayTokens(tokenAddress, receiverAddress, amountInWei);
-    console.log(`Relay tokens transaction hash: ${blockExplorer}/tx/${result.transactionHash}`);
+    await tokenBridge.relayTokens(tokenAddress, receiverAddress, amountInWei, (txnHash) =>
+      console.log(`Relay tokens transaction hash: ${blockExplorer}/tx/${txnHash}`)
+    );
+    console.log('completed relay');
   }
 }
 

--- a/packages/cardpay-cli/prepaid-card.ts
+++ b/packages/cardpay-cli/prepaid-card.ts
@@ -49,6 +49,7 @@ export async function create(
     console.log(`Created new prepaid card(s): ${prepaidCards.map((p) => p.address).join(', ')}`);
   let onTxHash = (txHash: string) => console.log(`Transaction hash: ${blockExplorer}/tx/${txHash}/token-transfers`);
   await prepaidCard.create(safe, tokenAddress, faceValues, customizationDID, onPrepaidCardCreated, onTxHash);
+  console.log('done');
 }
 
 export async function split(
@@ -64,10 +65,14 @@ export async function split(
   let blockExplorer = await getConstant('blockExplorer', web3);
 
   console.log(`Splitting prepaid card ${prepaidCard} into face value(s) §${faceValues.join(' SPEND, §')} SPEND...`);
-  let result = await prepaidCardAPI.split(prepaidCard, faceValues, customizationDID, (prepaidCards) =>
-    console.log(`Created new prepaid card(s): ${prepaidCards.map((p) => p.address).join(', ')}`)
+  await prepaidCardAPI.split(
+    prepaidCard,
+    faceValues,
+    customizationDID,
+    (prepaidCards) => console.log(`Created new prepaid card(s): ${prepaidCards.map((p) => p.address).join(', ')}`),
+    (txnHash) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`)
   );
-  console.log(`Transaction hash: ${blockExplorer}/tx/${result!.gnosisTxn.ethereumTx.txHash}/token-transfers`);
+  console.log('done');
 }
 
 export async function transfer(
@@ -82,8 +87,10 @@ export async function transfer(
   let blockExplorer = await getConstant('blockExplorer', web3);
 
   console.log(`Transferring prepaid card ${prepaidCard} to new owner ${newOwner}...`);
-  let result = await prepaidCardAPI.transfer(prepaidCard, newOwner);
-  console.log(`Transaction hash: ${blockExplorer}/tx/${result!.ethereumTx.txHash}/token-transfers`);
+  await prepaidCardAPI.transfer(prepaidCard, newOwner, (txnHash) =>
+    console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`)
+  );
+  console.log('done');
 }
 
 export async function payMerchant(
@@ -100,6 +107,8 @@ export async function payMerchant(
   console.log(
     `Paying merchant safe address ${merchantSafe} the amount §${spendAmount} SPEND from prepaid card address ${prepaidCardAddress}...`
   );
-  let result = await prepaidCard.payMerchant(merchantSafe, prepaidCardAddress, spendAmount);
-  console.log(`Transaction hash: ${blockExplorer}/tx/${result?.ethereumTx.txHash}/token-transfers`);
+  await prepaidCard.payMerchant(merchantSafe, prepaidCardAddress, spendAmount, (txnHash) =>
+    console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`)
+  );
+  console.log('done');
 }

--- a/packages/cardpay-cli/revenue-pool.ts
+++ b/packages/cardpay-cli/revenue-pool.ts
@@ -15,9 +15,11 @@ export async function registerMerchant(
   console.log(
     `Paying merchant registration fee in the amount of §${await revenuePool.merchantRegistrationFee()} SPEND from prepaid card address ${prepaidCardAddress}...`
   );
-  let { merchantSafe, gnosisTxn } = (await revenuePool.registerMerchant(prepaidCardAddress, infoDID)) ?? {};
-  console.log(`Created merchant safe: ${merchantSafe}`);
-  console.log(`Transaction hash: ${blockExplorer}/tx/${gnosisTxn?.ethereumTx.txHash}/token-transfers`);
+  let { merchantSafe } =
+    (await revenuePool.registerMerchant(prepaidCardAddress, infoDID, (txnHash) =>
+      console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`)
+    )) ?? {};
+  console.log(`Created merchant safe: ${merchantSafe.address}`);
 }
 
 export async function revenueBalances(network: string, merchantSafeAddress: string, mnemonic?: string): Promise<void> {
@@ -44,7 +46,9 @@ export async function claimRevenue(
   let weiAmount = toWei(amount);
   console.log(`Claiming ${amount} ${symbol} in revenue for merchant safe ${merchantSafeAddress}`);
 
-  let result = await revenuePool.claim(merchantSafeAddress, tokenAddress, weiAmount);
   let blockExplorer = await getConstant('blockExplorer', web3);
-  console.log(`Transaction hash: ${blockExplorer}/tx/${result.ethereumTx.txHash}/token-transfers`);
+  await revenuePool.claim(merchantSafeAddress, tokenAddress, weiAmount, (txnHash) =>
+    console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`)
+  );
+  console.log('done');
 }

--- a/packages/cardpay-cli/safe.ts
+++ b/packages/cardpay-cli/safe.ts
@@ -89,9 +89,11 @@ export async function transferTokens(
   let { symbol } = await assets.getTokenInfo(token);
 
   console.log(`transferring ${amount} ${symbol} from safe ${safe} to ${recipient}`);
-  let result = await safes.sendTokens(safe, token, recipient, weiAmount);
   let blockExplorer = await getConstant('blockExplorer', web3);
-  console.log(`Transaction hash: ${blockExplorer}/tx/${result.ethereumTx.txHash}/token-transfers`);
+  await safes.sendTokens(safe, token, recipient, weiAmount, (txnHash) =>
+    console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`)
+  );
+  console.log('done');
 }
 
 export async function setSupplierInfoDID(
@@ -106,7 +108,9 @@ export async function setSupplierInfoDID(
   let assets = await getSDK('Assets', web3);
   let { symbol } = await assets.getTokenInfo(gasToken);
   console.log(`setting the info DID for the supplier safe ${safe} to ${infoDID} using ${symbol} token to pay for gas`);
-  let result = await safes.setSupplierInfoDID(safe, infoDID, gasToken);
   let blockExplorer = await getConstant('blockExplorer', web3);
-  console.log(`Transaction hash: ${blockExplorer}/tx/${result.ethereumTx.txHash}/token-transfers`);
+  await safes.setSupplierInfoDID(safe, infoDID, gasToken, (txnHash) =>
+    console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`)
+  );
+  console.log('done');
 }

--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -6,7 +6,7 @@ This is a package that provides an SDK to use the Cardpay protocol.
 
 - [Function Parameters](#function-parameters)
   - [Nonce](#nonce)
-  - [Transaction Hash (TBD)](#transaction-hash-tbd)
+  - [Transaction Hash](#transaction-hash)
 - [`getSDK`](#getsdk)
 - [`Assets`](#assets)
   - [`Assets.getNativeTokenBalance`](#assetsgetnativetokenbalance)
@@ -59,13 +59,17 @@ This is a package that provides an SDK to use the Cardpay protocol.
 
 ## Function Parameters
 ### Nonce
-All the API's that mutate the state of the blockchain have 2 optional parameters:
+All the API's that mutate the state of the blockchain have 2 optional parameters for nonce:
 - `onNonce: (nonce: BN) => void`
 - `nonce: BN`
 
 The purpose of these nonce parameters are to allow the client to reattempt sending the transaction. Specifically this can be used to handle re-requesting a wallet to sign a transaction. When the `nonce` parameter is not specified, then the SDK will use the next available nonce for the transaction based on the transaction count for the EOA or safe (as the case may be). The `onNonce` callback will return the next available nonce (which is the nonce included in the signing request for the wallet). If the caller wishes to re-attempt sending the same transaction, the caller can specify the `nonce` to use when re-signing the transaction based on the nonce that was provided from the original `onNonce` callback. This will prevent the scenarios where the nonce will be increased on when the caller wants to force the wallet to resign the transaction. Care should be take though not to reuse a `nonce` value associated with a completed transaction. Such a situation could lead to the transaction being rejected because the nonce value is too low, or because the txn hash is identical to an already mined transaction.
 
-### Transaction Hash (TBD)
+### Transaction Hash
+All the API's that mutate the state of the blockchain have an optional parameters for obtaining the transaction hash:
+- `onTxHash(txHash: string) => unknown`
+
+The promise returned by all the API's that mutate the state of the blockchain will resolve after the transaction has been mined with a transaction receipt. In order for callers of the SDK to obtain the transaction hash (for purposes of tracking the transaction) before the transaction has been mined, all API's that mutate the state of the blockchain will also contain a callback `onTxnHash` that callers can use to obtain the transaction hash as soon as it is available.
 
 ## `getSDK`
 The cardpay SDK will automatically obtain the latest API version that works with the on-chain contracts. In order to obtain an API you need to leverage the `getSDK()` function and pass to it the API that you wish to work with, as well as any parameters necessary for obtaining an API (usually just an instance of Web3). This function then returns a promise for the requested API. For example, to obtain the `Safes` API, you would call:

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -281,13 +281,19 @@ export default abstract class Layer2ChainWeb3Strategy
     let tokenAddress = new TokenContractInfo(tokenSymbol, this.networkSymbol)!
       .address;
 
-    let result = await tokenBridge.relayTokens(
-      safeAddress,
-      tokenAddress,
-      receiverAddress,
-      amountInWei
-    );
-    return result.ethereumTx.txHash;
+    // in this case we don't want to wait for mining to complete. there is a
+    // purpose built await in the SDK for the bridge validators that is
+    // performed after this action--we can just rely on that for the timing
+    let transactionHash = await new Promise<TransactionHash>((res) => {
+      tokenBridge.relayTokens(
+        safeAddress,
+        tokenAddress,
+        receiverAddress,
+        amountInWei,
+        (txnHash) => res(txnHash)
+      );
+    });
+    return transactionHash;
   }
 
   async awaitBridgedToLayer1(


### PR DESCRIPTION
This PR fixes #CS-1434 which makes all of our blockchain mutating API returned promises consistent so that they are resolving with a TransactionReciept after the txn is mined as well as providing an `onTxnHash` callback into all of our blockchain mutating API's

This PR also fixes #CS-1433 in which we return a `MerchantSafe` object in register merchant instead of just the address of the merchant safe