### PR TITLE
web: Fix merchant colour in safe chooser dropdown

### DIFF
--- a/packages/web-client/app/components/card-pay/safe-chooser-dropdown/safe-option/index.css
+++ b/packages/web-client/app/components/card-pay/safe-chooser-dropdown/safe-option/index.css
@@ -12,6 +12,7 @@
   grid-area: logo;
   justify-self: center;
   align-self: center;
+  margin-right: 0;
 }
 
 .safe-option__name-and-type {

--- a/packages/web-client/app/components/card-pay/safe-chooser-dropdown/safe-option/index.hbs
+++ b/packages/web-client/app/components/card-pay/safe-chooser-dropdown/safe-option/index.hbs
@@ -4,7 +4,6 @@
   {{else}}
     <CardPay::MerchantLogo
       class='safe-option__logo'
-      style={{css-var merchant-margin-right=0}}
       @name={{first-char this.data.info.name}}
       @logoBackground={{this.data.info.backgroundColor}}
       @logoTextColor={{this.data.info.textColor}}

--- a/packages/web-client/tests/integration/components/card-pay/safe-chooser-dropdown-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/safe-chooser-dropdown-test.ts
@@ -9,6 +9,8 @@ import { MirageTestContext } from 'ember-cli-mirage/test-support';
 import { getResolver } from '@cardstack/did-resolver';
 import { Resolver } from 'did-resolver';
 
+import { TinyColor } from '@ctrl/tinycolor';
+
 interface Context extends MirageTestContext {
   safes: Safe[];
 }
@@ -120,8 +122,10 @@ module(
           '.ember-power-select-options li:nth-child(2) [data-test-merchant-logo]'
         )
         .containsText('M')
-        .hasAttribute('data-test-merchant-logo-background', '#00ffcc')
-        .hasAttribute('data-test-merchant-logo-text-color', '#000000');
+        .hasStyle({
+          'background-color': new TinyColor('#00ffcc').toRgbString(),
+          color: new TinyColor('#000000').toRgbString(),
+        });
     });
 
     test('it returns the chosen safe to the handler', async function (this: Context, assert) {


### PR DESCRIPTION
`...attributes` doesn’t merge the style attribute, unlike with
class, so setting the margin variable was clobbering the
background and colour-setting. This moves the margin into
the class instead and replaces the false-positive attribute
assertions with a style-checking one.

Before:

![image](https://user-images.githubusercontent.com/43280/133331205-069d4d48-aaea-4040-ab50-bdda36a88703.png)

After:

![image](https://user-images.githubusercontent.com/43280/133331256-9e181fa2-2ef6-4eda-a95c-ccc8c42974c7.png)
