### PR TITLE
Cleaner imports for workflow family of classes

### DIFF
--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
@@ -3,29 +3,25 @@ import { getOwner } from '@ember/application';
 import { inject as service } from '@ember/service';
 import { formatUsd, spendToUsd } from '@cardstack/cardpay-sdk';
 import {
-  IWorkflowMessage,
-  WorkflowMessage,
-} from '@cardstack/web-client/models/workflow/workflow-message';
-import {
-  Workflow,
   cardbot,
+  ArbitraryDictionary,
+  IWorkflowMessage,
+  Milestone,
+  Participant,
+  PostableCollection,
+  NetworkAwareWorkflowMessage,
+  NetworkAwareWorkflowCard,
+  Workflow,
+  WorkflowCard,
+  WorkflowMessage,
   WorkflowName,
+  WorkflowPostable,
 } from '@cardstack/web-client/models/workflow';
-import { Milestone } from '@cardstack/web-client/models/workflow/milestone';
-import { WorkflowCard } from '@cardstack/web-client/models/workflow/workflow-card';
-import PostableCollection from '@cardstack/web-client/models/workflow/postable-collection';
-import NetworkAwareWorkflowCard from '@cardstack/web-client/components/workflow-thread/network-aware-card';
-import NetworkAwareWorkflowMessage from '@cardstack/web-client/components/workflow-thread/network-aware-message';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { action } from '@ember/object';
 
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
-import {
-  Participant,
-  WorkflowPostable,
-} from '@cardstack/web-client/models/workflow/workflow-postable';
 import { taskFor } from 'ember-concurrency-ts';
-import { ArbitraryDictionary } from '@cardstack/web-client/models/workflow/workflow-session';
 
 const FAILURE_REASONS = {
   DISCONNECTED: 'DISCONNECTED',

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import MerchantInfoService from '@cardstack/web-client/services/merchant-info';
 import { inject as service } from '@ember/service';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 import { didCancel, restartableTask, timeout } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import { mostReadable, random as randomColor } from '@ctrl/tinycolor';

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/next-steps/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/next-steps/index.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import RouterService from '@ember/routing/router-service';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 
 class CardPayCreateMerchantWorkflowNextStepsComponent extends Component<WorkflowCardComponentArgs> {
   @service declare router: RouterService;

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import config from '@cardstack/web-client/config/environment';
-import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
+import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import MerchantInfoService from '@cardstack/web-client/services/merchant-info';
 import { isLayer2UserRejectionError } from '@cardstack/web-client/utils/is-user-rejection-error';

--- a/packages/web-client/app/components/card-pay/deposit-workflow/confirmation/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/confirmation/index.ts
@@ -9,7 +9,7 @@ import {
   TokenDisplayInfo,
   TokenSymbol,
 } from '@cardstack/web-client/utils/token';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 
 class CardPayDepositWorkflowConfirmationComponent extends Component<WorkflowCardComponentArgs> {
   @service declare layer1Network: Layer1Network;

--- a/packages/web-client/app/components/card-pay/deposit-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/index.ts
@@ -1,15 +1,15 @@
 import Component from '@glimmer/component';
 import { getOwner } from '@ember/application';
-import { WorkflowMessage } from '@cardstack/web-client/models/workflow/workflow-message';
-import NetworkAwareWorkflowMessage from '@cardstack/web-client/components/workflow-thread/network-aware-message';
 import {
-  Workflow,
   cardbot,
+  Workflow,
+  Milestone,
+  NetworkAwareWorkflowMessage,
+  PostableCollection,
   WorkflowName,
+  WorkflowMessage,
+  WorkflowCard,
 } from '@cardstack/web-client/models/workflow';
-import { Milestone } from '@cardstack/web-client/models/workflow/milestone';
-import { WorkflowCard } from '@cardstack/web-client/models/workflow/workflow-card';
-import PostableCollection from '@cardstack/web-client/models/workflow/postable-collection';
 import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { inject as service } from '@ember/service';

--- a/packages/web-client/app/components/card-pay/deposit-workflow/next-steps/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/next-steps/index.ts
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import RouterService from '@ember/routing/router-service';
 import { next } from '@ember/runloop';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 class CardPayDepositWorkflowNextStepsComponent extends Component<WorkflowCardComponentArgs> {
   @service declare router: RouterService;
 

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
@@ -12,7 +12,7 @@ import {
   BridgeableSymbol,
   TokenDisplayInfo,
 } from '@cardstack/web-client/utils/token';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
 import {
   shouldUseTokenInput,

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.ts
@@ -12,7 +12,7 @@ import {
   bridgeableSymbols,
   TokenBalance,
 } from '@cardstack/web-client/utils/token';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 
 class CardPayDepositWorkflowTransactionSetupComponent extends Component<WorkflowCardComponentArgs> {
   tokenOptions = bridgeableSymbols;

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.ts
@@ -7,7 +7,7 @@ import * as Sentry from '@sentry/browser';
 import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { TokenSymbol } from '@cardstack/web-client/utils/token';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
 import { TransactionReceipt } from 'web3-core';
 import { task } from 'ember-concurrency-decorators';

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/confirmation/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/confirmation/index.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { next } from '@ember/runloop';
 import { inject as service } from '@ember/service';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 
 export default class CardPayIssuePrepaidCardWorkflowConfirmationComponent extends Component<WorkflowCardComponentArgs> {

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.ts
@@ -11,7 +11,7 @@ import {
   TokenSymbol,
 } from '@cardstack/web-client/utils/token';
 import { faceValueOptions, spendToUsdRate } from '../workflow-config';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 
 interface FaceValue {
   spendAmount: number;

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -1,17 +1,17 @@
 import Component from '@glimmer/component';
 import { getOwner } from '@ember/application';
 import { inject as service } from '@ember/service';
-import { WorkflowMessage } from '@cardstack/web-client/models/workflow/workflow-message';
 import {
-  Workflow,
   cardbot,
+  Milestone,
+  NetworkAwareWorkflowMessage,
+  PostableCollection,
+  Workflow,
+  WorkflowCard,
   WorkflowName,
+  WorkflowMessage,
+  NetworkAwareWorkflowCard,
 } from '@cardstack/web-client/models/workflow';
-import { Milestone } from '@cardstack/web-client/models/workflow/milestone';
-import { WorkflowCard } from '@cardstack/web-client/models/workflow/workflow-card';
-import PostableCollection from '@cardstack/web-client/models/workflow/postable-collection';
-import NetworkAwareWorkflowCard from '@cardstack/web-client/components/workflow-thread/network-aware-card';
-import NetworkAwareWorkflowMessage from '@cardstack/web-client/components/workflow-thread/network-aware-message';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';
 import { action } from '@ember/object';

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.ts
@@ -8,7 +8,7 @@ import {
   default as CardCustomizationService,
 } from '@cardstack/web-client/services/card-customization';
 import { reads } from 'macro-decorators';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 
 export default class LayoutCustomizationCard extends Component<WorkflowCardComponentArgs> {
   @service('card-customization')

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/next-steps/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/next-steps/index.ts
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import RouterService from '@ember/routing/router-service';
 import { next } from '@ember/runloop';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 
 class CardPayIssuePrepaidCardWorkflowNextStepsComponent extends Component<WorkflowCardComponentArgs> {
   @service declare router: RouterService;

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { taskFor } from 'ember-concurrency-ts';
 import { reads } from 'macro-decorators';
-import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
+import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 import {
   task,
   TaskGenerator,

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
@@ -13,7 +13,7 @@ import walletProviders from '@cardstack/web-client/utils/wallet-providers';
 import cardstackLogo from '@cardstack/web-client/images/icons/cardstack-logo-navy-rounded.svg';
 import connectionSymbol from '@cardstack/web-client/images/icons/connection-symbol.svg';
 import { WalletProvider } from '@cardstack/web-client/utils/wallet-providers';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 
 interface CardPayDepositWorkflowConnectLayer1ComponentArgs
   extends WorkflowCardComponentArgs {

--- a/packages/web-client/app/components/card-pay/layer-two-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-two-connect-card/index.ts
@@ -14,7 +14,7 @@ import { taskFor } from 'ember-concurrency-ts';
 import { next } from '@ember/runloop';
 import { timeout } from 'ember-concurrency';
 import { action } from '@ember/object';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 
 interface CardPayLayerTwoConnectCardComponentArgs
   extends WorkflowCardComponentArgs {

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/check-balance/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/check-balance/index.ts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 import { next } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import Layer1Network from '@cardstack/web-client/services/layer1-network';

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
@@ -1,19 +1,18 @@
 import Component from '@glimmer/component';
 import { getOwner } from '@ember/application';
 import {
-  IWorkflowMessage,
-  WorkflowMessage,
-} from '@cardstack/web-client/models/workflow/workflow-message';
-import NetworkAwareWorkflowMessage from '@cardstack/web-client/components/workflow-thread/network-aware-message';
-import NetworkAwareWorkflowCard from '@cardstack/web-client/components/workflow-thread/network-aware-card';
-import {
-  Workflow,
   cardbot,
+  IWorkflowMessage,
+  Milestone,
+  NetworkAwareWorkflowCard,
+  NetworkAwareWorkflowMessage,
+  PostableCollection,
+  Workflow,
+  WorkflowCard,
+  WorkflowMessage,
   WorkflowName,
+  WorkflowPostable,
 } from '@cardstack/web-client/models/workflow';
-import { Milestone } from '@cardstack/web-client/models/workflow/milestone';
-import { WorkflowCard } from '@cardstack/web-client/models/workflow/workflow-card';
-import PostableCollection from '@cardstack/web-client/models/workflow/postable-collection';
 import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { inject as service } from '@ember/service';
@@ -21,7 +20,6 @@ import { action } from '@ember/object';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
 import { capitalize } from '@ember/string';
 import BN from 'bn.js';
-import { WorkflowPostable } from '@cardstack/web-client/models/workflow/workflow-postable';
 import { tracked } from '@glimmer/tracking';
 import { taskFor } from 'ember-concurrency-ts';
 import {

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/next-steps/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/next-steps/index.ts
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import RouterService from '@ember/routing/router-service';
 import { next } from '@ember/runloop';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 class CardPayWithdrawalWorkflowNextStepsComponent extends Component<WorkflowCardComponentArgs> {
   @service declare router: RouterService;
 

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.ts
@@ -12,7 +12,7 @@ import {
   TokenDisplayInfo,
   getUnbridgedSymbol,
 } from '@cardstack/web-client/utils/token';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 import { BridgeValidationResult } from '../../../../../../cardpay-sdk/sdk/token-bridge-home-side';
 import { taskFor } from 'ember-concurrency-ts';
 import walletProviders, {

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
@@ -13,7 +13,7 @@ import {
   getUnbridgedSymbol,
   bridgedSymbols,
 } from '@cardstack/web-client/utils/token';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 import {
   shouldUseTokenInput,
   validateTokenInput,

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-confirmed/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-confirmed/index.ts
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import BN from 'bn.js';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 import { next } from '@ember/runloop';
 import {
   TokenDisplayInfo,

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.ts
@@ -5,7 +5,7 @@ import BN from 'bn.js';
 import { taskFor } from 'ember-concurrency-ts';
 import { task, TaskGenerator } from 'ember-concurrency';
 import * as Sentry from '@sentry/browser';
-import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow/workflow-card';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';

--- a/packages/web-client/app/helpers/is-postable-on-new-day.ts
+++ b/packages/web-client/app/helpers/is-postable-on-new-day.ts
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
-import { WorkflowPostable } from '../models/workflow/workflow-postable';
+import { WorkflowPostable } from '../models/workflow';
 
 function isPostableOnNewDay([postable]: [WorkflowPostable]) {
   if (!postable) {

--- a/packages/web-client/app/helpers/postable-meta-hidden.ts
+++ b/packages/web-client/app/helpers/postable-meta-hidden.ts
@@ -1,7 +1,6 @@
 import { helper } from '@ember/component/helper';
 import { postableMetaIdentical } from './postable-meta-identical';
-import { WorkflowPostable } from '../models/workflow/workflow-postable';
-import { WorkflowCard } from '../models/workflow/workflow-card';
+import { WorkflowCard, WorkflowPostable } from '../models/workflow';
 
 function postableMetaHidden(
   [post]: [WorkflowPostable | WorkflowCard],

--- a/packages/web-client/app/helpers/postable-meta-identical.ts
+++ b/packages/web-client/app/helpers/postable-meta-identical.ts
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
-import { WorkflowPostable } from '../models/workflow/workflow-postable';
+import { WorkflowPostable } from '../models/workflow';
 
 // one minute
 const maxIntervalInMilliseconds = 1000 * 60;

--- a/packages/web-client/app/models/animated-workflow.ts
+++ b/packages/web-client/app/models/animated-workflow.ts
@@ -1,7 +1,5 @@
-import { Workflow } from './workflow';
+import { Milestone, PostableCollection, Workflow } from './workflow';
 import { reads } from 'macro-decorators';
-import { Milestone } from './workflow/milestone';
-import PostableCollection from './workflow/postable-collection';
 import { WorkflowPostable } from './workflow/workflow-postable';
 import { tracked } from '@glimmer/tracking';
 import { taskFor } from 'ember-concurrency-ts';

--- a/packages/web-client/app/models/workflow.ts
+++ b/packages/web-client/app/models/workflow.ts
@@ -6,7 +6,21 @@ import { tracked } from '@glimmer/tracking';
 import { SimpleEmitter } from '../utils/events';
 import { next } from '@ember/runloop';
 import WorkflowPersistence from '@cardstack/web-client/app/services/workflow-persistence';
-
+export { Milestone } from './workflow/milestone';
+export { default as PostableCollection } from './workflow/postable-collection';
+export { WorkflowMessage, IWorkflowMessage } from './workflow/workflow-message';
+export { default as NetworkAwareWorkflowMessage } from './workflow/network-aware-message';
+export {
+  CheckResult,
+  WorkflowCard,
+  WorkflowCardComponentArgs,
+} from './workflow/workflow-card';
+export { default as NetworkAwareWorkflowCard } from './workflow/network-aware-card';
+export { Participant, WorkflowPostable } from './workflow/workflow-postable';
+export {
+  ArbitraryDictionary,
+  default as WorkflowSession,
+} from './workflow/workflow-session';
 interface PostableIndices {
   isInMilestone: boolean;
   isInEpilogue: boolean;

--- a/packages/web-client/app/models/workflow/network-aware-card.ts
+++ b/packages/web-client/app/models/workflow/network-aware-card.ts
@@ -1,11 +1,9 @@
 import {
   CheckResult,
   WorkflowCard,
-} from '@cardstack/web-client/models/workflow/workflow-card';
-import {
   Participant,
   WorkflowPostable,
-} from '@cardstack/web-client/models/workflow/workflow-postable';
+} from '@cardstack/web-client/models/workflow';
 import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer1-network';
 import HubAuthentication from '@cardstack/web-client/services/hub-authentication';

--- a/packages/web-client/app/models/workflow/network-aware-message.ts
+++ b/packages/web-client/app/models/workflow/network-aware-message.ts
@@ -1,11 +1,8 @@
-import {
-  Participant,
-  WorkflowPostable,
-} from '@cardstack/web-client/models/workflow/workflow-postable';
-import { WorkflowMessage } from '@cardstack/web-client/models/workflow/workflow-message';
 import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer1-network';
 import HubAuthentication from '@cardstack/web-client/services/hub-authentication';
+import { Participant, WorkflowPostable } from './workflow-postable';
+import { WorkflowMessage } from './workflow-message';
 
 interface NetworkAwareWorkflowMessageOptions {
   author: Participant;

--- a/packages/web-client/app/models/workflow/session-aware-workflow-message.ts
+++ b/packages/web-client/app/models/workflow/session-aware-workflow-message.ts
@@ -1,0 +1,29 @@
+import {
+  ArbitraryDictionary,
+  IWorkflowMessage,
+  Participant,
+  WorkflowPostable,
+} from '@cardstack/web-client/models/workflow';
+
+interface SessionAwareWorkflowMessageOptions {
+  author: Participant;
+  includeIf: (this: WorkflowPostable) => boolean;
+  template: (session: ArbitraryDictionary) => string;
+}
+
+export class SessionAwareWorkflowMessage
+  extends WorkflowPostable
+  implements IWorkflowMessage
+{
+  private template: (session: ArbitraryDictionary) => string;
+  isComplete = true;
+
+  constructor(options: SessionAwareWorkflowMessageOptions) {
+    super(options.author, options.includeIf);
+    this.template = options.template;
+  }
+
+  get message() {
+    return this.template(this.workflow?.session.state!);
+  }
+}

--- a/packages/web-client/app/models/workflow/workflow-card.ts
+++ b/packages/web-client/app/models/workflow/workflow-card.ts
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import { Participant, WorkflowPostable } from './workflow-postable';
-import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
+import WorkflowSession from './workflow-session';
 
 export interface WorkflowCardComponentArgs {
   workflowSession: WorkflowSession;
@@ -12,10 +12,12 @@ export interface WorkflowCardComponentArgs {
 type SuccessCheckResult = {
   success: true;
 };
+
 type FailureCheckResult = {
   success: false;
   reason: string;
 };
+
 export type CheckResult = SuccessCheckResult | FailureCheckResult;
 
 interface WorkflowCardOptions {

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { click, fillIn, find, render, waitUntil } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
-import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
+import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { MirageTestContext } from 'ember-cli-mirage/test-support';

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { click, render, waitFor, waitUntil } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
-import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
+import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 import sinon from 'sinon';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { MirageTestContext } from 'ember-cli-mirage/test-support';

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
@@ -4,7 +4,7 @@ import { render, fillIn, typeIn, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
-import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
+import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 import BN from 'bn.js';
 import { toWei } from 'web3-utils';
 import sinon from 'sinon';

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-setup-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-setup-test.ts
@@ -4,7 +4,7 @@ import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
-import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
+import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
 import BN from 'bn.js';
 

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-status-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-status-test.ts
@@ -4,7 +4,7 @@ import { render, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
-import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
+import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 import BN from 'bn.js';
 import sinon from 'sinon';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';

--- a/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { click, render, waitFor, waitUntil } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
-import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
+import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 import sinon from 'sinon';
 import CardCustomization from '@cardstack/web-client/services/card-customization';
 import { taskFor } from 'ember-concurrency-ts';

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/choose-balance-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/choose-balance-test.ts
@@ -7,7 +7,7 @@ import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/
 import BN from 'bn.js';
 
 import { DepotSafe } from '@cardstack/cardpay-sdk/sdk/safes';
-import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
+import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 
 module(
   'Integration | Component | card-pay/withdrawal-workflow/choose-balance',

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-amount-test.ts
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { click, fillIn, render, typeIn, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
-import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
+import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 import { toWei } from 'web3-utils';
 import BN from 'bn.js';
 import sinon from 'sinon';

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-confirmed-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-confirmed-test.ts
@@ -7,7 +7,7 @@ import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/
 import BN from 'bn.js';
 
 import { DepotSafe } from '@cardstack/cardpay-sdk/sdk/safes';
-import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
+import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 
 module(
   'Integration | Component | card-pay/withdrawal-workflow/transaction-confirmed',

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
+import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
 
 import sinon from 'sinon';

--- a/packages/web-client/tests/integration/components/workflow-thread-test.ts
+++ b/packages/web-client/tests/integration/components/workflow-thread-test.ts
@@ -2,12 +2,14 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { Workflow } from '@cardstack/web-client/models/workflow';
-import { Milestone } from '@cardstack/web-client/models/workflow/milestone';
-import { WorkflowMessage } from '@cardstack/web-client/models/workflow/workflow-message';
-import { WorkflowPostable } from '@cardstack/web-client/models/workflow/workflow-postable';
-import PostableCollection from '@cardstack/web-client/models/workflow/postable-collection';
-import { WorkflowCard } from '@cardstack/web-client/models/workflow/workflow-card';
+import {
+  Milestone,
+  PostableCollection,
+  Workflow,
+  WorkflowMessage,
+  WorkflowPostable,
+  WorkflowCard,
+} from '@cardstack/web-client/models/workflow';
 
 module('Integration | Component | workflow-thread', function (hooks) {
   setupRenderingTest(hooks);

--- a/packages/web-client/tests/integration/helpers/postable-meta-hidden-test.ts
+++ b/packages/web-client/tests/integration/helpers/postable-meta-hidden-test.ts
@@ -2,8 +2,10 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { WorkflowMessage } from '@cardstack/web-client/models/workflow/workflow-message';
-import { WorkflowCard } from '@cardstack/web-client/models/workflow/workflow-card';
+import {
+  WorkflowCard,
+  WorkflowMessage,
+} from '@cardstack/web-client/models/workflow';
 
 module('Integration | Helper | postable-meta-hidden', function (hooks) {
   setupRenderingTest(hooks);

--- a/packages/web-client/tests/integration/helpers/postable-meta-identical-test.ts
+++ b/packages/web-client/tests/integration/helpers/postable-meta-identical-test.ts
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { WorkflowMessage } from '@cardstack/web-client/models/workflow/workflow-message';
+import { WorkflowMessage } from '@cardstack/web-client/models/workflow';
 
 module('Integration | Helper | postable-meta-identical', function (hooks) {
   setupRenderingTest(hooks);

--- a/packages/web-client/tests/unit/models/animated-workflow-test.ts
+++ b/packages/web-client/tests/unit/models/animated-workflow-test.ts
@@ -1,12 +1,15 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { WorkflowCard } from '@cardstack/web-client/models/workflow/workflow-card';
-import { Workflow, WorkflowName } from '@cardstack/web-client/models/workflow';
+import {
+  Milestone,
+  PostableCollection,
+  Workflow,
+  WorkflowCard,
+  WorkflowMessage,
+  WorkflowName,
+} from '@cardstack/web-client/models/workflow';
 import AnimatedWorkflow from '@cardstack/web-client/models/animated-workflow';
-import { Milestone } from '@cardstack/web-client/models/workflow/milestone';
 import { settled } from '@ember/test-helpers';
-import PostableCollection from '@cardstack/web-client/models/workflow/postable-collection';
-import { WorkflowMessage } from '@cardstack/web-client/models/workflow/workflow-message';
 
 class MockWorkflow extends Workflow {
   name = 'WITHDRAWAL' as WorkflowName;

--- a/packages/web-client/tests/unit/models/workflow-test.ts
+++ b/packages/web-client/tests/unit/models/workflow-test.ts
@@ -1,11 +1,13 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { Milestone } from '@cardstack/web-client/models/workflow/milestone';
-import { Workflow } from '@cardstack/web-client/models/workflow';
-import { WorkflowMessage } from '@cardstack/web-client/models/workflow/workflow-message';
-import { WorkflowCard } from '@cardstack/web-client/models/workflow/workflow-card';
-import { WorkflowPostable } from '@cardstack/web-client/models/workflow/workflow-postable';
-import PostableCollection from '@cardstack/web-client/models/workflow/postable-collection';
+import {
+  Milestone,
+  PostableCollection,
+  Workflow,
+  WorkflowCard,
+  WorkflowMessage,
+  WorkflowPostable,
+} from '@cardstack/web-client/models/workflow';
 
 module('Unit | Workflow model', function (hooks) {
   setupTest(hooks);

--- a/packages/web-client/tests/unit/models/workflow/milestone-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/milestone-test.ts
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { Milestone } from '@cardstack/web-client/models/workflow/milestone';
 import {
+  Milestone,
   Participant,
+  Workflow,
   WorkflowPostable,
-} from '@cardstack/web-client/models/workflow/workflow-postable';
-import { Workflow } from '@cardstack/web-client/models/workflow';
+} from '@cardstack/web-client/models/workflow';
 
 module('Unit | Milestone model', function (hooks) {
   setupTest(hooks);

--- a/packages/web-client/tests/unit/models/workflow/workflow-card-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/workflow-card-test.ts
@@ -1,13 +1,13 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { settled } from '@ember/test-helpers';
 import {
+  Milestone,
+  Workflow,
+  WorkflowCard,
   Participant,
   WorkflowPostable,
-} from '@cardstack/web-client/models/workflow/workflow-postable';
-import { WorkflowCard } from '@cardstack/web-client/models/workflow/workflow-card';
-import { Workflow } from '@cardstack/web-client/models/workflow';
-import { settled } from '@ember/test-helpers';
-import { Milestone } from '@cardstack/web-client/models/workflow/milestone';
+} from '@cardstack/web-client/models/workflow';
 
 module('Unit | WorkflowCard model', function (hooks) {
   setupTest(hooks);

--- a/packages/web-client/tests/unit/models/workflow/workflow-message-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/workflow-message-test.ts
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { Participant } from '../../../../app/models/workflow/workflow-postable';
 import { WorkflowMessage } from '@cardstack/web-client/models/workflow/workflow-message';
+import { Participant } from '@cardstack/web-client/models/workflow/workflow-postable';
 
 module('Unit | WorkflowMessage model', function (hooks) {
   setupTest(hooks);

--- a/packages/web-client/tests/unit/models/workflow/workflow-postable-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/workflow-postable-test.ts
@@ -1,8 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { Workflow } from '@cardstack/web-client/models/workflow';
-import { WorkflowPostable } from '@cardstack/web-client/models/workflow/workflow-postable';
-import { Participant } from '../../../../app/models/workflow/workflow-postable';
+import {
+  Participant,
+  WorkflowPostable,
+} from '@cardstack/web-client/models/workflow/workflow-postable';
 
 module('Unit | WorkflowPostable model', function (hooks) {
   setupTest(hooks);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7294,7 +7294,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@^4.1.4:
+axe-core@4.1.4, axe-core@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.4.tgz#f19cd99a84ee32a318b9c5b5bb8ed373ad94f143"
   integrity sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==
@@ -11580,7 +11580,7 @@ elliptic@6.5.4, elliptic@^6.0.0, elliptic@^6.4.0, elliptic@^6.5.2:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-ember-a11y-testing@^4.0.3:
+ember-a11y-testing@4.0.3, ember-a11y-testing@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-4.0.3.tgz#1f5c91266d39ea5b20614b0d294a562079887ac7"
   integrity sha512-Q7nq2crC9+bT+sZi/BORAM4FUhI080edEhnpsvB6vdkD9Ro2Rg4DksQs5Be65/DM108VNDMtbHZtrPS060Mzcw==


### PR DESCRIPTION
Re-export workflow-related classes from models/workflow to make imports cleaner as we often import them in groups