### PR TITLE
Fix crashes during reconnection preventing workflows from being opened

### DIFF
--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -160,7 +160,6 @@ export default abstract class Layer2ChainWeb3Strategy
         this.#safesApi = await getSDK('Safes', this.web3);
         this.#hubAuthApi = await getSDK('HubAuth', this.web3, config.hubURL);
         await this.updateWalletInfo(accounts);
-        this.isInitializing = false;
         this.#broadcastChannel.postMessage({
           type: BROADCAST_CHANNEL_MESSAGES.CONNECTED,
           session: this.connector?.session,
@@ -171,6 +170,8 @@ export default abstract class Layer2ChainWeb3Strategy
         );
         console.error(e);
         this.disconnect();
+      } finally {
+        this.isInitializing = false;
       }
     });
 


### PR DESCRIPTION
If there is a crash during reconnection to layer 2, `isInitializing` is not set to true, and workflows will not be able to be viewed. 

A common reason for a reconnection crash is changing your current network to one other than Sokol and reopening the DApp.