### PR TITLE
web: Add slug uniqueness check for create merchant

### DIFF
--- a/packages/web-client/app/services/merchant-info.ts
+++ b/packages/web-client/app/services/merchant-info.ts
@@ -15,6 +15,10 @@ interface PersistMerchantInfoTaskParams {
   textColor: string;
 }
 
+interface CheckMerchantSlugUniquenessTaskParams {
+  slug: string;
+}
+
 export default class MerchantInfoService extends Service {
   @service declare hubAuthentication: HubAuthentication;
 
@@ -66,6 +70,30 @@ export default class MerchantInfoService extends Service {
     return {
       did: info.data.attributes.did,
     };
+  }
+
+  @task *checkMerchantSlugUniquenessTask(
+    params: CheckMerchantSlugUniquenessTaskParams
+  ): TaskGenerator<boolean> {
+    let response = yield fetch(
+      `${config.hubURL}/api/merchant-infos/validate-slug/${params.slug}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer: ' + this.hubAuthentication.authToken,
+          Accept: 'application/vnd.api+json',
+          'Content-Type': 'application/vnd.api+json',
+        },
+      }
+    );
+
+    if (response.ok) {
+      let uniqueness = yield response.json();
+
+      return uniqueness.slugAvailable;
+    } else {
+      throw new Error(yield response.text());
+    }
   }
 }
 

--- a/packages/web-client/mirage/config.js
+++ b/packages/web-client/mirage/config.js
@@ -6,6 +6,25 @@ export default function () {
 
   this.post('/merchant-infos');
 
+  this.get(
+    '/merchant-infos/validate-slug/:slug',
+    function ({ merchantInfos }, { params: { slug } }) {
+      let merchantBySlug = merchantInfos.findBy({ slug });
+
+      if (merchantBySlug) {
+        return {
+          slugAvailable: false,
+          detail: 'Merchant slug already exists',
+        };
+      } else {
+        return {
+          slugAvailable: true,
+          detail: 'Merchant slug is available',
+        };
+      }
+    }
+  );
+
   this.get('/prepaid-card-color-schemes', (schema) => {
     return schema.prepaidCardColorSchemes.all();
   });


### PR DESCRIPTION
This adds a Mirage handler for the uniqueness check endpoint that
checks the Mirage schema for an existing `MerchantInfo`. It also
includes a message for when the validation call fails, with a
placeholder string that’s easily replaced:
> There was an error validating merchant ID uniqueness