### PR TITLE
handle not enough balance for gas in RevenuePool.claim

### DIFF
--- a/packages/cardpay-sdk/sdk/revenue-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/revenue-pool/base.ts
@@ -127,6 +127,14 @@ export default class RevenuePool {
       0,
       tokenAddress
     );
+    let gasCost = new BN(estimate.dataGas).add(new BN(estimate.baseGas)).mul(new BN(estimate.gasPrice));
+    if (unclaimedBalance.lt(new BN(amount).add(gasCost))) {
+      throw new Error(
+        `Merchant safe does not have enough enough to pay for gas when claiming revenue. The merchant safe ${merchantSafeAddress} unclaimed balance for token ${tokenAddress} is ${fromWei(
+          unclaimedBalance
+        )}, amount being claimed is ${fromWei(amount)}, the gas cost is ${fromWei(gasCost)}`
+      );
+    }
     if (nonce == null) {
       nonce = getNextNonceFromEstimate(estimate);
       if (typeof onNonce === 'function') {


### PR DESCRIPTION
Is this check is necessary for `RevenuePool.claim`? Can/does the funding for the gas come from somewhere else, or from another token? 

This was the only case I found where we move tokens around and don't check if the amount + gas is enough. 