### PR TITLE
hub: Introduce .env file for hub environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /packages/web-client/deploy/dist
 /packages/cardpay-subgraph/build
 /packages/cardpay-subgraph/generated
-/packages/hub/.env
+/packages/*/.env
 .eslintcache
 .vagrant
 .nvmrc

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /packages/web-client/deploy/dist
 /packages/cardpay-subgraph/build
 /packages/cardpay-subgraph/generated
+/packages/hub/.env
 .eslintcache
 .vagrant
 .nvmrc

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typescript": "4.2.3"
   },
   "scripts": {
-    "clean": "git clean -x -f --exclude=packages/web-client/.env",
+    "clean": "git clean -x -f --exclude=packages/*/.env",
     "compile": "yarn codegen:subgraph-sokol && tsc --build ./tsconfig.json",
     "prepare": "npm run compile",
     "codegen:subgraph-sokol": "cd ./packages/cardpay-subgraph && yarn codegen-sokol",

--- a/packages/hub/.eslintrc.ts
+++ b/packages/hub/.eslintrc.ts
@@ -1,4 +1,12 @@
 module.exports = {
   root: true,
   extends: '@cardstack/eslint-config',
+  rules: {
+    'node/no-unpublished-require': [
+      'error',
+      {
+        allowModules: ['dotenv'],
+      },
+    ],
+  },
 };

--- a/packages/hub/bin/console.ts
+++ b/packages/hub/bin/console.ts
@@ -3,9 +3,13 @@
 /* eslint-disable node/shebang */
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-require-imports */
+
+require('dotenv').config();
+
 //@ts-ignore not actually redefining block-scoped var
 const esmRequire = require('esm')(module, { cjs: true });
 let repl = require('repl');
+
 //@ts-ignore not actually redefining block-scoped var
 let container = esmRequire('./../main').bootEnvironment();
 let replServer = repl.start({

--- a/packages/hub/bin/server.ts
+++ b/packages/hub/bin/server.ts
@@ -3,6 +3,9 @@
 /* eslint-disable node/shebang */
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-require-imports */
+
+require('dotenv').config();
+
 //@ts-ignore not actually redefining block-scoped var
 const esmRequire = require('esm')(module, { cjs: true });
 module.exports = esmRequire('./../main').bootServer();

--- a/packages/hub/bin/worker.ts
+++ b/packages/hub/bin/worker.ts
@@ -2,6 +2,8 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-require-imports */
 
+require('dotenv').config();
+
 //@ts-ignore not actually redefining block-scoped var
 const esmRequire = require('esm')(module, { cjs: true });
 module.exports = esmRequire('./../main').bootWorker();

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -63,7 +63,8 @@
     "@types/supertest": "^2.0.11",
     "json-stable-stringify": "^1.0.1",
     "moment-timezone": "^0.5.33",
-    "supertest": "^6.1.3"
+    "supertest": "^6.1.3",
+    "dotenv": "^10.0.0"
   },
   "engines": {
     "node": "^14.0",


### PR DESCRIPTION
This PR is a suggestion to solve a developer experience type of problem I've been dealing with recently. 

To run the hub locally, at least one custom environment variable is needed: `SERVER_SECRET`. Currently, developers can provide this inline, for example `SERVER_SECRET=abc yarn start:worker`, or save the env variable export to their shell config, or modify development.js file, for example.  

Solutions like this are too brittle or cumbersome IMO. I think a better experience is to be able to save the custom environment variables to a git untracked file and run yarn commands without needing to provide these variables. 

I wanna get your opinion on introducing the `dotenv` library which reads from the `.env` file and populates the environment variables. An example of an .env file:

```
 LOG_LEVELS='*=debug'
 SERVER_SECRET=abc123
 AWS_PROFILE=cardstack_prod
```

Alternatively, we can perhaps use `custom-environment-variables.json` for this, and add it to `.gitignore`.