### PR TITLE
drop old cards config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /node_modules
 /packages/*/node_modules
-/cards/*/node_modules
 /packages/*/dist
 /packages/*/tmp
 /packages/*/vendor
@@ -26,9 +25,6 @@ package-lock.json
 /packages/hub/**/*.js
 /packages/hub/**/*.js.map
 !/packages/hub/db/migrations/*.js
-/cards/**/*.d.ts
-/cards/**/*.js
-/cards/**/*.js.map
 
 /packages/core/**/*.d.ts
 /packages/core/**/*.js
@@ -68,9 +64,6 @@ package-lock.json
 /packages/cardpay-subgraph/abis/generated/
 /packages/cardpay-subgraph/src/generated/
 
-# generated files you may end up with if you run the cli blueprint directly
-packages/cli/node-tests/sample-cards/*/node_modules/**/*
-
 # unconventional js
 /blueprints/*/files/
 /vendor/
@@ -96,7 +89,7 @@ packages/cli/node-tests/sample-cards/*/node_modules/**/*
 /packages/**/node_modules/@cardstack/**/*.js.map
 /packages/**/node_modules/@cardstack/**/*.d.ts
 
-# firebase functions 
+# firebase functions
 /packages/firebase-functions/**/node_modules
 /packages/firebase-functions/**/build
 /packages/firebase-functions/**/*.d.ts

--- a/package.json
+++ b/package.json
@@ -82,8 +82,7 @@
     "axe-core": "4.1.4"
   },
   "workspaces": [
-    "packages/**",
-    "cards/*"
+    "packages/**"
   ],
   "private": true,
   "volta": {

--- a/scripts/find-bad-deps.js
+++ b/scripts/find-bad-deps.js
@@ -3,12 +3,9 @@
 let glob = require('glob');
 let path = require('path');
 
-let packages = glob
-  .sync('./packages/*/package.json')
-  .concat(glob.sync('./cards/*/package.json'))
-  .map((p) => {
-    return require(path.join(process.cwd(), p));
-  });
+let packages = glob.sync('./packages/*/package.json').map((p) => {
+  return require(path.join(process.cwd(), p));
+});
 
 let ownPackages = new Map();
 for (let pkg of packages) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,13 +25,9 @@
     "./packages/firebase-functions/**/*.ts",
     "./packages/hub/**/*.ts",
     "./packages/test-support/**/*.ts",
-    "./scripts/**/*.js",
-    "./cards/**/*.ts",
     "**/.eslintrc.ts"
   ],
   "exclude": [
-    "./cards/*/tmp",
-    "./cards/*/dist",
     "./packages/*/dist",
     "./packages/*/tmp",
     "./packages/*/node_modules",


### PR DESCRIPTION
This is removing vestigial references to the cards directory, in preparation for reintroducing the card handling from the ef4-refactor branch.