### PR TITLE
Merchant account and prepaid-card select cards memorialized UI

### DIFF
--- a/packages/web-client/app/components/card-pay/account-display/index.css
+++ b/packages/web-client/app/components/card-pay/account-display/index.css
@@ -25,7 +25,7 @@
 }
 
 .account-display__name {
-  font-weight: 600;
+  font-weight: 700;
   font-size: var(--name-font-size);
   line-height: var(--name-line-height);
   letter-spacing: var(--boxel-lsp-xs);

--- a/packages/web-client/app/components/card-pay/balance-display/index.css
+++ b/packages/web-client/app/components/card-pay/balance-display/index.css
@@ -27,7 +27,7 @@
 }
 
 .balance-display__name {
-  font-weight: 600;
+  font-weight: 700;
   font-size: var(--name-font-size);
   line-height: var(--name-line-height);
   letter-spacing: var(--boxel-lsp-xs);
@@ -54,7 +54,7 @@
   --balance-line-height: calc(27 / 20);
 
   color: var(--large-text-color);
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .balance-display__balance--sm {

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.css
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.css
@@ -6,6 +6,10 @@
   gap: 0;
 }
 
+.merchant-customization__enter-name {
+  color: var(--boxel-light-600);
+}
+
 .merchant-customization__color {
   display: flex;
   align-items: center;

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.css
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.css
@@ -1,0 +1,20 @@
+.merchant-customization__name {
+  --field-label-alignment: center;
+
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 0;
+}
+
+.merchant-customization__color {
+  display: flex;
+  align-items: center;
+}
+
+.merchant-customization__color-preview {
+  width: 1.5rem;
+  height: 1.5rem;
+  margin-right: var(--boxel-sp-xxs);
+  border-radius: 3px;
+  background-color: var(--merchant-custom-color);
+}

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.hbs
@@ -12,6 +12,7 @@
         class={{unless this.merchantName "merchant-customization__enter-name"}}
         @name={{or this.merchantName "Enter merchant name"}}
         @logoBackground={{this.merchantBgColor}}
+        @logoTextColor={{@logoTextColor}}
         @size="large"
         @vertical={{true}}
       />

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.hbs
@@ -3,7 +3,40 @@
   @isComplete={{@isComplete}}
   data-test-layout-customization-is-complete={{@isComplete}}
 >
-  <ActionCardContainer::Section @title="Choose a name and ID for the merchant" />
+  <ActionCardContainer::Section @title="Choose a name and ID for the merchant">
+    <CardPay::LabeledValue
+      class="merchant-customization__name"
+      @label={{if @isComplete "Merchant Name" "Preview"}}
+    >
+      <CardPay::Merchant
+        @name={{@name}}
+        @size="large"
+        @vertical={{true}}
+      />
+    </CardPay::LabeledValue>
+    {{#unless @isComplete}}
+      <CardPay::LabeledValue @fieldMode="edit" @label="Merchant Name">
+
+      </CardPay::LabeledValue>
+    {{/unless}}
+    {{#if @isComplete}}
+      <CardPay::LabeledValue @label="Merchant ID">
+        {{!-- id here --}}
+      </CardPay::LabeledValue>
+      <CardPay::LabeledValue @label="Custom Color">
+        <div class="merchant-customization__color">
+          <div class="merchant-customization__color-preview" style={{css-var merchant-custom-color=@merchantColor}} />
+          {{!-- color code here --}}
+        </div>
+      </CardPay::LabeledValue>
+      <CardPay::LabeledValue @label="Manager Address">
+        <CardPay::AccountDisplay
+          @wrapped={{true}}
+          @address={{@address}}
+        />
+      </CardPay::LabeledValue>
+    {{/if}}
+  </ActionCardContainer::Section>
   <Boxel::ActionChin
     @state={{if @isComplete "memorialized" "default"}}
     data-test-layout-customization

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.hbs
@@ -9,30 +9,27 @@
       @label={{if @isComplete "Merchant Name" "Preview"}}
     >
       <CardPay::Merchant
-        @name={{@name}}
+        class={{unless this.merchantName "merchant-customization__enter-name"}}
+        @name={{or this.merchantName "Enter merchant name"}}
+        @logoBackground={{this.merchantBgColor}}
         @size="large"
         @vertical={{true}}
       />
     </CardPay::LabeledValue>
-    {{#unless @isComplete}}
-      <CardPay::LabeledValue @fieldMode="edit" @label="Merchant Name">
-
-      </CardPay::LabeledValue>
-    {{/unless}}
     {{#if @isComplete}}
       <CardPay::LabeledValue @label="Merchant ID">
-        {{!-- id here --}}
+        {{this.merchantId}}
       </CardPay::LabeledValue>
       <CardPay::LabeledValue @label="Custom Color">
         <div class="merchant-customization__color">
-          <div class="merchant-customization__color-preview" style={{css-var merchant-custom-color=@merchantColor}} />
-          {{!-- color code here --}}
+          <div class="merchant-customization__color-preview" style={{css-var merchant-custom-color=(or this.merchantBgColor "var(--boxel-blue)")}} />
+          {{or this.merchantBgColor "#0069F9"}}
         </div>
       </CardPay::LabeledValue>
-      <CardPay::LabeledValue @label="Manager Address">
+      <CardPay::LabeledValue @label="Manager">
         <CardPay::AccountDisplay
           @wrapped={{true}}
-          @address={{@address}}
+          @address={{this.layer2Network.walletInfo.firstAddress}}
         />
       </CardPay::LabeledValue>
     {{/if}}

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.css
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.css
@@ -1,3 +1,9 @@
+.prepaid-card-choice__cost {
+  --icon-alignment: flex-start;
+
+  font-weight: 600;
+}
+
 .prepaid-card-choice__loading-indicator {
   --icon-color: white;
 

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.css
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.css
@@ -1,5 +1,5 @@
 .prepaid-card-choice__field-label {
-  --field-label-width: minmax(4rem, 22%);
+  --field-label-width: minmax(4rem, 20%);
 }
 
 .prepaid-card-choice__cost {
@@ -11,7 +11,7 @@
 .prepaid-card-choice__loading-indicator {
   --icon-color: var(--boxel-light);
 
-  margin-right: var(--boxel-sp-sm);
+  margin-right: var(--boxel-sp-xs);
   flex-grow: 0;
   flex-shrink: 0;
 }

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.css
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.css
@@ -1,11 +1,15 @@
+.prepaid-card-choice__field-label {
+  --field-label-width: minmax(4rem, 22%);
+}
+
 .prepaid-card-choice__cost {
   --icon-alignment: flex-start;
 
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .prepaid-card-choice__loading-indicator {
-  --icon-color: white;
+  --icon-color: var(--boxel-light);
 
   margin-right: var(--boxel-sp-sm);
   flex-grow: 0;

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
@@ -5,7 +5,12 @@
 >
   <ActionCardContainer::Section @title="Choose a prepaid card to fund merchant creation">
     <CardPay::LabeledValue @label="Merchant Name" class="prepaid-card-choice__field-label">
-      <CardPay::Merchant @name={{@name}} @size="small" @logoBackground={{@logoBackground}} />
+      <CardPay::Merchant
+        @name={{@name}}
+        @size="small"
+        @logoBackground={{@logoBackground}}
+        @logoTextColor={{@logoTextColor}}
+      />
     </CardPay::LabeledValue>
     <CardPay::LabeledValue @label="Merchant ID" class="prepaid-card-choice__field-label">
       {{@id}}
@@ -27,9 +32,11 @@
     {{#if @isComplete}}
       <CardPay::LabeledValue @label="Merchant Address" class="prepaid-card-choice__field-label">
         <CardPay::Merchant
-          @size="small"
           @name={{@name}}
           @address={{@workflowSession.state.merchantSafe.address}}
+          @size="small"
+          @logoBackground={{@logoBackground}}
+          @logoTextColor={{@logoTextColor}}
           data-test-prepaid-card-choice-merchant-address
         />
       </CardPay::LabeledValue>

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
@@ -4,6 +4,35 @@
   data-test-layout-customization-is-complete={{@isComplete}}
 >
   <ActionCardContainer::Section @title="Choose a prepaid card to fund merchant creation">
+    <CardPay::LabeledValue @label="Merchant Name">
+      <CardPay::Merchant @name={{@name}} @size="small" />
+    </CardPay::LabeledValue>
+    <CardPay::LabeledValue @label="Merchant ID">
+      {{@id}}
+    </CardPay::LabeledValue>
+    <CardPay::LabeledValue @label="Merchant Creation Fee">
+      {{!-- TODO: Do not hardcode 100 SPEND amount --}}
+      <CardPay::BalanceDisplay
+        class="prepaid-card-choice__cost"
+        @icon="spend"
+        @sign="§"
+        @symbol="SPEND"
+        @balance="100"
+        @usdBalance={{spend-to-usd 100}}
+      />
+    </CardPay::LabeledValue>
+    <CardPay::LabeledValue @label="Pay Using Prepaid Card">
+      {{!-- TODO card picker and appearance --}}
+    </CardPay::LabeledValue>
+    {{#if @isComplete}}
+      <CardPay::LabeledValue @label="Merchant Address">
+        <CardPay::Merchant
+          @size="small"
+          @name={{@name}}
+          @address={{@address}}
+        />
+      </CardPay::LabeledValue>
+    {{/if}}
     {{#if this.error}}
       <CardPay::ErrorMessage data-test-prepaid-card-choice-error-message as |supportURL|>
         {{#if (eq this.error.message "INSUFFICIENT_FUNDS")}}

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
@@ -1,35 +1,36 @@
 <ActionCardContainer
   @header="Prepaid Card Choice"
   @isComplete={{@isComplete}}
-  data-test-layout-customization-is-complete={{@isComplete}}
+  data-test-prepaid-card-choice-is-complete={{@isComplete}}
 >
   <ActionCardContainer::Section @title="Choose a prepaid card to fund merchant creation">
-    <CardPay::LabeledValue @label="Merchant Name">
-      <CardPay::Merchant @name={{@name}} @size="small" />
+    <CardPay::LabeledValue @label="Merchant Name" class="prepaid-card-choice__field-label">
+      <CardPay::Merchant @name={{@name}} @size="small" @logoBackground={{@logoBackground}} />
     </CardPay::LabeledValue>
-    <CardPay::LabeledValue @label="Merchant ID">
+    <CardPay::LabeledValue @label="Merchant ID" class="prepaid-card-choice__field-label">
       {{@id}}
     </CardPay::LabeledValue>
-    <CardPay::LabeledValue @label="Merchant Creation Fee">
-      {{!-- TODO: Do not hardcode 100 SPEND amount --}}
+    <CardPay::LabeledValue @label="Merchant Creation Fee" class="prepaid-card-choice__field-label">
       <CardPay::BalanceDisplay
         class="prepaid-card-choice__cost"
         @icon="spend"
         @sign="§"
         @symbol="SPEND"
-        @balance="100"
-        @usdBalance={{spend-to-usd 100}}
+        @balance={{this.merchantRegistrationFee}}
+        @usdBalance={{spend-to-usd this.merchantRegistrationFee}}
+        data-test-prepaid-card-choice-merchant-fee
       />
     </CardPay::LabeledValue>
-    <CardPay::LabeledValue @label="Pay Using Prepaid Card">
-      {{!-- TODO card picker and appearance --}}
+    <CardPay::LabeledValue @label="Pay Using Prepaid Card" class="prepaid-card-choice__field-label">
+      {{!-- TODO: card picker --}}
     </CardPay::LabeledValue>
     {{#if @isComplete}}
-      <CardPay::LabeledValue @label="Merchant Address">
+      <CardPay::LabeledValue @label="Merchant Address" class="prepaid-card-choice__field-label">
         <CardPay::Merchant
           @size="small"
           @name={{@name}}
-          @address={{@address}}
+          @address={{@workflowSession.state.merchantSafe.address}}
+          data-test-prepaid-card-choice-merchant-address
         />
       </CardPay::LabeledValue>
     {{/if}}

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
@@ -31,8 +31,23 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
 
   @tracked chinInProgressMessage?: string;
   @tracked txHash?: TransactionHash;
+  @tracked merchantRegistrationFee?: number;
 
   @reads('createTask.last.error') declare error: Error | undefined;
+
+  constructor(
+    owner: unknown,
+    args: CardPayCreateMerchantWorkflowPrepaidCardChoiceComponentArgs
+  ) {
+    super(owner, args);
+    taskFor(this.merchantRegistrationFeeTask)
+      .perform()
+      .catch((e) => console.error(e));
+  }
+
+  @task *merchantRegistrationFeeTask() {
+    this.merchantRegistrationFee = yield this.layer2Network.strategy.merchantRegistrationFee();
+  }
 
   @action createMerchant() {
     taskFor(this.createTask)

--- a/packages/web-client/app/components/card-pay/labeled-value/index.css
+++ b/packages/web-client/app/components/card-pay/labeled-value/index.css
@@ -1,8 +1,8 @@
 .card-pay-labeled-value {
-  --label-width: minmax(4rem, 25%);
+  --label-width: minmax(4rem, 22%);
   --boxel-field-label-width: var(--field-label-width, var(--label-width));
 
-  align-items: start;
+  align-items: var(--field-label-alignment, start);
 }
 
 .card-pay-labeled-value__label {

--- a/packages/web-client/app/components/card-pay/labeled-value/index.css
+++ b/packages/web-client/app/components/card-pay/labeled-value/index.css
@@ -1,5 +1,5 @@
 .card-pay-labeled-value {
-  --label-width: minmax(4rem, 22%);
+  --label-width: minmax(4rem, 25%);
   --boxel-field-label-width: var(--field-label-width, var(--label-width));
 
   align-items: var(--field-label-alignment, start);

--- a/packages/web-client/app/components/card-pay/merchant-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/merchant-card/index.hbs
@@ -8,6 +8,8 @@
       @size="large"
       @vertical={{true}}
       @name={{@name}}
+      @logoBackground={{@logoBackground}}
+      @logoTextColor={{@logoTextColor}}
       @text="Merchant Account"
     />
     <div class="merchant-card__info">

--- a/packages/web-client/app/components/card-pay/merchant/index.css
+++ b/packages/web-client/app/components/card-pay/merchant/index.css
@@ -12,7 +12,7 @@
 }
 
 .merchant__logo {
-  --logo-size: var(--boxel-icon-lg);
+  --logo-size: var(--boxel-icon-sm);
 
   background: var(--merchant-logo-background);
   color: var(--merchant-logo-text-color);
@@ -23,7 +23,7 @@
   width: var(--logo-size);
   height: var(--logo-size);
   margin-right: var(--boxel-sp-xxs);
-  font-size: var(--boxel-font-size-lg);
+  font-size: var(--boxel-font-size-sm);
   font-weight: 600;
   border-radius: 50%;
 }
@@ -32,12 +32,6 @@
   margin-right: auto;
   margin-left: auto;
   margin-bottom: var(--boxel-sp-xxxs);
-}
-
-.merchant__logo--sm {
-  --logo-size: var(--boxel-icon-sm);
-
-  font-size: var(--boxel-font-size-sm);
 }
 
 .merchant__logo--lg {
@@ -58,7 +52,7 @@
 }
 
 .merchant__address {
-  color: var(--boxel-purple-400);
+  color: var(--boxel-purple-500);
   font: var(--boxel-font-size)/calc(22 / 16) var(--boxel-monospace-font-family);
   letter-spacing: var(--boxel-lsp-sm);
   max-width: 22ch;

--- a/packages/web-client/app/components/card-pay/merchant/index.css
+++ b/packages/web-client/app/components/card-pay/merchant/index.css
@@ -1,5 +1,5 @@
 .merchant {
-  --merchant-logo-background: var(--boxel-red);
+  --merchant-logo-background: var(--boxel-blue);
   --merchant-logo-text-color: var(--boxel-light);
 
   display: flex;

--- a/packages/web-client/app/components/card-pay/merchant/index.hbs
+++ b/packages/web-client/app/components/card-pay/merchant/index.hbs
@@ -9,13 +9,11 @@
   data-test-merchant-logo-text-color={{@logoTextColor}}
   ...attributes
 >
-  <div class={{cn
-    "merchant__logo"
-    merchant__logo--sm=(eq @size "small")
-    merchant__logo--lg=(eq @size "large")
-  }}>
-    {{first-char @name}}
-  </div>
+  {{#if (first-char @name)}}
+    <div class={{cn "merchant__logo" merchant__logo--lg=(eq @size "large")}}>
+      {{first-char @name}}
+    </div>
+  {{/if}}
   <div>
     <div class={{cn "merchant__name" merchant__name--lg=(eq @size "large")}}>
       {{@name}}

--- a/packages/web-client/app/components/card-pay/merchant/index.hbs
+++ b/packages/web-client/app/components/card-pay/merchant/index.hbs
@@ -1,7 +1,7 @@
 <div
   class={{cn "merchant" merchant--vertical=@vertical}}
   style={{css-var
-    merchant-logo-background=(or @logoBackground "var(--boxel-red)")
+    merchant-logo-background=(or @logoBackground "var(--boxel-blue)")
     merchant-logo-text-color=(or @logoTextColor "var(--boxel-light)")
   }}
   data-test-merchant={{@name}}

--- a/packages/web-client/app/helpers/first-char.ts
+++ b/packages/web-client/app/helpers/first-char.ts
@@ -1,8 +1,10 @@
 import { helper } from '@ember/component/helper';
 
-export function firstChar([val]: [string] /*, hash*/) {
-  let str = String(val).trim();
-  return str[0];
+export function firstChar([str]: [string] /*, hash*/) {
+  if (!str || typeof str !== 'string') {
+    return;
+  }
+  return str.trim()[0];
 }
 
 export default helper(firstChar);

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -131,6 +131,10 @@ export default class Layer2Network
     return address;
   }
 
+  @task *merchantRegistrationFee(): TaskGenerator<number> {
+    return yield this.strategy.merchantRegistrationFee();
+  }
+
   @task *registerMerchant(
     prepaidCardAddress: string,
     infoDid: string,

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -260,6 +260,11 @@ export default abstract class Layer2ChainWeb3Strategy
     return result.prepaidCards[0];
   }
 
+  async merchantRegistrationFee(): Promise<number> {
+    const RevenuePool = await getSDK('RevenuePool', this.web3);
+    return await RevenuePool.merchantRegistrationFee(); // this is a SPEND amount
+  }
+
   async registerMerchant(
     prepaidCardAddress: string,
     infoDid: string,

--- a/packages/web-client/app/utils/web3-strategies/test-layer2.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer2.ts
@@ -201,6 +201,10 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
     return deferred.promise;
   }
 
+  merchantRegistrationFee() {
+    return Promise.resolve(100);
+  }
+
   async registerMerchant(
     prepaidCardAddress: string,
     infoDID: string,

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -132,6 +132,7 @@ export interface Layer2Web3Strategy
     customizationDid: string,
     options?: IssuePrepaidCardOptions
   ): Promise<PrepaidCardSafe>;
+  merchantRegistrationFee(): Promise<number>;
   registerMerchant(
     prepaidCardAddress: string,
     infoDid: string,

--- a/packages/web-client/tests/acceptance/create-merchant-test.ts
+++ b/packages/web-client/tests/acceptance/create-merchant-test.ts
@@ -111,6 +111,7 @@ module('Acceptance | create merchant', function (hooks) {
     assert.dom(post).containsText('Choose a name and ID for the merchant');
 
     let prepaidCardAddress = '0x123400000000000000000000000000000000abcd';
+    let merchantAddress = '0x1234000000000000000000000000000000004321';
 
     layer2Service.test__simulateAccountSafes(layer2AccountAddress, [
       {
@@ -151,9 +152,14 @@ module('Acceptance | create merchant', function (hooks) {
 
     layer2Service.test__simulateRegisterMerchantForAddress(
       prepaidCardAddress,
-      'FIXME',
+      merchantAddress,
       {}
     );
+
+    await waitFor('[data-test-prepaid-card-choice-is-complete]');
+    assert
+      .dom('[data-test-prepaid-card-choice-merchant-address]')
+      .containsText(merchantAddress);
 
     await waitFor(milestoneCompletedSel(1));
     assert.dom(milestoneCompletedSel(1)).containsText('Merchant created');

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
@@ -76,6 +76,13 @@ module(
       `);
     });
 
+    test('it shows the correct data', async function (assert) {
+      assert
+        .dom('[data-test-prepaid-card-choice-merchant-fee]')
+        .containsText('100 SPEND');
+      // TODO: check other fields
+    });
+
     module('Test the sdk register merchant calls', async function () {
       test('it shows the correct text in the creation button in the beginning and after errors', async function (assert) {
         sinon

--- a/packages/web-client/tests/integration/helpers/first-char-test.ts
+++ b/packages/web-client/tests/integration/helpers/first-char-test.ts
@@ -18,9 +18,9 @@ module('Integration | Helper | first-char', function (hooks) {
     assert.equal(this.element.textContent?.trim(), '&');
   });
 
-  test('it converts non-string input to string and returns first character', async function (assert) {
+  test('it ignores non-string input', async function (assert) {
     this.set('val', 577);
     await render(hbs`{{first-char this.val}}`);
-    assert.equal(this.element.textContent?.trim(), '5');
+    assert.equal(this.element.textContent?.trim(), '');
   });
 });


### PR DESCRIPTION
Focused on the memorialized fields with existing data. Also displaying the merchant creation fee and merchant card address in the Prepaid Card Choice card. Will handle the card selector field separately.

<img width="550" alt="merchant-account" src="https://user-images.githubusercontent.com/16160806/129962751-b431fae9-271f-4121-8280-4c9990c54c30.png">
<img width="540" alt="prepaid-card-choice" src="https://user-images.githubusercontent.com/16160806/129964817-bb15eb55-7396-45a7-ade0-00769a0a4d9b.png">

With more data:
<img width="490" alt="more-data" src="https://user-images.githubusercontent.com/16160806/129964680-4bfa21f0-a6ed-4023-bd70-2b03cbae63f7.png">
