### PR TITLE
web: Add waitFor before asserting on selector text

### DIFF
--- a/packages/web-client/tests/acceptance/withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-test.ts
@@ -93,6 +93,8 @@ module('Acceptance | withdrawal', function (hooks) {
     assert
       .dom(postableSel(1, 1))
       .containsText(`Sufficient funds for claiming withdrawn tokens`);
+
+    await waitFor(milestoneCompletedSel(1));
     assert.dom(milestoneCompletedSel(1)).containsText(`ETH balance checked`);
 
     await waitFor(postableSel(2, 0));
@@ -440,7 +442,10 @@ module('Acceptance | withdrawal', function (hooks) {
       assert
         .dom(postableSel(1, 1))
         .containsText(`Sufficient funds for claiming withdrawn tokens`);
+
+      await waitFor(milestoneCompletedSel(1));
       assert.dom(milestoneCompletedSel(1)).containsText(`ETH balance checked`);
+
       await waitFor(postableSel(2, 0));
       assert
         .dom(postableSel(2, 0))


### PR DESCRIPTION
This is an attempt to fix CI failures like this one:
https://github.com/cardstack/cardstack/runs/3463351474?check_suite_focus=true#step:7:277