### PR TITLE
hub: Update merchant attributes to be dasherised

### DIFF
--- a/packages/hub/node-tests/routes/merchant-infos-test.ts
+++ b/packages/hub/node-tests/routes/merchant-infos-test.ts
@@ -100,8 +100,8 @@ describe('POST /api/merchant-infos', function () {
             slug: 'satoshi',
             did: 'the-did',
             color: 'ff0000',
-            textColor: 'ffffff',
-            ownerAddress: '0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13',
+            'text-color': 'ffffff',
+            'owner-address': '0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13',
           },
         },
       })

--- a/packages/hub/services/serializers/merchant-info-serializer.ts
+++ b/packages/hub/services/serializers/merchant-info-serializer.ts
@@ -23,8 +23,8 @@ export default class MerchantInfoSerializer {
           name: model.name,
           slug: model.slug,
           color: model.color,
-          textColor: model.textColor,
-          ownerAddress: model.ownerAddress,
+          'text-color': model.textColor,
+          'owner-address': model.ownerAddress,
         },
       },
     };


### PR DESCRIPTION
While I don’t think this is required by the specification, it’s now established
in other serialisers.