### PR TITLE
Merchant creation form edit state

### DIFF
--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.css
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.css
@@ -15,10 +15,14 @@
   align-items: center;
 }
 
-.merchant-customization__color-preview {
+.merchant-customization__color-preview,
+.merchant-customization__color-input {
   width: 1.5rem;
   height: 1.5rem;
   margin-right: var(--boxel-sp-xxs);
   border-radius: 3px;
+}
+
+.merchant-customization__color-preview {
   background-color: var(--merchant-custom-color);
 }

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.hbs
@@ -36,68 +36,68 @@
         />
       </CardPay::LabeledValue>
     {{else}}
-    <CardPay::FieldStack>
-      <CardPay::LabeledValue
-        @fieldMode="edit"
-        @label="Merchant name"
-        data-test-merchant-customization-merchant-name-field
-      >
-        <Boxel::Input
-          @value={{this.merchantName}}
-          @onInput={{this.onMerchantNameInput}}
-          @invalid={{this.merchantNameValidationMessage}}
-          @errorMessage={{this.merchantNameValidationMessage}}
-          @required={{true}}
-          autocomplete="off"
-          autocorrect="off"
-          autocapitalize="off"
-          spellcheck="false"
-          {{on "blur" this.validateMerchantName}}
-        />
-      </CardPay::LabeledValue>
-      <CardPay::LabeledValue
-        @fieldMode="edit"
-        @label="Merchant ID"
-        data-test-merchant-customization-merchant-id-field
-      >
-        <CardPay::CreateMerchantWorkflow::MerchantCustomization::ValidationStateInput
-          @state={{this.merchantIdInputState}}
-          @value={{this.merchantId}}
-          @onInput={{this.onMerchantIdInput}}
-          @errorMessage={{this.merchantIdValidationMessage}}
-          @helperText="This will be used to uniquely identify your merchant in Cardstack products and cannot be changed after your merchant is created."
-          autocomplete="off"
-          autocorrect="off"
-          autocapitalize="off"
-          spellcheck="false"
-          {{on "blur" this.validateMerchantId}}
-        />
-      </CardPay::LabeledValue>
-      <CardPay::LabeledValue
-        @fieldMode="edit"
-        @label="Custom color"
-        data-test-merchant-customization-color-field
-      >
-        {{!-- template-lint-disable require-input-label --}}
-        <div class="merchant-customization__color">
-          <input
-            type="color"
-            value={{this.merchantBgColor}}
-            class="merchant-customization__color-input"
-            {{on "input" this.onMerchantBgColorInput}}
-          >
-          {{this.merchantBgColor}}
-        </div>
-      </CardPay::LabeledValue>
-      <CardPay::LabeledValue @label="Manager">
-        <CardPay::AccountDisplay
-          @wrapped={{true}}
-          @address={{this.layer2Network.walletInfo.firstAddress}}
-          data-test-merchant-customization-manager-address
-        />
-      </CardPay::LabeledValue>
-    </CardPay::FieldStack>
-  {{/if}}
+      <CardPay::FieldStack>
+        <CardPay::LabeledValue
+          @fieldMode="edit"
+          @label="Merchant name"
+          data-test-merchant-customization-merchant-name-field
+        >
+          <Boxel::Input
+            @value={{this.merchantName}}
+            @onInput={{this.onMerchantNameInput}}
+            @invalid={{this.merchantNameValidationMessage}}
+            @errorMessage={{this.merchantNameValidationMessage}}
+            @required={{true}}
+            autocomplete="off"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+            {{on "blur" this.validateMerchantName}}
+          />
+        </CardPay::LabeledValue>
+        <CardPay::LabeledValue
+          @fieldMode="edit"
+          @label="Merchant ID"
+          data-test-merchant-customization-merchant-id-field
+        >
+          <CardPay::CreateMerchantWorkflow::MerchantCustomization::ValidationStateInput
+            @state={{this.merchantIdInputState}}
+            @value={{this.merchantId}}
+            @onInput={{this.onMerchantIdInput}}
+            @errorMessage={{this.merchantIdValidationMessage}}
+            @helperText="This will be used to uniquely identify your merchant in Cardstack products and cannot be changed after your merchant is created."
+            autocomplete="off"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+            {{on "blur" this.validateMerchantId}}
+          />
+        </CardPay::LabeledValue>
+        <CardPay::LabeledValue
+          @fieldMode="edit"
+          @label="Custom color"
+          data-test-merchant-customization-color-field
+        >
+          {{!-- template-lint-disable require-input-label --}}
+          <div class="merchant-customization__color">
+            <input
+              type="color"
+              value={{this.merchantBgColor}}
+              class="merchant-customization__color-input"
+              {{on "input" this.onMerchantBgColorInput}}
+            >
+            {{this.merchantBgColor}}
+          </div>
+        </CardPay::LabeledValue>
+        <CardPay::LabeledValue @label="Manager">
+          <CardPay::AccountDisplay
+            @wrapped={{true}}
+            @address={{this.layer2Network.walletInfo.firstAddress}}
+            data-test-merchant-customization-manager-address
+          />
+        </CardPay::LabeledValue>
+      </CardPay::FieldStack>
+    {{/if}}
   </ActionCardContainer::Section>
   <Boxel::ActionChin
     @state={{if @isComplete "memorialized" "default"}}

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.hbs
@@ -9,16 +9,14 @@
       @label={{if @isComplete "Merchant Name" "Preview"}}
       data-test-merchant-customization-merchant-preview
     >
-      {{#let (trim this.merchantName) as |trimmedName|}}
-        <CardPay::Merchant
-          class={{unless trimmedName "merchant-customization__enter-name"}}
-          @name={{or trimmedName "Enter merchant name"}}
-          @logoBackground={{this.merchantBgColor}}
-          @logoTextColor={{this.merchantTextColor}}
-          @size="large"
-          @vertical={{true}}
-        />
-      {{/let}}
+      <CardPay::Merchant
+        class={{unless this.trimmedMerchantName "merchant-customization__enter-name"}}
+        @name={{or this.trimmedMerchantName "Enter merchant name"}}
+        @logoBackground={{this.merchantBgColor}}
+        @logoTextColor={{this.merchantTextColor}}
+        @size="large"
+        @vertical={{true}}
+      />
     </CardPay::LabeledValue>
     {{#if @isComplete}}
       <CardPay::LabeledValue @label="Merchant ID" data-test-merchant-customization-merchant-id-field>

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.hbs
@@ -9,14 +9,16 @@
       @label={{if @isComplete "Merchant Name" "Preview"}}
       data-test-merchant-customization-merchant-preview
     >
-      <CardPay::Merchant
-        class={{unless this.merchantName "merchant-customization__enter-name"}}
-        @name={{or this.merchantName "Enter merchant name"}}
-        @logoBackground={{this.merchantBgColor}}
-        @logoTextColor={{this.merchantTextColor}}
-        @size="large"
-        @vertical={{true}}
-      />
+      {{#let (trim this.merchantName) as |trimmedName|}}
+        <CardPay::Merchant
+          class={{unless trimmedName "merchant-customization__enter-name"}}
+          @name={{or trimmedName "Enter merchant name"}}
+          @logoBackground={{this.merchantBgColor}}
+          @logoTextColor={{this.merchantTextColor}}
+          @size="large"
+          @vertical={{true}}
+        />
+      {{/let}}
     </CardPay::LabeledValue>
     {{#if @isComplete}}
       <CardPay::LabeledValue @label="Merchant ID" data-test-merchant-customization-merchant-id-field>

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.hbs
@@ -13,7 +13,7 @@
         class={{unless this.merchantName "merchant-customization__enter-name"}}
         @name={{or this.merchantName "Enter merchant name"}}
         @logoBackground={{this.merchantBgColor}}
-        @logoTextColor={{@logoTextColor}}
+        @logoTextColor={{this.merchantTextColor}}
         @size="large"
         @vertical={{true}}
       />

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.hbs
@@ -1,12 +1,13 @@
 <ActionCardContainer
   @header="Merchant Account"
   @isComplete={{@isComplete}}
-  data-test-layout-customization-is-complete={{@isComplete}}
+  data-test-merchant-customization-is-complete={{@isComplete}}
 >
   <ActionCardContainer::Section @title="Choose a name and ID for the merchant">
     <CardPay::LabeledValue
       class="merchant-customization__name"
       @label={{if @isComplete "Merchant Name" "Preview"}}
+      data-test-merchant-customization-merchant-preview
     >
       <CardPay::Merchant
         class={{unless this.merchantName "merchant-customization__enter-name"}}
@@ -18,10 +19,10 @@
       />
     </CardPay::LabeledValue>
     {{#if @isComplete}}
-      <CardPay::LabeledValue @label="Merchant ID">
+      <CardPay::LabeledValue @label="Merchant ID" data-test-merchant-customization-merchant-id-field>
         {{this.merchantId}}
       </CardPay::LabeledValue>
-      <CardPay::LabeledValue @label="Custom Color">
+      <CardPay::LabeledValue @label="Custom Color" data-test-merchant-customization-color-field>
         <div class="merchant-customization__color">
           <div class="merchant-customization__color-preview" style={{css-var merchant-custom-color=(or this.merchantBgColor "var(--boxel-blue)")}} />
           {{or this.merchantBgColor "#0069F9"}}
@@ -31,20 +32,92 @@
         <CardPay::AccountDisplay
           @wrapped={{true}}
           @address={{this.layer2Network.walletInfo.firstAddress}}
+          data-test-merchant-customization-manager-address
         />
       </CardPay::LabeledValue>
-    {{/if}}
+    {{else}}
+    <CardPay::FieldStack>
+      <CardPay::LabeledValue
+        @fieldMode="edit"
+        @label="Merchant name"
+        data-test-merchant-customization-merchant-name-field
+      >
+        <Boxel::Input
+          @value={{this.merchantName}}
+          @onInput={{this.onMerchantNameInput}}
+          @invalid={{this.merchantNameValidationMessage}}
+          @errorMessage={{this.merchantNameValidationMessage}}
+          @required={{true}}
+          autocomplete="off"
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+          {{on "blur" this.validateMerchantName}}
+        />
+      </CardPay::LabeledValue>
+      <CardPay::LabeledValue
+        @fieldMode="edit"
+        @label="Merchant ID"
+        data-test-merchant-customization-merchant-id-field
+      >
+        <CardPay::CreateMerchantWorkflow::MerchantCustomization::ValidationStateInput
+          @state={{this.merchantIdInputState}}
+          @value={{this.merchantId}}
+          @onInput={{this.onMerchantIdInput}}
+          @errorMessage={{this.merchantIdValidationMessage}}
+          @helperText="This will be used to uniquely identify your merchant in Cardstack products and cannot be changed after your merchant is created."
+          autocomplete="off"
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+          {{on "blur" this.validateMerchantId}}
+        />
+      </CardPay::LabeledValue>
+      <CardPay::LabeledValue
+        @fieldMode="edit"
+        @label="Custom color"
+        data-test-merchant-customization-color-field
+      >
+        {{!-- template-lint-disable require-input-label --}}
+        <div class="merchant-customization__color">
+          <input
+            type="color"
+            value={{this.merchantBgColor}}
+            class="merchant-customization__color-input"
+            {{on "input" this.onMerchantBgColorInput}}
+          >
+          {{this.merchantBgColor}}
+        </div>
+      </CardPay::LabeledValue>
+      <CardPay::LabeledValue @label="Manager">
+        <CardPay::AccountDisplay
+          @wrapped={{true}}
+          @address={{this.layer2Network.walletInfo.firstAddress}}
+          data-test-merchant-customization-manager-address
+        />
+      </CardPay::LabeledValue>
+    </CardPay::FieldStack>
+  {{/if}}
   </ActionCardContainer::Section>
   <Boxel::ActionChin
     @state={{if @isComplete "memorialized" "default"}}
-    data-test-layout-customization
+    @disabled={{or (not this.canSaveDetails) @frozen}}
   >
     <:default as |d|>
       <d.ActionButton
-        {{on "click" @onComplete}}
+        data-test-merchant-customization-save-details
+        {{on "click" this.saveDetails}}
       >
         Save Details
       </d.ActionButton>
     </:default>
+    <:memorialized as |m|>
+      <m.ActionButton
+      data-test-merchant-customization-edit
+        {{on "click" @onIncomplete}}
+      >
+        Edit
+      </m.ActionButton>
+    </:memorialized>
   </Boxel::ActionChin>
 </ActionCardContainer>

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
@@ -121,7 +121,7 @@ export default class CardPayDepositWorkflowTransactionAmountComponent extends Co
     this.lastCheckedMerchantId = value;
     if (merchantIdExists) {
       this.merchantIdValidationMessage =
-        'This merchant ID is already taken, please choose another ID.';
+        'This merchant ID is already taken, please choose another ID';
       return false;
     }
 

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
@@ -137,8 +137,8 @@ function findDomainNameErrors(value: string) {
     return 'Merchant ID can only contain lowercase alphabets, numbers, and hyphens';
   else if (/^[^a-zA-Z0-9]/.test(value) || /[^a-zA-Z0-9]$/.test(value))
     return 'Merchant ID must start and end with lowercase alphabet or number';
-  else if (value.length > 63)
-    return `Merchant ID must be at most 63 characters, currently ${value.length}`;
+  else if (value.length > 50)
+    return `Merchant ID must be at most 50 characters, currently ${value.length}`;
   return '';
 }
 

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
@@ -1,0 +1,142 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import Layer2Network from '@cardstack/web-client/services/layer2-network';
+import { inject as service } from '@ember/service';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { didCancel, restartableTask, timeout } from 'ember-concurrency';
+import { taskFor } from 'ember-concurrency-ts';
+
+export default class CardPayDepositWorkflowTransactionAmountComponent extends Component<WorkflowCardComponentArgs> {
+  @service declare layer2Network: Layer2Network;
+  @tracked merchantBgColor: string = '#ff0000'; // TODO: replace with random color
+  @tracked merchantName: string = '';
+  @tracked merchantId: string = '';
+  @tracked lastCheckedMerchantId = '';
+  @tracked merchantNameValidationMessage = '';
+  @tracked merchantIdValidationMessage = '';
+  @tracked merchantBgColorValidationMessage = '';
+
+  get canSaveDetails() {
+    return (
+      // all fields populated
+      this.merchantBgColor &&
+      this.merchantName &&
+      this.merchantId &&
+      // unique merchant name + valid id characters
+      this.merchantIdInputState === 'valid' &&
+      // no other validation errors
+      !this.merchantNameValidationMessage &&
+      !this.merchantBgColorValidationMessage
+    );
+  }
+
+  get merchantIdInputState() {
+    if (taskFor(this.validateMerchantIdTask).isRunning) {
+      return 'loading';
+    } else if (
+      this.lastCheckedMerchantId === this.merchantId &&
+      taskFor(this.validateMerchantIdTask).last?.value
+    ) {
+      return 'valid';
+    } else if (this.merchantIdValidationMessage) {
+      return 'invalid';
+    } else {
+      return 'initial';
+    }
+  }
+
+  @action onMerchantNameInput(value: string) {
+    this.merchantName = value;
+    this.validateMerchantName();
+  }
+
+  @action onMerchantIdInput(value: string) {
+    this.merchantId = value;
+    this.validateMerchantId();
+  }
+
+  @action onMerchantBgColorInput(event: InputEvent) {
+    let value = (event.target as HTMLInputElement).value;
+    this.merchantBgColor = value;
+  }
+
+  @action saveDetails() {
+    this.args.workflowSession.updateMany({
+      merchantName: this.merchantName,
+      merchantId: this.merchantId,
+      merchantBgColor: this.merchantBgColor,
+    });
+    this.args.onComplete?.();
+  }
+
+  @action validateMerchantName() {
+    if (this.merchantName) {
+      this.merchantNameValidationMessage = this.merchantName.trim()
+        ? ''
+        : 'Merchant name cannot contain only spaces';
+    } else {
+      this.merchantNameValidationMessage = 'This field is required';
+    }
+  }
+
+  @action async validateMerchantId() {
+    try {
+      await taskFor(this.validateMerchantIdTask).perform();
+    } catch (e) {
+      if (didCancel(e)) {
+        return;
+      }
+      console.error(e);
+    }
+  }
+
+  @restartableTask *validateMerchantIdTask() {
+    // debounce
+    yield timeout(500);
+    let value = this.merchantId;
+
+    if (value) {
+      this.merchantIdValidationMessage = findDomainNameErrors(value);
+    } else {
+      this.merchantIdValidationMessage = 'This field is required';
+    }
+
+    if (this.merchantIdValidationMessage) {
+      return false;
+    }
+
+    // replace w call to api
+    let merchantIdExists: boolean = yield checkIfMerchantIdExists(value);
+
+    this.lastCheckedMerchantId = value;
+    if (merchantIdExists) {
+      this.merchantIdValidationMessage =
+        'This merchant ID is already taken, please choose another ID.';
+      return false;
+    }
+
+    this.merchantIdValidationMessage = '';
+    return true;
+  }
+}
+
+function findDomainNameErrors(value: string) {
+  // international domain names start with xn--
+  if (value.startsWith('xn--')) return 'Merchant ID cannot start with xn--';
+  else if (/[^a-z0-9-]/.test(value))
+    return 'Merchant ID can only contain lowercase alphabets, numbers, and hyphens';
+  else if (/^[^a-zA-Z0-9]/.test(value) || /[^a-zA-Z0-9]$/.test(value))
+    return 'Merchant ID must start and end with lowercase alphabet or number';
+  else if (value.length > 63)
+    return `Merchant ID must be at most 63 characters, currently ${value.length}`;
+  return '';
+}
+
+async function checkIfMerchantIdExists(value: string) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(value.endsWith('y'));
+    }, 750);
+  });
+}

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
@@ -6,10 +6,11 @@ import { inject as service } from '@ember/service';
 import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
 import { didCancel, restartableTask, timeout } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
+import { mostReadable, random as randomColor } from '@ctrl/tinycolor';
 
 export default class CardPayDepositWorkflowTransactionAmountComponent extends Component<WorkflowCardComponentArgs> {
   @service declare layer2Network: Layer2Network;
-  @tracked merchantBgColor: string = '#ff0000'; // TODO: replace with random color
+  @tracked merchantBgColor: string = randomColor().toHexString();
   @tracked merchantName: string = '';
   @tracked merchantId: string = '';
   @tracked lastCheckedMerchantId = '';
@@ -46,6 +47,13 @@ export default class CardPayDepositWorkflowTransactionAmountComponent extends Co
     }
   }
 
+  get merchantTextColor() {
+    return mostReadable(this.merchantBgColor, [
+      '#ffffff',
+      '#000000',
+    ])!.toHexString();
+  }
+
   @action onMerchantNameInput(value: string) {
     this.merchantName = value;
     this.validateMerchantName();
@@ -66,6 +74,7 @@ export default class CardPayDepositWorkflowTransactionAmountComponent extends Co
       merchantName: this.merchantName,
       merchantId: this.merchantId,
       merchantBgColor: this.merchantBgColor,
+      merchantTextColor: this.merchantTextColor,
     });
     this.args.onComplete?.();
   }

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
@@ -20,14 +20,16 @@ export default class CardPayDepositWorkflowTransactionAmountComponent extends Co
   @tracked merchantBgColorValidationMessage = '';
 
   get canSaveDetails() {
+    return this.allFieldsPopulated && this.noValidationErrors;
+  }
+
+  get allFieldsPopulated() {
+    return this.merchantBgColor && this.merchantName && this.merchantId;
+  }
+
+  get noValidationErrors() {
     return (
-      // all fields populated
-      this.merchantBgColor &&
-      this.merchantName &&
-      this.merchantId &&
-      // unique merchant name + valid id characters
       this.merchantIdInputState === 'valid' &&
-      // no other validation errors
       !this.merchantNameValidationMessage &&
       !this.merchantBgColorValidationMessage
     );
@@ -46,6 +48,11 @@ export default class CardPayDepositWorkflowTransactionAmountComponent extends Co
     } else {
       return 'initial';
     }
+  }
+
+  // We might want to do some whitespace collapsing before saving?
+  get trimmedMerchantName() {
+    return this.merchantName.trim();
   }
 
   get merchantTextColor() {
@@ -72,7 +79,7 @@ export default class CardPayDepositWorkflowTransactionAmountComponent extends Co
 
   @action saveDetails() {
     this.args.workflowSession.updateMany({
-      merchantName: this.merchantName.trim(),
+      merchantName: this.trimmedMerchantName,
       merchantId: this.merchantId,
       merchantBgColor: this.merchantBgColor,
       merchantTextColor: this.merchantTextColor,
@@ -81,7 +88,7 @@ export default class CardPayDepositWorkflowTransactionAmountComponent extends Co
   }
 
   @action validateMerchantName() {
-    this.merchantNameValidationMessage = this.merchantName.trim()
+    this.merchantNameValidationMessage = this.trimmedMerchantName
       ? ''
       : 'This field is required';
   }

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
@@ -7,6 +7,7 @@ import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow
 import { didCancel, restartableTask, timeout } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import { mostReadable, random as randomColor } from '@ctrl/tinycolor';
+import config from '@cardstack/web-client/config/environment';
 
 export default class CardPayDepositWorkflowTransactionAmountComponent extends Component<WorkflowCardComponentArgs> {
   @service declare layer2Network: Layer2Network;
@@ -102,7 +103,7 @@ export default class CardPayDepositWorkflowTransactionAmountComponent extends Co
 
   @restartableTask *validateMerchantIdTask() {
     // debounce
-    yield timeout(500);
+    yield timeout(config.environment === 'test' ? 10 : 500);
     let value = this.merchantId;
 
     if (value) {
@@ -142,10 +143,6 @@ function findDomainNameErrors(value: string) {
   return '';
 }
 
-async function checkIfMerchantIdExists(value: string) {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve(value.endsWith('y'));
-    }, 750);
-  });
+async function checkIfMerchantIdExists(_value: string) {
+  return false;
 }

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
@@ -72,7 +72,7 @@ export default class CardPayDepositWorkflowTransactionAmountComponent extends Co
 
   @action saveDetails() {
     this.args.workflowSession.updateMany({
-      merchantName: this.merchantName,
+      merchantName: this.merchantName.trim(),
       merchantId: this.merchantId,
       merchantBgColor: this.merchantBgColor,
       merchantTextColor: this.merchantTextColor,
@@ -81,13 +81,9 @@ export default class CardPayDepositWorkflowTransactionAmountComponent extends Co
   }
 
   @action validateMerchantName() {
-    if (this.merchantName) {
-      this.merchantNameValidationMessage = this.merchantName.trim()
-        ? ''
-        : 'Merchant name cannot contain only spaces';
-    } else {
-      this.merchantNameValidationMessage = 'This field is required';
-    }
+    this.merchantNameValidationMessage = this.merchantName.trim()
+      ? ''
+      : 'This field is required';
   }
 
   @action async validateMerchantId() {

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/validation-state-input/index.css
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/validation-state-input/index.css
@@ -1,0 +1,26 @@
+.validation-state-input-group {
+  --input-height: 2.5rem;
+  --input-icon-size: var(--boxel-icon-sm);
+  --input-icon-space: var(--boxel-sp-xs);
+
+  position: relative;
+  font-family: var(--boxel-font-family);
+  line-height: calc(27 / 20);
+  letter-spacing: var(--boxel-lsp-xs);
+}
+
+.validation-state-input-group__input {
+  height: var(--input-height);
+  padding-right: calc(var(--input-icon-size) + var(--input-icon-space) * 2);
+  font: inherit;
+  letter-spacing: inherit;
+}
+
+.validation-state-input-group__icon {
+  position: absolute;
+  width: var(--input-icon-size);
+  height: var(--input-height);
+  right: var(--input-icon-space);
+  top: 0;
+  user-select: none;
+}

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/validation-state-input/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/validation-state-input/index.hbs
@@ -1,0 +1,16 @@
+<div class="validation-state-input-group" ...attributes>
+  <Boxel::Input
+    class="validation-state-input-group__input"
+    @value={{@value}}
+    @required={{true}}
+    @onInput={{@onInput}}
+    @invalid={{this.isInvalid}}
+    @errorMessage={{@errorMessage}}
+    @helperText={{@helperText}}
+    data-test-validation-state-input={{@state}}
+    autocomplete="off"
+  />
+  {{#if this.icon}}
+    {{svg-jar this.icon class="validation-state-input-group__icon" role="presentation"}}
+  {{/if}}
+</div>

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/validation-state-input/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/validation-state-input/index.ts
@@ -1,0 +1,26 @@
+import Component from '@glimmer/component';
+
+interface ValidationStateInputArgs {
+  state: 'valid' | 'invalid' | 'loading' | 'initial';
+}
+
+export default class ValidationStateInput extends Component<ValidationStateInputArgs> {
+  get icon() {
+    switch (this.args.state) {
+      case 'valid':
+        return 'success-bordered';
+      case 'invalid':
+        return 'failure-bordered';
+      case 'loading':
+        return 'loading-indicator';
+      case 'initial':
+        return '';
+      default:
+        return '';
+    }
+  }
+
+  get isInvalid() {
+    return this.args.state === 'invalid';
+  }
+}

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
@@ -12,7 +12,7 @@
         @logoTextColor={{@workflowSession.state.merchantTextColor}}
       />
     </CardPay::LabeledValue>
-    <CardPay::LabeledValue @label="Merchant ID" class="prepaid-card-choice__field-label">
+    <CardPay::LabeledValue @label="Merchant ID" class="prepaid-card-choice__field-label" data-test-prepaid-card-choice-merchant-id>
       {{@workflowSession.state.merchantId}}
     </CardPay::LabeledValue>
     <CardPay::LabeledValue @label="Merchant Creation Fee" class="prepaid-card-choice__field-label">

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
@@ -6,14 +6,14 @@
   <ActionCardContainer::Section @title="Choose a prepaid card to fund merchant creation">
     <CardPay::LabeledValue @label="Merchant Name" class="prepaid-card-choice__field-label">
       <CardPay::Merchant
-        @name={{@name}}
+        @name={{@workflowSession.state.merchantName}}
         @size="small"
-        @logoBackground={{@logoBackground}}
-        @logoTextColor={{@logoTextColor}}
+        @logoBackground={{@workflowSession.state.merchantBgColor}}
+        @logoTextColor={{@workflowSession.state.merchantTextColor}}
       />
     </CardPay::LabeledValue>
     <CardPay::LabeledValue @label="Merchant ID" class="prepaid-card-choice__field-label">
-      {{@id}}
+      {{@workflowSession.state.merchantId}}
     </CardPay::LabeledValue>
     <CardPay::LabeledValue @label="Merchant Creation Fee" class="prepaid-card-choice__field-label">
       <CardPay::BalanceDisplay
@@ -32,11 +32,11 @@
     {{#if @isComplete}}
       <CardPay::LabeledValue @label="Merchant Address" class="prepaid-card-choice__field-label">
         <CardPay::Merchant
-          @name={{@name}}
+          @name={{@workflowSession.state.merchantName}}
           @address={{@workflowSession.state.merchantSafe.address}}
           @size="small"
-          @logoBackground={{@logoBackground}}
-          @logoTextColor={{@logoTextColor}}
+          @logoBackground={{@workflowSession.state.merchantBgColor}}
+          @logoTextColor={{@workflowSession.state.merchantTextColor}}
           data-test-prepaid-card-choice-merchant-address
         />
       </CardPay::LabeledValue>

--- a/packages/web-client/app/helpers/first-char.ts
+++ b/packages/web-client/app/helpers/first-char.ts
@@ -4,7 +4,12 @@ export function firstChar([str]: [string] /*, hash*/) {
   if (!str || typeof str !== 'string') {
     return;
   }
-  return str.trim()[0];
+
+  // The string iterator (and by extension methods that use it, including Array.from)
+  // can iterate over astral code points (code points that are actually more than one code unit combined)
+  // This is necessary to handle emoji
+  // Detailed explanation: https://mathiasbynens.be/notes/javascript-unicode
+  return Array.from(str.trim())[0];
 }
 
 export default helper(firstChar);

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -148,6 +148,7 @@
     "extends": "../../package.json"
   },
   "dependencies": {
+    "@ctrl/tinycolor": "^3.4.0",
     "@metamask/safe-event-emitter": "^2.0.0",
     "@walletconnect/client": "^1.6.0",
     "@walletconnect/core": "^1.6.0",

--- a/packages/web-client/tests/acceptance/create-merchant-test.ts
+++ b/packages/web-client/tests/acceptance/create-merchant-test.ts
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import {
   click,
   currentURL,
+  fillIn,
   settled,
   visit,
   waitFor,
@@ -135,10 +136,21 @@ module('Acceptance | create merchant', function (hooks) {
 
     // // merchant-customization card
     // TODO verify and interact with merchant customization card default state
-    await click(
-      `${post} [data-test-boxel-action-chin] [data-test-boxel-button]`
+    await fillIn(
+      `[data-test-merchant-customization-merchant-name-field] input`,
+      'HELLO!'
     );
-    // TODO verify and interact with merchant customization card memorialized state
+    await fillIn(
+      `[data-test-merchant-customization-merchant-id-field] input`,
+      'a-valid-id'
+    );
+    await waitUntil(
+      () =>
+        (document.querySelector(
+          '[data-test-validation-state-input]'
+        ) as HTMLElement).dataset.testValidationStateInput === 'valid'
+    );
+    await click(`[data-test-merchant-customization-save-details]`);
 
     // prepaid-card-choice card
     post = postableSel(1, 4);

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
@@ -193,12 +193,6 @@ module(
 
       for (let invalidEntry of MERCHANT_ID_INVALID_INPUTS) {
         await fillIn(merchantIdInput, invalidEntry.value);
-        await waitUntil(
-          () =>
-            (document.querySelector(
-              '[data-test-validation-state-input]'
-            ) as HTMLElement).dataset.testValidationStateInput === 'invalid'
-        );
         assert
           .dom(`${MERCHANT_ID_FIELD} [data-test-boxel-input-error-message]`)
           .containsText(invalidEntry.errorMessage);

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
@@ -1,0 +1,268 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, fillIn, render, waitUntil } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
+import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
+
+// selectors
+let PREVIEW = '[data-test-merchant-customization-merchant-preview]';
+let MERCHANT = '[data-test-merchant]';
+let MERCHANT_NAME_FIELD =
+  '[data-test-merchant-customization-merchant-name-field]';
+let MERCHANT_ID_FIELD = '[data-test-merchant-customization-merchant-id-field]';
+let COLOR_FIELD = '[data-test-merchant-customization-color-field]';
+let MANAGER = '[data-test-merchant-customization-manager-address]';
+let SAVE_DETAILS_BUTTON = '[data-test-merchant-customization-save-details]';
+let EDIT_BUTTON = '[data-test-merchant-customization-edit]';
+let COMPLETED_SELECTOR = '[data-test-merchant-customization-is-complete]';
+
+// fixtures for validation
+const MERCHANT_NAME_INVALID_INPUTS = [
+  {
+    value: '',
+    errorMessage: 'This field is required',
+  },
+  {
+    value: ' ',
+    errorMessage: 'Merchant name cannot contain only spaces',
+  },
+];
+const MERCHANT_ID_INVALID_INPUTS = [
+  {
+    value: '',
+    errorMessage: 'This field is required',
+  },
+  {
+    value: 'xn--',
+    errorMessage: 'Merchant ID cannot start with xn--',
+  },
+  {
+    value: 'an invalid id because of spaces',
+    errorMessage:
+      'Merchant ID can only contain lowercase alphabets, numbers, and hyphens',
+  },
+  {
+    value: 'INVALIDCASING',
+    errorMessage:
+      'Merchant ID can only contain lowercase alphabets, numbers, and hyphens',
+  },
+  {
+    value: '😤',
+    errorMessage:
+      'Merchant ID can only contain lowercase alphabets, numbers, and hyphens',
+  },
+  {
+    value: '-an-otherwise-valid-id',
+    errorMessage:
+      'Merchant ID must start and end with lowercase alphabet or number',
+  },
+  {
+    value: 'this-is-exactly-sixty-five-characters-long-but-is-otherwise-valid',
+    errorMessage: 'Merchant ID must be at most 63 characters, currently 65',
+  },
+];
+
+let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
+
+module(
+  'Integration | Component | card-pay/create-merchant/merchant-customization',
+  function (hooks) {
+    let layer2Service: Layer2TestWeb3Strategy;
+    let workflowSession: WorkflowSession;
+
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(async function () {
+      layer2Service = this.owner.lookup('service:layer2-network')
+        .strategy as Layer2TestWeb3Strategy;
+      workflowSession = new WorkflowSession();
+
+      let prepaidCardAddress = '0x123400000000000000000000000000000000abcd';
+
+      layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
+
+      layer2Service.test__simulateAccountSafes(layer2AccountAddress, [
+        {
+          type: 'prepaid-card',
+          createdAt: Date.now() / 1000,
+
+          address: prepaidCardAddress,
+
+          tokens: [],
+          owners: [layer2AccountAddress],
+
+          issuingToken: '0xTOKEN',
+          spendFaceValue: 2324,
+          prepaidCardOwner: layer2AccountAddress,
+          hasBeenUsed: false,
+          issuer: layer2AccountAddress,
+          reloadable: false,
+          transferrable: false,
+        },
+      ]);
+
+      this.setProperties({
+        onComplete: () => {
+          this.set('isComplete', true);
+        },
+        onIncomplete: () => {
+          this.set('isComplete', false);
+        },
+        isComplete: false,
+        frozen: false,
+        workflowSession,
+      });
+
+      await render(hbs`
+        <CardPay::CreateMerchantWorkflow::MerchantCustomization
+          @onComplete={{this.onComplete}}
+          @isComplete={{this.isComplete}}
+          @onIncomplete={{this.onIncomplete}}
+          @workflowSession={{this.workflowSession}}
+          @frozen={{this.frozen}}
+        />
+      `);
+    });
+
+    test('It displays the default state correctly', async function (assert) {
+      assert.dom(PREVIEW).exists();
+      assert.dom(`${PREVIEW} ${MERCHANT}`).containsText('Enter merchant name');
+      assert
+        .dom(`${PREVIEW} ${MERCHANT}`)
+        .hasAttribute('data-test-merchant', 'Enter merchant name');
+      assert.dom(MERCHANT_NAME_FIELD).exists();
+      assert.dom(MERCHANT_ID_FIELD).exists();
+      assert.dom(COLOR_FIELD).exists();
+      assert.dom(SAVE_DETAILS_BUTTON).exists().isDisabled();
+      assert.dom(MANAGER).containsText(layer2AccountAddress);
+    });
+
+    test('It validates the merchant name field and updates the preview', async function (assert) {
+      // enter valid merchant id so we can check that the merchant name being valid will make
+      // the save details button enabled
+      let merchantIdInput = `${MERCHANT_ID_FIELD} input`;
+      await fillIn(merchantIdInput, 'a-valid-id');
+      await waitUntil(
+        () =>
+          (document.querySelector(
+            '[data-test-validation-state-input]'
+          ) as HTMLElement).dataset.testValidationStateInput === 'valid'
+      );
+      assert.dom(SAVE_DETAILS_BUTTON).isDisabled();
+
+      let merchantNameInput = `${MERCHANT_NAME_FIELD} input`;
+
+      // valid
+      await fillIn(merchantNameInput, 'HELLO!');
+      assert.dom(merchantNameInput).hasValue('HELLO!');
+      assert
+        .dom('[data-test-merchant]')
+        .hasAttribute('data-test-merchant', 'HELLO!')
+        .containsText('HELLO!');
+      assert.dom(SAVE_DETAILS_BUTTON).isEnabled();
+
+      for (let invalidEntry of MERCHANT_NAME_INVALID_INPUTS) {
+        await fillIn(merchantNameInput, invalidEntry.value);
+        assert
+          .dom(`${MERCHANT_NAME_FIELD} [data-test-boxel-input-error-message]`)
+          .containsText(invalidEntry.errorMessage);
+        assert.dom(SAVE_DETAILS_BUTTON).isDisabled();
+      }
+    });
+
+    test('It validates the merchant ID field', async function (assert) {
+      let merchantNameInput = `${MERCHANT_NAME_FIELD} input`;
+      await fillIn(merchantNameInput, 'HELLO!');
+      assert.dom(merchantNameInput).hasValue('HELLO!');
+      assert
+        .dom('[data-test-merchant]')
+        .hasAttribute('data-test-merchant', 'HELLO!')
+        .containsText('HELLO!');
+      assert.dom(SAVE_DETAILS_BUTTON).isDisabled();
+
+      let merchantIdInput = `${MERCHANT_ID_FIELD} input`;
+      await fillIn(merchantIdInput, 'a-valid-id');
+      await waitUntil(
+        () =>
+          (document.querySelector(
+            '[data-test-validation-state-input]'
+          ) as HTMLElement).dataset.testValidationStateInput === 'valid'
+      );
+      assert.dom(SAVE_DETAILS_BUTTON).isEnabled();
+
+      for (let invalidEntry of MERCHANT_ID_INVALID_INPUTS) {
+        await fillIn(merchantIdInput, invalidEntry.value);
+        await waitUntil(
+          () =>
+            (document.querySelector(
+              '[data-test-validation-state-input]'
+            ) as HTMLElement).dataset.testValidationStateInput === 'invalid'
+        );
+        assert
+          .dom(`${MERCHANT_ID_FIELD} [data-test-boxel-input-error-message]`)
+          .containsText(invalidEntry.errorMessage);
+        assert.dom(SAVE_DETAILS_BUTTON).isDisabled();
+      }
+    });
+
+    // test('It validates uniqueness of a given id', async function (assert) {});
+
+    test('It updates the workflow session when saved', async function (assert) {
+      assert.notOk(workflowSession.state.merchantName);
+      assert.notOk(workflowSession.state.merchantId);
+      assert.notOk(workflowSession.state.merchantBgColor);
+
+      let merchantNameInput = `${MERCHANT_NAME_FIELD} input`;
+      await fillIn(merchantNameInput, 'HELLO!');
+
+      let merchantIdInput = `${MERCHANT_ID_FIELD} input`;
+      await fillIn(merchantIdInput, 'a-valid-id');
+      await waitUntil(
+        () =>
+          (document.querySelector(
+            '[data-test-validation-state-input]'
+          ) as HTMLElement).dataset.testValidationStateInput === 'valid'
+      );
+
+      await click(SAVE_DETAILS_BUTTON);
+
+      assert.equal(workflowSession.state.merchantName, 'HELLO!');
+      assert.equal(workflowSession.state.merchantId, 'a-valid-id');
+      assert.ok(workflowSession.state.merchantBgColor);
+    });
+
+    test('It displays the memorialized state correctly', async function (assert) {
+      let merchantNameInput = `${MERCHANT_NAME_FIELD} input`;
+      await fillIn(merchantNameInput, 'HELLO!');
+
+      let merchantIdInput = `${MERCHANT_ID_FIELD} input`;
+      await fillIn(merchantIdInput, 'a-valid-id');
+      await waitUntil(
+        () =>
+          (document.querySelector(
+            '[data-test-validation-state-input]'
+          ) as HTMLElement).dataset.testValidationStateInput === 'valid'
+      );
+
+      await click(SAVE_DETAILS_BUTTON);
+
+      let bgColor = workflowSession.state.merchantBgColor;
+
+      assert.dom(COMPLETED_SELECTOR).exists();
+      assert.dom(EDIT_BUTTON).exists();
+      assert.dom(`${PREVIEW} ${MERCHANT}`).containsText('HELLO!');
+      assert
+        .dom(`${PREVIEW} ${MERCHANT}`)
+        .hasAttribute('data-test-merchant-logo-background', bgColor);
+      assert
+        .dom(`${PREVIEW} ${MERCHANT}`)
+        .hasAttribute('data-test-merchant', 'HELLO!');
+      // assert has right text color
+      assert.dom(MERCHANT_NAME_FIELD).doesNotExist();
+      assert.dom(MERCHANT_ID_FIELD).containsText('a-valid-id');
+      assert.dom(COLOR_FIELD).containsText(bgColor);
+      assert.dom(MANAGER).containsText(layer2AccountAddress);
+    });
+  }
+);

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
@@ -24,8 +24,8 @@ const MERCHANT_NAME_INVALID_INPUTS = [
     errorMessage: 'This field is required',
   },
   {
-    value: ' ',
-    errorMessage: 'Merchant name cannot contain only spaces',
+    value: '   ',
+    errorMessage: 'This field is required',
   },
 ];
 const MERCHANT_ID_INVALID_INPUTS = [

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, fillIn, render, waitUntil } from '@ember/test-helpers';
+import { click, fillIn, find, render, waitUntil } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
 import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
@@ -145,9 +145,8 @@ module(
       await fillIn(merchantIdInput, 'a-valid-id');
       await waitUntil(
         () =>
-          (document.querySelector(
-            '[data-test-validation-state-input]'
-          ) as HTMLElement).dataset.testValidationStateInput === 'valid'
+          (find('[data-test-validation-state-input]') as HTMLElement).dataset
+            .testValidationStateInput === 'valid'
       );
       assert.dom(SAVE_DETAILS_BUTTON).isDisabled();
 
@@ -185,9 +184,8 @@ module(
       await fillIn(merchantIdInput, 'a-valid-id');
       await waitUntil(
         () =>
-          (document.querySelector(
-            '[data-test-validation-state-input]'
-          ) as HTMLElement).dataset.testValidationStateInput === 'valid'
+          (find('[data-test-validation-state-input]') as HTMLElement).dataset
+            .testValidationStateInput === 'valid'
       );
       assert.dom(SAVE_DETAILS_BUTTON).isEnabled();
 
@@ -215,9 +213,8 @@ module(
       await fillIn(merchantIdInput, 'a-valid-id');
       await waitUntil(
         () =>
-          (document.querySelector(
-            '[data-test-validation-state-input]'
-          ) as HTMLElement).dataset.testValidationStateInput === 'valid'
+          (find('[data-test-validation-state-input]') as HTMLElement).dataset
+            .testValidationStateInput === 'valid'
       );
 
       await click(SAVE_DETAILS_BUTTON);
@@ -236,9 +233,8 @@ module(
       await fillIn(merchantIdInput, 'a-valid-id');
       await waitUntil(
         () =>
-          (document.querySelector(
-            '[data-test-validation-state-input]'
-          ) as HTMLElement).dataset.testValidationStateInput === 'valid'
+          (find('[data-test-validation-state-input]') as HTMLElement).dataset
+            .testValidationStateInput === 'valid'
       );
 
       await click(SAVE_DETAILS_BUTTON);

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
@@ -212,6 +212,7 @@ module(
       assert.notOk(workflowSession.state.merchantName);
       assert.notOk(workflowSession.state.merchantId);
       assert.notOk(workflowSession.state.merchantBgColor);
+      assert.notOk(workflowSession.state.merchantTextColor);
 
       let merchantNameInput = `${MERCHANT_NAME_FIELD} input`;
       await fillIn(merchantNameInput, 'HELLO!');
@@ -230,6 +231,7 @@ module(
       assert.equal(workflowSession.state.merchantName, 'HELLO!');
       assert.equal(workflowSession.state.merchantId, 'a-valid-id');
       assert.ok(workflowSession.state.merchantBgColor);
+      assert.ok(workflowSession.state.merchantTextColor);
     });
 
     test('It displays the memorialized state correctly', async function (assert) {
@@ -248,6 +250,7 @@ module(
       await click(SAVE_DETAILS_BUTTON);
 
       let bgColor = workflowSession.state.merchantBgColor;
+      let textColor = workflowSession.state.merchantTextColor;
 
       assert.dom(COMPLETED_SELECTOR).exists();
       assert.dom(EDIT_BUTTON).exists();
@@ -257,8 +260,10 @@ module(
         .hasAttribute('data-test-merchant-logo-background', bgColor);
       assert
         .dom(`${PREVIEW} ${MERCHANT}`)
+        .hasAttribute('data-test-merchant-logo-text-color', textColor);
+      assert
+        .dom(`${PREVIEW} ${MERCHANT}`)
         .hasAttribute('data-test-merchant', 'HELLO!');
-      // assert has right text color
       assert.dom(MERCHANT_NAME_FIELD).doesNotExist();
       assert.dom(MERCHANT_ID_FIELD).containsText('a-valid-id');
       assert.dom(COLOR_FIELD).containsText(bgColor);

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
@@ -59,7 +59,7 @@ const MERCHANT_ID_INVALID_INPUTS = [
   },
   {
     value: 'this-is-exactly-sixty-five-characters-long-but-is-otherwise-valid',
-    errorMessage: 'Merchant ID must be at most 63 characters, currently 65',
+    errorMessage: 'Merchant ID must be at most 50 characters, currently 65',
   },
 ];
 

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
@@ -57,6 +57,13 @@ module(
       ]);
 
       let workflowSession = new WorkflowSession();
+      workflowSession.updateMany({
+        merchantName: "It's a new merchant",
+        merchantId: 'merchant-id',
+        merchantBgColor: '#ffffff',
+        merchantTextColor: '#000000',
+      });
+
       this.setProperties({
         onComplete: () => {},
         onIncomplete: () => {},
@@ -80,7 +87,14 @@ module(
       assert
         .dom('[data-test-prepaid-card-choice-merchant-fee]')
         .containsText('100 SPEND');
-      // TODO: check other fields
+      assert
+        .dom('[data-test-merchant]')
+        .hasAttribute('data-test-merchant', "It's a new merchant")
+        .hasAttribute('data-test-merchant-logo-background', '#ffffff')
+        .hasAttribute('data-test-merchant-logo-text-color', '#000000');
+      assert
+        .dom('[data-test-prepaid-card-choice-merchant-id]')
+        .containsText('merchant-id');
     });
 
     module('Test the sdk register merchant calls', async function () {

--- a/packages/web-client/tests/integration/helpers/first-char-test.ts
+++ b/packages/web-client/tests/integration/helpers/first-char-test.ts
@@ -23,4 +23,10 @@ module('Integration | Helper | first-char', function (hooks) {
     await render(hbs`{{first-char this.val}}`);
     assert.equal(this.element.textContent?.trim(), '');
   });
+
+  test('it can return the first character which consists of more than one code unit', async function (assert) {
+    this.set('val', '😱 what???');
+    await render(hbs`{{first-char this.val}}`);
+    assert.equal(this.element.textContent?.trim(), '😱');
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2169,6 +2169,20 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@ctrl/tinycolor@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz#c3c5ae543c897caa9c2a68630bed355be5f9990f"
+  integrity sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ==
+
+"@dabh/diagnostics@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.2.tgz#290d08f7b381b8f94607dc8f471a12c675f9db31"
+  integrity sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==
+  dependencies:
+    colorspace "1.1.x"
+    enabled "2.0.x"
+    kuler "^2.0.0"
+
 "@discordjs/collection@^0.1.6":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-0.1.6.tgz#9e9a7637f4e4e0688fd8b2b5c63133c91607682c"
@@ -2182,15 +2196,6 @@
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
-
-"@dabh/diagnostics@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.2.tgz#290d08f7b381b8f94607dc8f471a12c675f9db31"
-  integrity sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==
-  dependencies:
-    colorspace "1.1.x"
-    enabled "2.0.x"
-    kuler "^2.0.0"
 
 "@ember-data/adapter@3.25.0":
   version "3.25.0"


### PR DESCRIPTION
This PR adds UI for the edit state of the merchant customization card, with a function mocking the check for uniqueness by checking if the id ends with y.

https://user-images.githubusercontent.com/39579264/130231271-84f90aa0-2b1c-4edd-bfbd-a30c48fead76.mov

Will check with design re: copy for validation messages and helper text.