### PR TITLE
Load depot balances via Assets API

### DIFF
--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.ts
@@ -18,13 +18,12 @@ class FundingSourceCard extends Component<WorkflowCardComponentArgs> {
   @tracked selectedTokenSymbol: BridgedTokenSymbol =
     this.args.workflowSession.state.prepaidFundingToken ??
     this.defaultTokenSymbol;
-  @tracked selectedToken: TokenBalance<BridgedTokenSymbol>;
 
-  constructor(owner: unknown, args: WorkflowCardComponentArgs) {
-    super(owner, args);
-    this.selectedToken =
+  get selectedToken(): TokenBalance<BridgedTokenSymbol> {
+    return (
       this.tokens.find((t) => t.symbol === this.selectedTokenSymbol) ??
-      this.tokens[0];
+      this.tokens[0]
+    );
   }
 
   get depotAddress() {
@@ -55,7 +54,7 @@ class FundingSourceCard extends Component<WorkflowCardComponentArgs> {
   }
 
   @action chooseSource(token: TokenBalance<BridgedTokenSymbol>) {
-    this.selectedToken = token;
+    this.selectedTokenSymbol = token.symbol;
   }
 
   @action save() {

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.hbs
@@ -1,30 +1,32 @@
-<WorkflowThread class="issue-prepaid-card-workflow" @workflow={{this.workflow}}>
-  <:before-content>
-    <Boxel::ExpandableBanner
-      @icon="info"
-      @summary="Issue a prepaid card"
-      open
-    >
-      <div class="issue-prepaid-card-workflow__banner">
-        <p>
-          As an Issuer, you assist customers in acquiring prepaid cards and reloading the balance when needed.
-          Customers can then use their prepaid cards to purchase a variety of products &amp; services from
-          participating merchants who accept Card Pay as a payment method.
-        </p>
-        <p>
-          <strong>To fund a prepaid card, you need a balance of DAI.CPXD (Dai stablecoin) in your {{network-display-info "layer2" "fullName"}} wallet.</strong>
-        </p>
-        <p>
-          <small>
-            <strong>Fees:</strong> Issuers may charge an issuance fee for each prepaid card they issue to a
-            customer. This could be a flat fee or a percentage of the face value. In addition, issuers may
-            charge a processing fee for issuing prepaid cards that are purchased via credit card payment.
-          </small>
-        </p>
-      </div>
-    </Boxel::ExpandableBanner>
-  </:before-content>
-</WorkflowThread>
+{{#if this.workflow}}
+  <WorkflowThread class="issue-prepaid-card-workflow" @workflow={{this.workflow}}>
+    <:before-content>
+      <Boxel::ExpandableBanner
+        @icon="info"
+        @summary="Issue a prepaid card"
+        open
+      >
+        <div class="issue-prepaid-card-workflow__banner">
+          <p>
+            As an Issuer, you assist customers in acquiring prepaid cards and reloading the balance when needed.
+            Customers can then use their prepaid cards to purchase a variety of products &amp; services from
+            participating merchants who accept Card Pay as a payment method.
+          </p>
+          <p>
+            <strong>To fund a prepaid card, you need a balance of DAI.CPXD (Dai stablecoin) in your {{network-display-info "layer2" "fullName"}} wallet.</strong>
+          </p>
+          <p>
+            <small>
+              <strong>Fees:</strong> Issuers may charge an issuance fee for each prepaid card they issue to a
+              customer. This could be a flat fee or a percentage of the face value. In addition, issuers may
+              charge a processing fee for issuing prepaid cards that are purchased via credit card payment.
+            </small>
+          </p>
+        </div>
+      </Boxel::ExpandableBanner>
+    </:before-content>
+  </WorkflowThread>
+{{/if}}
 <Listener
   @emitter={{this.layer2Network}}
   @event="disconnect"

--- a/packages/web-client/app/resources/safes.ts
+++ b/packages/web-client/app/resources/safes.ts
@@ -3,7 +3,6 @@ import { DepotSafe, Safe } from '@cardstack/cardpay-sdk/sdk/safes';
 import { Layer2Web3Strategy } from '@cardstack/web-client/utils/web3-strategies/types';
 import { taskFor, TaskFunction } from 'ember-concurrency-ts';
 import { reads } from 'macro-decorators';
-import { BN } from 'bn.js';
 
 interface Args {
   named: {
@@ -28,26 +27,8 @@ export class Safes extends Resource<Args> {
   }
 
   get depot() {
-    let safes = this.value;
-    let depotSafes = (safes || []).filter(
+    return (this.value || []).find(
       (safe: Safe) => safe.type === 'depot'
-    ) as DepotSafe[];
-
-    let value = depotSafes[depotSafes.length - 1] ?? null;
-
-    let { strategy } = this.args.named;
-    let defaultBalance = value?.tokens.find(
-      (tokenInfo) => tokenInfo.token.symbol === strategy.defaultTokenSymbol
-    )?.balance;
-
-    let cardBalance = value?.tokens.find(
-      (tokenInfo) => tokenInfo.token.symbol === 'CARD'
-    )?.balance;
-
-    return {
-      value,
-      defaultTokenBalance: new BN(defaultBalance ?? '0'),
-      cardBalance: new BN(cardBalance ?? '0'),
-    };
+    ) as DepotSafe | null;
   }
 }

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -13,7 +13,7 @@ import { PrepaidCardSafe } from '@cardstack/cardpay-sdk/sdk/safes';
 import Layer2TestWeb3Strategy from '../utils/web3-strategies/test-layer2';
 import XDaiWeb3Strategy from '../utils/web3-strategies/x-dai';
 import SokolWeb3Strategy from '../utils/web3-strategies/sokol';
-import { reads } from 'macro-decorators';
+import { or, reads } from 'macro-decorators';
 import WalletInfo from '../utils/wallet-info';
 import BN from 'bn.js';
 import { DepotSafe, Safe } from '@cardstack/cardpay-sdk/sdk/safes';
@@ -55,7 +55,8 @@ export default class Layer2Network
   @reads('strategy.defaultTokenBalance') defaultTokenBalance: BN | undefined;
   @reads('strategy.cardBalance') cardBalance: BN | undefined;
   @reads('strategy.depotSafe') depotSafe: DepotSafe | undefined;
-  @reads('strategy.safes.isLoading') declare isFetchingDepot: boolean;
+  @or('strategy.safes.isLoading', 'strategy.depotBalances.isRunning')
+  declare isFetchingDepot: boolean;
 
   bridgedSymbolToWithdrawalLimits: Map<BridgedTokenSymbol, WithdrawalLimits> =
     new Map();

--- a/packages/web-client/app/templates/card-pay/balances.hbs
+++ b/packages/web-client/app/templates/card-pay/balances.hbs
@@ -1,68 +1,68 @@
 {{page-title "Card Balances"}}
 
-  <section class="card-pay-dashboard__balances" role="tabpanel" aria-labelledby="card-pay.balances">
-    <CardPay::DashboardPanel @panel={{@model.panel}}>
-      {{#each @model.panel.sections as |section|}}
-        <CardPay::DashboardPanel::Section @section={{section}}>
-          <:cta>
+<section class="card-pay-dashboard__balances" role="tabpanel" aria-labelledby="card-pay.balances">
+  <CardPay::DashboardPanel @panel={{@model.panel}}>
+    {{#each @model.panel.sections as |section|}}
+      <CardPay::DashboardPanel::Section @section={{section}}>
+        <:cta>
+          <Boxel::Button
+            {{on "click" (fn this.transitionToBalances section.workflow)}}
+            @kind="primary"
+            @size="touch"
+            @disabled={{section.isCtaDisabled}}
+            data-test-workflow-button={{section.workflow}}
+          >
+            {{section.cta}}
+          </Boxel::Button>
+        </:cta>
+        <:disclaimer>
+          {{#if (eq section.workflow 'issue-prepaid-card')}}
+            This is possible if you have a balance of DAI.CPXD in your {{network-display-info "layer2" "fullName"}} wallet.
+            (You can <LinkTo @route="card-pay.token-suppliers">deposit DAI</LinkTo>
+            from your {{network-display-info "layer1" "conversationalName"}} wallet to get a balance of DAI.CPXD in your {{network-display-info "layer2" "fullName"}} wallet.)
+          {{/if}}
+        </:disclaimer>
+      </CardPay::DashboardPanel::Section>
+    {{/each}}
+  </CardPay::DashboardPanel>
+
+  {{#if this.layer2Network.isConnected}}
+    <section data-test-card-balances>
+      <h3 class="card-pay-dashboard__balances-title">Card Balances</h3>
+      <section class="card-pay-dashboard__balances-section">
+        <header class="card-pay-dashboard__balances-section-header">
+          <h4 class="card-pay-dashboard__balances-section-title">
+            Prepaid Cards
+            <span class="card-pay-dashboard__balances-count" data-test-prepaid-cards-count>{{this.prepaidCards.length}}</span>
+          </h4>
+
+          {{#let @model.panel.sections.lastObject as |section|}}
             <Boxel::Button
               {{on "click" (fn this.transitionToBalances section.workflow)}}
-              @kind="primary"
-              @size="touch"
+              @kind="secondary-dark"
+              @size="small"
               @disabled={{section.isCtaDisabled}}
+              @route="card-pay.balances"
               data-test-workflow-button={{section.workflow}}
             >
-              {{section.cta}}
+              <span>{{section.cta}}</span>
+              {{svg-jar "plus"
+                class="card-pay-dashboard__balances-section-header-button-icon"
+                role="presentation"
+              }}
             </Boxel::Button>
-          </:cta>
-          <:disclaimer>
-            {{#if (eq section.workflow 'issue-prepaid-card')}}
-              This is possible if you have a balance of DAI.CPXD in your {{network-display-info "layer2" "fullName"}} wallet.
-              (You can <LinkTo @route="card-pay.token-suppliers">deposit DAI</LinkTo>
-              from your {{network-display-info "layer1" "conversationalName"}} wallet to get a balance of DAI.CPXD in your {{network-display-info "layer2" "fullName"}} wallet.)
-            {{/if}}
-          </:disclaimer>
-        </CardPay::DashboardPanel::Section>
-      {{/each}}
-    </CardPay::DashboardPanel>
+          {{/let}}
+        </header>
 
-    {{#if this.layer2Network.isConnected}}
-      <section data-test-card-balances>
-        <h3 class="card-pay-dashboard__balances-title">Card Balances</h3>
-        <section class="card-pay-dashboard__balances-section">
-          <header class="card-pay-dashboard__balances-section-header">
-            <h4 class="card-pay-dashboard__balances-section-title">
-              Prepaid Cards
-              <span class="card-pay-dashboard__balances-count" data-test-prepaid-cards-count>{{this.prepaidCards.length}}</span>
-            </h4>
-
-            {{#let @model.panel.sections.lastObject as |section|}}
-              <Boxel::Button
-                {{on "click" (fn this.transitionToBalances section.workflow)}}
-                @kind="secondary-dark"
-                @size="small"
-                @disabled={{section.isCtaDisabled}}
-                @route="card-pay.balances"
-                data-test-workflow-button={{section.workflow}}
-              >
-                <span>{{section.cta}}</span>
-                {{svg-jar "plus"
-                  class="card-pay-dashboard__balances-section-header-button-icon"
-                  role="presentation"
-                }}
-              </Boxel::Button>
-            {{/let}}
-          </header>
-
-          <section class="card-pay-dashboard__balances-cards">
-            {{#each this.prepaidCards as |prepaidCard|}}
-              <CardPay::PrepaidCardSafe @safe={{prepaidCard}} />
-            {{/each}}
-          </section>
+        <section class="card-pay-dashboard__balances-cards">
+          {{#each this.prepaidCards as |prepaidCard|}}
+            <CardPay::PrepaidCardSafe @safe={{prepaidCard}} />
+          {{/each}}
         </section>
       </section>
-    {{/if}}
-  </section>
+    </section>
+  {{/if}}
+</section>
 
 <Boxel::Modal
   style={{css-var boxel-modal-max-width="65rem"}} {{!-- ~1040px --}}

--- a/packages/web-client/tests/acceptance/create-merchant-test.ts
+++ b/packages/web-client/tests/acceptance/create-merchant-test.ts
@@ -117,7 +117,7 @@ module('Acceptance | create merchant', function (hooks) {
 
     // Simulate the user scanning the QR code and connecting their mobile wallet
     layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
-    layer2Service.test__simulateBalances({
+    await layer2Service.test__simulateBalances({
       defaultToken: new BN(0),
     });
     layer2Service.test__simulateAccountSafes(layer2AccountAddress, [
@@ -252,7 +252,7 @@ module('Acceptance | create merchant', function (hooks) {
       layer2Service = this.owner.lookup('service:layer2-network')
         .strategy as Layer2TestWeb3Strategy;
       layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
-      layer2Service.test__simulateBalances({
+      await layer2Service.test__simulateBalances({
         defaultToken: new BN(0),
       });
 
@@ -466,7 +466,7 @@ module('Acceptance | create merchant', function (hooks) {
     let layer2Service = this.owner.lookup('service:layer2-network')
       .strategy as Layer2TestWeb3Strategy;
     layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
-    layer2Service.test__simulateBalances({
+    await layer2Service.test__simulateBalances({
       defaultToken: new BN(0),
     });
 
@@ -498,7 +498,7 @@ module('Acceptance | create merchant', function (hooks) {
     let layer2Service = this.owner.lookup('service:layer2-network')
       .strategy as Layer2TestWeb3Strategy;
     layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
-    layer2Service.test__simulateBalances({
+    await layer2Service.test__simulateBalances({
       defaultToken: new BN(0),
     });
 

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -121,6 +121,12 @@ module('Acceptance | deposit', function (hooks) {
       defaultToken: new BN(0),
     });
     await waitFor(`${postableSel(1, 2)} [data-test-balance-container]`);
+    await waitUntil(() => {
+      return (
+        document.querySelector('[data-test-balance="DAI.CPXD"]') === null &&
+        document.querySelector('[data-test-balance-container-loading]') === null
+      );
+    });
     assert
       .dom(`${postableSel(1, 2)} [data-test-balance="XDAI"]`)
       .doesNotExist();

--- a/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
@@ -35,15 +35,11 @@ module('Acceptance | issue prepaid card', function (hooks) {
     let layer2Service = this.owner.lookup('service:layer2-network')
       .strategy as Layer2TestWeb3Strategy;
     layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
-    await layer2Service.test__simulateBalances({
-      defaultToken: MIN_AMOUNT_TO_PASS,
-      card: new BN('500000000000000000000'),
-    });
     let testDepot = {
       address: '0xB236ca8DbAB0644ffCD32518eBF4924ba8666666',
       tokens: [
         {
-          balance: '250000000000000000000',
+          balance: MIN_AMOUNT_TO_PASS.toString(),
           token: {
             symbol: 'DAI',
           },

--- a/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
@@ -22,7 +22,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
   setupMirage(hooks);
   let workflowPersistenceService: WorkflowPersistence;
 
-  hooks.beforeEach(function () {
+  hooks.beforeEach(async function () {
     (this as any).server.db.loadData({
       prepaidCardColorSchemes,
       prepaidCardPatterns,
@@ -35,7 +35,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
     let layer2Service = this.owner.lookup('service:layer2-network')
       .strategy as Layer2TestWeb3Strategy;
     layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
-    layer2Service.test__simulateBalances({
+    await layer2Service.test__simulateBalances({
       defaultToken: MIN_AMOUNT_TO_PASS,
       card: new BN('500000000000000000000'),
     });
@@ -56,7 +56,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
         },
       ],
     };
-    layer2Service.test__simulateDepot(testDepot as DepotSafe);
+    await layer2Service.test__simulateDepot(testDepot as DepotSafe);
     layer2Service.authenticate();
     layer2Service.test__simulateHubAuthentication('abc123--def456--ghi789');
 

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -482,7 +482,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
       )} [data-test-prepaid-card-background="${backgroundChoice}"][data-test-prepaid-card-pattern="${patternChoice}"]`
     );
 
-    layer2Service.test__simulateBalances({
+    await layer2Service.test__simulateBalances({
       defaultToken: new BN('150000000000000000000'),
       card: new BN('500000000000000000000'),
     });
@@ -595,12 +595,12 @@ module('Acceptance | issue prepaid card', function (hooks) {
     let layer2Service: Layer2TestWeb3Strategy;
     let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
 
-    hooks.beforeEach(function () {
+    hooks.beforeEach(async function () {
       window.TEST__AUTH_TOKEN = 'abc123--def456--ghi789';
       layer2Service = this.owner.lookup('service:layer2-network')
         .strategy as Layer2TestWeb3Strategy;
       layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
-      layer2Service.test__simulateBalances({
+      await layer2Service.test__simulateBalances({
         defaultToken: MIN_AMOUNT_TO_PASS,
         card: new BN('500000000000000000000'),
       });
@@ -621,7 +621,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
           },
         ],
       };
-      layer2Service.test__simulateDepot(testDepot as DepotSafe);
+      await layer2Service.test__simulateDepot(testDepot as DepotSafe);
     });
 
     hooks.afterEach(function () {
@@ -735,7 +735,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
       await visit('/card-pay');
       assert.equal(currentURL(), '/card-pay/balances');
 
-      layer2Service.test__simulateBalances({
+      await layer2Service.test__simulateBalances({
         defaultToken: FAILING_AMOUNT,
       });
 

--- a/packages/web-client/tests/acceptance/withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-test.ts
@@ -125,28 +125,8 @@ module('Acceptance | withdrawal', function (hooks) {
       defaultToken: new BN('250000000000000000000'),
       card: new BN('500000000000000000000'),
     });
-    let depotAddress = '0xB236ca8DbAB0644ffCD32518eBF4924ba8666666';
-    let testDepot = {
-      address: depotAddress,
-      tokens: [
-        {
-          balance: '250000000000000000000',
-          token: {
-            symbol: 'DAI',
-          },
-        },
-        {
-          balance: '500000000000000000000',
-          token: {
-            symbol: 'CARD',
-          },
-        },
-      ],
-    };
-    await layer2Service.test__simulateDepot(testDepot as DepotSafe);
-
     let merchantAddress = '0xmerchantbAB0644ffCD32518eBF4924ba8666666';
-    layer2Service.test__simulateAccountSafes(layer2AccountAddress, [
+    await layer2Service.test__simulateAccountSafes(layer2AccountAddress, [
       {
         type: 'merchant',
         createdAt: Date.now() / 1000,
@@ -176,8 +156,27 @@ module('Acceptance | withdrawal', function (hooks) {
         accumulatedSpendValue: 100,
       },
     ]);
+    let depotAddress = '0xB236ca8DbAB0644ffCD32518eBF4924ba8666666';
+    let testDepot = {
+      address: depotAddress,
+      tokens: [
+        {
+          balance: '250000000000000000000',
+          token: {
+            symbol: 'DAI',
+          },
+        },
+        {
+          balance: '500000000000000000000',
+          token: {
+            symbol: 'CARD',
+          },
+        },
+      ],
+    };
+    await layer2Service.test__simulateDepot(testDepot as DepotSafe);
     layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
-    await waitFor(`${postableSel(2, 2)} [data-test-balance-container]`);
+    await waitFor(`${postableSel(2, 2)} [data-test-balance="DAI.CPXD"]`);
     assert
       .dom(`${postableSel(2, 2)} [data-test-balance="DAI.CPXD"]`)
       .containsText('250.00 DAI.CPXD');

--- a/packages/web-client/tests/acceptance/withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-test.ts
@@ -121,7 +121,7 @@ module('Acceptance | withdrawal', function (hooks) {
     // Simulate the user scanning the QR code and connecting their mobile wallet
     let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
     layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
-    layer2Service.test__simulateBalances({
+    await layer2Service.test__simulateBalances({
       defaultToken: new BN('250000000000000000000'),
       card: new BN('500000000000000000000'),
     });
@@ -143,7 +143,7 @@ module('Acceptance | withdrawal', function (hooks) {
         },
       ],
     };
-    layer2Service.test__simulateDepot(testDepot as DepotSafe);
+    await layer2Service.test__simulateDepot(testDepot as DepotSafe);
 
     let merchantAddress = '0xmerchantbAB0644ffCD32518eBF4924ba8666666';
     layer2Service.test__simulateAccountSafes(layer2AccountAddress, [
@@ -353,7 +353,7 @@ module('Acceptance | withdrawal', function (hooks) {
       .containsText(
         `This is the remaining balance in your ${c.layer2.fullName} wallet`
       );
-    layer2Service.test__simulateBalances({
+    await layer2Service.test__simulateBalances({
       defaultToken: new BN('2141100000000000000'), // TODO: choose numbers that make sense with the scenario
       card: new BN('10000000000000000000000'), // TODO: choose numbers that make sense with the scenario
     });
@@ -562,7 +562,7 @@ module('Acceptance | withdrawal', function (hooks) {
     let secondLayer2AccountAddress =
       '0x0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7';
 
-    hooks.beforeEach(function () {
+    hooks.beforeEach(async function () {
       layer1Service = this.owner.lookup('service:layer1-network')
         .strategy as Layer1TestWeb3Strategy;
       layer1Service.test__simulateAccountsChanged(
@@ -577,7 +577,7 @@ module('Acceptance | withdrawal', function (hooks) {
       layer2Service = this.owner.lookup('service:layer2-network')
         .strategy as Layer2TestWeb3Strategy;
       layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
-      layer2Service.test__simulateBalances({
+      await layer2Service.test__simulateBalances({
         defaultToken: new BN(0),
       });
     });

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/choose-balance-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/choose-balance-test.ts
@@ -33,7 +33,7 @@ module(
       let layer2Service = this.owner.lookup('service:layer2-network')
         .strategy as Layer2TestWeb3Strategy;
       let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
-      layer2Service.test__simulateBalances({
+      await layer2Service.test__simulateBalances({
         defaultToken: new BN('250000000000000000000'),
         card: new BN('500000000000000000000'),
       });
@@ -56,7 +56,7 @@ module(
         ],
       };
       layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
-      layer2Service.test__simulateDepot(testDepot as DepotSafe);
+      await layer2Service.test__simulateDepot(testDepot as DepotSafe);
 
       let merchantAddress = '0xmerchantbAB0644ffCD32518eBF4924ba8666666';
 

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-amount-test.ts
@@ -26,7 +26,7 @@ module(
       let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
       layer2Strategy.test__simulateAccountsChanged([layer2AccountAddress]);
 
-      layer2Strategy.test__simulateBalances({
+      await layer2Strategy.test__simulateBalances({
         defaultToken: new BN(startDaiAmount),
         dai: new BN(startDaiAmount),
         card: new BN('0'),

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-confirmed-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-confirmed-test.ts
@@ -33,7 +33,7 @@ module(
         .strategy as Layer2TestWeb3Strategy;
       let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
       layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
-      layer2Service.test__simulateBalances({
+      await layer2Service.test__simulateBalances({
         defaultToken: new BN('250000000000000000000'),
       });
       let depotAddress = '0xB236ca8DbAB0644ffCD32518eBF4924ba8666666';
@@ -48,7 +48,7 @@ module(
           },
         ],
       };
-      layer2Service.test__simulateDepot(testDepot as DepotSafe);
+      await layer2Service.test__simulateDepot(testDepot as DepotSafe);
       this.set('session.state.withdrawalToken', 'DAI.CPXD');
       this.set(
         'session.state.withdrawnAmount',

--- a/packages/web-client/tests/integration/components/layer-two-connect-card-test.ts
+++ b/packages/web-client/tests/integration/components/layer-two-connect-card-test.ts
@@ -41,7 +41,10 @@ module('Integration | Component | layer-two-connect-card', function (hooks) {
     });
 
     await waitUntil(() => {
-      return document.querySelector('[data-test-balance="DAI.CPXD"]') === null;
+      return (
+        document.querySelector('[data-test-balance="DAI.CPXD"]') === null &&
+        document.querySelector('[data-test-balance-container-loading]') === null
+      );
     });
 
     assert.dom('[data-test-balance="DAI.CPXD"]').doesNotExist();
@@ -53,7 +56,7 @@ module('Integration | Component | layer-two-connect-card', function (hooks) {
       .strategy as Layer2TestWeb3Strategy;
 
     layer2Service.test__autoResolveViewSafes = false;
-    await layer2Service.test__simulateAccountsChanged(['address']);
+    layer2Service.test__simulateAccountsChanged(['address']);
 
     await render(hbs`
       <CardPay::LayerTwoConnectCard/>

--- a/packages/web-client/tests/integration/components/layer-two-connect-card-test.ts
+++ b/packages/web-client/tests/integration/components/layer-two-connect-card-test.ts
@@ -12,8 +12,8 @@ module('Integration | Component | layer-two-connect-card', function (hooks) {
     let layer2Service = this.owner.lookup('service:layer2-network')
       .strategy as Layer2TestWeb3Strategy;
 
-    layer2Service.test__simulateAccountsChanged(['address']);
-    layer2Service.test__simulateBalances({
+    await layer2Service.test__simulateAccountsChanged(['address']);
+    await layer2Service.test__simulateBalances({
       defaultToken: new BN('2141100000000000000'),
       card: new BN('0'),
     });
@@ -25,7 +25,7 @@ module('Integration | Component | layer-two-connect-card', function (hooks) {
     assert.dom('[data-test-balance="DAI.CPXD"]').containsText('2.1411');
     assert.dom('[data-test-balance="CARD.CPXD"]').doesNotExist();
 
-    layer2Service.test__simulateBalances({
+    await layer2Service.test__simulateBalances({
       defaultToken: new BN('2141100000000000000'),
       card: new BN('2990000000000000000'),
     });
@@ -35,7 +35,7 @@ module('Integration | Component | layer-two-connect-card', function (hooks) {
     assert.dom('[data-test-balance="DAI.CPXD"]').containsText('2.1411');
     assert.dom('[data-test-balance="CARD.CPXD"]').containsText('2.99');
 
-    layer2Service.test__simulateBalances({
+    await layer2Service.test__simulateBalances({
       defaultToken: new BN('0'),
       card: new BN('0'),
     });
@@ -53,7 +53,7 @@ module('Integration | Component | layer-two-connect-card', function (hooks) {
       .strategy as Layer2TestWeb3Strategy;
 
     layer2Service.test__autoResolveViewSafes = false;
-    layer2Service.test__simulateAccountsChanged(['address']);
+    await layer2Service.test__simulateAccountsChanged(['address']);
 
     await render(hbs`
       <CardPay::LayerTwoConnectCard/>


### PR DESCRIPTION
Previously, depot balances came from the Safes API, which uses The Graph, an index that has a delay. This can result in workflows reporting incorrect depot balances immediately following a deposit or withdrawal, which is problematic. 

I'm not entirely happy with how this came out, so feel free to make suggestions for improved architecture if you've got them.