### PR TITLE
web: Change Sentry to remove host for source maps

### DIFF
--- a/.github/actions/deploy-web-client/action.yml
+++ b/.github/actions/deploy-web-client/action.yml
@@ -9,9 +9,6 @@ inputs:
   environment:
     description: Deployment environment
     required: true
-  sentry_url_prefix:
-    description: Adds a prefix to source map urls after stripping them
-    required: true
 
 runs:
   using: composite
@@ -50,4 +47,4 @@ runs:
         ignore_missing: true
         sourcemaps: packages/web-client/tmp/deploy-dist-uncompressed
         version: web-client-${{ github.sha }}@${{ steps.lerna-version.outputs.lerna-version }}
-        url_prefix: ${{ inputs.sentry_url_prefix }}
+        url_prefix: "~"

--- a/.github/workflows/manual-web-client.yml
+++ b/.github/workflows/manual-web-client.yml
@@ -30,12 +30,10 @@ jobs:
             echo "LAYER_1_CHAIN=keth" >> $GITHUB_ENV # set to "eth" when ready to go to real money
             echo "LAYER_2_CHAIN=sokol" >> $GITHUB_ENV # set to "xdai" when ready to go to real money
             echo "HUB_URL=https://hub.cardstack.com" >> $GITHUB_ENV
-            echo "SENTRY_URL_PREFIX=https://app.cardstack.com" >> $GITHUB_ENV
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
             echo "EMBER_DEPLOY_AWS_ACCESS_KEY=${{ secrets.STAGING_EMBER_DEPLOY_AWS_ACCESS_KEY }}" >> $GITHUB_ENV
             echo "EMBER_DEPLOY_AWS_ACCESS_SECRET=${{ secrets.STAGING_EMBER_DEPLOY_AWS_ACCESS_SECRET }}" >> $GITHUB_ENV
             echo "HUB_URL=https://hub-staging.stack.cards" >> $GITHUB_ENV
-            echo "SENTRY_URL_PREFIX=https://app-staging.stack.cards" >> $GITHUB_ENV
           else
             echo "unrecognized environment"
             exit 1;
@@ -57,7 +55,6 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref }}
           environment: ${{ github.event.inputs.environment }}
-          sentry_url_prefix: ${{ env.SENTRY_URL_PREFIX }}
 
       - name: Send success notification to Discord
         if: ${{ success() }}


### PR DESCRIPTION
As documented here, this will cause Sentry to strip the
domain when uploading source maps:
https://docs.sentry.io/platforms/javascript/guides/gatsby/sourcemaps/uploading/multiple-origins/

As a bonus, this simplifies the web client deployment action because we no longer need to care about deployment domain.

An [example](https://sentry.io/organizations/cardstack/issues/2661042522/?project=5879708&query=is%3Aunresolved&statsPeriod=14d) stacktrace on `wallet-staging.stack.cards` before this change:

![image](https://user-images.githubusercontent.com/43280/134039859-f78ae6b3-cac5-4585-a447-3b54164b2859.png)

When I temporarily overrode the `push-main` workflow to run on this branch and used `~` as the Sentry URL prefix, the stacktrace [showed](https://sentry.io/organizations/cardstack/issues/2558539178/?project=5879708&query=is%3Aignored&statsPeriod=14d) properly:

![image](https://user-images.githubusercontent.com/43280/134040040-e828c24f-03e0-4370-bf6b-8a4f36e4e934.png)
