### PR TITLE
Fix/misc UI

### DIFF
--- a/packages/boxel/addon/components/boxel/action-chin/index.css
+++ b/packages/boxel/addon/components/boxel/action-chin/index.css
@@ -51,7 +51,7 @@
   --boxel-action-chin-padding-vertical: var(--boxel-sp-xs);
 }
 
-.boxel-action-chin--disabled.boxel-action-chin--has-step {
+.boxel-action-chin--disabled.boxel-action-chin--has-step:not(.boxel-action-chin--memorialized) {
   --boxel-action-chin-background-color: var(--boxel-action-chin-disabled-background);
 }
 

--- a/packages/web-client/app/components/card-pay/layer-two-connect-card/index.css
+++ b/packages/web-client/app/components/card-pay/layer-two-connect-card/index.css
@@ -7,9 +7,10 @@
   color: var(--boxel-purple-500);
 }
 
-.layer-two-connect-card__app-store-links {
+.layer-two-connect-card__link-container {
   align-items: center;
   display: flex;
+  gap: var(--boxel-sp-sm);
   flex-wrap: wrap;
   justify-content: space-around;
   padding-top: var(--boxel-sp);
@@ -22,6 +23,11 @@
   align-items: center;
   gap: var(--boxel-sp-xs);
   font: 600 var(--boxel-font);
+  padding: var(--boxel-sp-sm);
+}
+
+.layer-two-connect-card__testflight-link-icon {
+  flex-shrink: 0;
 }
 
 .layer-two-connect-card__alternate-wallet {

--- a/packages/web-client/app/components/card-pay/layer-two-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-two-connect-card/index.hbs
@@ -76,7 +76,7 @@
             Please install the Card Wallet app on your mobile phone and create/add an account.
           </p>
         {{/if}}
-        <div class="layer-two-connect-card__app-store-links">
+        <div class="layer-two-connect-card__link-container">
           <img
             srcset="{{this.cardstackMobileAppPhone}},
                     {{this.cardstackMobileAppPhone2x}} 2x"
@@ -101,7 +101,7 @@
               height="40px"
             >
               Download TestFlight
-              {{svg-jar "caret-right-large"}}
+              {{svg-jar "caret-right-large" class="layer-two-connect-card__testflight-link-icon"}}
           </a>
         </div>
       </ActionCardContainer::Section>


### PR DESCRIPTION
Fixes some UI bugs that I missed when introducing modifications to the layer two connect card and action chin:

## Layer Two Connect Card @ 360px width
Before
![image](https://user-images.githubusercontent.com/39579264/130467108-4d3a2394-8ce2-4084-b0f7-ecb68258782b.png)

After
![image](https://user-images.githubusercontent.com/39579264/130467302-cfe23dc7-07d4-4435-bc6a-e94f31c244d9.png)

## Disabled memorialized action chin with steps
Before
![image](https://user-images.githubusercontent.com/39579264/130468919-a9b3ead4-e466-4897-863d-7d32a81d6ade.png)

![image](https://user-images.githubusercontent.com/39579264/130468820-ccafbffa-f54b-48e3-b27b-aaebb8b7bf72.png)


After
![image](https://user-images.githubusercontent.com/39579264/130468367-6292344b-3aac-481b-95ad-b66758dccc08.png)

![image](https://user-images.githubusercontent.com/39579264/130468621-55692dcf-e3c7-4c6c-a96d-bfbe4051c789.png)
