### PR TITLE
web: Change to Mirage test context vs casting this

### DIFF
--- a/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-persisted-prepaid-card-test.ts
@@ -22,8 +22,8 @@ module('Acceptance | issue prepaid card', function (hooks) {
   setupMirage(hooks);
   let workflowPersistenceService: WorkflowPersistence;
 
-  hooks.beforeEach(async function () {
-    (this as any).server.db.loadData({
+  hooks.beforeEach(async function (this: Context) {
+    this.server.db.loadData({
       prepaidCardColorSchemes,
       prepaidCardPatterns,
     });

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -59,9 +59,8 @@ module('Acceptance | issue prepaid card', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function () {
-    // TODO: fix typescript for mirage
-    (this as any).server.db.loadData({
+  hooks.beforeEach(function (this: Context) {
+    this.server.db.loadData({
       prepaidCardColorSchemes,
       prepaidCardPatterns,
     });


### PR DESCRIPTION
I noticed this while copying an existing acceptance test.