### PR TITLE
Handle layer one wallet workflow disconnect

### DIFF
--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
@@ -17,6 +17,7 @@
       @title={{this.connectedWalletProvider.name}}
       @imgUrl={{this.connectedWalletProvider.logo}}
       @dataTestId="layer-one-connect"
+      data-test-layer-1-wallet-summary
     >
       <CardPay::FieldStack>
         <CardPay::LabeledValue

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
@@ -72,33 +72,34 @@
       />
     </ActionCardContainer::Section>
   {{/if}}
-  <Boxel::ActionChin @state={{this.ctaState}} @disabled={{@frozen}}>
-    <:default as |a|>
-      <a.ActionButton {{on "click" this.connect}} data-test-mainnet-connect-button>
-        Connect Wallet
-      </a.ActionButton>
-    </:default>
-    <:in-progress as |i|>
-      <i.ActionStatusArea class="layer-one-connect-card__in-progress-logo" @icon={{concat this.radioWalletProviderId "-logo"}} style={{css-var status-icon-size="2.5rem"}}>
-        <Boxel::LoadingIndicator
-          class="layer-one-connect-card__loading-indicator"
-          @color="var(--boxel-light)"
-        />
-        <div class="layer-one-connect-card__waiting-status">
-          Waiting for you to connect Card Pay with your {{network-display-info "layer1" "conversationalName"}} wallet...
-          <i.CancelButton class="layer-one-connect-card__cancel-button" {{on "click" this.cancelConnection}}>
-            Cancel
-          </i.CancelButton>
-        </div>
-      </i.ActionStatusArea>
-      <i.InfoArea>
-        Only visible to you
-      </i.InfoArea>
-    </:in-progress>
-    <:memorialized as |m|>
-      <m.ActionButton {{on "click" this.disconnect}} data-test-mainnet-disconnect-button>
-        Disconnect Wallet
-      </m.ActionButton>
-    </:memorialized>
-  </Boxel::ActionChin>
+
+  {{#if this.showActions}}
+    <Boxel::ActionChin @state={{this.cardState}} @disabled={{@frozen}}>
+      <:default as |a|>
+        <a.ActionButton {{on "click" this.connect}} data-test-mainnet-connect-button>
+          Connect Wallet
+        </a.ActionButton>
+      </:default>
+      <:in-progress as |i|>
+        <i.ActionStatusArea class="layer-one-connect-card__in-progress-logo" @icon={{concat
+          this.radioWalletProviderId "-logo" }} style={{css-var status-icon-size="2.5rem" }}>
+          <Boxel::LoadingIndicator class="layer-one-connect-card__loading-indicator" @color="var(--boxel-light)" />
+          <div class="layer-one-connect-card__waiting-status">
+            Waiting for you to connect Card Pay with your {{network-display-info "layer1" "conversationalName"}} wallet...
+            <i.CancelButton class="layer-one-connect-card__cancel-button" {{on "click" this.cancelConnection}}>
+              Cancel
+            </i.CancelButton>
+          </div>
+        </i.ActionStatusArea>
+        <i.InfoArea>
+          Only visible to you
+        </i.InfoArea>
+      </:in-progress>
+      <:memorialized as |m|>
+        <m.ActionButton {{on "click" this.disconnect}} data-test-mainnet-disconnect-button>
+          Disconnect Wallet
+        </m.ActionButton>
+      </:memorialized>
+    </Boxel::ActionChin>
+  {{/if}}
 </ActionCardContainer>

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
@@ -71,7 +71,7 @@
       />
     </ActionCardContainer::Section>
   {{/if}}
-  <Boxel::ActionChin @state={{this.ctaState}} @disabled={{or @frozen this.ctaDisabled}}>
+  <Boxel::ActionChin @state={{this.ctaState}} @disabled={{@frozen}}>
     <:default as |a|>
       <a.ActionButton {{on "click" this.connect}} data-test-mainnet-connect-button>
         Connect Wallet

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.hbs
@@ -6,7 +6,7 @@
   data-test-mainnnet-connection-action-container
   ...attributes
 >
-  {{#if this.connectedWalletProvider}}
+  {{#if (eq this.cardState 'memorialized')}}
     <Listener
       @emitter={{this.layer1Network}}
       @event="disconnect"
@@ -23,32 +23,40 @@
           @label="Network"
           @value={{network-display-info "layer1" "fullName"}}
         />
-        <CardPay::LabeledValue
-          @label="Address"
-          @value={{this.layer1Network.walletInfo.firstAddress}}
-          @isAddress={{true}}
-        />
-        <CardPay::LabeledValue @label="Balance*" data-test-balance-container>
-          {{#if this.balancesToShow.length}}
-          <CardPay::BalancesList as |Balance|>
-            {{#each this.balancesToShow as |b|}}
-            <Balance @symbol={{b.symbol}} @amount={{b.amount}} />
-            {{/each}}
-          </CardPay::BalancesList>
-          {{else}}
-          None
-          {{/if}}
-        </CardPay::LabeledValue>
-        <CardPay::LabeledValue
-          @label="Status"
-          @value="Connected"
-          @icon="success-bordered"
-        />
+
+        {{#if this.isConnected}}
+          <CardPay::LabeledValue
+            @label="Address"
+            @value={{this.layer1Network.walletInfo.firstAddress}}
+            @isAddress={{true}}
+          />
+          <CardPay::LabeledValue @label="Balance*" data-test-balance-container>
+            {{#if this.balancesToShow.length}}
+              <CardPay::BalancesList as |Balance|>
+                {{#each this.balancesToShow as |b|}}
+                  <Balance @symbol={{b.symbol}} @amount={{b.amount}} />
+                {{/each}}
+              </CardPay::BalancesList>
+            {{else}}
+              None
+            {{/if}}
+          </CardPay::LabeledValue>
+        {{/if}}
       </CardPay::FieldStack>
-      <div class="layer-one-connect-card__disclaimer">
-        * This balance reflects some of the tokens that are accepted in the Card Pay network.
-          It may not reflect all the tokens in your wallet.
-      </div>
+
+      <CardPay::LabeledValue
+        @label="Status"
+        @value={{if this.isConnected "Connected" "Disconnected"}}
+        @icon={{if this.isConnected "success-bordered" "failure-bordered"}}
+      />
+
+      {{#if this.isConnected}}
+        <div class="layer-one-connect-card__disclaimer">
+          * This balance reflects some of the tokens that are accepted in the Card Pay network.
+            It may not reflect all the tokens in your wallet.
+        </div>
+      {{/if}}
+
     </ActionCardContainer::Section>
   {{else}}
     <ActionCardContainer::Section

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
@@ -117,11 +117,9 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
 
   @task *connectWalletTask() {
     this.isWaitingForConnection = true;
-    if (this.radioWalletProviderId) {
-      yield this.layer1Network.connect({
-        id: this.radioWalletProviderId,
-      } as WalletProvider);
-    }
+    yield this.layer1Network.connect({
+      id: this.radioWalletProviderId,
+    } as WalletProvider);
     this.isWaitingForConnection = false;
     yield timeout(500); // allow time for strategy to verify connected chain -- it might not accept the connection
     if (this.isConnected) {

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
@@ -71,12 +71,8 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
     }
   }
 
-  get ctaState(): string {
-    if (this.cardState === 'materialized') {
-      return 'default';
-    }
-
-    return this.cardState;
+  get showActions(): boolean {
+    return !this.args.isComplete || this.isConnected;
   }
 
   get balancesToShow() {

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
@@ -61,8 +61,8 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
     else return '';
   }
 
-  get ctaState(): string {
-    if (this.isConnected) {
+  get cardState(): string {
+    if (this.isConnected || this.args.isComplete) {
       return 'memorialized';
     } else if (this.isWaitingForConnection) {
       return 'in-progress';
@@ -70,8 +70,13 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
       return 'default';
     }
   }
-  get ctaDisabled() {
-    return !this.isConnected && !this.radioWalletProviderId;
+
+  get ctaState(): string {
+    if (this.cardState === 'materialized') {
+      return 'default';
+    }
+
+    return this.cardState;
   }
 
   get balancesToShow() {

--- a/packages/web-client/app/components/workflow-thread/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/index.hbs
@@ -19,7 +19,7 @@
         <WorkflowThread::Postable
           @postable={{postable}}
           @previous={{object-at milestone.visiblePostables (dec j)}}
-          @frozen={{or this.workflow.isComplete this.workflow.isCanceled}}
+          @frozen={{this.frozen}}
           @index={{j}}
           data-test-milestone={{i}}
         />
@@ -43,6 +43,7 @@
         <WorkflowThread::Postable
           @postable={{postable}}
           @previous={{object-at this.workflow.epilogue.visiblePostables (dec j)}}
+          @frozen={{this.frozen}}
           @index={{j}}
           data-test-epilogue
         />

--- a/packages/web-client/app/components/workflow-thread/index.ts
+++ b/packages/web-client/app/components/workflow-thread/index.ts
@@ -84,6 +84,10 @@ export default class WorkflowThread extends Component<WorkflowThreadArgs> {
     return postablesInLastMilestone[postablesInLastMilestone.length - 1];
   }
 
+  get frozen(): boolean {
+    return this.workflow.isComplete || this.workflow.isCanceled;
+  }
+
   willDestroy() {
     this.reducedMotionMediaQuery.removeEventListener(
       'change',

--- a/packages/web-client/tests/integration/components/layer-one-connect-card-test.ts
+++ b/packages/web-client/tests/integration/components/layer-one-connect-card-test.ts
@@ -27,6 +27,14 @@ module('Integration | Component | layer-one-connect-card', function (hooks) {
     assert.dom(WALLET_SELECTION_SELECTOR).isVisible();
   });
 
+  test('It should show card summary if card is completed and user disconnects the wallet', async function (assert) {
+    await render(hbs`
+        <CardPay::LayerOneConnectCard @isComplete={{true}}/>
+      `);
+
+    assert.dom('[data-test-layer-1-wallet-summary]').exists();
+  });
+
   test("It should render the wallet provider's name if it is connected before rendering", async function (assert) {
     let layer1Service = this.owner.lookup('service:layer1-network')
       .strategy as Layer1TestWeb3Strategy;


### PR DESCRIPTION
Ticket: [CS-1502](https://linear.app/cardstack/issue/CS-1502/when-workflow-epilogue-shows-includes-layer-1-wallet-card-as-a-summary)

This change affects the layer one connect card component when it's in the epilogue (i.e the deposit flow).

The problem is that when the wallet gets disconnected in a completed deposit flow, it shows the connect prompt, which doesn't make a lot of sense when the workflow is completed:

![image](https://user-images.githubusercontent.com/273660/128678586-34b48855-ec25-408e-90c0-9395c2114371.png)

This PR aims to:
1. Show the wallet summary instead
2. Simplify the logic for conditional showing of the prompt/summary, and contents in the chin

The result is that we now see a wallet summary:

![image](https://user-images.githubusercontent.com/273660/128679239-b29af9ef-d01b-4143-8c4e-0e3b4968722b.png)

⁉️ QUESTION:

In my previous [PR](https://github.com/cardstack/cardstack/pull/1923) I addressed the same problem but for layer 2. In that case I chose to simply hide the action chin once the wallet disconnects. But in this case, the chin has some more button logic included, and the acceptance tests expect the chin to always be present, so I kept the chin for now. 

Do we want to:
1. Remove the chin when the wallet disconnects in this case (layer one card) the same way we do now with layer two card
2. Add the chin back in layer two card and keep the same logic as here
3. Not worry about this inconsistency given it's a bit of an edge case

