### PR TITLE
Prototype/fix accessing visible postables too early

### DIFF
--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
@@ -3,6 +3,7 @@
   @header="Prepaid card funding"
   @isComplete={{@isComplete}}
   {{did-insert this.prepareFaceValueOptions}}
+  data-test-face-value-card
 >
   <ActionCardContainer::Section @title="Choose the face value of your prepaid card" class="face-value-card__section">
     <div class="face-value-card__container">

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
@@ -1,6 +1,7 @@
 <ActionCardContainer
   @header="Prepaid card funding"
   @isComplete={{@isComplete}}
+  data-test-funding-source-card
 >
   <ActionCardContainer::Section>
     <ActionCardContainer::Section @title="Choose a depot and balance to fund your prepaid card">

--- a/packages/web-client/app/models/workflow/workflow-card.ts
+++ b/packages/web-client/app/models/workflow/workflow-card.ts
@@ -52,6 +52,7 @@ export class WorkflowCard extends WorkflowPostable {
   }
 
   @action async onComplete() {
+    if (this.isComplete) return;
     let checkResult = await this.check();
     if (checkResult.success) {
       // visible-postables-will-change starts test waiters in animated-workflow.ts

--- a/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
@@ -7,6 +7,11 @@ import prepaidCardColorSchemes from '../../mirage/fixture-data/prepaid-card-colo
 import prepaidCardPatterns from '../../mirage/fixture-data/prepaid-card-patterns';
 
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
+import { DepotSafe } from '@cardstack/cardpay-sdk';
+import { BN } from 'bn.js';
+import { faceValueOptions } from '@cardstack/web-client/components/card-pay/issue-prepaid-card-workflow/workflow-config';
+import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
+import { toWei } from 'web3-utils';
 
 interface Context extends MirageTestContext {}
 
@@ -88,6 +93,76 @@ module('Acceptance | issue prepaid card', function (hooks) {
       assert
         .dom('[data-test-preview] [data-test-prepaid-card-balance]')
         .hasText('§10000');
+    });
+
+    test('it allows interactivity after restoring previously saved state', async function (this: Context, assert) {
+      let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
+      const MIN_AMOUNT_TO_PASS = new BN(
+        toWei(`${Math.ceil(Math.min(...faceValueOptions) / 100)}`)
+      );
+      let layer2Service = this.owner.lookup('service:layer2-network')
+        .strategy as Layer2TestWeb3Strategy;
+      layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
+      layer2Service.test__simulateBalances({
+        defaultToken: MIN_AMOUNT_TO_PASS,
+        card: new BN('500000000000000000000'),
+      });
+      let testDepot = {
+        address: '0xB236ca8DbAB0644ffCD32518eBF4924ba8666666',
+        tokens: [
+          {
+            balance: '250000000000000000000',
+            token: {
+              symbol: 'DAI',
+            },
+          },
+          {
+            balance: '500000000000000000000',
+            token: {
+              symbol: 'CARD',
+            },
+          },
+        ],
+      };
+      layer2Service.test__simulateDepot(testDepot as DepotSafe);
+      const state = {
+        completedCardNames: ['LAYER2_CONNECT', 'LAYOUT_CUSTOMIZATION'],
+        issuerName: 'Vitalik',
+        pattern: {
+          patternUrl:
+            '/assets/images/prepaid-card-customizations/pattern-3-be5bfc96d028c4ed55a5aafca645d213.svg',
+          id: '80cb8f99-c5f7-419e-9c95-2e87a9d8db32',
+        },
+        colorScheme: {
+          patternColor: 'white',
+          textColor: 'black',
+          background: '#37EB77',
+          id: '4f219852-33ee-4e4c-81f7-76318630a423',
+        },
+      };
+
+      localStorage.setItem(
+        `workflowPersistence:123`,
+        JSON.stringify({
+          name: 'Prepaid Card Issuance',
+          state,
+        })
+      );
+
+      await visit('/card-pay/balances?flow=issue-prepaid-card&flow-id=123');
+
+      assert.dom('[data-test-milestone="0"]').exists(); // L2
+      assert.dom('[data-test-milestone="1"]').exists(); // Customize layout
+      assert.dom('[data-test-milestone="2"]').exists(); // Choose funding source
+
+      assert.dom('[data-test-funding-source-card]').exists();
+      assert.dom('[data-test-face-value-card]').doesNotExist();
+
+      await click(
+        '[data-test-funding-source-card] [data-test-boxel-action-chin] [data-test-boxel-button]'
+      );
+
+      assert.dom('[data-test-face-value-card]').exists();
     });
   });
 });


### PR DESCRIPTION
The impact of the problem addressed in https://github.com/cardstack/cardstack/pull/2050/commits/c460425f42c90c38c6c5b4b17d374beb5bb2cfa8 is janky animations, and evaluating whether a postable needs to be shown before some important state is retrieved. As postables' `includeIf`s are only evaluated once, this may lead to divergence from the intended path for a workflow