### PR TITLE
web: Convert depot to be derived from safes

### DIFF
--- a/packages/web-client/app/utils/web3-strategies/test-layer2.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer2.ts
@@ -175,7 +175,7 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
   }
 
   async viewSafes(account: string): Promise<Safe[]> {
-    return Promise.resolve(this.accountSafes.get(account)!);
+    return Promise.resolve(this.accountSafes.get(account) || []);
   }
 
   test__simulateAccountSafes(account: string, safes: Safe[]) {
@@ -278,7 +278,11 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
 
   test__simulateDepot(depot: DepotSafe | null) {
     if (depot) {
-      this.depotSafe = depot;
+      this.depotSafe = { ...depot, type: 'depot' };
+      // FIXME what if one exists? also, add wallet address as parameter?
+      this.test__simulateAccountSafes(this.walletInfo.firstAddress!, [
+        this.depotSafe,
+      ]);
       return;
     }
     this.depotSafe = null;

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/choose-balance-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/choose-balance-test.ts
@@ -55,8 +55,9 @@ module(
           },
         ],
       };
-      layer2Service.test__simulateDepot(testDepot as DepotSafe);
+      // TODO can’t call simulateDepot with no address set… require address when setting depot?
       layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
+      layer2Service.test__simulateDepot(testDepot as DepotSafe);
       await render(hbs`
         <CardPay::WithdrawalWorkflow::ChooseBalance
           @workflowSession={{this.session}}


### PR DESCRIPTION
This is a work in progress, probably the balances computed
properties can be converted as well.

This seemed to me a useful precursor to allowing a merchant safe to fund a withdrawal, as then all eligible types of safe can be chosen from in the workflow.