### PR TITLE
web: Add generics for token utility classes

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
@@ -9,8 +9,8 @@ import { TransactionReceipt } from 'web3-core';
 import BN from 'bn.js';
 import { toWei } from 'web3-utils';
 import {
+  BridgeableSymbol,
   TokenDisplayInfo,
-  TokenSymbol,
 } from '@cardstack/web-client/utils/token';
 import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
@@ -36,11 +36,11 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<Workflo
 
   // assumption is this is always set by cards before it. It should be defined by the time
   // it gets to this part of the workflow
-  get currentTokenSymbol(): TokenSymbol {
+  get currentTokenSymbol(): BridgeableSymbol {
     return this.args.workflowSession.state.depositSourceToken;
   }
 
-  get currentTokenDetails(): TokenDisplayInfo | undefined {
+  get currentTokenDetails(): TokenDisplayInfo<BridgeableSymbol> | undefined {
     if (this.currentTokenSymbol) {
       return new TokenDisplayInfo(this.currentTokenSymbol);
     } else {

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.ts
@@ -7,6 +7,7 @@ import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import BN from 'bn.js';
 
 import {
+  BridgeableSymbol,
   TokenSymbol,
   bridgeableSymbols,
   TokenBalance,
@@ -17,7 +18,7 @@ class CardPayDepositWorkflowTransactionSetupComponent extends Component<Workflow
   tokenOptions = bridgeableSymbols;
   @service declare layer1Network: Layer1Network;
   @service declare layer2Network: Layer2Network;
-  @tracked selectedToken: TokenBalance | undefined;
+  @tracked selectedToken: TokenBalance<BridgeableSymbol> | undefined;
 
   get selectedTokenSymbol() {
     if (this.args.workflowSession.state.depositSourceToken) {
@@ -73,7 +74,7 @@ class CardPayDepositWorkflowTransactionSetupComponent extends Component<Workflow
     return true;
   }
 
-  @action chooseSource(token: TokenBalance) {
+  @action chooseSource(token: TokenBalance<BridgeableSymbol>) {
     this.selectedToken = token;
   }
 

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.ts
@@ -5,17 +5,20 @@ import { inject as service } from '@ember/service';
 import BN from 'bn.js';
 
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
-import { TokenBalance, TokenSymbol } from '@cardstack/web-client/utils/token';
+import {
+  TokenBalance,
+  BridgedTokenSymbol,
+} from '@cardstack/web-client/utils/token';
 import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
 
 class FundingSourceCard extends Component<WorkflowCardComponentArgs> {
-  defaultTokenSymbol: TokenSymbol = 'DAI.CPXD';
+  defaultTokenSymbol: BridgedTokenSymbol = 'DAI.CPXD';
   tokenOptions = [this.defaultTokenSymbol];
   @service declare layer2Network: Layer2Network;
-  @tracked selectedTokenSymbol: TokenSymbol =
+  @tracked selectedTokenSymbol: BridgedTokenSymbol =
     this.args.workflowSession.state.prepaidFundingToken ??
     this.defaultTokenSymbol;
-  @tracked selectedToken: TokenBalance;
+  @tracked selectedToken: TokenBalance<BridgedTokenSymbol>;
 
   constructor(owner: unknown, args: WorkflowCardComponentArgs) {
     super(owner, args);
@@ -35,7 +38,7 @@ class FundingSourceCard extends Component<WorkflowCardComponentArgs> {
     });
   }
 
-  getTokenBalance(symbol: TokenSymbol) {
+  getTokenBalance(symbol: BridgedTokenSymbol) {
     if (symbol === this.defaultTokenSymbol) {
       return this.layer2Network.defaultTokenBalance ?? new BN('0');
     }
@@ -51,7 +54,7 @@ class FundingSourceCard extends Component<WorkflowCardComponentArgs> {
     );
   }
 
-  @action chooseSource(token: TokenBalance) {
+  @action chooseSource(token: TokenBalance<BridgedTokenSymbol>) {
     this.selectedToken = token;
   }
 

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/check-balance/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/check-balance/index.ts
@@ -4,8 +4,8 @@ import { next } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import {
+  BridgeableSymbol,
   TokenDisplayInfo,
-  TokenSymbol,
 } from '@cardstack/web-client/utils/token';
 import { reads } from 'macro-decorators';
 import { WalletProvider } from '@cardstack/web-client/utils/wallet-providers';
@@ -55,9 +55,9 @@ export default class CardPayWithdrawalWorkflowCheckBalanceComponent extends Comp
     return `Check ${this.layer1Network.nativeTokenSymbol} balance`;
   }
 
-  get nativeTokenDisplayInfo(): TokenDisplayInfo | undefined {
+  get nativeTokenDisplayInfo(): TokenDisplayInfo<BridgeableSymbol> | undefined {
     return new TokenDisplayInfo(
-      this.layer1Network.nativeTokenSymbol as TokenSymbol
+      this.layer1Network.nativeTokenSymbol as BridgeableSymbol
     );
   }
   get minimumBalanceForWithdrawalClaim() {

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/choose-balance/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/choose-balance/index.ts
@@ -4,22 +4,25 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
-import { TokenBalance, TokenSymbol } from '@cardstack/web-client/utils/token';
+import {
+  TokenBalance,
+  BridgedTokenSymbol,
+} from '@cardstack/web-client/utils/token';
 import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
 import BN from 'bn.js';
 
 class CardPayWithdrawalWorkflowChooseBalanceComponent extends Component<WorkflowCardComponentArgs> {
-  defaultTokenSymbol: TokenSymbol = 'DAI.CPXD';
-  cardTokenSymbol: TokenSymbol = 'CARD.CPXD';
+  defaultTokenSymbol: BridgedTokenSymbol = 'DAI.CPXD';
+  cardTokenSymbol: BridgedTokenSymbol = 'CARD.CPXD';
   tokenOptions = [this.defaultTokenSymbol, this.cardTokenSymbol];
   @service declare layer1Network: Layer1Network;
   @service declare layer2Network: Layer2Network;
-  get selectedTokenSymbol(): TokenSymbol {
+  get selectedTokenSymbol(): BridgedTokenSymbol {
     return (
       this.args.workflowSession.state.withdrawalToken ?? this.defaultTokenSymbol
     );
   }
-  @tracked selectedToken: TokenBalance;
+  @tracked selectedToken: TokenBalance<BridgedTokenSymbol>;
 
   constructor(owner: unknown, args: WorkflowCardComponentArgs) {
     super(owner, args);
@@ -39,7 +42,7 @@ class CardPayWithdrawalWorkflowChooseBalanceComponent extends Component<Workflow
     });
   }
 
-  getTokenBalance(symbol: TokenSymbol) {
+  getTokenBalance(symbol: BridgedTokenSymbol) {
     if (symbol === this.defaultTokenSymbol) {
       return this.layer2Network.defaultTokenBalance ?? new BN('0');
     }
@@ -58,7 +61,7 @@ class CardPayWithdrawalWorkflowChooseBalanceComponent extends Component<Workflow
     );
   }
 
-  @action chooseSource(token: TokenBalance) {
+  @action chooseSource(token: TokenBalance<BridgedTokenSymbol>) {
     this.selectedToken = token;
   }
 

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.ts
@@ -7,9 +7,9 @@ import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import BN from 'bn.js';
 
 import {
+  BridgeableSymbol,
   BridgedTokenSymbol,
   TokenDisplayInfo,
-  TokenSymbol,
   getUnbridgedSymbol,
 } from '@cardstack/web-client/utils/token';
 import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
@@ -24,7 +24,7 @@ class CardPayWithdrawalWorkflowTokenClaimComponent extends Component<WorkflowCar
   @service declare layer1Network: Layer1Network;
   @reads('layer1Network.walletProvider') declare walletProvider: WalletProvider;
   @reads('args.workflowSession.state.withdrawalToken')
-  declare tokenSymbol: TokenSymbol;
+  declare tokenSymbol: BridgeableSymbol;
 
   @tracked isConfirming = false;
   @tracked txnHash: string | undefined;
@@ -45,11 +45,11 @@ class CardPayWithdrawalWorkflowTokenClaimComponent extends Component<WorkflowCar
     return new BN(this.args.workflowSession.state.withdrawnAmount);
   }
 
-  get tokenSymbolForConversion(): TokenSymbol {
+  get tokenSymbolForConversion(): BridgeableSymbol {
     return getUnbridgedSymbol(this.tokenSymbol as BridgedTokenSymbol);
   }
 
-  get tokenDetails(): TokenDisplayInfo | undefined {
+  get tokenDetails(): TokenDisplayInfo<BridgeableSymbol> | undefined {
     if (this.tokenSymbol) {
       return new TokenDisplayInfo(this.tokenSymbol);
     } else {

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
@@ -35,7 +35,7 @@ class CardPayWithdrawalWorkflowTransactionAmountComponent extends Component<Work
 
   // assumption is this is always set by cards before it. It should be defined by the time
   // it gets to this part of the workflow
-  get currentTokenSymbol(): TokenSymbol {
+  get currentTokenSymbol(): BridgedTokenSymbol {
     return this.args.workflowSession.state.withdrawalToken;
   }
 

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
@@ -39,7 +39,7 @@ class CardPayWithdrawalWorkflowTransactionAmountComponent extends Component<Work
     return this.args.workflowSession.state.withdrawalToken;
   }
 
-  get currentTokenDetails(): TokenDisplayInfo | undefined {
+  get currentTokenDetails(): TokenDisplayInfo<BridgedTokenSymbol> | undefined {
     if (this.currentTokenSymbol) {
       return new TokenDisplayInfo(this.currentTokenSymbol);
     } else {

--- a/packages/web-client/app/utils/token.ts
+++ b/packages/web-client/app/utils/token.ts
@@ -120,13 +120,13 @@ const _tokenDisplayInfoMap: Record<TokenSymbol, DisplayInfo> = {
   },
 };
 
-export class TokenDisplayInfo implements DisplayInfo {
+export class TokenDisplayInfo<T extends TokenSymbol> implements DisplayInfo {
   name: string;
-  symbol: TokenSymbol;
+  symbol: T;
   description: string;
   icon: string;
 
-  constructor(symbol: TokenSymbol) {
+  constructor(symbol: T) {
     this.symbol = symbol;
     let displayInfo = _tokenDisplayInfoMap[symbol];
     this.name = displayInfo.name!;
@@ -151,10 +151,10 @@ export class TokenDisplayInfo implements DisplayInfo {
   }
 }
 
-export class TokenBalance implements DisplayInfo {
-  tokenDisplayInfo: TokenDisplayInfo;
+export class TokenBalance<T extends TokenSymbol> implements DisplayInfo {
+  tokenDisplayInfo: TokenDisplayInfo<T>;
   balance: BN;
-  constructor(symbol: TokenSymbol, balance: BN) {
+  constructor(symbol: T, balance: BN) {
     this.tokenDisplayInfo = new TokenDisplayInfo(symbol);
     this.balance = balance;
   }

--- a/packages/web-client/app/utils/token.ts
+++ b/packages/web-client/app/utils/token.ts
@@ -6,23 +6,42 @@ import { NetworkSymbol } from './web3-strategies/types';
 import BN from 'bn.js';
 
 // symbols
-export type ConvertibleSymbol = 'DAI' | 'CARD';
-export type BridgeableSymbol = 'DAI' | 'CARD';
-export type Layer1BalanceSymbol = 'DAI' | 'CARD' | 'ETH';
-export type BridgedTokenSymbol = 'DAI.CPXD' | 'CARD.CPXD';
-export type TokenSymbol =
-  | ConvertibleSymbol
-  | BridgeableSymbol
-  | Layer1BalanceSymbol
-  | BridgedTokenSymbol;
+export const tokenSymbols = {
+  DAI: 'DAI',
+  CARD: 'CARD',
+  'DAI.CPXD': 'DAI.CPXD',
+  'CARD.CPXD': 'CARD.CPXD',
+  ETH: 'ETH',
+} as const;
+export type TokenSymbol = keyof typeof tokenSymbols;
 
 // conversion
-export type ConversionFunction = (amountInWei: string) => number;
-export const convertibleSymbols: ConvertibleSymbol[] = ['DAI', 'CARD'];
+export const convertibleSymbols = [
+  tokenSymbols.DAI,
+  tokenSymbols.CARD,
+] as const;
 
 // contract/bridging
-export const bridgeableSymbols: BridgeableSymbol[] = ['DAI', 'CARD'];
-export const bridgedSymbols: BridgedTokenSymbol[] = ['DAI.CPXD', 'CARD.CPXD'];
+export const bridgeableSymbols = [tokenSymbols.DAI, tokenSymbols.CARD] as const;
+export const bridgedSymbols = [
+  tokenSymbols['DAI.CPXD'],
+  tokenSymbols['CARD.CPXD'],
+] as const;
+
+// balances
+export const layer1BalanceSymbols = [
+  tokenSymbols.DAI,
+  tokenSymbols.CARD,
+  tokenSymbols.ETH,
+] as const;
+
+// symbol categories
+export type ConvertibleSymbol = typeof convertibleSymbols[number];
+export type BridgeableSymbol = typeof bridgeableSymbols[number];
+export type Layer1BalanceSymbol = typeof layer1BalanceSymbols[number];
+export type BridgedTokenSymbol = typeof bridgedSymbols[number];
+
+export type ConversionFunction = (amountInWei: string) => number;
 
 const contractNames: Record<NetworkSymbol, Record<BridgeableSymbol, string>> = {
   kovan: {
@@ -47,10 +66,10 @@ const contractNames: Record<NetworkSymbol, Record<BridgeableSymbol, string>> = {
 export function getUnbridgedSymbol(
   bridgedSymbol: BridgedTokenSymbol
 ): BridgeableSymbol {
-  if (bridgedSymbol === 'DAI.CPXD') {
-    return 'DAI';
-  } else if (bridgedSymbol === 'CARD.CPXD') {
-    return 'CARD';
+  if (bridgedSymbol === tokenSymbols['DAI.CPXD']) {
+    return tokenSymbols.DAI;
+  } else if (bridgedSymbol === tokenSymbols['CARD.CPXD']) {
+    return tokenSymbols.CARD;
   } else {
     throw new Error(`Unknown bridgedSymbol ${bridgedSymbol}`);
   }
@@ -132,18 +151,6 @@ export class TokenDisplayInfo<T extends TokenSymbol> implements DisplayInfo {
     this.name = displayInfo.name!;
     this.description = displayInfo.description!;
     this.icon = displayInfo.icon;
-  }
-
-  static isRecognizedSymbol(value: string): value is TokenSymbol {
-    return ['DAI', 'CARD', 'ETH'].includes(value);
-  }
-
-  static nameFor(symbol: TokenSymbol) {
-    return _tokenDisplayInfoMap[symbol].name;
-  }
-
-  static descriptionFor(symbol: TokenSymbol) {
-    return _tokenDisplayInfoMap[symbol].description;
   }
 
   static iconFor(symbol: TokenSymbol) {


### PR DESCRIPTION
I [need](https://github.com/cardstack/cardstack/blob/web/merchant-withdrawal-cs-1658/packages/web-client/app/components/card-pay/withdrawal-workflow/choose-balance/index.ts#L27) a way to say that `token.symbol` where `token: TokenBalance` would be a particular subtype, so I added generics for the relevant token utility classes to be able to specify what type of token was expected, if any. Hopefully this makes sense! I could probably use `as` but it seemed helpful to me to make things explicit.