### PR TITLE
boxel: Fix typo in icon class name

### DIFF
--- a/packages/boxel/addon/components/boxel/progress-icon/index.hbs
+++ b/packages/boxel/addon/components/boxel/progress-icon/index.hbs
@@ -2,7 +2,7 @@
   class={{cn
     "boxel-progress-icon"
     boxel-progress-icon--cancelled=@isCancelled
-    boxel-progress-icon--completr=@isComplete
+    boxel-progress-icon--complete=@isComplete
   }}
   style={{this.elementStyle}}
   ...attributes


### PR DESCRIPTION
Without this, `@isComplete={{true}}` [displayed](https://boxel.stack.cards/main/#/docs?s=Components&ss=%3CBoxel%3A%3AProgressIcon%3E) like this:

![image](https://user-images.githubusercontent.com/43280/134256932-65a3c95c-5579-4c44-8b68-beac1aecbd00.png)
