### PR TITLE
make merchant creation fee in spend an sdk constant

### DIFF
--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -29,6 +29,7 @@ const SOKOL = {
   relayServiceURL: 'https://relay-staging.stack.cards/api',
   subgraphURL: 'https://graph-staging.stack.cards/subgraphs/name/habdelra/cardpay-sokol',
   tallyServiceURL: 'https://tally-service-staging.stack.cards/api/v1',
+  merchantCreationFeeInSpend: '100',
 };
 const KOVAN = {
   apiBaseUrl: 'https://api-kovan.etherscan.io/api',
@@ -77,6 +78,7 @@ const XDAI = {
   rpcWssNode: 'wss://rpc.xdaichain.com/wss',
   relayServiceURL: 'https://relay.cardstack.com/api',
   subgraphURL: 'https://graph.cardstack.com/subgraphs/name/habdelra/cardpay-xdai',
+  merchantCreationFeeInSpend: '100',
 };
 
 type ConstantKeys = keyof typeof SOKOL | keyof typeof KOVAN | keyof typeof MAINNET | keyof typeof XDAI;

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/workflow-config.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/workflow-config.ts
@@ -1,1 +1,9 @@
-export const MERCHANT_CREATION_FEE_IN_SPEND = 100;
+import config from '@cardstack/web-client/config/environment';
+import { getConstantByNetwork } from '@cardstack/cardpay-sdk';
+
+export const MERCHANT_CREATION_FEE_IN_SPEND =
+  config.environment === 'test'
+    ? 100
+    : Number(
+        getConstantByNetwork('merchantCreationFeeInSpend', config.chains.layer2)
+      );


### PR DESCRIPTION
This PR moves the constant for merchant creation fee into the SDK.