### PR TITLE
Fix withdrawal workflow bugs

### DIFF
--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/check-balance/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/check-balance/index.ts
@@ -43,8 +43,11 @@ export default class CardPayWithdrawalWorkflowCheckBalanceComponent extends Comp
   @reads('layer1Network.walletProvider') declare walletProvider: WalletProvider;
 
   get hasSufficientBalance() {
-    return this.minimumBalanceForWithdrawalClaim.lte(
-      this.layer1Network.defaultTokenBalance
+    return (
+      this.layer1Network.defaultTokenBalance &&
+      this.minimumBalanceForWithdrawalClaim.lte(
+        this.layer1Network.defaultTokenBalance
+      )
     );
   }
 


### PR DESCRIPTION
Fixes bugs in withdrawal workflow as described in CS-1624:
- Check balance step never resolving when workflow is opened without an existing layer 1 connection
- App crashing when disconnecting from layer 1 in withdrawal workflow *when account does not have enough balance to claim tokens