### PR TITLE
web: Add validation enforcement of withdrawal limits

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
@@ -124,7 +124,7 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<Workflo
 
   validate() {
     this.validationMessage = validateTokenInput(this.amount, {
-      min: new BN(0),
+      tokenSymbol: this.currentTokenSymbol,
       max: this.currentTokenBalance,
     });
   }

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
@@ -125,7 +125,7 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<Workflo
   validate() {
     this.validationMessage = validateTokenInput(this.amount, {
       tokenSymbol: this.currentTokenSymbol,
-      max: this.currentTokenBalance,
+      balance: this.currentTokenBalance,
     });
   }
 

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -14,6 +14,8 @@ import {
   ConvertibleSymbol,
   ConversionFunction,
   TokenContractInfo,
+  BridgedTokenSymbol,
+  getUnbridgedSymbol,
 } from '../token';
 import WalletInfo from '../wallet-info';
 import CustomStorageWalletConnect from '../wc-connector';
@@ -23,6 +25,7 @@ import {
   TransactionHash,
   Layer2NetworkSymbol,
   Layer2ChainEvent,
+  WithdrawalLimits,
 } from './types';
 import {
   networkIds,
@@ -335,6 +338,25 @@ export default abstract class Layer2ChainWeb3Strategy
 
   get waitForAccount() {
     return this.waitForAccountDeferred.promise;
+  }
+
+  async getWithdrawalLimits(
+    tokenSymbol: BridgedTokenSymbol
+  ): Promise<WithdrawalLimits> {
+    let tokenBridge = await getSDK('TokenBridgeHomeSide', this.web3);
+    let contractInfo = this.getTokenContractInfo(
+      getUnbridgedSymbol(tokenSymbol),
+      this.networkSymbol
+    );
+
+    let { min, max } = await tokenBridge.getWithdrawalLimits(
+      contractInfo.address
+    );
+
+    return {
+      min: new BN(min),
+      max: new BN(max),
+    };
   }
 
   async awaitBridgedToLayer2(

--- a/packages/web-client/app/utils/web3-strategies/test-layer2.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer2.ts
@@ -1,8 +1,9 @@
 import { tracked } from '@glimmer/tracking';
 import WalletInfo from '../wallet-info';
-import { Layer2Web3Strategy, TransactionHash } from './types';
+import { Layer2Web3Strategy, TransactionHash, WithdrawalLimits } from './types';
 import {
   BridgeableSymbol,
+  BridgedTokenSymbol,
   ConvertibleSymbol,
   ConversionFunction,
 } from '@cardstack/web-client/utils/token';
@@ -79,6 +80,9 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
   // this is only a mock property
   @tracked balancesRefreshed = false;
 
+  test__withdrawalMinimum = new BN('500000000000000000');
+  test__withdrawalMaximum = new BN('1500000000000000000000000');
+
   @task *initializeTask(): TaskGenerator<void> {
     yield '';
     return;
@@ -111,6 +115,15 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
     let safes = this.accountSafes.get(this.walletInfo.firstAddress!) || [];
     let depotSafe = safes.find((safe) => safe.type === 'depot');
     return (depotSafe as DepotSafe) ?? null;
+  }
+
+  async getWithdrawalLimits(
+    _tokenSymbol: BridgedTokenSymbol
+  ): Promise<WithdrawalLimits> {
+    return {
+      min: this.test__withdrawalMinimum,
+      max: this.test__withdrawalMaximum,
+    };
   }
 
   awaitBridgedToLayer2(

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -11,6 +11,7 @@ import {
   ConvertibleSymbol,
   ConversionFunction,
   BridgeableSymbol,
+  BridgedTokenSymbol,
 } from '@cardstack/web-client/utils/token';
 import { Emitter } from '../events';
 import { BridgeValidationResult } from '@cardstack/cardpay-sdk/sdk/token-bridge-home-side';
@@ -45,6 +46,11 @@ export interface RelayTokensOptions {
 
 export interface ClaimBridgedTokensOptions {
   onTxnHash?(txnHash: TransactionHash): void;
+}
+
+export interface WithdrawalLimits {
+  min: BN;
+  max: BN;
 }
 
 export interface Layer1Web3Strategy
@@ -103,6 +109,9 @@ export interface Layer2Web3Strategy
     fromBlock: BN,
     receiver: ChainAddress
   ): Promise<TransactionReceipt>;
+  getWithdrawalLimits(
+    tokenSymbol: BridgedTokenSymbol
+  ): Promise<WithdrawalLimits>;
   bridgeToLayer1(
     safeAddress: string,
     receiverAddress: string,

--- a/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
@@ -290,8 +290,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
         state,
       });
 
-      const hubAuthentication = this.owner.lookup('service:hub-authentication');
-      hubAuthentication.authToken = null;
+      window.TEST__AUTH_TOKEN = undefined;
 
       await visit('/card-pay/balances?flow=issue-prepaid-card&flow-id=abc123');
 

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
@@ -57,6 +57,10 @@ module(
       assert.dom('[data-test-unlock-button]').isDisabled();
       await fillIn('[data-test-token-amount-input]', moreDaiThanBalance);
       assert.dom('[data-test-unlock-button]').isDisabled();
+      assert
+        .dom('[data-test-boxel-input-error-message]')
+        .containsText('Insufficient balance in your account');
+
       await fillIn('[data-test-token-amount-input]', daiInBalance);
       assert.dom('[data-test-unlock-button]').isNotDisabled();
     });

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn, typeIn, click } from '@ember/test-helpers';
+import { render, fillIn, typeIn, click, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
@@ -9,29 +9,27 @@ import BN from 'bn.js';
 import { toWei } from 'web3-utils';
 import sinon from 'sinon';
 
+let layer1Service: Layer1TestWeb3Strategy;
+
 module(
   'Integration | Component | card-pay/deposit-workflow/transaction-amount',
   function (hooks) {
     setupRenderingTest(hooks);
 
-    hooks.beforeEach(function () {
+    hooks.beforeEach(async function () {
       let layer2Service = this.owner.lookup('service:layer2-network');
       let layer2Strategy = layer2Service.strategy as Layer2TestWeb3Strategy;
 
       // Simulate being connected on layer 2 -- prereq to converting to USD
       let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
       layer2Strategy.test__simulateAccountsChanged([layer2AccountAddress]);
-    });
-
-    test('It disables the unlock button when amount entered is more than balance (18-decimal floating point)', async function (assert) {
-      const startDaiAmountString = '5.111111111111111110';
-      const daiToSend = '5.111111111111111111';
-      let startDaiAmount = toWei(startDaiAmountString);
 
       const session = new WorkflowSession();
       session.update('depositSourceToken', 'DAI');
-      const layer1Service = this.owner.lookup('service:layer1-network')
-        .strategy as Layer1TestWeb3Strategy;
+      layer1Service = this.owner.lookup('service:layer1-network').strategy;
+
+      const startDaiAmountString = '5.111111111111111110';
+      const startDaiAmount = toWei(startDaiAmountString);
 
       layer1Service.test__simulateBalances({
         defaultToken: new BN('0'),
@@ -50,43 +48,24 @@ module(
             @onIncomplete={{noop}}
           />
         `);
+    });
+
+    test('It disables the unlock button when amount entered is more than balance (18-decimal floating point)', async function (assert) {
+      const daiInBalance = '5.111111111111111110';
+      const moreDaiThanBalance = '5.111111111111111111';
 
       assert.dom('[data-test-unlock-button]').isDisabled();
-      await fillIn('[data-test-token-amount-input]', daiToSend);
+      await fillIn('[data-test-token-amount-input]', moreDaiThanBalance);
       assert.dom('[data-test-unlock-button]').isDisabled();
-      await fillIn('[data-test-token-amount-input]', startDaiAmountString);
+      await fillIn('[data-test-token-amount-input]', daiInBalance);
       assert.dom('[data-test-unlock-button]').isNotDisabled();
     });
 
     test('It accurately sends the amount to be handled by layer 1 (18-decimal floating point)', async function (assert) {
-      const daiToSend = '5.111111111111111111';
-      const daiToSendInWei = '5111111111111111111';
-      let startDaiAmount = toWei('10');
-
-      const session = new WorkflowSession();
-      session.update('depositSourceToken', 'DAI');
-      const layer1Service = this.owner.lookup('service:layer1-network')
-        .strategy as Layer1TestWeb3Strategy;
-
-      layer1Service.test__simulateBalances({
-        defaultToken: new BN('0'),
-        dai: new BN(startDaiAmount),
-        card: new BN('0'),
-      });
+      const daiToSend = '5.111111111111111110';
+      const daiToSendInWei = '5111111111111111110';
 
       let approveSpy = sinon.spy(layer1Service, 'approve');
-
-      this.setProperties({
-        session,
-      });
-
-      await render(hbs`
-          <CardPay::DepositWorkflow::TransactionAmount
-            @workflowSession={{this.session}}
-            @onComplete={{noop}}
-            @onIncomplete={{noop}}
-          />
-        `);
 
       await fillIn('[data-test-token-amount-input]', daiToSend);
       assert.dom('[data-test-unlock-button]').isNotDisabled();
@@ -109,28 +88,13 @@ module(
       const invalidDai4 = '12/'; /* invalid char */
       let startDaiAmount = toWei(startDaiString);
 
-      const session = new WorkflowSession();
-      session.update('depositSourceToken', 'DAI');
-      const layer1Service = this.owner.lookup('service:layer1-network')
-        .strategy as Layer1TestWeb3Strategy;
-
       layer1Service.test__simulateBalances({
         defaultToken: new BN('0'),
         dai: new BN(startDaiAmount),
         card: new BN('0'),
       });
 
-      this.setProperties({
-        session,
-      });
-
-      await render(hbs`
-          <CardPay::DepositWorkflow::TransactionAmount
-            @workflowSession={{this.session}}
-            @onComplete={{noop}}
-            @onIncomplete={{noop}}
-          />
-        `);
+      await settled();
 
       assert.dom('[data-test-token-amount-input]').hasValue('');
       assert.dom('[data-test-unlock-button]').isDisabled();
@@ -168,6 +132,14 @@ module(
       await fillIn('[data-test-token-amount-input]', startDaiString);
       assert.dom('[data-test-token-amount-input]').hasValue(startDaiString);
       assert.dom('[data-test-unlock-button]').isNotDisabled();
+    });
+
+    test('it rejects a value of zero', async function (assert) {
+      await fillIn('input', '0');
+      assert.dom('input').hasAria('invalid', 'true');
+      assert
+        .dom('[data-test-boxel-input-error-message]')
+        .containsText('Amount must be above 0.00 DAI');
     });
   }
 );


### PR DESCRIPTION
This adds checks that the withdrawal amount is within the limits returned by `TokenBridgeHomeSide.getWithdrawalLimits` and includes the relevant limit in the validation string if not.

![validation-screencast 2021-09-16 14-37-30](https://user-images.githubusercontent.com/43280/133675459-e1f789c3-a822-4d61-b179-e01076fa789d.gif)

This necessitated some adjustments to the validation function, which had a `min` option that was being used in the deposit transaction amount card to enforce that the value had to be higher than 0, which isn’t a true minimum. `min` is now optional and `> 0` is enforced in its absence. This didn’t have test representation so I added another test for that card and refactored out the duplicated setup.

The validation function now also accepts a `balance` to distinguish between the maximum from the withdrawal limit vs the maximum from the balance.

We [decided](https://github.com/cardstack/cardstack/pull/2100/files/6d06633303d6c6cdbc31651efd85f14624b59e65#r710214248) to not add the bridged tokens to the SDK’s `native-currencies` list, so there’s some string manipulation with the result of the call to `convertRawAmountToNativeDisplay` to display a bridged token in the validation message if that’s the context. It’s a bit unsightly but it works and seems okay to me, but other approaches are possible.

### Test failure

I see there’s a test failure for the acceptance test that asserts that a prepaid card workflow can’t be restored if the authentication token has been cleared. I don’t understand how that could be related, but I’ll look more into it tomorrow. I think this can be reviewed regardless, not to merge until it’s addressed.