### PR TITLE
boxel: Update dependency lint version

### DIFF
--- a/packages/boxel/package.json
+++ b/packages/boxel/package.json
@@ -113,7 +113,7 @@
     "ember-basic-dropdown": "^3.0.17",
     "ember-cli": "^3.26.1",
     "ember-cli-dependency-checker": "^3.1.0",
-    "ember-cli-dependency-lint": "^2.0.0",
+    "ember-cli-dependency-lint": "^2.0.1",
     "ember-cli-deploy": "^1.0.2",
     "ember-cli-deploy-build": "^2.0.0",
     "ember-cli-deploy-manifest": "^2.0.0",

--- a/packages/boxel/tests/dummy/config/dependency-lint.js
+++ b/packages/boxel/tests/dummy/config/dependency-lint.js
@@ -5,6 +5,5 @@ module.exports = {
     '@embroider/util': '0.39.1 || 0.40.x || 0.41.x',
     'ember-fetch': '6.x || 8.x',
     'ember-test-selectors': '2.1.0 || 5.x',
-    '@ember/test-waiters': '*',
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11974,6 +11974,16 @@ ember-cli-dependency-lint@^2.0.0:
     chalk "^2.3.0"
     semver "^5.5.0"
 
+ember-cli-dependency-lint@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-dependency-lint/-/ember-cli-dependency-lint-2.0.1.tgz#a51fcf845779ec855549e63fde60a2f9f15cfa36"
+  integrity sha512-FIWdE2ijwp9ZvgM43ZCnFtTLTM74QVrZmYy8tmEnAmDir2bWKtyryF0LmeiW29vfznRy7UvaDW7YiOFegTtHUA==
+  dependencies:
+    archy "^1.0.0"
+    broccoli-plugin "^1.3.0"
+    chalk "^2.3.0"
+    semver "^5.5.0"
+
 ember-cli-deploy-build@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-deploy-build/-/ember-cli-deploy-build-2.0.0.tgz#20d14836f5e8e1325a5b2c3d43367354783d2008"


### PR DESCRIPTION
This version obviates the need for #2005.