### PR TITLE
replace broken ts-ignores with casts

### DIFF
--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -431,11 +431,11 @@ module('Acceptance | issue prepaid card', function (hooks) {
 
     await settled();
 
-    // @ts-ignore
-    let customizationStorageRequest =
-      this.server.pretender.handledRequests.find((req: { url: string }) =>
-        req.url.includes('prepaid-card-customizations')
-      );
+    let customizationStorageRequest = (
+      this as any
+    ).server.pretender.handledRequests.find((req: { url: string }) =>
+      req.url.includes('prepaid-card-customizations')
+    );
 
     assert.equal(
       customizationStorageRequest.requestHeaders['authorization'],

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
@@ -326,11 +326,11 @@ module(
 
         await click('[data-test-create-merchant-button]');
 
-        // @ts-ignore
-        let merchantInfoStorageRequests =
-          this.server.pretender.handledRequests.filter((req: { url: string }) =>
-            req.url.includes('merchant-infos')
-          );
+        let merchantInfoStorageRequests = (
+          this as any
+        ).server.pretender.handledRequests.filter((req: { url: string }) =>
+          req.url.includes('merchant-infos')
+        );
 
         assert.equal(
           merchantInfoStorageRequests.length,


### PR DESCRIPTION
214a11a0324e04c49e50db7326cf8fc052c2d183 accidentally broke type checking because it reformatted code onto multiple lines, detaching it from the ts-ignore comments above.

These comments should really have been type casts anyway, because that is more precise and wouldn't hide unrelated problems.