### PR TITLE
Deploys should run when deploy code has changed

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -103,6 +103,7 @@ jobs:
               - 'packages/hub/**'
               - 'packages/did-resolver/**'
               - '.github/workflows/push-main.yml'
+              - '.github/actions/deploy-hub/**'
               - 'yarn.lock'
               - 'waypoint.hcl'
             web_client:
@@ -111,6 +112,7 @@ jobs:
               - 'packages/cardpay-sdk/**'
               - 'packages/did-resolver/**'
               - '.github/workflows/push-main.yml'
+              - '.github/actions/deploy-web-client/**'
               - 'yarn.lock'
             boxel:
               - 'packages/boxel/**'

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -102,15 +102,25 @@ jobs:
             hub:
               - 'packages/hub/**'
               - 'packages/did-resolver/**'
+              - '.github/workflows/push-main.yml'
+              - 'yarn.lock'
+              - 'waypoint.hcl'
             web_client:
               - 'packages/web-client/**'
               - 'packages/boxel/**'
               - 'packages/cardpay-sdk/**'
               - 'packages/did-resolver/**'
+              - '.github/workflows/push-main.yml'
+              - 'yarn.lock'
             boxel:
               - 'packages/boxel/**'
+              - '.github/workflows/push-main.yml'
+              - 'yarn.lock'
             cardie:
               - 'packages/cardie/**'
+              - '.github/workflows/push-main.yml'
+              - 'yarn.lock'
+              - 'waypoint.hcl'
 
   deploy-hub-staging:
     name: Deploy hub to staging cluster via waypoint


### PR DESCRIPTION
Without this change, you can easily introduce breakage into push-main.yml or waypoint.hcl and not notice until much later when one of the projects is updated.

This change ensures that all the project deploys will run if you touch their deploy code.