### PR TITLE
Cancel workflow if hub auth fails during merchant and prepaid card creation

### DIFF
--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
@@ -175,7 +175,7 @@ export default class CardPayCreateMerchantWorkflowMerchantCustomizationComponent
       this.merchantIdValidationMessage = '';
       return true;
     } catch (e) {
-      console.log('Error validating uniqueness', e);
+      console.error('Error validating uniqueness', e);
       Sentry.captureException(e);
 
       this.merchantIdValidationMessage =

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
@@ -180,6 +180,12 @@ export default class CardPayCreateMerchantWorkflowMerchantCustomizationComponent
 
       this.merchantIdValidationMessage =
         'There was an error validating merchant ID uniqueness';
+
+      if (e.message.startsWith('No valid auth token')) {
+        let { workflowSession } = this.args;
+        workflowSession?.workflow?.cancel('UNAUTHENTICATED');
+        throw new Error('UNAUTHENTICATED');
+      }
       return false;
     }
   }

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
@@ -81,7 +81,7 @@
   <Boxel::ActionChin
     class="prepaid-card-choice__footer"
     @state={{this.creationState}}
-    @disabled={{or @frozen this.isCtaDisabled}}
+    @disabled={{or @frozen (not this.selectedPrepaidCard)}}
   >
     <:default as |d|>
       <d.ActionButton

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
@@ -85,16 +85,10 @@
   >
     <:default as |d|>
       <d.ActionButton
-        {{on "click" (if this.shouldRestartWorkflow this.restartWorkflow this.createMerchant)}}
+        {{on "click" this.createMerchant}}
         data-test-create-merchant-button
       >
-        {{#if this.shouldRestartWorkflow}}
-          Restart Workflow
-        {{else if this.isUserRejection}}
-          Try Again
-        {{else}}
-          Create Merchant
-        {{/if}}
+        {{if this.hasTriedCreatingMerchant "Try Again" "Create Merchant"}}
       </d.ActionButton>
     </:default>
     <:in-progress as |i|>

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
@@ -85,10 +85,16 @@
   >
     <:default as |d|>
       <d.ActionButton
-        {{on "click" this.createMerchant}}
+        {{on "click" (if this.shouldRestartWorkflow this.restartWorkflow this.createMerchant)}}
         data-test-create-merchant-button
       >
-        {{if this.hasTriedCreatingMerchant "Try Again" "Create Merchant"}}
+        {{#if this.shouldRestartWorkflow}}
+          Restart Workflow
+        {{else if this.isUserRejection}}
+          Try Again
+        {{else}}
+          Create Merchant
+        {{/if}}
       </d.ActionButton>
     </:default>
     <:in-progress as |i|>

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
@@ -175,12 +175,12 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
       );
       let unauthenticated = e.message.startsWith('No valid auth token');
       if (unauthenticated) {
-        this.args.workflowSession?.workflow?.cancel('UNAUTHENTICATED');
+        workflowSession?.workflow?.cancel('UNAUTHENTICATED');
         throw new Error('UNAUTHENTICATED');
       } else if (insufficientFunds) {
         // This should only happen if the chosen prepaid card has been used
         // elsewhere as it should otherwise not be selectable.
-        this.args.workflowSession?.workflow?.cancel('INSUFFICIENT_FUNDS');
+        workflowSession?.workflow?.cancel('INSUFFICIENT_FUNDS');
         throw new Error('INSUFFICIENT_FUNDS');
       } else if (tookTooLong) {
         throw new Error('TIMEOUT');

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
@@ -85,9 +85,6 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
   }
 
   @action createMerchant() {
-    if (this.isCtaDisabled) {
-      return;
-    }
     taskFor(this.createTask)
       .perform()
       .catch((e) => console.error(e));
@@ -225,14 +222,5 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
 
   get txViewerUrl() {
     return this.txnHash && this.layer2Network.blockExplorerUrl(this.txnHash);
-  }
-
-  get isCtaDisabled() {
-    let error = this.error?.message;
-    return (
-      !this.selectedPrepaidCard ||
-      error === 'UNAUTHENTICATED' ||
-      error === 'INSUFFICIENT_FUNDS'
-    );
   }
 }

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
@@ -25,8 +25,6 @@ import {
   TransactionOptions,
 } from '@cardstack/cardpay-sdk';
 import BN from 'bn.js';
-import RouterService from '@ember/routing/router-service';
-import { next } from '@ember/runloop';
 
 interface CardPayCreateMerchantWorkflowPrepaidCardChoiceComponentArgs {
   workflowSession: WorkflowSession;
@@ -39,7 +37,6 @@ const A_WHILE = config.environment === 'test' ? 500 : 1000 * 10;
 export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent extends Component<CardPayCreateMerchantWorkflowPrepaidCardChoiceComponentArgs> {
   @service declare merchantInfo: MerchantInfoService;
   @service declare layer2Network: Layer2Network;
-  @service declare router: RouterService;
   @reads('createTask.last.error') declare error: Error | undefined;
   @reads('args.workflowSession.state.merchantRegistrationFee')
   declare merchantRegistrationFee: number;
@@ -48,7 +45,6 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
   @tracked txnHash?: TransactionHash;
   @tracked createTaskRunningForAWhile = false;
   @tracked selectedPrepaidCard!: PrepaidCardSafe;
-  @tracked isUserRejection = false;
 
   lastNonce?: string;
 
@@ -98,25 +94,7 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
   }
 
   @action cancel() {
-    this.isUserRejection = true;
     taskFor(this.createTask).cancelAll();
-  }
-
-  get shouldRestartWorkflow() {
-    return this.hasTriedCreatingMerchant && !this.isUserRejection;
-  }
-
-  @action async restartWorkflow() {
-    await this.router.transitionTo({
-      queryParams: { flow: null, 'flow-id': null },
-    });
-    next(this, () => {
-      this.router.transitionTo({
-        queryParams: {
-          flow: 'create-merchant',
-        },
-      });
-    });
   }
 
   @task *createTask(): TaskGenerator<void> {
@@ -192,21 +170,24 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
 
       this.args.onComplete();
     } catch (e) {
-      this.isUserRejection = false;
       let insufficientFunds = e.message.startsWith(
         'Prepaid card does not have enough balance to register a merchant.'
       );
       let tookTooLong = e.message.startsWith(
         'Transaction took too long to complete'
       );
-      if (insufficientFunds) {
+      let unauthenticated = e.message.startsWith('No valid auth token');
+      if (unauthenticated) {
+        this.args.workflowSession.workflow.cancel('UNAUTHENTICATED');
+        throw new Error('UNAUTHENTICATED');
+      } else if (insufficientFunds) {
         // This should only happen if the chosen prepaid card has been used
         // elsewhere as it should otherwise not be selectable.
+        this.args.workflowSession.workflow.cancel('INSUFFICIENT_FUNDS');
         throw new Error('INSUFFICIENT_FUNDS');
       } else if (tookTooLong) {
         throw new Error('TIMEOUT');
       } else if (isLayer2UserRejectionError(e)) {
-        this.isUserRejection = true;
         throw new Error('USER_REJECTION');
       } else {
         throw e;
@@ -247,10 +228,11 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
   }
 
   get isCtaDisabled() {
-    if (!this.selectedPrepaidCard) {
-      return true;
-    }
-    return false;
-    // TODO: other conditions
+    let error = this.error?.message;
+    return (
+      !this.selectedPrepaidCard ||
+      error === 'UNAUTHENTICATED' ||
+      error === 'INSUFFICIENT_FUNDS'
+    );
   }
 }

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
@@ -175,12 +175,12 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
       );
       let unauthenticated = e.message.startsWith('No valid auth token');
       if (unauthenticated) {
-        this.args.workflowSession.workflow.cancel('UNAUTHENTICATED');
+        this.args.workflowSession?.workflow?.cancel('UNAUTHENTICATED');
         throw new Error('UNAUTHENTICATED');
       } else if (insufficientFunds) {
         // This should only happen if the chosen prepaid card has been used
         // elsewhere as it should otherwise not be selectable.
-        this.args.workflowSession.workflow.cancel('INSUFFICIENT_FUNDS');
+        this.args.workflowSession?.workflow?.cancel('INSUFFICIENT_FUNDS');
         throw new Error('INSUFFICIENT_FUNDS');
       } else if (tookTooLong) {
         throw new Error('TIMEOUT');

--- a/packages/web-client/app/components/card-pay/hub-authentication/index.hbs
+++ b/packages/web-client/app/components/card-pay/hub-authentication/index.hbs
@@ -20,6 +20,7 @@
             @size="extra-small"
             @kind="secondary-dark"
             {{on "click" (perform this.authenticationTask)}}
+            data-test-authentication-retry-button
           >
             Try Again
           </Boxel::Button>

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
@@ -92,16 +92,10 @@
   >
     <:default as |d|>
       <d.ActionButton
-        {{on "click" (if this.shouldRestartWorkflow this.restartWorkflow this.issuePrepaidCard)}}
+        {{on "click" this.issuePrepaidCard}}
         data-test-issue-prepaid-card-button
       >
-        {{#if this.shouldRestartWorkflow}}
-          Restart Workflow
-        {{else if this.isUserRejection}}
-          Try Again
-        {{else}}
-          Create
-        {{/if}}
+        {{if this.hasTriedCreatingPrepaidCard "Try Again" "Create"}}
       </d.ActionButton>
     </:default>
     <:in-progress as |i|>

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
@@ -92,10 +92,16 @@
   >
     <:default as |d|>
       <d.ActionButton
-        {{on "click" this.issuePrepaidCard}}
+        {{on "click" (if this.shouldRestartWorkflow this.restartWorkflow this.issuePrepaidCard)}}
         data-test-issue-prepaid-card-button
       >
-        {{if this.hasTriedCreatingPrepaidCard "Try Again" "Create"}}
+        {{#if this.shouldRestartWorkflow}}
+          Restart Workflow
+        {{else if this.isUserRejection}}
+          Try Again
+        {{else}}
+          Create
+        {{/if}}
       </d.ActionButton>
     </:default>
     <:in-progress as |i|>

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
@@ -159,11 +159,12 @@ export default class CardPayPrepaidCardWorkflowPreviewComponent extends Componen
       );
       let unauthenticated = e.message.startsWith('No valid auth token');
       if (unauthenticated) {
-        this.args.workflowSession.workflow.cancel('UNAUTHENTICATED');
+        this.args.workflowSession?.workflow?.cancel('UNAUTHENTICATED');
         throw new Error('UNAUTHENTICATED');
       } else if (insufficientFunds) {
         // We probably want to cancel the workflow at this point
         // And tell the user to go deposit funds
+        this.args.workflowSession?.workflow?.cancel('INSUFFICIENT_FUNDS');
         throw new Error('INSUFFICIENT_FUNDS');
       } else if (tookTooLong) {
         throw new Error('TIMEOUT');

--- a/packages/web-client/app/models/workflow.ts
+++ b/packages/web-client/app/models/workflow.ts
@@ -97,7 +97,10 @@ export abstract class Workflow {
   }
 
   get isComplete() {
-    return this.completedMilestoneCount === this.milestones.length;
+    return Boolean(
+      this.milestones.length &&
+        this.completedMilestoneCount === this.milestones.length
+    );
   }
 
   cancel(reason?: string) {

--- a/packages/web-client/app/services/merchant-info.ts
+++ b/packages/web-client/app/services/merchant-info.ts
@@ -89,9 +89,9 @@ export default class MerchantInfoService extends Service {
 
     let info = yield response.json();
 
-    if (info.errors) {
+    if (info?.errors || !response.ok) {
       if (
-        info.errors.length === 1 &&
+        info?.errors?.length === 1 &&
         Number(info.errors[0].status) === 401 &&
         info.errors[0].title === 'No valid auth token'
       ) {

--- a/packages/web-client/app/services/merchant-info.ts
+++ b/packages/web-client/app/services/merchant-info.ts
@@ -87,13 +87,22 @@ export default class MerchantInfoService extends Service {
       }
     );
 
-    if (response.ok) {
-      let uniqueness = yield response.json();
+    let info = yield response.json();
 
-      return uniqueness.slugAvailable;
-    } else {
-      throw new Error(yield response.text());
+    if (info.errors) {
+      if (
+        info.errors.length === 1 &&
+        Number(info.errors[0].status) === 401 &&
+        info.errors[0].title === 'No valid auth token'
+      ) {
+        this.hubAuthentication.authToken = null;
+        throw new Error('No valid auth token');
+      } else {
+        throw new Error(yield response.text());
+      }
     }
+
+    return info.slugAvailable;
   }
 }
 

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
@@ -275,7 +275,7 @@ module(
 
         assert
           .dom('[data-test-create-merchant-button]')
-          .containsText('Try Again');
+          .containsText('Restart Workflow');
       });
 
       test('it shows the correct error message for a user rejection', async function (assert) {
@@ -290,6 +290,7 @@ module(
         assert
           .dom('[data-test-prepaid-card-choice-error-message]')
           .containsText(USER_REJECTION_ERROR_MESSAGE);
+        assert.dom('[data-test-create-merchant-button]').hasText('Try Again');
       });
 
       test('it shows the correct error message for a timeout', async function (assert) {
@@ -370,6 +371,9 @@ module(
         assert
           .dom('[data-test-prepaid-card-choice-error-message]')
           .containsText(DEFAULT_ERROR_MESSAGE);
+        assert
+          .dom('[data-test-issue-prepaid-card-button]')
+          .containsText('Restart Workflow');
       });
     });
 

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
@@ -273,7 +273,9 @@ module(
         await click('[data-test-create-merchant-button]');
         await waitFor('[data-test-prepaid-card-choice-error-message]');
 
-        assert.dom('[data-test-create-merchant-button]');
+        assert
+          .dom('[data-test-create-merchant-button]')
+          .containsText('Try Again');
       });
 
       test('it shows the correct error message for a user rejection', async function (assert) {
@@ -356,21 +358,6 @@ module(
           .containsText(INSUFFICIENT_FUNDS_ERROR_MESSAGE);
       });
 
-      test('it cancels the workflow if hub authentication fails', async function (assert) {
-        sinon
-          .stub(layer2Service, 'registerMerchant')
-          .throws(new Error('No valid auth token'));
-
-        await selectPrepaidCard(prepaidCardAddress);
-        await click('[data-test-create-merchant-button]');
-        await waitFor('[data-test-prepaid-card-choice-error-message]');
-
-        assert
-          .dom('[data-test-prepaid-card-choice-error-message]')
-          .containsText(DEFAULT_ERROR_MESSAGE);
-        assert.dom('[data-test-create-merchant-button]').isDisabled();
-      });
-
       test('it shows a correct fallback error message', async function (assert) {
         sinon
           .stub(layer2Service, 'registerMerchant')
@@ -383,7 +370,6 @@ module(
         assert
           .dom('[data-test-prepaid-card-choice-error-message]')
           .containsText(DEFAULT_ERROR_MESSAGE);
-        assert.dom('[data-test-create-merchant-button]').isNotDisabled();
       });
     });
 

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
@@ -273,9 +273,7 @@ module(
         await click('[data-test-create-merchant-button]');
         await waitFor('[data-test-prepaid-card-choice-error-message]');
 
-        assert
-          .dom('[data-test-create-merchant-button]')
-          .containsText('Restart Workflow');
+        assert.dom('[data-test-create-merchant-button]');
       });
 
       test('it shows the correct error message for a user rejection', async function (assert) {
@@ -290,7 +288,6 @@ module(
         assert
           .dom('[data-test-prepaid-card-choice-error-message]')
           .containsText(USER_REJECTION_ERROR_MESSAGE);
-        assert.dom('[data-test-create-merchant-button]').hasText('Try Again');
       });
 
       test('it shows the correct error message for a timeout', async function (assert) {
@@ -359,6 +356,21 @@ module(
           .containsText(INSUFFICIENT_FUNDS_ERROR_MESSAGE);
       });
 
+      test('it cancels the workflow if hub authentication fails', async function (assert) {
+        sinon
+          .stub(layer2Service, 'registerMerchant')
+          .throws(new Error('No valid auth token'));
+
+        await selectPrepaidCard(prepaidCardAddress);
+        await click('[data-test-create-merchant-button]');
+        await waitFor('[data-test-prepaid-card-choice-error-message]');
+
+        assert
+          .dom('[data-test-prepaid-card-choice-error-message]')
+          .containsText(DEFAULT_ERROR_MESSAGE);
+        assert.dom('[data-test-create-merchant-button]').isDisabled();
+      });
+
       test('it shows a correct fallback error message', async function (assert) {
         sinon
           .stub(layer2Service, 'registerMerchant')
@@ -371,9 +383,7 @@ module(
         assert
           .dom('[data-test-prepaid-card-choice-error-message]')
           .containsText(DEFAULT_ERROR_MESSAGE);
-        assert
-          .dom('[data-test-issue-prepaid-card-button]')
-          .containsText('Restart Workflow');
+        assert.dom('[data-test-create-merchant-button]').isNotDisabled();
       });
     });
 

--- a/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
@@ -89,7 +89,7 @@ module(
         await waitFor('[data-test-issue-prepaid-card-error-message]');
         assert
           .dom('[data-test-issue-prepaid-card-button]')
-          .containsText('Try Again');
+          .containsText('Restart Workflow');
       });
       test('it shows the correct error message for a user rejection', async function (assert) {
         sinon
@@ -103,6 +103,9 @@ module(
         assert
           .dom('[data-test-issue-prepaid-card-error-message]')
           .containsText(USER_REJECTION_ERROR_MESSAGE);
+        assert
+          .dom('[data-test-issue-prepaid-card-button]')
+          .containsText('Try Again');
       });
 
       test('it shows the correct error message for a timeout', async function (assert) {
@@ -200,6 +203,9 @@ module(
       assert
         .dom('[data-test-issue-prepaid-card-error-message]')
         .containsText(DEFAULT_ERROR_MESSAGE);
+      assert
+        .dom('[data-test-issue-prepaid-card-button]')
+        .containsText('Restart Workflow');
     });
   }
 );

--- a/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
@@ -89,7 +89,7 @@ module(
         await waitFor('[data-test-issue-prepaid-card-error-message]');
         assert
           .dom('[data-test-issue-prepaid-card-button]')
-          .containsText('Restart Workflow');
+          .containsText('Try Again');
       });
       test('it shows the correct error message for a user rejection', async function (assert) {
         sinon
@@ -103,9 +103,6 @@ module(
         assert
           .dom('[data-test-issue-prepaid-card-error-message]')
           .containsText(USER_REJECTION_ERROR_MESSAGE);
-        assert
-          .dom('[data-test-issue-prepaid-card-button]')
-          .containsText('Try Again');
       });
 
       test('it shows the correct error message for a timeout', async function (assert) {
@@ -144,6 +141,21 @@ module(
           .containsText(INSUFFICIENT_FUNDS_ERROR_MESSAGE);
       });
 
+      test('it cancels the workflow if hub authentication fails', async function (assert) {
+        sinon
+          .stub(layer2Service, 'issuePrepaidCard')
+          .throws(new Error('No valid auth token'));
+
+        await click('[data-test-issue-prepaid-card-button]');
+
+        await waitFor('[data-test-issue-prepaid-card-error-message]');
+
+        assert
+          .dom('[ata-test-issue-prepaid-card-error-message]')
+          .containsText(DEFAULT_ERROR_MESSAGE);
+        assert.dom('[data-test-issue-prepaid-card-button]').isDisabled();
+      });
+
       test('it shows a correct fallback error message', async function (assert) {
         sinon
           .stub(layer2Service, 'issuePrepaidCard')
@@ -156,6 +168,7 @@ module(
         assert
           .dom('[data-test-issue-prepaid-card-error-message]')
           .containsText(DEFAULT_ERROR_MESSAGE);
+        assert.dom('[data-test-issue-prepaid-card-button]').isNotDisabled();
       });
 
       test('it allow canceling and retrying after a while', async function (assert) {
@@ -203,9 +216,6 @@ module(
       assert
         .dom('[data-test-issue-prepaid-card-error-message]')
         .containsText(DEFAULT_ERROR_MESSAGE);
-      assert
-        .dom('[data-test-issue-prepaid-card-button]')
-        .containsText('Restart Workflow');
     });
   }
 );

--- a/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
@@ -141,21 +141,6 @@ module(
           .containsText(INSUFFICIENT_FUNDS_ERROR_MESSAGE);
       });
 
-      test('it cancels the workflow if hub authentication fails', async function (assert) {
-        sinon
-          .stub(layer2Service, 'issuePrepaidCard')
-          .throws(new Error('No valid auth token'));
-
-        await click('[data-test-issue-prepaid-card-button]');
-
-        await waitFor('[data-test-issue-prepaid-card-error-message]');
-
-        assert
-          .dom('[ata-test-issue-prepaid-card-error-message]')
-          .containsText(DEFAULT_ERROR_MESSAGE);
-        assert.dom('[data-test-issue-prepaid-card-button]').isDisabled();
-      });
-
       test('it shows a correct fallback error message', async function (assert) {
         sinon
           .stub(layer2Service, 'issuePrepaidCard')
@@ -168,7 +153,6 @@ module(
         assert
           .dom('[data-test-issue-prepaid-card-error-message]')
           .containsText(DEFAULT_ERROR_MESSAGE);
-        assert.dom('[data-test-issue-prepaid-card-button]').isNotDisabled();
       });
 
       test('it allow canceling and retrying after a while', async function (assert) {


### PR DESCRIPTION
Initial implementation - Added a Restart Workflow button and functionality to the card for any failure other than user rejection

Changes - Made the workflow cancellation specific to the hub auth failures mentioned in the ticket (CS-1707). Also, instead of just displaying a restart button, called for the cancellation of the workflow. This means the workflow will be frozen and the DefaultCancelationCta component will appear.

I'm not sure if this type of cancellation from within a card is a good idea, though. Another option would be to follow the event listener pattern to listen for hub auth token nullification. 

I also need to find a good place to add the tests