### PR TITLE
Remove spendBalance field from PrepaidCard

### DIFF
--- a/packages/cardpay-sdk/sdk/safes/base.ts
+++ b/packages/cardpay-sdk/sdk/safes/base.ts
@@ -86,7 +86,6 @@ const safeQueryFields = `
       symbol
       id
     }
-    spendBalance
     faceValue
     payments {
       id
@@ -378,7 +377,6 @@ interface GraphQLSafeResult {
     payments: {
       id: string;
     }[];
-    spendBalance: string;
     faceValue: string;
     issuer: { id: string };
     reloadable: boolean;

--- a/packages/web-client/tests/integration/components/card-pay/prepaid-card-safe-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/prepaid-card-safe-test.ts
@@ -52,7 +52,6 @@ module(
         id: '0xc9Cdb5EeD1c27fCc64DA096CA3b0bcc02c1d45C2',
       },
       reloadable: false,
-      spendBalance: '500',
       prepaidCardOwner: '0xc9Cdb5EeD1c27fCc64DA096CA3b0bcc02c1d45C2',
       hasBeenUsed: false,
       issuer: '0xc9Cdb5EeD1c27fCc64DA096CA3b0bcc02c1d45C2',


### PR DESCRIPTION
This field is no longer used since recent subgraph change that removed it from the schema.