### PR TITLE
Simplify pr-linter-check

### DIFF
--- a/.github/workflows/pr-linter-check.yml
+++ b/.github/workflows/pr-linter-check.yml
@@ -2,7 +2,6 @@ name: CI [linter-check]
 
 on:
   pull_request:
-    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
There's no reason to limit this only to PRs targeting main. Anybody opening a PR should get linter feedback.