### PR TITLE
Prepaid card workflow persistence

### DIFF
--- a/packages/cardpay-sdk/index.ts
+++ b/packages/cardpay-sdk/index.ts
@@ -17,7 +17,7 @@ export { IHubAuth } from './sdk/hub-auth';
 
 export { getAddress, getAddressByNetwork, getOracle, getOracleByNetwork, AddressKeys } from './contracts/addresses';
 export { getConstant, getConstantByNetwork, networks, networkIds } from './sdk/constants';
-export { waitUntilBlock } from './sdk/utils/general-utils';
+export { waitUntilBlock, TransactionOptions } from './sdk/utils/general-utils';
 export * from './sdk/currency-utils';
 export { validateMerchantId } from './sdk/utils/merchant-creation';
 export { getSDK } from './sdk/version-resolver';

--- a/packages/cardpay-sdk/sdk/prepaid-card/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card/base.ts
@@ -592,12 +592,6 @@ export default class PrepaidCard {
     };
   }
 
-  async getPrepaidCardSafesFromTxHash(txHash: string): Promise<PrepaidCardSafe[]> {
-    let prepaidCardAddresses = await this.getPrepaidCardsFromTxn(txHash);
-    await waitUntilTransactionMined(this.layer2Web3, txHash);
-    return await this.resolvePrepaidCards(prepaidCardAddresses);
-  }
-
   async convertFromSpendForPrepaidCard(
     prepaidCardAddress: string,
     minimumSpendBalance: number,

--- a/packages/cardpay-sdk/sdk/prepaid-card/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card/base.ts
@@ -592,6 +592,12 @@ export default class PrepaidCard {
     };
   }
 
+  async getPrepaidCardSafesFromTxHash(txHash: string): Promise<PrepaidCardSafe[]> {
+    let prepaidCardAddresses = await this.getPrepaidCardsFromTxn(txHash);
+    await waitUntilTransactionMined(this.layer2Web3, txHash);
+    return await this.resolvePrepaidCards(prepaidCardAddresses);
+  }
+
   async convertFromSpendForPrepaidCard(
     prepaidCardAddress: string,
     minimumSpendBalance: number,

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
@@ -6,7 +6,11 @@ import {
   IWorkflowMessage,
   WorkflowMessage,
 } from '@cardstack/web-client/models/workflow/workflow-message';
-import { Workflow, cardbot } from '@cardstack/web-client/models/workflow';
+import {
+  Workflow,
+  cardbot,
+  WorkflowName,
+} from '@cardstack/web-client/models/workflow';
 import { Milestone } from '@cardstack/web-client/models/workflow/milestone';
 import { WorkflowCard } from '@cardstack/web-client/models/workflow/workflow-card';
 import PostableCollection from '@cardstack/web-client/models/workflow/postable-collection';
@@ -54,7 +58,7 @@ class SessionAwareWorkflowMessage
 }
 
 class CreateMerchantWorkflow extends Workflow {
-  name = 'Merchant Creation';
+  name = 'MERCHANT_CREATION' as WorkflowName;
   milestones = [
     new Milestone({
       title: `Connect ${c.layer2.fullName} wallet`,

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
@@ -8,10 +8,7 @@ import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-sess
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import MerchantInfoService from '@cardstack/web-client/services/merchant-info';
 import { isLayer2UserRejectionError } from '@cardstack/web-client/utils/is-user-rejection-error';
-import {
-  RegisterMerchantOptions,
-  TransactionHash,
-} from '@cardstack/web-client/utils/web3-strategies/types';
+import { TransactionHash } from '@cardstack/web-client/utils/web3-strategies/types';
 
 import {
   race,
@@ -22,7 +19,8 @@ import {
 } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import { reads } from 'macro-decorators';
-import { PrepaidCardSafe } from '@cardstack/cardpay-sdk';
+import { PrepaidCardSafe, TransactionOptions } from '@cardstack/cardpay-sdk';
+import BN from 'bn.js';
 
 interface CardPayCreateMerchantWorkflowPrepaidCardChoiceComponentArgs {
   workflowSession: WorkflowSession;
@@ -97,7 +95,7 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
         workflowSession.update('merchantInfo', persistedMerchantInfo);
       }
 
-      let options: RegisterMerchantOptions = {
+      let options: TransactionOptions = {
         onTxnHash: (txnHash: TransactionHash) => {
           this.txnHash = txnHash;
           this.chinInProgressMessage = 'Processing transaction…';
@@ -105,10 +103,10 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
       };
 
       if (this.lastNonce) {
-        options.nonce = this.lastNonce;
+        options.nonce = new BN(this.lastNonce);
       } else {
-        options.onNonce = (nonce: string) => {
-          this.lastNonce = nonce;
+        options.onNonce = (nonce: BN) => {
+          this.lastNonce = nonce.toString();
         };
       }
 

--- a/packages/web-client/app/components/card-pay/deposit-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/index.ts
@@ -2,7 +2,11 @@ import Component from '@glimmer/component';
 import { getOwner } from '@ember/application';
 import { WorkflowMessage } from '@cardstack/web-client/models/workflow/workflow-message';
 import NetworkAwareWorkflowMessage from '@cardstack/web-client/components/workflow-thread/network-aware-message';
-import { Workflow, cardbot } from '@cardstack/web-client/models/workflow';
+import {
+  Workflow,
+  cardbot,
+  WorkflowName,
+} from '@cardstack/web-client/models/workflow';
 import { Milestone } from '@cardstack/web-client/models/workflow/milestone';
 import { WorkflowCard } from '@cardstack/web-client/models/workflow/workflow-card';
 import PostableCollection from '@cardstack/web-client/models/workflow/postable-collection';
@@ -19,7 +23,7 @@ const FAILURE_REASONS = {
 } as const;
 
 class DepositWorkflow extends Workflow {
-  name = 'Reserve Pool Deposit';
+  name = 'RESERVE_POOL_DEPOSIT' as WorkflowName;
   milestones = [
     new Milestone({
       title: `Connect ${c.layer1.conversationalName} wallet`,

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
@@ -3,6 +3,7 @@
   @header="Prepaid card funding"
   @isComplete={{@isComplete}}
   {{did-insert this.prepareFaceValueOptions}}
+  data-test-face-value-card
 >
   <ActionCardContainer::Section @title="Choose the face value of your prepaid card" class="face-value-card__section">
     <div class="face-value-card__container">

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
@@ -2,6 +2,7 @@
   class="face-value-card"
   @header="Prepaid card funding"
   @isComplete={{@isComplete}}
+  {{did-insert this.prepareFaceValueOptions}}
 >
   <ActionCardContainer::Section @title="Choose the face value of your prepaid card" class="face-value-card__section">
     <div class="face-value-card__container">

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.ts
@@ -32,6 +32,13 @@ class FaceValueCard extends Component<WorkflowCardComponentArgs> {
 
   constructor(owner: unknown, args: WorkflowCardComponentArgs) {
     super(owner, args);
+
+    this.selectedFaceValue = {
+      spendAmount: this.args.workflowSession.state.spendAmount,
+      approxTokenAmount: 10, // TODO: adjust this according to spendAmount
+      isOptionDisabled: false,
+    };
+
     this.getTokenAmounts('DAI', this.faceValueOptions);
   }
 

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.ts
@@ -7,7 +7,6 @@ import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { fromWei } from 'web3-utils';
 import BN from 'bn.js';
 import {
-  ConvertibleSymbol,
   TokenDisplayInfo,
   TokenSymbol,
 } from '@cardstack/web-client/utils/token';
@@ -30,23 +29,11 @@ class FaceValueCard extends Component<WorkflowCardComponentArgs> {
   @tracked selectedFaceValue?: FaceValue;
   @tracked options: FaceValue[] = [];
 
-  constructor(owner: unknown, args: WorkflowCardComponentArgs) {
-    super(owner, args);
-
-    this.selectedFaceValue = {
-      spendAmount: this.args.workflowSession.state.spendAmount,
-      approxTokenAmount: 10, // TODO: adjust this according to spendAmount
-      isOptionDisabled: false,
-    };
-
-    this.getTokenAmounts('DAI', this.faceValueOptions);
-  }
-
-  async getTokenAmounts(symbol: ConvertibleSymbol, spendArr: number[]) {
+  @action async prepareFaceValueOptions() {
     this.options = await Promise.all(
-      spendArr.map(async (spendAmount) => {
+      this.faceValueOptions.map(async (spendAmount) => {
         let result: string = await this.layer2Network.convertFromSpend(
-          symbol,
+          'DAI',
           spendAmount
         );
         let approxTokenAmount = Math.ceil(parseFloat(fromWei(result))); // for display only
@@ -57,7 +44,14 @@ class FaceValueCard extends Component<WorkflowCardComponentArgs> {
         };
       })
     );
-    return;
+
+    const defaultSpendAmount = this.args.workflowSession.state.spendFaceValue;
+    if (defaultSpendAmount) {
+      this.selectedFaceValue = this.options.findBy(
+        'spendAmount',
+        defaultSpendAmount
+      );
+    }
   }
 
   get fundingTokenBalance(): BN {

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
@@ -1,6 +1,7 @@
 <ActionCardContainer
   @header="Prepaid card funding"
   @isComplete={{@isComplete}}
+  data-test-funding-source-card
 >
   <ActionCardContainer::Section>
     <ActionCardContainer::Section @title="Choose a depot and balance to fund your prepaid card">

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -20,6 +20,7 @@ import RouterService from '@ember/routing/router-service';
 import { faceValueOptions } from './workflow-config';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
 import HubAuthentication from '@cardstack/web-client/services/hub-authentication';
+import { next } from '@ember/runloop';
 
 const FAILURE_REASONS = {
   DISCONNECTED: 'DISCONNECTED',
@@ -377,7 +378,9 @@ class IssuePrepaidCardWorkflowComponent extends Component {
       const errors = workflow.restorationErrors(persistedState);
 
       if (errors.length > 0) {
-        workflow.cancel(errors[0]);
+        next(this, () => {
+          workflow.cancel(errors[0]);
+        });
       } else {
         workflow.restoreFromPersistedWorkflow();
       }

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -272,7 +272,9 @@ class IssuePrepaidCardWorkflow extends Workflow {
   restoreFromPersistedWorkflow() {
     this.session.restoreFromStorage();
 
-    const lastCompletedCardName = this.session.state.lastCompletedCardName;
+    const [lastCompletedCardName] = (
+      this.session.state.completedCardNames || []
+    ).slice(-1);
 
     // TODO: Only attempt to restore when both layer 1 and 2 are connected
     if (lastCompletedCardName) {

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -62,6 +62,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
         }),
         new WorkflowCard({
           author: cardbot,
+          cardName: 'LAYER2_CONNECT',
           componentName: 'card-pay/layer-two-connect-card',
           async check() {
             let layer2Network = this.workflow?.owner.lookup(

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -2,7 +2,11 @@ import Component from '@glimmer/component';
 import { getOwner } from '@ember/application';
 import { inject as service } from '@ember/service';
 import { WorkflowMessage } from '@cardstack/web-client/models/workflow/workflow-message';
-import { Workflow, cardbot } from '@cardstack/web-client/models/workflow';
+import {
+  Workflow,
+  cardbot,
+  WorkflowName,
+} from '@cardstack/web-client/models/workflow';
 import { Milestone } from '@cardstack/web-client/models/workflow/milestone';
 import { WorkflowCard } from '@cardstack/web-client/models/workflow/workflow-card';
 import PostableCollection from '@cardstack/web-client/models/workflow/postable-collection';
@@ -25,7 +29,8 @@ const FAILURE_REASONS = {
 
 class IssuePrepaidCardWorkflow extends Workflow {
   workflowPersistenceId?: string;
-  name = 'Prepaid Card Issuance';
+  name = 'PREPAID_CARD_ISSUANCE' as WorkflowName;
+
   milestones = [
     new Milestone({
       title: `Connect ${c.layer2.fullName} wallet`,

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -276,6 +276,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
 
     // TODO: Only attempt to restore when both layer 1 and 2 are connected
     if (lastCompletedCardName) {
+      this.isRestored = true;
       const postables = this.milestones
         .flatMap((m: any) => m.postableCollection.postables)
         .concat(this.epilogue.postables);

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -305,11 +305,13 @@ class IssuePrepaidCardWorkflow extends Workflow {
       author: cardbot,
       componentName: 'workflow-thread/default-cancelation-cta',
       includeIf() {
-        return ([
-          FAILURE_REASONS.RESTORATION_UNAUTHENTICATED,
-          FAILURE_REASONS.RESTORATION_L2_ADDRESS_CHANGED,
-          FAILURE_REASONS.RESTORATION_L2_DISCONNECTED,
-        ] as String[]).includes(String(this.workflow?.cancelationReason));
+        return (
+          [
+            FAILURE_REASONS.RESTORATION_UNAUTHENTICATED,
+            FAILURE_REASONS.RESTORATION_L2_ADDRESS_CHANGED,
+            FAILURE_REASONS.RESTORATION_L2_DISCONNECTED,
+          ] as String[]
+        ).includes(String(this.workflow?.cancelationReason));
       },
     }),
   ]);

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -287,6 +287,10 @@ class IssuePrepaidCardWorkflow extends Workflow {
         p.isComplete = true;
       });
     }
+
+    if (this.session.state.cancelled && this.session.state.cancelationReason) {
+      this.cancel(this.session.state.cancelationReason);
+    }
   }
 }
 

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -101,6 +101,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
           },
         }),
         new NetworkAwareWorkflowCard({
+          cardName: 'HUB_AUTH',
           author: cardbot,
           componentName: 'card-pay/hub-authentication',
           includeIf(this: NetworkAwareWorkflowCard) {
@@ -113,6 +114,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
             'Let’s get started! First, you can choose the look and feel of your card, so that your customers and other users recognize that this prepaid card came from you.',
         }),
         new WorkflowCard({
+          cardName: 'LAYOUT_CUSTOMIZATION',
           author: cardbot,
           componentName:
             'card-pay/issue-prepaid-card-workflow/layout-customization',
@@ -132,6 +134,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
           message: `On to the next step: How do you want to fund your prepaid card? Please select a depot and balance from your ${c.layer2.fullName} wallet.`,
         }),
         new WorkflowCard({
+          cardName: 'FUNDING_SOURCE',
           author: cardbot,
           componentName: 'card-pay/issue-prepaid-card-workflow/funding-source',
         }),
@@ -142,6 +145,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
             After you have created your card, you can split it up into multiple cards with smaller balances to transfer to your customers.`,
         }),
         new WorkflowCard({
+          cardName: 'FACE_VALUE',
           author: cardbot,
           componentName: 'card-pay/issue-prepaid-card-workflow/face-value',
         }),
@@ -157,6 +161,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
             Now, we just need your confirmation to create the card.`,
         }),
         new WorkflowCard({
+          cardName: 'PREVIEW',
           author: cardbot,
           componentName: 'card-pay/issue-prepaid-card-workflow/preview',
         }),
@@ -170,6 +175,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
       message: `Congratulations, you have created a prepaid card! This prepaid card has been added to your ${c.layer2.fullName} wallet.`,
     }),
     new WorkflowCard({
+      cardName: 'CONFIRMATION',
       author: cardbot,
       componentName: 'card-pay/issue-prepaid-card-workflow/confirmation',
     }),
@@ -178,10 +184,12 @@ class IssuePrepaidCardWorkflow extends Workflow {
       message: `This is the remaining balance in your ${c.layer2.fullName} wallet:`,
     }),
     new WorkflowCard({
+      cardName: 'EPILOGUE_LAYER_TWO_CONNECT_CARD',
       author: cardbot,
       componentName: 'card-pay/layer-two-connect-card',
     }),
     new WorkflowCard({
+      cardName: 'EPILOGUE_NEXT_STEPS',
       author: cardbot,
       componentName: 'card-pay/issue-prepaid-card-workflow/next-steps',
     }),

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -302,7 +302,7 @@ class IssuePrepaidCardWorkflowComponent extends Component {
 
     const workflow = new IssuePrepaidCardWorkflow(
       getOwner(this),
-      this.router.currentRoute.queryParams.workflowPersistenceId!
+      this.router.currentRoute.queryParams['flow-id']!
     );
 
     workflow.restoreFromPersistedWorkflow();

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.ts
@@ -31,11 +31,8 @@ export default class LayoutCustomizationCard extends Component<WorkflowCardCompo
         this.colorScheme = this.colorSchemeOptions[0];
         this.pattern = this.patternOptions[0];
 
-        let {
-          colorScheme,
-          pattern,
-          issuerName,
-        } = this.args.workflowSession.state;
+        let { colorScheme, pattern, issuerName } =
+          this.args.workflowSession.state;
         if (colorScheme && pattern) {
           this.colorScheme = colorScheme;
           this.pattern = pattern;

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.ts
@@ -30,6 +30,17 @@ export default class LayoutCustomizationCard extends Component<WorkflowCardCompo
       .then(() => {
         this.colorScheme = this.colorSchemeOptions[0];
         this.pattern = this.patternOptions[0];
+
+        let {
+          colorScheme,
+          pattern,
+          issuerName,
+        } = this.args.workflowSession.state;
+        if (colorScheme && pattern) {
+          this.colorScheme = colorScheme;
+          this.pattern = pattern;
+          this.issuerName = issuerName;
+        }
       });
   }
 

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/next-steps/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/next-steps/index.ts
@@ -16,7 +16,9 @@ class CardPayIssuePrepaidCardWorkflowNextStepsComponent extends Component<Workfl
   }
 
   @action returnToDashboard() {
-    this.router.transitionTo({ queryParams: { flow: null } });
+    this.router.transitionTo({
+      queryParams: { flow: null, worklowPersistenceId: null },
+    });
   }
 }
 

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/next-steps/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/next-steps/index.ts
@@ -9,9 +9,15 @@ class CardPayIssuePrepaidCardWorkflowNextStepsComponent extends Component<Workfl
   @service declare router: RouterService;
 
   @action async openNewIssuanceWorkflow() {
-    await this.router.transitionTo({ queryParams: { flow: null } });
+    await this.router.transitionTo({
+      queryParams: { flow: null, worklowPersistenceId: null },
+    });
     next(this, () => {
-      this.router.transitionTo({ queryParams: { flow: 'issue-prepaid-card' } });
+      this.router.transitionTo({
+        queryParams: {
+          flow: 'issue-prepaid-card',
+        },
+      });
     });
   }
 

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/next-steps/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/next-steps/index.ts
@@ -10,7 +10,7 @@ class CardPayIssuePrepaidCardWorkflowNextStepsComponent extends Component<Workfl
 
   @action async openNewIssuanceWorkflow() {
     await this.router.transitionTo({
-      queryParams: { flow: null, worklowPersistenceId: null },
+      queryParams: { flow: null, 'flow-id': null },
     });
     next(this, () => {
       this.router.transitionTo({

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
@@ -27,6 +27,7 @@
               @address={{placeholder-address}}
               @network={{network-display-info "layer2" "fullName"}}
               @mockOptions={{true}}
+              {{did-insert this.checkForPendingTransaction}}
             />
           </div>
         </Boxel::Field>

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
@@ -68,6 +68,13 @@ export default class CardPayPrepaidCardWorkflowPreviewComponent extends Componen
     super(owner, args);
   }
 
+  @action checkForPendingTransaction() {
+    if (this.args.workflowSession.state.txHash) {
+      taskFor(this.issueTask).perform();
+    }
+  }
+
+  // TODO: Refactor long method
   @task *issueTask(): TaskGenerator<void> {
     let { workflowSession } = this.args;
     try {
@@ -92,40 +99,63 @@ export default class CardPayPrepaidCardWorkflowPreviewComponent extends Componen
         this.args.workflowSession.update('did', did);
       }
 
-      this.chinInProgressMessage =
-        'You will receive a confirmation request from the Card Wallet app in a few moments…';
-      let options: IssuePrepaidCardOptions = {
-        onTxnHash: (txnHash: TransactionHash) => {
-          this.txnHash = txnHash;
-          this.chinInProgressMessage = 'Processing transaction…';
-        },
-      };
-      if (this.lastNonce) {
-        options.nonce = this.lastNonce;
+      if (
+        workflowSession.state.txHash &&
+        !workflowSession.state.prepaidCardSafe
+      ) {
+        const txHash = workflowSession.state.txHash;
+        this.chinInProgressMessage =
+          'Waiting for the transaction to be finalized…';
+
+        const safes = yield taskFor(
+          this.layer2Network.getPrepaidCardSafesFromTxHash
+        ).perform(txHash);
+
+        const prepaidCardSafe = safes[0];
+
+        if (prepaidCardSafe) {
+          this.args.workflowSession.update('prepaidCardSafe', prepaidCardSafe);
+        }
+
+        this.args.onComplete();
       } else {
-        options.onNonce = (nonce: string) => {
-          this.lastNonce = nonce;
+        this.chinInProgressMessage =
+          'You will receive a confirmation request from the Card Wallet app in a few moments…';
+        let options: IssuePrepaidCardOptions = {
+          onTxHash: (txHash: TransactionHash) => {
+            this.txHash = txHash;
+            this.args.workflowSession.update('txHash', txHash);
+            this.chinInProgressMessage =
+              'Waiting for the transaction to be finalized…';
+          },
         };
+        if (this.lastNonce) {
+          options.nonce = this.lastNonce;
+        } else {
+          options.onNonce = (nonce: string) => {
+            this.lastNonce = nonce;
+          };
+        }
+
+        let prepaidCardSafeTaskInstance = taskFor(
+          this.layer2Network.issuePrepaidCardTask
+        ).perform(this.faceValue, did, options);
+
+        let prepaidCardSafe = yield race([
+          prepaidCardSafeTaskInstance,
+          taskFor(this.timerTask).perform(),
+        ]);
+        this.issueTaskRunningForAWhile = false;
+
+        this.args.workflowSession.updateMany({
+          prepaidCardAddress: prepaidCardSafe.address,
+          reloadable: prepaidCardSafe.reloadable,
+          transferrable: prepaidCardSafe.transferrable,
+        });
+
+        this.args.workflowSession.update('prepaidCardSafe', prepaidCardSafe);
+        this.args.onComplete();
       }
-
-      let prepaidCardSafeTaskInstance = taskFor(
-        this.layer2Network.issuePrepaidCardTask
-      ).perform(this.faceValue, did, options);
-
-      let prepaidCardSafe = yield race([
-        prepaidCardSafeTaskInstance,
-        taskFor(this.timerTask).perform(),
-      ]);
-      this.issueTaskRunningForAWhile = false;
-
-      this.args.workflowSession.updateMany({
-        prepaidCardAddress: prepaidCardSafe.address,
-        reloadable: prepaidCardSafe.reloadable,
-        transferrable: prepaidCardSafe.transferrable,
-      });
-
-      this.args.workflowSession.update('prepaidCardSafe', prepaidCardSafe);
-      this.args.onComplete();
     } catch (e) {
       let insufficientFunds = e.message.startsWith(
         'Safe does not have enough balance to make prepaid card(s).'

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
@@ -75,7 +75,6 @@ export default class CardPayPrepaidCardWorkflowPreviewComponent extends Componen
     }
   }
 
-  // TODO: Refactor long method
   @task *issueTask(): TaskGenerator<void> {
     let { workflowSession } = this.args;
     try {
@@ -112,11 +111,7 @@ export default class CardPayPrepaidCardWorkflowPreviewComponent extends Componen
           this.layer2Network.resumeIssuePrepaidCardTransactionTask
         ).perform(txnHash);
 
-        if (prepaidCardSafe) {
-          this.args.workflowSession.update('prepaidCardSafe', prepaidCardSafe);
-        }
-
-        this.args.onComplete();
+        this.args.workflowSession.update('prepaidCardSafe', prepaidCardSafe);
       } else {
         this.chinInProgressMessage =
           'You will receive a confirmation request from the Card Wallet app in a few moments…';
@@ -150,11 +145,11 @@ export default class CardPayPrepaidCardWorkflowPreviewComponent extends Componen
           prepaidCardAddress: prepaidCardSafe.address,
           reloadable: prepaidCardSafe.reloadable,
           transferrable: prepaidCardSafe.transferrable,
+          prepaidCardSafe: prepaidCardSafe,
         });
-
-        this.args.workflowSession.update('prepaidCardSafe', prepaidCardSafe);
-        this.args.onComplete();
       }
+
+      this.args.onComplete();
     } catch (e) {
       let insufficientFunds = e.message.startsWith(
         'Safe does not have enough balance to make prepaid card(s).'

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
@@ -69,7 +69,7 @@ export default class CardPayPrepaidCardWorkflowPreviewComponent extends Componen
   }
 
   @action checkForPendingTransaction() {
-    if (this.args.workflowSession.state.txHash) {
+    if (this.args.workflowSession.state.txnHash) {
       taskFor(this.issueTask).perform();
     }
   }
@@ -100,10 +100,10 @@ export default class CardPayPrepaidCardWorkflowPreviewComponent extends Componen
       }
 
       if (
-        workflowSession.state.txHash &&
+        workflowSession.state.txnHash &&
         !workflowSession.state.prepaidCardSafe
       ) {
-        const txHash = workflowSession.state.txHash;
+        const txHash = workflowSession.state.txnHash;
         this.chinInProgressMessage =
           'Waiting for the transaction to be finalized…';
 
@@ -122,9 +122,9 @@ export default class CardPayPrepaidCardWorkflowPreviewComponent extends Componen
         this.chinInProgressMessage =
           'You will receive a confirmation request from the Card Wallet app in a few moments…';
         let options: IssuePrepaidCardOptions = {
-          onTxHash: (txHash: TransactionHash) => {
-            this.txHash = txHash;
-            this.args.workflowSession.update('txHash', txHash);
+          onTxnHash: (txnHash: TransactionHash) => {
+            this.txnHash = txnHash;
+            this.args.workflowSession.update('txnHash', txnHash);
             this.chinInProgressMessage =
               'Waiting for the transaction to be finalized…';
           },

--- a/packages/web-client/app/components/card-pay/layer-two-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-two-connect-card/index.ts
@@ -63,6 +63,10 @@ class CardPayLayerTwoConnectCardComponent extends Component<CardPayLayerTwoConne
     yield timeout(500); // allow time for strategy to verify connected chain -- it might not accept the connection
     if (this.isConnected) {
       this.args.onConnect?.();
+      this.args.workflowSession.update(
+        'layer2WalletAddress',
+        this.layer2Network.walletInfo.firstAddress
+      );
       this.args.onComplete?.();
     }
   }

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
@@ -6,7 +6,11 @@ import {
 } from '@cardstack/web-client/models/workflow/workflow-message';
 import NetworkAwareWorkflowMessage from '@cardstack/web-client/components/workflow-thread/network-aware-message';
 import NetworkAwareWorkflowCard from '@cardstack/web-client/components/workflow-thread/network-aware-card';
-import { Workflow, cardbot } from '@cardstack/web-client/models/workflow';
+import {
+  Workflow,
+  cardbot,
+  WorkflowName,
+} from '@cardstack/web-client/models/workflow';
 import { Milestone } from '@cardstack/web-client/models/workflow/milestone';
 import { WorkflowCard } from '@cardstack/web-client/models/workflow/workflow-card';
 import PostableCollection from '@cardstack/web-client/models/workflow/postable-collection';
@@ -115,7 +119,7 @@ ${
 }
 
 class WithdrawalWorkflow extends Workflow {
-  name = 'Withdrawal';
+  name = 'WITHDRAWAL' as WorkflowName;
   milestones = [
     new Milestone({
       title: `Connect ${c.layer1.conversationalName} wallet`,

--- a/packages/web-client/app/components/workflow-thread/default-cancelation-cta/index.ts
+++ b/packages/web-client/app/components/workflow-thread/default-cancelation-cta/index.ts
@@ -13,7 +13,11 @@ class WorkflowThreadDisconnectionComponent extends Component {
 
   @action async restartWorkflow() {
     const { queryParams } = this.router.currentRoute;
-    await this.router.transitionTo({ queryParams: { flow: null } });
+    delete queryParams['flow-id']; // Persistence id
+
+    await this.router.transitionTo({
+      queryParams: { flow: null, 'flow-id': null },
+    });
     next(this, () => {
       this.router.transitionTo({
         queryParams,

--- a/packages/web-client/app/components/workflow-thread/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/index.hbs
@@ -9,7 +9,7 @@
   ...attributes
 >
   <:header>
-    <Boxel::ThreadHeader @title={{this.workflow.name}} />
+    <Boxel::ThreadHeader @title={{this.workflow.displayName}} />
   </:header>
   <:content>
     {{#if (has-block 'before-content')}}
@@ -35,7 +35,7 @@
           data-test-milestone={{i}}
         />
         {{sentry-breadcrumb
-          message=(concat "Milestone completed: " this.workflow.name " → " milestone.title)
+          message=(concat "Milestone completed: " this.workflow.displayName " → " milestone.title)
         }}
       {{/if}}
     {{/each}}
@@ -62,10 +62,11 @@
     {{/if}}
     <div data-thread-end></div>
   </:content>
+
   <:sidebar as |SidebarSection|>
     <SidebarSection>
       <Boxel::Sidebar::CardContainer
-        @header={{html-safe (concat "Workflow:<br>" this.workflow.name)}}
+        @header={{html-safe (concat "Workflow:<br>" this.workflow.displayName)}}
         @attachNext={{true}}
       >
         <div>

--- a/packages/web-client/app/components/workflow-thread/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/index.hbs
@@ -3,6 +3,7 @@
   class="workflow-thread workflow-thread-animated"
   tabindex="0"
   {{did-insert this.focus}}
+  {{did-insert this.scrollToEnd}}
   data-test-workflow-thread
   style={{css-var thread-animation-interval=this.threadAnimationInterval}}
   ...attributes

--- a/packages/web-client/app/components/workflow-thread/network-aware-card/index.ts
+++ b/packages/web-client/app/components/workflow-thread/network-aware-card/index.ts
@@ -11,6 +11,7 @@ import Layer2Network from '@cardstack/web-client/services/layer1-network';
 import HubAuthentication from '@cardstack/web-client/services/hub-authentication';
 
 interface NetworkAwareWorkflowCardOptions {
+  cardName?: string;
   author: Participant;
   componentName: string; // this should eventually become a card reference
   includeIf(this: NetworkAwareWorkflowCard): boolean;

--- a/packages/web-client/app/controllers/card-pay/balances.ts
+++ b/packages/web-client/app/controllers/card-pay/balances.ts
@@ -3,10 +3,11 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { action } from '@ember/object';
-import * as short from 'short-uuid';
+import RouterService from '@ember/routing/router-service';
 
 class CardPayBalancesController extends Controller {
   @service declare layer2Network: Layer2Network;
+  @service declare router: RouterService;
 
   queryParams = ['flow', { workflowPersistenceId: 'flow-id' }];
   @tracked flow: string | null = null;
@@ -17,8 +18,9 @@ class CardPayBalancesController extends Controller {
   }
 
   @action setFlow(flow: string) {
-    this.flow = flow;
-    this.workflowPersistenceId = short.generate();
+    this.router.transitionTo('card-pay.balances', {
+      queryParams: { flow },
+    });
   }
 
   @action resetQueryParams() {

--- a/packages/web-client/app/controllers/card-pay/balances.ts
+++ b/packages/web-client/app/controllers/card-pay/balances.ts
@@ -3,16 +3,22 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { action } from '@ember/object';
+import * as short from 'short-uuid';
 
 class CardPayBalancesController extends Controller {
   @service declare layer2Network: Layer2Network;
 
-  queryParams = ['flow', 'workflowPersistenceId'];
+  queryParams = ['flow', { workflowPersistenceId: 'flow-id' }];
   @tracked flow: string | null = null;
   @tracked workflowPersistenceId: string | null = null;
 
   get prepaidCards() {
     return this.layer2Network.safes.value?.filterBy('type', 'prepaid-card');
+  }
+
+  @action setFlow(flow: string) {
+    this.flow = flow;
+    this.workflowPersistenceId = short.generate();
   }
 
   @action resetQueryParams() {

--- a/packages/web-client/app/controllers/card-pay/balances.ts
+++ b/packages/web-client/app/controllers/card-pay/balances.ts
@@ -2,15 +2,22 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
+import { action } from '@ember/object';
 
 class CardPayBalancesController extends Controller {
   @service declare layer2Network: Layer2Network;
 
-  queryParams = ['flow'];
-  @tracked flow: 'deposit' | null = null;
+  queryParams = ['flow', 'workflowPersistenceId'];
+  @tracked flow: string | null = null;
+  @tracked workflowPersistenceId: string | null = null;
 
   get prepaidCards() {
     return this.layer2Network.safes.value?.filterBy('type', 'prepaid-card');
+  }
+
+  @action resetQueryParams() {
+    this.flow = null;
+    this.workflowPersistenceId = null;
   }
 }
 

--- a/packages/web-client/app/controllers/card-pay/balances.ts
+++ b/packages/web-client/app/controllers/card-pay/balances.ts
@@ -17,7 +17,7 @@ class CardPayBalancesController extends Controller {
     return this.layer2Network.safes.value?.filterBy('type', 'prepaid-card');
   }
 
-  @action setFlow(flow: string) {
+  @action transitionToBalances(flow: string) {
     this.router.transitionTo('card-pay.balances', {
       queryParams: { flow },
     });

--- a/packages/web-client/app/models/animated-workflow.ts
+++ b/packages/web-client/app/models/animated-workflow.ts
@@ -59,7 +59,8 @@ class AnimatedMilestone {
   }
 
   syncRevealPointerToModel() {
-    let revealedLastPostable = this.postableCollection.syncRevealPointerToModel();
+    let revealedLastPostable =
+      this.postableCollection.syncRevealPointerToModel();
     this.isCompletionRevealed = this.model.isComplete;
     return revealedLastPostable;
   }

--- a/packages/web-client/app/models/animated-workflow.ts
+++ b/packages/web-client/app/models/animated-workflow.ts
@@ -169,7 +169,8 @@ export default class AnimatedWorkflow {
     }
     taskFor(this.tickerTask).perform();
   }
-  @reads('model.name') declare name: string;
+
+  @reads('model.displayName') declare displayName: string;
 
   @task
   *tickerTask() {

--- a/packages/web-client/app/models/workflow.ts
+++ b/packages/web-client/app/models/workflow.ts
@@ -22,6 +22,7 @@ export abstract class Workflow {
   session: WorkflowSession;
   owner: any;
   simpleEmitter = new SimpleEmitter();
+  isRestored = false;
 
   constructor(owner: any) {
     this.owner = owner;

--- a/packages/web-client/app/models/workflow.ts
+++ b/packages/web-client/app/models/workflow.ts
@@ -69,10 +69,17 @@ export abstract class Workflow {
   }
 
   cancel(reason?: string) {
+    const cancelationReason = reason || 'UNKNOWN';
+
+    this.session.updateMany({
+      isCancelled: true,
+      cancelationReason: cancelationReason,
+    });
+
     if (!this.isComplete && !this.isCanceled) {
       // visible-postables-will-change starts test waiters in animated-workflow.ts
       this.emit('visible-postables-will-change');
-      this.cancelationReason = reason || 'UNKNOWN';
+      this.cancelationReason = cancelationReason;
       this.isCanceled = true;
     }
   }

--- a/packages/web-client/app/models/workflow.ts
+++ b/packages/web-client/app/models/workflow.ts
@@ -19,12 +19,13 @@ export abstract class Workflow {
   cancelationMessages: PostableCollection = new PostableCollection();
   @tracked isCanceled = false;
   @tracked cancelationReason: null | string = null;
-  session: WorkflowSession = new WorkflowSession();
+  session: WorkflowSession;
   owner: any;
   simpleEmitter = new SimpleEmitter();
 
   constructor(owner: any) {
     this.owner = owner;
+    this.session = new WorkflowSession(this);
   }
 
   attachWorkflow() {

--- a/packages/web-client/app/models/workflow.ts
+++ b/packages/web-client/app/models/workflow.ts
@@ -5,6 +5,7 @@ import WorkflowSession from './workflow/workflow-session';
 import { tracked } from '@glimmer/tracking';
 import { SimpleEmitter } from '../utils/events';
 import { next } from '@ember/runloop';
+import WorkflowPersistence from '@cardstack/web-client/app/services/workflow-persistence';
 
 interface PostableIndices {
   isInMilestone: boolean;
@@ -31,10 +32,13 @@ export abstract class Workflow {
   simpleEmitter = new SimpleEmitter();
   isRestored = false;
   workflowDisplayNames = WORKFLOW_NAMES;
+  workflowPersistence: WorkflowPersistence;
+  workflowPersistenceId?: string;
 
   constructor(owner: any) {
     this.owner = owner;
     this.session = new WorkflowSession(this);
+    this.workflowPersistence = owner.lookup('service:workflow-persistence');
   }
 
   attachWorkflow() {

--- a/packages/web-client/app/models/workflow.ts
+++ b/packages/web-client/app/models/workflow.ts
@@ -12,8 +12,14 @@ interface PostableIndices {
   collectionIndex: number;
 }
 
+export type WorkflowName =
+  | 'PREPAID_CARD_ISSUANCE'
+  | 'RESERVE_POOL_DEPOSIT'
+  | 'WITHDRAWAL'
+  | 'MERCHANT_CREATION';
+
 export abstract class Workflow {
-  name!: string;
+  name!: WorkflowName;
   milestones: Milestone[] = [];
   epilogue: PostableCollection = new PostableCollection();
   cancelationMessages: PostableCollection = new PostableCollection();
@@ -23,6 +29,7 @@ export abstract class Workflow {
   owner: any;
   simpleEmitter = new SimpleEmitter();
   isRestored = false;
+  workflowDisplayNames = WORKFLOW_NAMES;
 
   constructor(owner: any) {
     this.owner = owner;
@@ -33,6 +40,10 @@ export abstract class Workflow {
     this.milestones.invoke('setWorkflow', this);
     this.epilogue.setWorkflow(this);
     this.cancelationMessages.setWorkflow(this);
+  }
+
+  get displayName() {
+    return WORKFLOW_NAMES[this.name];
   }
 
   get completedMilestones() {
@@ -155,3 +166,10 @@ export abstract class Workflow {
 }
 
 export let cardbot = { name: 'Cardbot', imgURL: '/images/icons/cardbot.svg' };
+
+export const WORKFLOW_NAMES = {
+  PREPAID_CARD_ISSUANCE: 'Prepaid Card Issuance',
+  MERCHANT_CREATION: 'Merchant Creation',
+  RESERVE_POOL_DEPOSIT: 'Reserve Pool Deposit',
+  WITHDRAWAL: 'Withdrawal',
+};

--- a/packages/web-client/app/models/workflow.ts
+++ b/packages/web-client/app/models/workflow.ts
@@ -4,6 +4,7 @@ import { WorkflowPostable } from './workflow/workflow-postable';
 import WorkflowSession from './workflow/workflow-session';
 import { tracked } from '@glimmer/tracking';
 import { SimpleEmitter } from '../utils/events';
+import { next } from '@ember/runloop';
 
 interface PostableIndices {
   isInMilestone: boolean;
@@ -188,7 +189,9 @@ export abstract class Workflow {
       this.session.state.isCancelled &&
       this.session.state.cancelationReason
     ) {
-      this.cancel(this.session.state.cancelationReason);
+      next(this, () => {
+        this.cancel(this.session.state.cancelationReason);
+      });
     }
   }
 }

--- a/packages/web-client/app/models/workflow/workflow-card.ts
+++ b/packages/web-client/app/models/workflow/workflow-card.ts
@@ -19,6 +19,7 @@ type FailureCheckResult = {
 export type CheckResult = SuccessCheckResult | FailureCheckResult;
 
 interface WorkflowCardOptions {
+  cardName?: string;
   author: Participant;
   componentName: string; // this should eventually become a card reference
   includeIf(this: WorkflowCard): boolean;
@@ -26,12 +27,15 @@ interface WorkflowCardOptions {
 }
 
 export class WorkflowCard extends WorkflowPostable {
+  cardName: string;
   componentName: string;
   check?: (this: WorkflowCard) => Promise<CheckResult>;
 
   constructor(options: Partial<WorkflowCardOptions>) {
     super(options.author!, options.includeIf);
     this.componentName = options.componentName!;
+    this.cardName = options.cardName || '';
+
     this.reset = () => {
       if (this.isComplete) {
         this.isComplete = false;
@@ -57,6 +61,10 @@ export class WorkflowCard extends WorkflowPostable {
     } else {
       this.workflow?.emit('visible-postables-will-change');
       this.isComplete = true;
+    }
+
+    if (this.isComplete && this.cardName) {
+      this.workflow?.session.update('lastCompletedCardName', this.cardName);
     }
   }
 

--- a/packages/web-client/app/models/workflow/workflow-card.ts
+++ b/packages/web-client/app/models/workflow/workflow-card.ts
@@ -62,7 +62,15 @@ export class WorkflowCard extends WorkflowPostable {
     }
 
     if (this.isComplete && this.cardName) {
-      this.workflow?.session.update('lastCompletedCardName', this.cardName);
+      const existingCompletedCardNames =
+        this.session?.state.completedCardNames || [];
+
+      if (!existingCompletedCardNames.includes(this.cardName)) {
+        this.session?.update('completedCardNames', [
+          ...existingCompletedCardNames,
+          this.cardName,
+        ]);
+      }
     }
   }
 

--- a/packages/web-client/app/models/workflow/workflow-card.ts
+++ b/packages/web-client/app/models/workflow/workflow-card.ts
@@ -52,6 +52,7 @@ export class WorkflowCard extends WorkflowPostable {
   }
 
   @action async onComplete() {
+    if (this.isComplete) return;
     let checkResult = await this.check();
     if (checkResult.success) {
       // visible-postables-will-change starts test waiters in animated-workflow.ts

--- a/packages/web-client/app/models/workflow/workflow-card.ts
+++ b/packages/web-client/app/models/workflow/workflow-card.ts
@@ -67,10 +67,11 @@ export class WorkflowCard extends WorkflowPostable {
         this.session?.state.completedCardNames || [];
 
       if (!existingCompletedCardNames.includes(this.cardName)) {
-        this.session?.update('completedCardNames', [
-          ...existingCompletedCardNames,
-          this.cardName,
-        ]);
+        this.session?.updateMany({
+          completedCardNames: [...existingCompletedCardNames, this.cardName],
+          completedMilestonesCount: this.workflow?.completedMilestoneCount,
+          milestonesCount: this.workflow?.milestones.length,
+        });
       }
     }
   }

--- a/packages/web-client/app/models/workflow/workflow-session.ts
+++ b/packages/web-client/app/models/workflow/workflow-session.ts
@@ -1,4 +1,4 @@
-import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';
+import { isPresent } from '@ember/utils';
 import { tracked } from '@glimmer/tracking';
 
 export interface ArbitraryDictionary {
@@ -7,23 +7,15 @@ export interface ArbitraryDictionary {
 
 export default class WorkflowSession {
   workflow: any;
-  workflowPersistenceStorage: WorkflowPersistence | undefined;
 
   constructor(workflow?: any) {
     this.workflow = workflow;
-
-    // Allow WorkflowSession to be instantiated as a POJO (for unit tests)
-    if (this.workflow && typeof this.workflow.owner.lookup === 'function') {
-      this.workflowPersistenceStorage = this.workflow.owner.lookup(
-        'service:workflow-persistence'
-      );
-    }
   }
 
   @tracked state: ArbitraryDictionary = {};
 
   get hasPersistence() {
-    return !!this.workflow?.workflowPersistenceId;
+    return isPresent(this.workflow?.workflowPersistenceId);
   }
 
   update(key: string, val: any) {
@@ -63,7 +55,7 @@ export default class WorkflowSession {
   }
 
   getPersistedData(): any {
-    return this.workflowPersistenceStorage?.getPersistedData(
+    return this.workflow?.workflowPersistence.getPersistedData(
       this.workflow.workflowPersistenceId
     );
   }
@@ -71,7 +63,7 @@ export default class WorkflowSession {
   private persistToStorage(): void {
     if (!this.hasPersistence) return;
 
-    this.workflowPersistenceStorage?.persistData(
+    this.workflow?.workflowPersistence.persistData(
       this.workflow.workflowPersistenceId,
       { name: this.workflow.name, state: this.state }
     );

--- a/packages/web-client/app/models/workflow/workflow-session.ts
+++ b/packages/web-client/app/models/workflow/workflow-session.ts
@@ -44,6 +44,14 @@ export default class WorkflowSession {
     this.persistToStorage();
   }
 
+  delete(key: string) {
+    delete this.state[key];
+    // eslint-disable-next-line no-self-assign
+    this.state = this.state; // for reactivity
+
+    this.persistToStorage();
+  }
+
   restoreFromStorage(): void {
     if (!this.isPersisted) return;
 
@@ -63,11 +71,5 @@ export default class WorkflowSession {
       this.workflow.workflowPersistenceId,
       { name: this.workflow.name, state: this.state }
     );
-  }
-
-  delete(key: string) {
-    delete this.state[key];
-    // eslint-disable-next-line no-self-assign
-    this.state = this.state; // for reactivity
   }
 }

--- a/packages/web-client/app/models/workflow/workflow-session.ts
+++ b/packages/web-client/app/models/workflow/workflow-session.ts
@@ -1,14 +1,28 @@
+import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';
 import { tracked } from '@glimmer/tracking';
 
 export interface ArbitraryDictionary {
   [key: string]: any;
 }
+
 export default class WorkflowSession {
+  workflow: any;
+  workflowPersistenceStorage: WorkflowPersistence;
+
+  constructor(workflow?: any) {
+    this.workflow = workflow;
+    this.workflowPersistenceStorage = this.workflow.owner.lookup(
+      'service:workflow-persistence'
+    );
+  }
+
   @tracked state: ArbitraryDictionary = {};
   update(key: string, val: any) {
     this.state[key] = val;
     // eslint-disable-next-line no-self-assign
     this.state = this.state; // for reactivity
+
+    this.persistToStorage();
   }
 
   updateMany(hash: Record<string, any>) {
@@ -17,6 +31,29 @@ export default class WorkflowSession {
     }
     // eslint-disable-next-line no-self-assign
     this.state = this.state; // for reactivity
+
+    this.persistToStorage();
+  }
+
+  restoreFromStorage(): void {
+    if (!this.workflow.workflowPersistenceId) return;
+
+    const persistedState = this.workflowPersistenceStorage.getPersistedState(
+      this.workflow.workflowPersistenceId
+    );
+
+    if (persistedState) {
+      this.state = persistedState;
+    }
+  }
+
+  persistToStorage(): void {
+    if (!this.workflow.workflowPersistenceId) return;
+
+    this.workflowPersistenceStorage.persistState(
+      this.workflow.workflowPersistenceId,
+      this.state
+    );
   }
 
   delete(key: string) {

--- a/packages/web-client/app/models/workflow/workflow-session.ts
+++ b/packages/web-client/app/models/workflow/workflow-session.ts
@@ -22,7 +22,7 @@ export default class WorkflowSession {
 
   @tracked state: ArbitraryDictionary = {};
 
-  get isPersisted() {
+  get hasPersistence() {
     return !!this.workflow?.workflowPersistenceId;
   }
 
@@ -53,19 +53,23 @@ export default class WorkflowSession {
   }
 
   restoreFromStorage(): void {
-    if (!this.isPersisted) return;
+    if (!this.hasPersistence) return;
 
-    const persistedData = this.workflowPersistenceStorage?.getPersistedData(
-      this.workflow.workflowPersistenceId
-    );
+    const persistedData = this.getPersistedData();
 
     if (persistedData?.state) {
       this.state = persistedData.state;
     }
   }
 
-  persistToStorage(): void {
-    if (!this.isPersisted) return;
+  getPersistedData(): any {
+    return this.workflowPersistenceStorage?.getPersistedData(
+      this.workflow.workflowPersistenceId
+    );
+  }
+
+  private persistToStorage(): void {
+    if (!this.hasPersistence) return;
 
     this.workflowPersistenceStorage?.persistData(
       this.workflow.workflowPersistenceId,

--- a/packages/web-client/app/models/workflow/workflow-session.ts
+++ b/packages/web-client/app/models/workflow/workflow-session.ts
@@ -38,21 +38,20 @@ export default class WorkflowSession {
   restoreFromStorage(): void {
     if (!this.workflow.workflowPersistenceId) return;
 
-    const persistedState = this.workflowPersistenceStorage.getPersistedState(
+    const persistedData = this.workflowPersistenceStorage.getPersistedData(
       this.workflow.workflowPersistenceId
     );
 
-    if (persistedState) {
-      this.state = persistedState;
+    if (persistedData?.state) {
+      this.state = persistedData.state;
     }
   }
 
   persistToStorage(): void {
     if (!this.workflow.workflowPersistenceId) return;
-
-    this.workflowPersistenceStorage.persistState(
+    this.workflowPersistenceStorage.persistData(
       this.workflow.workflowPersistenceId,
-      this.state
+      { name: this.workflow.name, state: this.state }
     );
   }
 

--- a/packages/web-client/app/routes/card-pay/balances.ts
+++ b/packages/web-client/app/routes/card-pay/balances.ts
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import '../../css/card-pay/balances.css';
 import heroImageUrl from '@cardstack/web-client/images/dashboard/balances-hero.svg';
 import summaryHeroImageUrl from '@cardstack/web-client/images/dashboard/balances-summary-hero.svg';
+import { v4 as uuidv4 } from 'uuid';
 
 const BALANCES_PANEL = {
   title: 'Easy Payments',
@@ -43,6 +44,26 @@ const BALANCES_PANEL = {
 };
 
 export default class CardPayBalancesRoute extends Route {
+  queryParams = {
+    flow: {
+      refreshModel: true,
+    },
+  };
+
+  beforeModel(transition: any) {
+    const { flow, workflowPersistenceId } = transition.to.queryParams;
+
+    if (flow && !workflowPersistenceId) {
+      transition.abort(); // https://github.com/emberjs/ember.js/issues/17118
+      this.transitionTo(transition.to.name, {
+        queryParams: {
+          flow: flow,
+          workflowPersistenceId: uuidv4(), // TODO: Something shorter for a prettier URL?
+        },
+      });
+    }
+  }
+
   model() {
     return {
       panel: BALANCES_PANEL,

--- a/packages/web-client/app/routes/card-pay/balances.ts
+++ b/packages/web-client/app/routes/card-pay/balances.ts
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 import '../../css/card-pay/balances.css';
 import heroImageUrl from '@cardstack/web-client/images/dashboard/balances-hero.svg';
 import summaryHeroImageUrl from '@cardstack/web-client/images/dashboard/balances-summary-hero.svg';
-import { v4 as uuidv4 } from 'uuid';
 
 const BALANCES_PANEL = {
   title: 'Easy Payments',
@@ -44,26 +43,6 @@ const BALANCES_PANEL = {
 };
 
 export default class CardPayBalancesRoute extends Route {
-  queryParams = {
-    flow: {
-      refreshModel: true,
-    },
-  };
-
-  beforeModel(transition: any) {
-    const { flow, workflowPersistenceId } = transition.to.queryParams;
-
-    if (flow && !workflowPersistenceId) {
-      transition.abort(); // https://github.com/emberjs/ember.js/issues/17118
-      this.transitionTo(transition.to.name, {
-        queryParams: {
-          flow: flow,
-          workflowPersistenceId: uuidv4(), // TODO: Something shorter for a prettier URL?
-        },
-      });
-    }
-  }
-
   model() {
     return {
       panel: BALANCES_PANEL,

--- a/packages/web-client/app/routes/card-pay/balances.ts
+++ b/packages/web-client/app/routes/card-pay/balances.ts
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import BaseRoute from './base';
 import '../../css/card-pay/balances.css';
 import heroImageUrl from '@cardstack/web-client/images/dashboard/balances-hero.svg';
 import summaryHeroImageUrl from '@cardstack/web-client/images/dashboard/balances-summary-hero.svg';
@@ -42,8 +42,9 @@ const BALANCES_PANEL = {
   ],
 };
 
-export default class CardPayBalancesRoute extends Route {
-  model() {
+export default class CardPayBalancesRoute extends BaseRoute {
+  model(params: any, transition: any) {
+    super.model(params, transition);
     return {
       panel: BALANCES_PANEL,
     };

--- a/packages/web-client/app/routes/card-pay/base.ts
+++ b/packages/web-client/app/routes/card-pay/base.ts
@@ -1,0 +1,25 @@
+import Route from '@ember/routing/route';
+import '../../css/card-pay/balances.css';
+import * as short from 'short-uuid';
+
+export default class CardPayTabBaseRoute extends Route {
+  queryParams = {
+    flow: {
+      refreshModel: true,
+    },
+    workflowPersistenceId: {
+      refreshModel: true,
+    },
+  };
+  model(params: any, transition: any) {
+    if (params.flow && !params.workflowPersistenceId) {
+      transition.abort();
+      this.transitionTo(this.routeName, {
+        queryParams: {
+          flow: params.flow,
+          workflowPersistenceId: short.generate(),
+        },
+      });
+    }
+  }
+}

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -5,10 +5,8 @@ import { TaskGenerator } from 'ember-concurrency';
 import { task } from 'ember-concurrency-decorators';
 import { useResource } from 'ember-resources';
 import {
-  IssuePrepaidCardOptions,
   Layer2ChainEvent,
   Layer2Web3Strategy,
-  RegisterMerchantOptions,
   TransactionHash,
 } from '../utils/web3-strategies/types';
 import { PrepaidCardSafe } from '@cardstack/cardpay-sdk/sdk/safes';
@@ -35,10 +33,10 @@ import { action } from '@ember/object';
 import HubAuthentication from '@cardstack/web-client/services/hub-authentication';
 import { taskFor } from 'ember-concurrency-ts';
 import { UsdConvertibleSymbol } from './token-to-usd';
+import { TransactionOptions } from '@cardstack/cardpay-sdk';
 export default class Layer2Network
   extends Service
-  implements Emitter<Layer2ChainEvent>
-{
+  implements Emitter<Layer2ChainEvent> {
   @service declare hubAuthentication: HubAuthentication;
   strategy!: Layer2Web3Strategy;
   simpleEmitter = new SimpleEmitter();
@@ -123,9 +121,9 @@ export default class Layer2Network
   @task *issuePrepaidCardTask(
     faceValue: number,
     customizationDid: string,
-    options: IssuePrepaidCardOptions
+    options: TransactionOptions
   ): any {
-    let address = yield this.strategy.issuePrepaidCard(
+    let prepaidCardSafe = yield this.strategy.issuePrepaidCard(
       this.depotSafe?.address!,
       faceValue,
       customizationDid,
@@ -135,7 +133,18 @@ export default class Layer2Network
     // Refreshes safes so that external component shows up-to-date list of the user's prepaid cards
     this.refreshSafesAndBalances();
 
-    return address;
+    return prepaidCardSafe;
+  }
+
+  @task *resumeIssuePrepaidCardTransactionTask(
+    txnHash: string
+  ): TaskGenerator<PrepaidCardSafe> {
+    let prepaidCardSafe = yield this.strategy.resumeIssuePrepaidCardTransaction(
+      txnHash
+    );
+    // Refreshes safes so that external component shows up-to-date list of the user's prepaid cards
+    this.refreshSafesAndBalances();
+    return prepaidCardSafe;
   }
 
   @task *fetchMerchantRegistrationFeeTask(): TaskGenerator<number> {
@@ -145,7 +154,7 @@ export default class Layer2Network
   @task *registerMerchantTask(
     prepaidCardAddress: string,
     infoDid: string,
-    options: RegisterMerchantOptions
+    options: TransactionOptions
   ): any {
     let merchant = yield this.strategy.registerMerchant(
       prepaidCardAddress,
@@ -189,12 +198,6 @@ export default class Layer2Network
       fromBlock,
       this.walletInfo.firstAddress!
     );
-  }
-
-  @task *getPrepaidCardSafesFromTxHash(
-    txHash: string
-  ): TaskGenerator<PrepaidCardSafe[]> {
-    return yield this.strategy.getPrepaidCardSafesFromTxHash(txHash);
   }
 
   blockExplorerUrl(txnHash: string | undefined): string | undefined {

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -11,6 +11,7 @@ import {
   RegisterMerchantOptions,
   TransactionHash,
 } from '../utils/web3-strategies/types';
+import { PrepaidCardSafe } from '@cardstack/cardpay-sdk/sdk/safes';
 import Layer2TestWeb3Strategy from '../utils/web3-strategies/test-layer2';
 import XDaiWeb3Strategy from '../utils/web3-strategies/x-dai';
 import SokolWeb3Strategy from '../utils/web3-strategies/sokol';
@@ -188,6 +189,12 @@ export default class Layer2Network
       fromBlock,
       this.walletInfo.firstAddress!
     );
+  }
+
+  @task *getPrepaidCardSafesFromTxHash(
+    txHash: string
+  ): TaskGenerator<PrepaidCardSafe[]> {
+    return yield this.strategy.getPrepaidCardSafesFromTxHash(txHash);
   }
 
   blockExplorerUrl(txnHash: string | undefined): string | undefined {

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -36,7 +36,8 @@ import { UsdConvertibleSymbol } from './token-to-usd';
 import { TransactionOptions } from '@cardstack/cardpay-sdk';
 export default class Layer2Network
   extends Service
-  implements Emitter<Layer2ChainEvent> {
+  implements Emitter<Layer2ChainEvent>
+{
   @service declare hubAuthentication: HubAuthentication;
   strategy!: Layer2Web3Strategy;
   simpleEmitter = new SimpleEmitter();

--- a/packages/web-client/app/services/workflow-persistence.ts
+++ b/packages/web-client/app/services/workflow-persistence.ts
@@ -1,17 +1,25 @@
 import { default as Service } from '@ember/service';
 
+interface WorkflowPersistencePersistedData {
+  name: string;
+  state: any;
+}
+
 export default class WorkflowPersistence extends Service {
-  getPersistedState(workflowPersistenceId: string) {
+  getPersistedData(workflowPersistenceId: string) {
     return JSON.parse(
       localStorage.getItem(`workflowPersistence:${workflowPersistenceId}`) ||
         '{}'
     );
   }
 
-  persistState(workflowPersistenceId: string, state: any) {
+  persistData(
+    workflowPersistenceId: string,
+    data: WorkflowPersistencePersistedData
+  ) {
     return localStorage.setItem(
       `workflowPersistence:${workflowPersistenceId}`,
-      JSON.stringify(state)
+      JSON.stringify(data)
     );
   }
 }

--- a/packages/web-client/app/services/workflow-persistence.ts
+++ b/packages/web-client/app/services/workflow-persistence.ts
@@ -1,4 +1,6 @@
 import { default as Service } from '@ember/service';
+import { MockLocalStorage } from '../utils/browser-mocks';
+import config from '../config/environment';
 
 interface WorkflowPersistencePersistedData {
   name: string;
@@ -6,9 +8,20 @@ interface WorkflowPersistencePersistedData {
 }
 
 export default class WorkflowPersistence extends Service {
+  storage!: Storage | MockLocalStorage;
+
+  constructor() {
+    super(...arguments);
+    if (config.environment === 'test') {
+      this.storage = new MockLocalStorage();
+    } else {
+      this.storage = window.localStorage;
+    }
+  }
+
   getPersistedData(workflowPersistenceId: string) {
     return JSON.parse(
-      localStorage.getItem(`workflowPersistence:${workflowPersistenceId}`) ||
+      this.storage.getItem(`workflowPersistence:${workflowPersistenceId}`) ||
         '{}'
     );
   }
@@ -17,7 +30,7 @@ export default class WorkflowPersistence extends Service {
     workflowPersistenceId: string,
     data: WorkflowPersistencePersistedData
   ) {
-    return localStorage.setItem(
+    return this.storage.setItem(
       `workflowPersistence:${workflowPersistenceId}`,
       JSON.stringify(data)
     );

--- a/packages/web-client/app/services/workflow-persistence.ts
+++ b/packages/web-client/app/services/workflow-persistence.ts
@@ -1,0 +1,23 @@
+import { default as Service } from '@ember/service';
+
+export default class WorkflowPersistence extends Service {
+  getPersistedState(workflowPersistenceId: string) {
+    return JSON.parse(
+      localStorage.getItem(`workflowPersistence:${workflowPersistenceId}`) ||
+        '{}'
+    );
+  }
+
+  persistState(workflowPersistenceId: string, state: any) {
+    return localStorage.setItem(
+      `workflowPersistence:${workflowPersistenceId}`,
+      JSON.stringify(state)
+    );
+  }
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    'workflow-persistence': WorkflowPersistence;
+  }
+}

--- a/packages/web-client/app/templates/card-pay/balances.hbs
+++ b/packages/web-client/app/templates/card-pay/balances.hbs
@@ -42,6 +42,9 @@
                 @kind="secondary-dark"
                 @size="small"
                 @disabled={{section.isCtaDisabled}}
+                @as="link-to"
+                @route="card-pay.balances"
+                @query={{hash flow=section.workflow}}
                 data-test-workflow-button={{section.workflow}}
               >
                 <span>{{section.cta}}</span>
@@ -66,7 +69,7 @@
 <Boxel::Modal
   style={{css-var boxel-modal-max-width="65rem"}} {{!-- ~1040px --}}
   @isOpen={{eq this.flow 'issue-prepaid-card'}}
-  @onClose={{set this "flow" null}}
+  @onClose={{this.resetQueryParams}}
 >
   {{#if (is-network-initialized)}}
     <CardPay::IssuePrepaidCardWorkflow />

--- a/packages/web-client/app/templates/card-pay/balances.hbs
+++ b/packages/web-client/app/templates/card-pay/balances.hbs
@@ -6,7 +6,7 @@
         <CardPay::DashboardPanel::Section @section={{section}}>
           <:cta>
             <Boxel::Button
-              {{on "click" (fn this.setFlow section.workflow)}}
+              {{on "click" (fn this.transitionToBalances section.workflow)}}
               @kind="primary"
               @size="touch"
               @disabled={{section.isCtaDisabled}}
@@ -38,7 +38,7 @@
 
             {{#let @model.panel.sections.lastObject as |section|}}
               <Boxel::Button
-                {{on "click" (fn this.setFlow section.workflow)}}
+                {{on "click" (fn this.transitionToBalances section.workflow)}}
                 @kind="secondary-dark"
                 @size="small"
                 @disabled={{section.isCtaDisabled}}

--- a/packages/web-client/app/templates/card-pay/balances.hbs
+++ b/packages/web-client/app/templates/card-pay/balances.hbs
@@ -6,7 +6,7 @@
         <CardPay::DashboardPanel::Section @section={{section}}>
           <:cta>
             <Boxel::Button
-              {{on "click" (set this "flow" section.workflow)}}
+              {{on "click" (fn this.setFlow section.workflow)}}
               @kind="primary"
               @size="touch"
               @disabled={{section.isCtaDisabled}}
@@ -38,13 +38,11 @@
 
             {{#let @model.panel.sections.lastObject as |section|}}
               <Boxel::Button
-                {{on "click" (set this "flow" section.workflow)}}
+                {{on "click" (fn this.setFlow section.workflow)}}
                 @kind="secondary-dark"
                 @size="small"
                 @disabled={{section.isCtaDisabled}}
-                @as="link-to"
                 @route="card-pay.balances"
-                @query={{hash flow=section.workflow}}
                 data-test-workflow-button={{section.workflow}}
               >
                 <span>{{section.cta}}</span>

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -194,6 +194,13 @@ export default abstract class Layer2ChainWeb3Strategy
     yield this.provider.enable();
   }
 
+  async getPrepaidCardSafesFromTxHash(
+    txHash: string
+  ): Promise<PrepaidCardSafe[]> {
+    const PrepaidCard = await getSDK('PrepaidCard', this.web3);
+    return await PrepaidCard.getPrepaidCardSafesFromTxHash(txHash);
+  }
+
   private getTokenContractInfo(
     symbol: ConvertibleSymbol,
     network: Layer2NetworkSymbol

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -57,7 +57,8 @@ interface Layer2ConnectEvent {
 const BRIDGE = 'https://safe-walletconnect.gnosis.io/';
 
 export default abstract class Layer2ChainWeb3Strategy
-  implements Layer2Web3Strategy, Emitter<Layer2ChainEvent> {
+  implements Layer2Web3Strategy, Emitter<Layer2ChainEvent>
+{
   chainId: number;
   networkSymbol: Layer2NetworkSymbol;
   provider: WalletConnectProvider | undefined;

--- a/packages/web-client/app/utils/web3-strategies/test-layer2.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer2.ts
@@ -226,6 +226,10 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
     return Promise.resolve(100);
   }
 
+  getPrepaidCardSafesFromTxHash(_txHash: string): Promise<PrepaidCardSafe[]> {
+    return defer<PrepaidCardSafe[]>().promise;
+  }
+
   async registerMerchant(
     prepaidCardAddress: string,
     infoDID: string,

--- a/packages/web-client/app/utils/web3-strategies/test-layer2.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer2.ts
@@ -428,7 +428,7 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
 
       ...options,
     };
-    request?.onTxnHash?.('exampleTxHnash');
+    request?.onTxnHash?.('exampleTxnHash');
 
     this.test__simulateAccountSafes(walletAddress, [prepaidCardSafe]);
 

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -143,6 +143,7 @@ export interface Layer2Web3Strategy
   defaultTokenSymbol: ConvertibleSymbol;
   refreshSafesAndBalances(): void;
   convertFromSpend(symbol: ConvertibleSymbol, amount: number): Promise<any>;
+  getPrepaidCardSafesFromTxHash(txHash: string): Promise<PrepaidCardSafe[]>;
 }
 
 export type TransactionHash = string;

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -16,6 +16,7 @@ import { Emitter } from '../events';
 import { BridgeValidationResult } from '@cardstack/cardpay-sdk/sdk/token-bridge-home-side';
 import { TaskGenerator } from 'ember-concurrency';
 import { UsdConvertibleSymbol } from '@cardstack/web-client/services/token-to-usd';
+import { TransactionOptions } from '@cardstack/cardpay-sdk';
 
 export type Layer1ChainEvent =
   | 'disconnect'
@@ -40,18 +41,6 @@ export interface ApproveOptions {
 
 export interface RelayTokensOptions {
   onTxnHash?(txnHash: TransactionHash): void;
-}
-
-export interface IssuePrepaidCardOptions {
-  onTxnHash?(txnHash: TransactionHash): void;
-  nonce?: string;
-  onNonce?(nonce: string): void;
-}
-
-export interface RegisterMerchantOptions {
-  onTxnHash?(txnHash: TransactionHash): void;
-  nonce?: string;
-  onNonce?(nonce: string): void;
 }
 
 export interface ClaimBridgedTokensOptions {
@@ -132,18 +121,18 @@ export interface Layer2Web3Strategy
     safeAddress: string,
     amount: number,
     customizationDid: string,
-    options?: IssuePrepaidCardOptions
+    options?: TransactionOptions
   ): Promise<PrepaidCardSafe>;
+  resumeIssuePrepaidCardTransaction(txnHash: string): Promise<PrepaidCardSafe>;
   fetchMerchantRegistrationFee(): Promise<number>;
   registerMerchant(
     prepaidCardAddress: string,
     infoDid: string,
-    options: RegisterMerchantOptions
+    options: TransactionOptions
   ): Promise<MerchantSafe>;
   defaultTokenSymbol: ConvertibleSymbol;
   refreshSafesAndBalances(): void;
   convertFromSpend(symbol: ConvertibleSymbol, amount: number): Promise<any>;
-  getPrepaidCardSafesFromTxHash(txHash: string): Promise<PrepaidCardSafe[]>;
 }
 
 export type TransactionHash = string;

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -165,6 +165,7 @@
     "eth-block-tracker": "^5.0.1",
     "json-rpc-random-id": "^1.0.1",
     "macro-decorators": "^0.1.2",
+    "short-uuid": "^4.2.0",
     "typescript": "^4.2.3",
     "web3-core": "^1.3.6",
     "web3-core-helpers": "^1.5.1",

--- a/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
@@ -7,6 +7,11 @@ import prepaidCardColorSchemes from '../../mirage/fixture-data/prepaid-card-colo
 import prepaidCardPatterns from '../../mirage/fixture-data/prepaid-card-patterns';
 
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
+import { DepotSafe } from '@cardstack/cardpay-sdk';
+import { BN } from 'bn.js';
+import { faceValueOptions } from '@cardstack/web-client/components/card-pay/issue-prepaid-card-workflow/workflow-config';
+import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
+import { toWei } from 'web3-utils';
 
 interface Context extends MirageTestContext {}
 
@@ -88,6 +93,76 @@ module('Acceptance | issue prepaid card', function (hooks) {
       assert
         .dom('[data-test-preview] [data-test-prepaid-card-balance]')
         .hasText('§10000');
+    });
+
+    test('it allows interactivity after restoring previously saved state', async function (this: Context, assert) {
+      let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
+      const MIN_AMOUNT_TO_PASS = new BN(
+        toWei(`${Math.ceil(Math.min(...faceValueOptions) / 100)}`)
+      );
+      let layer2Service = this.owner.lookup('service:layer2-network')
+        .strategy as Layer2TestWeb3Strategy;
+      layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
+      layer2Service.test__simulateBalances({
+        defaultToken: MIN_AMOUNT_TO_PASS,
+        card: new BN('500000000000000000000'),
+      });
+      let testDepot = {
+        address: '0xB236ca8DbAB0644ffCD32518eBF4924ba8666666',
+        tokens: [
+          {
+            balance: '250000000000000000000',
+            token: {
+              symbol: 'DAI',
+            },
+          },
+          {
+            balance: '500000000000000000000',
+            token: {
+              symbol: 'CARD',
+            },
+          },
+        ],
+      };
+      layer2Service.test__simulateDepot(testDepot as DepotSafe);
+      const state = {
+        completedCardNames: ['LAYER2_CONNECT', 'LAYOUT_CUSTOMIZATION'],
+        issuerName: 'Vitalik',
+        pattern: {
+          patternUrl:
+            '/assets/images/prepaid-card-customizations/pattern-3-be5bfc96d028c4ed55a5aafca645d213.svg',
+          id: '80cb8f99-c5f7-419e-9c95-2e87a9d8db32',
+        },
+        colorScheme: {
+          patternColor: 'white',
+          textColor: 'black',
+          background: '#37EB77',
+          id: '4f219852-33ee-4e4c-81f7-76318630a423',
+        },
+      };
+
+      localStorage.setItem(
+        `workflowPersistence:123`,
+        JSON.stringify({
+          name: 'Prepaid Card Issuance',
+          state,
+        })
+      );
+
+      await visit('/card-pay/balances?flow=issue-prepaid-card&flow-id=123');
+
+      assert.dom('[data-test-milestone="0"]').exists(); // L2
+      assert.dom('[data-test-milestone="1"]').exists(); // Customize layout
+      assert.dom('[data-test-milestone="2"]').exists(); // Choose funding source
+
+      assert.dom('[data-test-funding-source-card]').exists();
+      assert.dom('[data-test-face-value-card]').doesNotExist();
+
+      await click(
+        '[data-test-funding-source-card] [data-test-boxel-action-chin] [data-test-boxel-button]'
+      );
+
+      assert.dom('[data-test-face-value-card]').exists();
     });
   });
 });

--- a/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
@@ -320,6 +320,68 @@ module('Acceptance | issue prepaid card', function (hooks) {
       assert.equal(workflowPersistenceId!.length, 22);
     });
 
+    test('it should reset the persisted card names when editing one of the previous steps', async function (this: Context, assert) {
+      const state = {
+        completedCardNames: [
+          'LAYER2_CONNECT',
+          'LAYOUT_CUSTOMIZATION',
+          'FUNDING_SOURCE',
+          'FACE_VALUE',
+        ],
+        issuerName: 'Vitalik',
+        pattern: {
+          patternUrl:
+            '/assets/images/prepaid-card-customizations/pattern-3-be5bfc96d028c4ed55a5aafca645d213.svg',
+          id: '80cb8f99-c5f7-419e-9c95-2e87a9d8db32',
+        },
+        colorScheme: {
+          patternColor: 'white',
+          textColor: 'black',
+          background: '#37EB77',
+          id: '4f219852-33ee-4e4c-81f7-76318630a423',
+        },
+        prepaidFundingToken: 'DAI.CPXD',
+        spendFaceValue: 10000,
+        did: 'did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e',
+        prepaidCardAddress: '0x81c89274Dc7C9BAcE082d2ca00697d2d2857D2eE',
+        reloadable: true,
+        transferrable: true,
+        txHash:
+          '0x8bcc3e419d09a0403d1491b5bb8ac8bee7c67f85cc37e6e17ef8eb77f946497b',
+        prepaidCardSafe: {
+          type: 'prepaid-card',
+          address: '0x81c89274Dc7C9BAcE082d2ca00697d2d2857D2eE',
+          customizationDID:
+            'did:cardstack:1pkYh9uJHdfMJZt4mURGmhps96b157a2d744efd9',
+          reloadable: false,
+          spendFaceValue: 500,
+          transferrable: true,
+        },
+      };
+
+      workflowPersistenceService.persistData('abc123', {
+        name: 'PREPAID_CARD_ISSUANCE',
+        state,
+      });
+
+      await visit('/card-pay/balances?flow=issue-prepaid-card&flow-id=abc123');
+      assert.dom('[data-test-milestone="0"]').exists(); // L2
+      assert.dom('[data-test-milestone="1"]').exists(); // Customize layout
+      assert.dom('[data-test-milestone="2"]').exists(); // Choose face value
+      assert.dom('[data-test-milestone="3"]').exists(); // Prepaid card preview
+
+      await waitFor('[data-test-milestone="1"] [data-test-boxel-button]');
+
+      await click('[data-test-milestone="1"] [data-test-boxel-button]');
+
+      await visit('/card-pay/balances?flow=issue-prepaid-card&flow-id=abc123');
+
+      assert.dom('[data-test-milestone="0"]').exists(); // L2
+      assert.dom('[data-test-milestone="1"]').exists(); // Customize layout
+      assert.dom('[data-test-milestone="2"]').doesNotExist(); // Choose face value
+      assert.dom('[data-test-milestone="3"]').doesNotExist(); // Prepaid card preview
+    });
+
     test('it cancels a persisted flow when card wallet address is different', async function (this: Context, assert) {
       const state = {
         completedCardNames: [

--- a/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
@@ -27,7 +27,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
     await click('[data-test-workflow-button="issue-prepaid-card"]');
 
     assert.equal(
-      // @ts-ignore
+      // @ts-ignore (complains object is possibly null)
       new URL('http://domain.test/' + currentURL()).searchParams.get('flow-id')
         .length,
       22
@@ -37,7 +37,12 @@ module('Acceptance | issue prepaid card', function (hooks) {
   module('Restoring from previously saved state', function () {
     test('it restores the workflow', async function (this: Context, assert) {
       const state = {
-        lastCompletedCardName: 'FACE_VALUE',
+        completedCardNames: [
+          'LAYER2_CONNECT',
+          'LAYOUT_CUSTOMIZATION',
+          'FUNDING_SOURCE',
+          'FACE_VALUE',
+        ],
         issuerName: 'Vitalik',
         pattern: {
           patternUrl:

--- a/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
@@ -1,0 +1,88 @@
+import { module, test } from 'qunit';
+import { click, visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import prepaidCardColorSchemes from '../../mirage/fixture-data/prepaid-card-color-schemes';
+import prepaidCardPatterns from '../../mirage/fixture-data/prepaid-card-patterns';
+
+import { MirageTestContext } from 'ember-cli-mirage/test-support';
+
+interface Context extends MirageTestContext {}
+
+module('Acceptance | issue prepaid card', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    // TODO: fix typescript for mirage
+    (this as any).server.db.loadData({
+      prepaidCardColorSchemes,
+      prepaidCardPatterns,
+    });
+  });
+
+  test('Generates a flow uuid query parameter used as a persistence identifier', async function (this: Context, assert) {
+    await visit('/card-pay');
+    await click('[data-test-workflow-button="issue-prepaid-card"]');
+
+    assert.equal(
+      // @ts-ignore
+      new URL('http://domain.test/' + currentURL()).searchParams.get('flow-id')
+        .length,
+      22
+    );
+  });
+
+  module('Restoring from previously saved state', function () {
+    test('it restores the workflow', async function (this: Context, assert) {
+      const state = {
+        lastCompletedCardName: 'FACE_VALUE',
+        issuerName: 'Vitalik',
+        pattern: {
+          patternUrl:
+            '/assets/images/prepaid-card-customizations/pattern-3-be5bfc96d028c4ed55a5aafca645d213.svg',
+          id: '80cb8f99-c5f7-419e-9c95-2e87a9d8db32',
+        },
+        colorScheme: {
+          patternColor: 'white',
+          textColor: 'black',
+          background: '#37EB77',
+          id: '4f219852-33ee-4e4c-81f7-76318630a423',
+        },
+        prepaidFundingToken: 'DAI.CPXD',
+        spendFaceValue: 10000,
+        did: 'did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e',
+        prepaidCardAddress: '0xaeFbA62A2B3e90FD131209CC94480E722704E1F8',
+        reloadable: true,
+        transferrable: true,
+      };
+
+      localStorage.setItem(
+        `workflowPersistence:123`,
+        JSON.stringify({
+          name: 'Prepaid Card Issuance',
+          state,
+        })
+      );
+
+      // FIXME: Route never resolves, possibly due to the testwaiter in the animated workflow
+      await visit('/card-pay/balances?flow=issue-prepaid-card&flow-id=123');
+
+      assert.dom('[data-test-milestone="0"]').exists(); // L2
+      assert.dom('[data-test-milestone="1"]').exists(); // Customize layout
+      assert.dom('[data-test-milestone="2"]').exists(); // Choose face value
+      assert.dom('[data-test-milestone="3"]').exists(); // Prepaid card preview
+
+      assert
+        .dom(
+          '[data-test-preview] [data-test-prepaid-card-issuer-name-labeled-value]'
+        )
+        .hasText('Issued by Vitalik');
+
+      assert
+        .dom('[data-test-preview] [data-test-prepaid-card-balance]')
+        .hasText('§10000');
+    });
+  });
+});

--- a/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
@@ -301,6 +301,20 @@ module('Acceptance | issue prepaid card', function (hooks) {
         .includesText(
           'You attempted to restore an unfinished workflow, but you are no longer authenticated. Please restart the workflow.'
         );
+
+      await click('[data-test-workflow-default-cancelation-restart]');
+
+      // Starts over
+      assert.dom('[data-test-milestone="0"]').exists(); // L2
+      assert.dom('[data-test-milestone="1"]').exists(); // Customize layout
+      assert.dom('[data-test-milestone="2"]').doesNotExist(); // Choose funding source
+
+      const workflowPersistenceId = new URL(
+        'http://domain.test/' + currentURL()
+      ).searchParams.get('flow-id');
+
+      assert.notEqual(workflowPersistenceId!, 'abc123'); // flow-id param should be regenerated
+      assert.equal(workflowPersistenceId!.length, 22);
     });
 
     test('it cancels a persisted flow when card wallet address is different', async function (this: Context, assert) {

--- a/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
@@ -190,9 +190,12 @@ module('Acceptance | issue prepaid card', function (hooks) {
 
       assert.dom('[data-test-layer-2-wallet-summary]').exists();
 
-      assert
-        .dom('[data-test-issue-prepaid-card-next-step="new-issuance"]') // Issue A New Prepaid Card button
-        .exists();
+      await click('[data-test-issue-prepaid-card-next-step="new-issuance"]');
+
+      // Starts over
+      assert.dom('[data-test-milestone="0"]').exists(); // L2
+      assert.dom('[data-test-milestone="1"]').exists(); // Customize layout
+      assert.dom('[data-test-milestone="2"]').doesNotExist(); // Choose funding source
     });
 
     test('it restores a cancelled workflow', async function (this: Context, assert) {

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -584,7 +584,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
       reloadable: true,
       spendFaceValue: 10000,
       transferrable: true,
-      txHash: 'exampleTxHash',
+      txnHash: 'exampleTxnHash',
     });
   });
 

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -22,6 +22,7 @@ import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3
 import { faceValueOptions } from '@cardstack/web-client/components/card-pay/issue-prepaid-card-workflow/workflow-config';
 
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
+import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';
 
 interface Context extends MirageTestContext {}
 
@@ -519,6 +520,72 @@ module('Acceptance | issue prepaid card', function (hooks) {
     assert.dom('[data-test-workflow-thread]').doesNotExist();
 
     assert.dom('[data-test-prepaid-cards-count]').containsText('2');
+
+    let workflowPersistenceService = this.owner.lookup(
+      'service:workflow-persistence'
+    ) as WorkflowPersistence;
+
+    const workflowPersistenceId = new URL(
+      'http://domain.test/' + currentURL()
+    ).searchParams.get('flow-id')!;
+
+    const persistedData = workflowPersistenceService.getPersistedData(
+      workflowPersistenceId
+    );
+
+    assert.equal(persistedData.name, 'PREPAID_CARD_ISSUANCE');
+    let persistedState = persistedData.state;
+    delete persistedState.prepaidCardSafe.createdAt;
+
+    assert.deepEqual(persistedState, {
+      colorScheme: {
+        background: '#37EB77',
+        id: '4f219852-33ee-4e4c-81f7-76318630a423',
+        patternColor: 'white',
+        textColor: 'black',
+      },
+      completedCardNames: [
+        'LAYER2_CONNECT',
+        'HUB_AUTH',
+        'LAYOUT_CUSTOMIZATION',
+        'FUNDING_SOURCE',
+        'FACE_VALUE',
+        'PREVIEW',
+        'CONFIRMATION',
+        'EPILOGUE_LAYER_TWO_CONNECT_CARD',
+      ],
+      completedMilestonesCount: 4,
+      did: 'did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e',
+      issuerName: 'JJ',
+      layer2WalletAddress: '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44',
+      milestonesCount: 4,
+      pattern: {
+        id: '80cb8f99-c5f7-419e-9c95-2e87a9d8db32',
+        patternUrl:
+          '/assets/images/prepaid-card-customizations/pattern-3-be5bfc96d028c4ed55a5aafca645d213.svg',
+      },
+      prepaidCardAddress: '0xaeFbA62A2B3e90FD131209CC94480E722704E1F8',
+      prepaidCardSafe: {
+        address: '0xaeFbA62A2B3e90FD131209CC94480E722704E1F8',
+        customizationDID:
+          'did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e',
+        hasBeenUsed: false,
+        issuer: '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44',
+        issuingToken: '0xTOKEN',
+        owners: ['0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44'],
+        prepaidCardOwner: '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44',
+        reloadable: true,
+        spendFaceValue: 10000,
+        tokens: [],
+        transferrable: true,
+        type: 'prepaid-card',
+      },
+      prepaidFundingToken: 'DAI.CPXD',
+      reloadable: true,
+      spendFaceValue: 10000,
+      transferrable: true,
+      txHash: 'exampleTxHash',
+    });
   });
 
   // test('Initiating workflow with layer 2 wallet already connected', async function (assert) {

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
@@ -83,7 +83,8 @@ module(
         merchantId: 'mandello1',
         merchantBgColor: '#ff5050',
         merchantTextColor: '#fff',
-        merchantRegistrationFee: await layer2Service.fetchMerchantRegistrationFee(),
+        merchantRegistrationFee:
+          await layer2Service.fetchMerchantRegistrationFee(),
       });
 
       this.setProperties({
@@ -326,8 +327,10 @@ module(
 
         await click('[data-test-create-merchant-button]');
 
-        let merchantInfoStorageRequests = (this as any).server.pretender.handledRequests.filter(
-          (req: { url: string }) => req.url.includes('merchant-infos')
+        let merchantInfoStorageRequests = (
+          this as any
+        ).server.pretender.handledRequests.filter((req: { url: string }) =>
+          req.url.includes('merchant-infos')
         );
 
         assert.equal(

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
@@ -8,6 +8,7 @@ import sinon from 'sinon';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
 import { Response as MirageResponse } from 'ember-cli-mirage';
+import BN from 'bn.js';
 
 interface Context extends MirageTestContext {}
 
@@ -82,8 +83,7 @@ module(
         merchantId: 'mandello1',
         merchantBgColor: '#ff5050',
         merchantTextColor: '#fff',
-        merchantRegistrationFee:
-          await layer2Service.fetchMerchantRegistrationFee(),
+        merchantRegistrationFee: await layer2Service.fetchMerchantRegistrationFee(),
       });
 
       this.setProperties({
@@ -221,7 +221,7 @@ module(
       await waitFor('[data-test-create-merchant-cancel-button]');
       layer2Service.test__simulateOnNonceForRegisterMerchantRequest(
         prepaidCardAddress,
-        '12345'
+        new BN('12345')
       );
 
       await click('[data-test-create-merchant-cancel-button]');
@@ -326,10 +326,8 @@ module(
 
         await click('[data-test-create-merchant-button]');
 
-        let merchantInfoStorageRequests = (
-          this as any
-        ).server.pretender.handledRequests.filter((req: { url: string }) =>
-          req.url.includes('merchant-infos')
+        let merchantInfoStorageRequests = (this as any).server.pretender.handledRequests.filter(
+          (req: { url: string }) => req.url.includes('merchant-infos')
         );
 
         assert.equal(

--- a/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
@@ -12,6 +12,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import prepaidCardColorSchemes from '../../../../../mirage/fixture-data/prepaid-card-color-schemes';
 import prepaidCardPatterns from '../../../../../mirage/fixture-data/prepaid-card-patterns';
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
+import BN from 'bn.js';
 
 const USER_REJECTION_ERROR_MESSAGE =
   'It looks like you have canceled the request in your wallet. Please try again if you want to continue with this workflow.';
@@ -166,7 +167,7 @@ module(
         await waitFor('[data-test-issue-prepaid-card-cancel-button]');
         layer2Service.test__simulateOnNonceForIssuePrepaidCardRequest(
           100000,
-          '12345'
+          new BN('12345')
         );
         await click('[data-test-issue-prepaid-card-cancel-button]');
         assert

--- a/packages/web-client/tests/unit/models/animated-workflow-test.ts
+++ b/packages/web-client/tests/unit/models/animated-workflow-test.ts
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { WorkflowCard } from '@cardstack/web-client/models/workflow/workflow-card';
-import { Workflow } from '@cardstack/web-client/models/workflow';
+import { Workflow, WorkflowName } from '@cardstack/web-client/models/workflow';
 import AnimatedWorkflow from '@cardstack/web-client/models/animated-workflow';
 import { Milestone } from '@cardstack/web-client/models/workflow/milestone';
 import { settled } from '@ember/test-helpers';
@@ -9,7 +9,7 @@ import PostableCollection from '@cardstack/web-client/models/workflow/postable-c
 import { WorkflowMessage } from '@cardstack/web-client/models/workflow/workflow-message';
 
 class MockWorkflow extends Workflow {
-  name = 'Mock workflow';
+  name = 'WITHDRAWAL' as WorkflowName;
 }
 
 let message = (message: string = 'Default message') =>

--- a/packages/web-client/tests/unit/models/workflow-test.ts
+++ b/packages/web-client/tests/unit/models/workflow-test.ts
@@ -31,7 +31,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('attachWorkflow sets workflow on milestones', function (assert) {
-    let workflow = new ConcreteWorkflow({});
+    let workflow = new ConcreteWorkflow(this.owner);
     workflow.milestones = [exampleMilestone];
     assert.ok(!exampleMilestone.workflow);
     workflow.attachWorkflow();
@@ -39,7 +39,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('attachWorkflow sets workflow on epiloguePostables', function (assert) {
-    let workflow = new ConcreteWorkflow({});
+    let workflow = new ConcreteWorkflow(this.owner);
     workflow.milestones = [exampleMilestone];
     workflow.epilogue.postables = [exampleMessage];
     assert.ok(!exampleMessage.workflow);
@@ -48,7 +48,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('attachWorkflow sets workflow on cancelationMessages', function (assert) {
-    let workflow = new ConcreteWorkflow({});
+    let workflow = new ConcreteWorkflow(this.owner);
     workflow.milestones = [exampleMilestone];
     workflow.cancelationMessages = new PostableCollection([exampleMessage]);
     assert.ok(!exampleMessage.workflow);
@@ -57,7 +57,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('completedMilestoneCount returns count of milestones with isComplete true', function (assert) {
-    let workflow = new ConcreteWorkflow({});
+    let workflow = new ConcreteWorkflow(this.owner);
     let milestone2Postable = new WorkflowPostable({ name: 'cardbot' });
     milestone2Postable.isComplete = false;
 
@@ -76,7 +76,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('visibleMilestones returns milestones up to and including first incomplete milestone', function (assert) {
-    let workflow = new ConcreteWorkflow({});
+    let workflow = new ConcreteWorkflow(this.owner);
     let milestone2Postable = new WorkflowPostable({ name: 'cardbot' });
     milestone2Postable.isComplete = false;
 
@@ -103,7 +103,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('progressStatus returns the "completedDetail" of the last complete milestone', function (assert) {
-    let workflow = new ConcreteWorkflow({});
+    let workflow = new ConcreteWorkflow(this.owner);
     let milestone2Postable = new WorkflowPostable({ name: 'cardbot' });
     milestone2Postable.isComplete = false;
 
@@ -121,20 +121,20 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('progressStatus returns "Workflow started" when no milestones are complete', function (assert) {
-    let workflow = new ConcreteWorkflow({});
+    let workflow = new ConcreteWorkflow(this.owner);
     workflow.milestones = [exampleMilestone];
     assert.equal(workflow.progressStatus, 'Workflow started');
   });
 
   test('progressStatus returns "Workflow canceled" when workflow is canceled', function (assert) {
-    let workflow = new ConcreteWorkflow({});
+    let workflow = new ConcreteWorkflow(this.owner);
     workflow.milestones = [exampleMilestone];
     workflow.cancel('TEST');
     assert.equal(workflow.progressStatus, 'Workflow canceled');
   });
 
   test('Incomplete workflow is canceled when workflow.cancel is called', function (assert) {
-    let workflow = new ConcreteWorkflow({});
+    let workflow = new ConcreteWorkflow(this.owner);
     workflow.milestones = [exampleMilestone];
     workflow.cancel('TEST');
     assert.equal(workflow.isCanceled, true);
@@ -142,7 +142,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('Workflow cannot be canceled twice', function (assert) {
-    let workflow = new ConcreteWorkflow({});
+    let workflow = new ConcreteWorkflow(this.owner);
     workflow.milestones = [exampleMilestone];
     workflow.cancel('FIRST');
     workflow.cancel('SECOND');
@@ -151,7 +151,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('Completed workflow is not canceled when workflow.cancel is called', function (assert) {
-    let workflow = new ConcreteWorkflow({});
+    let workflow = new ConcreteWorkflow(this.owner);
     workflow.milestones = [exampleMilestone];
     examplePostable.isComplete = true;
 
@@ -161,7 +161,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('Workflow.resetTo resets each milestone and its epilogue correctly', function (assert) {
-    const testWorkflow = new ConcreteWorkflow({});
+    const testWorkflow = new ConcreteWorkflow(this.owner);
     let indicesArray: string[] = [];
 
     class DummyResetFromEpilogue extends PostableCollection {
@@ -251,7 +251,7 @@ module('Unit | Workflow model', function (hooks) {
     let calledIncludeIf: boolean;
 
     hooks.beforeEach(function () {
-      workflow = new ConcreteWorkflow({});
+      workflow = new ConcreteWorkflow(this.owner);
       calledIncludeIf = false;
       let secondMilestone = new Milestone({
         title: 'Milestone 2',

--- a/packages/web-client/tests/unit/models/workflow/milestone-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/milestone-test.ts
@@ -82,7 +82,7 @@ module('Unit | Milestone model', function (hooks) {
     class ConcreteWorkflow extends Workflow {}
 
     test('setWorkflow does exactly that', function (assert) {
-      let workflow = new ConcreteWorkflow({});
+      let workflow = new ConcreteWorkflow(this.owner);
       subject.setWorkflow(workflow);
       assert.strictEqual(subject.workflow, workflow);
     });

--- a/packages/web-client/tests/unit/models/workflow/workflow-postable-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/workflow-postable-test.ts
@@ -35,7 +35,7 @@ module('Unit | WorkflowPostable model', function (hooks) {
   });
 
   test('setWorkflow does exactly that', function (assert) {
-    let workflow = new ConcreteWorkflow({});
+    let workflow = new ConcreteWorkflow(this.owner);
     let subject = new WorkflowPostable(participant);
     subject.setWorkflow(workflow);
     assert.strictEqual(subject.workflow, workflow);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7296,7 +7296,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@4.1.4, axe-core@^4.1.4:
+axe-core@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.4.tgz#f19cd99a84ee32a318b9c5b5bb8ed373ad94f143"
   integrity sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==
@@ -11582,7 +11582,7 @@ elliptic@6.5.4, elliptic@^6.0.0, elliptic@^6.4.0, elliptic@^6.5.2:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-ember-a11y-testing@4.0.3, ember-a11y-testing@^4.0.3:
+ember-a11y-testing@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-4.0.3.tgz#1f5c91266d39ea5b20614b0d294a562079887ac7"
   integrity sha512-Q7nq2crC9+bT+sZi/BORAM4FUhI080edEhnpsvB6vdkD9Ro2Rg4DksQs5Be65/DM108VNDMtbHZtrPS060Mzcw==


### PR DESCRIPTION
This PR adds a persistence feature to prepaid card workflow:

1. It restores the state when a user reloads the window in the middle of the workflow (completed cards)
2. It restores the state of a finished workflow (for inspection and to keep track of completed workflows)
3. It restores cancelled workflows
4. It prevents restoration in case the user is disconnected from the wallet or is unauthenticated or has changed the wallet address

The way it works is that when a user clicks on the "Issue prepaid card", the url becomes `some-domain.com/card-pay/balances?flow=issue-prepaid-card&flow-id=idDtMNYqfeAcj6kpoiBtkZ`. Notice the `flow-id` param - it maps to `workflowPersistenceId` which is used to restore and persist the workflow session state, which is persisted in `localStorage`:

![image](https://user-images.githubusercontent.com/273660/132847053-68220de7-ea98-41ff-b1d6-f69d5b1f913e.png)

Then, when a workflow is initialized, and we can find its persisted state, we check which cards have been completed and then mark them as such; the completed cards will be immediately rendered using the restored session state and next cards will be offered. 

To support this, a couple of components have been adjusted to read from the workflow session state rather than rely on their local state to get their data. 

In case you review PRs commit by commit - there's quite a few of commits here and some of them partly overwrite the previous ones, which makes the review a bit more difficult, but luckily not too much. I wanted to rebase/squash more aggressively but other authors have contributed code in the middle so I decided to keep that history.