### PR TITLE
Enhancement/account changed event

### DIFF
--- a/packages/web-client/app/services/layer1-network.ts
+++ b/packages/web-client/app/services/layer1-network.ts
@@ -37,7 +37,7 @@ export default class Layer1Network
   @reads('strategy.isInitializing') declare isInitializing: boolean;
   @reads('strategy.isConnected', false) isConnected!: boolean;
   @reads('strategy.walletConnectUri') walletConnectUri: string | undefined;
-  @reads('strategy.walletInfo', new WalletInfo([], -1)) walletInfo!: WalletInfo;
+  @reads('strategy.walletInfo', new WalletInfo([])) walletInfo!: WalletInfo;
   @reads('strategy.waitForAccount') waitForAccount!: Promise<void>;
   @reads('strategy.defaultTokenBalance') defaultTokenBalance: BN | undefined;
   @reads('strategy.daiBalance') daiBalance: BN | undefined;

--- a/packages/web-client/app/services/layer1-network.ts
+++ b/packages/web-client/app/services/layer1-network.ts
@@ -63,6 +63,7 @@ export default class Layer1Network
     }
 
     this.strategy.on('disconnect', this.onDisconnect);
+    this.strategy.on('account-changed', this.onAccountChanged);
     this.strategy.on('incorrect-chain', this.onIncorrectChain);
     this.strategy.on('correct-chain', this.onCorrectChain);
   }
@@ -86,6 +87,10 @@ export default class Layer1Network
 
   @action onCorrectChain() {
     this.simpleEmitter.emit('correct-chain');
+  }
+
+  @action onAccountChanged() {
+    this.simpleEmitter.emit('account-changed');
   }
 
   // basically only allow re-emitting of events from the strategy

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -64,6 +64,7 @@ export default class Layer2Network
 
     this.strategy.on('disconnect', this.onDisconnect);
     this.strategy.on('incorrect-chain', this.onIncorrectChain);
+    this.strategy.on('account-changed', this.onAccountChanged);
 
     taskFor(this.strategy.initializeTask).perform();
   }
@@ -136,6 +137,10 @@ export default class Layer2Network
 
   @action onIncorrectChain() {
     this.simpleEmitter.emit('incorrect-chain');
+  }
+
+  @action onAccountChanged() {
+    this.simpleEmitter.emit('account-changed');
   }
 
   on(event: Layer2ChainEvent, cb: Function): UnbindEventListener {

--- a/packages/web-client/app/utils/wallet-info.ts
+++ b/packages/web-client/app/utils/wallet-info.ts
@@ -15,13 +15,12 @@ class WalletAccount {
 
 export default class WalletInfo {
   accounts: WalletAccount[];
-  chainId: number;
 
   get firstAddress(): string | undefined {
     return this.accounts.length ? this.accounts[0].address : undefined;
   }
 
-  constructor(rawAccounts: string[] | any[], chainId: number) {
+  constructor(rawAccounts: string[] | any[]) {
     if (rawAccounts.length > 0 && typeof rawAccounts[0] === 'string') {
       this.accounts = rawAccounts.map(
         (address: string) => new WalletAccount(address, address)
@@ -36,13 +35,9 @@ export default class WalletInfo {
           )
       );
     }
-
-    this.chainId = chainId;
   }
 
   isEqualTo(other: WalletInfo) {
-    return (
-      this.chainId === other.chainId && this.firstAddress === other.firstAddress
-    );
+    return this.firstAddress === other.firstAddress;
   }
 }

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -207,7 +207,16 @@ export default abstract class Layer1ChainWeb3Strategy
   }
 
   private async updateWalletInfo(accounts: string[]) {
-    this.walletInfo = new WalletInfo(accounts);
+    let newWalletInfo = new WalletInfo(accounts);
+    if (this.walletInfo.isEqualTo(newWalletInfo)) {
+      return;
+    }
+
+    if (this.walletInfo.firstAddress && newWalletInfo.firstAddress) {
+      this.simpleEmitter.emit('account-changed');
+    }
+
+    this.walletInfo = newWalletInfo;
     if (accounts.length > 0) {
       await this.refreshBalances();
     } else {

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -59,7 +59,7 @@ export default abstract class Layer1ChainWeb3Strategy
 
   constructor(networkSymbol: Layer1NetworkSymbol) {
     this.chainId = networkIds[networkSymbol];
-    this.walletInfo = new WalletInfo([], this.chainId);
+    this.walletInfo = new WalletInfo([]);
     this.networkSymbol = networkSymbol;
     this.bridgeConfirmationBlockCount = Number(
       getConstantByNetwork('ambFinalizationRate', this.networkSymbol)
@@ -119,7 +119,7 @@ export default abstract class Layer1ChainWeb3Strategy
 
   @action
   async onConnect(accounts: string[]) {
-    await this.updateWalletInfo(accounts, this.chainId);
+    await this.updateWalletInfo(accounts);
     this.currentProviderId = this.connectionManager?.providerId;
     this.#waitForAccountDeferred.resolve();
   }
@@ -206,8 +206,8 @@ export default abstract class Layer1ChainWeb3Strategy
     return this.simpleEmitter.on(event, cb);
   }
 
-  private async updateWalletInfo(accounts: string[], chainId: number) {
-    this.walletInfo = new WalletInfo(accounts, chainId);
+  private async updateWalletInfo(accounts: string[]) {
+    this.walletInfo = new WalletInfo(accounts);
     if (accounts.length > 0) {
       await this.refreshBalances();
     } else {
@@ -218,7 +218,7 @@ export default abstract class Layer1ChainWeb3Strategy
   }
 
   private clearWalletInfo() {
-    this.updateWalletInfo([], -1);
+    this.updateWalletInfo([]);
   }
 
   contractForToken(symbol: BridgeableSymbol) {

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -84,7 +84,7 @@ export default abstract class Layer2ChainWeb3Strategy
   constructor(networkSymbol: Layer2NetworkSymbol) {
     this.chainId = networkIds[networkSymbol];
     this.networkSymbol = networkSymbol;
-    this.walletInfo = new WalletInfo([], this.chainId);
+    this.walletInfo = new WalletInfo([]);
     let defaultTokenContractInfo = this.getTokenContractInfo(
       this.defaultTokenSymbol,
       networkSymbol
@@ -158,7 +158,7 @@ export default abstract class Layer2ChainWeb3Strategy
         this.#layerTwoOracleApi = await getSDK('LayerTwoOracle', this.web3);
         this.#safesApi = await getSDK('Safes', this.web3);
         this.#hubAuthApi = await getSDK('HubAuth', this.web3, config.hubURL);
-        await this.updateWalletInfo(accounts, this.chainId);
+        await this.updateWalletInfo(accounts);
         this.isInitializing = false;
         this.#broadcastChannel.postMessage({
           type: BROADCAST_CHANNEL_MESSAGES.CONNECTED,
@@ -200,8 +200,8 @@ export default abstract class Layer2ChainWeb3Strategy
     return new TokenContractInfo(symbol, network);
   }
 
-  async updateWalletInfo(accounts: string[], chainId: number) {
-    let newWalletInfo = new WalletInfo(accounts, chainId);
+  async updateWalletInfo(accounts: string[]) {
+    let newWalletInfo = new WalletInfo(accounts);
     if (this.walletInfo.isEqualTo(newWalletInfo)) {
       return;
     }
@@ -217,7 +217,7 @@ export default abstract class Layer2ChainWeb3Strategy
   }
 
   clearWalletInfo() {
-    this.updateWalletInfo([], this.chainId);
+    this.updateWalletInfo([]);
   }
 
   async refreshBalances() {

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -205,6 +205,11 @@ export default abstract class Layer2ChainWeb3Strategy
     if (this.walletInfo.isEqualTo(newWalletInfo)) {
       return;
     }
+
+    if (this.walletInfo.firstAddress && newWalletInfo.firstAddress) {
+      this.simpleEmitter.emit('account-changed');
+    }
+
     this.walletInfo = newWalletInfo;
     if (accounts.length) {
       await taskFor(this.fetchDepotTask).perform();

--- a/packages/web-client/app/utils/web3-strategies/test-layer1.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer1.ts
@@ -32,7 +32,7 @@ export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
   @tracked isInitializing = false;
   @tracked currentProviderId: string | undefined;
   @tracked walletConnectUri: string | undefined;
-  @tracked walletInfo: WalletInfo = new WalletInfo([], -1);
+  @tracked walletInfo: WalletInfo = new WalletInfo([]);
   simpleEmitter = new SimpleEmitter();
   nativeTokenSymbol = 'ETH';
 
@@ -111,11 +111,11 @@ export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
   test__simulateAccountsChanged(accounts: string[], walletProviderId?: string) {
     if (accounts.length && walletProviderId) {
       this.currentProviderId = walletProviderId;
-      this.walletInfo = new WalletInfo(accounts, this.chainId);
+      this.walletInfo = new WalletInfo(accounts);
       this.waitForAccountDeferred.resolve();
     } else {
       this.currentProviderId = '';
-      this.walletInfo = new WalletInfo([], this.chainId);
+      this.walletInfo = new WalletInfo([]);
       this.waitForAccountDeferred.resolve();
     }
   }

--- a/packages/web-client/app/utils/web3-strategies/test-layer2.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer2.ts
@@ -43,7 +43,7 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
   chainId = '-1';
   simpleEmitter = new SimpleEmitter();
   @tracked walletConnectUri: string | undefined;
-  @tracked walletInfo: WalletInfo = new WalletInfo([], -1);
+  @tracked walletInfo: WalletInfo = new WalletInfo([]);
   waitForAccountDeferred = defer();
   bridgingToLayer2Deferred!: RSVP.Deferred<TransactionReceipt>;
   bridgingToLayer1HashDeferred!: RSVP.Deferred<TransactionHash>;
@@ -209,7 +209,7 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
   }
 
   test__simulateAccountsChanged(accounts: string[]) {
-    this.walletInfo = new WalletInfo(accounts, parseInt(this.chainId, 10));
+    this.walletInfo = new WalletInfo(accounts);
     this.waitForAccountDeferred.resolve();
   }
 

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -18,11 +18,13 @@ import { TaskGenerator } from 'ember-concurrency';
 export type Layer1ChainEvent =
   | 'disconnect'
   | 'incorrect-chain'
-  | 'correct-chain';
+  | 'correct-chain'
+  | 'account-changed';
 export type Layer2ChainEvent =
   | 'disconnect'
   | 'incorrect-chain'
-  | 'correct-chain';
+  | 'correct-chain'
+  | 'account-changed';
 
 export interface Web3Strategy {
   isConnected: boolean;


### PR DESCRIPTION
Part of CS-1286.

- Removes chainId from WalletInfo as this is hardcoded in many places, not read, and potentially misleading.
- Adds an `account-changed` event to Layer 1 and 2, that is only emitted if a new account is connected while the dApp already has an existing account for that layer.