### PR TITLE
Extract Merchant component

### DIFF
--- a/packages/boxel/addon/styles/variables.css
+++ b/packages/boxel/addon/styles/variables.css
@@ -39,6 +39,8 @@
   /* common icon sizes */
   --boxel-icon-sm: 1.25rem; /* 20px */
   --boxel-icon-lg: 2.5rem;  /* 40px */
+  --boxel-icon-xl: 3.75rem; /* 60px */
+  --boxel-icon-xxl: 5rem;   /* 80px */
 
   /* other */
   --boxel-border-color: var(--boxel-light-500);

--- a/packages/web-client/app/components/card-pay/merchant-card/index.css
+++ b/packages/web-client/app/components/card-pay/merchant-card/index.css
@@ -1,11 +1,10 @@
 .merchant-card {
-  --merchant-logo-background: var(--boxel-red);
-  --merchant-logo-text-color: var(--boxel-light);
-
   display: grid;
   grid-template-rows: auto 1fr;
   width: 22.75rem; /* 364px */
   min-height: 14.375rem; /* 230px */
+  margin-right: auto;
+  margin-left: auto;
   color: var(--boxel-dark);
   background-color: var(--boxel-light);
   border-radius: var(--boxel-border-radius);
@@ -49,35 +48,6 @@
   padding: var(--boxel-sp-lg) var(--boxel-sp) var(--boxel-sp-xs);
   font: var(--boxel-font-sm);
   letter-spacing: var(--boxel-lsp);
-}
-
-.merchant-card__merchant {
-  text-align: center;
-}
-
-.merchant-card__logo {
-  /* This will become merchant logo upload */
-  background: var(--merchant-logo-background);
-  color: var(--merchant-logo-text-color);
-  width: 5rem;
-  height: 5rem;
-  margin: auto;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 3rem;
-  border-radius: 50%;
-}
-
-.merchant-card__name {
-  margin-top: var(--boxel-sp-xxxs);
-  font: 700 var(--boxel-font-lg);
-  letter-spacing: 0;
-}
-
-.merchant-card__type {
-  color: var(--boxel-purple-400);
-  font: var(--boxel-font-sm);
 }
 
 .merchant-card__info {

--- a/packages/web-client/app/components/card-pay/merchant-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/merchant-card/index.hbs
@@ -1,25 +1,15 @@
-<article
-  class="merchant-card"
-  style={{css-var
-    merchant-logo-background=@logoBackground
-    merchant-logo-text-color=(or @logoTextColor "var(--boxel-light)")
-  }}
-  data-test-merchant-card-logo-background={{@logoBackground}}
-  data-test-merchant-card-logo-text-color={{@logoTextColor}}
-  data-test-merchant-card={{@id}}
-  ...attributes
->
+<article class="merchant-card" data-test-merchant-card={{@id}} ...attributes>
   <header class="merchant-card__header">
     <div class="merchant-card__header-network">on {{@network}}</div>
     <div class="merchant-card__header-address">{{truncate-middle @address}}</div>
   </header>
   <section class="merchant-card__content">
-    <div class="merchant-card__merchant">
-      {{!-- Make the logo + name a new component if needed. --}}
-      <div class="merchant-card__logo">{{truncate @name 1 false}}</div>
-      <h3 class="merchant-card__name">{{@name}}</h3>
-      <h4 class="merchant-card__type">Merchant Account</h4>
-    </div>
+    <CardPay::Merchant
+      @size="large"
+      @vertical={{true}}
+      @name={{@name}}
+      @text="Merchant Account"
+    />
     <div class="merchant-card__info">
       <div>
         <div class="merchant-card__label">Merchant ID</div>

--- a/packages/web-client/app/components/card-pay/merchant/index.css
+++ b/packages/web-client/app/components/card-pay/merchant/index.css
@@ -11,18 +11,11 @@
   text-align: center;
 }
 
-.merchant--vertical .merchant__logo {
-  margin-right: auto;
-  margin-left: auto;
-  margin-bottom: var(--boxel-sp-xxxs);
-}
-
 .merchant__logo {
   --logo-size: var(--boxel-icon-lg);
 
   background: var(--merchant-logo-background);
   color: var(--merchant-logo-text-color);
-
   align-self: flex-start;
   display: flex;
   align-items: center;
@@ -33,6 +26,12 @@
   font-size: var(--boxel-font-size-lg);
   font-weight: 600;
   border-radius: 50%;
+}
+
+.merchant--vertical .merchant__logo {
+  margin-right: auto;
+  margin-left: auto;
+  margin-bottom: var(--boxel-sp-xxxs);
 }
 
 .merchant__logo--sm {

--- a/packages/web-client/app/components/card-pay/merchant/index.css
+++ b/packages/web-client/app/components/card-pay/merchant/index.css
@@ -1,0 +1,72 @@
+.merchant {
+  --merchant-logo-background: var(--boxel-red);
+  --merchant-logo-text-color: var(--boxel-light);
+
+  display: flex;
+  align-items: center;
+}
+
+.merchant--vertical {
+  flex-flow: column;
+  text-align: center;
+}
+
+.merchant--vertical .merchant__logo {
+  margin-right: auto;
+  margin-left: auto;
+  margin-bottom: var(--boxel-sp-xxxs);
+}
+
+.merchant__logo {
+  --logo-size: var(--boxel-icon-lg);
+
+  background: var(--merchant-logo-background);
+  color: var(--merchant-logo-text-color);
+
+  align-self: flex-start;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--logo-size);
+  height: var(--logo-size);
+  margin-right: var(--boxel-sp-xxs);
+  font-size: var(--boxel-font-size-lg);
+  font-weight: 600;
+  border-radius: 50%;
+}
+
+.merchant__logo--sm {
+  --logo-size: var(--boxel-icon-sm);
+
+  font-size: var(--boxel-font-size-sm);
+}
+
+.merchant__logo--lg {
+  --logo-size: var(--boxel-icon-xxl);
+
+  font-size: 2.8rem;
+  font-weight: 700;
+}
+
+.merchant__name {
+  font: 700 var(--boxel-font);
+  letter-spacing: var(--boxel-lsp-xs);
+}
+
+.merchant__name--lg {
+  font: 700 var(--boxel-font-lg);
+  letter-spacing: 0;
+}
+
+.merchant__address {
+  color: var(--boxel-purple-400);
+  font: var(--boxel-font-size)/calc(22 / 16) var(--boxel-monospace-font-family);
+  letter-spacing: var(--boxel-lsp-sm);
+  max-width: 22ch;
+  word-break: break-all;
+}
+
+.merchant__text {
+  color: var(--boxel-purple-400);
+  font: var(--boxel-font-sm);
+}

--- a/packages/web-client/app/components/card-pay/merchant/index.hbs
+++ b/packages/web-client/app/components/card-pay/merchant/index.hbs
@@ -1,0 +1,30 @@
+<div
+  class={{cn "merchant" merchant--vertical=@vertical}}
+  style={{css-var
+    merchant-logo-background=(or @logoBackground "var(--boxel-red)")
+    merchant-logo-text-color=(or @logoTextColor "var(--boxel-light)")
+  }}
+  data-test-merchant={{@name}}
+  data-test-merchant-logo-background={{@logoBackground}}
+  data-test-merchant-logo-text-color={{@logoTextColor}}
+  ...attributes
+>
+  <div class={{cn
+    "merchant__logo"
+    merchant__logo--sm=(eq @size "small")
+    merchant__logo--lg=(eq @size "large")
+  }}>
+    {{truncate @name 1 false}}
+  </div>
+  <div>
+    <div class={{cn "merchant__name" merchant__name--lg=(eq @size "large")}}>
+      {{@name}}
+    </div>
+    {{#if @address}}
+      <div class="merchant__address">{{@address}}</div>
+    {{/if}}
+    {{#if @text}}
+      <div class="merchant__text">{{@text}}</div>
+    {{/if}}
+  </div>
+</div>

--- a/packages/web-client/app/components/card-pay/merchant/index.hbs
+++ b/packages/web-client/app/components/card-pay/merchant/index.hbs
@@ -14,7 +14,7 @@
     merchant__logo--sm=(eq @size "small")
     merchant__logo--lg=(eq @size "large")
   }}>
-    {{truncate @name 1 false}}
+    {{first-char @name}}
   </div>
   <div>
     <div class={{cn "merchant__name" merchant__name--lg=(eq @size "large")}}>

--- a/packages/web-client/app/helpers/first-char.ts
+++ b/packages/web-client/app/helpers/first-char.ts
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+
+export function firstChar([val]: [string] /*, hash*/) {
+  let str = String(val).trim();
+  return str[0];
+}
+
+export default helper(firstChar);

--- a/packages/web-client/tests/integration/helpers/first-char-test.ts
+++ b/packages/web-client/tests/integration/helpers/first-char-test.ts
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | first-char', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it returns first character of given string', async function (assert) {
+    this.set('val', 'Crazy Horse');
+    await render(hbs`{{first-char this.val}}`);
+    assert.equal(this.element.textContent?.trim(), 'C');
+  });
+
+  test('it ignores empty space at the beginning', async function (assert) {
+    this.set('val', '   &Crazy Horse');
+    await render(hbs`{{first-char this.val}}`);
+    assert.equal(this.element.textContent?.trim(), '&');
+  });
+
+  test('it converts non-string input to string and returns first character', async function (assert) {
+    this.set('val', 577);
+    await render(hbs`{{first-char this.val}}`);
+    assert.equal(this.element.textContent?.trim(), '5');
+  });
+});


### PR DESCRIPTION
As I was working on memorialized view, ended up making a `Merchant` component and decided to make it a separate PR.

**Usage:**
Basic usage:
```
<CardPay::Merchant @name={{@name}} />
```

```
<CardPay::Merchant
      @name={{@name}}
      @address={{@address}}
      @text="Merchant Account"
      @size="large"
      @vertical={{true}}
      @logoBackground="#ff5050"
      @logoTextColor="#fff"
/>
```
`@name`: merchant name

**Optional args:**
`@address`: merchant address
`@text`: short description
`@size`: `large`, `small` (if no arg given, it'll be default size)
`@vertical`: `true` (default is horizontal flex)

**Examples:**
With just `@name` arg (default):
<img width="166" alt="merchant-default" src="https://user-images.githubusercontent.com/16160806/129636795-225a4e2e-f884-4840-b41b-aaf09620370c.png">

With `@name`, `@text`, `@size="large"`, `@vertical={{true}}` args:
<img width="182" alt="merchant-large-vertical" src="https://user-images.githubusercontent.com/16160806/129636828-115f5e1a-4b2c-48b8-8c8a-4577998f717f.png">

With `@name`, `@address`, `@size="small"` args:
<img width="273" alt="merchant-small" src="https://user-images.githubusercontent.com/16160806/129636754-e8af39e7-2b5a-468c-99e4-b0950a776aa0.png">

