### PR TITLE
rename existing e-concurency tasks to use the task suffix

### DIFF
--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
@@ -104,7 +104,7 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
       let placeholderPrepaidCard = prepaidCards[0]!;
 
       let registerMerchantTaskInstance = taskFor(
-        this.layer2Network.registerMerchant
+        this.layer2Network.registerMerchantTask
       ).perform(
         placeholderPrepaidCard.address,
         workflowSession.state.merchantInfo.did,

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
@@ -135,7 +135,7 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<Workflo
     try {
       this.isUnlocking = true;
       let transactionReceipt = await taskFor(
-        this.layer1Network.approve
+        this.layer1Network.approveTask
       ).perform(this.amountAsBigNumber, this.currentTokenSymbol, (txHash) => {
         this.unlockTokensTxHash = txHash;
       });
@@ -161,7 +161,7 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<Workflo
         layer2BlockHeightBeforeBridging
       );
       let transactionReceipt = await taskFor(
-        this.layer1Network.relayTokens
+        this.layer1Network.relayTokensTask
       ).perform(
         this.currentTokenSymbol,
         layer2Address,

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
@@ -93,7 +93,7 @@ export default class CardPayPrepaidCardWorkflowPreviewComponent extends Componen
         };
       }
       let prepaidCardSafeTaskInstance = taskFor(
-        this.layer2Network.issuePrepaidCard
+        this.layer2Network.issuePrepaidCardTask
       ).perform(this.faceValue, customization.did, options);
       let prepaidCardSafe = yield race([
         prepaidCardSafeTaskInstance,

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/check-balance/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/check-balance/index.ts
@@ -24,12 +24,12 @@ export default class CardPayWithdrawalWorkflowCheckBalanceComponent extends Comp
         this.args.onComplete?.();
       });
     } else {
-      taskFor(this.waitForSufficientBalance).perform();
+      taskFor(this.waitForSufficientBalanceTask).perform();
     }
   }
 
   @task
-  *waitForSufficientBalance() {
+  *waitForSufficientBalanceTask() {
     while (!this.hasSufficientBalance) {
       yield timeout(BALANCE_CHECK_INTERVAL);
       this.layer1Network.refreshBalances();

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.ts
@@ -76,7 +76,7 @@ class CardPayWithdrawalWorkflowTokenClaimComponent extends Component<WorkflowCar
     this.errorMessage = '';
     try {
       this.isConfirming = true;
-      await taskFor(this.layer1Network.claimBridgedTokens).perform(
+      await taskFor(this.layer1Network.claimBridgedTokensTask).perform(
         this.bridgeValidationResult,
         {
           onTxHash: (txHash: string) => (this.txHash = txHash),

--- a/packages/web-client/app/services/card-customization.ts
+++ b/packages/web-client/app/services/card-customization.ts
@@ -81,11 +81,11 @@ export default class CardCustomization extends Service {
 
   async ensureCustomizationOptionsLoaded() {
     if (!this.loaded) {
-      return taskFor(this.fetchCustomizationOptions).perform();
+      return taskFor(this.fetchCustomizationOptionsTask).perform();
     }
   }
 
-  @task *fetchPatternOptions(): any {
+  @task *fetchPatternOptionsTask(): any {
     let response = yield fetch(`${config.hubURL}/api/prepaid-card-patterns`, {
       method: 'GET',
       headers: {
@@ -96,7 +96,7 @@ export default class CardCustomization extends Service {
     return _patternOptions.data.map(convertToPatternCustomizationOption);
   }
 
-  @task *fetchColorSchemeOptions(): any {
+  @task *fetchColorSchemeOptionsTask(): any {
     let response = yield fetch(
       `${config.hubURL}/api/prepaid-card-color-schemes`,
       {
@@ -136,11 +136,11 @@ export default class CardCustomization extends Service {
   }
 
   @task({ drop: true })
-  *fetchCustomizationOptions(): any {
+  *fetchCustomizationOptionsTask(): any {
     try {
       let [_colorSchemeOptions, _patternOptions] = yield all([
-        taskFor(this.fetchColorSchemeOptions).perform(),
-        taskFor(this.fetchPatternOptions).perform(),
+        taskFor(this.fetchColorSchemeOptionsTask).perform(),
+        taskFor(this.fetchPatternOptionsTask).perform(),
       ]);
 
       this.colorSchemeOptions = this.groupColors(_colorSchemeOptions);

--- a/packages/web-client/app/services/layer1-network.ts
+++ b/packages/web-client/app/services/layer1-network.ts
@@ -99,7 +99,7 @@ export default class Layer1Network
     return this.simpleEmitter.on(event, cb);
   }
 
-  @task *approve(
+  @task *approveTask(
     amount: BN,
     tokenSymbol: string,
     onTxHash: (txHash: TransactionHash) => void
@@ -110,7 +110,7 @@ export default class Layer1Network
     return txnReceipt;
   }
 
-  @task *relayTokens(
+  @task *relayTokensTask(
     tokenSymbol: string,
     destinationAddress: string,
     amount: BN,
@@ -134,7 +134,7 @@ export default class Layer1Network
     return txnHash ? this.strategy.bridgeExplorerUrl(txnHash) : undefined;
   }
 
-  @task *claimBridgedTokens(
+  @task *claimBridgedTokensTask(
     bridgeValidationResult: BridgeValidationResult,
     options?: ClaimBridgedTokensOptions
   ): TaskGenerator<TransactionReceipt> {

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -103,11 +103,11 @@ export default class Layer2Network
     return txnHash ? this.strategy.bridgeExplorerUrl(txnHash) : undefined;
   }
 
-  @task *viewSafe(address: string): TaskGenerator<Safe> {
+  @task *viewSafeTask(address: string): TaskGenerator<Safe> {
     return yield this.strategy.viewSafe(address);
   }
 
-  @task *viewSafes(account: string): TaskGenerator<Safe[]> {
+  @task *viewSafesTask(account: string): TaskGenerator<Safe[]> {
     return yield this.strategy.viewSafes(account);
   }
 
@@ -116,7 +116,7 @@ export default class Layer2Network
     walletAddress: this.walletInfo.firstAddress!,
   }));
 
-  @task *issuePrepaidCard(
+  @task *issuePrepaidCardTask(
     faceValue: number,
     customizationDid: string,
     options: IssuePrepaidCardOptions
@@ -138,7 +138,7 @@ export default class Layer2Network
     return yield this.strategy.fetchMerchantRegistrationFee();
   }
 
-  @task *registerMerchant(
+  @task *registerMerchantTask(
     prepaidCardAddress: string,
     infoDid: string,
     options: RegisterMerchantOptions


### PR DESCRIPTION
We're using the `-Task` suffix in most parts of the DApp to easily distinguish tasks from generic async functions. This PR renames remaining tasks that do not follow this convention.

Manually tried:
- Merchant creation happy path
- Deposit happy path
- Withdrawal happy path
- Prepaid card happy path
- Withdrawal balance check failure