### PR TITLE
Add registration functions for reward program

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -617,6 +617,23 @@
         "--mnemonic",
         "fortune reduce accuse famous fetch waste debate alcohol notice salmon wish okay"
       ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Cardpay testnet: Register Reward Program",
+      "program": "${workspaceFolder}/packages/cardpay-cli/cardpay.js",
+      "console": "integratedTerminal",
+      "env": {},
+      "args": [
+        "register-reward-program",
+        "0x36731EC6C6c10d99f09580820b8D30607A383288",
+        "0x159ADe032073d930E85f95AbBAB9995110c43C71",
+        "--network",
+        "sokol",
+        "--mnemonic",
+        "fortune reduce accuse famous fetch waste debate alcohol notice salmon wish okay"
+      ]
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -634,6 +634,23 @@
         "--mnemonic",
         "fortune reduce accuse famous fetch waste debate alcohol notice salmon wish okay"
       ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Cardpay testnet: Register Rewardee",
+      "program": "${workspaceFolder}/packages/cardpay-cli/cardpay.js",
+      "console": "integratedTerminal",
+      "env": {},
+      "args": [
+        "register-rewardee",
+        "0x36731EC6C6c10d99f09580820b8D30607A383288",
+        "0x22593fefedddafbf5b0d92ac026138f4da1e707f",
+        "--network",
+        "sokol",
+        "--mnemonic",
+        "fortune reduce accuse famous fetch waste debate alcohol notice salmon wish okay"
+      ]
     }
   ]
 }

--- a/packages/cardpay-cli/index.ts
+++ b/packages/cardpay-cli/index.ts
@@ -111,7 +111,6 @@ interface Options {
   prepaidCards?: string[];
   rewardProgramId?: string;
   admin?: string;
-  rewardProgramID?: string;
 }
 let {
   network,
@@ -144,7 +143,6 @@ let {
   hubRootUrl,
   rewardProgramId,
   admin,
-  rewardProgramID,
 } = yargs(process.argv.slice(2))
   .scriptName('cardpay')
   .usage('Usage: $0 <command> [options]')
@@ -656,12 +654,12 @@ let {
     });
     command = 'registerRewardProgram';
   })
-  .command('register-rewardee <prepaidCard> <rewardProgramID>', 'Register rewardee', (yargs) => {
+  .command('register-rewardee <prepaidCard> <rewardProgramId>', 'Register rewardee', (yargs) => {
     yargs.positional('prepaidCard', {
       type: 'string',
       description: 'The address of the prepaid card that is being used to pay the merchant',
     });
-    yargs.positional('rewardProgramID', {
+    yargs.positional('rewardProgramId', {
       type: 'string',
       description: 'Reward program id',
     });
@@ -945,15 +943,15 @@ if (!command) {
       await registerRewardProgram(network, prepaidCard, admin, mnemonic);
       break;
     case 'registerRewardee':
-      if (rewardProgramID == null) {
-        showHelpAndExit('rewardProgramID is a required value');
+      if (rewardProgramId == null) {
+        showHelpAndExit('rewardProgramId is a required value');
         return;
       }
       if (prepaidCard == null) {
         showHelpAndExit('prepaid card is a required value');
         return;
       }
-      await registerRewardee(network, prepaidCard, rewardProgramID, mnemonic);
+      await registerRewardee(network, prepaidCard, rewardProgramId, mnemonic);
       break;
     default:
       assertNever(command);

--- a/packages/cardpay-cli/index.ts
+++ b/packages/cardpay-cli/index.ts
@@ -20,7 +20,7 @@ import {
   gasFee,
   getPaymentLimits,
 } from './prepaid-card.js';
-import { registerRewardProgram } from './reward-manager';
+import { registerRewardProgram, registerRewardee } from './reward-manager';
 import { ethToUsdPrice, priceOracleUpdatedAt as layer1PriceOracleUpdatedAt } from './layer-one-oracle';
 import {
   usdPrice as layer2UsdPrice,
@@ -76,7 +76,8 @@ type Commands =
   | 'hubAuth'
   | 'rewardTokenBalances'
   | 'withdrawalLimits'
-  | 'registerRewardProgram';
+  | 'registerRewardProgram'
+  | 'registerRewardee';
 
 let command: Commands | undefined;
 interface Options {
@@ -110,6 +111,7 @@ interface Options {
   prepaidCards?: string[];
   rewardProgramId?: string;
   admin?: string;
+  rewardProgramID?: string;
 }
 let {
   network,
@@ -142,6 +144,7 @@ let {
   hubRootUrl,
   rewardProgramId,
   admin,
+  rewardProgramID,
 } = yargs(process.argv.slice(2))
   .scriptName('cardpay')
   .usage('Usage: $0 <command> [options]')
@@ -653,6 +656,17 @@ let {
     });
     command = 'registerRewardProgram';
   })
+  .command('register-rewardee <prepaidCard> <rewardProgramID>', 'Register rewardee', (yargs) => {
+    yargs.positional('prepaidCard', {
+      type: 'string',
+      description: 'The address of the prepaid card that is being used to pay the merchant',
+    });
+    yargs.positional('rewardProgramID', {
+      type: 'string',
+      description: 'Reward program id',
+    });
+    command = 'registerRewardee';
+  })
   .options({
     network: {
       alias: 'n',
@@ -929,6 +943,17 @@ if (!command) {
         return;
       }
       await registerRewardProgram(network, prepaidCard, admin, mnemonic);
+      break;
+    case 'registerRewardee':
+      if (rewardProgramID == null) {
+        showHelpAndExit('rewardProgramID is a required value');
+        return;
+      }
+      if (prepaidCard == null) {
+        showHelpAndExit('prepaid card is a required value');
+        return;
+      }
+      await registerRewardee(network, prepaidCard, rewardProgramID, mnemonic);
       break;
     default:
       assertNever(command);

--- a/packages/cardpay-cli/reward-manager.ts
+++ b/packages/cardpay-cli/reward-manager.ts
@@ -1,0 +1,18 @@
+import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
+import { getWeb3 } from './utils';
+
+export async function registerRewardProgram(
+  network: string,
+  prepaidCard: string,
+  admin: string,
+  mnemonic?: string
+): Promise<void> {
+  let web3 = await getWeb3(network, mnemonic);
+  let prepaidCardAPI = await getSDK('PrepaidCard', web3);
+  let blockExplorer = await getConstant('blockExplorer', web3);
+  console.log(`Registering reward program`);
+  await prepaidCardAPI.registerRewardProgram(prepaidCard, admin, {
+    onTxnHash: (txnHash) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),
+  });
+  console.log('done');
+}

--- a/packages/cardpay-cli/reward-manager.ts
+++ b/packages/cardpay-cli/reward-manager.ts
@@ -10,10 +10,14 @@ export async function registerRewardProgram(
   let web3 = await getWeb3(network, mnemonic);
   let prepaidCardAPI = await getSDK('PrepaidCard', web3);
   let blockExplorer = await getConstant('blockExplorer', web3);
-  console.log(`Registering reward program`);
   await prepaidCardAPI.registerRewardProgram(prepaidCard, admin, {
     onTxnHash: (txnHash) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),
   });
+  let { rewardProgramId } =
+    (await prepaidCardAPI.registerRewardProgram(prepaidCard, admin, {
+      onTxnHash: (txnHash) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),
+    })) ?? {};
+  console.log(`Registered reward program ${rewardProgramId} with admin ${admin}`);
   console.log('done');
 }
 
@@ -26,8 +30,10 @@ export async function registerRewardee(
   let web3 = await getWeb3(network, mnemonic);
   let prepaidCardAPI = await getSDK('PrepaidCard', web3);
   let blockExplorer = await getConstant('blockExplorer', web3);
-  console.log(`Registering rewardee for reward program ${rewardProgramId}`);
-  await prepaidCardAPI.registerRewardee(prepaidCard, rewardProgramId, {
-    onTxnHash: (txnHash) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),
-  });
+  let { rewardSafe } =
+    (await prepaidCardAPI.registerRewardee(prepaidCard, rewardProgramId, {
+      onTxnHash: (txnHash) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),
+    })) ?? {};
+  console.log(`Registered rewardee for reward progrm ${rewardProgramId}. Created reward safe: ${rewardSafe}`);
+  console.log('done');
 }

--- a/packages/cardpay-cli/reward-manager.ts
+++ b/packages/cardpay-cli/reward-manager.ts
@@ -20,14 +20,14 @@ export async function registerRewardProgram(
 export async function registerRewardee(
   network: string,
   prepaidCard: string,
-  rewardProgramID: string,
+  rewardProgramId: string,
   mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
   let prepaidCardAPI = await getSDK('PrepaidCard', web3);
   let blockExplorer = await getConstant('blockExplorer', web3);
-  console.log(`Registering rewardee for reward program ${rewardProgramID}`);
-  await prepaidCardAPI.registerRewardee(prepaidCard, rewardProgramID, {
+  console.log(`Registering rewardee for reward program ${rewardProgramId}`);
+  await prepaidCardAPI.registerRewardee(prepaidCard, rewardProgramId, {
     onTxnHash: (txnHash) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),
   });
 }

--- a/packages/cardpay-cli/reward-manager.ts
+++ b/packages/cardpay-cli/reward-manager.ts
@@ -16,3 +16,18 @@ export async function registerRewardProgram(
   });
   console.log('done');
 }
+
+export async function registerRewardee(
+  network: string,
+  prepaidCard: string,
+  rewardProgramID: string,
+  mnemonic?: string
+): Promise<void> {
+  let web3 = await getWeb3(network, mnemonic);
+  let prepaidCardAPI = await getSDK('PrepaidCard', web3);
+  let blockExplorer = await getConstant('blockExplorer', web3);
+  console.log(`Registering rewardee for reward program ${rewardProgramID}`);
+  await prepaidCardAPI.registerRewardee(prepaidCard, rewardProgramID, {
+    onTxnHash: (txnHash) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),
+  });
+}

--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -54,6 +54,9 @@ This is a package that provides an SDK to use the Cardpay protocol.
 - [`RewardPool`](#rewardpool)
   - [`RewardPool.rewardTokenBalance`](#rewardpoolrewardtokenbalance)
   - [`RewardPool.claim` (TBD)](#rewardpoolclaim-tbd)
+- [`RewardManager`](#rewardpool)
+  - [`RewardManager.registerRewardProgram`](#rewardmanagerregisterrewardprogram)
+  - [`RewardManager.registerRewardee` (TBD)](#rewardmanagerregisterrewardee)
 - [`LayerOneOracle`](#layeroneoracle)
   - [`LayerOneOracle.ethToUsd`](#layeroneoracleethtousd)
   - [LayerOneOracle.getEthToUsdConverter](#layeroneoraclegetethtousdconverter)
@@ -710,6 +713,30 @@ let balanceForAllTokens = await rewardPool.rewardTokenBalances(address)
 ```
 
 ### `RewardPool.claim` (TBD)
+
+## `RewardPool.addTokens` (TBD)
+
+## `RewardManager`
+
+The `RewardManager` API is used to interact to manage reward program. Those intending to offer or receive rewards have to register using this sdk. 
+
+## `RewardManager.registerRewardProgram`
+
+The `RegisterRewardProgram` API is used to register a reward program using a prepaid card. The call can specify an EOA admin account -- it defaults to the owner of the prepaid card itself. The reward program admin will then be able to manage the reward program using other api functions like`lockRewardProgram`, `addRewardRule`, etc. A fee of 500 spend is charged when registering a reward program. Currently, tally only gives rewards to a single reward program (sokol: "0x4767D0D74356433d54880Fcd7f083751d64388aF"). 
+
+```js
+let prepaidCardAPI = await getSDK('PrepaidCard', web3);
+await prepaidCardAPI.registerRewardProgram(prepaidCard, admin) 
+```
+
+## `RewardManager.registerRewardee`
+
+The `RegistereRewardee` API is used to register a rewardee for a reward program using a prepaid card. The purpose of registering is not to "be considered to receive rewards" rather to "be able to claim rewards that have been given". By registering, the owner of the prepaid card is given ownership of a reward safe that will be used to retrieve rewards from the reward pool. A rewardee/eoa is eligible to only have one reward safe for each reward program; any attempts to re-register will result in a revert error. A fee of 500 spend is charged when registering a rewardee.
+
+```js
+let prepaidCardAPI = await getSDK('PrepaidCard', web3);
+await prepaidCardAPI.registerRewardee(prepaidCard , rewardProgramId) 
+```
 
 ## `LayerOneOracle`
 The `LayerOneOracle` API is used to get the current exchange rates in USD of ETH. This rate us fed by the Chainlink price feeds. Please supply a layer 1 web3 instance obtaining an `LayerOneOracle` API from `getSDK()`.

--- a/packages/cardpay-sdk/contracts/abi/v0.8.0/reward-manager.ts
+++ b/packages/cardpay-sdk/contracts/abi/v0.8.0/reward-manager.ts
@@ -1,0 +1,779 @@
+  export default [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newAdmin",
+          "type": "address"
+        }
+      ],
+      "name": "RewardProgramAdminUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "admin",
+          "type": "address"
+        }
+      ],
+      "name": "RewardProgramCreated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        }
+      ],
+      "name": "RewardProgramLocked",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        }
+      ],
+      "name": "RewardProgramRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "ruleDID",
+          "type": "string"
+        }
+      ],
+      "name": "RewardRuleAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "ruleDID",
+          "type": "string"
+        }
+      ],
+      "name": "RewardRuleRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "oldOwner",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "RewardSafeTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "rewardee",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "rewardSafe",
+          "type": "address"
+        }
+      ],
+      "name": "RewardeeRegistered",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "Setup",
+      "type": "event"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "actionDispatcher",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "cardpayVersion",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "gnosisProxyFactory",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "gnosisSafe",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "isOwner",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "rewardFeeReceiver",
+      "outputs": [
+        {
+          "internalType": "address payable",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "rewardProgramAdmins",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "rewardProgramLocked",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "rewardProgramRegistrationFeeInSPEND",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "rewardPrograms",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "admin",
+          "type": "address"
+        },
+        {
+          "internalType": "bool",
+          "name": "locked",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "rewardSafes",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "rewardeeRegistrationFeeInSPEND",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "name": "rule",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "tallyRuleDID",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "benefitDID",
+          "type": "string"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_actionDispatcher",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_gsMasterCopy",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_gsProxyFactory",
+          "type": "address"
+        },
+        {
+          "internalType": "address payable",
+          "name": "_rewardFeeReceiver",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_rewardeeRegistrationFeeInSPEND",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_rewardProgramRegistrationFeeInSPEND",
+          "type": "uint256"
+        }
+      ],
+      "name": "setup",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "admin",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        }
+      ],
+      "name": "registerRewardProgram",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        }
+      ],
+      "name": "removeRewardProgram",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "newAdmin",
+          "type": "address"
+        }
+      ],
+      "name": "updateAdmin",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        },
+        {
+          "internalType": "string",
+          "name": "ruleDID",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "tallyRuleDID",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "benefitDID",
+          "type": "string"
+        }
+      ],
+      "name": "addRewardRule",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        },
+        {
+          "internalType": "string",
+          "name": "ruleDID",
+          "type": "string"
+        }
+      ],
+      "name": "removeRewardRule",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        }
+      ],
+      "name": "lockRewardProgram",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "prepaidCardOwner",
+          "type": "address"
+        }
+      ],
+      "name": "registerRewardee",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "address payable",
+          "name": "rewardSafe",
+          "type": "address"
+        }
+      ],
+      "name": "getRewardSafeOwner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        }
+      ],
+      "name": "isRewardProgram",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "address payable",
+          "name": "rewardSafe",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        }
+      ],
+      "name": "isValidRewardSafe",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        },
+        {
+          "internalType": "string",
+          "name": "ruleDID",
+          "type": "string"
+        }
+      ],
+      "name": "hasRule",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "rewardProgramID",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "prepaidCardOwner",
+          "type": "address"
+        }
+      ],
+      "name": "hasRewardSafe",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+

--- a/packages/cardpay-sdk/contracts/abi/v0.8.0/reward-manager.ts
+++ b/packages/cardpay-sdk/contracts/abi/v0.8.0/reward-manager.ts
@@ -1,779 +1,778 @@
-  export default [
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "previousOwner",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "newOwner",
-          "type": "address"
-        }
-      ],
-      "name": "OwnershipTransferred",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "newAdmin",
-          "type": "address"
-        }
-      ],
-      "name": "RewardProgramAdminUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "admin",
-          "type": "address"
-        }
-      ],
-      "name": "RewardProgramCreated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        }
-      ],
-      "name": "RewardProgramLocked",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        }
-      ],
-      "name": "RewardProgramRemoved",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "ruleDID",
-          "type": "string"
-        }
-      ],
-      "name": "RewardRuleAdded",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "ruleDID",
-          "type": "string"
-        }
-      ],
-      "name": "RewardRuleRemoved",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "oldOwner",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "newOwner",
-          "type": "address"
-        }
-      ],
-      "name": "RewardSafeTransferred",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "rewardee",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "rewardSafe",
-          "type": "address"
-        }
-      ],
-      "name": "RewardeeRegistered",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [],
-      "name": "Setup",
-      "type": "event"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "actionDispatcher",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "cardpayVersion",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "pure",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "gnosisProxyFactory",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "gnosisSafe",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "sender",
-          "type": "address"
-        }
-      ],
-      "name": "initialize",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "isOwner",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "owner",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [],
-      "name": "renounceOwnership",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "rewardFeeReceiver",
-      "outputs": [
-        {
-          "internalType": "address payable",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "name": "rewardProgramAdmins",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "name": "rewardProgramLocked",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "rewardProgramRegistrationFeeInSPEND",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "name": "rewardPrograms",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "admin",
-          "type": "address"
-        },
-        {
-          "internalType": "bool",
-          "name": "locked",
-          "type": "bool"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "name": "rewardSafes",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "rewardeeRegistrationFeeInSPEND",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        },
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "name": "rule",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "tallyRuleDID",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "benefitDID",
-          "type": "string"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "newOwner",
-          "type": "address"
-        }
-      ],
-      "name": "transferOwnership",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_actionDispatcher",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "_gsMasterCopy",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "_gsProxyFactory",
-          "type": "address"
-        },
-        {
-          "internalType": "address payable",
-          "name": "_rewardFeeReceiver",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "_rewardeeRegistrationFeeInSPEND",
-          "type": "uint256"
-        },
-        {
-          "internalType": "uint256",
-          "name": "_rewardProgramRegistrationFeeInSPEND",
-          "type": "uint256"
-        }
-      ],
-      "name": "setup",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "admin",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        }
-      ],
-      "name": "registerRewardProgram",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        }
-      ],
-      "name": "removeRewardProgram",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "newAdmin",
-          "type": "address"
-        }
-      ],
-      "name": "updateAdmin",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        },
-        {
-          "internalType": "string",
-          "name": "ruleDID",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "tallyRuleDID",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "benefitDID",
-          "type": "string"
-        }
-      ],
-      "name": "addRewardRule",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        },
-        {
-          "internalType": "string",
-          "name": "ruleDID",
-          "type": "string"
-        }
-      ],
-      "name": "removeRewardRule",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        }
-      ],
-      "name": "lockRewardProgram",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "prepaidCardOwner",
-          "type": "address"
-        }
-      ],
-      "name": "registerRewardee",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [
-        {
-          "internalType": "address payable",
-          "name": "rewardSafe",
-          "type": "address"
-        }
-      ],
-      "name": "getRewardSafeOwner",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        }
-      ],
-      "name": "isRewardProgram",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [
-        {
-          "internalType": "address payable",
-          "name": "rewardSafe",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        }
-      ],
-      "name": "isValidRewardSafe",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        },
-        {
-          "internalType": "string",
-          "name": "ruleDID",
-          "type": "string"
-        }
-      ],
-      "name": "hasRule",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "rewardProgramID",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "prepaidCardOwner",
-          "type": "address"
-        }
-      ],
-      "name": "hasRewardSafe",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    }
-  ]
-
+export default [
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'previousOwner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnershipTransferred',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'newAdmin',
+        type: 'address',
+      },
+    ],
+    name: 'RewardProgramAdminUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'admin',
+        type: 'address',
+      },
+    ],
+    name: 'RewardProgramCreated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+    ],
+    name: 'RewardProgramLocked',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+    ],
+    name: 'RewardProgramRemoved',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'string',
+        name: 'ruleDID',
+        type: 'string',
+      },
+    ],
+    name: 'RewardRuleAdded',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'string',
+        name: 'ruleDID',
+        type: 'string',
+      },
+    ],
+    name: 'RewardRuleRemoved',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'oldOwner',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'RewardSafeTransferred',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'rewardee',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'rewardSafe',
+        type: 'address',
+      },
+    ],
+    name: 'RewardeeRegistered',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [],
+    name: 'Setup',
+    type: 'event',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'actionDispatcher',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'cardpayVersion',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    payable: false,
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'gnosisProxyFactory',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'gnosisSafe',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+    ],
+    name: 'initialize',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'isOwner',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'owner',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [],
+    name: 'renounceOwnership',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'rewardFeeReceiver',
+    outputs: [
+      {
+        internalType: 'address payable',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'rewardProgramAdmins',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'rewardProgramLocked',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'rewardProgramRegistrationFeeInSPEND',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'rewardPrograms',
+    outputs: [
+      {
+        internalType: 'address',
+        name: 'admin',
+        type: 'address',
+      },
+      {
+        internalType: 'bool',
+        name: 'locked',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'rewardSafes',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'rewardeeRegistrationFeeInSPEND',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    name: 'rule',
+    outputs: [
+      {
+        internalType: 'string',
+        name: 'tallyRuleDID',
+        type: 'string',
+      },
+      {
+        internalType: 'string',
+        name: 'benefitDID',
+        type: 'string',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'transferOwnership',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_actionDispatcher',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_gsMasterCopy',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_gsProxyFactory',
+        type: 'address',
+      },
+      {
+        internalType: 'address payable',
+        name: '_rewardFeeReceiver',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_rewardeeRegistrationFeeInSPEND',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_rewardProgramRegistrationFeeInSPEND',
+        type: 'uint256',
+      },
+    ],
+    name: 'setup',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'admin',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+    ],
+    name: 'registerRewardProgram',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+    ],
+    name: 'removeRewardProgram',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'newAdmin',
+        type: 'address',
+      },
+    ],
+    name: 'updateAdmin',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+      {
+        internalType: 'string',
+        name: 'ruleDID',
+        type: 'string',
+      },
+      {
+        internalType: 'string',
+        name: 'tallyRuleDID',
+        type: 'string',
+      },
+      {
+        internalType: 'string',
+        name: 'benefitDID',
+        type: 'string',
+      },
+    ],
+    name: 'addRewardRule',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+      {
+        internalType: 'string',
+        name: 'ruleDID',
+        type: 'string',
+      },
+    ],
+    name: 'removeRewardRule',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+    ],
+    name: 'lockRewardProgram',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'prepaidCardOwner',
+        type: 'address',
+      },
+    ],
+    name: 'registerRewardee',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address payable',
+        name: 'rewardSafe',
+        type: 'address',
+      },
+    ],
+    name: 'getRewardSafeOwner',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+    ],
+    name: 'isRewardProgram',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address payable',
+        name: 'rewardSafe',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+    ],
+    name: 'isValidRewardSafe',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+      {
+        internalType: 'string',
+        name: 'ruleDID',
+        type: 'string',
+      },
+    ],
+    name: 'hasRule',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'prepaidCardOwner',
+        type: 'address',
+      },
+    ],
+    name: 'hasRewardSafe',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+];

--- a/packages/cardpay-sdk/contracts/addresses.ts
+++ b/packages/cardpay-sdk/contracts/addresses.ts
@@ -52,6 +52,7 @@ const SOKOL = {
   uniswapV2Router: '0xd57B4D7B7FED6b47492A362e113e26F9804DbCc6', // This is the UniswapV2Router02
   uniswapV2Factory: '0x6b67f08F08B715B162aa09239488318A660F24BF',
   rewardPool: '0x2D23acfEA32492911E8DF12E697AF0013B8D4E7b',
+  rewardManager: '0x9A89A110238201c12568f3a4a02BE5Ae63284497',
   deprecatedMerchantManager_v0_6_7: '0xA113ECa0Af275e1906d1fe1B7Bef1dDB033113E2', // eslint-disable-line @typescript-eslint/naming-convention
   oracles: {
     DAI: '0x74beF86c9d4a5b96B81D8d8e44157DFd35Eda5fB', // eslint-disable-line @typescript-eslint/naming-convention

--- a/packages/cardpay-sdk/sdk/prepaid-card/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card/base.ts
@@ -479,7 +479,7 @@ export default class PrepaidCard {
   async registerRewardProgram(txnHash: string): Promise<TransactionReceipt>;
   async registerRewardProgram(
     prepaidCardAddress: string,
-    rewardProgramID: string,
+    rewardProgramId: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
   ): Promise<TransactionReceipt>;
@@ -511,7 +511,7 @@ export default class PrepaidCard {
         )
     );
 
-    let rewardProgramID = randomHex(20);
+    let rewardProgramId = randomHex(20);
     let prepaidCardMgr = await this.getPrepaidCardMgr();
     let owner = await prepaidCardMgr.methods.getPrepaidCardOwner(prepaidCard).call();
 
@@ -524,7 +524,7 @@ export default class PrepaidCard {
         let payload = await this.getRegisterRewardProgramPayload(
           prepaidCardAddressOrTxnHash,
           admin ?? owner,
-          rewardProgramID,
+          rewardProgramId,
           REWARD_PROGRAM_REGISTRATION_FEE_IN_SPEND,
           rateLock
         );
@@ -552,7 +552,7 @@ export default class PrepaidCard {
         gnosisResult = await this.executeRegisterRewardProgram(
           prepaidCardAddressOrTxnHash,
           admin ?? owner,
-          rewardProgramID,
+          rewardProgramId,
           REWARD_PROGRAM_REGISTRATION_FEE_IN_SPEND,
           rateLock,
           payload.gasPrice,
@@ -561,7 +561,7 @@ export default class PrepaidCard {
           signatures,
           nonce
         );
-        console.log(`Reward program ${rewardProgramID} registered with admin ${admin ?? owner}`);
+        console.log(`Reward program ${rewardProgramId} registered with admin ${admin ?? owner}`);
         break;
       } catch (e: any) {
         // The rate updates about once an hour, so if this is triggered, it should only be once
@@ -596,13 +596,13 @@ export default class PrepaidCard {
   async registerRewardee(txnHash: string): Promise<TransactionReceipt>;
   async registerRewardee(
     prepaidCardAddress: string,
-    rewardProgramID: string,
+    rewardProgramId: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
   ): Promise<TransactionReceipt>;
   async registerRewardee(
     prepaidCardAddressOrTxnHash: string,
-    rewardProgramID?: string,
+    rewardProgramId?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
   ): Promise<TransactionReceipt> {
@@ -613,8 +613,8 @@ export default class PrepaidCard {
     if (!prepaidCardAddressOrTxnHash) {
       throw new Error('prepaidCardAddress is required');
     }
-    if (!rewardProgramID) {
-      throw new Error('rewardProgramID is required');
+    if (!rewardProgramId) {
+      throw new Error('rewardProgramId is required');
     }
     let prepaidCard = prepaidCardAddressOrTxnHash;
     let { nonce, onNonce, onTxnHash } = txnOptions ?? {};
@@ -639,7 +639,7 @@ export default class PrepaidCard {
       try {
         let payload = await this.getRegisterRewardeePayload(
           prepaidCardAddressOrTxnHash,
-          rewardProgramID,
+          rewardProgramId,
           REWARD_PROGRAM_REGISTRATION_FEE_IN_SPEND,
           rateLock
         );
@@ -666,7 +666,7 @@ export default class PrepaidCard {
         );
         gnosisResult = await this.executeRegisterRewardee(
           prepaidCardAddressOrTxnHash,
-          rewardProgramID,
+          rewardProgramId,
           REWARDEE_REGISTRATION_FEE_IN_SPEND,
           rateLock,
           payload.gasPrice,
@@ -676,7 +676,7 @@ export default class PrepaidCard {
           nonce
         );
         let rewardSafeAddress = await this.getRewardSafeFromTxn(gnosisResult.ethereumTx.txHash);
-        console.log(`Rewardee registered for ${rewardProgramID} with reward safe ${rewardSafeAddress}`);
+        console.log(`Rewardee registered for ${rewardProgramId} with reward safe ${rewardSafeAddress}`);
         break;
       } catch (e: any) {
         // The rate updates about once an hour, so if this is triggered, it should only be once
@@ -860,7 +860,7 @@ export default class PrepaidCard {
   private async getRegisterRewardProgramPayload(
     prepaidCardAddress: string,
     admin: string,
-    rewardProgramID: string,
+    rewardProgramId: string,
     spendAmount: number,
     rate: string
   ): Promise<SendPayload> {
@@ -870,13 +870,13 @@ export default class PrepaidCard {
       spendAmount,
       rate,
       'registerRewardProgram',
-      this.layer2Web3.eth.abi.encodeParameters(['address', 'address'], [admin, rewardProgramID])
+      this.layer2Web3.eth.abi.encodeParameters(['address', 'address'], [admin, rewardProgramId])
     );
   }
 
   private async getRegisterRewardeePayload(
     prepaidCardAddress: string,
-    rewardProgramID: string,
+    rewardProgramId: string,
     spendAmount: number,
     rate: string
   ): Promise<SendPayload> {
@@ -886,7 +886,7 @@ export default class PrepaidCard {
       spendAmount,
       rate,
       'registerRewardee',
-      this.layer2Web3.eth.abi.encodeParameters(['address'], [rewardProgramID])
+      this.layer2Web3.eth.abi.encodeParameters(['address'], [rewardProgramId])
     );
   }
 
@@ -964,7 +964,7 @@ export default class PrepaidCard {
   private async executeRegisterRewardProgram(
     prepaidCardAddress: string,
     admin: string,
-    rewardProgramID: string,
+    rewardProgramId: string,
     spendAmount: number,
     rate: string,
     gasPrice: string,
@@ -982,7 +982,7 @@ export default class PrepaidCard {
       safeTxGas,
       dataGas,
       'registerRewardProgram',
-      this.layer2Web3.eth.abi.encodeParameters(['address', 'address'], [admin, rewardProgramID]),
+      this.layer2Web3.eth.abi.encodeParameters(['address', 'address'], [admin, rewardProgramId]),
       signatures,
       nonce
     );
@@ -990,7 +990,7 @@ export default class PrepaidCard {
 
   private async executeRegisterRewardee(
     prepaidCardAddress: string,
-    rewardProgramID: string,
+    rewardProgramId: string,
     spendAmount: number,
     rate: string,
     gasPrice: string,
@@ -1008,7 +1008,7 @@ export default class PrepaidCard {
       safeTxGas,
       dataGas,
       'registerRewardee',
-      this.layer2Web3.eth.abi.encodeParameters(['address'], [rewardProgramID]),
+      this.layer2Web3.eth.abi.encodeParameters(['address'], [rewardProgramId]),
       signatures,
       nonce
     );
@@ -1062,7 +1062,7 @@ export default class PrepaidCard {
       abis: [
         {
           type: 'address',
-          name: 'rewardProgramID',
+          name: 'rewardProgramId',
         },
         {
           type: 'address',

--- a/packages/cardpay-sdk/sdk/prepaid-card/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card/base.ts
@@ -1,6 +1,6 @@
 import BN from 'bn.js';
 import Web3 from 'web3';
-import { AbiItem, randomHex } from 'web3-utils';
+import { AbiItem, randomHex, toChecksumAddress } from 'web3-utils';
 import { Contract, ContractOptions } from 'web3-eth-contract';
 import ERC677ABI from '../../contracts/abi/erc-677';
 import GnosisSafeABI from '../../contracts/abi/gnosis-safe';
@@ -511,7 +511,7 @@ export default class PrepaidCard {
         )
     );
 
-    let rewardProgramId = randomHex(20);
+    let rewardProgramId = toChecksumAddress(randomHex(20));
     let prepaidCardMgr = await this.getPrepaidCardMgr();
     let owner = await prepaidCardMgr.methods.getPrepaidCardOwner(prepaidCard).call();
 

--- a/packages/cardpay-sdk/sdk/prepaid-card/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card/base.ts
@@ -1,6 +1,6 @@
 import BN from 'bn.js';
 import Web3 from 'web3';
-import { AbiItem, randomHex, toChecksumAddress } from 'web3-utils';
+import { AbiItem } from 'web3-utils';
 import { Contract, ContractOptions } from 'web3-eth-contract';
 import ERC677ABI from '../../contracts/abi/erc-677';
 import GnosisSafeABI from '../../contracts/abi/gnosis-safe';
@@ -487,7 +487,8 @@ export default class PrepaidCard {
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
   ): Promise<{ rewardProgramId: string; txReceipt: TransactionReceipt }> {
-    let rewardProgramId = toChecksumAddress(randomHex(20));
+    let rewardManager = await getSDK('RewardManager', this.layer2Web3);
+    let rewardProgramId = await rewardManager.newRewardProgramId();
     if (isTransactionHash(prepaidCardAddressOrTxnHash)) {
       let txnHash = prepaidCardAddressOrTxnHash;
       return {
@@ -501,7 +502,6 @@ export default class PrepaidCard {
     let prepaidCardAddress = prepaidCardAddressOrTxnHash;
     let { nonce, onNonce, onTxnHash } = txnOptions ?? {};
     let from = contractOptions?.from ?? (await this.layer2Web3.eth.getAccounts())[0];
-    let rewardManager = await getSDK('RewardManager', this.layer2Web3);
     let rewardProgramRegistrationFees = await rewardManager.getRewardProgramRegistrationFees();
     await this.convertFromSpendForPrepaidCard(
       prepaidCardAddress,

--- a/packages/cardpay-sdk/sdk/prepaid-card/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card/base.ts
@@ -1,6 +1,6 @@
 import BN from 'bn.js';
 import Web3 from 'web3';
-import { AbiItem } from 'web3-utils';
+import { AbiItem, randomHex } from 'web3-utils';
 import { Contract, ContractOptions } from 'web3-eth-contract';
 import ERC677ABI from '../../contracts/abi/erc-677';
 import GnosisSafeABI from '../../contracts/abi/gnosis-safe';
@@ -34,6 +34,7 @@ const TIMEOUT = 1000 * 60 * 5;
 // stay below the AML limit of $10,000 USD.
 export const MAXIMUM_PAYMENT_AMOUNT = 10000 * 100;
 export const MAX_PREPAID_CARD_AMOUNT = 10;
+const REWARD_PROGRAM_REGISTRATION_FEE_IN_SPEND = 500;
 
 export default class PrepaidCard {
   private prepaidCardManager: Contract | undefined;
@@ -474,6 +475,123 @@ export default class PrepaidCard {
     };
   }
 
+  async registerRewardProgram(txnHash: string): Promise<TransactionReceipt>;
+  async registerRewardProgram(
+    prepaidCardAddress: string,
+    admin: string,
+    txnOptions?: TransactionOptions,
+    contractOptions?: ContractOptions
+  ): Promise<TransactionReceipt>;
+  async registerRewardProgram(
+    prepaidCardAddressOrTxnHash: string,
+    admin?: string,
+    txnOptions?: TransactionOptions,
+    contractOptions?: ContractOptions
+  ): Promise<TransactionReceipt> {
+    if (isTransactionHash(prepaidCardAddressOrTxnHash)) {
+      let txnHash = prepaidCardAddressOrTxnHash;
+      return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+    }
+    if (!prepaidCardAddressOrTxnHash) {
+      throw new Error('prepaidCardAddress is required');
+    }
+    let prepaidCard = prepaidCardAddressOrTxnHash;
+    let { nonce, onNonce, onTxnHash } = txnOptions ?? {};
+    let from = contractOptions?.from ?? (await this.layer2Web3.eth.getAccounts())[0];
+    let issuingToken = await this.issuingToken(prepaidCardAddressOrTxnHash);
+    await this.convertFromSpendForPrepaidCard(
+      prepaidCardAddressOrTxnHash,
+      REWARD_PROGRAM_REGISTRATION_FEE_IN_SPEND,
+      (issuingToken, balanceAmount, requiredTokenAmount, symbol) =>
+        new Error(
+          `Prepaid card does not have enough balance to register reward program. The issuing token ${issuingToken} balance of prepaid card ${prepaidCardAddressOrTxnHash} is ${fromWei(
+            balanceAmount
+          )} ${symbol}, payment amount in issuing token is ${fromWei(requiredTokenAmount)} ${symbol}`
+        )
+    );
+
+    let rewardProgramID = randomHex(20);
+    let prepaidCardMgr = await this.getPrepaidCardMgr();
+    let owner = await prepaidCardMgr.methods.getPrepaidCardOwner(prepaidCard).call();
+
+    let rateChanged = false;
+    let layerTwoOracle = await getSDK('LayerTwoOracle', this.layer2Web3);
+    let gnosisResult: GnosisExecTx | undefined;
+    do {
+      let rateLock = await layerTwoOracle.getRateLock(issuingToken);
+      try {
+        let payload = await this.getRegisterRewardProgramPayload(
+          prepaidCardAddressOrTxnHash,
+          admin ?? owner,
+          rewardProgramID,
+          REWARD_PROGRAM_REGISTRATION_FEE_IN_SPEND,
+          rateLock
+        );
+        if (nonce == null) {
+          nonce = getNextNonceFromEstimate(payload);
+          if (typeof onNonce === 'function') {
+            onNonce(nonce);
+          }
+        }
+        let signatures = await signSafeTxAsRSV(
+          this.layer2Web3,
+          issuingToken,
+          0,
+          payload.data,
+          0,
+          payload.safeTxGas,
+          payload.dataGas,
+          payload.gasPrice,
+          payload.gasToken,
+          payload.refundReceiver,
+          nonce,
+          from,
+          prepaidCardAddressOrTxnHash
+        );
+        gnosisResult = await this.executeRegisterRewardProgram(
+          prepaidCardAddressOrTxnHash,
+          admin ?? owner,
+          rewardProgramID,
+          REWARD_PROGRAM_REGISTRATION_FEE_IN_SPEND,
+          rateLock,
+          payload.gasPrice,
+          payload.safeTxGas,
+          payload.dataGas,
+          signatures,
+          nonce
+        );
+        console.log(`Reward program ${rewardProgramID} registered with admin ${admin ?? owner}`);
+        break;
+      } catch (e: any) {
+        // The rate updates about once an hour, so if this is triggered, it should only be once
+        if (e.message.includes('rate is beyond the allowable bounds')) {
+          rateChanged = true;
+          // TODO in this situation we should surface a message to the user that
+          // the rate has changed and that we need to try again with a new rate
+          console.warn(
+            'The USD rate has fluctuated beyond allowable bounds between when the txn was signed and when it was executed, prompting the user to sign the txn again with a new rate'
+          );
+        } else {
+          throw e;
+        }
+      }
+    } while (rateChanged);
+
+    if (!gnosisResult) {
+      throw new Error(
+        `Unable to obtain a gnosis transaction result for merchant payment from prepaid card ${prepaidCardAddressOrTxnHash} to merchant safe ${prepaidCard} for ${REWARD_PROGRAM_REGISTRATION_FEE_IN_SPEND} SPEND`
+      );
+    }
+
+    let txnHash = gnosisResult.ethereumTx.txHash;
+
+    if (typeof onTxnHash === 'function') {
+      await onTxnHash(txnHash);
+    }
+
+    return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+  }
+
   async convertFromSpendForPrepaidCard(
     prepaidCardAddress: string,
     minimumSpendBalance: number,
@@ -617,6 +735,23 @@ export default class PrepaidCard {
     );
   }
 
+  private async getRegisterRewardProgramPayload(
+    prepaidCardAddress: string,
+    admin: string,
+    rewardProgramID: string,
+    spendAmount: number,
+    rate: string
+  ): Promise<SendPayload> {
+    return getSendPayload(
+      this.layer2Web3,
+      prepaidCardAddress,
+      spendAmount,
+      rate,
+      'registerRewardProgram',
+      this.layer2Web3.eth.abi.encodeParameters(['address', 'address'], [admin, rewardProgramID])
+    );
+  }
+
   private async executePayMerchant(
     prepaidCardAddress: string,
     merchantSafe: string,
@@ -683,6 +818,33 @@ export default class PrepaidCard {
       payload,
       'transfer',
       this.layer2Web3.eth.abi.encodeParameters(['address', 'bytes'], [newOwner, previousOwnerSignature]),
+      signatures,
+      nonce
+    );
+  }
+
+  private async executeRegisterRewardProgram(
+    prepaidCardAddress: string,
+    admin: string,
+    rewardProgramID: string,
+    spendAmount: number,
+    rate: string,
+    gasPrice: string,
+    safeTxGas: string,
+    dataGas: string,
+    signatures: Signature[],
+    nonce: BN
+  ): Promise<GnosisExecTx> {
+    return await executeSend(
+      this.layer2Web3,
+      prepaidCardAddress,
+      spendAmount,
+      rate,
+      gasPrice,
+      safeTxGas,
+      dataGas,
+      'registerRewardProgram',
+      this.layer2Web3.eth.abi.encodeParameters(['address', 'address'], [admin, rewardProgramID]),
       signatures,
       nonce
     );

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -1,0 +1,30 @@
+import Web3 from 'web3';
+import RewardManagerABI from '../../contracts/abi/v0.8.0/reward-manager';
+import { Contract } from 'web3-eth-contract';
+import { getAddress } from '../../contracts/addresses';
+import { AbiItem } from 'web3-utils';
+
+export default class RewardManager {
+  private rewardManager: Contract | undefined;
+
+  constructor(private layer2Web3: Web3) {}
+
+  async getRewardProgramRegistrationFees(): Promise<number> {
+      return Number(await (await this.getRewardManager()).methods.rewardProgramRegistrationFeeInSPEND().call());
+  }
+
+  async getRewardeeRegistrationFees(): Promise<number> {
+      return Number(await (await this.getRewardManager()).methods.rewardeeRegistrationFeeInSPEND().call());
+  }
+
+  private async getRewardManager(): Promise<Contract> {
+    if (this.rewardManager) {
+      return this.rewardManager;
+    }
+    this.rewardManager = new this.layer2Web3.eth.Contract(
+      RewardManagerABI as AbiItem[],
+      await getAddress('rewardManager', this.layer2Web3)
+    );
+    return this.rewardManager;
+  }
+}

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -2,7 +2,7 @@ import Web3 from 'web3';
 import RewardManagerABI from '../../contracts/abi/v0.8.0/reward-manager';
 import { Contract } from 'web3-eth-contract';
 import { getAddress } from '../../contracts/addresses';
-import { AbiItem } from 'web3-utils';
+import { AbiItem, randomHex, toChecksumAddress } from 'web3-utils';
 
 export default class RewardManager {
   private rewardManager: Contract | undefined;
@@ -10,11 +10,25 @@ export default class RewardManager {
   constructor(private layer2Web3: Web3) {}
 
   async getRewardProgramRegistrationFees(): Promise<number> {
-      return Number(await (await this.getRewardManager()).methods.rewardProgramRegistrationFeeInSPEND().call());
+    return Number(await (await this.getRewardManager()).methods.rewardProgramRegistrationFeeInSPEND().call());
   }
 
   async getRewardeeRegistrationFees(): Promise<number> {
-      return Number(await (await this.getRewardManager()).methods.rewardeeRegistrationFeeInSPEND().call());
+    return Number(await (await this.getRewardManager()).methods.rewardeeRegistrationFeeInSPEND().call());
+  }
+
+  async isRewardProgram(rewardProgramId: string): Promise<boolean> {
+    return (await this.getRewardManager()).methods.isRewardProgram(rewardProgramId).call();
+  }
+
+  async newRewardProgramId(): Promise<string> {
+    let rewardProgramIdExists: boolean;
+    let rewardProgramId: string;
+    do {
+      rewardProgramId = toChecksumAddress(randomHex(20));
+      rewardProgramIdExists = await this.isRewardProgram(rewardProgramId);
+    } while (rewardProgramIdExists);
+    return rewardProgramId;
   }
 
   private async getRewardManager(): Promise<Contract> {

--- a/packages/cardpay-sdk/sdk/reward-manager/index.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/index.ts
@@ -1,0 +1,16 @@
+
+/* eslint @typescript-eslint/naming-convention: "off" */
+
+import { ContractMeta } from '../version-resolver';
+
+import v0_8_0 from './v0.8.0';
+
+
+// add more versions as we go, but also please do drop version that we don't
+// want to maintain simultaneously
+export type RewardManager = v0_8_0;
+
+export const rewardManagerMeta = {
+  apiVersions: { v0_8_0 },
+  contractName: 'rewardManager',
+} as ContractMeta;

--- a/packages/cardpay-sdk/sdk/reward-manager/index.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/index.ts
@@ -1,10 +1,8 @@
-
 /* eslint @typescript-eslint/naming-convention: "off" */
 
 import { ContractMeta } from '../version-resolver';
 
 import v0_8_0 from './v0.8.0';
-
 
 // add more versions as we go, but also please do drop version that we don't
 // want to maintain simultaneously

--- a/packages/cardpay-sdk/sdk/reward-manager/v0.8.0.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/v0.8.0.ts
@@ -1,0 +1,3 @@
+import Base from './base';
+
+export default class RewardManager extends Base {}

--- a/packages/cardpay-sdk/sdk/version-resolver.ts
+++ b/packages/cardpay-sdk/sdk/version-resolver.ts
@@ -13,6 +13,7 @@ import TokenBridgeHomeSide from './token-bridge-home-side';
 import TokenBridgeForeignSide from './token-bridge-foreign-side';
 import { revenuePoolMeta, RevenuePool } from './revenue-pool';
 import { rewardPoolMeta, RewardPool } from './reward-pool';
+import { rewardManagerMeta, RewardManager } from './reward-manager';
 import HubAuth from './hub-auth';
 
 type SDK =
@@ -26,7 +27,9 @@ type SDK =
   | 'HubAuth'
   | 'TokenBridgeHomeSide'
   | 'TokenBridgeForeignSide'
-  | 'RewardPool';
+  | 'RewardPool'
+  | 'RewardManager';
+
 type MapReturnType<T> = T extends 'Assets'
   ? Assets
   : T extends 'HubAuth'
@@ -43,6 +46,8 @@ type MapReturnType<T> = T extends 'Assets'
   ? RevenuePool
   : T extends 'RewardPool'
   ? RewardPool
+  : T extends 'RewardManager'
+  ? RewardManager
   : T extends 'Safes'
   ? Safes
   : T extends 'TokenBridgeHomeSide'
@@ -100,6 +105,9 @@ export async function getSDK<T extends SDK>(sdk: T, ...args: any[]): Promise<Map
       break;
     case 'RewardPool':
       apiClass = await resolveApiVersion(rewardPoolMeta, web3);
+      break;
+    case 'RewardManager':
+      apiClass = await resolveApiVersion(rewardManagerMeta, web3);
       break;
     case 'Safes':
       apiClass = await resolveApiVersion(safesMeta, web3);


### PR DESCRIPTION
Added two functions: `RegisterRewardProgram` and `RegisterRewardee`

- The `RegisterRewardProgram` API is used to register a reward program using a prepaid card. The call can specify an EOA admin account -- it defaults to the owner of the prepaid card itself. The reward program admin will then be able to manage the reward program using other api functions like`lockRewardProgram`, `addRewardRule`, etc. A fee of 500 spend is charged when registering a reward program. Currently, tally only gives rewards to a single reward program (sokol: "0x4767D0D74356433d54880Fcd7f083751d64388aF"). 

- The `RegistereRewardee` API is used to register a rewardee for a reward program using a prepaid card. The purpose of registering is not to "be considered to receive rewards" rather to "be able to claim rewards that have been given". By registering, the owner of the prepaid card is given ownership of a reward safe that will be used to retrieve rewards from the reward pool. A rewardee/eoa is eligible to only have one reward safe for each reward program; any attempts to re-register will result in a revert error. A fee of 500 spend is charged when registering a rewardee.

Demo: https://www.loom.com/share/1540ea3042814576868e5a46842c248c