### PR TITLE
Make cardie private for now

### DIFF
--- a/packages/cardie/package.json
+++ b/packages/cardie/package.json
@@ -3,6 +3,7 @@
   "version": "0.21.2",
   "description": "",
   "main": "index.js",
+  "private": true,
   "scripts": {
     "start": "ts-node index.ts"
   },


### PR DESCRIPTION
`npx lerna publish --force-publish` will fail because we don't have permissions to publish `discord-bot` to npm. This makes the package private for now until it is ready for publishing.
