### PR TITLE
using generics to type our getSDK() function

### DIFF
--- a/packages/cardpay-cli/assets.ts
+++ b/packages/cardpay-cli/assets.ts
@@ -1,4 +1,4 @@
-import { getConstantByNetwork, getSDK, ERC20ABI } from '@cardstack/cardpay-sdk';
+import { getConstantByNetwork, getSDK, ERC20ABI, Assets } from '@cardstack/cardpay-sdk';
 import { AbiItem } from 'web3-utils';
 import { getWeb3 } from './utils';
 
@@ -8,7 +8,7 @@ export const viewTokenBalance = async (
   mnemonic?: string
 ): Promise<void> => {
   let web3 = await getWeb3(network, mnemonic);
-  let assets = await getSDK('Assets', web3);
+  let assets = await getSDK<Assets>('Assets', web3);
 
   if (!tokenAddress) {
     const nativeTokenSymbol = getConstantByNetwork('nativeTokenSymbol', network);

--- a/packages/cardpay-cli/bridge.ts
+++ b/packages/cardpay-cli/bridge.ts
@@ -1,14 +1,14 @@
 import Web3 from 'web3';
 import { getWeb3 } from './utils';
-import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
+import { getConstant, getSDK, TokenBridgeHomeSide, TokenBridgeForeignSide, Assets } from '@cardstack/cardpay-sdk';
 
 const { toWei, fromWei } = Web3.utils;
 
 export async function getWithdrawalLimits(network: string, tokenAddress: string, mnemonic?: string): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let tokenBridge = await getSDK('TokenBridgeHomeSide', web3);
+  let tokenBridge = await getSDK<TokenBridgeHomeSide>('TokenBridgeHomeSide', web3);
   let { max, min } = await tokenBridge.getWithdrawalLimits(tokenAddress);
-  let assets = await getSDK('Assets', web3);
+  let assets = await getSDK<Assets>('Assets', web3);
   let { symbol } = await assets.getTokenInfo(tokenAddress);
   console.log(`The withdrawal limits for bridging ${symbol} to layer 1 are:
   minimum withdrawal ${fromWei(min)} ${symbol}
@@ -26,8 +26,8 @@ export async function bridgeToLayer1(
   const amountInWei = toWei(amount);
 
   let web3 = await getWeb3(network, mnemonic);
-  let tokenBridge = await getSDK('TokenBridgeHomeSide', web3);
-  let assets = await getSDK('Assets', web3);
+  let tokenBridge = await getSDK<TokenBridgeHomeSide>('TokenBridgeHomeSide', web3);
+  let assets = await getSDK<Assets>('Assets', web3);
   let { symbol } = await assets.getTokenInfo(tokenAddress);
   receiverAddress = receiverAddress ?? (await web3.eth.getAccounts())[0];
 
@@ -45,7 +45,7 @@ export async function awaitBridgedToLayer1(
   mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let tokenBridge = await getSDK('TokenBridgeHomeSide', web3);
+  let tokenBridge = await getSDK<TokenBridgeHomeSide>('TokenBridgeHomeSide', web3);
 
   console.log(`Waiting for bridge validation to complete for ${txnHash}...`);
 
@@ -65,7 +65,7 @@ export async function claimLayer1BridgedTokens(
   mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let tokenBridge = await getSDK('TokenBridgeForeignSide', web3);
+  let tokenBridge = await getSDK<TokenBridgeForeignSide>('TokenBridgeForeignSide', web3);
   let blockExplorer = await getConstant('blockExplorer', web3);
 
   console.log(`Claiming layer 1 bridge tokens for message ID ${messageId}...`);
@@ -85,8 +85,8 @@ export async function bridgeToLayer2(
   const amountInWei = toWei(amount);
 
   let web3 = await getWeb3(network, mnemonic);
-  let tokenBridge = await getSDK('TokenBridgeForeignSide', web3);
-  let assets = await getSDK('Assets', web3);
+  let tokenBridge = await getSDK<TokenBridgeForeignSide>('TokenBridgeForeignSide', web3);
+  let assets = await getSDK<Assets>('Assets', web3);
   let { symbol } = await assets.getTokenInfo(tokenAddress);
   receiverAddress = receiverAddress ?? (await web3.eth.getAccounts())[0];
 
@@ -118,7 +118,7 @@ export async function awaitBridgedToLayer2(
   mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let tokenBridge = await getSDK('TokenBridgeHomeSide', web3);
+  let tokenBridge = await getSDK<TokenBridgeHomeSide>('TokenBridgeHomeSide', web3);
   recipient = recipient ?? (await web3.eth.getAccounts())[0];
 
   let blockExplorer = await getConstant('blockExplorer', web3);

--- a/packages/cardpay-cli/hub-auth.ts
+++ b/packages/cardpay-cli/hub-auth.ts
@@ -1,8 +1,8 @@
 import { getWeb3 } from './utils';
-import { getSDK } from '@cardstack/cardpay-sdk';
+import { getSDK, HubAuth } from '@cardstack/cardpay-sdk';
 
 export const hubAuth = async (hubRootUrl: string, network: string, mnemonic?: string): Promise<void> => {
   let web3 = await getWeb3(network, mnemonic);
-  let authToken = await (await getSDK('HubAuth', web3, hubRootUrl)).authenticate();
+  let authToken = await (await getSDK<HubAuth>('HubAuth', web3, hubRootUrl)).authenticate();
   console.log(`Authentication token: ${authToken}`);
 };

--- a/packages/cardpay-cli/layer-one-oracle.ts
+++ b/packages/cardpay-cli/layer-one-oracle.ts
@@ -1,19 +1,19 @@
 import Web3 from 'web3';
 import { getWeb3 } from './utils';
-import { getSDK } from '@cardstack/cardpay-sdk';
+import { getSDK, LayerOneOracle } from '@cardstack/cardpay-sdk';
 const { toWei } = Web3.utils;
 
 export async function ethToUsdPrice(network: string, ethAmount?: string, mnemonic?: string): Promise<void> {
   ethAmount = ethAmount ?? '1';
   let web3 = await getWeb3(network, mnemonic);
   let ethAmountInWei = toWei(ethAmount);
-  let layerOneOracle = await getSDK('LayerOneOracle', web3);
+  let layerOneOracle = await getSDK<LayerOneOracle>('LayerOneOracle', web3);
   let usdPrice = await layerOneOracle.ethToUsd(ethAmountInWei);
   console.log(`USD value: $${usdPrice.toFixed(2)} USD`);
 }
 export async function priceOracleUpdatedAt(network: string, mnemonic?: string): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let layerOneOracle = await getSDK('LayerOneOracle', web3);
+  let layerOneOracle = await getSDK<LayerOneOracle>('LayerOneOracle', web3);
   let date = await layerOneOracle.getEthToUsdUpdatedAt();
   console.log(`The ETH / USD rate was last updated at ${date.toString()}`);
 }

--- a/packages/cardpay-cli/layer-two-oracle.ts
+++ b/packages/cardpay-cli/layer-two-oracle.ts
@@ -1,13 +1,13 @@
 import Web3 from 'web3';
 import { getWeb3 } from './utils';
-import { getSDK } from '@cardstack/cardpay-sdk';
+import { getSDK, LayerTwoOracle } from '@cardstack/cardpay-sdk';
 const { toWei, fromWei } = Web3.utils;
 
 export async function usdPrice(network: string, token: string, amount?: string, mnemonic?: string): Promise<void> {
   amount = amount ?? '1';
   let web3 = await getWeb3(network, mnemonic);
   let amountInWei = toWei(amount);
-  let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+  let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', web3);
   let usdPrice = await layerTwoOracle.getUSDPrice(token, amountInWei);
   console.log(`USD value: $${usdPrice.toFixed(2)} USD`);
 }
@@ -15,13 +15,13 @@ export async function ethPrice(network: string, token: string, amount?: string, 
   amount = amount ?? '1';
   let web3 = await getWeb3(network, mnemonic);
   let amountInWei = toWei(amount);
-  let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+  let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', web3);
   let ethWeiPrice = await layerTwoOracle.getETHPrice(token, amountInWei);
   console.log(`ETH value: ${fromWei(ethWeiPrice)} ETH`);
 }
 export async function priceOracleUpdatedAt(network: string, token: string, mnemonic?: string): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+  let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', web3);
   let date = await layerTwoOracle.getUpdatedAt(token);
   console.log(`The ${token} rate was last updated at ${date.toString()}`);
 }

--- a/packages/cardpay-cli/prepaid-card.ts
+++ b/packages/cardpay-cli/prepaid-card.ts
@@ -1,5 +1,5 @@
 import Web3 from 'web3';
-import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
+import { Assets, getConstant, getSDK, PrepaidCard } from '@cardstack/cardpay-sdk';
 import { getWeb3 } from './utils';
 
 const { fromWei } = Web3.utils;
@@ -11,7 +11,7 @@ export async function priceForFaceValue(
   mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let prepaidCard = await getSDK('PrepaidCard', web3);
+  let prepaidCard = await getSDK<PrepaidCard>('PrepaidCard', web3);
   let weiAmount = await prepaidCard.priceForFaceValue(tokenAddress, spendFaceValue);
   console.log(
     `To achieve a SPEND face value of §${spendFaceValue} you must send ${fromWei(weiAmount)} units of this token`
@@ -20,14 +20,14 @@ export async function priceForFaceValue(
 
 export async function gasFee(network: string, tokenAddress: string, mnemonic?: string): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let prepaidCard = await getSDK('PrepaidCard', web3);
+  let prepaidCard = await getSDK<PrepaidCard>('PrepaidCard', web3);
   let weiAmount = await prepaidCard.gasFee(tokenAddress);
   console.log(`The gas fee for a new prepaid card in units of this token is ${fromWei(weiAmount)}`);
 }
 
 export async function getPaymentLimits(network: string, mnemonic?: string): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let prepaidCard = await getSDK('PrepaidCard', web3);
+  let prepaidCard = await getSDK<PrepaidCard>('PrepaidCard', web3);
   let { min, max } = await prepaidCard.getPaymentLimits();
   console.log(`The prepaid card payments limits are:
   minimum amount §${min} SPEND
@@ -44,9 +44,9 @@ export async function create(
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
 
-  let prepaidCard = await getSDK('PrepaidCard', web3);
+  let prepaidCard = await getSDK<PrepaidCard>('PrepaidCard', web3);
   let blockExplorer = await getConstant('blockExplorer', web3);
-  let assets = await getSDK('Assets', web3);
+  let assets = await getSDK<Assets>('Assets', web3);
   let { symbol } = await assets.getTokenInfo(tokenAddress);
 
   console.log(
@@ -71,7 +71,7 @@ export async function split(
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
 
-  let prepaidCardAPI = await getSDK('PrepaidCard', web3);
+  let prepaidCardAPI = await getSDK<PrepaidCard>('PrepaidCard', web3);
   let blockExplorer = await getConstant('blockExplorer', web3);
 
   console.log(
@@ -94,7 +94,7 @@ export async function transfer(
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
 
-  let prepaidCardAPI = await getSDK('PrepaidCard', web3);
+  let prepaidCardAPI = await getSDK<PrepaidCard>('PrepaidCard', web3);
   let blockExplorer = await getConstant('blockExplorer', web3);
 
   console.log(`Transferring prepaid card ${prepaidCard} to new owner ${newOwner}...`);
@@ -112,7 +112,7 @@ export async function payMerchant(
   mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let prepaidCard = await getSDK('PrepaidCard', web3);
+  let prepaidCard = await getSDK<PrepaidCard>('PrepaidCard', web3);
   let blockExplorer = await getConstant('blockExplorer', web3);
 
   console.log(

--- a/packages/cardpay-cli/revenue-pool.ts
+++ b/packages/cardpay-cli/revenue-pool.ts
@@ -1,4 +1,4 @@
-import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
+import { Assets, getConstant, getSDK, RevenuePool } from '@cardstack/cardpay-sdk';
 import { fromWei, toWei } from 'web3-utils';
 import { getWeb3 } from './utils';
 
@@ -9,7 +9,7 @@ export async function registerMerchant(
   mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let revenuePool = await getSDK('RevenuePool', web3);
+  let revenuePool = await getSDK<RevenuePool>('RevenuePool', web3);
   let blockExplorer = await getConstant('blockExplorer', web3);
 
   console.log(
@@ -24,7 +24,7 @@ export async function registerMerchant(
 
 export async function revenueBalances(network: string, merchantSafeAddress: string, mnemonic?: string): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let revenuePool = await getSDK('RevenuePool', web3);
+  let revenuePool = await getSDK<RevenuePool>('RevenuePool', web3);
   let balanceInfo = await revenuePool.balances(merchantSafeAddress);
   console.log(`Merchant revenue balance for merchant safe ${merchantSafeAddress}:`);
   for (let { tokenSymbol, balance } of balanceInfo) {
@@ -40,8 +40,8 @@ export async function claimRevenue(
   mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let revenuePool = await getSDK('RevenuePool', web3);
-  let assets = await getSDK('Assets', web3);
+  let revenuePool = await getSDK<RevenuePool>('RevenuePool', web3);
+  let assets = await getSDK<Assets>('Assets', web3);
   let { symbol } = await assets.getTokenInfo(tokenAddress);
   let weiAmount = toWei(amount);
   console.log(`Claiming ${amount} ${symbol} in revenue for merchant safe ${merchantSafeAddress}`);
@@ -61,8 +61,8 @@ export async function claimRevenueGasEstimate(
   mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let revenuePool = await getSDK('RevenuePool', web3);
-  let assets = await getSDK('Assets', web3);
+  let revenuePool = await getSDK<RevenuePool>('RevenuePool', web3);
+  let assets = await getSDK<Assets>('Assets', web3);
   let { symbol } = await assets.getTokenInfo(tokenAddress);
   let weiAmount = toWei(amount);
   let estimate = await revenuePool.claimGasEstimate(merchantSafeAddress, tokenAddress, weiAmount);

--- a/packages/cardpay-cli/reward-pool.ts
+++ b/packages/cardpay-cli/reward-pool.ts
@@ -1,4 +1,4 @@
-import { getSDK } from '@cardstack/cardpay-sdk';
+import { getSDK, RewardPool } from '@cardstack/cardpay-sdk';
 import { getWeb3 } from './utils';
 import Web3 from 'web3';
 const { fromWei } = Web3.utils;
@@ -6,7 +6,7 @@ import { RewardTokenBalance } from '@cardstack/cardpay-sdk/sdk/reward-pool';
 
 export async function rewardTokenBalances(network: string, address: string, mnemonic?: string): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let rewardPool = await getSDK('RewardPool', web3);
+  let rewardPool = await getSDK<RewardPool>('RewardPool', web3);
   const tokenBalances = await rewardPool.rewardTokenBalances(address);
   displayRewardTokenBalance(address, tokenBalances);
 }
@@ -21,6 +21,6 @@ function displayRewardTokenBalance(address: string, tokenBalances: RewardTokenBa
 
 export async function rewardTokensAvailable(network: string, address: string, mnemonic?: string): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let rewardPool = await getSDK('RewardPool', web3);
+  let rewardPool = await getSDK<RewardPool>('RewardPool', web3);
   await rewardPool.rewardTokensAvailable(address);
 }

--- a/packages/cardpay-cli/safe.ts
+++ b/packages/cardpay-cli/safe.ts
@@ -1,5 +1,5 @@
 import Web3 from 'web3';
-import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
+import { getConstant, getSDK, Safes, Assets } from '@cardstack/cardpay-sdk';
 import { getWeb3 } from './utils';
 import { Safe } from '@cardstack/cardpay-sdk/sdk/safes';
 
@@ -8,7 +8,7 @@ const { toWei, fromWei } = Web3.utils;
 export async function viewSafe(network: string, address: string, mnemonic?: string): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
 
-  let safesApi = await getSDK('Safes', web3);
+  let safesApi = await getSDK<Safes>('Safes', web3);
   console.log(`Getting safe ${address}`);
   let safe = await safesApi.viewSafe(address);
   console.log();
@@ -24,7 +24,7 @@ export async function viewSafe(network: string, address: string, mnemonic?: stri
 export async function viewSafes(network: string, address: string | undefined, mnemonic?: string): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
 
-  let safesApi = await getSDK('Safes', web3);
+  let safesApi = await getSDK<Safes>('Safes', web3);
   console.log('Getting safes...');
   console.log();
   let safes = (await safesApi.view(address)).filter((safe) => safe.type !== 'external');
@@ -84,8 +84,8 @@ export async function transferTokens(
   let web3 = await getWeb3(network, mnemonic);
   let weiAmount = toWei(amount);
 
-  let safes = await getSDK('Safes', web3);
-  let assets = await getSDK('Assets', web3);
+  let safes = await getSDK<Safes>('Safes', web3);
+  let assets = await getSDK<Assets>('Assets', web3);
   let { symbol } = await assets.getTokenInfo(token);
 
   console.log(`transferring ${amount} ${symbol} from safe ${safe} to ${recipient}`);
@@ -107,8 +107,8 @@ export async function transferTokensGasEstimate(
   let web3 = await getWeb3(network, mnemonic);
   let weiAmount = toWei(amount);
 
-  let safes = await getSDK('Safes', web3);
-  let assets = await getSDK('Assets', web3);
+  let safes = await getSDK<Safes>('Safes', web3);
+  let assets = await getSDK<Assets>('Assets', web3);
   let { symbol } = await assets.getTokenInfo(token);
   let estimate = await safes.sendTokensGasEstimate(safe, token, recipient, weiAmount);
   console.log(
@@ -126,8 +126,8 @@ export async function setSupplierInfoDID(
   mnemonic?: string
 ): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
-  let safes = await getSDK('Safes', web3);
-  let assets = await getSDK('Assets', web3);
+  let safes = await getSDK<Safes>('Safes', web3);
+  let assets = await getSDK<Assets>('Assets', web3);
   let { symbol } = await assets.getTokenInfo(gasToken);
   console.log(`setting the info DID for the supplier safe ${safe} to ${infoDID} using ${symbol} token to pay for gas`);
   let blockExplorer = await getConstant('blockExplorer', web3);

--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -89,38 +89,38 @@ TransactionOptions has an optional parameter for obtaining the transaction hash:
 The promise returned by all the API's that mutate the state of the blockchain will resolve after the transaction has been mined with a transaction receipt. In order for callers of the SDK to obtain the transaction hash (for purposes of tracking the transaction) before the transaction has been mined, all API's that mutate the state of the blockchain will also contain a callback `onTxnHash` that callers can use to obtain the transaction hash as soon as it is available.
 
 ## `getSDK`
-The cardpay SDK will automatically obtain the latest API version that works with the on-chain contracts. In order to obtain an API you need to leverage the `getSDK()` function and pass to it the API that you wish to work with, as well as any parameters necessary for obtaining an API (usually just an instance of Web3). This function then returns a promise for the requested API. For example, to obtain the `Safes` API, you would call:
+The cardpay SDK will automatically obtain the latest API version that works with the on-chain contracts. In order to obtain an API you need to leverage the `getSDK()` function and pass to it the API that you wish to work with, as well as any parameters necessary for obtaining an API (usually just an instance of Web3). Additionally, pass into it the type of the API that you are retrieving This function then returns a promise for the requested API. For example, to obtain the `Safes` API, you would call:
 ```js
-import { getSDK } from "@cardstack/cardpay-sdk";
-let safesAPI = await getSDK('Safes', web3);
+import { getSDK, Safes } from "@cardstack/cardpay-sdk";
+let safesAPI = await getSDK<Safes>('Safes', web3);
 ```
 
 ## `Assets`
 Thie `Assets` API is used issue queries for native coin balances and ERC-20 token balances, as well as to get ERC-20 token info. The `Assets` API can be obtained from `getSDK()` with a `Web3` instance that is configured to operate on either layer 1 or layer 2, depending on where the asset you wish to query lives.
 ```js
-import { getSDK } from "@cardstack/cardpay-sdk";
+import { getSDK, Assets } from "@cardstack/cardpay-sdk";
 let web3 = new Web3(myProvider);
-let assetAPI = await getSDK('Assets', web3);
+let assetAPI = await getSDK<Assets>('Assets', web3);
 ```
 
 ### `Assets.getNativeTokenBalance`
 This call returns the balance in native token for the specified address. So in Ethereum mainnet, this would be the ether balance. In xDai this would be the DAI token balance. This call returns a promise for the native token amount as a string in units of `wei`. If no address is provided, then the balance of the first address in the wallet will be retrieved.
 ```js
-let assetsAPI = await getSDK('Assets', web3);
+let assetsAPI = await getSDK<Assets>('Assets', web3);
 let etherBalance = await assetsAPI.getNativeTokenBalance(walletAddress);
 ```
 
 ### `Assets.getBalanceForToken`
 This call returns the balance in for an ERC-20 token from the specified address. This call returns a promise for the token amount as a string in units of `wei`. If no token holder address is provided, then the balance of the first address in the wallet will be retrieved.
 ```js
-let assetsAPI = await getSDK('Assets', web3);
+let assetsAPI = await getSDK<Assets>('Assets', web3);
 let cardBalance = await assetsAPI.getBalanceForToken(cardTokenAddress, walletAddress);
 ```
 
 ### `Assets.getTokenInfo`
 This call returns ERC-20 token information: the token name, the token symbol, and the token decimals for an ERC-20 token.
 ```js
-let assetsAPI = await getSDK('Assets', web3);
+let assetsAPI = await getSDK<Assets>('Assets', web3);
 let { name, symbol, decimals } = await assetsAPI.getTokenInfo(cardTokenAddress);
 ```
 The response of this call is a promise for an object shaped like:
@@ -135,9 +135,9 @@ The response of this call is a promise for an object shaped like:
 ## `TokenBridgeForeignSide`
 The `TokenBridgeForeignSide` API is used to bridge tokens into the layer 2 network in which the Card Protocol runs. The `TokenBridgeForeignSide` API can be obtained from `getSDK()` with a `Web3` instance that is configured to operate on a layer 1 network (like Ethereum Mainnet or Kovan).
 ```js
-import { getSDK } from "@cardstack/cardpay-sdk";
+import { getSDK, TokenBridgeForeignSide } from "@cardstack/cardpay-sdk";
 let web3 = new Web3(myProvider); // Layer 1 web3 instance
-let tokenBridge = await getSDK('TokenBridgeForeignSide', web3);
+let tokenBridge = await getSDK<TokenBridgeForeignSide>('TokenBridgeForeignSide', web3);
 ```
 
 ### `TokenBridgeForeignSide.unlockTokens`
@@ -194,9 +194,9 @@ This method returns a promise for a web3 transaction receipt.
 ## `TokenBridgeHomeSide`
 The `TokenBridgeHomeSide` API is used to bridge tokens into the layer 2 network in which the Card Protocol runs. The `TokenBridgeHomeSide` API can be obtained from `getSDK()` with a `Web3` instance that is configured to operate on a layer 2 network (like xDai or Sokol).
 ```js
-import { getSDK } from "@cardstack/cardpay-sdk";
+import { getSDK, TokenBridgeHomeSide } from "@cardstack/cardpay-sdk";
 let web3 = new Web3(myProvider); // Layer 2 web3 instance
-let tokenBridge = await getSDK('TokenBridgeHomeSide', web3);
+let tokenBridge = await getSDK<TokenBridgeHomeSide>('TokenBridgeHomeSide', web3);
 ```
 
 ### `TokenBridgeHomeSide.withdrawlLimits`
@@ -277,9 +277,9 @@ let txnReceipt = await tokenBridge.waitForBridgingToLayer2Completed(
 ## `Safes`
 The `Safes` API is used to query the card protocol about the gnosis safes in the layer 2 network in which the Card Protocol runs. This can includes safes in which bridged tokens are deposited as well as prepaid cards (which in turn are actually gnosis safes). The `Safes` API can be obtained from `getSDK()` with a `Web3` instance that is configured to operate on a layer 2 network (like xDai or Sokol).
 ```js
-import { getSDK } from "@cardstack/cardpay-sdk";
+import { getSDK, Safes } from "@cardstack/cardpay-sdk";
 let web3 = new Web3(myProvider); // Layer 2 web3 instance
-let safes = await getSDK('Safes', web3);
+let safes = await getSDK<Safes>('Safes', web3);
 ```
 
 ### `Safe.viewSafe`
@@ -385,9 +385,9 @@ This method returns a promise for a web3 transaction receipt.
 ## `PrepaidCard`
 The `PrepaidCard` API is used to create and interact with prepaid cards within the layer 2 network in which the Card Protocol runs. The `PrepaidCard` API can be obtained from `getSDK()` with a `Web3` instance that is configured to operate on a layer 2 network (like xDai or Sokol).
 ```js
-import { getSDK } from "@cardstack/cardpay-sdk";
+import { getSDK, PrepaidCard } from "@cardstack/cardpay-sdk";
 let web3 = new Web3(myProvider); // Layer 2 web3 instance
-let prepaidCard = await getSDK('PrepaidCard', web3);
+let prepaidCard = await getSDK<PrepaidCard>('PrepaidCard', web3);
 ```
 
 ### `PrepaidCard.create`
@@ -531,9 +531,9 @@ This method returns a promise for a web3 transaction receipt.
 ## `RevenuePool`
 The `RevenuePool` API is used register merchants and view/claim merchant revenue from prepaid card payments within the layer 2 network in which the Card Protocol runs. The `RevenuePool` API can be obtained from `getSDK()` with a `Web3` instance that is configured to operate on a layer 2 network (like xDai or Sokol).
 ```js
-import { getSDK } from "@cardstack/cardpay-sdk";
+import { getSDK, RevenuePool } from "@cardstack/cardpay-sdk";
 let web3 = new Web3(myProvider); // Layer 2 web3 instance
-let revenuePool = await getSDK('RevenuePool', web3);
+let revenuePool = await getSDK<RevenuePool>('RevenuePool', web3);
 ```
 ### `RevenuePool.merchantRegistrationFee`
 This call will return the fee in SPEND to register as a merchant. This call returns a promise for a number which represents the amount of SPEND it costs to register as a merchant.
@@ -626,15 +626,15 @@ let balanceForAllTokens = await rewardPool.rewardTokenBalances(address)
 ## `LayerOneOracle`
 The `LayerOneOracle` API is used to get the current exchange rates in USD of ETH. This rate us fed by the Chainlink price feeds. Please supply a layer 1 web3 instance obtaining an `LayerOneOracle` API from `getSDK()`.
 ```js
-import { getSDK } from "@cardstack/cardpay-sdk";
+import { getSDK, LayerOneOracle } from "@cardstack/cardpay-sdk";
 let web3 = new Web3(myProvider); // Layer 1 web3 instance
-let layerOneOracle = await getSDK('LayerOneOracle', web3);
+let layerOneOracle = await getSDK<LayerOneOracle>('LayerOneOracle', web3);
 ```
 ### `LayerOneOracle.ethToUsd`
 This call will return the USD value for the specified amount of ETH. This API requires that the amount be specified in `wei` (10<sup>18</sup> `wei` = 1 token) as a string, and will return a floating point value in units of USD. You can easily convert an ETH value to wei by using the `Web3.utils.toWei()` function.
 
 ```js
-let layerOneOracle = await getSDK('LayerOneOracle', web3);
+let layerOneOracle = await getSDK<LayerOneOracle>('LayerOneOracle', web3);
 let usdPrice = await exchangelayerOneOracleRate.ethToUsd(amountInWei);
 console.log(`USD value: $${usdPrice.toFixed(2)} USD`);
 ```
@@ -642,7 +642,7 @@ console.log(`USD value: $${usdPrice.toFixed(2)} USD`);
 This returns a function that converts an amount of ETH in wei to USD. The returned function accepts a string that represents an amount in wei and returns a number that represents the USD value of that amount of ETH.
 
 ```js
-let layerOneOracle = await getSDK('LayerOneOracle', web3);
+let layerOneOracle = await getSDK<LayerOneOracle>('LayerOneOracle', web3);
 let converter = await layerOneOracle.getEthToUsdConverter();
 console.log(`USD value: $${converter(amountInWei)} USD`);
 ```
@@ -650,16 +650,16 @@ console.log(`USD value: $${converter(amountInWei)} USD`);
 This call will return a `Date` instance that indicates the date the exchange rate was last updated.
 
 ```js
-let layerOneOracle = await getSDK('LayerOneOracle', web3);
+let layerOneOracle = await getSDK<LayerOneOracle>('LayerOneOracle', web3);
 let date = await layerOneOracle.getUpdatedAt();
 console.log(`The ETH / USD rate was last updated at ${date.toString()}`);
 ```
 ## `LayerTwoOracle`
 The `LayerTwoOracle` API is used to get the current exchange rates in USD and ETH for the various stablecoin that we support. These rates are fed by the Chainlink price feeds for the stablecoin rates and the DIA oracle for the CARD token rates. As we onboard new stablecoin we'll add more exchange rates. The price oracles that we use reside in layer 2, so please supply a layer 2 web3 instance obtaining an `LayerTwoOracle` API from `getSDK()`.
 ```js
-import { getSDK } from "@cardstack/cardpay-sdk";
+import { getSDK, LayerTwoOracle> } from "@cardstack/cardpay-sdk";
 let web3 = new Web3(myProvider); // Layer 2 web3 instance
-let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', web3);
 ```
 ### `LayerTwoOracle.convertToSpend`
 This call will convert an amount in the specified token to a SPEND amount. This function returns a number representing the SPEND amount. The input to this function is the token amount as a string in units of `wei`.
@@ -677,7 +677,7 @@ console.log(`DAI value ${fromWei(weiAmount)}`);
 This call will return the USD value for the specified amount of the specified token. If we do not have an exchange rate for the token, then an exception will be thrown. This API requires that the token amount be specified in `wei` (10<sup>18</sup> `wei` = 1 token) as a string, and will return a floating point value in units of USD. You can easily convert a token value to wei by using the `Web3.utils.toWei()` function.
 
 ```js
-let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', web3);
 let usdPrice = await layerTwoOracleRate.getUSDPrice("DAI", amountInWei);
 console.log(`USD value: $${usdPrice.toFixed(2)} USD`);
 ```
@@ -685,7 +685,7 @@ console.log(`USD value: $${usdPrice.toFixed(2)} USD`);
 This returns a function that converts an amount of a token in wei to USD. Similar to `LayerTwoOracle.getUSDPrice`, an exception will be thrown if we don't have the exchange rate for the token. The returned function accepts a string that represents an amount in wei and returns a number that represents the USD value of that amount of the token.
 
 ```js
-let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', web3);
 let converter = await layerTwoOracle.getUSDConverter("DAI");
 console.log(`USD value: $${converter(amountInWei)} USD`);
 ```
@@ -693,7 +693,7 @@ console.log(`USD value: $${converter(amountInWei)} USD`);
 This call will return the ETH value for the specified amount of the specified token. If we do not have an exchange rate for the token, then an exception will be thrown. This API requires that the token amount be specified in `wei` (10<sup>18</sup> `wei` = 1 token) as a string, and will return a string that represents the ETH value in units of `wei` as well. You can easily convert a token value to wei by using the `Web3.utils.toWei()` function. You can also easily convert units of `wei` back into `ethers` by using the `Web3.utils.fromWei()` function.
 
 ```js
-let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', web3);
 let ethWeiPrice = await layerTwoOracle.getETHPrice("CARD", amountInWei);
 console.log(`ETH value: ${fromWei(ethWeiPrice)} ETH`);
 ```
@@ -701,7 +701,7 @@ console.log(`ETH value: ${fromWei(ethWeiPrice)} ETH`);
 This call will return a `Date` instance that indicates the date the token rate was last updated.
 
 ```js
-let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', web3);
 let date = await layerTwoOracle.getUpdatedAt("DAI");
 console.log(`The ${token} rate was last updated at ${date.toString()}`);
 ```

--- a/packages/cardpay-sdk/index.ts
+++ b/packages/cardpay-sdk/index.ts
@@ -1,19 +1,13 @@
-export { ITokenBridgeForeignSide } from './sdk/token-bridge-foreign-side';
-export { ITokenBridgeHomeSide, BridgeValidationResult } from './sdk/token-bridge-home-side';
-export {
-  Safes as ISafes,
-  Safe,
-  DepotSafe,
-  MerchantSafe,
-  PrepaidCardSafe,
-  ExternalSafe,
-  TokenInfo,
-  viewSafe,
-} from './sdk/safes';
-export { ILayerOneOracle } from './sdk/layer-one-oracle';
-export { LayerTwoOracle as ILayerTwoOracle } from './sdk/layer-two-oracle';
-export { IAssets } from './sdk/assets';
-export { IHubAuth } from './sdk/hub-auth';
+export { ITokenBridgeForeignSide as TokenBridgeForeignSide } from './sdk/token-bridge-foreign-side';
+export { ITokenBridgeHomeSide as TokenBridgeHomeSide, BridgeValidationResult } from './sdk/token-bridge-home-side';
+export { Safes, Safe, DepotSafe, MerchantSafe, PrepaidCardSafe, ExternalSafe, TokenInfo, viewSafe } from './sdk/safes';
+export { ILayerOneOracle as LayerOneOracle } from './sdk/layer-one-oracle';
+export { LayerTwoOracle } from './sdk/layer-two-oracle';
+export { IAssets as Assets } from './sdk/assets';
+export { IHubAuth as HubAuth } from './sdk/hub-auth';
+export { PrepaidCard } from './sdk/prepaid-card';
+export { RevenuePool } from './sdk/revenue-pool';
+export { RewardPool } from './sdk/reward-pool';
 
 export { getAddress, getAddressByNetwork, getOracle, getOracleByNetwork, AddressKeys } from './contracts/addresses';
 export { getConstant, getConstantByNetwork, networks, networkIds } from './sdk/constants';

--- a/packages/cardpay-sdk/sdk/prepaid-card/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card/base.ts
@@ -25,6 +25,8 @@ import { isTransactionHash, TransactionOptions, waitUntilTransactionMined } from
 import { signSafeTxAsRSV, Signature, signSafeTxAsBytes } from '../utils/signing-utils';
 import { PrepaidCardSafe } from '../safes';
 import { TransactionReceipt } from 'web3-core';
+import { LayerTwoOracle } from '../layer-two-oracle';
+import { Safes } from '../safes';
 
 const { fromWei } = Web3.utils;
 const POLL_INTERVAL = 500;
@@ -120,7 +122,7 @@ export default class PrepaidCard {
     );
 
     let rateChanged = false;
-    let layerTwoOracle = await getSDK('LayerTwoOracle', this.layer2Web3);
+    let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', this.layer2Web3);
     let gnosisResult: GnosisExecTx | undefined;
     do {
       let rateLock = await layerTwoOracle.getRateLock(issuingToken);
@@ -218,7 +220,7 @@ export default class PrepaidCard {
     let from = contractOptions?.from ?? (await this.layer2Web3.eth.getAccounts())[0];
     let rateChanged = false;
     let prepaidCardMgr = await this.getPrepaidCardMgr();
-    let layerTwoOracle = await getSDK('LayerTwoOracle', this.layer2Web3);
+    let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', this.layer2Web3);
     let gasToken = await getAddress('cardCpxd', this.layer2Web3);
     let issuingToken = await this.issuingToken(prepaidCardAddress);
     let transferData = await prepaidCardMgr.methods.getTransferCardData(prepaidCardAddress, newOwner).call();
@@ -353,7 +355,7 @@ export default class PrepaidCard {
       throw new Error(`The prepaid card ${prepaidCardAddress} is not allowed to be split`);
     }
     let from = contractOptions?.from ?? (await this.layer2Web3.eth.getAccounts())[0];
-    let layerTwoOracle = await getSDK('LayerTwoOracle', this.layer2Web3);
+    let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', this.layer2Web3);
     let issuingToken = await this.issuingToken(prepaidCardAddress);
     let amountCache = new Map<number, string>();
     let amounts: BN[] = [];
@@ -609,7 +611,7 @@ export default class PrepaidCard {
     onError: (issuingToken: string, balanceAmount: string, requiredTokenAmount: string, symbol: string) => Error
   ): Promise<string> {
     let issuingToken = await this.issuingToken(prepaidCardAddress);
-    let layerTwoOracle = await getSDK('LayerTwoOracle', this.layer2Web3);
+    let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', this.layer2Web3);
     let weiAmount = await layerTwoOracle.convertFromSpend(issuingToken, minimumSpendBalance);
     let token = new this.layer2Web3.eth.Contract(ERC20ABI as AbiItem[], issuingToken);
     let symbol = await token.methods.symbol().call();
@@ -621,7 +623,7 @@ export default class PrepaidCard {
   }
 
   private async resolvePrepaidCards(prepaidCardAddresses: string[]): Promise<PrepaidCardSafe[]> {
-    let safes = await getSDK('Safes', this.layer2Web3);
+    let safes = await getSDK<Safes>('Safes', this.layer2Web3);
     let prepaidCards: PrepaidCardSafe[] | undefined;
     let startTime = Date.now();
     do {

--- a/packages/cardpay-sdk/sdk/prepaid-card/v0.7.0.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card/v0.7.0.ts
@@ -23,9 +23,10 @@ import {
 } from '../utils/safe-utils';
 import { isTransactionHash, TransactionOptions, waitUntilTransactionMined } from '../utils/general-utils';
 import { signSafeTxAsRSV, Signature, signSafeTxAsBytes } from '../utils/signing-utils';
-import { PrepaidCardSafe } from '../safes';
+import { PrepaidCardSafe, Safes } from '../safes';
 import { TransactionReceipt } from 'web3-core';
 import { MAXIMUM_PAYMENT_AMOUNT } from './base';
+import { LayerTwoOracle } from '../layer-two-oracle';
 
 const { fromWei } = Web3.utils;
 const POLL_INTERVAL = 500;
@@ -118,7 +119,7 @@ export default class PrepaidCard {
     );
 
     let rateChanged = false;
-    let layerTwoOracle = await getSDK('LayerTwoOracle', this.layer2Web3);
+    let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', this.layer2Web3);
     let gnosisResult: GnosisExecTx | undefined;
     do {
       let rateLock = await layerTwoOracle.getRateLock(issuingToken);
@@ -213,7 +214,7 @@ export default class PrepaidCard {
     let from = contractOptions?.from ?? (await this.layer2Web3.eth.getAccounts())[0];
     let rateChanged = false;
     let prepaidCardMgr = await this.getPrepaidCardMgr();
-    let layerTwoOracle = await getSDK('LayerTwoOracle', this.layer2Web3);
+    let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', this.layer2Web3);
     let gasToken = await getAddress('cardCpxd', this.layer2Web3);
     let issuingToken = await this.issuingToken(prepaidCardAddress);
     let transferData = await prepaidCardMgr.methods.getTransferCardData(prepaidCardAddress, newOwner).call();
@@ -348,7 +349,7 @@ export default class PrepaidCard {
       throw new Error(`The prepaid card ${prepaidCardAddress} is not allowed to be split`);
     }
     let from = contractOptions?.from ?? (await this.layer2Web3.eth.getAccounts())[0];
-    let layerTwoOracle = await getSDK('LayerTwoOracle', this.layer2Web3);
+    let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', this.layer2Web3);
     let issuingToken = await this.issuingToken(prepaidCardAddress);
     let amountCache = new Map<number, string>();
     let amounts: BN[] = [];
@@ -593,7 +594,7 @@ export default class PrepaidCard {
     onError: (issuingToken: string, balanceAmount: string, requiredTokenAmount: string, symbol: string) => Error
   ): Promise<string> {
     let issuingToken = await this.issuingToken(prepaidCardAddress);
-    let layerTwoOracle = await getSDK('LayerTwoOracle', this.layer2Web3);
+    let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', this.layer2Web3);
     let weiAmount = await layerTwoOracle.convertFromSpend(issuingToken, minimumSpendBalance);
     let token = new this.layer2Web3.eth.Contract(ERC20ABI as AbiItem[], issuingToken);
     let symbol = await token.methods.symbol().call();
@@ -605,7 +606,7 @@ export default class PrepaidCard {
   }
 
   private async resolvePrepaidCards(prepaidCardAddresses: string[]): Promise<PrepaidCardSafe[]> {
-    let safes = await getSDK('Safes', this.layer2Web3);
+    let safes = await getSDK<Safes>('Safes', this.layer2Web3);
     let prepaidCards: PrepaidCardSafe[] | undefined;
     let startTime = Date.now();
     do {

--- a/packages/cardpay-sdk/sdk/revenue-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/revenue-pool/base.ts
@@ -22,6 +22,9 @@ import { getSDK } from '../version-resolver';
 import BN from 'bn.js';
 import { TransactionReceipt } from 'web3-core';
 import { MerchantSafe, Safe } from '../safes';
+import { PrepaidCard } from '../prepaid-card';
+import { LayerTwoOracle } from '../layer-two-oracle';
+import { Safes } from '../safes';
 
 const { fromWei } = Web3.utils;
 const POLL_INTERVAL = 500;
@@ -224,7 +227,7 @@ export default class RevenuePool {
     }
     let { nonce, onNonce, onTxnHash } = txnOptions ?? {};
     let from = contractOptions?.from ?? (await this.layer2Web3.eth.getAccounts())[0];
-    let prepaidCard = await getSDK('PrepaidCard', this.layer2Web3);
+    let prepaidCard = await getSDK<PrepaidCard>('PrepaidCard', this.layer2Web3);
     let issuingToken = await prepaidCard.issuingToken(prepaidCardAddress);
     let registrationFee = await this.merchantRegistrationFee();
     infoDID = infoDID ?? '';
@@ -240,7 +243,7 @@ export default class RevenuePool {
     );
 
     let rateChanged = false;
-    let layerTwoOracle = await getSDK('LayerTwoOracle', this.layer2Web3);
+    let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', this.layer2Web3);
     let gnosisResult: GnosisExecTx | undefined;
     do {
       let rateLock = await layerTwoOracle.getRateLock(issuingToken);
@@ -341,7 +344,7 @@ export default class RevenuePool {
   }
 
   private async resolveMerchantSafe(merchantSafeAddress: string): Promise<MerchantSafe> {
-    let safes = await getSDK('Safes', this.layer2Web3);
+    let safes = await getSDK<Safes>('Safes', this.layer2Web3);
     let startTime = Date.now();
     let merchantSafe: Safe | undefined;
     let isFirstTime = true;

--- a/packages/cardpay-sdk/sdk/revenue-pool/v0.7.0.ts
+++ b/packages/cardpay-sdk/sdk/revenue-pool/v0.7.0.ts
@@ -21,7 +21,9 @@ import { signSafeTxAsRSV, Signature } from '../utils/signing-utils';
 import { getSDK } from '../version-resolver';
 import BN from 'bn.js';
 import { TransactionReceipt } from 'web3-core';
-import { MerchantSafe, Safe } from '../safes';
+import { MerchantSafe, Safe, Safes } from '../safes';
+import { PrepaidCard } from '../prepaid-card';
+import { LayerTwoOracle } from '../layer-two-oracle';
 
 const { fromWei } = Web3.utils;
 const POLL_INTERVAL = 500;
@@ -224,7 +226,7 @@ export default class RevenuePool {
     }
     let { nonce, onNonce, onTxnHash } = txnOptions ?? {};
     let from = contractOptions?.from ?? (await this.layer2Web3.eth.getAccounts())[0];
-    let prepaidCard = await getSDK('PrepaidCard', this.layer2Web3);
+    let prepaidCard = await getSDK<PrepaidCard>('PrepaidCard', this.layer2Web3);
     let issuingToken = await prepaidCard.issuingToken(prepaidCardAddress);
     let registrationFee = await this.merchantRegistrationFee();
     infoDID = infoDID ?? '';
@@ -240,7 +242,7 @@ export default class RevenuePool {
     );
 
     let rateChanged = false;
-    let layerTwoOracle = await getSDK('LayerTwoOracle', this.layer2Web3);
+    let layerTwoOracle = await getSDK<LayerTwoOracle>('LayerTwoOracle', this.layer2Web3);
     let gnosisResult: GnosisExecTx | undefined;
     do {
       let rateLock = await layerTwoOracle.getRateLock(issuingToken);
@@ -338,7 +340,7 @@ export default class RevenuePool {
   }
 
   private async resolveMerchantSafe(merchantSafeAddress: string): Promise<MerchantSafe> {
-    let safes = await getSDK('Safes', this.layer2Web3);
+    let safes = await getSDK<Safes>('Safes', this.layer2Web3);
     let startTime = Date.now();
     let merchantSafe: Safe | undefined;
     let isFirstTime = true;

--- a/packages/cardpay-sdk/sdk/token-bridge-foreign-side.ts
+++ b/packages/cardpay-sdk/sdk/token-bridge-foreign-side.ts
@@ -37,6 +37,7 @@ export interface ITokenBridgeForeignSide {
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
   ): Promise<TransactionReceipt>;
+  getEstimatedGasForWithdrawalClaim(_tokenAddress: string): Promise<BN>;
 }
 
 const CLAIM_BRIDGED_TOKENS_GAS_LIMIT = 290000;

--- a/packages/cardpay-sdk/sdk/token-bridge-home-side.ts
+++ b/packages/cardpay-sdk/sdk/token-bridge-home-side.ts
@@ -19,6 +19,17 @@ import { TransactionOptions, waitUntilTransactionMined, isTransactionHash } from
 
 export interface ITokenBridgeHomeSide {
   waitForBridgingToLayer2Completed(recipientAddress: string, fromBlock: string): Promise<TransactionReceipt>;
+  waitForBridgingValidation(fromBlock: string, bridgingTxnHash: string): Promise<BridgeValidationResult>;
+  getWithdrawalLimits(tokenAddress: string): Promise<{ min: string; max: string }>;
+  relayTokens(txnHash: string): Promise<TransactionReceipt>;
+  relayTokens(
+    safeAddress: string,
+    tokenAddress: string,
+    recipientAddress: string,
+    amount: string,
+    txnOptions?: TransactionOptions,
+    contractOptions?: ContractOptions
+  ): Promise<TransactionReceipt>;
 }
 
 export interface BridgeValidationResult {

--- a/packages/cardpay-sdk/sdk/version-resolver.ts
+++ b/packages/cardpay-sdk/sdk/version-resolver.ts
@@ -3,15 +3,15 @@ import { AddressKeys, getAddress } from '../contracts/addresses';
 import { AbiItem } from 'web3-utils';
 import { satisfies } from 'semver';
 import mapKeys from 'lodash/mapKeys';
-import { LayerTwoOracle, layerTwoOracleMeta } from './layer-two-oracle';
-import { Safes, safesMeta } from './safes';
-import { PrepaidCard, prepaidCardMeta } from './prepaid-card';
+import { layerTwoOracleMeta } from './layer-two-oracle';
+import { safesMeta } from './safes';
+import { prepaidCardMeta } from './prepaid-card';
 import Assets from './assets';
 import LayerOneOracle from './layer-one-oracle';
 import TokenBridgeHomeSide from './token-bridge-home-side';
 import TokenBridgeForeignSide from './token-bridge-foreign-side';
-import { revenuePoolMeta, RevenuePool } from './revenue-pool';
-import { rewardPoolMeta, RewardPool } from './reward-pool';
+import { revenuePoolMeta } from './revenue-pool';
+import { rewardPoolMeta } from './reward-pool';
 import HubAuth from './hub-auth';
 
 type SDK =
@@ -48,17 +48,7 @@ const cardPayVersionABI: AbiItem[] = [
   },
 ];
 
-export async function getSDK(sdk: 'Assets', web3: Web3): Promise<Assets>;
-export async function getSDK(sdk: 'HubAuth', web3: Web3, hubRootUrl: string): Promise<HubAuth>;
-export async function getSDK(sdk: 'LayerOneOracle', web3: Web3): Promise<LayerOneOracle>;
-export async function getSDK(sdk: 'LayerTwoOracle', web3: Web3): Promise<LayerTwoOracle>;
-export async function getSDK(sdk: 'PrepaidCard', web3: Web3): Promise<PrepaidCard>;
-export async function getSDK(sdk: 'RevenuePool', web3: Web3): Promise<RevenuePool>;
-export async function getSDK(sdk: 'RewardPool', web3: Web3): Promise<RewardPool>;
-export async function getSDK(sdk: 'Safes', web3: Web3): Promise<Safes>;
-export async function getSDK(sdk: 'TokenBridgeHomeSide', web3: Web3): Promise<TokenBridgeHomeSide>;
-export async function getSDK(sdk: 'TokenBridgeForeignSide', web3: Web3): Promise<TokenBridgeForeignSide>;
-export async function getSDK(sdk: SDK, ...args: any[]): Promise<any> {
+export async function getSDK<T>(sdk: SDK, ...args: any[]): Promise<T> {
   let [web3] = args;
   let apiClass;
   switch (sdk) {

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -28,8 +28,9 @@ import {
   BridgeValidationResult,
   getConstantByNetwork,
   getSDK,
-  ILayerOneOracle,
+  LayerOneOracle,
   networkIds,
+  TokenBridgeForeignSide,
   waitUntilBlock,
 } from '@cardstack/cardpay-sdk';
 import {
@@ -51,7 +52,7 @@ export default abstract class Layer1ChainWeb3Strategy
   // changes with connection state
   #waitForAccountDeferred = defer<void>();
   web3: Web3 | undefined;
-  #layerOneOracleApi!: ILayerOneOracle;
+  #layerOneOracleApi!: LayerOneOracle;
   connectionManager: ConnectionManager;
   eventListenersToUnbind: {
     [event in ConnectionManagerEvent]?: UnbindEventListener;
@@ -159,7 +160,10 @@ export default abstract class Layer1ChainWeb3Strategy
 
       this.web3 = new Web3();
       await this.connectionManager.reconnect(this.web3, providerId);
-      this.#layerOneOracleApi = await getSDK('LayerOneOracle', this.web3);
+      this.#layerOneOracleApi = await getSDK<LayerOneOracle>(
+        'LayerOneOracle',
+        this.web3
+      );
     } catch (e) {
       console.error('Failed to initialize connection from local storage');
       console.error(e);
@@ -173,7 +177,10 @@ export default abstract class Layer1ChainWeb3Strategy
     try {
       this.web3 = new Web3();
       await this.connectionManager.connect(this.web3, walletProvider.id);
-      this.#layerOneOracleApi = await getSDK('LayerOneOracle', this.web3);
+      this.#layerOneOracleApi = await getSDK<LayerOneOracle>(
+        'LayerOneOracle',
+        this.web3
+      );
     } catch (e) {
       console.error(
         `Failed to create connection manager: ${walletProvider.id}`
@@ -279,7 +286,10 @@ export default abstract class Layer1ChainWeb3Strategy
     { onTxnHash }: ApproveOptions
   ): Promise<TransactionReceipt> {
     if (!this.web3) throw new Error('Cannot unlock tokens without web3');
-    let tokenBridge = await getSDK('TokenBridgeForeignSide', this.web3);
+    let tokenBridge = await getSDK<TokenBridgeForeignSide>(
+      'TokenBridgeForeignSide',
+      this.web3
+    );
     return tokenBridge.unlockTokens(
       new TokenContractInfo(tokenSymbol, this.networkSymbol).address,
       amountInWei.toString(),
@@ -294,7 +304,10 @@ export default abstract class Layer1ChainWeb3Strategy
     { onTxnHash }: RelayTokensOptions
   ): Promise<TransactionReceipt> {
     if (!this.web3) throw new Error('Cannot relay tokens without web3');
-    let tokenBridge = await getSDK('TokenBridgeForeignSide', this.web3);
+    let tokenBridge = await getSDK<TokenBridgeForeignSide>(
+      'TokenBridgeForeignSide',
+      this.web3
+    );
     return tokenBridge.relayTokens(
       new TokenContractInfo(tokenSymbol, this.networkSymbol).address,
       receiverAddress,
@@ -308,7 +321,10 @@ export default abstract class Layer1ChainWeb3Strategy
     options?: ClaimBridgedTokensOptions
   ): Promise<TransactionReceipt> {
     if (!this.web3) throw new Error('Cannot claim bridged tokens without web3');
-    let tokenBridge = await getSDK('TokenBridgeForeignSide', this.web3);
+    let tokenBridge = await getSDK<TokenBridgeForeignSide>(
+      'TokenBridgeForeignSide',
+      this.web3
+    );
     return tokenBridge.claimBridgedTokens(
       bridgeValidationResult.messageId,
       bridgeValidationResult.encodedData,
@@ -343,7 +359,10 @@ export default abstract class Layer1ChainWeb3Strategy
     if (!this.web3)
       throw new Error('Cannot getEstimatedGasForWithdrawalClaim without web3');
 
-    let tokenBridge = await getSDK('TokenBridgeForeignSide', this.web3);
+    let tokenBridge = await getSDK<TokenBridgeForeignSide>(
+      'TokenBridgeForeignSide',
+      this.web3
+    );
     let { address } = new TokenContractInfo(symbol, this.networkSymbol);
     return tokenBridge.getEstimatedGasForWithdrawalClaim(address);
   }


### PR DESCRIPTION
Workaround for the issue that we are getting from the cardwallet consumption of our SDK: 
> The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.

It looks like TS recognizes that the overload would have worked, but that the overload signatures are not actually externally visible, and hence the cardwallet cannot consume them. Instead we are using generics to type our SDK. its not as great, but it is at least something...