### PR TITLE
Clarify DI system asynchrony

### DIFF
--- a/packages/hub/di/container.ts
+++ b/packages/hub/di/container.ts
@@ -6,7 +6,7 @@ export interface FactoryByConstructor<T, A extends unknown[] = []> {
   new (...a: A): T;
 }
 export interface FactoryByCreateMethod<T, A extends unknown[] = []> {
-  create(...a: A): Promise<T>;
+  create(...a: A): T;
 }
 
 export type Factory<T, A extends unknown[] = []> = FactoryByConstructor<T, A> | FactoryByCreateMethod<T, A>;

--- a/packages/hub/node-tests/di/dependency-injection-test.ts
+++ b/packages/hub/node-tests/di/dependency-injection-test.ts
@@ -15,7 +15,6 @@ describe('hub/di/dependency-injection', function () {
     registry.register('testCircleThree', CircleThreeService);
     registry.register('testCircleFour', CircleFourService);
     registry.register('testCircleFive', new CircleFiveServiceFactory());
-    registry.register('testCircleSix', new CircleSixAsyncServiceFactory());
   });
 
   beforeEach(function () {
@@ -102,12 +101,6 @@ describe('hub/di/dependency-injection', function () {
     expect(five.iAmFive).equals(true);
     expect(five.testCircleTwo?.iAmTwo).equals(true);
   });
-
-  it('method factory can be async', async function () {
-    let six = await container.lookup('testCircleSix');
-    expect(six.iAmSix).equals(true);
-    expect(six.testCircleTwo?.iAmTwo).equals(true);
-  });
 });
 
 let exampleServiceTornDown = false;
@@ -176,22 +169,8 @@ class CircleFiveService {
   iAmFive = true;
 }
 class CircleFiveServiceFactory {
-  async create() {
+  create() {
     return new CircleFiveService();
-  }
-}
-
-class CircleSixService {
-  testCircleTwo = inject('testCircleTwo');
-  iAmSix = true;
-}
-class CircleSixAsyncServiceFactory {
-  async create() {
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(new CircleSixService());
-      }, 0);
-    });
   }
 }
 
@@ -206,6 +185,5 @@ declare module '@cardstack/hub/di/dependency-injection' {
     testCircleThree: CircleThreeService;
     testCircleFour: CircleFourService;
     testCircleFive: CircleFiveService;
-    testCircleSix: CircleSixService;
   }
 }


### PR DESCRIPTION
This reverts commit 1b6fdccb1373ad1f2a895dae9e8cf9c9078578e4.

@lukemelia asked me to review this change because we were talking about the DI system.

This change is not correct because it evades our existing deadlock detection and adds a second way to do asynchronous setup when we already had one.

Javascript does not have asynchronous constructors. When an object needs async initialization, the object still necessarily exists during its initialization process. In order for it to access other things from the DI system during initialization, the DI system needs to be able to see it even in its not-yet-initialized state. That is why we implemented synchronous `create` with an optional `async ready() {}` method.

### When can other objects see my object?

If you implement `async ready() {}` we guarantee that no other object will see yours until after `ready` resolves. The only exception is if your `ready` method itself passes `this` elsewhere.

### When can my object see its injected dependencies?

Normally your object accesses injected dependencies directly as synchronous properties (`this.someInjectedThing`). We guarantee that the objects you see have already finished their own `ready()`.

However, there is one special case: accessing your injected dependencies _during your own ready()_ is allowed, but requires one extra step. During `ready()`, before you can access `this.someInjectedThing` you must `await injectionReady(this, 'someInjectedThing')`. See tests for examples.

This allows graphs of asynchronously-initialized objects to depend on each other, even during their own initialization. As long as there are no cycles, everybody gets what they want. If there is a cycle, rather than deadlocking we detect the cycle and throw a descriptive error.

`injectionReady` is safe to use at any time, so if you have some method that can run during `ready` but also later, it's safe to always `await injectionReady`.