### PR TITLE
Enhancement/improve merchant payment page

### DIFF
--- a/packages/web-client/app/config/environment.d.ts
+++ b/packages/web-client/app/config/environment.d.ts
@@ -27,6 +27,7 @@ declare const config: {
   locationType: string;
   rootURL: string;
   hubURL: string;
+  universalLinkDomain: string;
   chains: ChainsOptions;
   features: FeaturesOptions;
   version: string;

--- a/packages/web-client/app/controllers/pay.ts
+++ b/packages/web-client/app/controllers/pay.ts
@@ -6,6 +6,7 @@ import { inject as service } from '@ember/service';
 import IsIOS from '../services/is-ios';
 import { useResource } from 'ember-resources';
 import { MerchantInfo } from '../resources/merchant-info';
+import config from '@cardstack/web-client/config/environment';
 
 export default class CardPayMerchantServicesController extends Controller {
   @service('is-ios') declare isIOSService: IsIOS;
@@ -47,10 +48,8 @@ export default class CardPayMerchantServicesController extends Controller {
     return !isNaN(this.amount) && this.amount > 0;
   }
   get paymentURL() {
-    // TODO: add domain to arguments (wallet.cardstack.com)
-    // currently using the default domain which is cardwallet:/
-    // because wallet.cardstack.com does not open up the payment UI
     return generateMerchantPaymentUrl({
+      domain: config.universalLinkDomain,
       network: this.model.network,
       merchantSafeID: this.model.merchantSafe.address,
       currency: this.currency,

--- a/packages/web-client/app/router.ts
+++ b/packages/web-client/app/router.ts
@@ -16,7 +16,7 @@ Router.map(function () {
   this.route('pay', {
     path: '/pay/:network/:merchant_safe_id',
   });
-  this.route('pay-error', {
+  this.route('pay-missing-route', {
     path: '/pay/:*',
   });
   this.route('boom');

--- a/packages/web-client/app/router.ts
+++ b/packages/web-client/app/router.ts
@@ -16,5 +16,8 @@ Router.map(function () {
   this.route('pay', {
     path: '/pay/:network/:merchant_safe_id',
   });
+  this.route('pay-error', {
+    path: '/pay/:*',
+  });
   this.route('boom');
 });

--- a/packages/web-client/app/routes/pay-error.ts
+++ b/packages/web-client/app/routes/pay-error.ts
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+import '../css/pay.css';
+
+export default class PayErrorRoute extends Route {}

--- a/packages/web-client/app/routes/pay-missing-route.ts
+++ b/packages/web-client/app/routes/pay-missing-route.ts
@@ -1,0 +1,6 @@
+import Route from '@ember/routing/route';
+import '../css/pay.css';
+
+export default class PayMissingRoute extends Route {
+  templateName = 'pay-error';
+}

--- a/packages/web-client/config/environment.js
+++ b/packages/web-client/config/environment.js
@@ -1,8 +1,12 @@
 'use strict';
-
 const infuraIdsByTarget = {
   staging: '558ee533522a468e9d421d818e06fadb', // this infura id is specific to https://app-staging.stack.cards/
   production: '5d6efa6b750b45459184cd11dd2c8697', // this infura id is specific to https://app.cardstack.com/
+};
+
+const universalLinkHostnamesByTarget = {
+  staging: 'https://wallet-staging.stack.cards',
+  production: 'https://wallet.cardstack.com',
 };
 
 const pkg = require('../package.json');
@@ -15,6 +19,9 @@ module.exports = function (environment) {
     rootURL: '/',
     locationType: 'auto',
     hubURL: process.env.HUB_URL,
+    universalLinkDomain:
+      universalLinkHostnamesByTarget[process.env.DEPLOY_TARGET] ??
+      'https://wallet-staging.stack.cards',
     version: pkg.version,
     sentryDsn: process.env.SENTRY_DSN,
     '@sentry/ember': {

--- a/packages/web-client/tests/acceptance/pay-test.ts
+++ b/packages/web-client/tests/acceptance/pay-test.ts
@@ -13,6 +13,7 @@ import {
 } from '@cardstack/cardpay-sdk';
 import { getResolver } from '@cardstack/did-resolver';
 import { Resolver } from 'did-resolver';
+import config from '@cardstack/web-client/config/environment';
 
 // selectors
 const MERCHANT = '[data-test-merchant]';
@@ -29,6 +30,7 @@ const DEEP_LINK = '[data-test-payment-request-deep-link]';
 const PAYMENT_URL = '[data-test-payment-request-url]';
 
 // fixed data
+const domain = config.universalLinkDomain;
 const exampleDid = 'did:cardstack:1moVYMRNGv6E5Ca3t7aXVD2Yb11e4e91103f084a';
 const spendSymbol = 'SPD';
 const usdSymbol = 'USD';
@@ -111,7 +113,8 @@ module('Acceptance | pay', function (hooks) {
       .containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
 
     let expectedUrl = generateMerchantPaymentUrl({
-      network: network,
+      domain,
+      network,
       merchantSafeID: merchantSafe.address,
       currency: spendSymbol,
       amount: spendAmount,
@@ -145,7 +148,8 @@ module('Acceptance | pay', function (hooks) {
       .dom(USD_AMOUNT)
       .containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
     let expectedUrl = generateMerchantPaymentUrl({
-      network: network,
+      domain,
+      network,
       merchantSafeID: merchantSafe.address,
       currency: spendSymbol,
       amount: spendAmount,
@@ -178,7 +182,8 @@ module('Acceptance | pay', function (hooks) {
       .dom(USD_AMOUNT)
       .containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
     let expectedUrl = generateMerchantPaymentUrl({
-      network: network,
+      domain,
+      network,
       merchantSafeID: merchantSafe.address,
       currency: usdSymbol,
       amount: usdAmount,
@@ -214,7 +219,8 @@ module('Acceptance | pay', function (hooks) {
     // displaying the amounts if we don't recognize the currency
     // currently this is anything that is not SPD or USD
     let expectedUrl = generateMerchantPaymentUrl({
-      network: network,
+      domain,
+      network,
       merchantSafeID: merchantSafe.address,
       currency: invalidCurrencySymbol,
       amount: 300,
@@ -247,7 +253,8 @@ module('Acceptance | pay', function (hooks) {
     assert.dom(USD_AMOUNT).doesNotExist();
 
     let expectedUrl = generateMerchantPaymentUrl({
-      network: network,
+      domain,
+      network,
       merchantSafeID: merchantSafe.address,
       currency: spendSymbol,
       amount: 0,
@@ -287,7 +294,8 @@ module('Acceptance | pay', function (hooks) {
     // assert that the deep link view is rendered
     assert.dom(QR_CODE).doesNotExist();
     let expectedUrl = generateMerchantPaymentUrl({
-      network: network,
+      domain,
+      network,
       merchantSafeID: merchantSafe.address,
       currency: spendSymbol,
       amount: spendAmount,
@@ -320,7 +328,8 @@ module('Acceptance | pay', function (hooks) {
       .containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
 
     let expectedUrl = generateMerchantPaymentUrl({
-      network: network,
+      domain,
+      network,
       merchantSafeID: merchantSafeWithoutInfo.address,
       currency: spendSymbol,
       amount: spendAmount,
@@ -333,6 +342,18 @@ module('Acceptance | pay', function (hooks) {
     await visit(
       `/pay/${network}/${nonexistentMerchantId}?amount=${spendAmount}&currency=${spendSymbol}`
     );
+
+    await waitFor(MERCHANT_MISSING_MESSAGE);
+
+    assert
+      .dom(MERCHANT_MISSING_MESSAGE)
+      .containsText(
+        'Oops, no Merchant found - please ask the merchant to confirm the payment link'
+      );
+  });
+
+  test('it renders appropriate UI when URL is not complete', async function (assert) {
+    await visit(`/pay/sok`);
 
     await waitFor(MERCHANT_MISSING_MESSAGE);
 


### PR DESCRIPTION
This PR addresses:
- [CS-1830]: makes the url generated on the merchant payment request page start with `https://wallet.cardstack.com` in production, and `https://wallet-staging.stack.cards` in staging and dev. Did not add these as constants to the SDK for now due to difficulties getting imports to work.
- [CS-1837]: makes incomplete routes (eg. `https://wallet.cardstack.com/pay/sok`) match the `pay-error` page.