### PR TITLE
ci: Add cardie workflow

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -225,3 +225,33 @@ jobs:
           S3_PREVIEW_REGION: us-east-1
           PREVIEW_DEPLOY_AWS_ACCESS_KEY: ${{ secrets.PREVIEW_DEPLOY_AWS_ACCESS_KEY }}
           PREVIEW_DEPLOY_AWS_ACCESS_SECRET: ${{ secrets.PREVIEW_DEPLOY_AWS_ACCESS_SECRET }}
+
+  deploy-cardie:
+    name: Deploy cardie via waypoint
+    needs: change_check
+    if: ${{ needs.change_check.outputs.cardie == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install apt packages including waypoint
+        run: |
+          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+          sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+          sudo apt-get install awscli waypoint
+      - name: Configure waypoint client
+        run: waypoint context create -server-addr=${{ secrets.WAYPOINT_SERVER_ADDR }} -server-auth-token=${{ secrets.WAYPOINT_AUTH_TOKEN }} -server-tls=true -server-tls-skip-verify=true -set-default -server-require-auth waypoint-staging
+      - uses: volta-cli/action@v1
+      - name: Set up yarn cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn --prefer-offline
+      - name: Deploy cardie
+        run: waypoint up --app=cardie -prune-retain=0 -plain
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.WAYPOINT_AWS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.WAYPOINT_AWS_SECRET }}
+          AWS_DEFAULT_REGION: us-east-1

--- a/packages/cardie/Procfile
+++ b/packages/cardie/Procfile
@@ -1,0 +1,1 @@
+worker: node ./index.ts

--- a/packages/cardie/config.json
+++ b/packages/cardie/config.json
@@ -6,8 +6,8 @@
       "environment": "production",
       "ref": "main"
     },
-    "allowedChannels": [],
-    "allowedRoles": []
+    "allowedChannels": ["866667164764471346"],
+    "allowedRoles": ["deploy"]
   },
   "github": {
     "owner": "cardstack",

--- a/waypoint.hcl
+++ b/waypoint.hcl
@@ -77,3 +77,33 @@ app "hub-worker" {
         }
     }
 }
+
+app "cardie" {
+    path = "./packages/cardie"
+
+    build {
+        use "pack" {
+            process_type = "worker"
+        }
+
+        registry {
+            use "aws-ecr" {
+                region     = "us-east-1"
+                repository = "cardie"
+                tag        = "latest"
+            }
+        }
+    }
+
+    deploy {
+        use "aws-ecs" {
+            region = "us-east-1"
+            memory = "512"
+            count = 1
+            cluster = "default"
+            subnets = ["subnet-89968ba2"]
+            task_role_name = "cardie-ecr-task"
+            disable_alb = true
+        }
+    }
+}


### PR DESCRIPTION
This PR add necessary workflow to deploy and update `cardie`.
`cardie` is a discord bot and thus requires creation following this guide: https://discordjs.guide/preparations/setting-up-a-bot-application.html#creating-your-bot

It takes in two environment variables, `DISCORD_TOKEN` and `GITHUB_TOKEN`, which have to be set using `waypoint`:
```
waypoint config set DISCORD_TOKEN=<> -app=cardie
waypoint config set GITHUB_TOKEN=<> -app=cardie
```