### PR TITLE
Fix/misc payment page issues

### DIFF
--- a/packages/web-client/app/components/card-pay/hamburger-menu/index.css
+++ b/packages/web-client/app/components/card-pay/hamburger-menu/index.css
@@ -16,8 +16,6 @@
 }
 
 .hamburger-menu__trigger {
-  --icon-color: var(--boxel-highlight);
-
   width: 2rem;
   height: 2rem;
   display: flex;
@@ -26,6 +24,12 @@
   appearance: none;
   background-color: transparent;
   border: none;
+}
+
+.hamburger-menu__trigger-icon {
+  --icon-color: var(--boxel-highlight);
+
+  flex-shrink: 0;
 }
 
 .hamburger-menu__list {

--- a/packages/web-client/app/components/card-pay/hamburger-menu/index.hbs
+++ b/packages/web-client/app/components/card-pay/hamburger-menu/index.hbs
@@ -5,7 +5,7 @@
     disabled={{@open}}
     {{on "click" (optional @onOpen)}}
   >
-    {{svg-jar "hamburger-menu" width="20" height="14"}}
+    {{svg-jar "hamburger-menu" class="hamburger-menu__trigger-icon" width="20" height="14"}}
   </button>
 
   {{#if @open}}
@@ -20,7 +20,7 @@
         }}
       >
         <button type="button" class="hamburger-menu__trigger hamburger-menu__trigger--close" {{on "click" (optional @onClose)}}>
-          {{svg-jar "close-thick" width="14" height="14"}}
+          {{svg-jar "close-thick" class="hamburger-menu__trigger-icon" width="14" height="14"}}
         </button>
       </Boxel::OrgHeader>
       <ul class="hamburger-menu__list">

--- a/packages/web-client/app/components/card-pay/merchant-payment-request-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/merchant-payment-request-card/index.hbs
@@ -23,6 +23,7 @@
   <CardPay::MerchantPaymentRequestCard::PaymentRequest
     class="merchant-payment-request-card__section"
     @paymentURL={{@paymentURL}}
+    @deepLinkPaymentURL={{@deepLinkPaymentURL}}
     @image={{this.cardstackLogoForQR}}
     @merchant={{@merchant}}
     @merchantAddress={{@merchantAddress}}

--- a/packages/web-client/app/components/card-pay/merchant-payment-request-card/payment-request/index.hbs
+++ b/packages/web-client/app/components/card-pay/merchant-payment-request-card/payment-request/index.hbs
@@ -67,7 +67,7 @@
           @as="anchor"
           @kind="primary"
           @size="touch"
-          href={{@paymentURL}}
+          href={{@deepLinkPaymentURL}}
           data-test-payment-request-deep-link
         >
           Pay Merchant

--- a/packages/web-client/app/controllers/pay.ts
+++ b/packages/web-client/app/controllers/pay.ts
@@ -47,6 +47,20 @@ export default class CardPayMerchantServicesController extends Controller {
   get isValidAmount() {
     return !isNaN(this.amount) && this.amount > 0;
   }
+
+  // This is necessary because iOS respects users' decisions to visit your site
+  // and will stay on the site if the link has the same domain
+  // see https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html
+  // also might be useful for folks on older versions of iOS (~9)
+  get deepLinkPaymentURL() {
+    return generateMerchantPaymentUrl({
+      network: this.model.network,
+      merchantSafeID: this.model.merchantSafe.address,
+      currency: this.currency,
+      amount: this.isValidAmount ? this.amount : 0,
+    });
+  }
+
   get paymentURL() {
     return generateMerchantPaymentUrl({
       domain: config.universalLinkDomain,

--- a/packages/web-client/app/templates/pay.hbs
+++ b/packages/web-client/app/templates/pay.hbs
@@ -8,6 +8,7 @@
     @merchant={{this.merchantInfo}}
     @merchantAddress={{@model.merchantSafe.address}}
     @paymentURL={{this.paymentURL}}
+    @deepLinkPaymentURL={{this.deepLinkPaymentURL}}
     @canDeepLink={{this.canDeepLink}}
   />
 </div>

--- a/packages/web-client/tests/acceptance/pay-test.ts
+++ b/packages/web-client/tests/acceptance/pay-test.ts
@@ -30,7 +30,7 @@ const DEEP_LINK = '[data-test-payment-request-deep-link]';
 const PAYMENT_URL = '[data-test-payment-request-url]';
 
 // fixed data
-const domain = config.universalLinkDomain;
+const universalLinkDomain = config.universalLinkDomain;
 const exampleDid = 'did:cardstack:1moVYMRNGv6E5Ca3t7aXVD2Yb11e4e91103f084a';
 const spendSymbol = 'SPD';
 const usdSymbol = 'USD';
@@ -113,7 +113,7 @@ module('Acceptance | pay', function (hooks) {
       .containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
 
     let expectedUrl = generateMerchantPaymentUrl({
-      domain,
+      domain: universalLinkDomain,
       network,
       merchantSafeID: merchantSafe.address,
       currency: spendSymbol,
@@ -148,7 +148,7 @@ module('Acceptance | pay', function (hooks) {
       .dom(USD_AMOUNT)
       .containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
     let expectedUrl = generateMerchantPaymentUrl({
-      domain,
+      domain: universalLinkDomain,
       network,
       merchantSafeID: merchantSafe.address,
       currency: spendSymbol,
@@ -182,7 +182,7 @@ module('Acceptance | pay', function (hooks) {
       .dom(USD_AMOUNT)
       .containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
     let expectedUrl = generateMerchantPaymentUrl({
-      domain,
+      domain: universalLinkDomain,
       network,
       merchantSafeID: merchantSafe.address,
       currency: usdSymbol,
@@ -219,7 +219,7 @@ module('Acceptance | pay', function (hooks) {
     // displaying the amounts if we don't recognize the currency
     // currently this is anything that is not SPD or USD
     let expectedUrl = generateMerchantPaymentUrl({
-      domain,
+      domain: universalLinkDomain,
       network,
       merchantSafeID: merchantSafe.address,
       currency: invalidCurrencySymbol,
@@ -253,7 +253,7 @@ module('Acceptance | pay', function (hooks) {
     assert.dom(USD_AMOUNT).doesNotExist();
 
     let expectedUrl = generateMerchantPaymentUrl({
-      domain,
+      domain: universalLinkDomain,
       network,
       merchantSafeID: merchantSafe.address,
       currency: spendSymbol,
@@ -293,18 +293,27 @@ module('Acceptance | pay', function (hooks) {
 
     // assert that the deep link view is rendered
     assert.dom(QR_CODE).doesNotExist();
-    let expectedUrl = generateMerchantPaymentUrl({
-      domain,
-      network,
-      merchantSafeID: merchantSafe.address,
-      currency: spendSymbol,
-      amount: spendAmount,
-    });
     assert
       .dom(DEEP_LINK)
       .containsText('Pay Merchant')
-      .hasAttribute('href', expectedUrl);
-    assert.dom(PAYMENT_URL).containsText(expectedUrl);
+      .hasAttribute(
+        'href',
+        generateMerchantPaymentUrl({
+          network,
+          merchantSafeID: merchantSafe.address,
+          currency: spendSymbol,
+          amount: spendAmount,
+        })
+      );
+    assert.dom(PAYMENT_URL).containsText(
+      generateMerchantPaymentUrl({
+        domain: universalLinkDomain,
+        network,
+        merchantSafeID: merchantSafe.address,
+        currency: spendSymbol,
+        amount: spendAmount,
+      })
+    );
   });
 
   test('it renders appropriate UI when merchant info is not fetched', async function (assert) {
@@ -328,7 +337,7 @@ module('Acceptance | pay', function (hooks) {
       .containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
 
     let expectedUrl = generateMerchantPaymentUrl({
-      domain,
+      domain: universalLinkDomain,
       network,
       merchantSafeID: merchantSafeWithoutInfo.address,
       currency: spendSymbol,

--- a/packages/web-client/tests/integration/components/card-pay/merchant-payment-request-card-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/merchant-payment-request-card-test.ts
@@ -26,6 +26,8 @@ const amount = '300';
 const usdAmount = '3';
 const paymentURL =
   'https://pay.cardstack.com/merchat-asdnsadkasd?id=0x1238urfds&amount=73298587423545';
+const deepLinkPaymentURL =
+  'https://deep-link.cardstack.com/merchat-asdnsadkasd?id=0x1238urfds&amount=73298587423545';
 let merchant: MerchantInfoResource;
 const merchantAddress = '0xE73604fC1724a50CEcBC1096d4229b81aF117c94';
 
@@ -47,6 +49,7 @@ module(
         amount,
         usdAmount,
         paymentURL,
+        deepLinkPaymentURL,
         merchant,
         merchantAddress,
       });
@@ -59,6 +62,7 @@ module(
           @usdAmount={{this.usdAmount}}
           @merchant={{this.merchant}}
           @paymentURL={{this.paymentURL}}
+          @deepLinkPaymentURL={{this.deepLinkPaymentURL}}
           @canDeepLink={{false}}
         />
       `);
@@ -92,6 +96,7 @@ module(
           @usdAmount={{this.usdAmount}}
           @merchant={{this.merchant}}
           @paymentURL={{this.paymentURL}}
+          @deepLinkPaymentURL={{this.deepLinkPaymentURL}}
           @canDeepLink={{true}}
         />
       `);
@@ -118,7 +123,7 @@ module(
       assert
         .dom(DEEP_LINK)
         .containsText('Pay Merchant')
-        .hasAttribute('href', paymentURL);
+        .hasAttribute('href', deepLinkPaymentURL);
       assert.dom(PAYMENT_URL).containsText(paymentURL);
       assert.dom(LINK_VIEW_TOGGLE).containsText('Show as QR Code');
 
@@ -138,6 +143,7 @@ module(
           @merchant={{this.merchant}}
           @merchantAddress={{this.merchantAddress}}
           @paymentURL={{this.paymentURL}}
+          @deepLinkPaymentURL={{this.deepLinkPaymentURL}}
           @canDeepLink={{false}}
         />
       `);
@@ -167,6 +173,7 @@ module(
           @merchant={{this.merchant}}
           @merchantAddress={{this.merchantAddress}}
           @paymentURL={{this.paymentURL}}
+          @deepLinkPaymentURL={{this.deepLinkPaymentURL}}
           @canDeepLink={{false}}
         />
       `);


### PR DESCRIPTION
Fix some issues I noticed when trying out the payment page in staging:
- Clicking on the deep link in an iOS browser simply refreshes the page, it doesn't attempt to open the app. Apple's documentation says that clicking on a link with the same domain as the current window will not open deep links in apps. As such, the clickable link was changed to a `cardwallet:` custom protocol link.
- Hamburger menu icon was squished to invisibility in Safari's rendering.