### PR TITLE
checks must run when yarn.lock changes

### DIFF
--- a/.github/workflows/pr-boxel.yml
+++ b/.github/workflows/pr-boxel.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - 'packages/boxel/**'
+      - '.github/workflows/pr-boxel.yml'
+      - 'package.json'
+      - 'yarn.lock'
 
 jobs:
   test:

--- a/.github/workflows/pr-cardpay-subgraph.yml
+++ b/.github/workflows/pr-cardpay-subgraph.yml
@@ -7,6 +7,8 @@ on:
       - 'packages/cardpay-subgraph/**'
       - 'packages/eslint-config/**'
       - '.github/workflows/pr-cardpay-subgraph.yml'
+      - 'package.json'
+      - 'yarn.lock'
 
 jobs:
   test:

--- a/.github/workflows/pr-did-resolver.yml
+++ b/.github/workflows/pr-did-resolver.yml
@@ -8,6 +8,8 @@ on:
       - 'packages/test-support/**'
       - 'packages/eslint-config/**'
       - '.github/workflows/pr-did-resolver.yml'
+      - 'package.json'
+      - 'yarn.lock'
 
 jobs:
   test:

--- a/.github/workflows/pr-hub.yml
+++ b/.github/workflows/pr-hub.yml
@@ -9,6 +9,8 @@ on:
       - 'packages/test-support/**'
       - 'packages/eslint-config/**'
       - '.github/workflows/hub.yml'
+      - 'package.json'
+      - 'yarn.lock'
 
 jobs:
   test:

--- a/.github/workflows/pr-web-client.yml
+++ b/.github/workflows/pr-web-client.yml
@@ -11,6 +11,8 @@ on:
       - 'packages/test-support/**'
       - 'packages/eslint-config/**'
       - '.github/workflows/pr-web-client.yml'
+      - 'package.json'
+      - 'yarn.lock'
 
 jobs:
   test:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/github": "^4.0.0",
-    "@types/console-ui": "^2.2.3",
     "@types/filenamify-url": "^1.0.1",
     "@types/json-stable-stringify": "^1.0.32",
     "@types/mkdirp": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4952,13 +4952,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/console-ui@^2.2.3":
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/@types/console-ui/-/console-ui-2.2.3.tgz#14fb18729de6820d07c9b9d81249add14a7c5eba"
-  integrity sha512-7liVkn1GHdFNiI9QQr6MJJnOFdRFsxbhyljGlrZz0pu87HNDMK8bB2ICsv5Xud73KbU0ZR+Uf9jbzVDovG9Hsw==
-  dependencies:
-    "@types/inquirer" "*"
-
 "@types/content-disposition@*":
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/@types/content-disposition/-/content-disposition-0.5.3.tgz#0aa116701955c2faa0717fc69cd1596095e49d96"
@@ -5408,14 +5401,6 @@
   resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-1.8.0.tgz#682477dbbbd07cd032731cb3b0e7eaee3d026b69"
   integrity sha512-2aoSC4UUbHDj2uCsCxcG/vRMXey/m17bC7UwitVm5hn22nI8O8Y9iDpA76Orc+DWkQ4zZrOKEshCqR/jSuXAHA==
 
-"@types/inquirer@*":
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-6.5.0.tgz#b83b0bf30b88b8be7246d40e51d32fe9d10e09be"
-  integrity sha512-rjaYQ9b9y/VFGOpqBEXRavc3jh0a+e6evAbI31tMda8VlPaSy0AZJfXsvmIe3wklc7W6C3zCSfleuMXR7NOyXw==
-  dependencies:
-    "@types/through" "*"
-    rxjs "^6.4.0"
-
 "@types/jquery@*":
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.5.5.tgz#2c63f47c9c8d96693d272f5453602afd8338c903"
@@ -5755,13 +5740,6 @@
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.7.tgz#545158342f949e8fd3bfd813224971ecddc3fac4"
   integrity sha512-0VBprVqfgFD7Ehb2vd8Lh9TG3jP98gvr8rgehQqzztZNI7o8zS8Ad4jyZneKELphpuE212D8J70LnSNQSyO6bQ==
-
-"@types/through@*":
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/@types/through/-/through-0.0.29.tgz#72943aac922e179339c651fa34a4428a4d722f93"
-  integrity sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==
-  dependencies:
-    "@types/node" "*"
 
 "@types/tmp@^0.2.0":
   version "0.2.0"


### PR DESCRIPTION
Changing the top-level yarn.lock can break any package. So it's necessary for each of these workflows to run when it changes.

This will make CI slower when changing dependencies, but there's really no finer-grained way to tell which packages need to be tested when yarn.lock changes.