### PR TITLE
Rename ExchangeRate SDK to LayerTwoOracle SDK

### DIFF
--- a/packages/cardpay-cli/index.ts
+++ b/packages/cardpay-cli/index.ts
@@ -18,7 +18,7 @@ import {
   payMerchant,
   gasFee,
 } from './prepaid-card.js';
-import { usdPrice, ethPrice, priceOracleUpdatedAt } from './exchange-rate';
+import { usdPrice, ethPrice, priceOracleUpdatedAt } from './layer-two-oracle';
 import { claimRevenue, claimRevenueGasEstimate, registerMerchant, revenueBalances } from './revenue-pool.js';
 import { rewardTokenBalances } from './reward-pool.js';
 import { hubAuth } from './hub-auth';

--- a/packages/cardpay-cli/layer-two-oracle.ts
+++ b/packages/cardpay-cli/layer-two-oracle.ts
@@ -7,21 +7,21 @@ export async function usdPrice(network: string, token: string, amount?: string, 
   amount = amount ?? '1';
   let web3 = await getWeb3(network, mnemonic);
   let amountInWei = toWei(amount);
-  let exchangeRate = await getSDK('ExchangeRate', web3);
-  let usdPrice = await exchangeRate.getUSDPrice(token, amountInWei);
+  let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+  let usdPrice = await layerTwoOracle.getUSDPrice(token, amountInWei);
   console.log(`USD value: $${usdPrice.toFixed(2)} USD`);
 }
 export async function ethPrice(network: string, token: string, amount?: string, mnemonic?: string): Promise<void> {
   amount = amount ?? '1';
   let web3 = await getWeb3(network, mnemonic);
   let amountInWei = toWei(amount);
-  let exchangeRate = await getSDK('ExchangeRate', web3);
-  let ethWeiPrice = await exchangeRate.getETHPrice(token, amountInWei);
+  let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+  let ethWeiPrice = await layerTwoOracle.getETHPrice(token, amountInWei);
   console.log(`ETH value: ${fromWei(ethWeiPrice)} ETH`);
 }
 export async function priceOracleUpdatedAt(network: string, token: string, mnemonic?: string): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let exchangeRate = await getSDK('ExchangeRate', web3);
-  let date = await exchangeRate.getUpdatedAt(token);
+  let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+  let date = await layerTwoOracle.getUpdatedAt(token);
   console.log(`The ${token} rate was last updated at ${date.toString()}`);
 }

--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -46,12 +46,13 @@ This is a package that provides an SDK to use the Cardpay protocol.
   - [`RewardPool.rewardTokenBalance`](#rewardpoolrewardtokenbalance)
   - [`RewardPool.claim` (TBD)](#rewardpoolclaim-tbd)
 - [`ExchangeRate`](#exchangerate)
-  - [`ExchangeRate.convertToSpend`](#exchangerateconverttospend)
-  - [`ExchangeRate.convertFromSpend`](#exchangerateconvertfromspend)
-  - [`ExchangeRate.getUSDPrice`](#exchangerategetusdprice)
-  - [ExchangeRate.getUSDConverter](#exchangerategetusdconverter)
-  - [`ExchangeRate.getETHPrice`](#exchangerategetethprice)
-  - [`ExchangeRate.getUpdatedAt`](#exchangerategetupdatedat)
+- [`LayerTwoOracle`](#layertwooracle)
+  - [`LayerTwoOracle.convertToSpend`](#layertwooracleconverttospend)
+  - [`LayerTwoOracle.convertFromSpend`](#layertwooracleconvertfromspend)
+  - [`LayerTwoOracle.getUSDPrice`](#layertwooraclegetusdprice)
+  - [`LayerTwoOracle.getUSDConverter`](#layertwooraclegetusdconverter)
+  - [`LayerTwoOracle.getETHPrice`](#layertwooraclegetethprice)
+  - [`LayerTwoOracle.getUpdatedAt`](#layertwooraclegetupdatedat)
 - [`HubAuth` (TODO)](#hubauth-todo)
 - [`getAddress`](#getaddress)
 - [`getOracle`](#getoracle)
@@ -579,54 +580,57 @@ let balanceForAllTokens = await rewardPool.rewardTokenBalances(address)
 
 ### `RewardPool.claim` (TBD)
 ## `ExchangeRate`
-The `ExchangeRate` API is used to get the current exchange rates in USD and ETH for the various stablecoin that we support. These rates are fed by the Chainlink price feeds for the stablecoin rates and the DIA oracle for the CARD token rates. As we onboard new stablecoin we'll add more exchange rates. The price oracles that we use reside in layer 2, so please supply a layer 2 web3 instance obtaining an `ExchangeRate` API from `getSDK()`.
+The `ExchangeRate` API is deprecated. Please move to use the `LayerTwoOracle` API.
+
+## `LayerTwoOracle`
+The `LayerTwoOracle` API is used to get the current exchange rates in USD and ETH for the various stablecoin that we support. These rates are fed by the Chainlink price feeds for the stablecoin rates and the DIA oracle for the CARD token rates. As we onboard new stablecoin we'll add more exchange rates. The price oracles that we use reside in layer 2, so please supply a layer 2 web3 instance obtaining an `LayerTwoOracle` API from `getSDK()`.
 ```js
 import { getSDK } from "@cardstack/cardpay-sdk";
 let web3 = new Web3(myProvider); // Layer 2 web3 instance
-let exchangeRate = await getSDK('ExchangeRate', web3);
+let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
 ```
-### `ExchangeRate.convertToSpend`
+### `LayerTwoOracle.convertToSpend`
 This call will convert an amount in the specified token to a SPEND amount. This function returns a number representing the SPEND amount. The input to this function is the token amount as a string in units of `wei`.
 ```js
-let spendAmount = await exchangeRate.convertFromSpend(daicpxdAddress, toWei(10)); // convert 10 DAI to SPEND
+let spendAmount = await layerTwoOracle.convertFromSpend(daicpxdAddress, toWei(10)); // convert 10 DAI to SPEND
 console.log(`SPEND value ${spendAmount}`);
 ```
-### `ExchangeRate.convertFromSpend`
+### `LayerTwoOracle.convertFromSpend`
 This call will convert a SPEND amount into the specified token amount, where the result is a string that represents the token in units of `wei`. Since SPEND tokens represent $0.01 USD, it is safe to represent SPEND as a number when providing the input value.
 ```js
-let weiAmount = await exchangeRate.convertFromSpend(daicpxdAddress, 10000); // convert 10000 SPEND into DAI
+let weiAmount = await layerTwoOracle.convertFromSpend(daicpxdAddress, 10000); // convert 10000 SPEND into DAI
 console.log(`DAI value ${fromWei(weiAmount)}`);
 ```
-### `ExchangeRate.getUSDPrice`
+### `LayerTwoOracle.getUSDPrice`
 This call will return the USD value for the specified amount of the specified token. If we do not have an exchange rate for the token, then an exception will be thrown. This API requires that the token amount be specified in `wei` (10<sup>18</sup> `wei` = 1 token) as a string, and will return a floating point value in units of USD. You can easily convert a token value to wei by using the `Web3.utils.toWei()` function.
 
 ```js
-let exchangeRate = await getSDK('ExchangeRate', web3);
-let usdPrice = await exchangeRate.getUSDPrice("DAI", amountInWei);
+let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+let usdPrice = await exchangelayerTwoOracleRate.getUSDPrice("DAI", amountInWei);
 console.log(`USD value: $${usdPrice.toFixed(2)} USD`);
 ```
-### ExchangeRate.getUSDConverter
-This returns a function that converts an amount of a token in wei to USD. Similar to `ExchangeRate.getUSDPrice`, an exception will be thrown if we don't have the exchange rate for the token. The returned function accepts a string that represents an amount in wei and returns a number that represents the USD value of that amount of the token.
+### LayerTwoOracle.getUSDConverter
+This returns a function that converts an amount of a token in wei to USD. Similar to `LayerTwoOracle.getUSDPrice`, an exception will be thrown if we don't have the exchange rate for the token. The returned function accepts a string that represents an amount in wei and returns a number that represents the USD value of that amount of the token.
 
 ```js
-let exchangeRate = await getSDK('ExchangeRate', web3);
-let converter = await exchangeRate.getUSDConverter("DAI");
+let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+let converter = await layerTwoOracle.getUSDConverter("DAI");
 console.log(`USD value: $${converter(amountInWei)} USD`);
 ```
-### `ExchangeRate.getETHPrice`
+### `LayerTwoOracle.getETHPrice`
 This call will return the ETH value for the specified amount of the specified token. If we do not have an exchange rate for the token, then an exception will be thrown. This API requires that the token amount be specified in `wei` (10<sup>18</sup> `wei` = 1 token) as a string, and will return a string that represents the ETH value in units of `wei` as well. You can easily convert a token value to wei by using the `Web3.utils.toWei()` function. You can also easily convert units of `wei` back into `ethers` by using the `Web3.utils.fromWei()` function.
 
 ```js
-let exchangeRate = await getSDK('ExchangeRate', web3);
-let ethWeiPrice = await exchangeRate.getETHPrice("CARD", amountInWei);
+let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+let ethWeiPrice = await layerTwoOracle.getETHPrice("CARD", amountInWei);
 console.log(`ETH value: ${fromWei(ethWeiPrice)} ETH`);
 ```
-### `ExchangeRate.getUpdatedAt`
+### `LayerTwoOracle.getUpdatedAt`
 This call will return a `Date` instance that indicates the date the token rate was last updated.
 
 ```js
-let exchangeRate = await getSDK('ExchangeRate', web3);
-let date = await exchangeRate.getUpdatedAt("DAI");
+let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+let date = await layerTwoOracle.getUpdatedAt("DAI");
 console.log(`The ${token} rate was last updated at ${date.toString()}`);
 ```
 

--- a/packages/cardpay-sdk/index.ts
+++ b/packages/cardpay-sdk/index.ts
@@ -2,6 +2,7 @@ export { ITokenBridgeForeignSide } from './sdk/token-bridge-foreign-side';
 export { ITokenBridgeHomeSide, BridgeValidationResult } from './sdk/token-bridge-home-side';
 export { Safes as ISafes, Safe, DepotSafe, MerchantSafe, PrepaidCardSafe, ExternalSafe, TokenInfo } from './sdk/safes';
 export { ExchangeRate as IExchangeRate } from './sdk/exchange-rate';
+export { LayerTwoOracle as ILayerTwoOracle } from './sdk/layer-two-oracle';
 export { IAssets } from './sdk/assets';
 export { IHubAuth } from './sdk/hub-auth';
 

--- a/packages/cardpay-sdk/sdk/layer-two-oracle/base.ts
+++ b/packages/cardpay-sdk/sdk/layer-two-oracle/base.ts
@@ -1,0 +1,89 @@
+import Web3 from 'web3';
+import { Contract } from 'web3-eth-contract';
+import { AbiItem } from 'web3-utils';
+import PriceOracleABI from '../../contracts/abi/v0.7.0/price-oracle';
+import ExchangeABI from '../../contracts/abi/v0.7.0/exchange';
+import { getOracle, getAddress } from '../../contracts/addresses';
+import BN from 'bn.js';
+
+const tokenDecimals = new BN('18');
+const ten = new BN('10');
+
+export default class LayerTwoOracle {
+  constructor(private layer2Web3: Web3) {}
+
+  async convertToSpend(token: string, amount: string): Promise<number> {
+    let exchange = new this.layer2Web3.eth.Contract(
+      ExchangeABI as AbiItem[],
+      await getAddress('exchange', this.layer2Web3)
+    );
+    let spendAmount = await exchange.methods.convertToSpend(token, amount).call();
+    // 1 SPEND == $0.01 USD, and SPEND decimals is 0, so this is safe to
+    // represent as a javascript number
+    return Number(spendAmount);
+  }
+
+  async convertFromSpend(token: string, amount: number): Promise<string> {
+    let exchange = new this.layer2Web3.eth.Contract(
+      ExchangeABI as AbiItem[],
+      await getAddress('exchange', this.layer2Web3)
+    );
+    return await exchange.methods.convertFromSpend(token, amount.toString()).call();
+  }
+
+  async getRateLock(tokenAddress: string): Promise<string> {
+    let exchange = new this.layer2Web3.eth.Contract(
+      ExchangeABI as AbiItem[],
+      await getAddress('exchange', this.layer2Web3)
+    );
+    let { price } = await exchange.methods.exchangeRateOf(tokenAddress).call();
+    return price;
+  }
+
+  async getUSDConverter(token: string): Promise<(amountInWei: string) => number> {
+    const oracle = await this.getOracleContract(token);
+    const usdRawRate = new BN((await oracle.methods.usdPrice().call()).price);
+    const oracleDecimals = Number(await oracle.methods.decimals().call());
+
+    return (amountInWei) => {
+      let rawAmount = usdRawRate.mul(new BN(amountInWei)).div(ten.pow(tokenDecimals));
+      return safeFloatConvert(rawAmount, oracleDecimals);
+    };
+  }
+
+  async getUSDPrice(token: string, amount: string): Promise<number> {
+    let oracle = await this.getOracleContract(token);
+    let usdRawRate = new BN((await oracle.methods.usdPrice().call()).price);
+    let oracleDecimals = Number(await oracle.methods.decimals().call());
+    let rawAmount = usdRawRate.mul(new BN(amount)).div(ten.pow(tokenDecimals));
+    return safeFloatConvert(rawAmount, oracleDecimals);
+  }
+
+  async getETHPrice(token: string, amount: string): Promise<string> {
+    let oracle = await this.getOracleContract(token);
+    let ethRawRate = new BN((await oracle.methods.ethPrice().call()).price);
+    let oracleDecimals = new BN(await oracle.methods.decimals().call());
+    let weiAmount = ethRawRate.mul(new BN(amount)).div(ten.pow(oracleDecimals));
+    return weiAmount.toString();
+  }
+
+  async getUpdatedAt(token: string): Promise<Date> {
+    let oracle = await this.getOracleContract(token);
+    let unixTime = Number((await oracle.methods.usdPrice().call()).updatedAt);
+    return new Date(unixTime * 1000);
+  }
+
+  private async getOracleContract(token: string): Promise<Contract> {
+    let address = await getOracle(token, this.layer2Web3);
+    return new this.layer2Web3.eth.Contract(PriceOracleABI as AbiItem[], address);
+  }
+}
+
+// because BN does not handle floating point, and the numbers from ethereum
+// might be too large for JS to handle, we'll use string manipulation to move
+// the decimal point. After this operation, the number should be safely in JS's
+// territory.
+function safeFloatConvert(rawAmount: BN, decimals: number): number {
+  let amountStr = rawAmount.toString().padStart(decimals, '0');
+  return Number(`${amountStr.slice(0, -1 * decimals)}.${amountStr.slice(-1 * decimals)}`);
+}

--- a/packages/cardpay-sdk/sdk/layer-two-oracle/index.ts
+++ b/packages/cardpay-sdk/sdk/layer-two-oracle/index.ts
@@ -1,0 +1,14 @@
+/* eslint @typescript-eslint/naming-convention: "off" */
+
+import { ContractMeta } from '../version-resolver';
+import v0_6_3 from './v0.6.3';
+import v0_7_0 from './v0.7.0';
+
+// add more versions as we go, but also please do drop version that we don't
+// want to maintain simultaneously
+export type LayerTwoOracle = v0_7_0;
+
+export const layerTwoOracleMeta = {
+  apiVersions: { v0_6_3, v0_7_0 },
+  contractName: 'revenuePool',
+} as ContractMeta;

--- a/packages/cardpay-sdk/sdk/layer-two-oracle/v0.6.3.ts
+++ b/packages/cardpay-sdk/sdk/layer-two-oracle/v0.6.3.ts
@@ -1,0 +1,3 @@
+import Base from './base';
+
+export default class LayerTwoOracle extends Base {}

--- a/packages/cardpay-sdk/sdk/layer-two-oracle/v0.7.0.ts
+++ b/packages/cardpay-sdk/sdk/layer-two-oracle/v0.7.0.ts
@@ -1,0 +1,3 @@
+import Base from './base';
+
+export default class LayerTwoOracle extends Base {}

--- a/packages/cardpay-sdk/sdk/prepaid-card/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card/base.ts
@@ -93,10 +93,10 @@ export default class PrepaidCard {
     );
 
     let rateChanged = false;
-    let exchange = await getSDK('ExchangeRate', this.layer2Web3);
+    let layerTwoOracle = await getSDK('LayerTwoOracle', this.layer2Web3);
     let gnosisResult: GnosisExecTx | undefined;
     do {
-      let rateLock = await exchange.getRateLock(issuingToken);
+      let rateLock = await layerTwoOracle.getRateLock(issuingToken);
       try {
         let payload = await this.getPayMerchantPayload(prepaidCardAddress, merchantSafe, spendAmount, rateLock);
         if (nonce == null) {
@@ -171,7 +171,7 @@ export default class PrepaidCard {
     let from = options?.from ?? (await this.layer2Web3.eth.getAccounts())[0];
     let rateChanged = false;
     let prepaidCardMgr = await this.getPrepaidCardMgr();
-    let exchange = await getSDK('ExchangeRate', this.layer2Web3);
+    let layerTwoOracle = await getSDK('LayerTwoOracle', this.layer2Web3);
     let gasToken = await getAddress('cardCpxd', this.layer2Web3);
     let issuingToken = await this.issuingToken(prepaidCardAddress);
     let transferData = await prepaidCardMgr.methods.getTransferCardData(prepaidCardAddress, newOwner).call();
@@ -207,7 +207,7 @@ export default class PrepaidCard {
     );
     let gnosisResult: GnosisExecTx | undefined;
     do {
-      let rateLock = await exchange.getRateLock(issuingToken);
+      let rateLock = await layerTwoOracle.getRateLock(issuingToken);
       try {
         let payload = await this.getTransferPayload(prepaidCardAddress, newOwner, previousOwnerSignature, rateLock);
         if (nonce == null) {
@@ -285,7 +285,7 @@ export default class PrepaidCard {
       throw new Error(`The prepaid card ${prepaidCardAddress} is not allowed to be split`);
     }
     let from = options?.from ?? (await this.layer2Web3.eth.getAccounts())[0];
-    let exchange = await getSDK('ExchangeRate', this.layer2Web3);
+    let layerTwoOracle = await getSDK('LayerTwoOracle', this.layer2Web3);
     let issuingToken = await this.issuingToken(prepaidCardAddress);
     let amountCache = new Map<number, string>();
     let amounts: BN[] = [];
@@ -301,7 +301,7 @@ export default class PrepaidCard {
       totalWeiAmount = totalWeiAmount.add(weiAmountBN);
       amounts.push(weiAmountBN);
     }
-    let totalAmountInSpend = await exchange.convertToSpend(issuingToken, totalWeiAmount.toString());
+    let totalAmountInSpend = await layerTwoOracle.convertToSpend(issuingToken, totalWeiAmount.toString());
     // add 1 SPEND to account for rounding errors, unconsumed tokens are
     // refunded back to the prepaid card
     totalAmountInSpend++;
@@ -322,7 +322,7 @@ export default class PrepaidCard {
     let rateChanged = false;
     let gnosisResult: GnosisExecTx | undefined;
     do {
-      let rateLock = await exchange.getRateLock(issuingToken);
+      let rateLock = await layerTwoOracle.getRateLock(issuingToken);
       try {
         let payload = await this.getSplitPayload(
           prepaidCardAddress,
@@ -536,8 +536,8 @@ export default class PrepaidCard {
     onError: (issuingToken: string, balanceAmount: string, requiredTokenAmount: string, symbol: string) => Error
   ): Promise<string> {
     let issuingToken = await this.issuingToken(prepaidCardAddress);
-    let exchangeRate = await getSDK('ExchangeRate', this.layer2Web3);
-    let weiAmount = await exchangeRate.convertFromSpend(issuingToken, minimumSpendBalance);
+    let layerTwoOracle = await getSDK('LayerTwoOracle', this.layer2Web3);
+    let weiAmount = await layerTwoOracle.convertFromSpend(issuingToken, minimumSpendBalance);
     let token = new this.layer2Web3.eth.Contract(ERC20ABI as AbiItem[], issuingToken);
     let symbol = await token.methods.symbol().call();
     let prepaidCardBalance = new BN(await token.methods.balanceOf(prepaidCardAddress).call());

--- a/packages/cardpay-sdk/sdk/revenue-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/revenue-pool/base.ts
@@ -195,10 +195,10 @@ export default class RevenuePool {
     );
 
     let rateChanged = false;
-    let exchange = await getSDK('ExchangeRate', this.layer2Web3);
+    let layerTwoOracle = await getSDK('LayerTwoOracle', this.layer2Web3);
     let gnosisResult: GnosisExecTx | undefined;
     do {
-      let rateLock = await exchange.getRateLock(issuingToken);
+      let rateLock = await layerTwoOracle.getRateLock(issuingToken);
       try {
         let payload = await this.getRegisterMerchantPayload(prepaidCardAddress, registrationFee, rateLock, infoDID);
         if (nonce == null) {

--- a/packages/cardpay-sdk/sdk/version-resolver.ts
+++ b/packages/cardpay-sdk/sdk/version-resolver.ts
@@ -4,6 +4,7 @@ import { AbiItem } from 'web3-utils';
 import { satisfies } from 'semver';
 import mapKeys from 'lodash/mapKeys';
 import { ExchangeRate, exchangeRateMeta } from './exchange-rate';
+import { LayerTwoOracle, layerTwoOracleMeta } from './layer-two-oracle';
 import { Safes, safesMeta } from './safes';
 import { PrepaidCard, prepaidCardMeta } from './prepaid-card';
 import Assets from './assets';
@@ -16,6 +17,7 @@ import HubAuth from './hub-auth';
 type SDK =
   | 'Assets'
   | 'ExchangeRate'
+  | 'LayerTwoOracle'
   | 'PrepaidCard'
   | 'RevenuePool'
   | 'Safes'
@@ -49,6 +51,7 @@ const cardPayVersionABI: AbiItem[] = [
 export async function getSDK(sdk: 'Assets', web3: Web3): Promise<Assets>;
 export async function getSDK(sdk: 'HubAuth', web3: Web3, hubRootUrl: string): Promise<HubAuth>;
 export async function getSDK(sdk: 'ExchangeRate', web3: Web3): Promise<ExchangeRate>;
+export async function getSDK(sdk: 'LayerTwoOracle', web3: Web3): Promise<LayerTwoOracle>;
 export async function getSDK(sdk: 'PrepaidCard', web3: Web3): Promise<PrepaidCard>;
 export async function getSDK(sdk: 'RevenuePool', web3: Web3): Promise<RevenuePool>;
 export async function getSDK(sdk: 'RewardPool', web3: Web3): Promise<RewardPool>;
@@ -67,6 +70,9 @@ export async function getSDK(sdk: SDK, ...args: any[]): Promise<any> {
       break;
     case 'ExchangeRate':
       apiClass = await resolveApiVersion(exchangeRateMeta, web3);
+      break;
+    case 'LayerTwoOracle':
+      apiClass = await resolveApiVersion(layerTwoOracleMeta, web3);
       break;
     case 'PrepaidCard':
       apiClass = await resolveApiVersion(prepaidCardMeta, web3);

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -32,10 +32,10 @@ import {
   BridgeValidationResult,
   DepotSafe,
   Safe,
-  IExchangeRate,
   IHubAuth,
   ISafes,
   PrepaidCardSafe,
+  ILayerTwoOracle,
 } from '@cardstack/cardpay-sdk';
 import { taskFor } from 'ember-concurrency-ts';
 import config from '../../config/environment';
@@ -63,7 +63,7 @@ export default abstract class Layer2ChainWeb3Strategy
   defaultTokenSymbol: ConvertibleSymbol = 'DAI';
   defaultTokenContractAddress?: string;
   web3!: Web3;
-  #exchangeRateApi!: IExchangeRate;
+  #layerTwoOracleApi!: ILayerTwoOracle;
   #safesApi!: ISafes;
   #hubAuthApi!: IHubAuth;
   #broadcastChannel: TypedChannel<Layer2ConnectEvent>;
@@ -155,7 +155,7 @@ export default abstract class Layer2ChainWeb3Strategy
       try {
         // try to initialize things safely
         // one expected failure is if we connect to a chain which we don't have an rpc url for
-        this.#exchangeRateApi = await getSDK('ExchangeRate', this.web3);
+        this.#layerTwoOracleApi = await getSDK('LayerTwoOracle', this.web3);
         this.#safesApi = await getSDK('Safes', this.web3);
         this.#hubAuthApi = await getSDK('HubAuth', this.web3, config.hubURL);
         await this.updateWalletInfo(accounts, this.chainId);
@@ -283,7 +283,7 @@ export default abstract class Layer2ChainWeb3Strategy
       Promise<ConversionFunction>
     >;
     for (let symbol of symbolsToUpdate) {
-      promisesHash[symbol] = this.#exchangeRateApi.getUSDConverter(symbol);
+      promisesHash[symbol] = this.#layerTwoOracleApi.getUSDConverter(symbol);
     }
     return hash(promisesHash);
   }
@@ -393,7 +393,7 @@ export default abstract class Layer2ChainWeb3Strategy
       return '0';
     }
 
-    return await this.#exchangeRateApi.convertFromSpend(address, amount);
+    return await this.#layerTwoOracleApi.convertFromSpend(address, amount);
   }
 
   async authenticate(): Promise<string> {


### PR DESCRIPTION
Once this is released, cardwallet should update to use the new name.

The next version after that will drop the ExchangeRate SDK code.

The reason we are making this change is because we need to introduce some exchange rate functionality that derives from Layer 1. We'll call that SDK LayerOneOracle.