### PR TITLE
web: Extract CardPay::MerchantLogo component

### DIFF
--- a/packages/web-client/app/components/card-pay/merchant-logo/index.css
+++ b/packages/web-client/app/components/card-pay/merchant-logo/index.css
@@ -1,0 +1,27 @@
+.merchant-logo {
+  --merchant-logo-background: var(--boxel-blue);
+  --merchant-logo-text-color: var(--boxel-light);
+  --logo-size: var(--boxel-icon-sm);
+
+  background: var(--merchant-logo-background);
+  color: var(--merchant-logo-text-color);
+  align-self: flex-start;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  letter-spacing: -1px;
+  line-height: var(--logo-size);
+  width: var(--logo-size);
+  height: var(--logo-size);
+  margin-right: var(--boxel-sp-xxs);
+  font-size: var(--boxel-font-size-sm);
+  font-weight: 600;
+  border-radius: 50%;
+}
+
+.merchant-logo--lg {
+  --logo-size: var(--boxel-icon-xxl);
+
+  font-size: 2.8rem;
+  font-weight: 700;
+}

--- a/packages/web-client/app/components/card-pay/merchant-logo/index.hbs
+++ b/packages/web-client/app/components/card-pay/merchant-logo/index.hbs
@@ -1,0 +1,15 @@
+{{#if (first-char @name)}}
+  <div
+    class={{cn "merchant-logo" merchant-logo--lg=(eq @size "large")}}
+    style={{css-var
+      merchant-logo-background=(or @logoBackground "var(--boxel-blue)")
+      merchant-logo-text-color=(or @logoTextColor "var(--boxel-light)")
+    }}
+    data-test-merchant-logo
+    data-test-merchant-logo-background={{@logoBackground}}
+    data-test-merchant-logo-text-color={{@logoTextColor}}
+    ...attributes
+  >
+    {{first-char @name}}
+  </div>
+{{/if}}

--- a/packages/web-client/app/components/card-pay/merchant/index.css
+++ b/packages/web-client/app/components/card-pay/merchant/index.css
@@ -1,7 +1,4 @@
 .merchant {
-  --merchant-logo-background: var(--boxel-blue);
-  --merchant-logo-text-color: var(--boxel-light);
-
   display: flex;
   align-items: center;
 }
@@ -11,36 +8,10 @@
   text-align: center;
 }
 
-.merchant__logo {
-  --logo-size: var(--boxel-icon-sm);
-
-  background: var(--merchant-logo-background);
-  color: var(--merchant-logo-text-color);
-  align-self: flex-start;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  letter-spacing: -1px;
-  line-height: var(--logo-size);
-  width: var(--logo-size);
-  height: var(--logo-size);
-  margin-right: var(--boxel-sp-xxs);
-  font-size: var(--boxel-font-size-sm);
-  font-weight: 600;
-  border-radius: 50%;
-}
-
 .merchant--vertical .merchant__logo {
   margin-right: auto;
   margin-left: auto;
   margin-bottom: var(--boxel-sp-xxxs);
-}
-
-.merchant__logo--lg {
-  --logo-size: var(--boxel-icon-xxl);
-
-  font-size: 2.8rem;
-  font-weight: 700;
 }
 
 .merchant__name {

--- a/packages/web-client/app/components/card-pay/merchant/index.hbs
+++ b/packages/web-client/app/components/card-pay/merchant/index.hbs
@@ -1,19 +1,15 @@
 <div
   class={{cn "merchant" merchant--vertical=@vertical}}
-  style={{css-var
-    merchant-logo-background=(or @logoBackground "var(--boxel-blue)")
-    merchant-logo-text-color=(or @logoTextColor "var(--boxel-light)")
-  }}
   data-test-merchant={{@name}}
-  data-test-merchant-logo-background={{@logoBackground}}
-  data-test-merchant-logo-text-color={{@logoTextColor}}
   ...attributes
 >
-  {{#if (first-char @name)}}
-    <div class={{cn "merchant__logo" merchant__logo--lg=(eq @size "large")}}>
-      {{first-char @name}}
-    </div>
-  {{/if}}
+  <CardPay::MerchantLogo
+    class="merchant__logo"
+    @name={{@name}}
+    @size={{@size}}
+    @logoBackground={{@logoBackground}}
+    @logoTextColor={{@logoTextColor}}
+  />
   <div>
     <div class={{cn "merchant__name" merchant__name--lg=(eq @size "large")}}>
       {{@name}}

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
@@ -14,6 +14,7 @@ interface Context extends MirageTestContext {}
 // selectors
 let PREVIEW = '[data-test-merchant-customization-merchant-preview]';
 let MERCHANT = '[data-test-merchant]';
+let MERCHANT_LOGO = '[data-test-merchant-logo]';
 let MERCHANT_NAME_FIELD =
   '[data-test-merchant-customization-merchant-name-field]';
 let MERCHANT_ID_FIELD = '[data-test-merchant-customization-merchant-id-field]';
@@ -301,10 +302,10 @@ module(
       assert.dom(EDIT_BUTTON).exists();
       assert.dom(`${PREVIEW} ${MERCHANT}`).containsText('HELLO!');
       assert
-        .dom(`${PREVIEW} ${MERCHANT}`)
+        .dom(`${PREVIEW} ${MERCHANT_LOGO}`)
         .hasAttribute('data-test-merchant-logo-background', bgColor);
       assert
-        .dom(`${PREVIEW} ${MERCHANT}`)
+        .dom(`${PREVIEW} ${MERCHANT_LOGO}`)
         .hasAttribute('data-test-merchant-logo-text-color', textColor);
       assert
         .dom(`${PREVIEW} ${MERCHANT}`)

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
@@ -119,7 +119,9 @@ module(
         .containsText('100 SPEND');
       assert
         .dom('[data-test-merchant]')
-        .hasAttribute('data-test-merchant', 'Mandello')
+        .hasAttribute('data-test-merchant', 'Mandello');
+      assert
+        .dom('[data-test-merchant-logo]')
         .hasAttribute('data-test-merchant-logo-background', '#ff5050')
         .hasAttribute('data-test-merchant-logo-text-color', '#fff');
       assert

--- a/packages/web-client/tests/integration/components/card-pay/merchant-payment-request-card-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/merchant-payment-request-card-test.ts
@@ -7,6 +7,7 @@ import config from '@cardstack/web-client/config/environment';
 // selectors
 const BETA_ACCESS_LINK = '[data-test-payment-request-beta-access-link]';
 const MERCHANT = '[data-test-merchant]';
+const MERCHANT_LOGO = '[data-test-merchant-logo]';
 const AMOUNT = '[data-test-payment-request-amount]';
 const USD_AMOUNT = '[data-test-payment-request-usd-amount]';
 const QR_CODE = '[data-test-styled-qr-code]';
@@ -55,13 +56,13 @@ module(
         .hasAttribute('href', config.urls.testFlightLink);
       assert.dom(MERCHANT).hasAttribute('data-test-merchant', merchant.name);
       assert
-        .dom(MERCHANT)
+        .dom(MERCHANT_LOGO)
         .hasAttribute(
           'data-test-merchant-logo-background',
           merchant.logoBackground
         );
       assert
-        .dom(MERCHANT)
+        .dom(MERCHANT_LOGO)
         .hasAttribute(
           'data-test-merchant-logo-text-color',
           merchant.logoTextColor
@@ -88,13 +89,13 @@ module(
         .hasAttribute('href', config.urls.testFlightLink);
       assert.dom(MERCHANT).hasAttribute('data-test-merchant', merchant.name);
       assert
-        .dom(MERCHANT)
+        .dom(MERCHANT_LOGO)
         .hasAttribute(
           'data-test-merchant-logo-background',
           merchant.logoBackground
         );
       assert
-        .dom(MERCHANT)
+        .dom(MERCHANT_LOGO)
         .hasAttribute(
           'data-test-merchant-logo-text-color',
           merchant.logoTextColor


### PR DESCRIPTION
I need to be able to use this separately in #2038.

Left is with this change, right is `main`:

![image](https://user-images.githubusercontent.com/43280/132390711-17123224-4a09-49ae-957d-a2a9582e90ac.png)
