### PR TITLE
Fix accidental invocation of ts

### DIFF
--- a/packages/cardie/Procfile
+++ b/packages/cardie/Procfile
@@ -1,1 +1,1 @@
-worker: node ./index.ts
+worker: node ./index.js

--- a/packages/hub/Procfile
+++ b/packages/hub/Procfile
@@ -1,2 +1,2 @@
-web: node ./bin/server.ts
-worker: node ./bin/worker.ts
+web: node ./bin/server.js
+worker: node ./bin/worker.js


### PR DESCRIPTION
These were working by accident, only because no typescript-specific syntax was used in these files. The typescript would execute as javascript and work, and the next-level `require()` doesn't use an explicit extension so gets handled by the compiled JS.

Really we should be invoking the compiled js at the top level instead.