### PR TITLE
Fix $NaN in prepaid card creation

### DIFF
--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/display-view/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/display-view/index.hbs
@@ -14,7 +14,7 @@
         @mockBalance={{true}}
         @mockOptions={{true}}
         @balance="123,456"
-        @usdBalance="1,234.56"
+        @usdBalance="1234.56"
         @address={{placeholder-address}}
         @network={{network-display-info "layer2" "fullName"}}
       />

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/form-view/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/form-view/index.hbs
@@ -12,7 +12,7 @@
         @mockBalance={{true}}
         @mockOptions={{true}}
         @balance="123,456"
-        @usdBalance="1,234.56"
+        @usdBalance="1234.56"
         @address={{placeholder-address}}
         @network={{network-display-info "layer2" "fullName"}}
       />


### PR DESCRIPTION
Fixes commas in the string causing problems with the SDK's currency utilities and producing an NaN. This change still directly uses the output of the SDK's USD formatting, which doesn't use commas to group/separate groups of numbers.

Before
![image](https://user-images.githubusercontent.com/39579264/130662027-098817f2-8488-4755-ab42-df9baa3dd43f.png)

After
![image](https://user-images.githubusercontent.com/39579264/130662185-19f9498b-f43b-4ce1-a65d-a25f756dffdf.png)

@burieberry, is it important that we have a consistent 3-number separation using commas (eg. 1,234.56 and 123,456)? If so, this may be something we can add to the SDK currency utils (with some coordination with the React Native team, who also use these currency utils). If you think this is important, I'll create a Linear task for this.