### PR TITLE
web: Add prepaid card-choosing card

### DIFF
--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
@@ -88,6 +88,11 @@ class CreateMerchantWorkflow extends Workflow {
           componentName:
             'card-pay/create-merchant-workflow/merchant-customization',
         }),
+        new WorkflowCard({
+          author: cardbot,
+          componentName:
+            'card-pay/create-merchant-workflow/prepaid-card-choice',
+        }),
       ],
       completedDetail: 'Merchant created',
     }),

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
@@ -1,9 +1,9 @@
 <ActionCardContainer
-  @header="Merchant Account"
+  @header="Prepaid Card Choice"
   @isComplete={{@isComplete}}
   data-test-layout-customization-is-complete={{@isComplete}}
 >
-  <ActionCardContainer::Section @title="Choose a name and ID for the merchant" />
+  <ActionCardContainer::Section @title="Choose a prepaid card to fund merchant creation" />
   <Boxel::ActionChin
     @state={{if @isComplete "memorialized" "default"}}
     data-test-layout-customization
@@ -12,7 +12,7 @@
       <d.ActionButton
         {{on "click" @onComplete}}
       >
-        Save Details
+        Create Merchant
       </d.ActionButton>
     </:default>
   </Boxel::ActionChin>

--- a/packages/web-client/tests/acceptance/create-merchant-test.ts
+++ b/packages/web-client/tests/acceptance/create-merchant-test.ts
@@ -117,6 +117,16 @@ module('Acceptance | create merchant', function (hooks) {
     );
     // TODO verify and interact with merchant customization card memorialized state
 
+    // prepaid-card-choice card
+    post = postableSel(1, 4);
+    await waitFor(post);
+    assert
+      .dom(post)
+      .containsText('Choose a prepaid card to fund merchant creation');
+    await click(
+      `${post} [data-test-boxel-action-chin] [data-test-boxel-button]`
+    );
+
     await waitFor(milestoneCompletedSel(1));
     assert.dom(milestoneCompletedSel(1)).containsText('Merchant created');
 


### PR DESCRIPTION
This adds a new card to the create merchant workflow that
will permit choosing a prepaid card to fund merchant
creation.