### PR TITLE
Comma grouping of numbers

### DIFF
--- a/packages/cardpay-sdk/sdk/currency-utils.ts
+++ b/packages/cardpay-sdk/sdk/currency-utils.ts
@@ -343,3 +343,7 @@ export const formatUsd = (value: BigNumberish, options: FormatUsdOptions = { sym
   }
   return result;
 };
+
+export const formatCurrencyAmount = (amount: BigNumberish, decimalPlaces = 2) => {
+  return new BigNumber(amount).toFormat(decimalPlaces);
+};

--- a/packages/cardpay-sdk/sdk/currency-utils.ts
+++ b/packages/cardpay-sdk/sdk/currency-utils.ts
@@ -328,22 +328,6 @@ export const usdToSpend = (amountInUsd: number): number | undefined => {
   return Math.ceil(amountInUsd / SPEND_TO_USD_RATE);
 };
 
-export interface FormatUsdOptions {
-  symbol: string | false;
-  suffix: string | false;
-}
-
-export const formatUsd = (value: BigNumberish, options: FormatUsdOptions = { symbol: '$', suffix: ' USD' }): string => {
-  let result = toFixedDecimals(value, 2);
-  if (options.symbol) {
-    result = options.symbol + result;
-  }
-  if (options.suffix) {
-    result = result + options.suffix;
-  }
-  return result;
-};
-
 export const formatCurrencyAmount = (amount: BigNumberish, decimalPlaces = 2) => {
   return new BigNumber(amount).toFormat(decimalPlaces);
 };

--- a/packages/web-client/app/components/card-pay/balance-chooser-dropdown/index.hbs
+++ b/packages/web-client/app/components/card-pay/balance-chooser-dropdown/index.hbs
@@ -15,7 +15,7 @@ as |token|>
     @size="small"
     @icon={{token.icon}}
     @name={{token.symbol}}
-    @balance={{format-token-amount token.balance}}
+    @balance={{format-wei-amount token.balance}}
     @symbol={{token.symbol}}
   />
 </PowerSelect>

--- a/packages/web-client/app/components/card-pay/balances-list/balance/index.hbs
+++ b/packages/web-client/app/components/card-pay/balances-list/balance/index.hbs
@@ -1,3 +1,3 @@
 <li class="card-pay-balances-list-balance" data-test-balance={{@symbol}} ...attributes>
-  {{svg-jar this.icon class="card-pay-balances-list-balance__small-icon" role="presentation"}} {{format-token-amount @amount}} {{@symbol}}
+  {{svg-jar this.icon class="card-pay-balances-list-balance__small-icon" role="presentation"}} {{format-wei-amount @amount}} {{@symbol}}
 </li>

--- a/packages/web-client/app/components/card-pay/card-picker/card-option/index.hbs
+++ b/packages/web-client/app/components/card-pay/card-picker/card-option/index.hbs
@@ -1,7 +1,7 @@
 <div class="card-picker-option" ...attributes>
   <span class="card-picker-option__network-label">On {{network-display-info "layer2" "fullName"}}</span>
   <div class="card-picker-option__address">{{@card.address}}</div>
-  <div class="card-picker-option__balance">§{{@card.spendFaceValue}} SPEND</div>
+  <div class="card-picker-option__balance">§{{format-amount @card.spendFaceValue}} SPEND</div>
   <div class="card-picker-option__card-container">
     <CardPay::PrepaidCardSafe class="card-picker-option__card" @safe={{@card}} />
   </div>

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
@@ -1,7 +1,10 @@
 import Component from '@glimmer/component';
 import { getOwner } from '@ember/application';
 import { inject as service } from '@ember/service';
-import { formatUsd, spendToUsd } from '@cardstack/cardpay-sdk';
+import {
+  convertAmountToNativeDisplay,
+  spendToUsd,
+} from '@cardstack/cardpay-sdk';
 import {
   cardbot,
   ArbitraryDictionary,
@@ -239,8 +242,9 @@ class CreateMerchantWorkflow extends Workflow {
       template: (session: ArbitraryDictionary) =>
         `It looks like you don’t have a prepaid card in your wallet. You will need one to pay the ${
           session.merchantRegistrationFee
-        } SPEND (${formatUsd(
-          spendToUsd(session.merchantRegistrationFee)!
+        } SPEND (${convertAmountToNativeDisplay(
+          spendToUsd(session.merchantRegistrationFee)!,
+          'USD'
         )}) merchant creation fee. Please buy a prepaid card in your Card Wallet mobile app before you continue with this workflow.`,
       includeIf() {
         return (
@@ -263,8 +267,9 @@ class CreateMerchantWorkflow extends Workflow {
       template: (session: ArbitraryDictionary) =>
         `It looks like you don’t have a prepaid card with enough funds to pay the ${
           session.merchantRegistrationFee
-        } SPEND (${formatUsd(
-          spendToUsd(session.merchantRegistrationFee)!
+        } SPEND (${convertAmountToNativeDisplay(
+          spendToUsd(session.merchantRegistrationFee)!,
+          'USD'
         )}) merchant creation fee. Please buy a prepaid card in your Card Wallet mobile app before you continue with this workflow.`,
       includeIf() {
         return (

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
@@ -26,6 +26,7 @@ import { next } from '@ember/runloop';
 import HubAuthentication from '@cardstack/web-client/services/hub-authentication';
 import RouterService from '@ember/routing/router-service';
 import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';
+import { formatAmount } from '@cardstack/web-client/helpers/format-amount';
 
 const FAILURE_REASONS = {
   DISCONNECTED: 'DISCONNECTED',
@@ -240,9 +241,9 @@ class CreateMerchantWorkflow extends Workflow {
     new SessionAwareWorkflowMessage({
       author: cardbot,
       template: (session: ArbitraryDictionary) =>
-        `It looks like you don’t have a prepaid card in your wallet. You will need one to pay the ${
+        `It looks like you don’t have a prepaid card in your wallet. You will need one to pay the ${formatAmount(
           session.merchantRegistrationFee
-        } SPEND (${convertAmountToNativeDisplay(
+        )} SPEND (${convertAmountToNativeDisplay(
           spendToUsd(session.merchantRegistrationFee)!,
           'USD'
         )}) merchant creation fee. Please buy a prepaid card in your Card Wallet mobile app before you continue with this workflow.`,
@@ -265,9 +266,9 @@ class CreateMerchantWorkflow extends Workflow {
     new SessionAwareWorkflowMessage({
       author: cardbot,
       template: (session: ArbitraryDictionary) =>
-        `It looks like you don’t have a prepaid card with enough funds to pay the ${
+        `It looks like you don’t have a prepaid card with enough funds to pay the ${formatAmount(
           session.merchantRegistrationFee
-        } SPEND (${convertAmountToNativeDisplay(
+        )} SPEND (${convertAmountToNativeDisplay(
           spendToUsd(session.merchantRegistrationFee)!,
           'USD'
         )}) merchant creation fee. Please buy a prepaid card in your Card Wallet mobile app before you continue with this workflow.`,

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
@@ -23,7 +23,7 @@
         @icon="spend"
         @sign="§"
         @symbol="SPEND"
-        @balance={{this.merchantRegistrationFee}}
+        @balance={{format-amount this.merchantRegistrationFee}}
         @usdBalance={{spend-to-usd this.merchantRegistrationFee}}
         data-test-prepaid-card-choice-merchant-fee
       />

--- a/packages/web-client/app/components/card-pay/deposit-workflow/confirmation/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/confirmation/index.hbs
@@ -7,7 +7,7 @@
       @isLayer1={{true}}
       @link={{this.depositTxnViewerUrl}}
       @token={{this.depositedToken}}
-      @amount={{format-token-amount this.depositedAmount}}
+      @amount={{format-wei-amount this.depositedAmount}}
       @preposition="from"
       @walletAddress={{this.layer1Network.walletInfo.firstAddress}}
       data-test-deposit-confirmation-from
@@ -34,7 +34,7 @@
       @isLayer2={{true}}
       @link={{this.blockscoutUrl}}
       @token={{this.receivedToken}}
-      @amount={{format-token-amount this.depositedAmount}}
+      @amount={{format-wei-amount this.depositedAmount}}
       @preposition="in"
       @walletAddress={{this.layer2Network.walletInfo.firstAddress}}
       @depotAddress={{this.depotAddress}}

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -14,7 +14,7 @@
           @tokenSymbol={{this.currentTokenSymbol}}
           @tokenIcon={{this.currentTokenDetails.icon}}
           @address={{this.layer1Network.walletInfo.firstAddress}}
-          @balance={{format-token-amount this.currentTokenBalance}}
+          @balance={{format-wei-amount this.currentTokenBalance}}
           @balanceInUsd={{token-to-usd this.currentTokenSymbol this.currentTokenBalance}}
           @isComplete={{@isComplete}}
         />
@@ -30,7 +30,7 @@
             class="transaction-amount__token"
             @size="large"
             @icon={{this.currentTokenDetails.icon}}
-            @balance={{format-token-amount this.amountAsBigNumber}}
+            @balance={{format-wei-amount this.amountAsBigNumber}}
             @symbol={{this.currentTokenSymbol}}
             @text={{concat (format-usd (token-to-usd this.currentTokenSymbol this.amountAsBigNumber)) "*"}}
             data-test-deposit-amount-entered

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.hbs
@@ -19,7 +19,7 @@
               <CardPay::BalanceDisplay
                 @size="large"
                 @icon={{this.selectedToken.icon}}
-                @balance={{format-token-amount this.selectedToken.balance}}
+                @balance={{format-wei-amount this.selectedToken.balance}}
                 @symbol={{this.selectedToken.symbol}}
                 @usdBalance={{token-to-usd this.selectedToken.symbol this.selectedToken.balance}}
                 data-test-deposit-transaction-setup-from-balance={{this.selectedToken.symbol}}
@@ -37,10 +37,10 @@
               <CardPay::DepositWorkflow::TransactionSetup::TokenOption
                 @checked={{unless this.noTokenBalance (eq this.selectedToken.symbol token.symbol)}}
                 @onInput={{fn this.chooseSource token}}
-                @balance={{format-token-amount token.balance}}
+                @balance={{format-wei-amount token.balance}}
                 @balanceInUsd={{token-to-usd token.symbol token.balance}}
                 @token={{token}}
-                @disabled={{eq (format-token-amount token.balance) "0.00"}}
+                @disabled={{eq (format-wei-amount token.balance) "0.00"}}
                 data-test-deposit-transaction-setup-from-option={{token.symbol}}
               />
             {{/each}}

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
@@ -30,7 +30,7 @@
             @icon="spend"
             @sign="§"
             @symbol="SPEND"
-            @balance={{this.selectedFaceValue.spendAmount}}
+            @balance={{format-amount this.selectedFaceValue.spendAmount}}
             @usdBalance={{spend-to-usd this.selectedFaceValue.spendAmount}}
             @text={{concat "≈ " this.selectedFaceValue.approxTokenAmount " " this.fundingTokenSymbol "*"}}
             data-test-face-value-display

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
@@ -19,7 +19,7 @@
           @walletAddress={{this.layer2Network.walletInfo.firstAddress}}
           @depotAddress={{this.layer2Network.depotSafe.address}}
           @token={{this.fundingToken}}
-          @balance={{format-token-amount this.fundingTokenBalance}}
+          @balance={{format-wei-amount this.fundingTokenBalance}}
         />
       </CardPay::LabeledValue>
       {{#if @isComplete}}

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
@@ -11,7 +11,7 @@
         <span>Prepaid cards are denominated in SPEND:</span>
         <span class="face-value-card__exchange-rate">
           {{svg-jar "spend" width="20" height="20" role="presentation"}}
-          §1 SPEND = ${{this.spendToUsdRate}} USD
+          §1 SPEND = {{format-usd this.spendToUsdRate}}
         </span>
       </p>
       <CardPay::LabeledValue @vertical={{true}} @label="Funding From:">

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/option/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/option/index.hbs
@@ -19,7 +19,7 @@
   <div class="face-value-option__value">
     {{svg-jar "spend" width="20" height="20" role="presentation"}}
     <div class="face-value-option__amount">
-      §{{@spendFaceValue}} SPEND
+      §{{format-amount @spendFaceValue}} SPEND
     </div>
     <div class="face-value-option__conversion">
       ${{@usdAmount}} USD

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/display-view/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/display-view/index.hbs
@@ -13,7 +13,7 @@
         @headerPatternColor={{@colorScheme.patternColor}}
         @mockBalance={{true}}
         @mockOptions={{true}}
-        @balance="123,456"
+        @balance="123456"
         @usdBalance="1234.56"
         @address={{placeholder-address}}
         @network={{network-display-info "layer2" "fullName"}}

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/form-view/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/form-view/index.hbs
@@ -11,7 +11,7 @@
         @headerPatternColor={{@colorScheme.patternColor}}
         @mockBalance={{true}}
         @mockOptions={{true}}
-        @balance="123,456"
+        @balance="123456"
         @usdBalance="1234.56"
         @address={{placeholder-address}}
         @network={{network-display-info "layer2" "fullName"}}

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
@@ -64,7 +64,7 @@
             @icon="spend"
             @sign="§"
             @symbol="SPEND"
-            @balance={{this.faceValue}}
+            @balance={{format-amount this.faceValue}}
             @usdBalance={{spend-to-usd this.faceValue}}
           />
         </CardPay::LabeledValue>

--- a/packages/web-client/app/components/card-pay/nested-depot-balance-chooser/index.hbs
+++ b/packages/web-client/app/components/card-pay/nested-depot-balance-chooser/index.hbs
@@ -18,7 +18,7 @@
         <CardPay::BalanceDisplay
           @size="large"
           @icon={{@selectedToken.icon}}
-          @balance={{format-token-amount @selectedToken.balance}}
+          @balance={{format-wei-amount @selectedToken.balance}}
           @symbol={{@selectedTokenSymbol}}
           data-test-account-balance
         />

--- a/packages/web-client/app/components/card-pay/prepaid-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/prepaid-card/index.hbs
@@ -42,7 +42,7 @@
         class={{cn "prepaid-card__balance" prepaid-card__balance--mock=@mockBalance}}
         data-test-prepaid-card-balance
       >
-        §{{@balance}}
+        §{{format-amount @balance}}
       </div>
       <div
         class={{cn "prepaid-card__usd-balance" prepaid-card__usd-balance--mock=@mockBalance}}

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/check-balance/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/check-balance/index.hbs
@@ -26,7 +26,7 @@
               <CardPay::BalanceDisplay
                 @size="large"
                 @icon={{this.nativeTokenDisplayInfo.icon}}
-                @balance={{format-token-amount this.layer1Network.defaultTokenBalance}}
+                @balance={{format-wei-amount this.layer1Network.defaultTokenBalance}}
                 @symbol={{this.nativeTokenDisplayInfo.symbol}}
                 @usdBalance={{token-to-usd 'ETH' this.layer1Network.defaultTokenBalance}}
                 class="withdrawal-workflow-check-balance__balance"
@@ -51,7 +51,7 @@
         <CardPay::BalanceDisplay
           @size="large"
           @icon={{this.nativeTokenDisplayInfo.icon}}
-          @balance={{format-token-amount this.minimumBalanceForWithdrawalClaim}}
+          @balance={{format-wei-amount this.minimumBalanceForWithdrawalClaim}}
           @symbol={{this.nativeTokenDisplayInfo.symbol}}
           @usdBalance={{token-to-usd 'ETH' this.minimumBalanceForWithdrawalClaim}}
         />
@@ -69,7 +69,7 @@
     <:default as |i|>
       <i.ActionStatusArea class="withdrawal-workflow-check-balance__passed-status" @icon={{this.walletProvider.iconName}} style={{css-var status-icon-size="2.5rem"}}>
         <div class="withdrawal-workflow-check-balance__passed-status-message">
-          Insufficient {{this.nativeTokenDisplayInfo.symbol}} for withdrawal on 
+          Insufficient {{this.nativeTokenDisplayInfo.symbol}} for withdrawal on
           {{network-display-info "layer1" "fullName"}}. Please deposit amount specified above.
         </div>
       </i.ActionStatusArea>

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/choose-balance/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/choose-balance/index.hbs
@@ -40,7 +40,7 @@
                 @label="Available Balance"
                 @size="large"
                 @icon={{this.selectedToken.icon}}
-                @balance={{format-token-amount this.selectedToken.balance}}
+                @balance={{format-wei-amount this.selectedToken.balance}}
                 @symbol={{this.selectedToken.symbol}}
                 data-test-choose-balance-from-display
               />

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
@@ -29,7 +29,7 @@ import {
   waitForQueue,
 } from 'ember-concurrency';
 import { task } from 'ember-concurrency-decorators';
-import { formatTokenAmount } from '@cardstack/web-client/helpers/format-token-amount';
+import { formatWeiAmount } from '@cardstack/web-client/helpers/format-wei-amount';
 
 const FAILURE_REASONS = {
   DISCONNECTED: 'DISCONNECTED',
@@ -82,16 +82,16 @@ It looks like you have enough ${
         c.layer1.nativeTokenSymbol
       } in your account on ${
         c.layer1.fullName
-      } to perform the last step of this withdrawal workflow, which requires ~${formatTokenAmount(
+      } to perform the last step of this withdrawal workflow, which requires ~${formatWeiAmount(
         minimumBalanceForWithdrawalClaim
       )} ${c.layer1.nativeTokenSymbol}.`;
     } else {
       return `Checking your balance...
 
-The last step of this withdrawal requires that you have at least **~${formatTokenAmount(
+The last step of this withdrawal requires that you have at least **~${formatWeiAmount(
         minimumBalanceForWithdrawalClaim
       )} ${c.layer1.nativeTokenSymbol}**.
-You only have **${formatTokenAmount(layer1Network.defaultTokenBalance)} ${
+You only have **${formatWeiAmount(layer1Network.defaultTokenBalance)} ${
         c.layer1.nativeTokenSymbol
       }**. You will need to deposit more
 ${

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.hbs
@@ -12,7 +12,7 @@
         class="token-claim__balance-display"
         @size="large"
         @icon={{this.tokenDetails.icon}}
-        @balance={{format-token-amount this.withdrawalAmount}}
+        @balance={{format-wei-amount this.withdrawalAmount}}
         @symbol={{this.tokenSymbol}}
         @text={{concat (format-usd (token-to-usd this.tokenSymbolForConversion this.withdrawalAmount)) "*"}}
         data-test-withdrawal-token-claim-amount

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
@@ -17,7 +17,7 @@
           @size="small"
           @icon={{this.currentTokenDetails.icon}}
           @name={{this.currentTokenDetails.symbol}}
-          @balance={{format-token-amount this.currentTokenBalance}}
+          @balance={{format-wei-amount this.currentTokenBalance}}
           @symbol={{this.currentTokenDetails.symbol}}
           data-test-withdrawal-balance
         />
@@ -34,7 +34,7 @@
             class="withdrawal-transaction-amount__token"
             @size="large"
             @icon={{this.currentTokenDetails.icon}}
-            @balance={{format-token-amount this.amountAsBigNumber}}
+            @balance={{format-wei-amount this.amountAsBigNumber}}
             @symbol={{this.currentTokenSymbol}}
             @text={{concat (format-usd (token-to-usd this.currentTokenSymbol this.amountAsBigNumber)) "*"}}
             data-test-amount-entered

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-confirmed/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-confirmed/index.hbs
@@ -8,7 +8,7 @@
       @isLayer2={{true}}
       @link={{this.blockscoutUrl}}
       @token={{this.withdrawToken}}
-      @amount={{format-token-amount this.withdrawAmount}}
+      @amount={{format-wei-amount this.withdrawAmount}}
       @preposition="from"
       @walletAddress={{this.layer2Network.walletInfo.firstAddress}}
       @depotAddress={{this.depotAddress}}
@@ -35,7 +35,7 @@
       @isLayer1={{true}}
       @link={{this.withdrawTxnViewerUrl}}
       @token={{this.receivedToken}}
-      @amount={{format-token-amount this.withdrawAmount}}
+      @amount={{format-wei-amount this.withdrawAmount}}
       @preposition="in"
       @walletAddress={{this.layer1Network.walletInfo.firstAddress}}
       data-test-withdrawal-transaction-confirmed-to

--- a/packages/web-client/app/controllers/pay.ts
+++ b/packages/web-client/app/controllers/pay.ts
@@ -13,6 +13,7 @@ import IsIOS from '../services/is-ios';
 import { useResource } from 'ember-resources';
 import { MerchantInfo } from '../resources/merchant-info';
 import config from '@cardstack/web-client/config/environment';
+import { formatAmount } from '../helpers/format-amount';
 
 export default class CardPayMerchantServicesController extends Controller {
   @service('is-ios') declare isIOSService: IsIOS;
@@ -53,7 +54,7 @@ export default class CardPayMerchantServicesController extends Controller {
       return {
         amount,
         displayed: {
-          amount: `§${amount}`,
+          amount: `§${formatAmount(amount)}`,
           secondaryAmount: convertAmountToNativeDisplay(
             spendToUsd(amount)!,
             'USD'
@@ -68,7 +69,7 @@ export default class CardPayMerchantServicesController extends Controller {
         amount,
         displayed: {
           amount: convertAmountToNativeDisplay(amount, 'USD'),
-          secondaryAmount: `§${usdToSpend(Number(amount))}`,
+          secondaryAmount: `§${formatAmount(usdToSpend(Number(amount))!)}`,
         },
       };
     } else {

--- a/packages/web-client/app/helpers/format-amount.ts
+++ b/packages/web-client/app/helpers/format-amount.ts
@@ -4,9 +4,12 @@ import {
 } from '@cardstack/cardpay-sdk';
 import Helper from '@ember/component/helper';
 
-type FormatAmountHelperParams = [number, number];
+type FormatAmountHelperParams = [number | string, number];
 
-export function formatAmount(amount: number, minDecimals: number = 0): string {
+export function formatAmount(
+  amount: number | string,
+  minDecimals: number = 0
+): string {
   if (amount == null || amount === undefined) {
     return '';
   }

--- a/packages/web-client/app/helpers/format-amount.ts
+++ b/packages/web-client/app/helpers/format-amount.ts
@@ -1,0 +1,26 @@
+import {
+  countDecimalPlaces,
+  formatCurrencyAmount,
+} from '@cardstack/cardpay-sdk';
+import Helper from '@ember/component/helper';
+
+type FormatAmountHelperParams = [number, number];
+
+export function formatAmount(amount: number, minDecimals: number = 0): string {
+  if (amount == null || amount === undefined) {
+    return '';
+  }
+
+  return formatCurrencyAmount(
+    amount,
+    Math.max(minDecimals, countDecimalPlaces(amount))
+  );
+}
+
+class FormatWeiAmountHelper extends Helper {
+  compute([amount, minDecimals]: FormatAmountHelperParams /*, hash*/) {
+    return formatAmount(amount, minDecimals);
+  }
+}
+
+export default FormatWeiAmountHelper;

--- a/packages/web-client/app/helpers/format-token-amount.ts
+++ b/packages/web-client/app/helpers/format-token-amount.ts
@@ -1,3 +1,7 @@
+import {
+  countDecimalPlaces,
+  formatCurrencyAmount,
+} from '@cardstack/cardpay-sdk';
 import Helper from '@ember/component/helper';
 import BN from 'bn.js';
 import { fromWei } from 'web3-utils';
@@ -6,7 +10,7 @@ type FormatTokenAmountHelperParams = [BN, number];
 
 export function formatTokenAmount(
   amountInSmallestUnit: BN,
-  minPrecision?: number
+  minDecimals?: number
 ): string {
   if (amountInSmallestUnit == null) {
     return '';
@@ -15,41 +19,29 @@ export function formatTokenAmount(
   // fallback to the reasonable default of 2
   // assume that non-numbers and numbers < 0 are mistakes
   if (
-    minPrecision === undefined ||
-    minPrecision === null ||
-    isNaN(minPrecision) ||
-    minPrecision < 0
+    minDecimals === undefined ||
+    minDecimals === null ||
+    isNaN(minDecimals) ||
+    minDecimals < 0
   ) {
-    minPrecision = 2;
+    minDecimals = 2;
   }
   let result = fromWei(amountInSmallestUnit).toString();
 
-  if (minPrecision === 0) {
-    return result;
-  }
-
-  if (!result.includes('.')) {
-    result += '.';
-    result = result.padEnd(minPrecision + result.length, '0');
-  } else {
-    let floatingDecimals = result.split('.')[1]?.length;
-    if (floatingDecimals < minPrecision) {
-      let difference = minPrecision - floatingDecimals;
-      result = result.padEnd(difference + result.length, '0');
-    }
-  }
-
-  return result;
+  return formatCurrencyAmount(
+    result,
+    Math.max(minDecimals, countDecimalPlaces(result))
+  );
 }
 
 class FormatTokenAmountHelper extends Helper {
   compute(
     [
       amountInSmallestUnit,
-      minPrecision,
+      minDecimals,
     ]: FormatTokenAmountHelperParams /*, hash*/
   ) {
-    return formatTokenAmount(amountInSmallestUnit, minPrecision);
+    return formatTokenAmount(amountInSmallestUnit, minDecimals);
   }
 }
 

--- a/packages/web-client/app/helpers/format-usd.ts
+++ b/packages/web-client/app/helpers/format-usd.ts
@@ -1,17 +1,9 @@
 import { helper } from '@ember/component/helper';
-import { formatUsd, FormatUsdOptions } from '@cardstack/cardpay-sdk';
+import { convertAmountToNativeDisplay } from '@cardstack/cardpay-sdk';
 
-let DEFAULT_OPTIONS = {
-  symbol: '$',
-  suffix: ' USD',
-};
-
-export default helper(
-  ([usdAmount]: [number], options: Partial<FormatUsdOptions> = {}) => {
-    let opts = Object.assign({}, DEFAULT_OPTIONS, options) as FormatUsdOptions;
-    if (usdAmount || usdAmount === 0) {
-      return formatUsd(usdAmount, opts);
-    }
-    return undefined;
+export default helper(([usdAmount]: [number]) => {
+  if (usdAmount || usdAmount === 0) {
+    return convertAmountToNativeDisplay(usdAmount, 'USD');
   }
-);
+  return undefined;
+});

--- a/packages/web-client/app/helpers/format-wei-amount.ts
+++ b/packages/web-client/app/helpers/format-wei-amount.ts
@@ -6,9 +6,9 @@ import Helper from '@ember/component/helper';
 import BN from 'bn.js';
 import { fromWei } from 'web3-utils';
 
-type FormatTokenAmountHelperParams = [BN, number];
+type FormatWeiAmountHelperParams = [BN, number];
 
-export function formatTokenAmount(
+export function formatWeiAmount(
   amountInSmallestUnit: BN,
   minDecimals?: number
 ): string {
@@ -34,15 +34,12 @@ export function formatTokenAmount(
   );
 }
 
-class FormatTokenAmountHelper extends Helper {
+class FormatWeiAmountHelper extends Helper {
   compute(
-    [
-      amountInSmallestUnit,
-      minDecimals,
-    ]: FormatTokenAmountHelperParams /*, hash*/
+    [amountInSmallestUnit, minDecimals]: FormatWeiAmountHelperParams /*, hash*/
   ) {
-    return formatTokenAmount(amountInSmallestUnit, minDecimals);
+    return formatWeiAmount(amountInSmallestUnit, minDecimals);
   }
 }
 
-export default FormatTokenAmountHelper;
+export default FormatWeiAmountHelper;

--- a/packages/web-client/tests/acceptance/card-balances-test.ts
+++ b/packages/web-client/tests/acceptance/card-balances-test.ts
@@ -81,7 +81,7 @@ module('Acceptance | card balances', function (hooks) {
 
     assert
       .dom('[data-test-card-balances]')
-      .containsText('§2324')
+      .containsText('§2,324')
       .containsText('0x1234...abcd');
 
     assert
@@ -126,7 +126,7 @@ module('Acceptance | card balances', function (hooks) {
 
     assert
       .dom('[data-test-card-balances]')
-      .containsText('§4648')
+      .containsText('§4,648')
       .containsText('0x5678...abcd');
   });
 });

--- a/packages/web-client/tests/acceptance/create-merchant-test.ts
+++ b/packages/web-client/tests/acceptance/create-merchant-test.ts
@@ -13,7 +13,11 @@ import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
 import BN from 'bn.js';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { formatUsd, PrepaidCardSafe, spendToUsd } from '@cardstack/cardpay-sdk';
+import {
+  convertAmountToNativeDisplay,
+  PrepaidCardSafe,
+  spendToUsd,
+} from '@cardstack/cardpay-sdk';
 
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
 
@@ -504,8 +508,9 @@ module('Acceptance | create merchant', function (hooks) {
     assert
       .dom('[data-test-postable="0"][data-test-cancelation]')
       .containsText(
-        `It looks like you don’t have a prepaid card in your wallet. You will need one to pay the ${merchantRegistrationFee} SPEND (${formatUsd(
-          spendToUsd(merchantRegistrationFee)!
+        `It looks like you don’t have a prepaid card in your wallet. You will need one to pay the ${merchantRegistrationFee} SPEND (${convertAmountToNativeDisplay(
+          spendToUsd(merchantRegistrationFee)!,
+          'USD'
         )}) merchant creation fee. Please buy a prepaid card in your Card Wallet mobile app before you continue with this workflow.`
       );
     assert
@@ -542,8 +547,9 @@ module('Acceptance | create merchant', function (hooks) {
     assert
       .dom('[data-test-postable="0"][data-test-cancelation]')
       .containsText(
-        `It looks like you don’t have a prepaid card with enough funds to pay the ${merchantRegistrationFee} SPEND (${formatUsd(
-          spendToUsd(merchantRegistrationFee)!
+        `It looks like you don’t have a prepaid card with enough funds to pay the ${merchantRegistrationFee} SPEND (${convertAmountToNativeDisplay(
+          spendToUsd(merchantRegistrationFee)!,
+          'USD'
         )}) merchant creation fee. Please buy a prepaid card in your Card Wallet mobile app before you continue with this workflow.`
       );
     assert

--- a/packages/web-client/tests/acceptance/create-merchant-test.ts
+++ b/packages/web-client/tests/acceptance/create-merchant-test.ts
@@ -20,6 +20,7 @@ import {
 } from '@cardstack/cardpay-sdk';
 
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
+import { formatAmount } from '@cardstack/web-client/helpers/format-amount';
 
 interface Context extends MirageTestContext {}
 
@@ -508,7 +509,9 @@ module('Acceptance | create merchant', function (hooks) {
     assert
       .dom('[data-test-postable="0"][data-test-cancelation]')
       .containsText(
-        `It looks like you don’t have a prepaid card in your wallet. You will need one to pay the ${merchantRegistrationFee} SPEND (${convertAmountToNativeDisplay(
+        `It looks like you don’t have a prepaid card in your wallet. You will need one to pay the ${formatAmount(
+          merchantRegistrationFee
+        )} SPEND (${convertAmountToNativeDisplay(
           spendToUsd(merchantRegistrationFee)!,
           'USD'
         )}) merchant creation fee. Please buy a prepaid card in your Card Wallet mobile app before you continue with this workflow.`
@@ -547,7 +550,9 @@ module('Acceptance | create merchant', function (hooks) {
     assert
       .dom('[data-test-postable="0"][data-test-cancelation]')
       .containsText(
-        `It looks like you don’t have a prepaid card with enough funds to pay the ${merchantRegistrationFee} SPEND (${convertAmountToNativeDisplay(
+        `It looks like you don’t have a prepaid card with enough funds to pay the ${formatAmount(
+          merchantRegistrationFee
+        )} SPEND (${convertAmountToNativeDisplay(
           spendToUsd(merchantRegistrationFee)!,
           'USD'
         )}) merchant creation fee. Please buy a prepaid card in your Card Wallet mobile app before you continue with this workflow.`

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -82,7 +82,7 @@ module('Acceptance | deposit', function (hooks) {
     await waitFor(`${post} [data-test-balance="ETH"]`);
     assert.dom(`${post} [data-test-balance="ETH"]`).containsText('2.1411');
     assert.dom(`${post} [data-test-balance="DAI"]`).containsText('250.50');
-    assert.dom(`${post} [data-test-balance="CARD"]`).containsText('10000.00');
+    assert.dom(`${post} [data-test-balance="CARD"]`).containsText('10,000.00');
 
     await settled();
 
@@ -320,7 +320,7 @@ module('Acceptance | deposit', function (hooks) {
       .containsText('0.50');
     assert
       .dom(`${epiloguePostableSel(3)} [data-test-balance="CARD"]`)
-      .containsText('10000.00');
+      .containsText('10,000.00');
 
     let milestoneCtaButtonCount = Array.from(
       document.querySelectorAll(

--- a/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
@@ -124,7 +124,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
 
       assert
         .dom('[data-test-preview] [data-test-prepaid-card-balance]')
-        .hasText('§10000');
+        .hasText('§10,000');
 
       assert.dom('[data-test-issue-prepaid-card-button]').hasText('Create'); // Create prepaid card CTA
     });

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -315,7 +315,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
     assert.dom('[data-test-face-value-option="50000"] input').isDisabled();
     assert
       .dom('[data-test-face-value-option="50000"]')
-      .containsText('50000 SPEND');
+      .containsText('50,000 SPEND');
     assert
       .dom('[data-test-face-value-option="50000"]')
       .containsText('$500 USD');
@@ -335,7 +335,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
     );
 
     assert.dom('[data-test-face-value-option]').doesNotExist();
-    assert.dom('[data-test-face-value-display]').containsText('5000 SPEND');
+    assert.dom('[data-test-face-value-display]').containsText('5,000 SPEND');
     await click(
       `${postableSel(
         2,
@@ -352,7 +352,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
       )} [data-test-boxel-action-chin] [data-test-boxel-button]`
     );
 
-    assert.dom('[data-test-face-value-display]').containsText('10000 SPEND');
+    assert.dom('[data-test-face-value-display]').containsText('10,000 SPEND');
     assert.dom('[data-test-face-value-display]').containsText('$100.00 USD');
     assert.dom('[data-test-face-value-display]').containsText('≈ 100 DAI.CPXD');
 
@@ -378,12 +378,12 @@ module('Acceptance | issue prepaid card', function (hooks) {
       .dom(
         `${postableSel(3, 1)} [data-test-prepaid-card-face-value-labeled-value]`
       )
-      .containsText('10000 SPEND')
+      .containsText('10,000 SPEND')
       .containsText('$100.00 USD');
 
     assert
       .dom(`${postableSel(3, 1)} [data-test-prepaid-card-balance]`)
-      .containsText('10000');
+      .containsText('10,000');
     assert
       .dom(`${postableSel(3, 1)} [data-test-prepaid-card-usd-balance]`)
       .containsText('100');

--- a/packages/web-client/tests/acceptance/pay-test.ts
+++ b/packages/web-client/tests/acceptance/pay-test.ts
@@ -7,7 +7,6 @@ import sinon from 'sinon';
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
 import {
   convertAmountToNativeDisplay,
-  formatUsd,
   generateMerchantPaymentUrl,
   MerchantSafe,
   roundAmountToNativeCurrencyDecimals,
@@ -110,7 +109,9 @@ module('Acceptance | pay', function (hooks) {
     assert.dom(AMOUNT).containsText(`§${spendAmount}`);
     assert
       .dom(SECONDARY_AMOUNT)
-      .containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
+      .containsText(
+        `${convertAmountToNativeDisplay(spendToUsd(spendAmount)!, 'USD')}`
+      );
 
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,
@@ -145,7 +146,12 @@ module('Acceptance | pay', function (hooks) {
     assert.dom(AMOUNT).containsText(`§${roundedSpendAmount}`);
     assert
       .dom(SECONDARY_AMOUNT)
-      .containsText(`${formatUsd(spendToUsd(roundedSpendAmount)!)}`);
+      .containsText(
+        `${convertAmountToNativeDisplay(
+          spendToUsd(roundedSpendAmount)!,
+          'USD'
+        )}`
+      );
 
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,
@@ -179,7 +185,9 @@ module('Acceptance | pay', function (hooks) {
     assert.dom(AMOUNT).containsText(`§${spendAmount}`);
     assert
       .dom(SECONDARY_AMOUNT)
-      .containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
+      .containsText(
+        `${convertAmountToNativeDisplay(spendToUsd(spendAmount)!, 'USD')}`
+      );
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,
       network,
@@ -208,7 +216,11 @@ module('Acceptance | pay', function (hooks) {
         'data-test-merchant-logo-text-color',
         merchantInfoTextColor
       );
-    assert.dom(AMOUNT).containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
+    assert
+      .dom(AMOUNT)
+      .containsText(
+        `${convertAmountToNativeDisplay(spendToUsd(spendAmount)!, 'USD')}`
+      );
     assert.dom(SECONDARY_AMOUNT).containsText(`§${spendAmount}`);
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,
@@ -353,7 +365,9 @@ module('Acceptance | pay', function (hooks) {
     assert.dom(AMOUNT).containsText(`§${spendAmount}`);
     assert
       .dom(SECONDARY_AMOUNT)
-      .containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
+      .containsText(
+        `${convertAmountToNativeDisplay(spendToUsd(spendAmount)!, 'USD')}`
+      );
 
     // assert that the deep link view is rendered
     assert.dom(QR_CODE).doesNotExist();
@@ -398,7 +412,9 @@ module('Acceptance | pay', function (hooks) {
     assert.dom(AMOUNT).containsText(`§${spendAmount}`);
     assert
       .dom(SECONDARY_AMOUNT)
-      .containsText(`${formatUsd(spendToUsd(spendAmount)!)}`);
+      .containsText(
+        `${convertAmountToNativeDisplay(spendToUsd(spendAmount)!, 'USD')}`
+      );
 
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,

--- a/packages/web-client/tests/acceptance/withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-test.ts
@@ -73,7 +73,7 @@ module('Acceptance | withdrawal', function (hooks) {
     await waitFor(`${post} [data-test-balance="ETH"]`);
     assert.dom(`${post} [data-test-balance="ETH"]`).containsText('2.1411');
     assert.dom(`${post} [data-test-balance="DAI"]`).containsText('150.50');
-    assert.dom(`${post} [data-test-balance="CARD"]`).containsText('10000.00');
+    assert.dom(`${post} [data-test-balance="CARD"]`).containsText('10,000.00');
     await settled();
     assert
       .dom(milestoneCompletedSel(0))
@@ -362,7 +362,7 @@ module('Acceptance | withdrawal', function (hooks) {
       .containsText('2.1411');
     assert
       .dom(`${epiloguePostableSel(3)} [data-test-balance="CARD.CPXD"]`)
-      .containsText('10000.00');
+      .containsText('10,000.00');
     let milestoneCtaButtonCount = Array.from(
       document.querySelectorAll(
         '[data-test-milestone] [data-test-boxel-action-chin] button[data-test-boxel-button]'

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
@@ -175,7 +175,7 @@ module(
         .containsText(prepaidCardAddress);
       assert
         .dom(`[data-test-prepaid-card-choice-selected-card]`)
-        .containsText('2324 SPEND');
+        .containsText('2,324 SPEND');
 
       await selectPrepaidCard(prepaidCardAddress2);
 

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-setup-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-setup-test.ts
@@ -70,7 +70,7 @@ module(
       assert.dom(`[data-test-balance="DAI"]`).hasText('250.50 DAI');
       assert.dom(`[data-test-usd-balance="DAI"]`).hasText('$50.10 USD');
       assert.dom(`[data-test-balance="CARD"]`).hasText('10,000.00 CARD');
-      assert.dom(`[data-test-usd-balance="CARD"]`).hasText('$2000.00 USD');
+      assert.dom(`[data-test-usd-balance="CARD"]`).hasText('$2,000.00 USD');
       assert
         .dom(`[data-test-deposit-transaction-setup-to-wallet]`)
         .hasText(`${c.layer2.fullName} wallet`);

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-setup-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-setup-test.ts
@@ -69,7 +69,7 @@ module(
         .hasText(layer1AccountAddress);
       assert.dom(`[data-test-balance="DAI"]`).hasText('250.50 DAI');
       assert.dom(`[data-test-usd-balance="DAI"]`).hasText('$50.10 USD');
-      assert.dom(`[data-test-balance="CARD"]`).hasText('10000.00 CARD');
+      assert.dom(`[data-test-balance="CARD"]`).hasText('10,000.00 CARD');
       assert.dom(`[data-test-usd-balance="CARD"]`).hasText('$2000.00 USD');
       assert
         .dom(`[data-test-deposit-transaction-setup-to-wallet]`)
@@ -238,7 +238,7 @@ module(
       );
       assert
         .dom('[data-test-deposit-transaction-setup-from-balance="CARD"]')
-        .containsText('10000.00 CARD');
+        .containsText('10,000.00 CARD');
       assert
         .dom('[data-test-deposit-transaction-setup-from-balance="DAI"]')
         .doesNotExist();

--- a/packages/web-client/tests/integration/components/layer-one-connect-card-test.ts
+++ b/packages/web-client/tests/integration/components/layer-one-connect-card-test.ts
@@ -65,7 +65,7 @@ module('Integration | Component | layer-one-connect-card', function (hooks) {
 
     assert.dom('[data-test-balance="ETH"]').containsText('2.1411');
     assert.dom('[data-test-balance="DAI"]').containsText('0.50');
-    assert.dom('[data-test-balance="CARD"]').containsText('10000.00');
+    assert.dom('[data-test-balance="CARD"]').containsText('10,000.00');
 
     layer1Service.test__simulateBalances({
       defaultToken: new BN('0'),
@@ -79,7 +79,7 @@ module('Integration | Component | layer-one-connect-card', function (hooks) {
 
     assert.dom('[data-test-balance="ETH"]').doesNotExist();
     assert.dom('[data-test-balance="DAI"]').doesNotExist();
-    assert.dom('[data-test-balance="CARD"]').containsText('10000.00');
+    assert.dom('[data-test-balance="CARD"]').containsText('10,000.00');
 
     layer1Service.test__simulateBalances({
       defaultToken: new BN('0'),

--- a/packages/web-client/tests/integration/helpers/format-token-amount-test.ts
+++ b/packages/web-client/tests/integration/helpers/format-token-amount-test.ts
@@ -16,23 +16,19 @@ module('Integration | Helper | format-token-amount', function (hooks) {
 
   test('It should add zeros to fulfil the required precision', async function (assert) {
     this.set('inputValue', toWei(new BN('1')));
-    this.set('minPrecision', 1);
-    await render(
-      hbs`{{format-token-amount this.inputValue this.minPrecision}}`
-    );
+    this.set('minDecimals', 1);
+    await render(hbs`{{format-token-amount this.inputValue this.minDecimals}}`);
     assert.dom(this.element).hasText('1.0');
 
-    this.set('minPrecision', 2);
+    this.set('minDecimals', 2);
     assert.dom(this.element).hasText('1.00');
   });
 
   test('It should respect existing non-zero floating decimals when adding zeros', async function (assert) {
     // 1.1
     this.set('inputValue', toWei(new BN('11')).div(new BN('10')));
-    this.set('minPrecision', 3);
-    await render(
-      hbs`{{format-token-amount this.inputValue this.minPrecision}}`
-    );
+    this.set('minDecimals', 3);
+    await render(hbs`{{format-token-amount this.inputValue this.minDecimals}}`);
     assert.dom(this.element).hasText('1.100');
 
     // 1.11
@@ -40,32 +36,34 @@ module('Integration | Helper | format-token-amount', function (hooks) {
     assert.dom(this.element).hasText('1.110');
   });
 
-  test('It should have a minPrecision of 2 by default', async function (assert) {
+  test('It should have a minDecimals of 2 by default', async function (assert) {
     this.set('inputValue', toWei(new BN('1')));
     await render(hbs`{{format-token-amount this.inputValue}}`);
 
     assert.dom(this.element).hasText('1.00');
   });
 
-  test('It should have a minPrecision of 2 if an invalid minPrecision is provided', async function (assert) {
+  test('It should have a minDecimals of 2 if an invalid minDecimals is provided', async function (assert) {
     this.set('inputValue', toWei(new BN('1')));
-    this.set('minPrecision', 'beep');
-    await render(
-      hbs`{{format-token-amount this.inputValue this.minPrecision}}`
-    );
+    this.set('minDecimals', 'beep');
+    await render(hbs`{{format-token-amount this.inputValue this.minDecimals}}`);
 
     assert.dom(this.element).hasText('1.00');
 
-    this.set('minPrecision', -30);
+    this.set('minDecimals', -30);
     assert.dom(this.element).hasText('1.00');
   });
 
-  test('It should not add floating zeros if minPrecision is 0', async function (assert) {
+  test('It should not add floating zeros if minDecimals is 0', async function (assert) {
     this.set('inputValue', toWei(new BN('1')));
-    this.set('minPrecision', 0);
-    await render(
-      hbs`{{format-token-amount this.inputValue this.minPrecision}}`
-    );
+    this.set('minDecimals', 0);
+    await render(hbs`{{format-token-amount this.inputValue this.minDecimals}}`);
     assert.dom(this.element).hasText('1');
+  });
+
+  test('It should render separator commas if amount is 1000 or greater', async function (assert) {
+    this.set('inputValue', toWei(new BN('1000')));
+    await render(hbs`{{format-token-amount this.inputValue}}`);
+    assert.dom(this.element).hasText('1,000.00');
   });
 });

--- a/packages/web-client/tests/integration/helpers/format-usd-test.ts
+++ b/packages/web-client/tests/integration/helpers/format-usd-test.ts
@@ -6,7 +6,7 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Helper | format-usd', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('It should return a string with two digits after the decimal point', async function (assert) {
+  test('It should return a string formatted as $<amountWithTwoDecimals> USD', async function (assert) {
     this.set('inputValue', 0);
     await render(hbs`{{format-usd this.inputValue}} `);
     assert.dom(this.element).hasText('$0.00 USD');
@@ -20,31 +20,10 @@ module('Integration | Helper | format-usd', function (hooks) {
     assert.dom(this.element).hasText('$5.16 USD');
   });
 
-  test('It should have a symbol of $ prefixed by default unless false or another symbol is specified', async function (assert) {
-    this.set('inputValue', 5);
+  test('It preserves a minimum precision of 3 for an amount less than 1', async function (assert) {
+    this.set('inputValue', 0.00516);
 
     await render(hbs`{{format-usd this.inputValue}} `);
-    assert.dom(this.element).hasText('$5.00 USD');
-
-    this.set('symbol', false);
-    await render(hbs`{{format-usd this.inputValue symbol=this.symbol}} `);
-    assert.dom(this.element).hasText('5.00 USD');
-
-    this.set('symbol', '#');
-    assert.dom(this.element).hasText('#5.00 USD');
-  });
-
-  test('It should have a suffix of " USD" unless false or another suffix is specified', async function (assert) {
-    this.set('inputValue', 5);
-
-    await render(hbs`{{format-usd this.inputValue}} `);
-    assert.dom(this.element).hasText('$5.00 USD');
-
-    this.set('suffix', false);
-    await render(hbs`{{format-usd this.inputValue suffix=this.suffix}} `);
-    assert.dom(this.element).hasText('$5.00');
-
-    this.set('suffix', ' bucks');
-    assert.dom(this.element).hasText('$5.00 bucks');
+    assert.dom(this.element).hasText('$0.00516 USD');
   });
 });

--- a/packages/web-client/tests/integration/helpers/format-wei-amount-test.ts
+++ b/packages/web-client/tests/integration/helpers/format-wei-amount-test.ts
@@ -5,19 +5,19 @@ import hbs from 'htmlbars-inline-precompile';
 import { toWei } from 'web3-utils';
 import BN from 'bn.js';
 
-module('Integration | Helper | format-token-amount', function (hooks) {
+module('Integration | Helper | format-wei-amount', function (hooks) {
   setupRenderingTest(hooks);
 
   test('It should return a precise value up to 18 decimals', async function (assert) {
     this.set('inputValue', new BN('123456789123456789'));
-    await render(hbs`{{format-token-amount this.inputValue}}`);
+    await render(hbs`{{format-wei-amount this.inputValue}}`);
     assert.dom(this.element).hasText('0.123456789123456789');
   });
 
   test('It should add zeros to fulfil the required precision', async function (assert) {
     this.set('inputValue', toWei(new BN('1')));
     this.set('minDecimals', 1);
-    await render(hbs`{{format-token-amount this.inputValue this.minDecimals}}`);
+    await render(hbs`{{format-wei-amount this.inputValue this.minDecimals}}`);
     assert.dom(this.element).hasText('1.0');
 
     this.set('minDecimals', 2);
@@ -28,7 +28,7 @@ module('Integration | Helper | format-token-amount', function (hooks) {
     // 1.1
     this.set('inputValue', toWei(new BN('11')).div(new BN('10')));
     this.set('minDecimals', 3);
-    await render(hbs`{{format-token-amount this.inputValue this.minDecimals}}`);
+    await render(hbs`{{format-wei-amount this.inputValue this.minDecimals}}`);
     assert.dom(this.element).hasText('1.100');
 
     // 1.11
@@ -38,7 +38,7 @@ module('Integration | Helper | format-token-amount', function (hooks) {
 
   test('It should have a minDecimals of 2 by default', async function (assert) {
     this.set('inputValue', toWei(new BN('1')));
-    await render(hbs`{{format-token-amount this.inputValue}}`);
+    await render(hbs`{{format-wei-amount this.inputValue}}`);
 
     assert.dom(this.element).hasText('1.00');
   });
@@ -46,7 +46,7 @@ module('Integration | Helper | format-token-amount', function (hooks) {
   test('It should have a minDecimals of 2 if an invalid minDecimals is provided', async function (assert) {
     this.set('inputValue', toWei(new BN('1')));
     this.set('minDecimals', 'beep');
-    await render(hbs`{{format-token-amount this.inputValue this.minDecimals}}`);
+    await render(hbs`{{format-wei-amount this.inputValue this.minDecimals}}`);
 
     assert.dom(this.element).hasText('1.00');
 
@@ -57,13 +57,13 @@ module('Integration | Helper | format-token-amount', function (hooks) {
   test('It should not add floating zeros if minDecimals is 0', async function (assert) {
     this.set('inputValue', toWei(new BN('1')));
     this.set('minDecimals', 0);
-    await render(hbs`{{format-token-amount this.inputValue this.minDecimals}}`);
+    await render(hbs`{{format-wei-amount this.inputValue this.minDecimals}}`);
     assert.dom(this.element).hasText('1');
   });
 
   test('It should render separator commas if amount is 1000 or greater', async function (assert) {
     this.set('inputValue', toWei(new BN('1000')));
-    await render(hbs`{{format-token-amount this.inputValue}}`);
+    await render(hbs`{{format-wei-amount this.inputValue}}`);
     assert.dom(this.element).hasText('1,000.00');
   });
 });


### PR DESCRIPTION
This PR adds separator commas to various currency amounts in the DApp. This was implemented by:
- Adding a new `formatCurrencyAmount` function to the SDK's currency utils that formats a `BigNumberish` to a string with separators + the specified amount of decimals
- Changing `format-token-amount` to `format-wei-amount` to reflect that it is supposed to act on wei amounts
- Making `format-wei-amount` use the new `formatCurrencyAmount` utility
- Making `format-usd` use the older `convertAmountToNativeDisplay` utility and removes the `formatUsd` utility, hence providing it with separator commas. This changes its behaviour when dealing with amounts < 1 (see tests), and removes the ability to specify prefix/suffixes.
- Adding a `format-amount` helper/utility to format SPEND

There are a few issues with this PR:
- Which components should be formatting amounts, and which components should rely on their parents/context formatting amounts? 
- Should we be using something similar to `convertAmountToNativeDisplay` for tokens (which has responsibility for adding the correct suffixes and prefixes) and bypassing the necessity for a `format-wei-amount` helper? If we do so what is a good escape hatch for customization?