### PR TITLE
Extract boxel org title

### DIFF
--- a/packages/boxel/addon/components/boxel/org-header/index.css
+++ b/packages/boxel/addon/components/boxel/org-header/index.css
@@ -14,34 +14,3 @@
   background-color: var(--boxel-org-header-background-color);
   color: var(--boxel-org-header-color);
 }
-
-.boxel-org-header__title {
-  display: grid;
-  align-items: center;
-  gap: 0 3px;
-  min-height: 3.125rem; /* 50px */
-  margin: 0;
-  font: var(--boxel-font-sm);
-  font-weight: 700;
-  letter-spacing: var(--boxel-lsp-xxl);
-  text-transform: uppercase;
-}
-
-.boxel-org-header__title--has-logo {
-  grid-template-columns: auto 1fr;
-}
-
-.boxel-org-header__logo {
-  width: 3.125rem; /* 50px */
-  height: 3.125rem;
-  background-position: var(--boxel-org-header-logo-position);
-  background-repeat: no-repeat;
-  background-size: var(--boxel-org-header-logo-size);
-}
-
-.boxel-org-header__logo svg {
-  display: block;
-  margin: auto;
-  max-width: 100%;
-  max-height: 100%;
-}

--- a/packages/boxel/addon/components/boxel/org-header/index.hbs
+++ b/packages/boxel/addon/components/boxel/org-header/index.hbs
@@ -1,15 +1,13 @@
 <header class="boxel-org-header" ...attributes>
-  {{#if @title}}
-    <h1 class={{cn
-      "boxel-org-header__title"
-      boxel-org-header__title--has-logo=@iconURL
-    }}>
-      {{#if @iconURL}}
-        <span class="boxel-org-header__logo" style={{css-url "background-image" @iconURL}} />
-      {{/if}}
-      {{@title}}
-    </h1>
-  {{/if}}
+  <Boxel::OrgTitle
+    @iconURL={{@iconURL}}
+    @title={{@title}}
+    style={{css-var
+      boxel-org-title-text-color="var(--boxel-org-header-color)"
+      boxel-org-title-logo-position="var(--boxel-org-header-logo-position)"
+      boxel-org-title-logo-size="var(--boxel-org-header-logo-size)"
+    }}
+  />
 
   {{yield}}
 </header>

--- a/packages/boxel/addon/components/boxel/org-header/usage.hbs
+++ b/packages/boxel/addon/components/boxel/org-header/usage.hbs
@@ -20,6 +20,7 @@
     <Args.String
       @name="title"
       @value={{this.title}}
+      @required={{true}}
       @onInput={{fn (mut this.title)}}
     />
     <Args.String

--- a/packages/boxel/addon/components/boxel/org-header/usage.hbs
+++ b/packages/boxel/addon/components/boxel/org-header/usage.hbs
@@ -1,6 +1,10 @@
 <Freestyle::Usage @name="Boxel:OrgHeader">
   <:description>
-    Usually shown at the top of a dashboard. See also Boxel::OrgTitle
+    Usually shown at the top of a dashboard. See also
+      <LinkTo @query={{hash f=null s="Components" ss="<Boxel::OrgTitle>"}} class="doc-link">
+        Boxel::OrgTitle
+      </LinkTo>
+    which allows you to use just the title + an optional icon.
   </:description>
   <:example>
     <Boxel::OrgHeader

--- a/packages/boxel/addon/components/boxel/org-header/usage.hbs
+++ b/packages/boxel/addon/components/boxel/org-header/usage.hbs
@@ -5,7 +5,7 @@
   <:example>
     <Boxel::OrgHeader
       @title={{this.title}}
-      @logoURL={{this.logoURL}}
+      @iconURL={{this.iconURL}}
       style={{css-var
         boxel-org-header-background-color=this.backgroundColor
         boxel-org-header-color=this.color
@@ -23,9 +23,9 @@
       @onInput={{fn (mut this.title)}}
     />
     <Args.String
-      @name="logoURL"
-      @value={{this.logoURL}}
-      @onInput={{fn (mut this.logoURL)}}
+      @name="iconURL"
+      @value={{this.iconURL}}
+      @onInput={{fn (mut this.iconURL)}}
     />
     <Args.String
       @name="--boxel-org-header-background-color"

--- a/packages/boxel/addon/components/boxel/org-header/usage.ts
+++ b/packages/boxel/addon/components/boxel/org-header/usage.ts
@@ -4,7 +4,7 @@ import CRDLogo from '@cardstack/boxel/usage-support/images/orgs/crd-icon.svg';
 
 export default class BoxelOrgHeaderComponent extends Component {
   @tracked title = 'CRD Records';
-  @tracked logoURL = CRDLogo;
+  @tracked iconURL = CRDLogo;
   @tracked backgroundColor = 'var(--boxel-blue)';
   @tracked color = 'var(--boxel-light)';
   @tracked logoSize = 'auto 2rem';

--- a/packages/boxel/addon/components/boxel/org-title/index.css
+++ b/packages/boxel/addon/components/boxel/org-title/index.css
@@ -1,0 +1,31 @@
+.boxel-org-title {
+  display: grid;
+  align-items: center;
+  gap: 0 3px;
+  min-height: 3.125rem;
+  margin: 0;
+  font: var(--boxel-font-sm);
+  font-weight: 700;
+  letter-spacing: var(--boxel-lsp-xxl);
+  text-transform: uppercase;
+  color: var(--boxel-org-title-color, inherit);
+}
+
+.boxel-org-title--has-logo {
+  grid-template-columns: auto 1fr;
+}
+
+.boxel-org-title__logo {
+  width: 3.125rem;
+  height: 3.125rem;
+  background-position: var(--boxel-org-title-logo-position, center);
+  background-repeat: no-repeat;
+  background-size: var(--boxel-org-title-logo-size, 3.125rem 3.125rem);
+}
+
+.boxel-org-title__logo svg {
+  display: block;
+  margin: auto;
+  max-width: 100%;
+  max-height: 100%;
+}

--- a/packages/boxel/addon/components/boxel/org-title/index.hbs
+++ b/packages/boxel/addon/components/boxel/org-title/index.hbs
@@ -1,0 +1,12 @@
+<h1
+  class={{cn
+    "boxel-org-title"
+    boxel-org-title--has-logo=@iconURL
+  }}
+  ...attributes
+>
+  {{#if @iconURL}}
+    <span class="boxel-org-title__logo" style={{css-url "background-image" @iconURL}} />
+  {{/if}}
+  {{@title}}
+</h1>

--- a/packages/boxel/addon/components/boxel/org-title/usage.hbs
+++ b/packages/boxel/addon/components/boxel/org-title/usage.hbs
@@ -1,6 +1,10 @@
 <Freestyle::Usage @name="Boxel:OrgTitle">
   <:description>
-    Shows an organization's title +- logo/icon with some preset styling
+    Shows an organization's title +- logo/icon with some preset styling. See also
+      <LinkTo @query={{hash f=null s="Components" ss="<Boxel::OrgHeader>"}} class="doc-link">
+        Boxel::OrgHeader
+      </LinkTo>
+    which applies some built-in layout concerns.
   </:description>
   <:example>
   <div

--- a/packages/boxel/addon/components/boxel/org-title/usage.hbs
+++ b/packages/boxel/addon/components/boxel/org-title/usage.hbs
@@ -1,20 +1,22 @@
-<Freestyle::Usage @name="Boxel:OrgHeader">
+<Freestyle::Usage @name="Boxel:OrgTitle">
   <:description>
-    Usually shown at the top of a dashboard. See also Boxel::OrgTitle
+    Shows an organization's title +- logo/icon with some preset styling
   </:description>
   <:example>
-    <Boxel::OrgHeader
+  <div
+    {{!-- template-lint-disable no-inline-styles --}}
+    style="background-color: var(--boxel-blue)"
+  >
+    <Boxel::OrgTitle
       @title={{this.title}}
       @iconURL={{this.iconURL}}
       style={{css-var
-        boxel-org-header-background-color=this.backgroundColor
-        boxel-org-header-color=this.color
-        boxel-org-header-logo-size=this.logoSize
-        boxel-org-header-logo-position=this.logoPosition
+        boxel-org-title-color=this.color
+        boxel-org-title-logo-size=this.logoSize
+        boxel-org-title-logo-position=this.logoPosition
       }}
-    >
-      More Stuff Here
-    </Boxel::OrgHeader>
+    />
+  </div>
   </:example>
   <:api as |Args|>
     <Args.String
@@ -29,35 +31,25 @@
       @onInput={{fn (mut this.iconURL)}}
     />
     <Args.String
-      @name="--boxel-org-header-background-color"
-      @description="background-color CSS style"
-      @defaultValue="inherit"
-      @value={{this.backgroundColor}}
-      @onInput={{fn (mut this.backgroundColor)}}
-    />
-    <Args.String
-      @name="--boxel-org-header-color"
+      @name="--boxel-org-title-color"
       @description="color CSS style"
       @defaultValue="inherit"
       @value={{this.color}}
       @onInput={{fn (mut this.color)}}
     />
     <Args.String
-      @name="--boxel-org-header-logo-size"
+      @name="--boxel-org-title-logo-size"
       @description="background-size CSS style for the icon"
       @defaultValue="auto 2rem"
       @value={{this.logoSize}}
       @onInput={{fn (mut this.logoSize)}}
     />
     <Args.String
-      @name="--boxel-org-header-logo-position"
+      @name="--boxel-org-title-logo-position"
       @description="background-position CSS style for the icon"
       @defaultValue="center"
       @value={{this.logoPosition}}
       @onInput={{fn (mut this.logoPosition)}}
-    />
-    <Args.Yield
-      @description="Other header content"
     />
   </:api>
 </Freestyle::Usage>

--- a/packages/boxel/addon/components/boxel/org-title/usage.ts
+++ b/packages/boxel/addon/components/boxel/org-title/usage.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import CRDLogo from '@cardstack/boxel/usage-support/images/orgs/crd-icon.svg';
+
+export default class BoxelOrgTitleComponent extends Component {
+  @tracked title = 'CRD Records';
+  @tracked iconURL = CRDLogo;
+  @tracked color = '#ffffff';
+  @tracked logoSize = 'auto 2rem';
+  @tracked logoPosition = 'center';
+}

--- a/packages/boxel/tests/dummy/app/styles/app.css
+++ b/packages/boxel/tests/dummy/app/styles/app.css
@@ -1,1 +1,3 @@
-/* nothing yet */
+.doc-link {
+  text-decoration: underline;
+}


### PR DESCRIPTION
Extracts a Boxel::OrgTitle component from Boxel::OrgHeader as this is also used in a hamburger menu (see top left of each image).

![image](https://user-images.githubusercontent.com/39579264/132355461-ea25b8c9-8686-45ab-9109-0e9de9fd5346.png)


![image](https://user-images.githubusercontent.com/39579264/132355399-1783fdf3-63aa-440d-a7f6-15616f2e820d.png)

Also in the merchant payment request landing page:

![image](https://user-images.githubusercontent.com/39579264/132356443-35d4f158-711e-4f9d-aaaa-18dc3626f4dc.png)
