### PR TITLE
Refactor how workflow checks for complete milestones...

### DIFF
--- a/packages/web-client/app/models/animated-workflow.ts
+++ b/packages/web-client/app/models/animated-workflow.ts
@@ -7,7 +7,6 @@ import { tracked } from '@glimmer/tracking';
 import { taskFor } from 'ember-concurrency-ts';
 import { task } from 'ember-concurrency-decorators';
 import { rawTimeout } from 'ember-concurrency';
-import { A } from '@ember/array';
 import { buildWaiter } from '@ember/test-waiters';
 import RSVP, { defer } from 'rsvp';
 import { UnbindEventListener } from '../utils/events';
@@ -214,11 +213,24 @@ export default class AnimatedWorkflow {
   }
 
   get isComplete() {
-    return A(this.milestones).isEvery('isComplete');
+    return this.completedMilestoneCount === this.milestones.length;
+  }
+
+  get completedMilestones() {
+    let milestones = [];
+    for (let i = 0; i < this.milestones.length; i++) {
+      let milestone = this.milestones[i];
+      if (milestone.isComplete) {
+        milestones.push(milestone);
+      } else {
+        break;
+      }
+    }
+    return milestones;
   }
 
   get completedMilestoneCount() {
-    return this.milestones.filterBy('isComplete').length;
+    return this.completedMilestones.length;
   }
 
   get progressStatus() {
@@ -226,7 +238,7 @@ export default class AnimatedWorkflow {
       return 'Workflow canceled';
     }
 
-    let completedMilestones = this.milestones.filterBy('isComplete');
+    let { completedMilestones } = this;
     let lastMilestone = completedMilestones[completedMilestones.length - 1];
     return lastMilestone?.completedDetail ?? 'Workflow started';
   }

--- a/packages/web-client/app/models/workflow.ts
+++ b/packages/web-client/app/models/workflow.ts
@@ -1,4 +1,3 @@
-import { A } from '@ember/array';
 import { Milestone } from './workflow/milestone';
 import PostableCollection from './workflow/postable-collection';
 import { WorkflowPostable } from './workflow/workflow-postable';
@@ -34,8 +33,21 @@ export abstract class Workflow {
     this.cancelationMessages.setWorkflow(this);
   }
 
+  get completedMilestones() {
+    let milestones = [];
+    for (let i = 0; i < this.milestones.length; i++) {
+      let milestone = this.milestones[i];
+      if (milestone.isComplete) {
+        milestones.push(milestone);
+      } else {
+        break;
+      }
+    }
+    return milestones;
+  }
+
   get completedMilestoneCount() {
-    return this.milestones.filterBy('isComplete').length;
+    return this.completedMilestones.length;
   }
 
   get visibleMilestones(): Milestone[] {
@@ -51,7 +63,7 @@ export abstract class Workflow {
   }
 
   get isComplete() {
-    return A(this.milestones).isEvery('isComplete');
+    return this.completedMilestoneCount === this.milestones.length;
   }
 
   cancel(reason?: string) {
@@ -64,7 +76,7 @@ export abstract class Workflow {
   }
 
   get progressStatus() {
-    let completedMilestones = this.milestones.filterBy('isComplete');
+    let { completedMilestones } = this;
     let lastMilestone = completedMilestones[completedMilestones.length - 1];
     if (this.isCanceled) return 'Workflow canceled';
     else return lastMilestone?.completedDetail ?? 'Workflow started';

--- a/packages/web-client/tests/unit/models/workflow-test.ts
+++ b/packages/web-client/tests/unit/models/workflow-test.ts
@@ -245,4 +245,49 @@ module('Unit | Workflow model', function (hooks) {
     assert.equal(indicesArray.length, 1);
     assert.ok(indicesArray.includes('epilogue-1'));
   });
+
+  module('with includeIf', async function (hooks) {
+    let workflow: Workflow;
+    let calledIncludeIf: boolean;
+
+    hooks.beforeEach(function () {
+      workflow = new ConcreteWorkflow({});
+      calledIncludeIf = false;
+      let secondMilestone = new Milestone({
+        title: 'Milestone 2',
+        postables: [
+          new WorkflowPostable(
+            {
+              name: 'cardbot',
+            },
+            () => {
+              calledIncludeIf = true;
+              return false;
+            }
+          ),
+        ],
+        completedDetail: 'Second mile-stoned',
+      });
+      workflow.milestones = [exampleMilestone, secondMilestone];
+    });
+
+    test('includeIf called only once a postable is a candidate for display', async function (assert) {
+      // simulate calls made while rendering a workflow
+      workflow.visibleMilestones.map((milestone) => milestone.visiblePostables);
+      workflow.isComplete;
+      workflow.progressStatus;
+      assert.equal(
+        calledIncludeIf,
+        false,
+        'includeIf for the second milestone’s postables was NOT called'
+      );
+      examplePostable.isComplete = true;
+      workflow.visibleMilestones.map((milestone) => milestone.visiblePostables);
+      assert.equal(
+        calledIncludeIf,
+        true,
+        'includeIf for the second milestone’s postables was called'
+      );
+    });
+  });
 });


### PR DESCRIPTION
...to avoid being too eager in checking postable completeness.

This means that `includeIf` methods will be called closer to when the postable is due to be displayed.