### PR TITLE
web: Add merchant safes as withdrawal source options

### DIFF
--- a/packages/web-client/app/components/card-pay/merchant-logo/index.css
+++ b/packages/web-client/app/components/card-pay/merchant-logo/index.css
@@ -1,6 +1,7 @@
 .merchant-logo {
   --merchant-logo-background: var(--boxel-blue);
   --merchant-logo-text-color: var(--boxel-light);
+  --merchant-margin-right: var(--boxel-sp-xxs);
   --logo-size: var(--boxel-icon-sm);
 
   background: var(--merchant-logo-background);
@@ -13,7 +14,7 @@
   line-height: var(--logo-size);
   width: var(--logo-size);
   height: var(--logo-size);
-  margin-right: var(--boxel-sp-xxs);
+  margin-right: var(--merchant-margin-right);
   font-size: var(--boxel-font-size-sm);
   font-weight: 600;
   border-radius: 50%;

--- a/packages/web-client/app/components/card-pay/safe-chooser-dropdown/index.css
+++ b/packages/web-client/app/components/card-pay/safe-chooser-dropdown/index.css
@@ -1,11 +1,11 @@
-.balance-chooser-dropdown {
+.safe-chooser-dropdown {
   --field-height: 3.75rem;
 
   position: relative;
   min-height: var(--field-height);
 }
 
-.balance-chooser-dropdown > .ember-power-select-trigger {
+.safe-chooser-dropdown > .ember-power-select-trigger {
   background: url('/images/icons/caret-dropdown.svg') right 1.125rem center/auto 0.5rem no-repeat;
   background-color: var(--boxel-light);
   border: 1px solid var(--boxel-purple-300);
@@ -13,12 +13,12 @@
   transition: border-color var(--boxel-transition);
 }
 
-.balance-chooser-dropdown > .ember-power-select-trigger:hover {
+.safe-chooser-dropdown > .ember-power-select-trigger:hover {
   border-color: var(--boxel-dark);
   cursor: pointer;
 }
 
-.balance-chooser-dropdown .ember-basic-dropdown-content {
+.safe-chooser-dropdown .ember-basic-dropdown-content {
   position: absolute;
   z-index: 1;
   width: 100%;
@@ -28,36 +28,35 @@
   overflow: hidden;
 }
 
-.balance-chooser-dropdown .ember-basic-dropdown-content.ember-basic-dropdown--transitioning-in {
+.safe-chooser-dropdown .ember-basic-dropdown-content.ember-basic-dropdown--transitioning-in {
   animation: drop-fade-below var(--boxel-transition);
 }
 
-.balance-chooser-dropdown .ember-basic-dropdown-content.ember-basic-dropdown--transitioning-out {
+.safe-chooser-dropdown .ember-basic-dropdown-content.ember-basic-dropdown--transitioning-out {
   animation: drop-fade-below var(--boxel-transition) reverse;
 }
 
-.balance-chooser-dropdown__option {
+.safe-chooser-dropdown__option {
   min-height: var(--field-height);
-  padding-right: var(--boxel-sp-xxl);
-  padding-left: var(--boxel-sp);
+  padding: var(--boxel-sp-xs) var(--boxel-sp-xxl) var(--boxel-sp-xs) var(--boxel-sp-xxxs);
 }
 
-.balance-chooser-dropdown__option--selected {
+.safe-chooser-dropdown__option--selected {
   background-image: url('/images/icons/checkmark.svg');
   background-repeat: no-repeat;
   background-position: right 1.125rem center;
   background-size: 0.75rem 0.75rem;
 }
 
-.ember-power-select-selected-item .balance-chooser-dropdown__option--selected {
+.ember-power-select-selected-item .safe-chooser-dropdown__option--selected {
   background-image: unset;
 }
 
-.balance-chooser-dropdown__option:hover {
+.safe-chooser-dropdown__option:hover {
   background-color: var(--boxel-light-300);
   cursor: pointer;
 }
 
-.ember-power-select-selected-item .balance-chooser-dropdown__option:hover {
+.ember-power-select-selected-item .safe-chooser-dropdown__option:hover {
   background-color: initial;
 }

--- a/packages/web-client/app/components/card-pay/safe-chooser-dropdown/index.hbs
+++ b/packages/web-client/app/components/card-pay/safe-chooser-dropdown/index.hbs
@@ -1,0 +1,21 @@
+{{#let (or @selectedSafe @safes.firstObject) as |selectedSafe|}}
+  <PowerSelect
+    class="safe-chooser-dropdown"
+    @options={{@safes}}
+    @selected={{selectedSafe}}
+    @onChange={{@onChooseSafe}}
+    @renderInPlace={{true}}
+    @eventType="click" {{!-- to prevent auto-selection of first item, as discussed at https://github.com/cardstack/cardstack/pull/2051 --}}
+    @verticalPosition="below"
+    data-test-safe-chooser-dropdown
+    ...attributes
+  as |safe|>
+    <CardPay::SafeChooserDropdown::SafeOption
+        class={{cn
+        "safe-chooser-dropdown__option"
+        safe-chooser-dropdown__option--selected=(eq safe.address selectedSafe.address)
+      }}
+      @safe={{safe}}
+    />
+  </PowerSelect>
+{{/let}}

--- a/packages/web-client/app/components/card-pay/safe-chooser-dropdown/safe-option/index.css
+++ b/packages/web-client/app/components/card-pay/safe-chooser-dropdown/safe-option/index.css
@@ -1,0 +1,36 @@
+.safe-option {
+  display: grid;
+  grid-template-columns: var(--boxel-sp-xxl) 1fr;
+  grid-template-rows: 1fr 1fr;
+  grid-template-areas:
+    "logo name-and-type"
+    "logo address";
+  font-size: var(--boxel-font-size-sm);
+}
+
+.safe-option__logo {
+  grid-area: logo;
+  justify-self: center;
+  align-self: center;
+}
+
+.safe-option__name-and-type {
+  grid-area: name-and-type;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow-x: hidden;
+}
+
+.safe-option__name {
+  font-weight: 700;
+}
+
+.safe-option__type {
+  color: var(--boxel-purple-500);
+}
+
+.safe-option__address {
+  grid-area: address;
+  font-family: var(--boxel-monospace-font-family);
+  color: var(--boxel-purple-500);
+}

--- a/packages/web-client/app/components/card-pay/safe-chooser-dropdown/safe-option/index.hbs
+++ b/packages/web-client/app/components/card-pay/safe-chooser-dropdown/safe-option/index.hbs
@@ -1,0 +1,20 @@
+<div class='safe-option' ...attributes>
+  {{#if this.data.icon}}
+    {{svg-jar this.data.icon width="20" height="20" class='safe-option__logo'}}
+  {{else}}
+    <CardPay::MerchantLogo
+      class='safe-option__logo'
+      style={{css-var merchant-margin-right=0}}
+      @name={{first-char this.data.info.name}}
+      @logoBackground={{this.data.info.backgroundColor}}
+      @logoTextColor={{this.data.info.textColor}}
+    />
+  {{/if}}
+  <div class='safe-option__name-and-type'>
+    <span class='safe-option__name'>{{this.data.info.name}}</span>
+    {{#if this.data.type}}
+      <span class='safe-option__type'>{{this.data.type}}</span>
+    {{/if}}
+  </div>
+  <div class='safe-option__address'>{{@safe.address}}</div>
+</div>

--- a/packages/web-client/app/components/card-pay/safe-chooser-dropdown/safe-option/index.ts
+++ b/packages/web-client/app/components/card-pay/safe-chooser-dropdown/safe-option/index.ts
@@ -1,0 +1,37 @@
+import Component from '@glimmer/component';
+import { MerchantInfo } from '@cardstack/web-client/resources/merchant-info';
+import { MerchantSafe, Safe } from '@cardstack/cardpay-sdk';
+import { useResource } from 'ember-resources';
+
+interface CardPaySafeChooserDropdownSafeOptionComponentArgs {
+  safe: Safe;
+}
+
+export default class CardPaySafeChooserDropdownSafeOptionComponent extends Component<CardPaySafeChooserDropdownSafeOptionComponentArgs> {
+  get data() {
+    if (this.args.safe.type === 'merchant') {
+      let merchant = this.args.safe as MerchantSafe;
+
+      return {
+        type: 'Merchant account',
+        info: useResource(this, MerchantInfo, () => ({
+          infoDID: merchant.infoDID,
+        })),
+      };
+    } else if (this.args.safe.type === 'depot') {
+      return {
+        icon: 'depot',
+        info: {
+          name: 'DEPOT',
+        },
+      };
+    } else {
+      return {
+        icon: 'question',
+        info: {
+          name: 'Unknown',
+        },
+      };
+    }
+  }
+}

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/choose-balance/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/choose-balance/index.hbs
@@ -5,8 +5,8 @@
   data-test-withdrawal-choose-balance-is-complete={{@isComplete}}
 >
   <ActionCardContainer::Section>
-    <ActionCardContainer::Section @title="Withdraw tokens">
-      <CardPay::LabeledValue @label="From:" class="choose-balance__field">
+    <ActionCardContainer::Section @title="Choose a source and balance to withdraw from">
+      <CardPay::LabeledValue @label="Source:" class="choose-balance__field">
         <CardPay::AccountDisplay @name={{concat (network-display-info "layer2" "fullName") " wallet"}} data-test-choose-balance-from-wallet />
         <CardPay::NestedItems @noInnerBorder={{not @isComplete}} class="choose-balance__nested-items">
           <:outer>
@@ -18,13 +18,21 @@
             />
           </:outer>
           <:inner>
-            <CardPay::AccountDisplay
-              @size={{if @isComplete "small"}}
-              @icon="depot"
-              @name="DEPOT:"
-              @address={{if @isComplete (truncate-middle this.depotAddress) this.depotAddress}}
-              data-test-choose-balance-from-depot
-            />
+            {{#if @isComplete}}
+              <CardPay::AccountDisplay
+                @size="small"
+                @icon={{this.selectedSafe.type}}
+                @name={{uppercase this.selectedSafe.type}}
+                @address={{truncate-middle this.selectedSafe.address}}
+              />
+            {{else}}
+              <CardPay::SafeChooserDropdown
+                @safes={{this.compatibleSafes}}
+                @selectedSafe={{this.selectedSafe}}
+                @onChooseSafe={{this.chooseSafe}}
+                data-test-choose-balance-from-safe
+              />
+            {{/if}}
           </:inner>
           <:innermost>
             {{#if @isComplete}}
@@ -42,7 +50,7 @@
                   @tokens={{this.tokens}}
                   @selectedToken={{this.selectedToken}}
                   @selectedTokenSymbol={{this.selectedTokenSymbol}}
-                  @chooseToken={{this.chooseSource}}
+                  @chooseToken={{this.chooseBalance}}
                 />
               </div>
             {{/if}}

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.css
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.css
@@ -6,6 +6,11 @@
   --field-label-width: 15%;
 }
 
+.withdrawal-transaction-amount__balance .balance-display__icon {
+  width: var(--boxel-sp-xxl);
+  margin-right: 0;
+}
+
 .withdrawal-transaction-amount__token {
   display: flex;
   align-items: center;

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
@@ -5,12 +5,21 @@
 >
   <ActionCardContainer::Section @title="Choose an amount to withdraw" @dataTestId="withdrawal-transaction-amount">
     <div class="withdrawal-transaction-amount__fields">
-      <CardPay::LabeledValue @vertical={{this.isConfirmed}} @label="Funding from" class="withdrawal-transaction-amount__label">
-        <CardPay::BalanceViewBanner
-          @walletAddress={{this.layer2Network.walletInfo.firstAddress}}
-          @depotAddress={{this.layer2Network.depotSafe.address}}
-          @token={{this.currentTokenDetails}}
+      <CardPay::LabeledValue @vertical={{this.isConfirmed}} @label="Withdrawal source" class="withdrawal-transaction-amount__label">
+        <CardPay::SafeChooserDropdown::SafeOption
+          @safe={{this.currentSafe}}
+          data-test-withdrawal-source
+        />
+      </CardPay::LabeledValue>
+      <CardPay::LabeledValue @vertical={{this.isConfirmed}} @label="Source balance" class="withdrawal-transaction-amount__label">
+        <CardPay::BalanceDisplay
+          class="withdrawal-transaction-amount__balance"
+          @size="small"
+          @icon={{this.currentTokenDetails.icon}}
+          @name={{this.currentTokenDetails.symbol}}
           @balance={{format-token-amount this.currentTokenBalance}}
+          @symbol={{this.currentTokenDetails.symbol}}
+          data-test-withdrawal-balance
         />
       </CardPay::LabeledValue>
       <CardPay::LabeledValue

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
@@ -19,6 +19,7 @@ import {
   validateTokenInput,
 } from '@cardstack/web-client/utils/validation';
 import { isLayer2UserRejectionError } from '@cardstack/web-client/utils/is-user-rejection-error';
+import { Safe } from '@cardstack/cardpay-sdk/sdk/safes';
 import { taskFor } from 'ember-concurrency-ts';
 import { task, TaskGenerator } from 'ember-concurrency';
 import { reads } from 'macro-decorators';
@@ -33,8 +34,12 @@ class CardPayWithdrawalWorkflowTransactionAmountComponent extends Component<Work
   @tracked validationMessage = '';
   @reads('withdrawTask.last.error') declare error: Error | undefined;
 
-  // assumption is this is always set by cards before it. It should be defined by the time
+  // assumption is these are always set by cards before it. They should be defined by the time
   // it gets to this part of the workflow
+  get currentSafe(): Safe {
+    return this.args.workflowSession.state.withdrawalSafe;
+  }
+
   get currentTokenSymbol(): BridgedTokenSymbol {
     return this.args.workflowSession.state.withdrawalToken;
   }
@@ -48,13 +53,16 @@ class CardPayWithdrawalWorkflowTransactionAmountComponent extends Component<Work
   }
 
   get currentTokenBalance(): BN {
-    let balance;
-    if (this.currentTokenSymbol === 'DAI.CPXD') {
-      balance = this.layer2Network.defaultTokenBalance;
-    } else if (this.currentTokenSymbol === 'CARD.CPXD') {
-      balance = this.layer2Network.cardBalance;
-    }
-    return balance || new BN(0);
+    let safe = this.currentSafe;
+    let tokenSymbol = this.currentTokenSymbol;
+    let unbridgedSymbol = getUnbridgedSymbol(tokenSymbol);
+    // SDK returns bridged token symbols without the CPXD suffix
+
+    let balance = safe.tokens.find(
+      (token) => token.token.symbol === unbridgedSymbol
+    )?.balance;
+
+    return balance ? new BN(balance) : new BN(0);
   }
 
   get amountCtaState() {
@@ -135,7 +143,7 @@ class CardPayWithdrawalWorkflowTransactionAmountComponent extends Component<Work
       assertBridgedTokenSymbol(currentTokenSymbol);
 
       let transactionHash = yield this.layer2Network.bridgeToLayer1(
-        this.layer2Network.depotSafe?.address!,
+        this.currentSafe.address,
         layer1Address!,
         getUnbridgedSymbol(currentTokenSymbol),
         withdrawnAmount

--- a/packages/web-client/app/styles/app.css
+++ b/packages/web-client/app/styles/app.css
@@ -31,3 +31,27 @@ ol {
   margin: 0;
   padding: 0;
 }
+
+@keyframes drop-fade-below {
+  0% {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes drop-fade-above {
+  0% {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/packages/web-client/tests/acceptance/withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-test.ts
@@ -144,6 +144,38 @@ module('Acceptance | withdrawal', function (hooks) {
       ],
     };
     layer2Service.test__simulateDepot(testDepot as DepotSafe);
+
+    let merchantAddress = '0xmerchantbAB0644ffCD32518eBF4924ba8666666';
+    layer2Service.test__simulateAccountSafes(layer2AccountAddress, [
+      {
+        type: 'merchant',
+        createdAt: Date.now() / 1000,
+        address: merchantAddress,
+        merchant: '0xprepaidDbAB0644ffCD32518eBF4924ba8666666',
+        tokens: [
+          {
+            balance: '125000000000000000000',
+            tokenAddress: '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1',
+            token: {
+              name: 'Dai Stablecoin.CPXD',
+              symbol: 'DAI',
+              decimals: 2,
+            },
+          },
+          {
+            balance: '450000000000000000000',
+            tokenAddress: '0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee',
+            token: {
+              name: 'CARD Token Kovan.CPXD',
+              symbol: 'CARD',
+              decimals: 2,
+            },
+          },
+        ],
+        owners: [],
+        accumulatedSpendValue: 100,
+      },
+    ]);
     layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
     await waitFor(`${postableSel(2, 2)} [data-test-balance-container]`);
     assert
@@ -168,8 +200,21 @@ module('Acceptance | withdrawal', function (hooks) {
       .dom(`${post} [data-test-balance-chooser-dropdown="DAI.CPXD"]`)
       .containsText('250.00 DAI.CPXD');
     assert
-      .dom(`${post} [data-test-choose-balance-from-depot]`)
-      .hasText(`DEPOT: ${depotAddress}`);
+      .dom(`${post} [data-test-choose-balance-from-safe]`)
+      .hasText(`DEPOT ${depotAddress}`);
+
+    await click(
+      '[data-test-safe-chooser-dropdown] .ember-power-select-trigger'
+    );
+    assert
+      .dom('[data-test-safe-chooser-dropdown] li:nth-child(1)')
+      .containsText(depotAddress);
+    assert
+      .dom('[data-test-safe-chooser-dropdown] li:nth-child(2)')
+      .containsText(merchantAddress);
+
+    await click('[data-test-safe-chooser-dropdown] li:nth-child(2)');
+
     await click(
       '[data-test-balance-chooser-dropdown] .ember-power-select-trigger'
     );
@@ -179,6 +224,9 @@ module('Acceptance | withdrawal', function (hooks) {
     assert
       .dom(`${post} li:nth-child(2) [data-test-balance-display-name]`)
       .containsText('CARD.CPXD');
+
+    await click('[data-test-balance-chooser-dropdown] li:nth-child(2)');
+
     await click(
       `${post} [data-test-withdrawal-choose-balance] [data-test-boxel-button]`
     );
@@ -190,7 +238,7 @@ module('Acceptance | withdrawal', function (hooks) {
     assert.dom('[data-test-withdrawal-choose-balance-is-complete]').exists();
     assert
       .dom(`${post} [data-test-choose-balance-from-display]`)
-      .containsText('250.00 DAI.CPXD');
+      .containsText('450.00 CARD.CPXD');
     assert.dom('[data-test-choose-balance-footnote]').containsText('gas fee');
 
     // // transaction-amount card
@@ -208,7 +256,7 @@ module('Acceptance | withdrawal', function (hooks) {
 
     assert
       .dom(`${post} [data-test-balance-display-amount]`)
-      .containsText('250.00 DAI.CPXD');
+      .containsText('450.00 CARD.CPXD');
 
     assert
       .dom(
@@ -251,7 +299,13 @@ module('Acceptance | withdrawal', function (hooks) {
         `withdrawn funds from the ${c.layer2.fullName}, your tokens will be bridged to ${c.layer1.fullName}`
       );
     await waitFor(postableSel(4, 1));
-    layer2Service.test__simulateBridgedToLayer1();
+
+    layer2Service.test__simulateBridgedToLayer1(
+      merchantAddress,
+      layer1AccountAddress,
+      'CARD',
+      toWei('200')
+    );
     await settled();
     assert
       .dom(milestoneCompletedSel(4))
@@ -286,12 +340,12 @@ module('Acceptance | withdrawal', function (hooks) {
       .dom(
         '[data-test-withdrawal-transaction-confirmed-from] [data-test-bridge-item-amount]'
       )
-      .containsText('200.00 DAI.CPXD');
+      .containsText('200.00 CARD.CPXD');
     assert
       .dom(
         '[data-test-withdrawal-transaction-confirmed-to] [data-test-bridge-item-amount]'
       )
-      .containsText('200.00 DAI');
+      .containsText('200.00 CARD');
 
     await waitFor(epiloguePostableSel(2));
     assert

--- a/packages/web-client/tests/integration/components/card-pay/safe-chooser-dropdown-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/safe-chooser-dropdown-test.ts
@@ -1,0 +1,191 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render, settled } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { Safe } from '@cardstack/cardpay-sdk/sdk/safes';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+import { MirageTestContext } from 'ember-cli-mirage/test-support';
+import { getResolver } from '@cardstack/did-resolver';
+import { Resolver } from 'did-resolver';
+
+interface Context extends MirageTestContext {
+  safes: Safe[];
+}
+
+let chosenSafe: Safe | null = null;
+
+const EXAMPLE_DID = 'did:cardstack:1moVYMRNGv6E5Ca3t7aXVD2Yb11e4e91103f084a';
+
+module(
+  'Integration | Component | card-pay/safe-chooser-dropdown',
+  function (hooks) {
+    setupRenderingTest(hooks);
+    setupMirage(hooks);
+
+    hooks.beforeEach(async function (this: Context) {
+      let resolver = new Resolver({ ...getResolver() });
+      let resolvedDID = await resolver.resolve(EXAMPLE_DID);
+      let didAlsoKnownAs = resolvedDID?.didDocument?.alsoKnownAs![0]!;
+      let customizationJsonFilename = didAlsoKnownAs
+        .split('/')[4]
+        .split('.')[0];
+
+      this.server.create('merchant-info', {
+        id: customizationJsonFilename,
+        name: 'Mandello',
+        slug: 'mandello1',
+        did: EXAMPLE_DID,
+        color: '#00ffcc',
+        'text-color': '#000000',
+        'owner-address': '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44',
+      });
+
+      this.setProperties({
+        safes: [
+          {
+            type: 'depot',
+            address: '0xB236ca8DbAB0644ffCD32518eBF4924ba8666666',
+            tokens: [
+              {
+                balance: '250000000000000000000',
+                token: {
+                  symbol: 'DAI',
+                },
+              },
+              {
+                balance: '500000000000000000000',
+                token: {
+                  symbol: 'CARD',
+                },
+              },
+            ],
+          },
+          {
+            type: 'merchant',
+            createdAt: Date.now() / 1000,
+            address: '0xmerchantbAB0644ffCD32518eBF4924ba8666666',
+            merchant: '0xprepaidDbAB0644ffCD32518eBF4924ba8666666',
+            tokens: [
+              {
+                balance: '125000000000000000000',
+                tokenAddress: '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1',
+                token: {
+                  name: 'Dai Stablecoin.CPXD',
+                  symbol: 'DAI',
+                  decimals: 2,
+                },
+              },
+              {
+                balance: '450000000000000000000',
+                tokenAddress: '0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee',
+                token: {
+                  name: 'CARD Token Kovan.CPXD',
+                  symbol: 'CARD',
+                  decimals: 2,
+                },
+              },
+            ],
+            owners: [],
+            accumulatedSpendValue: 100,
+            infoDID: EXAMPLE_DID,
+          },
+        ],
+        chooseSafe: (safe: Safe) => (chosenSafe = safe),
+      });
+    });
+
+    test('it renders choices for each passed-in safe', async function (assert) {
+      await render(hbs`
+        <CardPay::SafeChooserDropdown
+          @safes={{this.safes}}
+          @selectedSafe={{this.selectedSafe}}
+          @onChooseSafe={{this.chooseSafe}}
+        />
+      `);
+
+      await click('.ember-power-select-trigger');
+      assert.dom('.ember-power-select-options li').exists({ count: 2 });
+      await settled();
+      assert
+        .dom('.ember-power-select-options li:nth-child(1)')
+        .containsText('DEPOT 0xB236ca8DbAB0644ffCD32518eBF4924ba8666666');
+      assert
+        .dom('.ember-power-select-options li:nth-child(2)')
+        .containsText('Mandello')
+        .containsText('Merchant account')
+        .containsText('0xmerchantbAB0644ffCD32518eBF4924ba8666666');
+      assert
+        .dom(
+          '.ember-power-select-options li:nth-child(2) [data-test-merchant-logo]'
+        )
+        .containsText('M')
+        .hasAttribute('data-test-merchant-logo-background', '#00ffcc')
+        .hasAttribute('data-test-merchant-logo-text-color', '#000000');
+    });
+
+    test('it returns the chosen safe to the handler', async function (this: Context, assert) {
+      await render(hbs`
+        <CardPay::SafeChooserDropdown
+          @safes={{this.safes}}
+          @selectedSafe={{this.selectedSafe}}
+          @onChooseSafe={{this.chooseSafe}}
+        />
+    `);
+
+      await click('.ember-power-select-trigger');
+      await click('.ember-power-select-options li:nth-child(2)');
+
+      assert.equal(chosenSafe, this.safes[1]);
+    });
+
+    test('it renders with @selectedSafe chosen', async function (this: Context, assert) {
+      this.set('selectedSafe', this.safes[1]);
+      await render(hbs`
+        <CardPay::SafeChooserDropdown
+          @safes={{this.safes}}
+          @selectedSafe={{this.selectedSafe}}
+          @onChooseSafe={{this.chooseSafe}}
+        />
+      `);
+
+      assert
+        .dom('[data-test-safe-chooser-dropdown]')
+        .containsText(this.safes[1].address);
+
+      await click('.ember-power-select-trigger');
+      assert
+        .dom(
+          '.ember-power-select-options li:nth-child(2) .safe-chooser-dropdown__option--selected'
+        )
+        .exists();
+
+      this.set('selectedSafe', this.safes[0]);
+      await settled();
+
+      assert
+        .dom('[data-test-safe-chooser-dropdown]')
+        .containsText(this.safes[0].address);
+    });
+
+    test('it renders the first safe as chosen by default', async function (this: Context, assert) {
+      await render(hbs`
+        <CardPay::SafeChooserDropdown
+          @safes={{this.safes}}
+          @onChooseSafe={{this.chooseSafe}}
+        />
+      `);
+
+      assert
+        .dom('[data-test-safe-chooser-dropdown]')
+        .containsText(this.safes[0].address);
+
+      await click('.ember-power-select-trigger');
+      assert
+        .dom(
+          '.ember-power-select-options li:nth-child(1) .safe-chooser-dropdown__option--selected'
+        )
+        .exists();
+    });
+  }
+);

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
@@ -37,7 +37,7 @@ module(
       layer2Service = this.owner.lookup('service:layer2-network')
         .strategy as Layer2TestWeb3Strategy;
 
-      layer2Service.bridgeToLayer1('0xbridged', 'DAI', '20');
+      layer2Service.bridgeToLayer1('0xsource', '0xdestination', 'DAI', '20');
     });
 
     test('It renders transaction status and links', async function (assert) {


### PR DESCRIPTION
This updates the withdrawal workflow to support merchant safes as sources. While reward safes don’t yet exist in the API, this is designed with that future addition in mind.

The `choose-balance` card lists the depot and merchant safes as possible sources:

![image](https://user-images.githubusercontent.com/43280/133288052-a3d4c17a-cd23-4057-83cc-9235eea7ca59.png)

The `transaction-amount` card now shows the chosen safe and balance:

![image](https://user-images.githubusercontent.com/43280/133288205-3bfe6b54-4210-4609-a7f4-4fc4bdc14c36.png)

In contrast to my previous acceptance test approach that involves a somewhat [murky interface](https://github.com/cardstack/cardstack/blob/a0d9e4c8b030a333cab375ea6f5439b3e91550b3/packages/web-client/app/utils/web3-strategies/test-layer2.ts#L409), I added optional parameters for `test__simulateBridgedToLayer1` that cause it throw an error when no matching call to `bridgeToLayer1` was made. I’m open to suggestions on a better way to accomplish this, I just want some assurance that the correct values are getting passed along through the workflow and make it into the SDK call at the end.