### PR TITLE
web: Fix withdrawal typos

### DIFF
--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
@@ -71,9 +71,11 @@ class CheckBalanceWorkflowMessage extends WorkflowPostable {
     ) {
       return `Checking your balance...
 
-It looks like you have enough ${c.layer1.nativeTokenSymbol} in you account on ${
+It looks like you have enough ${
+        c.layer1.nativeTokenSymbol
+      } in your account on ${
         c.layer1.fullName
-      }, to perform the last step of this withrawal workflow, which requires ~${formatTokenAmount(
+      } to perform the last step of this withdrawal workflow, which requires ~${formatTokenAmount(
         minimumBalanceForWithdrawalClaim
       )} ${c.layer1.nativeTokenSymbol}.`;
     } else {


### PR DESCRIPTION
I wonder if extracting these strings in an i18n fashion would make it
easier to survey at a high level to ensure consistency.