### PR TITLE
web: Fix merchant info repersistance after change

### DIFF
--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
@@ -83,12 +83,30 @@ export default class CardPayCreateMerchantWorkflowMerchantCustomizationComponent
   }
 
   @action saveDetails() {
-    this.args.workflowSession.updateMany({
+    let valuesToStore = {
       merchantName: this.trimmedMerchantName,
       merchantId: this.merchantId,
       merchantBgColor: this.merchantBgColor,
       merchantTextColor: this.merchantTextColor,
-    });
+    };
+
+    let merchantInfoHasBeenPersisted = this.args.workflowSession.state
+      .merchantInfo;
+
+    if (merchantInfoHasBeenPersisted) {
+      let state = this.args.workflowSession.state;
+      let detailsHaveChangedSincePersistence =
+        state.merchantName !== valuesToStore.merchantName ||
+        state.merchantId !== valuesToStore.merchantId ||
+        state.merchantBgColor !== valuesToStore.merchantBgColor ||
+        state.merchantTextColor !== valuesToStore.merchantTextColor;
+
+      if (detailsHaveChangedSincePersistence) {
+        this.args.workflowSession.delete('merchantInfo');
+      }
+    }
+
+    this.args.workflowSession.updateMany(valuesToStore);
     this.args.onComplete?.();
   }
 

--- a/packages/web-client/app/models/workflow/workflow-session.ts
+++ b/packages/web-client/app/models/workflow/workflow-session.ts
@@ -18,4 +18,10 @@ export default class WorkflowSession {
     // eslint-disable-next-line no-self-assign
     this.state = this.state; // for reactivity
   }
+
+  delete(key: string) {
+    delete this.state[key];
+    // eslint-disable-next-line no-self-assign
+    this.state = this.state; // for reactivity
+  }
 }

--- a/packages/web-client/app/utils/web3-strategies/test-layer2.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer2.ts
@@ -388,6 +388,15 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
     return request?.deferred.resolve(merchantSafe);
   }
 
+  async test__simulateRegisterMerchantRejectionForAddress(
+    prepaidCardAddress: string
+  ) {
+    let request = this.registerMerchantRequests.get(prepaidCardAddress);
+    return request?.deferred.reject(
+      new Error('User rejected merchant creation')
+    );
+  }
+
   test__simulateHubAuthentication(authToken: string) {
     return this.test__deferredHubAuthentication.resolve(authToken);
   }


### PR DESCRIPTION
This addresses a bug where if a user clicked the button to create a merchant
but then rejected the request in Card Wallet, if they then changed their
merchant details and tried again, the old details would be attached to the
merchant safe. This updates the merchant customisation card to delete
a persisted merchant DID from the session if the details have changed
so a new one will be persisted in the following card.

Dealing with the [orphaned DID](https://linear.app/cardstack/issue/CS-1696/card-customisation-and-merchant-info-dids-can-be-orphaned) is out of scope for this PR.

This might produce confusion if the user goes back to edit their details but
leaves the slug the same, as it will then be invalid because the old details
have already been persisted.

The steady increase in implicit state shared between workflow cards makes
me wonder whether something like XState would be helpful here.