### PR TITLE
Enhancement/propagate connection events

### DIFF
--- a/packages/web-client/app/utils/typed-channel.ts
+++ b/packages/web-client/app/utils/typed-channel.ts
@@ -1,0 +1,31 @@
+export class TypedChannel<MessageType = any> {
+  channelName: string;
+  private broadcastChannel: BroadcastChannel;
+
+  constructor(channelName: string) {
+    this.channelName = channelName;
+    this.broadcastChannel = new BroadcastChannel(channelName);
+  }
+
+  addEventListener(
+    event: keyof BroadcastChannelEventMap,
+    callback: (ev: MessageEvent<MessageType>) => any
+  ) {
+    this.broadcastChannel.addEventListener(event, callback);
+  }
+
+  removeEventListener(
+    event: keyof BroadcastChannelEventMap,
+    callback: (ev: MessageEvent<MessageType>) => any
+  ) {
+    this.broadcastChannel.removeEventListener(event, callback);
+  }
+
+  close() {
+    this.broadcastChannel.close();
+  }
+
+  postMessage(message: MessageType) {
+    this.broadcastChannel.postMessage(message);
+  }
+}

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -10,6 +10,7 @@ import { WalletProviderId } from '../wallet-providers';
 import { action } from '@ember/object';
 import { getConstantByNetwork, networkIds } from '@cardstack/cardpay-sdk';
 import { NetworkSymbol } from './types';
+import Web3 from 'web3';
 
 const GET_PROVIDER_STORAGE_KEY = (chainId: number) =>
   `cardstack-chain-${chainId}-provider`;
@@ -116,19 +117,23 @@ export class ConnectionManager {
     this.strategy = undefined;
   }
 
-  async setup(providerId: WalletProviderId, session?: any) {
+  private async setup(providerId: WalletProviderId, session?: any) {
     this.strategy = this.createStrategy(providerId);
     this.strategy.on('connected', this.onConnect);
     this.strategy.on('disconnected', this.onDisconnect);
     this.strategy.on('chain-changed', this.onChainChanged);
-    await this.strategy?.setup(session);
+    await this.strategy.setup(session);
   }
 
-  async connect() {
+  async connect(web3: Web3, providerId: WalletProviderId) {
+    await this.setup(providerId);
+    web3.setProvider(this.provider);
     await this.strategy?.connect();
   }
 
-  async reconnect() {
+  async reconnect(web3: Web3, providerId: WalletProviderId, session?: any) {
+    await this.setup(providerId, session);
+    web3.setProvider(this.provider);
     await this.strategy?.reconnect();
   }
 

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -1,6 +1,4 @@
 import detectEthereumProvider from '@metamask/detect-provider';
-import Web3 from 'web3';
-import { NetworkSymbol } from './types';
 import WalletConnectProvider from '../wc-provider';
 import WalletConnectQRCodeModal from '@walletconnect/qrcode-modal';
 import config from '../../config/environment';
@@ -11,75 +9,70 @@ import { Emitter, SimpleEmitter } from '../events';
 import { WalletProviderId } from '../wallet-providers';
 import { action } from '@ember/object';
 import { getConstantByNetwork, networkIds } from '@cardstack/cardpay-sdk';
+import { NetworkSymbol } from './types';
 
 const GET_PROVIDER_STORAGE_KEY = (chainId: number) =>
   `cardstack-chain-${chainId}-provider`;
 const WALLET_CONNECT_BRIDGE = 'https://safe-walletconnect.gnosis.io/';
-
 interface ConnectionManagerOptions {
   chainId: number;
   networkSymbol: NetworkSymbol;
 }
 
-export type ConnectionManagerEvent =
+type ConnectionManagerWalletEvent =
   | 'connected'
   | 'disconnected'
   | 'chain-changed';
 
+type ConnectionManagerCrossTabEvent = 'cross-tab-connection';
+
+export type ConnectionManagerEvent =
+  | ConnectionManagerWalletEvent
+  | ConnectionManagerCrossTabEvent;
+
 const BROADCAST_CHANNEL_MESSAGES = {
   DISCONNECTED: 'DISCONNECTED',
+  CONNECTED: 'CONNECTED',
 } as const;
 
 /**
  * # ConnectionManager
- * This class instantiates a web3 provider given a WalletProviderId. It then handles the EIP-1193
- * events that come from the web3 provider and filters them for events that we want to handle
- * in the Dapp:
+ * This class simplifies the interface to communicate with wallet providers (MetaMask or WalletConnect).
+ *
+ * Calling setup with a valid provider id and optionally a session will set up a provider and bind
+ * event handlers for connection, disconnection, and chain change events.
  *
  * - connected: A wallet is connected, or the address is changed
  * - disconnected: A wallet is disconnected
  * - chain-changed: A wallet's chain is updated or detected for the first time
  *
- * It handles cross-tab communication and persistence of connection information across refreshes.
+ * It also handles cross-tab communication and persistence of connection information across refreshes.
+ * Cross-tab disconnection is handled internally while cross-tab connection is handled by emitting the event
+ * to this class' consumer (layer 1 chain), which needs to set up a web3 instance first so that the event handlers
+ * it has can work correctly as they use the web3 instance.
+ *
  * This class does not, at the moment, store any state used directly by the UI besides providerId.
  */
-export abstract class ConnectionManager
-  implements Emitter<ConnectionManagerEvent> {
-  networkSymbol: NetworkSymbol;
+export class ConnectionManager {
+  private strategy: ConnectionStrategy | undefined;
+  private broadcastChannel: BroadcastChannel | undefined;
   chainId: number;
-  protected simpleEmitter: SimpleEmitter;
-  protected broadcastChannel: BroadcastChannel;
-  protected provider: any;
-  abstract providerId: WalletProviderId;
+  networkSymbol: NetworkSymbol;
+  simpleEmitter = new SimpleEmitter();
 
-  constructor(options: ConnectionManagerOptions) {
-    this.networkSymbol = options.networkSymbol;
-    this.chainId = options.chainId;
-    this.simpleEmitter = new SimpleEmitter();
-    // the broadcast channel is really for metamask disconnections
-    // since metamask doesn't allow you to disconnect from the dapp side
+  constructor(networkSymbol: NetworkSymbol) {
+    this.networkSymbol = networkSymbol;
+    this.chainId = networkIds[networkSymbol];
+
     // we want to ensure that users don't get confused by different tabs having
-    // different wallets connected
+    // different wallets connected so we communicate disconnections across tabs
     this.broadcastChannel = new BroadcastChannel(
-      `cardstack-connection-manager-${this.chainId}`
+      `cardstack-layer-1-connection-sync`
     );
     this.broadcastChannel.addEventListener(
       'message',
       this.onBroadcastChannelMessage
     );
-  }
-
-  static create(
-    providerId: WalletProviderId,
-    options: ConnectionManagerOptions
-  ): ConnectionManager {
-    if (providerId === 'metamask') {
-      return new MetaMaskConnectionManager(options);
-    } else if (providerId === 'wallet-connect') {
-      return new WalletConnectConnectionManager(options);
-    } else {
-      throw new Error(`Unrecognised id for connection manager: ${providerId}`);
-    }
   }
 
   static getProviderIdForChain(chainId: number) {
@@ -94,6 +87,55 @@ export abstract class ConnectionManager
     window.localStorage.setItem(GET_PROVIDER_STORAGE_KEY(chainId), providerId);
   }
 
+  get provider() {
+    return this.strategy?.provider;
+  }
+
+  get providerId() {
+    return this.strategy?.providerId;
+  }
+
+  createStrategy(providerId: WalletProviderId) {
+    if (providerId === 'metamask') {
+      return new MetaMaskConnectionStrategy({
+        chainId: this.chainId,
+        networkSymbol: this.networkSymbol,
+      });
+    } else if (providerId === 'wallet-connect') {
+      return new WalletConnectConnectionStrategy({
+        chainId: this.chainId,
+        networkSymbol: this.networkSymbol,
+      });
+    } else {
+      throw new Error(`Unrecognised id for connection manager: ${providerId}`);
+    }
+  }
+
+  reset() {
+    this.strategy?.destroy();
+    this.strategy = undefined;
+  }
+
+  async setup(providerId: WalletProviderId, session?: any) {
+    this.strategy = this.createStrategy(providerId);
+    this.strategy.on('connected', this.onConnect);
+    this.strategy.on('disconnected', this.onDisconnect);
+    this.strategy.on('chain-changed', this.onChainChanged);
+    await this.strategy?.setup(session);
+  }
+
+  async connect() {
+    await this.strategy?.connect();
+  }
+
+  async reconnect() {
+    await this.strategy?.reconnect();
+  }
+
+  disconnect() {
+    this.strategy?.disconnect();
+  }
+
   on(event: ConnectionManagerEvent, cb: Function) {
     return this.simpleEmitter.on(event, cb);
   }
@@ -104,47 +146,98 @@ export abstract class ConnectionManager
 
   @action
   onBroadcastChannelMessage(event: MessageEvent) {
-    if (event.data === BROADCAST_CHANNEL_MESSAGES.DISCONNECTED) {
+    if (event.data.type === BROADCAST_CHANNEL_MESSAGES.DISCONNECTED) {
       this.onDisconnect(false);
+    } else if (
+      event.data.type === BROADCAST_CHANNEL_MESSAGES.CONNECTED &&
+      !this.strategy
+    ) {
+      this.emit('cross-tab-connection', event.data);
     }
   }
 
-  onDisconnect(broadcast = true) {
+  @action onDisconnect(broadcast: boolean) {
+    if (!this.strategy) return;
     ConnectionManager.removeProviderFromStorage(this.chainId);
-    if (broadcast)
-      this.broadcastChannel.postMessage(
-        BROADCAST_CHANNEL_MESSAGES.DISCONNECTED
-      );
-    // the layer1-chain will destroy the instance of ConnectionManager so we emit as the last item
     this.emit('disconnected');
+    if (broadcast)
+      this.broadcastChannel?.postMessage({
+        type: BROADCAST_CHANNEL_MESSAGES.DISCONNECTED,
+      });
+  }
+
+  @action onConnect(accounts: string[]) {
+    if (!this.strategy) return;
+    ConnectionManager.addProviderToStorage(
+      this.chainId,
+      this.strategy.providerId
+    );
+    this.emit('connected', accounts);
+    this.broadcastChannel?.postMessage({
+      type: BROADCAST_CHANNEL_MESSAGES.CONNECTED,
+      providerId: this.providerId,
+      session: this.strategy.getSession(),
+    });
+  }
+
+  @action onChainChanged(chainId: number) {
+    this.emit('chain-changed', chainId);
+  }
+}
+
+abstract class ConnectionStrategy
+  implements Emitter<ConnectionManagerWalletEvent> {
+  private simpleEmitter: SimpleEmitter;
+
+  // concrete classes will need to implement these
+  abstract providerId: WalletProviderId;
+  abstract setup(session?: any): Promise<any>;
+  abstract reconnect(): Promise<void>;
+  abstract connect(): Promise<void>;
+  abstract disconnect(): Promise<void>;
+
+  // concrete classes may optionally implement these methods
+  getSession() {}
+  destroy() {}
+
+  // networkSymbol and chainId are initialized in the constructor
+  networkSymbol: NetworkSymbol;
+  chainId: number;
+
+  // this is initialized in the `setup` method of concrete classes
+  provider: any;
+
+  constructor(options: ConnectionManagerOptions) {
+    this.chainId = options.chainId;
+    this.networkSymbol = options.networkSymbol;
+    this.simpleEmitter = new SimpleEmitter();
+  }
+
+  on(event: ConnectionManagerWalletEvent, cb: Function) {
+    return this.simpleEmitter.on(event, cb);
+  }
+
+  emit(event: ConnectionManagerWalletEvent, ...args: any[]) {
+    return this.simpleEmitter.emit(event, ...args);
+  }
+
+  onDisconnect(broadcast = true) {
+    this.emit('disconnected', broadcast);
   }
 
   onConnect(accounts: string[]) {
-    ConnectionManager.addProviderToStorage(this.chainId, this.providerId);
     this.emit('connected', accounts);
   }
 
   onChainChanged(chainId: number) {
     this.emit('chain-changed', chainId);
   }
-
-  abstract reconnect(): Promise<void>;
-  abstract connect(): Promise<void>;
-  abstract disconnect(): Promise<void>;
-
-  // create provider and setup event listeners here
-  // also call web3.setProvider
-  abstract setup(web3: Web3): Promise<any>;
-
-  destroy() {
-    this.broadcastChannel.close();
-  }
 }
 
-class MetaMaskConnectionManager extends ConnectionManager {
+class MetaMaskConnectionStrategy extends ConnectionStrategy {
   providerId = 'metamask' as WalletProviderId;
 
-  async setup(web3: Web3) {
+  async setup() {
     let provider: any | undefined = await detectEthereumProvider();
 
     if (!provider) {
@@ -180,7 +273,6 @@ class MetaMaskConnectionManager extends ConnectionManager {
     });
 
     this.provider = provider;
-    web3?.setProvider(provider);
   }
 
   async connect() {
@@ -247,10 +339,14 @@ class MetaMaskConnectionManager extends ConnectionManager {
   }
 }
 
-class WalletConnectConnectionManager extends ConnectionManager {
+class WalletConnectConnectionStrategy extends ConnectionStrategy {
   providerId = 'wallet-connect' as WalletProviderId;
 
-  async setup(web3: Web3) {
+  getSession() {
+    return this.provider.connector.session;
+  }
+
+  async setup(session?: any) {
     let { chainId } = this;
     // in case we've disconnected, we should clear wallet connect's local storage data as well
     // As per https://github.com/WalletConnect/walletconnect-monorepo/issues/258 there is no way
@@ -259,8 +355,17 @@ class WalletConnectConnectionManager extends ConnectionManager {
     if (ConnectionManager.getProviderIdForChain(chainId) !== this.providerId) {
       clearWalletConnectStorage(chainId);
     }
+
+    let connectorOptions;
+    if (session) {
+      connectorOptions = { session };
+    } else {
+      connectorOptions = {
+        bridge: WALLET_CONNECT_BRIDGE,
+        qrcodeModal: WalletConnectQRCodeModal,
+      };
+    }
     let provider = new WalletConnectProvider({
-      pollingInterval: 30000,
       chainId,
       infuraId: config.infuraId,
       rpc: {
@@ -276,13 +381,7 @@ class WalletConnectConnectionManager extends ConnectionManager {
         ),
       },
       // based on https://github.com/WalletConnect/walletconnect-monorepo/blob/7aa9a7213e15489fa939e2e020c7102c63efd9c4/packages/providers/web3-provider/src/index.ts#L47-L52
-      connector: new CustomStorageWalletConnect(
-        {
-          bridge: WALLET_CONNECT_BRIDGE,
-          qrcodeModal: WalletConnectQRCodeModal,
-        },
-        chainId
-      ),
+      connector: new CustomStorageWalletConnect(connectorOptions, chainId),
     });
 
     // Subscribe to accounts change
@@ -305,8 +404,6 @@ class WalletConnectConnectionManager extends ConnectionManager {
     });
 
     this.provider = provider;
-    // ts is not happy with WalletConnectProvider
-    web3.setProvider(provider as any);
     return;
   }
 

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -96,15 +96,13 @@ export default abstract class Layer1ChainWeb3Strategy
         return;
       }
 
-      await this.connectionManager.setup(payload.providerId, payload.session);
-
-      if (this.connectionManager.provider) {
-        this.web3 = new Web3();
-        this.web3.setProvider(this.connectionManager.provider);
-        await this.connectionManager.reconnect(); // use the reconnect method because of edge cases
-      }
+      this.web3 = new Web3();
+      await this.connectionManager.reconnect(
+        this.web3,
+        payload.providerId,
+        payload.session
+      );
     } catch (e) {
-      // we might want to get the user to reload the page here
       console.error(
         `Failed to establish connection to ${payload.providerId} from cross-tab communication`
       );
@@ -146,13 +144,8 @@ export default abstract class Layer1ChainWeb3Strategy
         return;
       }
 
-      await this.connectionManager.setup(providerId);
-
-      if (this.connectionManager.provider) {
-        this.web3 = new Web3();
-        this.web3.setProvider(this.connectionManager.provider);
-        await this.connectionManager.reconnect(); // use the reconnect method because of edge cases
-      }
+      this.web3 = new Web3();
+      await this.connectionManager.reconnect(this.web3, providerId);
     } catch (e) {
       console.error('Failed to initialize connection from local storage');
       console.error(e);
@@ -164,13 +157,8 @@ export default abstract class Layer1ChainWeb3Strategy
 
   async connect(walletProvider: WalletProvider): Promise<void> {
     try {
-      await this.connectionManager.setup(walletProvider.id);
-
-      if (this.connectionManager.provider) {
-        this.web3 = new Web3();
-        this.web3.setProvider(this.connectionManager.provider);
-        await this.connectionManager.connect();
-      }
+      this.web3 = new Web3();
+      await this.connectionManager.connect(this.web3, walletProvider.id);
     } catch (e) {
       console.error(
         `Failed to create connection manager: ${walletProvider.id}`

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -156,6 +156,7 @@ export default abstract class Layer1ChainWeb3Strategy
     } catch (e) {
       console.error('Failed to initialize connection from local storage');
       console.error(e);
+      Sentry.captureException(e);
       this.cleanupConnectionState();
       ConnectionManager.removeProviderFromStorage(this.chainId);
     }
@@ -175,6 +176,7 @@ export default abstract class Layer1ChainWeb3Strategy
         `Failed to create connection manager: ${walletProvider.id}`
       );
       console.error(e);
+      Sentry.captureException(e);
       this.cleanupConnectionState();
       ConnectionManager.removeProviderFromStorage(this.chainId);
     }

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -8,7 +8,7 @@ import { Contract } from 'web3-eth-contract';
 import { Emitter, SimpleEmitter, UnbindEventListener } from '../events';
 import { BridgeableSymbol, TokenContractInfo } from '../token';
 import WalletInfo from '../wallet-info';
-import { WalletProvider } from '../wallet-providers';
+import { WalletProvider, WalletProviderId } from '../wallet-providers';
 import {
   ApproveOptions,
   Layer1ChainEvent,
@@ -32,6 +32,7 @@ import {
 } from './layer-1-connection-manager';
 import { task } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
+import { action } from '@ember/object';
 
 export default abstract class Layer1ChainWeb3Strategy
   implements Layer1Web3Strategy, Emitter<Layer1ChainEvent> {
@@ -42,7 +43,7 @@ export default abstract class Layer1ChainWeb3Strategy
   // changes with connection state
   #waitForAccountDeferred = defer<void>();
   web3: Web3 | undefined;
-  connectionManager: ConnectionManager | undefined;
+  connectionManager: ConnectionManager;
   eventListenersToUnbind: {
     [event in ConnectionManagerEvent]?: UnbindEventListener;
   } = {};
@@ -61,6 +62,15 @@ export default abstract class Layer1ChainWeb3Strategy
     this.bridgeConfirmationBlockCount = Number(
       getConstantByNetwork('ambFinalizationRate', this.networkSymbol)
     );
+    this.connectionManager = new ConnectionManager(networkSymbol);
+    // may need this for testing?
+    this.connectionManager.on('connected', this.onConnect);
+    this.connectionManager.on('disconnected', this.onDisconnect);
+    this.connectionManager.on('chain-changed', this.onChainChanged);
+    this.connectionManager.on(
+      'cross-tab-connection',
+      this.onCrossTabConnection
+    );
     taskFor(this.initializeTask).perform();
   }
 
@@ -69,40 +79,77 @@ export default abstract class Layer1ChainWeb3Strategy
   }
 
   @task *initializeTask() {
+    yield this.reconnect();
+  }
+
+  @action
+  async onCrossTabConnection(payload: {
+    providerId: WalletProviderId;
+    session?: any;
+  }) {
     try {
-      let web3 = new Web3();
+      if (
+        payload.providerId !== 'wallet-connect' &&
+        payload.providerId !== 'metamask'
+      ) {
+        return;
+      }
+
+      await this.connectionManager.setup(payload.providerId, payload.session);
+
+      if (this.connectionManager.provider) {
+        this.web3 = new Web3();
+        this.web3.setProvider(this.connectionManager.provider);
+        await this.connectionManager.reconnect(); // use the reconnect method because of edge cases
+      }
+    } catch (e) {
+      // we might want to get the user to reload the page here
+      console.error(
+        `Failed to establish connection to ${payload.providerId} from cross-tab communication`
+      );
+      console.error(e);
+      this.cleanupConnectionState();
+    }
+  }
+
+  @action
+  async onConnect(accounts: string[]) {
+    this.updateWalletInfo(accounts, this.chainId);
+    this.currentProviderId = this.connectionManager?.providerId;
+    this.#waitForAccountDeferred.resolve();
+  }
+
+  @action
+  onChainChanged(chainId: number) {
+    this.connectedChainId = chainId;
+    if (this.connectedChainId !== this.chainId) {
+      this.simpleEmitter.emit('incorrect-chain');
+    } else {
+      this.simpleEmitter.emit('correct-chain');
+    }
+  }
+
+  @action
+  private onDisconnect() {
+    if (this.isConnected) {
+      this.simpleEmitter.emit('disconnect');
+    }
+    this.cleanupConnectionState();
+  }
+
+  async reconnect() {
+    try {
       let providerId = ConnectionManager.getProviderIdForChain(this.chainId);
       if (providerId !== 'wallet-connect' && providerId !== 'metamask') {
         return;
       }
 
-      let connectionManager: ConnectionManager = ConnectionManager.create(
-        providerId,
-        {
-          networkSymbol: this.networkSymbol,
-          chainId: this.chainId,
-        }
-      );
+      await this.connectionManager.setup(providerId);
 
-      this.eventListenersToUnbind.connected = connectionManager.on(
-        'connected',
-        this.onConnect.bind(this)
-      );
-      this.eventListenersToUnbind.disconnected = connectionManager.on(
-        'disconnected',
-        this.onDisconnect.bind(this)
-      );
-      this.eventListenersToUnbind['chain-changed'] = connectionManager.on(
-        'chain-changed',
-        this.onChainChanged.bind(this)
-      );
-
-      yield connectionManager.setup(web3);
-
-      if (connectionManager) {
-        this.web3 = web3;
-        this.connectionManager = connectionManager;
-        yield connectionManager.reconnect(); // use the reconnect method because of edge cases
+      if (this.connectionManager.provider) {
+        this.web3 = new Web3();
+        this.web3.setProvider(this.connectionManager.provider);
+        await this.connectionManager.reconnect(); // use the reconnect method because of edge cases
       }
     } catch (e) {
       console.error('Failed to initialize connection from local storage');
@@ -114,32 +161,13 @@ export default abstract class Layer1ChainWeb3Strategy
 
   async connect(walletProvider: WalletProvider): Promise<void> {
     try {
-      let web3 = new Web3();
-      let connectionManager: ConnectionManager = ConnectionManager.create(
-        walletProvider.id,
-        {
-          networkSymbol: this.networkSymbol,
-          chainId: this.chainId,
-        }
-      );
-      this.eventListenersToUnbind.connected = connectionManager.on(
-        'connected',
-        this.onConnect.bind(this)
-      );
-      this.eventListenersToUnbind.disconnected = connectionManager.on(
-        'disconnected',
-        this.onDisconnect.bind(this)
-      );
-      this.eventListenersToUnbind['chain-changed'] = connectionManager.on(
-        'chain-changed',
-        this.onChainChanged.bind(this)
-      );
+      await this.connectionManager.setup(walletProvider.id);
 
-      await connectionManager.setup(web3);
-
-      this.web3 = web3;
-      this.connectionManager = connectionManager;
-      await connectionManager.connect();
+      if (this.connectionManager.provider) {
+        this.web3 = new Web3();
+        this.web3.setProvider(this.connectionManager.provider);
+        await this.connectionManager.connect();
+      }
     } catch (e) {
       console.error(
         `Failed to create connection manager: ${walletProvider.id}`
@@ -147,21 +175,6 @@ export default abstract class Layer1ChainWeb3Strategy
       console.error(e);
       this.cleanupConnectionState();
       ConnectionManager.removeProviderFromStorage(this.chainId);
-    }
-  }
-
-  async onConnect(accounts: string[]) {
-    this.updateWalletInfo(accounts, this.chainId);
-    this.currentProviderId = this.connectionManager?.providerId;
-    this.#waitForAccountDeferred.resolve();
-  }
-
-  onChainChanged(chainId: number) {
-    this.connectedChainId = chainId;
-    if (this.connectedChainId !== this.chainId) {
-      this.simpleEmitter.emit('incorrect-chain');
-    } else {
-      this.simpleEmitter.emit('correct-chain');
     }
   }
 
@@ -177,19 +190,11 @@ export default abstract class Layer1ChainWeb3Strategy
         delete this.eventListenersToUnbind[event];
       }
     );
-    this.connectionManager?.destroy();
-    this.connectionManager = undefined;
+    this.connectionManager?.reset();
     this.web3 = undefined;
     this.currentProviderId = '';
     this.connectedChainId = undefined;
     this.#waitForAccountDeferred = defer();
-  }
-
-  private onDisconnect() {
-    if (this.isConnected) {
-      this.simpleEmitter.emit('disconnect');
-    }
-    this.cleanupConnectionState();
   }
 
   get waitForAccount(): Promise<void> {

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -4,6 +4,7 @@ import BN from 'bn.js';
 import Web3 from 'web3';
 import { TransactionReceipt } from 'web3-core';
 import { Contract } from 'web3-eth-contract';
+import * as Sentry from '@sentry/browser';
 
 import { Emitter, SimpleEmitter, UnbindEventListener } from '../events';
 import { BridgeableSymbol, TokenContractInfo } from '../token';
@@ -108,6 +109,7 @@ export default abstract class Layer1ChainWeb3Strategy
         `Failed to establish connection to ${payload.providerId} from cross-tab communication`
       );
       console.error(e);
+      Sentry.captureException(e);
       this.cleanupConnectionState();
     }
   }

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -40,6 +40,11 @@ import {
 import { taskFor } from 'ember-concurrency-ts';
 import config from '../../config/environment';
 import { TaskGenerator } from 'ember-concurrency';
+import { action } from '@ember/object';
+
+const BROADCAST_CHANNEL_MESSAGES = {
+  CONNECTED: 'CONNECTED',
+} as const;
 
 const BRIDGE = 'https://safe-walletconnect.gnosis.io/';
 
@@ -55,6 +60,7 @@ export default abstract class Layer2ChainWeb3Strategy
   #exchangeRateApi!: IExchangeRate;
   #safesApi!: ISafes;
   #hubAuthApi!: IHubAuth;
+  #broadcastChannel: BroadcastChannel;
   @tracked depotSafe: DepotSafe | null = null;
   @tracked walletInfo: WalletInfo;
   @tracked walletConnectUri: string | undefined;
@@ -78,12 +84,39 @@ export default abstract class Layer2ChainWeb3Strategy
       networkSymbol
     );
     this.defaultTokenContractAddress = defaultTokenContractInfo.address;
+    this.#broadcastChannel = new BroadcastChannel(
+      `cardstack-layer-2-connection-sync`
+    );
+    this.#broadcastChannel.addEventListener(
+      'message',
+      this.onBroadcastChannelMessage
+    );
   }
 
-  @task *initializeTask(): TaskGenerator<void> {
+  @action onBroadcastChannelMessage(event: MessageEvent) {
+    // only try to connect if we weren't already connected
+    // if we were already connected and there was an account change
+    // we should be receiving the same "accountsChanged" event in each tab
+    // from WalletConnect
+    if (
+      event.data.type === BROADCAST_CHANNEL_MESSAGES.CONNECTED &&
+      !this.isConnected
+    ) {
+      taskFor(this.initializeTask).perform(event.data.session);
+    }
+  }
+
+  @task *initializeTask(session?: any): TaskGenerator<void> {
+    let connectorOptions;
+    if (session) {
+      connectorOptions = { session };
+    } else {
+      connectorOptions = {
+        bridge: BRIDGE,
+      };
+    }
     this.web3 = new Web3();
     this.provider = new WalletConnectProvider({
-      pollingInterval: 30000,
       chainId: this.chainId,
       rpc: {
         [networkIds[this.networkSymbol]]: getConstantByNetwork(
@@ -97,12 +130,7 @@ export default abstract class Layer2ChainWeb3Strategy
           this.networkSymbol
         ),
       },
-      connector: new CustomStorageWalletConnect(
-        {
-          bridge: BRIDGE,
-        },
-        this.chainId
-      ),
+      connector: new CustomStorageWalletConnect(connectorOptions, this.chainId),
     });
     this.web3.setProvider(this.provider as any);
 
@@ -126,6 +154,10 @@ export default abstract class Layer2ChainWeb3Strategy
         this.#hubAuthApi = await getSDK('HubAuth', this.web3, config.hubURL);
         await this.updateWalletInfo(accounts, this.chainId);
         this.isInitializing = false;
+        this.#broadcastChannel.postMessage({
+          type: BROADCAST_CHANNEL_MESSAGES.CONNECTED,
+          session: this.connector?.session,
+        });
       } catch (e) {
         console.error(
           'Error initializing layer 2 wallet and services. Wallet may be connected to an unsupported chain'

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -41,10 +41,16 @@ import { taskFor } from 'ember-concurrency-ts';
 import config from '../../config/environment';
 import { TaskGenerator } from 'ember-concurrency';
 import { action } from '@ember/object';
+import { TypedChannel } from '../typed-channel';
 
 const BROADCAST_CHANNEL_MESSAGES = {
   CONNECTED: 'CONNECTED',
 } as const;
+
+interface Layer2ConnectEvent {
+  type: typeof BROADCAST_CHANNEL_MESSAGES.CONNECTED;
+  session?: any;
+}
 
 const BRIDGE = 'https://safe-walletconnect.gnosis.io/';
 
@@ -60,7 +66,7 @@ export default abstract class Layer2ChainWeb3Strategy
   #exchangeRateApi!: IExchangeRate;
   #safesApi!: ISafes;
   #hubAuthApi!: IHubAuth;
-  #broadcastChannel: BroadcastChannel;
+  #broadcastChannel: TypedChannel<Layer2ConnectEvent>;
   @tracked depotSafe: DepotSafe | null = null;
   @tracked walletInfo: WalletInfo;
   @tracked walletConnectUri: string | undefined;
@@ -84,7 +90,7 @@ export default abstract class Layer2ChainWeb3Strategy
       networkSymbol
     );
     this.defaultTokenContractAddress = defaultTokenContractInfo.address;
-    this.#broadcastChannel = new BroadcastChannel(
+    this.#broadcastChannel = new TypedChannel(
       `cardstack-layer-2-connection-sync`
     );
     this.#broadcastChannel.addEventListener(
@@ -93,7 +99,7 @@ export default abstract class Layer2ChainWeb3Strategy
     );
   }
 
-  @action onBroadcastChannelMessage(event: MessageEvent) {
+  @action onBroadcastChannelMessage(event: MessageEvent<Layer2ConnectEvent>) {
     // only try to connect if we weren't already connected
     // if we were already connected and there was an account change
     // we should be receiving the same "accountsChanged" event in each tab


### PR DESCRIPTION
This PR fixes CS-1490 by ensuring that connection events are propagated to other tabs. 

## Communicating connection events between tabs
- Using broadcast channels, as we were doing for disconnections, we send a message with a type of 'CONNECTED' to the layer-specific channel (one for layer 1 and another for layer 2).
- WalletConnect does not store its session in LocalStorage quickly enough, so we are unable to leverage that to establish connections. Instead we send the whole session over through the broadcast channel. MetaMask does not require this.

## Keeping cross-tab communication a responsibility of the ConnectionManager rather than leaking it into Layer1Chain
- Make ConnectionManager long-lived, and have it delegate to strategies for WalletConnect and MetaMask. Necessary to keep it long-lived as opposed to created upon connection + destroyed upon disconnection, so that it can listen for connection events.
- Have the now long-lived ConnectionManager post messages to, and listen for messages from the layer-specific broadcast channel. 

## Full flow for a layer 1 connection event being propagated to another tab and a session being established in that tab
- In tab A, the user initiates connection.
- After the user has confirmed that they want to connect on their wallet, a connection is established between wallet and dApp. The provider's `accountsChanged` event is fired with the newly connected account.
- The ConnectionManager posts a message to the broadcast channel. This message contains information about which provider (WalletConnect or MetaMask) was used and optionally (for WalletConnect), the session
- In tab B, the broadcast channel's message event listener picks up on the message. If the receiving ConnectionManager is not connected (there is no ConnectionStrategy), then it will emit a `cross-tab-connection` event to its consumer with the whole message.
- The consumer (layer 1 chain in the other tab) initiates connection using the information in the message (`providerId` and possibly `session`).