### PR TITLE
Demonstrate a more idiomatic use of resources

### DIFF
--- a/packages/web-client/app/components/card-pay/prepaid-card-safe/index.ts
+++ b/packages/web-client/app/components/card-pay/prepaid-card-safe/index.ts
@@ -1,10 +1,7 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
-
-import CardCustomization from '@cardstack/web-client/services/card-customization';
+import { CardCustomization } from '@cardstack/web-client/resources/card-customization';
 import { PrepaidCardSafe } from '@cardstack/cardpay-sdk';
-import { taskFor } from 'ember-concurrency-ts';
-import { useTask } from 'ember-resources';
+import { useResource } from 'ember-resources';
 
 interface CardPayPrepaidCardSafeComponentArgs {
   safe: PrepaidCardSafe;
@@ -12,21 +9,8 @@ interface CardPayPrepaidCardSafeComponentArgs {
 }
 
 export default class CardPayPrepaidCardSafeComponent extends Component<CardPayPrepaidCardSafeComponentArgs> {
-  @service declare cardCustomization: CardCustomization;
-  fetchTask: any;
-
-  constructor(owner: unknown, args: CardPayPrepaidCardSafeComponentArgs) {
-    super(owner, args);
-
-    // This is inside the constructor because the service needs to be initialised
-    this.fetchTask = useTask(
-      this,
-      taskFor(this.cardCustomization.fetchCardCustomization),
-      () => [this.args.safe.customizationDID, this.args.waitForCustomization]
-    );
-  }
-
-  get customization() {
-    return this.fetchTask?.value;
-  }
+  customization = useResource(this, CardCustomization, () => ({
+    customizationDID: this.args.safe.customizationDID,
+    waitForCustomization: this.args.waitForCustomization,
+  }));
 }

--- a/packages/web-client/app/resources/card-customization.ts
+++ b/packages/web-client/app/resources/card-customization.ts
@@ -1,0 +1,102 @@
+import { timeout } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
+import { getResolver } from '@cardstack/did-resolver';
+import { Resolver } from 'did-resolver';
+import { Resource } from 'ember-resources';
+import config from '../config/environment';
+
+const FIRST_RETRY_DELAY = config.environment === 'test' ? 100 : 1000;
+
+interface Args {
+  named: {
+    customizationDID: string;
+    waitForCustomization: boolean;
+  };
+}
+
+export class CardCustomization extends Resource<Args> {
+  // our output values
+  @tracked issuerName: string | undefined;
+  @tracked background: string | undefined;
+  @tracked patternColor: string | undefined;
+  @tracked textColor: string | undefined;
+  @tracked patternUrl: string | undefined;
+
+  // our derived state so you can check when the output values are ready, if you
+  // want to
+  @tracked loading = true;
+  @tracked errored: Error | undefined;
+
+  #didResolver = new Resolver(getResolver());
+
+  constructor(owner: unknown, args: Args) {
+    super(owner, args);
+    this.run();
+  }
+
+  private async run() {
+    try {
+      await this.fetchCardCustomization(
+        this.args.named.customizationDID,
+        this.args.named.waitForCustomization
+      );
+      this.loading = false;
+    } catch (err) {
+      this.errored = err;
+      this.loading = false;
+    }
+  }
+
+  private async fetchCardCustomization(
+    customizationDID: string,
+    waitForCustomization = false
+  ): Promise<void> {
+    let did = await this.#didResolver.resolve(customizationDID);
+
+    let alsoKnownAs = did?.didDocument?.alsoKnownAs;
+
+    if (alsoKnownAs) {
+      let jsonApiDocument = await this.fetchJson(
+        alsoKnownAs[0], // FIXME: the original code had a type error here that was hiding
+        waitForCustomization
+      );
+
+      let included = jsonApiDocument.included;
+
+      let colorScheme = included.findBy('type', 'prepaid-card-color-schemes')
+        .attributes;
+      let pattern = included.findBy('type', 'prepaid-card-patterns').attributes;
+
+      this.issuerName = jsonApiDocument.data.attributes['issuer-name'];
+      this.background = colorScheme.background;
+      this.patternColor = colorScheme['pattern-color'];
+      this.textColor = colorScheme['text-color'];
+      this.patternUrl = pattern['pattern-url'];
+    }
+  }
+
+  private async fetchJson(
+    alsoKnownAs: string,
+    waitForCustomization: boolean
+  ): Promise<any> {
+    let maxAttempts = waitForCustomization ? 10 : 1;
+    let attemptNum = 1;
+    while (attemptNum <= maxAttempts) {
+      try {
+        let jsonApiResponse = await fetch(alsoKnownAs);
+        if (!jsonApiResponse.ok) {
+          let errorBodyText = await jsonApiResponse.text();
+          throw new Error(errorBodyText);
+        }
+        let jsonApiDocument = await jsonApiResponse.json();
+        return jsonApiDocument;
+      } catch (err) {
+        if (attemptNum === maxAttempts) {
+          throw err;
+        }
+        attemptNum++;
+        await timeout(FIRST_RETRY_DELAY * attemptNum);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Here's an example of a more idiomatic way to take advantage of resources. The key idea is that a resource encapsulates what you want, and all the state for getting it, without the consumer needing to worry about any of that.

It would also be possible to split the `fetchJSON` method into a separate `Resource` in its own right, so it can be shared by other resources. It wasn't being reused at the moment, so I didn't bother. 

This implementation is restart and teardown safe, even though it doesn't use ember-concurrency-based generators. The idea is that these async functions do always run to completion, but if the app or test suite has moved on, nobody is observing our resource instance anymore anyway. Each time a Resource's arguments change, it gets replaced by a new instance.

I left a comment about a type error that was revealed by this refactor. `alsoKnownAs` is a `string[]`, not a `string`, so I just took the first one. I don't know what the real desired semantics are.

This also points toward how to answer @backspace's other question about intentionally triggering an update. When you're implementing your own `Resource` class you can just put a method on it, and call it from the component.