### PR TITLE
stricter checks for auth token + validity

### DIFF
--- a/packages/web-client/app/components/card-pay/hub-authentication/index.ts
+++ b/packages/web-client/app/components/card-pay/hub-authentication/index.ts
@@ -19,8 +19,9 @@ export default class CardPayWorkflowHubAuthComponent extends Component<CardPayWo
     try {
       this.error = undefined;
       yield this.hubAuthentication.ensureAuthenticated();
-      this.args.onComplete();
+      if (this.hubAuthentication.isAuthenticated) this.args.onComplete();
     } catch (e) {
+      console.error(e);
       this.error = e;
     }
   }

--- a/packages/web-client/app/services/hub-authentication.ts
+++ b/packages/web-client/app/services/hub-authentication.ts
@@ -93,3 +93,10 @@ export default class HubAuthentication extends Service {
     }
   }
 }
+
+// DO NOT DELETE: this is how TypeScript knows how to look up your services.
+declare module '@ember/service' {
+  interface Registry {
+    'hub-authentication': HubAuthentication;
+  }
+}

--- a/packages/web-client/tests/integration/components/card-pay/hub-authentication-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/hub-authentication-test.ts
@@ -54,7 +54,7 @@ module(
 
     module('Test the sdk hub authentication calls', async function () {
       test('It shows the failure message if the signing request fails or is rejected', async function (assert) {
-        let deferred = RSVP.defer<string>();
+        let deferred = RSVP.defer<void>();
         sinon
           .stub(hubAuthentication, 'ensureAuthenticated')
           .returns(deferred.promise);
@@ -74,7 +74,7 @@ module(
       });
 
       test('It shows the successful state if authentication succeeds', async function (assert) {
-        let deferred = RSVP.defer<string>();
+        let deferred = RSVP.defer<void>();
         sinon
           .stub(hubAuthentication, 'ensureAuthenticated')
           .returns(deferred.promise);
@@ -85,7 +85,7 @@ module(
           .containsText(
             'You will receive a confirmation request from the Card Wallet app in a few moments'
           );
-        deferred.resolve('some-auth-token');
+        deferred.resolve();
         await settled();
         assert
           .dom('[data-test-boxel-action-chin]')

--- a/packages/web-client/tests/integration/components/card-pay/hub-authentication-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/hub-authentication-test.ts
@@ -23,9 +23,7 @@ module(
     setupMirage(hooks);
 
     hooks.beforeEach(async function (this: Context) {
-      hubAuthentication = this.owner.lookup(
-        'service:hub-authentication'
-      ) as HubAuthentication;
+      hubAuthentication = this.owner.lookup('service:hub-authentication');
 
       this.setProperties({
         onComplete: () => {

--- a/packages/web-client/tests/integration/components/card-pay/hub-authentication-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/hub-authentication-test.ts
@@ -85,6 +85,8 @@ module(
           .containsText(
             'You will receive a confirmation request from the Card Wallet app in a few moments'
           );
+        hubAuthentication.authToken = 'some-auth-token';
+        hubAuthentication.isAuthenticated = true;
         deferred.resolve();
         await settled();
         assert

--- a/packages/web-client/tests/unit/services/hub-authentication-test.ts
+++ b/packages/web-client/tests/unit/services/hub-authentication-test.ts
@@ -182,16 +182,10 @@ module('Unit | Service | HubAuthentication', function (hooks) {
     sinon
       .stub(layer2Service, 'checkHubAuthenticationValid')
       .returns(Promise.resolve(false));
-    let error = null;
-    try {
-      await hubAuthentication.ensureAuthenticated();
-    } catch (e) {
-      error = e;
-    }
 
-    assert.equal(
-      error.message,
-      'Failed to fetch auth token',
+    await assert.rejects(
+      hubAuthentication.ensureAuthenticated(),
+      /Failed to fetch auth token/,
       'It fails with the error message for a falsey auth token'
     );
     assert.ok(
@@ -214,16 +208,10 @@ module('Unit | Service | HubAuthentication', function (hooks) {
     sinon
       .stub(layer2Service, 'checkHubAuthenticationValid')
       .returns(Promise.resolve(false));
-    let error = null;
-    try {
-      await hubAuthentication.ensureAuthenticated();
-    } catch (e) {
-      error = e;
-    }
 
-    assert.equal(
-      error.message,
-      'A test error',
+    await assert.rejects(
+      hubAuthentication.ensureAuthenticated(),
+      /A test error/,
       'It fails with the error message from our stubbed function'
     );
     assert.ok(

--- a/packages/web-client/tests/unit/services/hub-authentication-test.ts
+++ b/packages/web-client/tests/unit/services/hub-authentication-test.ts
@@ -1,0 +1,234 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import HubAuthentication from '@cardstack/web-client/services/hub-authentication';
+import TestLayer2Web3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
+import { settled } from '@ember/test-helpers';
+
+let HUB_AUTH_TOKEN = 'HUB_AUTH_TOKEN';
+let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
+let layer2Service: TestLayer2Web3Strategy;
+let hubAuthentication: HubAuthentication;
+
+module('Unit | Service | HubAuthentication', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    // this is the condition for initializing with an authenticated state
+    // assumption made that layer2Service.checkHubAuthenticationValid returns Promise<true>
+    window.TEST__AUTH_TOKEN = HUB_AUTH_TOKEN;
+    layer2Service = this.owner.lookup('service:layer2-network').strategy;
+    layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
+  });
+
+  // Test initialization
+  test('it can initialize with an authenticated state', async function (assert) {
+    hubAuthentication = this.owner.lookup('service:hub-authentication');
+    await settled();
+
+    assert.ok(
+      hubAuthentication.authToken === HUB_AUTH_TOKEN &&
+        hubAuthentication.isAuthenticated,
+      'authenticated'
+    );
+  });
+
+  test('it can initialize with a non-authenticated state when layer 2 is not connected', async function (assert) {
+    layer2Service.test__simulateAccountsChanged([]);
+
+    assert.ok(!layer2Service.isConnected, 'Layer 2 is not connected');
+
+    hubAuthentication = this.owner.lookup('service:hub-authentication');
+    await settled();
+
+    assert.ok(
+      !hubAuthentication.authToken && !hubAuthentication.isAuthenticated,
+      'not authenticated'
+    );
+  });
+
+  test('it can initialize with a non-authenticated state when there is no initial auth token', async function (assert) {
+    window.TEST__AUTH_TOKEN = undefined;
+    hubAuthentication = this.owner.lookup('service:hub-authentication');
+    await settled();
+
+    assert.ok(
+      !hubAuthentication.authToken && !hubAuthentication.isAuthenticated,
+      'not authenticated'
+    );
+  });
+
+  test('it can initialize with a non-authenticated state when the initial auth token is not valid', async function (assert) {
+    sinon
+      .stub(layer2Service, 'checkHubAuthenticationValid')
+      .returns(Promise.resolve(false));
+    hubAuthentication = this.owner.lookup('service:hub-authentication');
+    await settled();
+
+    assert.ok(
+      !hubAuthentication.authToken && !hubAuthentication.isAuthenticated,
+      'not authenticated'
+    );
+  });
+
+  // test being able to clear auth token
+  test('its state becomes non-authenticated when the auth token is cleared', async function (assert) {
+    hubAuthentication = this.owner.lookup('service:hub-authentication');
+    await settled();
+    assert.ok(
+      hubAuthentication.authToken === HUB_AUTH_TOKEN &&
+        hubAuthentication.isAuthenticated,
+      'authenticated'
+    );
+
+    hubAuthentication.authToken = null;
+
+    assert.ok(
+      !hubAuthentication.authToken && !hubAuthentication.isAuthenticated,
+      'not authenticated'
+    );
+  });
+
+  // test ensureAuthenticated
+  test('it can reuse an existing valid auth token', async function (assert) {
+    hubAuthentication = this.owner.lookup('service:hub-authentication');
+    await settled();
+
+    assert.ok(
+      hubAuthentication.authToken === HUB_AUTH_TOKEN &&
+        hubAuthentication.isAuthenticated,
+      'authenticated'
+    );
+
+    let authenticateStub = sinon
+      .stub(layer2Service, 'authenticate')
+      .returns(Promise.resolve(HUB_AUTH_TOKEN));
+    await hubAuthentication.ensureAuthenticated();
+
+    assert.ok(authenticateStub.notCalled, 'Did not fetch a new auth token');
+    assert.ok(
+      hubAuthentication.authToken === HUB_AUTH_TOKEN &&
+        hubAuthentication.isAuthenticated,
+      'authenticated'
+    );
+  });
+
+  test('it can fetch a new auth token when an existing one is invalid', async function (assert) {
+    hubAuthentication = this.owner.lookup('service:hub-authentication');
+    await settled();
+
+    assert.ok(
+      hubAuthentication.authToken === HUB_AUTH_TOKEN &&
+        hubAuthentication.isAuthenticated,
+      'authenticated'
+    );
+
+    sinon
+      .stub(layer2Service, 'checkHubAuthenticationValid')
+      .returns(Promise.resolve(false));
+    let authenticateStub = sinon
+      .stub(layer2Service, 'authenticate')
+      .returns(Promise.resolve(HUB_AUTH_TOKEN));
+    await hubAuthentication.ensureAuthenticated();
+
+    assert.ok(
+      authenticateStub.calledOnce,
+      'Called the authenticate method to get a new auth token'
+    );
+    assert.ok(
+      hubAuthentication.authToken === HUB_AUTH_TOKEN &&
+        hubAuthentication.isAuthenticated,
+      'authenticated'
+    );
+  });
+
+  test("it can fetch a new auth token when one doesn't exist", async function (assert) {
+    window.TEST__AUTH_TOKEN = undefined;
+    hubAuthentication = this.owner.lookup('service:hub-authentication');
+    await settled();
+
+    assert.ok(
+      !hubAuthentication.authToken && !hubAuthentication.isAuthenticated,
+      'not authenticated'
+    );
+
+    let authenticateStub = sinon
+      .stub(layer2Service, 'authenticate')
+      .returns(Promise.resolve(HUB_AUTH_TOKEN));
+    await hubAuthentication.ensureAuthenticated();
+
+    assert.ok(
+      authenticateStub.calledOnce,
+      'Called the authenticate method to get a new auth token'
+    );
+    assert.ok(
+      hubAuthentication.authToken === HUB_AUTH_TOKEN &&
+        hubAuthentication.isAuthenticated,
+      'authenticated'
+    );
+  });
+
+  test('it throws an error when fetching a new auth token fails with an empty string', async function (assert) {
+    hubAuthentication = this.owner.lookup('service:hub-authentication');
+    await settled();
+
+    assert.ok(
+      hubAuthentication.authToken === HUB_AUTH_TOKEN &&
+        hubAuthentication.isAuthenticated,
+      'authenticated'
+    );
+
+    sinon.stub(layer2Service, 'authenticate').returns(Promise.resolve(''));
+    sinon
+      .stub(layer2Service, 'checkHubAuthenticationValid')
+      .returns(Promise.resolve(false));
+    let error = null;
+    try {
+      await hubAuthentication.ensureAuthenticated();
+    } catch (e) {
+      error = e;
+    }
+
+    assert.equal(
+      error.message,
+      'Failed to fetch auth token',
+      'It fails with the error message for a falsey auth token'
+    );
+    assert.ok(
+      !hubAuthentication.authToken && !hubAuthentication.isAuthenticated,
+      'not authenticated'
+    );
+  });
+
+  test('it throws an error when errors are thrown while fetching a new auth token', async function (assert) {
+    hubAuthentication = this.owner.lookup('service:hub-authentication');
+    await settled();
+
+    assert.ok(
+      hubAuthentication.authToken === HUB_AUTH_TOKEN &&
+        hubAuthentication.isAuthenticated,
+      'authenticated'
+    );
+
+    sinon.stub(layer2Service, 'authenticate').throws(new Error('A test error'));
+    sinon
+      .stub(layer2Service, 'checkHubAuthenticationValid')
+      .returns(Promise.resolve(false));
+    let error = null;
+    try {
+      await hubAuthentication.ensureAuthenticated();
+    } catch (e) {
+      error = e;
+    }
+
+    assert.equal(
+      error.message,
+      'A test error',
+      'It fails with the error message from our stubbed function'
+    );
+    assert.ok(
+      !hubAuthentication.authToken && !hubAuthentication.isAuthenticated,
+      'not authenticated'
+    );
+  });
+});


### PR DESCRIPTION
This PR:
- makes the hub auth service (and by extension the hub auth card) check whether an existing auth token is valid instead of simply returning if there is one, when `HubAuthenticationService.ensureAuthenticated` is called
- makes the return type of `HubAuthenticationService.ensureAuthenticated` void because we don't use the returned value anywhere
- makes `HubAuthenticationService.isAuthenticated` false whenever the `authToken` setter receives a falsey value