### PR TITLE
[hub] Merchant info offchain upload

### DIFF
--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -23,6 +23,7 @@ import PrepaidCardPatternsRoute from './routes/prepaid-card-patterns';
 import PrepaidCardCustomizationSerializer from './services/serializers/prepaid-card-customization-serializer';
 import PrepaidCardCustomizationsRoute from './routes/prepaid-card-customizations';
 import PersistOffChainPrepaidCardCustomizationTask from './tasks/persist-off-chain-prepaid-card-customization';
+import PersistOffChainMerchantInfoTask from './tasks/persist-off-chain-merchant-info';
 import MerchantInfosRoute from './routes/merchant-infos';
 import MerchantInfoSerializer from './services/serializers/merchant-info-serializer';
 import { AuthenticationUtils } from './utils/authentication';
@@ -50,6 +51,7 @@ export function wireItUp(registryCallback?: RegistryCallback): Container {
   registry.register('boom-route', BoomRoute);
   registry.register('session-route', SessionRoute);
   registry.register('persist-off-chain-prepaid-card-customization', PersistOffChainPrepaidCardCustomizationTask);
+  registry.register('persist-off-chain-merchant-info', PersistOffChainMerchantInfoTask);
   registry.register('prepaid-card-customizations-route', PrepaidCardCustomizationsRoute);
   registry.register('prepaid-card-customization-serializer', PrepaidCardCustomizationSerializer);
   registry.register('prepaid-card-color-schemes-route', PrepaidCardColorSchemesRoute);
@@ -216,6 +218,10 @@ export async function bootWorker() {
       boom: boom,
       'persist-off-chain-prepaid-card-customization': async (payload: any, helpers: Helpers) => {
         let task = await container.instantiate(PersistOffChainPrepaidCardCustomizationTask);
+        return task.perform(payload, helpers);
+      },
+      'persist-off-chain-merchant-info': async (payload: any, helpers: Helpers) => {
+        let task = await container.instantiate(PersistOffChainMerchantInfoTask);
         return task.perform(payload, helpers);
       },
       's3-put-json': s3PutJson,

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -26,6 +26,7 @@ import PersistOffChainPrepaidCardCustomizationTask from './tasks/persist-off-cha
 import PersistOffChainMerchantInfoTask from './tasks/persist-off-chain-merchant-info';
 import MerchantInfosRoute from './routes/merchant-infos';
 import MerchantInfoSerializer from './services/serializers/merchant-info-serializer';
+import MerchantInfoQueries from './services/queries/merchant-info';
 import { AuthenticationUtils } from './utils/authentication';
 import JsonapiMiddleware from './services/jsonapi-middleware';
 import NonceTracker from './services/nonce-tracker';
@@ -60,6 +61,7 @@ export function wireItUp(registryCallback?: RegistryCallback): Container {
   registry.register('prepaid-card-pattern-serializer', PrepaidCardPatternSerializer);
   registry.register('merchant-infos-route', MerchantInfosRoute);
   registry.register('merchant-info-serializer', MerchantInfoSerializer);
+  registry.register('merchant-info-queries', MerchantInfoQueries);
   registry.register('worker-client', WorkerClient);
   registry.register('wyre', WyreService);
   if (registryCallback) {

--- a/packages/hub/routes/merchant-infos.ts
+++ b/packages/hub/routes/merchant-infos.ts
@@ -8,6 +8,15 @@ import MerchantInfoSerializer from '../services/serializers/merchant-info-serial
 import { ensureLoggedIn } from './utils/auth';
 import WorkerClient from '../services/worker-client';
 
+export interface MerchantInfo {
+  id: string;
+  name: string;
+  slug: string;
+  color: string;
+  textColor: string;
+  ownerAddress: string;
+}
+
 export default class MerchantInfosRoute {
   authenticationUtils: AuthenticationUtils = inject('authentication-utils', { as: 'authenticationUtils' });
   databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });

--- a/packages/hub/services/queries/merchant-info.ts
+++ b/packages/hub/services/queries/merchant-info.ts
@@ -1,0 +1,45 @@
+import DatabaseManager from '../database-manager';
+import { inject } from '../../di/dependency-injection';
+import { MerchantInfo } from '../../routes/merchant-infos';
+
+export default class MerchantInfoQueries {
+  databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
+
+  async fetch(id: string): Promise<MerchantInfo> {
+    let db = await this.databaseManager.getClient();
+
+    let queryResult = await db.query(
+      'SELECT id, name, slug, color, text_color, owner_address, created_at from merchant_infos WHERE id = $1',
+      [id]
+    );
+
+    if (queryResult.rowCount === 0) {
+      return Promise.reject(new Error(`No merchant_infos record found with id ${id}`));
+    }
+
+    let row = queryResult.rows[0];
+    return {
+      id: row['id'],
+      name: row['name'],
+      slug: row['slug'],
+      color: row['color'],
+      textColor: row['text_color'],
+      ownerAddress: row['owner_address'],
+    };
+  }
+
+  async insert(model: MerchantInfo) {
+    let db = await this.databaseManager.getClient();
+
+    await db.query(
+      'INSERT INTO merchant_infos (id, name, slug, color, text_color, owner_address) VALUES($1, $2, $3, $4, $5, $6)',
+      [model.id, model.name, model.slug, model.color, model.textColor, model.ownerAddress]
+    );
+  }
+}
+
+declare module '@cardstack/hub/di/dependency-injection' {
+  interface KnownServices {
+    'merchant-info-queries': MerchantInfoQueries;
+  }
+}

--- a/packages/hub/services/serializers/merchant-info-serializer.ts
+++ b/packages/hub/services/serializers/merchant-info-serializer.ts
@@ -1,15 +1,7 @@
 import { encodeDID } from '@cardstack/did-resolver';
 import { inject } from '../../di/dependency-injection';
 import DatabaseManager from '../database-manager';
-
-interface MerchantInfo {
-  id: string;
-  name: string;
-  slug: string;
-  color: string;
-  textColor: string;
-  ownerAddress: string;
-}
+import { MerchantInfo } from '../../routes/merchant-infos';
 
 interface JSONAPIDocument {
   data: any;
@@ -19,56 +11,25 @@ interface JSONAPIDocument {
 export default class MerchantInfoSerializer {
   databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
 
-  async serialize(content: MerchantInfo | string): Promise<JSONAPIDocument> {
-    let data: MerchantInfo;
-    let did: string;
-
-    if (typeof content === 'string') {
-      did = encodeDID({ type: 'MerchantInfo', uniqueId: content });
-      data = await this.loadMerchantInfo(content);
-    } else {
-      did = encodeDID({ type: 'MerchantInfo', uniqueId: content.id });
-      data = content;
-    }
+  async serialize(model: MerchantInfo): Promise<JSONAPIDocument> {
+    let did = encodeDID({ type: 'MerchantInfo', uniqueId: model.id });
 
     const result = {
       data: {
-        id: data.id,
+        id: model.id,
         type: 'merchant-infos',
         attributes: {
           did,
-          name: data.name,
-          slug: data.slug,
-          color: data.color,
-          textColor: data.textColor,
-          ownerAddress: data.ownerAddress,
+          name: model.name,
+          slug: model.slug,
+          color: model.color,
+          textColor: model.textColor,
+          ownerAddress: model.ownerAddress,
         },
       },
     };
 
     return result as JSONAPIDocument;
-  }
-
-  async loadMerchantInfo(id: string): Promise<MerchantInfo> {
-    let db = await this.databaseManager.getClient();
-    let queryResult = await db.query(
-      'SELECT id, name, slug, color, text_color, owner_address, created_at from merchant_infos WHERE id = $1',
-      [id]
-    );
-
-    if (queryResult.rowCount === 0) {
-      return Promise.reject(new Error(`No merchant_infos record found with id ${id}`));
-    }
-
-    let row = queryResult.rows[0];
-    return {
-      id: row['id'],
-      name: row['name'],
-      slug: row['slug'],
-      color: row['color'],
-      textColor: row['text_color'],
-      ownerAddress: row['owner_address'],
-    };
   }
 }
 

--- a/packages/hub/services/serializers/merchant-info-serializer.ts
+++ b/packages/hub/services/serializers/merchant-info-serializer.ts
@@ -19,27 +19,56 @@ interface JSONAPIDocument {
 export default class MerchantInfoSerializer {
   databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
 
-  async serialize(content: MerchantInfo): Promise<JSONAPIDocument> {
-    const did = encodeDID({ type: 'MerchantInfo', uniqueId: content.id });
+  async serialize(content: MerchantInfo | string): Promise<JSONAPIDocument> {
+    let data: MerchantInfo;
+    let did: string;
 
-    const data = {
-      id: content.id,
-      type: 'merchant-infos',
-      attributes: {
-        did,
-        name: content.name,
-        slug: content.slug,
-        color: content.color,
-        textColor: content.textColor,
-        ownerAddress: content.ownerAddress,
+    if (typeof content === 'string') {
+      did = encodeDID({ type: 'MerchantInfo', uniqueId: content });
+      data = await this.loadMerchantInfo(content);
+    } else {
+      did = encodeDID({ type: 'MerchantInfo', uniqueId: content.id });
+      data = content;
+    }
+
+    const result = {
+      data: {
+        id: data.id,
+        type: 'merchant-infos',
+        attributes: {
+          did,
+          name: data.name,
+          slug: data.slug,
+          color: data.color,
+          textColor: data.textColor,
+          ownerAddress: data.ownerAddress,
+        },
       },
     };
 
-    const result = {
-      data,
-    } as JSONAPIDocument;
+    return result as JSONAPIDocument;
+  }
 
-    return result;
+  async loadMerchantInfo(id: string): Promise<MerchantInfo> {
+    let db = await this.databaseManager.getClient();
+    let queryResult = await db.query(
+      'SELECT id, name, slug, color, text_color, owner_address, created_at from merchant_infos WHERE id = $1',
+      [id]
+    );
+
+    if (queryResult.rowCount === 0) {
+      return Promise.reject(new Error(`No merchant_infos record found with id ${id}`));
+    }
+
+    let row = queryResult.rows[0];
+    return {
+      id: row['id'],
+      name: row['name'],
+      slug: row['slug'],
+      color: row['color'],
+      textColor: row['text_color'],
+      ownerAddress: row['owner_address'],
+    };
   }
 }
 

--- a/packages/hub/tasks/persist-off-chain-merchant-info.ts
+++ b/packages/hub/tasks/persist-off-chain-merchant-info.ts
@@ -1,0 +1,24 @@
+import { Helpers } from 'graphile-worker';
+import MerchantInfoSerializer from '../services/serializers/merchant-info-serializer';
+import { inject } from '../di/dependency-injection';
+import config from 'config';
+import shortUuid from 'short-uuid';
+
+export default class PersistOffChainMerchantInfo {
+  merchantInfoSerializer: MerchantInfoSerializer = inject('merchant-info-serializer', {
+    as: 'merchantInfoSerializer',
+  });
+
+  async perform(payload: any, helpers: Helpers) {
+    const { id } = payload;
+    let jsonAPIDoc = await this.merchantInfoSerializer.serialize(id);
+
+    helpers.addJob('s3-put-json', {
+      bucket: config.get('aws.offchainStorage.bucketName'),
+      path: `merchant-info/${shortUuid().fromUUID(id)}.json`,
+      json: jsonAPIDoc,
+      region: config.get('aws.offchainStorage.region'),
+      roleChain: config.get('aws.offchainStorage.roleChain'),
+    });
+  }
+}

--- a/packages/hub/tasks/persist-off-chain-merchant-info.ts
+++ b/packages/hub/tasks/persist-off-chain-merchant-info.ts
@@ -3,15 +3,21 @@ import MerchantInfoSerializer from '../services/serializers/merchant-info-serial
 import { inject } from '../di/dependency-injection';
 import config from 'config';
 import shortUuid from 'short-uuid';
+import MerchantInfoQueries from '../services/queries/merchant-info';
 
 export default class PersistOffChainMerchantInfo {
   merchantInfoSerializer: MerchantInfoSerializer = inject('merchant-info-serializer', {
     as: 'merchantInfoSerializer',
   });
+  merchantInfoQueries: MerchantInfoQueries = inject('merchant-info-queries', {
+    as: 'merchantInfoQueries',
+  });
 
   async perform(payload: any, helpers: Helpers) {
     const { id } = payload;
-    let jsonAPIDoc = await this.merchantInfoSerializer.serialize(id);
+
+    let merchantInfo = await this.merchantInfoQueries.fetch(id);
+    let jsonAPIDoc = await this.merchantInfoSerializer.serialize(merchantInfo);
 
     helpers.addJob('s3-put-json', {
       bucket: config.get('aws.offchainStorage.bucketName'),

--- a/packages/hub/utils/aws-config.ts
+++ b/packages/hub/utils/aws-config.ts
@@ -16,7 +16,10 @@ export default async function awsConfig({ roleChain = [] }) {
   let accessKeyId = config.get('aws.config.credentials.AccessKeyId');
   let secretAccessKey = config.get('aws.config.credentials.SecretAccessKey');
   if (accessKeyId || secretAccessKey) {
-    result.credentials = config.get('aws.config.credentials');
+    result.credentials = {
+      accessKeyId,
+      secretAccessKey,
+    };
   }
 
   let region = config.get('aws.config.region');


### PR DESCRIPTION
Ticket: [CS-1432](https://linear.app/cardstack/issue/CS-1432/hub-endpoint-to-create-merchantinfo-generates-and-returns-a-did)

This PR implements uploading the merchant info JSON-API resource to S3 via a worker.

I tested it locally and confirmed the documents appear in the storage.cardstack.com bucket
inside the `merchant-info/` folder. 