### PR TITLE
[CS-1495] - Update apple-app-site-association

### DIFF
--- a/packages/web-client/public/.well-known/apple-app-site-association
+++ b/packages/web-client/public/.well-known/apple-app-site-association
@@ -1,10 +1,21 @@
 {
   "applinks": {
-    "details": {
-      "appIDs: [
-        "QS5AFH4668.com.cardstack.cardpay"
-      ],
-      "paths": [ "*" ]
-    }
+    "apps": [],
+    "details": [
+      {
+        "appID": "QS5AFH4668.com.cardstack.cardpay",
+        "paths": [
+          "*"
+        ],
+        "appIDs": [
+          "QS5AFH4668.com.cardstack.cardpay"
+        ],
+        "components": [
+          {
+            "/": "/*"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
Apple changed the structure of `apple-app-site-association`, unfortunately it does not have any docs regarding this besides this [WWDC video](https://developer.apple.com/videos/play/wwdc2019/717/), the new format only supports iOS 13+, so in other to support previous versions we need to have both patterns.

`"apps": [],`, `"paths":`  and `"appID"` are for previous versions.
`"appIDs"` and `components` are for 13+ 