### PR TITLE
Fix lint breaking

### DIFF
--- a/packages/firebase-functions/push/functions/src/index.ts
+++ b/packages/firebase-functions/push/functions/src/index.ts
@@ -5,6 +5,8 @@ import { register } from './routes/register';
 import cors from 'cors';
 import { IResponse } from './types';
 
+// Disabling eslint bc we need to use require since service-account will be generated on deploy
+// eslint-disable-next-line @typescript-eslint/no-require-imports, node/no-missing-require
 const serviceAccount = require('./service-account.json') || {};
 
 const adminConfig = process.env.FIREBASE_CONFIG ? JSON.parse(process.env.FIREBASE_CONFIG) : undefined;


### PR DESCRIPTION
`service-account.json` will be decrypted while deploying it, so this file will only exist during the deployment, that's why we need to use the node `require` so it won't complain that it doesn't exist, open to hear if there's a better solution for this, for the time being I'm disabling the eslint rule. 