### PR TITLE
Update queries to use reward program id

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -522,7 +522,7 @@
         "reward-balances",
         "0x159ADe032073d930E85f95AbBAB9995110c43C71", // Justin's address
         "--rewardProgramId",
-        "0x271e381a892A0d2D830268A4D1EFb5144952A6DE", 
+        "0x4767D0D74356433d54880Fcd7f083751d64388aF",
         "--network",
         "sokol",
         "--mnemonic",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -521,10 +521,12 @@
       "args": [
         "reward-balances",
         "0x159ADe032073d930E85f95AbBAB9995110c43C71", // Justin's address
+        "--rewardProgramId",
+        "0x271e381a892A0d2D830268A4D1EFb5144952A6DE", 
         "--network",
         "sokol",
         "--mnemonic",
-        "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
+        "fortune reduce accuse famous fetch waste debate alcohol notice salmon wish okay"
       ]
     }
   ]

--- a/packages/cardpay-cli/index.ts
+++ b/packages/cardpay-cli/index.ts
@@ -90,6 +90,7 @@ interface Options {
   encodedData?: string;
   signatures?: string[];
   faceValues?: number[];
+  rewardProgramId?: string;
 }
 let {
   network,
@@ -116,6 +117,7 @@ let {
   encodedData,
   signatures,
   hubRootUrl,
+  rewardProgramId,
 } = yargs(process.argv.slice(2))
   .scriptName('cardpay')
   .usage('Usage: $0 <command> [options]')
@@ -529,13 +531,21 @@ let {
       command = 'hubAuth';
     }
   )
-  .command('reward-balances [address]', 'View token balances of unclaimed rewards in the reward pool.', (yargs) => {
-    yargs.positional('address', {
-      type: 'string',
-      description: 'The address that tally rewarded -- The owner of prepaid card.',
-    });
-    command = 'rewardTokenBalances';
-  })
+  .command(
+    'reward-balances <address> [rewardProgramId]',
+    'View token balances of unclaimed rewards in the reward pool.',
+    (yargs) => {
+      yargs.positional('address', {
+        type: 'string',
+        description: 'The address that tally rewarded -- The owner of prepaid card.',
+      });
+      yargs.positional('rewardProgramId', {
+        type: 'string',
+        description: 'The reward program id.',
+      });
+      command = 'rewardTokenBalances';
+    }
+  )
   .options({
     network: {
       alias: 'n',
@@ -765,7 +775,7 @@ if (!command) {
         showHelpAndExit('address is a required value');
         return;
       }
-      await rewardTokenBalances(network, address, mnemonic);
+      await rewardTokenBalances(network, address, rewardProgramId, mnemonic);
       break;
     default:
       assertNever(command);

--- a/packages/cardpay-cli/reward-pool.ts
+++ b/packages/cardpay-cli/reward-pool.ts
@@ -4,10 +4,15 @@ import Web3 from 'web3';
 const { fromWei } = Web3.utils;
 import { RewardTokenBalance } from '@cardstack/cardpay-sdk/sdk/reward-pool';
 
-export async function rewardTokenBalances(network: string, address: string, mnemonic?: string): Promise<void> {
+export async function rewardTokenBalances(
+  network: string,
+  address: string,
+  rewardProgramId?: string,
+  mnemonic?: string
+): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let rewardPool = await getSDK('RewardPool', web3);
-  const tokenBalances = await rewardPool.rewardTokenBalances(address);
+  const tokenBalances = await rewardPool.rewardTokenBalances(address, rewardProgramId);
   displayRewardTokenBalance(address, tokenBalances);
 }
 

--- a/packages/cardpay-sdk/contracts/addresses.ts
+++ b/packages/cardpay-sdk/contracts/addresses.ts
@@ -50,7 +50,7 @@ const SOKOL = {
   actionDispatcher: '0xaE5AC3685630b33Ed2677438EEaAe0aD5372c795',
   uniswapV2Router: '0xd57B4D7B7FED6b47492A362e113e26F9804DbCc6', // This is the UniswapV2Router02
   uniswapV2Factory: '0x6b67f08F08B715B162aa09239488318A660F24BF',
-  rewardPool: '0x9d8Ea61555Ee7A5d1Ca9422de7Fd7866430710bB',
+  rewardPool: '0x2D23acfEA32492911E8DF12E697AF0013B8D4E7b',
   deprecatedMerchantManager_v0_6_7: '0xA113ECa0Af275e1906d1fe1B7Bef1dDB033113E2', // eslint-disable-line @typescript-eslint/naming-convention
   oracles: {
     DAI: '0x74beF86c9d4a5b96B81D8d8e44157DFd35Eda5fB', // eslint-disable-line @typescript-eslint/naming-convention

--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -56,11 +56,18 @@ export default class RewardPool {
     return json['tokenAddresses'];
   }
 
-  async getProofs(address: string, tokenAddress?: string, offset?: number, limit?: number): Promise<Proof[]> {
+  async getProofs(
+    address: string,
+    tokenAddress?: string,
+    rewardProgramID?: string,
+    offset?: number,
+    limit?: number
+  ): Promise<Proof[]> {
     let tallyServiceURL = await getConstant('tallyServiceURL', this.layer2Web3);
     let url =
       `${tallyServiceURL}/merkle-proofs/${address}` +
       (tokenAddress ? `?token_address=${tokenAddress}` : '') +
+      (rewardProgramID ? `?reward_program_id=${rewardProgramID}` : '') +
       (offset ? `?offset=${offset}` : '') +
       (limit ? `?limit=${limit}` : `?limit=${DEFAULT_PAGE_SIZE}`);
     let options = {
@@ -91,7 +98,6 @@ export default class RewardPool {
     let ungroupedTokenBalance = await Promise.all(
       proofs.map(async (o: Proof) => {
         const balance = await rewardPool.methods.balanceForProofWithAddress(o.tokenAddress, address, o.proof).call();
-        // returns a string in wei amount
         return {
           tokenAddress: o.tokenAddress,
           tokenSymbol,

--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -88,14 +88,19 @@ export default class RewardPool {
     return json['results'];
   }
 
-  async rewardTokenBalance(address: string, tokenAddress: string): Promise<RewardTokenBalance> {
-    let rewardTokensAvailable = await this.rewardTokensAvailable(address);
+  async rewardTokenBalance(
+    address: string,
+    tokenAddress: string,
+    rewardProgramId?: string
+  ): Promise<RewardTokenBalance> {
+    let rewardTokensAvailable = await this.rewardTokensAvailable(address, rewardProgramId);
     if (!rewardTokensAvailable.includes(tokenAddress)) {
       throw new Error(`Payee does not have any reward token ${tokenAddress}`);
     }
     const tokenContract = new this.layer2Web3.eth.Contract(ERC20ABI as AbiItem[], tokenAddress);
     let tokenSymbol = await tokenContract.methods.symbol().call();
-    let proofs = await this.getProofs(address, tokenAddress);
+    let proofs = await this.getProofs(address, tokenAddress, rewardProgramId);
+
     let rewardPool = await this.getRewardPool();
     let ungroupedTokenBalance = await Promise.all(
       proofs.map(async (o: Proof) => {
@@ -112,11 +117,11 @@ export default class RewardPool {
     return aggregateBalance(ungroupedTokenBalance);
   }
 
-  async rewardTokenBalances(address: string): Promise<RewardTokenBalance[]> {
-    let rewardTokensAvailable = await this.rewardTokensAvailable(address);
+  async rewardTokenBalances(address: string, rewardProgramId?: string): Promise<RewardTokenBalance[]> {
+    let rewardTokensAvailable = await this.rewardTokensAvailable(address, rewardProgramId);
     const ungroupedTokenBalance = await Promise.all(
       rewardTokensAvailable.map(async (tokenAddress: string) => {
-        return this.rewardTokenBalance(address, tokenAddress);
+        return this.rewardTokenBalance(address, tokenAddress, rewardProgramId);
       })
     );
     return ungroupedTokenBalance;

--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -18,6 +18,8 @@ interface Proof {
   blockNumber: number;
 }
 
+const DEFAULT_PAGE_SIZE = 1000000;
+
 export interface RewardTokenBalance {
   tokenAddress: string;
   tokenSymbol: string;
@@ -54,9 +56,13 @@ export default class RewardPool {
     return json['tokenAddresses'];
   }
 
-  async getProofs(address: string, tokenAddress?: string): Promise<Proof[]> {
+  async getProofs(address: string, tokenAddress?: string, offset?: number, limit?: number): Promise<Proof[]> {
     let tallyServiceURL = await getConstant('tallyServiceURL', this.layer2Web3);
-    let url = `${tallyServiceURL}/merkle-proofs/${address}` + (tokenAddress ? `?token_address=${tokenAddress}` : '');
+    let url =
+      `${tallyServiceURL}/merkle-proofs/${address}` +
+      (tokenAddress ? `?token_address=${tokenAddress}` : '') +
+      (offset ? `?offset=${offset}` : '') +
+      (limit ? `?limit=${limit}` : `?limit=${DEFAULT_PAGE_SIZE}`);
     let options = {
       method: 'GET',
       headers: {

--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -35,8 +35,15 @@ export default class RewardPool {
     return await (await this.getRewardPool()).methods.numPaymentCycles().call();
   }
 
-  async getBalanceForProof(tokenAddress: string, address: string, proof: string): Promise<string> {
-    return (await this.getRewardPool()).methods.balanceForProofWithAddress(tokenAddress, address, proof).call();
+  async getBalanceForProof(
+    rewardProgramId: string,
+    tokenAddress: string,
+    address: string,
+    proof: string
+  ): Promise<string> {
+    return (await this.getRewardPool()).methods
+      .balanceForProofWithAddress(rewardProgramId, tokenAddress, address, proof)
+      .call();
   }
 
   async rewardTokensAvailable(address: string, rewardProgramId?: string): Promise<string[]> {

--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -16,7 +16,7 @@ interface Proof {
   proof: string;
   timestamp: string;
   blockNumber: number;
-  rewardProgramId: string
+  rewardProgramId: string;
 }
 
 const DEFAULT_PAGE_SIZE = 1000000;
@@ -60,8 +60,8 @@ export default class RewardPool {
 
   async getProofs(
     address: string,
-    rewardProgramId?: string,
     tokenAddress?: string,
+    rewardProgramId?: string,
     offset?: number,
     limit?: number
   ): Promise<Proof[]> {
@@ -69,9 +69,9 @@ export default class RewardPool {
     let url =
       `${tallyServiceURL}/merkle-proofs/${address}` +
       (tokenAddress ? `?token_address=${tokenAddress}` : '') +
-      (rewardProgramId ? `?reward_program_id=${rewardProgramId}` : '') +
-      (offset ? `?offset=${offset}` : '') +
-      (limit ? `?limit=${limit}` : `?limit=${DEFAULT_PAGE_SIZE}`);
+      (rewardProgramId ? `&reward_program_id=${rewardProgramId}` : '') +
+      (offset ? `&offset=${offset}` : '') +
+      (limit ? `&limit=${limit}` : `&limit=${DEFAULT_PAGE_SIZE}`);
     let options = {
       method: 'GET',
       headers: {


### PR DESCRIPTION
- Wait for staging cardpay deploy so can update abi. Tested on tally and my personal cardpay protocol.
- updated sdk methods to include reward program id as optional param