### PR TITLE
Merchant info endpoint groundwork

### DIFF
--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -591,6 +591,23 @@ CREATE TABLE graphile_worker.migrations (
 ALTER TABLE graphile_worker.migrations OWNER TO postgres;
 
 --
+-- Name: merchant_infos; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.merchant_infos (
+    id uuid NOT NULL,
+    name text NOT NULL,
+    slug text NOT NULL,
+    color text NOT NULL,
+    text_color text NOT NULL,
+    owner_address text NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.merchant_infos OWNER TO postgres;
+
+--
 -- Name: pgmigrations; Type: TABLE; Schema: public; Owner: postgres
 --
 
@@ -724,6 +741,14 @@ ALTER TABLE ONLY graphile_worker.migrations
 
 
 --
+-- Name: merchant_infos merchant_infos_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.merchant_infos
+    ADD CONSTRAINT merchant_infos_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: pgmigrations pgmigrations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
@@ -760,6 +785,13 @@ ALTER TABLE ONLY public.prepaid_card_patterns
 --
 
 CREATE INDEX jobs_priority_run_at_id_locked_at_without_failures_idx ON graphile_worker.jobs USING btree (priority, run_at, id, locked_at) WHERE (attempts < max_attempts);
+
+
+--
+-- Name: merchant_infos_slug_unique_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX merchant_infos_slug_unique_index ON public.merchant_infos USING btree (slug);
 
 
 --
@@ -884,6 +916,8 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 1	20210527151505645_create-prepaid-card-tables	2021-07-29 23:45:29.577801
 2	20210614080132698_create-prepaid-card-customizations-table	2021-07-29 23:45:29.577801
 3	20210623052200757_create-graphile-worker-schema	2021-07-29 23:45:29.577801
+4	20210809113449561_merchant-infos	2021-08-09 14:47:15.726385
+5	20210809113449561_merchant-infos	2021-08-12 09:52:27.790806
 \.
 
 
@@ -891,7 +925,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 -- Name: pgmigrations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.pgmigrations_id_seq', 3, true);
+SELECT pg_catalog.setval('public.pgmigrations_id_seq', 4, true);
 
 
 --

--- a/packages/hub/db/migrations/20210809113449561_merchant-infos.js
+++ b/packages/hub/db/migrations/20210809113449561_merchant-infos.js
@@ -1,0 +1,19 @@
+const TABLE = 'merchant_infos';
+
+exports.up = (pgm) => {
+  pgm.createTable(TABLE, {
+    id: { type: 'uuid', primaryKey: true },
+    name: { type: 'string', notNull: true },
+    slug: { type: 'string', notNull: true },
+    color: { type: 'string', notNull: true },
+    text_color: { type: 'string', notNull: true },
+    owner_address: { type: 'string', notNull: true },
+    created_at: { type: 'timestamp', notNull: true, default: pgm.func('current_timestamp') },
+  });
+
+  pgm.createIndex(TABLE, 'slug', { unique: true });
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable(TABLE);
+};

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -22,6 +22,8 @@ import PrepaidCardPatternsRoute from './routes/prepaid-card-patterns';
 import PrepaidCardCustomizationSerializer from './services/serializers/prepaid-card-customization-serializer';
 import PrepaidCardCustomizationsRoute from './routes/prepaid-card-customizations';
 import PersistOffChainPrepaidCardCustomizationTask from './tasks/persist-off-chain-prepaid-card-customization';
+import MerchantInfosRoute from './routes/merchant-infos';
+import MerchantInfoSerializer from './services/serializers/merchant-info-serializer';
 import { AuthenticationUtils } from './utils/authentication';
 import JsonapiMiddleware from './services/jsonapi-middleware';
 import NonceTracker from './services/nonce-tracker';
@@ -51,6 +53,8 @@ export function wireItUp(registryCallback?: RegistryCallback): Container {
   registry.register('prepaid-card-color-scheme-serializer', PrepaidCardColorSchemeSerializer);
   registry.register('prepaid-card-patterns-route', PrepaidCardPatternsRoute);
   registry.register('prepaid-card-pattern-serializer', PrepaidCardPatternSerializer);
+  registry.register('merchant-infos-route', MerchantInfosRoute);
+  registry.register('merchant-info-serializer', MerchantInfoSerializer);
   registry.register('worker-client', WorkerClient);
   if (registryCallback) {
     registryCallback(registry);

--- a/packages/hub/node-tests/routes/merchant-infos-test.ts
+++ b/packages/hub/node-tests/routes/merchant-infos-test.ts
@@ -1,0 +1,110 @@
+import { Server } from 'http';
+import supertest, { Test } from 'supertest';
+import { bootServerForTesting } from '../../main';
+import { Registry } from '../../di/dependency-injection';
+
+const stubNonce = 'abc:123';
+let stubAuthToken = 'def--456';
+let stubTimestamp = process.hrtime.bigint();
+
+class StubAuthenticationUtils {
+  generateNonce() {
+    return stubNonce;
+  }
+  buildAuthToken() {
+    return stubAuthToken;
+  }
+  extractVerifiedTimestamp(_nonce: string) {
+    return stubTimestamp;
+  }
+
+  validateAuthToken(encryptedAuthToken: string) {
+    return handleValidateAuthToken(encryptedAuthToken);
+  }
+}
+
+let stubUserAddress = '0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13';
+function handleValidateAuthToken(encryptedString: string) {
+  expect(encryptedString).to.equal('abc123--def456--ghi789');
+  return stubUserAddress;
+}
+
+describe('POST /api/merchant-infos', function () {
+  let server: Server;
+  let request: supertest.SuperTest<Test>;
+
+  this.beforeEach(async function () {
+    server = await bootServerForTesting({
+      port: 3001,
+      registryCallback(registry: Registry) {
+        registry.register('authentication-utils', StubAuthenticationUtils);
+      },
+    });
+
+    request = supertest(server);
+  });
+
+  this.afterEach(async function () {
+    server.close();
+  });
+
+  it('persists merchant info', async function () {
+    const payload = {
+      data: {
+        type: 'merchant-infos',
+        attributes: {
+          name: 'Satoshi Nakamoto',
+          slug: 'satoshi',
+          color: 'ff0000',
+          'text-color': 'ffffff',
+          'owner-address': '0x00000000000',
+        },
+      },
+    };
+
+    await request
+      .post('/api/merchant-infos')
+      .send(payload)
+      .set('Authorization', 'Bearer: abc123--def456--ghi789')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(201)
+      .expect(function (res) {
+        res.body.data.id = 'the-id';
+        res.body.data.attributes.did = 'the-did';
+      })
+      .expect({
+        data: {
+          type: 'merchant-infos',
+          id: 'the-id',
+          attributes: {
+            name: 'Satoshi Nakamoto',
+            slug: 'satoshi',
+            did: 'the-did',
+            color: 'ff0000',
+            textColor: 'ffffff',
+            ownerAddress: '0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13',
+          },
+        },
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('returns 401 without bearer token', async function () {
+    await request
+      .post('/api/merchant-infos')
+      .send({})
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(401)
+      .expect({
+        errors: [
+          {
+            status: '401',
+            title: 'No valid auth token',
+          },
+        ],
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+});

--- a/packages/hub/routes/merchant-infos.ts
+++ b/packages/hub/routes/merchant-infos.ts
@@ -1,0 +1,108 @@
+import Koa from 'koa';
+import autoBind from 'auto-bind';
+import DatabaseManager from '../services/database-manager';
+import { inject } from '../di/dependency-injection';
+import shortUuid from 'short-uuid';
+import { AuthenticationUtils } from '../utils/authentication';
+import MerchantInfoSerializer from '../services/serializers/merchant-info-serializer';
+
+export default class MerchantInfosRoute {
+  authenticationUtils: AuthenticationUtils = inject('authentication-utils', { as: 'authenticationUtils' });
+  databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
+  merchantInfoSerializer: MerchantInfoSerializer = inject('merchant-info-serializer', {
+    as: 'merchantInfoSerializer',
+  });
+
+  constructor() {
+    autoBind(this);
+  }
+
+  async post(ctx: Koa.Context) {
+    if (!ensureLoggedIn(ctx)) {
+      return;
+    }
+
+    let db = await this.databaseManager.getClient();
+
+    if (!ensureValidPayload(ctx)) {
+      return;
+    }
+
+    let newId = shortUuid.uuid();
+    let name = ctx.request.body.data.attributes['name'];
+    let slug = ctx.request.body.data.attributes['slug']; // TODO: validate uniqueness
+    let color = ctx.request.body.data.attributes['color'];
+    let textColor = ctx.request.body.data.attributes['text-color'];
+    let ownerAddress = ctx.state.userAddress;
+
+    await db.query(
+      'INSERT INTO merchant_infos (id, name, slug, color, text_color, owner_address) VALUES($1, $2, $3, $4, $5, $6)',
+      [newId, name, slug, color, textColor, ownerAddress]
+    );
+
+    let serialized = await this.merchantInfoSerializer.serialize({
+      id: newId,
+      name,
+      slug,
+      color,
+      textColor,
+      ownerAddress,
+    });
+
+    ctx.status = 201;
+    ctx.body = serialized;
+    ctx.type = 'application/vnd.api+json';
+  }
+}
+
+function ensureLoggedIn(ctx: Koa.Context) {
+  if (ctx.state.userAddress) {
+    return true;
+  }
+  ctx.body = {
+    errors: [
+      {
+        status: '401',
+        title: 'No valid auth token',
+      },
+    ],
+  };
+  ctx.status = 401;
+  ctx.type = 'application/vnd.api+json';
+  return false;
+}
+
+function ensureValidPayload(ctx: Koa.Context) {
+  let errors = [errorForAttribute(ctx, 'name'), errorForAttribute(ctx, 'slug'), errorForAttribute(ctx, 'color')].filter(
+    Boolean
+  );
+
+  if (errors.length === 0) {
+    return true;
+  }
+  ctx.body = {
+    errors,
+  };
+  ctx.status = 422;
+  ctx.type = 'application/vnd.api+json';
+  return false;
+}
+
+function errorForAttribute(ctx: Koa.Context, attributeName: string) {
+  let attributeValue = ctx.request.body?.data?.attributes?.[attributeName];
+  if (attributeValue && attributeValue.length > 0) {
+    return;
+  }
+
+  return {
+    status: '422',
+    title: `Missing required attribute: ${attributeName}`,
+    detail: `Required field ${attributeName} was not provided`,
+  };
+}
+
+declare module '@cardstack/hub/di/dependency-injection' {
+  interface KnownServices {
+    'merchant-infos-route': MerchantInfosRoute;
+  }
+}

--- a/packages/hub/services/jsonapi-middleware.ts
+++ b/packages/hub/services/jsonapi-middleware.ts
@@ -12,6 +12,7 @@ import SessionRoute from '../routes/session';
 import PrepaidCardColorSchemesRoute from '../routes/prepaid-card-color-schemes';
 import PrepaidCardPatternsRoute from '../routes/prepaid-card-patterns';
 import PrepaidCardCustomizationsRoute from '../routes/prepaid-card-customizations';
+import MerchantInfosRoute from '../routes/merchant-infos';
 import { inject } from '../di/dependency-injection';
 
 const API_PREFIX = '/api';
@@ -28,6 +29,9 @@ export default class JSONAPIMiddleware {
   });
   prepaidCardCustomizationsRoute: PrepaidCardCustomizationsRoute = inject('prepaid-card-customizations-route', {
     as: 'prepaidCardCustomizationsRoute',
+  });
+  merchantInfosRoute: MerchantInfosRoute = inject('merchant-infos-route', {
+    as: 'merchantInfosRoute',
   });
   middleware() {
     return (ctxt: Koa.ParameterizedContext<SessionContext, Record<string, unknown>>, next: Koa.Next) => {
@@ -62,6 +66,7 @@ export default class JSONAPIMiddleware {
       prepaidCardColorSchemesRoute,
       prepaidCardPatternsRoute,
       prepaidCardCustomizationsRoute,
+      merchantInfosRoute,
       sessionRoute,
     } = this;
 
@@ -74,6 +79,7 @@ export default class JSONAPIMiddleware {
       route.get('/prepaid-card-color-schemes', prepaidCardColorSchemesRoute.get),
       route.get('/prepaid-card-patterns', prepaidCardPatternsRoute.get),
       route.post('/prepaid-card-customizations', prepaidCardCustomizationsRoute.post),
+      route.post('/merchant-infos', merchantInfosRoute.post),
       route.all('/(.*)', notFound),
     ]);
   }

--- a/packages/hub/services/serializers/merchant-info-serializer.ts
+++ b/packages/hub/services/serializers/merchant-info-serializer.ts
@@ -1,0 +1,50 @@
+import { encodeDID } from '@cardstack/did-resolver';
+import { inject } from '../../di/dependency-injection';
+import DatabaseManager from '../database-manager';
+
+interface MerchantInfo {
+  id: string;
+  name: string;
+  slug: string;
+  color: string;
+  textColor: string;
+  ownerAddress: string;
+}
+
+interface JSONAPIDocument {
+  data: any;
+  included?: any[];
+}
+
+export default class MerchantInfoSerializer {
+  databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
+
+  async serialize(content: MerchantInfo): Promise<JSONAPIDocument> {
+    const did = encodeDID({ type: 'MerchantInfo', uniqueId: content.id });
+
+    const data = {
+      id: content.id,
+      type: 'merchant-infos',
+      attributes: {
+        did,
+        name: content.name,
+        slug: content.slug,
+        color: content.color,
+        textColor: content.textColor,
+        ownerAddress: content.ownerAddress,
+      },
+    };
+
+    const result = {
+      data,
+    } as JSONAPIDocument;
+
+    return result;
+  }
+}
+
+declare module '@cardstack/hub/di/dependency-injection' {
+  interface KnownServices {
+    'merchant-info-serializer': MerchantInfoSerializer;
+  }
+}


### PR DESCRIPTION
Ticket: [CS-1432](https://linear.app/cardstack/issue/CS-1432/hub-endpoint-to-create-merchantinfo-generates-and-returns-a-did)

This PR includes all the boilerplate code of adding a new route and a very basic endpoint functionality (insert to DB via POST). 

This is only a part of the bigger feature. I think splitting this feature up into smaller PRs is more convenient to review. 

Missing things (will be added later, probably in a separate PR):
1. Validations
2. DID creation 
3. More comprehensive tests
4. Refactor / DRY up (currently some code is duplicated - serialization, validation stuff)

