### PR TITLE
Web/improve merchant payment currency handling

### DIFF
--- a/packages/cardpay-sdk/sdk/currency-utils.ts
+++ b/packages/cardpay-sdk/sdk/currency-utils.ts
@@ -294,6 +294,9 @@ export const spendToUsd = (amountInSpend: number): number | undefined => {
   return amountInSpend * SPEND_TO_USD_RATE;
 };
 
+/**
+ * Converts USD to SPEND. The amount is rounded up to the nearest integer
+ */
 export const usdToSpend = (amountInUsd: number): number | undefined => {
   if ((amountInUsd as unknown) === '') {
     return 0;
@@ -302,7 +305,7 @@ export const usdToSpend = (amountInUsd: number): number | undefined => {
     return undefined;
   }
 
-  return amountInUsd / SPEND_TO_USD_RATE;
+  return Math.ceil(amountInUsd / SPEND_TO_USD_RATE);
 };
 
 export interface FormatUsdOptions {

--- a/packages/cardpay-sdk/sdk/currency-utils.ts
+++ b/packages/cardpay-sdk/sdk/currency-utils.ts
@@ -164,6 +164,26 @@ export const handleSignificantDecimalsWithThreshold = (
   return lessThan(result, threshold) ? `< ${threshold}` : result;
 };
 
+export const roundAmountToNativeCurrencyDecimals = (
+  value: BigNumberish,
+  currency: string,
+  roundingMode = BigNumber.ROUND_UP
+): string => {
+  if (!isSupportedCurrency(currency)) {
+    throw new Error(`Unknown currency ${currency}`);
+  }
+
+  let bnValue = new BigNumber(value);
+
+  if (bnValue.isNaN()) {
+    throw new Error(`Unable to convert ${value} to BigNumber`);
+  }
+
+  let { decimals } = get(supportedNativeCurrencies, currency);
+
+  return bnValue.dp(decimals, roundingMode).toString();
+};
+
 export const handleSignificantDecimals = (value: BigNumberish, decimals: number, buffer = 3): string => {
   if (lessThan(new BigNumber(value).abs(), 1)) {
     decimals = new BigNumber(value).toFixed().slice(2).search(/[^0]/g) + buffer;

--- a/packages/web-client/app/components/card-pay/merchant-payment-request-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/merchant-payment-request-card/index.hbs
@@ -28,7 +28,7 @@
     @merchant={{@merchant}}
     @merchantAddress={{@merchantAddress}}
     @amount={{@amount}}
-    @usdAmount={{@usdAmount}}
+    @secondaryAmount={{@secondaryAmount}}
     @canDeepLink={{@canDeepLink}}
   />
 </Boxel::CardContainer>

--- a/packages/web-client/app/components/card-pay/merchant-payment-request-card/payment-request/index.css
+++ b/packages/web-client/app/components/card-pay/merchant-payment-request-card/payment-request/index.css
@@ -89,7 +89,7 @@
   letter-spacing: var(--boxel-lsp-xs);
 }
 
-.payment-request__usd-amount {
+.payment-request__secondary-amount {
   color: var(--boxel-purple-400);
   font: var(--boxel-font-sm);
   letter-spacing: var(--boxel-lsp-lg);

--- a/packages/web-client/app/components/card-pay/merchant-payment-request-card/payment-request/index.hbs
+++ b/packages/web-client/app/components/card-pay/merchant-payment-request-card/payment-request/index.hbs
@@ -37,10 +37,12 @@
 
     {{#if @amount}}
       <div class="payment-request__amount" data-test-payment-request-amount>
-        §{{@amount}}
+        {{@amount}}
       </div>
-      <div class="payment-request__usd-amount" data-test-payment-request-usd-amount>
-        {{format-usd @usdAmount}}
+    {{/if}}
+    {{#if (and @amount @secondaryAmount)}}
+      <div class="payment-request__secondary-amount" data-test-payment-request-secondary-amount>
+        {{@secondaryAmount}}
       </div>
     {{/if}}
 

--- a/packages/web-client/app/templates/pay.hbs
+++ b/packages/web-client/app/templates/pay.hbs
@@ -3,8 +3,8 @@
 <div class="merchant-payment-request-page">
   <CardPay::MerchantPaymentRequestHeader/>
   <CardPay::MerchantPaymentRequestCard
-    @amount={{this.displayedAmounts.SPD}}
-    @usdAmount={{this.displayedAmounts.USD}}
+    @amount={{this.cleanedAmounts.displayed.amount}}
+    @secondaryAmount={{this.cleanedAmounts.displayed.secondaryAmount}}
     @merchant={{this.merchantInfo}}
     @merchantAddress={{@model.merchantSafe.address}}
     @paymentURL={{this.paymentURL}}

--- a/packages/web-client/tests/acceptance/pay-test.ts
+++ b/packages/web-client/tests/acceptance/pay-test.ts
@@ -6,9 +6,11 @@ import sinon from 'sinon';
 
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
 import {
+  convertAmountToNativeDisplay,
   formatUsd,
   generateMerchantPaymentUrl,
   MerchantSafe,
+  roundAmountToNativeCurrencyDecimals,
   spendToUsd,
 } from '@cardstack/cardpay-sdk';
 import { getResolver } from '@cardstack/did-resolver';
@@ -24,7 +26,7 @@ const MERCHANT_INFO_MISSING_MESSAGE =
 const MERCHANT_MISSING_MESSAGE = '[data-test-merchant-missing]';
 const MERCHANT_LOGO = '[data-test-merchant-logo]';
 const AMOUNT = '[data-test-payment-request-amount]';
-const USD_AMOUNT = '[data-test-payment-request-usd-amount]';
+const SECONDARY_AMOUNT = '[data-test-payment-request-secondary-amount]';
 const QR_CODE = '[data-test-styled-qr-code]';
 const DEEP_LINK = '[data-test-payment-request-deep-link]';
 const PAYMENT_URL = '[data-test-payment-request-url]';
@@ -109,7 +111,7 @@ module('Acceptance | pay', function (hooks) {
       );
     assert.dom(AMOUNT).containsText(`§${spendAmount}`);
     assert
-      .dom(USD_AMOUNT)
+      .dom(SECONDARY_AMOUNT)
       .containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
 
     let expectedUrl = generateMerchantPaymentUrl({
@@ -118,6 +120,43 @@ module('Acceptance | pay', function (hooks) {
       merchantSafeID: merchantSafe.address,
       currency: spendSymbol,
       amount: spendAmount,
+    });
+    assert.dom(QR_CODE).hasAttribute('data-test-styled-qr-code', expectedUrl);
+    assert.dom(PAYMENT_URL).containsText(expectedUrl);
+  });
+
+  test('it rounds display but not url with floating point SPD', async function (assert) {
+    const floatingSpendAmount = 279.17;
+    const roundedSpendAmount = Math.ceil(floatingSpendAmount);
+    await visit(
+      `/pay/${network}/${merchantSafe.address}?amount=${floatingSpendAmount}&currency=${spendSymbol}`
+    );
+    await waitFor(MERCHANT);
+
+    assert.dom(MERCHANT).hasAttribute('data-test-merchant', merchantName);
+    assert
+      .dom(MERCHANT_LOGO)
+      .hasAttribute(
+        'data-test-merchant-logo-background',
+        merchantInfoBackground
+      );
+    assert
+      .dom(MERCHANT_LOGO)
+      .hasAttribute(
+        'data-test-merchant-logo-text-color',
+        merchantInfoTextColor
+      );
+    assert.dom(AMOUNT).containsText(`§${roundedSpendAmount}`);
+    assert
+      .dom(SECONDARY_AMOUNT)
+      .containsText(`${formatUsd(spendToUsd(roundedSpendAmount)!)}`);
+
+    let expectedUrl = generateMerchantPaymentUrl({
+      domain: universalLinkDomain,
+      network,
+      merchantSafeID: merchantSafe.address,
+      currency: spendSymbol,
+      amount: roundedSpendAmount,
     });
     assert.dom(QR_CODE).hasAttribute('data-test-styled-qr-code', expectedUrl);
     assert.dom(PAYMENT_URL).containsText(expectedUrl);
@@ -145,7 +184,7 @@ module('Acceptance | pay', function (hooks) {
       );
     assert.dom(AMOUNT).containsText(`§${spendAmount}`);
     assert
-      .dom(USD_AMOUNT)
+      .dom(SECONDARY_AMOUNT)
       .containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,
@@ -177,16 +216,57 @@ module('Acceptance | pay', function (hooks) {
         'data-test-merchant-logo-text-color',
         merchantInfoTextColor
       );
-    assert.dom(AMOUNT).containsText(`§${spendAmount}`);
-    assert
-      .dom(USD_AMOUNT)
-      .containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
+    assert.dom(AMOUNT).containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
+    assert.dom(SECONDARY_AMOUNT).containsText(`§${spendAmount}`);
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,
       network,
       merchantSafeID: merchantSafe.address,
       currency: usdSymbol,
       amount: usdAmount,
+    });
+    assert.dom(QR_CODE).hasAttribute('data-test-styled-qr-code', expectedUrl);
+    assert.dom(PAYMENT_URL).containsText(expectedUrl);
+  });
+
+  test('it renders correctly if currency is non-USD and non-SPEND', async function (assert) {
+    const jpyAmount = 300.335;
+    const jpySymbol = 'JPY';
+    const roundedJpyAmount = roundAmountToNativeCurrencyDecimals(
+      jpyAmount,
+      jpySymbol
+    );
+
+    await visit(
+      `/pay/${network}/${merchantSafe.address}?amount=${jpyAmount}&currency=${jpySymbol}`
+    );
+    await waitFor(MERCHANT);
+
+    assert.dom(MERCHANT).hasAttribute('data-test-merchant', merchantName);
+    assert
+      .dom(MERCHANT_LOGO)
+      .hasAttribute(
+        'data-test-merchant-logo-background',
+        merchantInfoBackground
+      );
+    assert
+      .dom(MERCHANT_LOGO)
+      .hasAttribute(
+        'data-test-merchant-logo-text-color',
+        merchantInfoTextColor
+      );
+
+    assert
+      .dom(AMOUNT)
+      .containsText(convertAmountToNativeDisplay(roundedJpyAmount, jpySymbol));
+    assert.dom(SECONDARY_AMOUNT).doesNotExist();
+
+    let expectedUrl = generateMerchantPaymentUrl({
+      domain: universalLinkDomain,
+      network,
+      merchantSafeID: merchantSafe.address,
+      currency: jpySymbol,
+      amount: Number(roundedJpyAmount),
     });
     assert.dom(QR_CODE).hasAttribute('data-test-styled-qr-code', expectedUrl);
     assert.dom(PAYMENT_URL).containsText(expectedUrl);
@@ -213,7 +293,7 @@ module('Acceptance | pay', function (hooks) {
       );
 
     assert.dom(AMOUNT).doesNotExist();
-    assert.dom(USD_AMOUNT).doesNotExist();
+    assert.dom(SECONDARY_AMOUNT).doesNotExist();
 
     // we just pass this currency to the wallet to handle without
     // displaying the amounts if we don't recognize the currency
@@ -250,7 +330,7 @@ module('Acceptance | pay', function (hooks) {
       );
 
     assert.dom(AMOUNT).doesNotExist();
-    assert.dom(USD_AMOUNT).doesNotExist();
+    assert.dom(SECONDARY_AMOUNT).doesNotExist();
 
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,
@@ -288,7 +368,7 @@ module('Acceptance | pay', function (hooks) {
 
     assert.dom(AMOUNT).containsText(`§${spendAmount}`);
     assert
-      .dom(USD_AMOUNT)
+      .dom(SECONDARY_AMOUNT)
       .containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
 
     // assert that the deep link view is rendered
@@ -333,7 +413,7 @@ module('Acceptance | pay', function (hooks) {
       );
     assert.dom(AMOUNT).containsText(`§${spendAmount}`);
     assert
-      .dom(USD_AMOUNT)
+      .dom(SECONDARY_AMOUNT)
       .containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
 
     let expectedUrl = generateMerchantPaymentUrl({

--- a/packages/web-client/tests/acceptance/pay-test.ts
+++ b/packages/web-client/tests/acceptance/pay-test.ts
@@ -102,9 +102,7 @@ module('Acceptance | pay', function (hooks) {
       .hasAttribute(
         'data-test-merchant-logo-background',
         merchantInfoBackground
-      );
-    assert
-      .dom(MERCHANT_LOGO)
+      )
       .hasAttribute(
         'data-test-merchant-logo-text-color',
         merchantInfoTextColor
@@ -139,9 +137,7 @@ module('Acceptance | pay', function (hooks) {
       .hasAttribute(
         'data-test-merchant-logo-background',
         merchantInfoBackground
-      );
-    assert
-      .dom(MERCHANT_LOGO)
+      )
       .hasAttribute(
         'data-test-merchant-logo-text-color',
         merchantInfoTextColor
@@ -175,9 +171,7 @@ module('Acceptance | pay', function (hooks) {
       .hasAttribute(
         'data-test-merchant-logo-background',
         merchantInfoBackground
-      );
-    assert
-      .dom(MERCHANT_LOGO)
+      )
       .hasAttribute(
         'data-test-merchant-logo-text-color',
         merchantInfoTextColor
@@ -209,9 +203,7 @@ module('Acceptance | pay', function (hooks) {
       .hasAttribute(
         'data-test-merchant-logo-background',
         merchantInfoBackground
-      );
-    assert
-      .dom(MERCHANT_LOGO)
+      )
       .hasAttribute(
         'data-test-merchant-logo-text-color',
         merchantInfoTextColor
@@ -248,9 +240,7 @@ module('Acceptance | pay', function (hooks) {
       .hasAttribute(
         'data-test-merchant-logo-background',
         merchantInfoBackground
-      );
-    assert
-      .dom(MERCHANT_LOGO)
+      )
       .hasAttribute(
         'data-test-merchant-logo-text-color',
         merchantInfoTextColor
@@ -284,9 +274,7 @@ module('Acceptance | pay', function (hooks) {
       .hasAttribute(
         'data-test-merchant-logo-background',
         merchantInfoBackground
-      );
-    assert
-      .dom(MERCHANT_LOGO)
+      )
       .hasAttribute(
         'data-test-merchant-logo-text-color',
         merchantInfoTextColor
@@ -321,9 +309,7 @@ module('Acceptance | pay', function (hooks) {
       .hasAttribute(
         'data-test-merchant-logo-background',
         merchantInfoBackground
-      );
-    assert
-      .dom(MERCHANT_LOGO)
+      )
       .hasAttribute(
         'data-test-merchant-logo-text-color',
         merchantInfoTextColor
@@ -358,9 +344,7 @@ module('Acceptance | pay', function (hooks) {
       .hasAttribute(
         'data-test-merchant-logo-background',
         merchantInfoBackground
-      );
-    assert
-      .dom(MERCHANT_LOGO)
+      )
       .hasAttribute(
         'data-test-merchant-logo-text-color',
         merchantInfoTextColor

--- a/packages/web-client/tests/integration/components/card-pay/merchant-payment-request-card-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/merchant-payment-request-card-test.ts
@@ -14,7 +14,7 @@ const MERCHANT_INFO_MISSING_MESSAGE =
   '[data-test-payment-request-merchant-info-missing]';
 const MERCHANT_LOGO = '[data-test-merchant-logo]';
 const AMOUNT = '[data-test-payment-request-amount]';
-const USD_AMOUNT = '[data-test-payment-request-usd-amount]';
+const SECONDARY_AMOUNT = '[data-test-payment-request-secondary-amount]';
 const QR_CODE = '[data-test-styled-qr-code]';
 const DEEP_LINK = '[data-test-payment-request-deep-link]';
 const LINK_VIEW_TOGGLE = '[data-test-payment-request-link-view-toggle]';
@@ -22,8 +22,8 @@ const PAYMENT_URL = '[data-test-payment-request-url]';
 const LOADING_INDICATOR = '[data-test-merchant-loading-indicator]';
 
 // fixed data
-const amount = '300';
-const usdAmount = '3';
+const amount = `§300`;
+const secondaryAmount = '$3.00 USD';
 const paymentURL =
   'https://pay.cardstack.com/merchat-asdnsadkasd?id=0x1238urfds&amount=73298587423545';
 const deepLinkPaymentURL =
@@ -47,7 +47,7 @@ module(
       };
       this.setProperties({
         amount,
-        usdAmount,
+        secondaryAmount,
         paymentURL,
         deepLinkPaymentURL,
         merchant,
@@ -59,7 +59,7 @@ module(
       await render(hbs`
         <CardPay::MerchantPaymentRequestCard
           @amount={{this.amount}}
-          @usdAmount={{this.usdAmount}}
+          @secondaryAmount={{this.secondaryAmount}}
           @merchant={{this.merchant}}
           @paymentURL={{this.paymentURL}}
           @deepLinkPaymentURL={{this.deepLinkPaymentURL}}
@@ -84,7 +84,7 @@ module(
           merchant.textColor!
         );
       assert.dom(AMOUNT).containsText(`§300`);
-      assert.dom(USD_AMOUNT).containsText(`$3.00 USD`);
+      assert.dom(SECONDARY_AMOUNT).containsText(`$3.00 USD`);
       assert.dom(QR_CODE).hasAttribute('data-test-styled-qr-code', paymentURL);
       assert.dom(PAYMENT_URL).containsText(paymentURL);
     });
@@ -93,7 +93,7 @@ module(
       await render(hbs`
         <CardPay::MerchantPaymentRequestCard
           @amount={{this.amount}}
-          @usdAmount={{this.usdAmount}}
+          @secondaryAmount={{this.secondaryAmount}}
           @merchant={{this.merchant}}
           @paymentURL={{this.paymentURL}}
           @deepLinkPaymentURL={{this.deepLinkPaymentURL}}
@@ -118,7 +118,7 @@ module(
           merchant.textColor!
         );
       assert.dom(AMOUNT).containsText(`§300`);
-      assert.dom(USD_AMOUNT).containsText(`$3.00 USD`);
+      assert.dom(SECONDARY_AMOUNT).containsText(`$3.00 USD`);
       assert.dom(QR_CODE).doesNotExist();
       assert
         .dom(DEEP_LINK)
@@ -139,7 +139,7 @@ module(
       await render(hbs`
         <CardPay::MerchantPaymentRequestCard
           @amount={{this.amount}}
-          @usdAmount={{this.usdAmount}}
+          @secondaryAmount={{this.secondaryAmount}}
           @merchant={{this.merchant}}
           @merchantAddress={{this.merchantAddress}}
           @paymentURL={{this.paymentURL}}
@@ -159,7 +159,7 @@ module(
           'Unable to find merchant details for this address. Use caution when paying.'
         );
       assert.dom(AMOUNT).containsText(`§300`);
-      assert.dom(USD_AMOUNT).containsText(`$3.00 USD`);
+      assert.dom(SECONDARY_AMOUNT).containsText(`$3.00 USD`);
       assert.dom(QR_CODE).hasAttribute('data-test-styled-qr-code', paymentURL);
       assert.dom(PAYMENT_URL).containsText(paymentURL);
     });
@@ -169,7 +169,7 @@ module(
       await render(hbs`
         <CardPay::MerchantPaymentRequestCard
           @amount={{this.amount}}
-          @usdAmount={{this.usdAmount}}
+          @secondaryAmount={{this.secondaryAmount}}
           @merchant={{this.merchant}}
           @merchantAddress={{this.merchantAddress}}
           @paymentURL={{this.paymentURL}}
@@ -184,7 +184,7 @@ module(
       assert.dom(MERCHANT).doesNotExist();
       assert.dom(LOADING_INDICATOR).exists();
       assert.dom(AMOUNT).containsText(`§300`);
-      assert.dom(USD_AMOUNT).containsText(`$3.00 USD`);
+      assert.dom(SECONDARY_AMOUNT).containsText(`$3.00 USD`);
       assert.dom(QR_CODE).hasAttribute('data-test-styled-qr-code', paymentURL);
       assert.dom(PAYMENT_URL).containsText(paymentURL);
     });


### PR DESCRIPTION
This allows the payment page to display currencies supported by Card Wallet (assuming that `packages/cardpay-sdk/sdk/native-currencies.ts` properly represents native currencies supported in Card Wallet). It also rounds supported native currencies + SPEND to an appropriate amount of decimals, rounding up each time.