### PR TITLE
prevent autoselection of first prepaid card

### DIFF
--- a/packages/web-client/app/components/card-pay/card-picker/index.css
+++ b/packages/web-client/app/components/card-pay/card-picker/index.css
@@ -55,7 +55,6 @@
 
 .card-picker-dropdown .ember-basic-dropdown-content.ember-basic-dropdown--transitioning-in {
   animation: drop-fade-below var(--boxel-transition);
-  pointer-events: none;
 }
 
 .card-picker-dropdown .ember-basic-dropdown-content.ember-basic-dropdown--transitioning-out {

--- a/packages/web-client/app/components/card-pay/card-picker/index.hbs
+++ b/packages/web-client/app/components/card-pay/card-picker/index.hbs
@@ -6,6 +6,7 @@
   @placeholder="Select card"
   @onChange={{@chooseCard}}
   @renderInPlace={{true}}
+  @eventType="click"
   @verticalPosition="below"
   data-test-card-picker-dropdown
 as |card|>

--- a/packages/web-client/app/styles/app.css
+++ b/packages/web-client/app/styles/app.css
@@ -31,11 +31,3 @@ ol {
   margin: 0;
   padding: 0;
 }
-
-/*
-  Fixes a problem where Power Select would auto-choose the first item
-  https://github.com/cibernox/ember-power-select/issues/1408
-*/
-.ember-power-select-dropdown {
-  margin-top: 1px;
-}


### PR DESCRIPTION
This circumvents our previous problems by changing the trigger of the dropdown to a click instead - problems were caused by the mousedown event opening the dropdown, allowing elements that slid under the cursor to become the target of a click or mouseup event, and triggering click/mouseup event listeners before the user was ready to respond. For autoselection, this was a dropdown option; for difficulty opening when clicking the bottom border, this was the dropdown option container.

https://github.com/cibernox/ember-power-select/issues/1282