### PR TITLE
web: Fix Power Select auto-choosing bug

### DIFF
--- a/packages/web-client/app/styles/app.css
+++ b/packages/web-client/app/styles/app.css
@@ -31,3 +31,11 @@ ol {
   margin: 0;
   padding: 0;
 }
+
+/*
+  Fixes a problem where Power Select would auto-choose the first item
+  https://github.com/cibernox/ember-power-select/issues/1408
+*/
+.ember-power-select-dropdown {
+  margin-top: 1px;
+}


### PR DESCRIPTION
When I run this locally, it fixes the problem where the prepaid
card chooser in the merchant creation workflow looks like
it’s not opening but is really selecting the first card and
closing.

Thanks to @johanrd for documenting and @Aierie for finding:
https://github.com/cibernox/ember-power-select/issues/1408