### PR TITLE
Type safety for  workflowSession

### DIFF
--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
@@ -7,7 +7,6 @@ import {
 } from '@cardstack/cardpay-sdk';
 import {
   cardbot,
-  ArbitraryDictionary,
   Milestone,
   PostableCollection,
   NetworkAwareWorkflowMessage,
@@ -17,6 +16,7 @@ import {
   WorkflowCard,
   WorkflowMessage,
   WorkflowName,
+  WorkflowSession,
 } from '@cardstack/web-client/models/workflow';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { action } from '@ember/object';
@@ -92,7 +92,7 @@ class CreateMerchantWorkflow extends Workflow {
               layer2Network.fetchMerchantRegistrationFeeTask
             ).perform();
 
-            this.workflow?.session.update(
+            this.workflow?.session.setValue(
               'merchantRegistrationFee',
               merchantRegistrationFee
             );
@@ -240,11 +240,11 @@ class CreateMerchantWorkflow extends Workflow {
     // cancelation for not having prepaid card
     new SessionAwareWorkflowMessage({
       author: cardbot,
-      template: (session: ArbitraryDictionary) =>
+      template: (session: WorkflowSession) =>
         `It looks like you don’t have a prepaid card in your wallet. You will need one to pay the ${formatAmount(
-          session.merchantRegistrationFee
+          session.getValue('merchantRegistrationFee')
         )} SPEND (${convertAmountToNativeDisplay(
-          spendToUsd(session.merchantRegistrationFee)!,
+          spendToUsd(session.getValue('merchantRegistrationFee')!)!,
           'USD'
         )}) merchant creation fee. Please buy a prepaid card in your Card Wallet mobile app before you continue with this workflow.`,
       includeIf() {
@@ -265,11 +265,11 @@ class CreateMerchantWorkflow extends Workflow {
     // cancelation for insufficient balance
     new SessionAwareWorkflowMessage({
       author: cardbot,
-      template: (session: ArbitraryDictionary) =>
+      template: (session: WorkflowSession) =>
         `It looks like you don’t have a prepaid card with enough funds to pay the ${formatAmount(
-          session.merchantRegistrationFee
+          session.getValue('merchantRegistrationFee')
         )} SPEND (${convertAmountToNativeDisplay(
-          spendToUsd(session.merchantRegistrationFee)!,
+          spendToUsd(session.getValue('merchantRegistrationFee')!)!,
           'USD'
         )}) merchant creation fee. Please buy a prepaid card in your Card Wallet mobile app before you continue with this workflow.`,
       includeIf() {

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/merchant-customization/index.ts
@@ -27,18 +27,19 @@ export default class CardPayCreateMerchantWorkflowMerchantCustomizationComponent
 
   constructor(owner: unknown, args: WorkflowCardComponentArgs) {
     super(owner, args);
-
-    let { merchantName, merchantId, merchantBgColor } =
-      this.args.workflowSession.state;
+    let { workflowSession } = this.args;
+    let merchantName = workflowSession.getValue<string>('merchantName');
+    let merchantId = workflowSession.getValue<string>('merchantId');
+    let merchantBgColor = workflowSession.getValue<string>('merchantBgColor');
 
     if (
       isPresent(merchantName) &&
       isPresent(merchantId) &&
       isPresent(merchantBgColor)
     ) {
-      this.merchantName = merchantName;
-      this.merchantBgColor = merchantBgColor;
-      this.merchantId = merchantId;
+      this.merchantName = merchantName!;
+      this.merchantBgColor = merchantBgColor!;
+      this.merchantId = merchantId!;
       this.validateMerchantId(); // this is necessary for enabling the CTA
     }
   }
@@ -111,24 +112,26 @@ export default class CardPayCreateMerchantWorkflowMerchantCustomizationComponent
       merchantBgColor: this.merchantBgColor,
       merchantTextColor: this.merchantTextColor,
     };
-
+    let { workflowSession } = this.args;
     let merchantInfoHasBeenPersisted =
-      this.args.workflowSession.state.merchantInfo;
+      !!workflowSession.getValue('merchantInfo');
 
     if (merchantInfoHasBeenPersisted) {
-      let state = this.args.workflowSession.state;
       let detailsHaveChangedSincePersistence =
-        state.merchantName !== valuesToStore.merchantName ||
-        state.merchantId !== valuesToStore.merchantId ||
-        state.merchantBgColor !== valuesToStore.merchantBgColor ||
-        state.merchantTextColor !== valuesToStore.merchantTextColor;
+        workflowSession.getValue('merchantName') !==
+          valuesToStore.merchantName ||
+        workflowSession.getValue('merchantId') !== valuesToStore.merchantId ||
+        workflowSession.getValue('merchantBgColor') !==
+          valuesToStore.merchantBgColor ||
+        workflowSession.getValue('merchantTextColor') !==
+          valuesToStore.merchantTextColor;
 
       if (detailsHaveChangedSincePersistence) {
-        this.args.workflowSession.delete('merchantInfo');
+        workflowSession.delete('merchantInfo');
       }
     }
 
-    this.args.workflowSession.updateMany(valuesToStore);
+    this.args.workflowSession.setValue(valuesToStore);
     this.args.onComplete?.();
   }
 

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
@@ -38,8 +38,9 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
   @service declare merchantInfo: MerchantInfoService;
   @service declare layer2Network: Layer2Network;
   @reads('createTask.last.error') declare error: Error | undefined;
-  @reads('args.workflowSession.state.merchantRegistrationFee')
-  declare merchantRegistrationFee: number;
+  get merchantRegistrationFee(): number {
+    return this.args.workflowSession.getValue('merchantRegistrationFee')!;
+  }
 
   @tracked chinInProgressMessage?: string;
   @tracked txnHash?: TransactionHash;
@@ -53,8 +54,11 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
     args: CardPayCreateMerchantWorkflowPrepaidCardChoiceComponentArgs
   ) {
     super(owner, args);
+    let { workflowSession } = this.args;
 
-    let { txnHash, prepaidCardChoice } = this.args.workflowSession.state;
+    let txnHash = workflowSession.getValue<TransactionHash>('txnHash');
+    let prepaidCardChoice =
+      workflowSession.getValue<PrepaidCardSafe>('prepaidCardChoice');
 
     if (txnHash) {
       this.txnHash = txnHash;
@@ -66,7 +70,9 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
   }
 
   @action checkForPendingTransaction() {
-    let { txnHash, merchantSafe } = this.args.workflowSession.state;
+    let { workflowSession } = this.args;
+    let txnHash = workflowSession.getValue('txnHash');
+    let merchantSafe = workflowSession.getValue('merchantSafe');
 
     if (txnHash && !merchantSafe) {
       this.createMerchant();
@@ -104,40 +110,40 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
       this.chinInProgressMessage =
         'You will receive a confirmation request from the Card Wallet app in a few moments…';
 
-      if (!workflowSession.state.prepaidCardChoice) {
-        workflowSession.update('prepaidCardChoice', this.selectedPrepaidCard);
+      if (!workflowSession.getValue('prepaidCardChoice')) {
+        workflowSession.setValue('prepaidCardChoice', this.selectedPrepaidCard);
       }
 
-      if (!workflowSession.state.merchantInfo) {
+      if (!workflowSession.getValue('merchantInfo')) {
         let persistedMerchantInfo = yield taskFor(
           this.merchantInfo.persistMerchantInfoTask
         ).perform({
-          name: workflowSession.state.merchantName,
-          slug: workflowSession.state.merchantId,
-          color: workflowSession.state.merchantBgColor,
-          textColor: workflowSession.state.merchantTextColor,
+          name: workflowSession.getValue('merchantName')!,
+          slug: workflowSession.getValue('merchantId')!,
+          color: workflowSession.getValue('merchantBgColor')!,
+          textColor: workflowSession.getValue('merchantTextColor')!,
         });
 
-        workflowSession.update('merchantInfo', persistedMerchantInfo);
+        workflowSession.setValue('merchantInfo', persistedMerchantInfo);
       }
 
       if (
-        workflowSession.state.txnHash &&
-        !workflowSession.state.merchantSafe
+        workflowSession.getValue('txnHash') &&
+        !workflowSession.getValue('merchantSafe')
       ) {
-        const txnHash = workflowSession.state.txnHash;
+        let txnHash = workflowSession.getValue<TransactionHash>('txnHash')!;
         this.chinInProgressMessage = 'Processing transaction…';
 
         const merchantSafe: MerchantSafe = yield taskFor(
           this.layer2Network.resumeRegisterMerchantTransactionTask
         ).perform(txnHash);
 
-        workflowSession.update('merchantSafe', merchantSafe);
+        workflowSession.setValue('merchantSafe', merchantSafe);
       } else {
         let options: TransactionOptions = {
           onTxnHash: (txnHash: TransactionHash) => {
             this.txnHash = txnHash;
-            workflowSession.update('txnHash', txnHash);
+            workflowSession.setValue('txnHash', txnHash);
             this.chinInProgressMessage = 'Processing transaction…';
           },
         };
@@ -154,7 +160,7 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
           this.layer2Network.registerMerchantTask
         ).perform(
           this.selectedPrepaidCard.address,
-          workflowSession.state.merchantInfo.did,
+          workflowSession.getValue<Record<string, string>>('merchantInfo')!.did,
           options
         );
 
@@ -163,7 +169,7 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
           taskFor(this.timerTask).perform(),
         ]);
 
-        workflowSession.update('merchantSafe', merchantSafe);
+        workflowSession.setValue('merchantSafe', merchantSafe);
 
         this.createTaskRunningForAWhile = false;
       }

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-setup/index.ts
@@ -22,8 +22,10 @@ class CardPayDepositWorkflowTransactionSetupComponent extends Component<Workflow
   @tracked selectedToken: TokenBalance<BridgeableSymbol> | undefined;
 
   get selectedTokenSymbol() {
-    if (this.args.workflowSession.state.depositSourceToken) {
-      return this.args.workflowSession.state.depositSourceToken;
+    let depositSourceToken =
+      this.args.workflowSession.getValue<string>('depositSourceToken');
+    if (depositSourceToken) {
+      return depositSourceToken;
     } else if (this.layer1Network.daiBalance?.gt(new BN('0'))) {
       return 'DAI';
     } else if (this.layer1Network.cardBalance?.gt(new BN('0'))) {
@@ -38,7 +40,7 @@ class CardPayDepositWorkflowTransactionSetupComponent extends Component<Workflow
       (t) => t.symbol === this.selectedTokenSymbol
     );
     next(this, () => {
-      this.args.workflowSession.update(
+      this.args.workflowSession.setValue(
         'depositSourceToken',
         this.selectedToken?.symbol
       );
@@ -83,7 +85,7 @@ class CardPayDepositWorkflowTransactionSetupComponent extends Component<Workflow
 
   @action chooseSource(token: TokenBalance<BridgeableSymbol>) {
     this.selectedToken = token;
-    this.args.workflowSession.update(
+    this.args.workflowSession.setValue(
       'depositSourceToken',
       this.selectedToken.symbol
     );
@@ -94,7 +96,7 @@ class CardPayDepositWorkflowTransactionSetupComponent extends Component<Workflow
       return;
     }
     if (this.selectedToken) {
-      this.args.workflowSession.update(
+      this.args.workflowSession.setValue(
         'depositSourceToken',
         this.selectedToken.symbol
       );

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.ts
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import BN from 'bn.js';
 import { tracked } from '@glimmer/tracking';
-import { reads } from 'macro-decorators';
 import * as Sentry from '@sentry/browser';
 import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
@@ -17,15 +16,20 @@ import { TaskGenerator } from 'ember-concurrency';
 class CardPayDepositWorkflowTransactionStatusComponent extends Component<WorkflowCardComponentArgs> {
   @service declare layer1Network: Layer1Network;
   @service declare layer2Network: Layer2Network;
-  @reads('args.workflowSession.state.depositSourceToken')
-  declare selectedTokenSymbol: TokenSymbol;
-  @reads('args.workflowSession.state.relayTokensTxnReceipt')
-  declare relayTokensTxnReceipt: TransactionReceipt;
-  @reads('args.workflowSession.state.completedLayer2TxnReceipt')
-  declare completedLayer2TxnReceipt: TransactionReceipt | undefined;
+  get selectedTokenSymbol(): TokenSymbol {
+    return this.args.workflowSession.getValue('depositSourceToken')!;
+  }
+  get relayTokensTxnReceipt(): TransactionReceipt {
+    return this.args.workflowSession.getValue('relayTokensTxnReceipt')!;
+  }
+  get completedLayer2TxnReceipt(): TransactionReceipt | null {
+    return this.args.workflowSession.getValue('completedLayer2TxnReceipt');
+  }
+
   get layer2BlockHeightBeforeBridging(): BN {
-    let s = this.args.workflowSession.state.layer2BlockHeightBeforeBridging;
-    return new BN(s);
+    return this.args.workflowSession.getValue(
+      'layer2BlockHeightBeforeBridging'
+    )!;
   }
   @tracked completedStepCount = 1;
   @tracked bridgeError = false;
@@ -94,7 +98,7 @@ class CardPayDepositWorkflowTransactionStatusComponent extends Component<Workflo
         this.layer2BlockHeightBeforeBridging
       );
       this.layer2Network.refreshSafesAndBalances();
-      this.args.workflowSession.update(
+      this.args.workflowSession.setValue(
         'completedLayer2TxnReceipt',
         transactionReceipt
       );

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.ts
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { reads } from 'macro-decorators';
 import { inject as service } from '@ember/service';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { fromWei } from 'web3-utils';
@@ -24,8 +23,9 @@ class FaceValueCard extends Component<WorkflowCardComponentArgs> {
   spendToUsdRate = spendToUsdRate;
 
   @service declare layer2Network: Layer2Network;
-  @reads('args.workflowSession.state.prepaidFundingToken')
-  declare fundingTokenSymbol: TokenSymbol;
+  get fundingTokenSymbol(): TokenSymbol {
+    return this.args.workflowSession.getValue('prepaidFundingToken')!;
+  }
   @tracked selectedFaceValue?: FaceValue;
   @tracked options: FaceValue[] = [];
 
@@ -45,7 +45,8 @@ class FaceValueCard extends Component<WorkflowCardComponentArgs> {
       })
     );
 
-    const defaultSpendAmount = this.args.workflowSession.state.spendFaceValue;
+    const defaultSpendAmount =
+      this.args.workflowSession.getValue<number>('spendFaceValue');
     if (defaultSpendAmount) {
       this.selectedFaceValue = this.options.findBy(
         'spendAmount',
@@ -89,7 +90,7 @@ class FaceValueCard extends Component<WorkflowCardComponentArgs> {
     }
     let amount = this.selectedFaceValue?.spendAmount;
     if (amount) {
-      this.args.workflowSession.update('spendFaceValue', amount);
+      this.args.workflowSession.setValue('spendFaceValue', amount);
     }
     this.args.onComplete?.();
   }

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.ts
@@ -16,7 +16,7 @@ class FundingSourceCard extends Component<WorkflowCardComponentArgs> {
   tokenOptions = [this.defaultTokenSymbol];
   @service declare layer2Network: Layer2Network;
   @tracked selectedTokenSymbol: BridgedTokenSymbol =
-    this.args.workflowSession.state.prepaidFundingToken ??
+    this.args.workflowSession.getValue('prepaidFundingToken') ??
     this.defaultTokenSymbol;
 
   get selectedToken(): TokenBalance<BridgedTokenSymbol> {
@@ -62,7 +62,7 @@ class FundingSourceCard extends Component<WorkflowCardComponentArgs> {
       return;
     }
     if (this.selectedTokenSymbol) {
-      this.args.workflowSession.update(
+      this.args.workflowSession.setValue(
         'prepaidFundingToken',
         this.selectedTokenSymbol
       );

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.ts
@@ -30,13 +30,16 @@ export default class LayoutCustomizationCard extends Component<WorkflowCardCompo
       .then(() => {
         this.colorScheme = this.colorSchemeOptions[0];
         this.pattern = this.patternOptions[0];
-
-        let { colorScheme, pattern, issuerName } =
-          this.args.workflowSession.state;
+        let { workflowSession } = this.args;
+        let colorScheme =
+          workflowSession.getValue<ColorCustomizationOption>('colorScheme');
+        let pattern =
+          workflowSession.getValue<PatternCustomizationOption>('pattern');
+        let issuerName = workflowSession.getValue<string>('issuerName');
         if (colorScheme && pattern) {
           this.colorScheme = colorScheme;
           this.pattern = pattern;
-          this.issuerName = issuerName;
+          this.issuerName = issuerName!;
         }
       });
   }
@@ -81,7 +84,7 @@ export default class LayoutCustomizationCard extends Component<WorkflowCardCompo
 
   @action save() {
     if (this.issuerName && this.colorScheme && this.pattern) {
-      this.args.workflowSession.updateMany({
+      this.args.workflowSession.setValue({
         issuerName: this.issuerName,
         pattern: this.pattern,
         colorScheme: this.colorScheme,
@@ -91,10 +94,10 @@ export default class LayoutCustomizationCard extends Component<WorkflowCardCompo
   }
 
   @action edit() {
-    this.args.workflowSession.updateMany({
+    this.args.workflowSession.setValue({
       issuerName: '',
-      pattern: '',
-      colorScheme: '',
+      pattern: null,
+      colorScheme: null,
     });
     this.args.onIncomplete?.();
   }

--- a/packages/web-client/app/components/card-pay/layer-two-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-two-connect-card/index.ts
@@ -63,7 +63,7 @@ class CardPayLayerTwoConnectCardComponent extends Component<CardPayLayerTwoConne
     yield timeout(500); // allow time for strategy to verify connected chain -- it might not accept the connection
     if (this.isConnected) {
       this.args.onConnect?.();
-      this.args.workflowSession.update(
+      this.args.workflowSession.setValue(
         'layer2WalletAddress',
         this.layer2Network.walletInfo.firstAddress
       );

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/check-balance/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/check-balance/index.ts
@@ -13,6 +13,7 @@ import { taskFor } from 'ember-concurrency-ts';
 import { task } from 'ember-concurrency-decorators';
 import { timeout } from 'ember-concurrency';
 import config from '@cardstack/web-client/config/environment';
+import BN from 'bn.js';
 
 const BALANCE_CHECK_INTERVAL = config.environment === 'test' ? 100 : 5000;
 
@@ -60,7 +61,10 @@ export default class CardPayWithdrawalWorkflowCheckBalanceComponent extends Comp
       this.layer1Network.nativeTokenSymbol as BridgeableSymbol
     );
   }
-  get minimumBalanceForWithdrawalClaim() {
-    return this.args.workflowSession.state['minimumBalanceForWithdrawalClaim'];
+
+  get minimumBalanceForWithdrawalClaim(): BN {
+    return this.args.workflowSession.getValue(
+      'minimumBalanceForWithdrawalClaim'
+    )!;
   }
 }

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/choose-balance/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/choose-balance/index.ts
@@ -35,7 +35,8 @@ class CardPayWithdrawalWorkflowChooseBalanceComponent extends Component<Workflow
 
   get withdrawalToken(): BridgedTokenSymbol {
     return (
-      this.args.workflowSession.state.withdrawalToken ?? this.defaultTokenSymbol
+      this.args.workflowSession.getValue('withdrawalToken') ??
+      this.defaultTokenSymbol
     );
   }
 
@@ -87,7 +88,7 @@ class CardPayWithdrawalWorkflowChooseBalanceComponent extends Component<Workflow
       return;
     }
     if (this.selectedToken) {
-      this.args.workflowSession.updateMany({
+      this.args.workflowSession.setValue({
         withdrawalSafe: this.selectedSafe,
         withdrawalToken: this.selectedToken.symbol,
       });

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
@@ -59,7 +59,10 @@ class CheckBalanceWorkflowMessage
     let minimum: BN =
       yield this.layer1Network.getEstimatedGasForWithdrawalClaim('DAI');
     this.minimumBalanceForWithdrawalClaim = minimum;
-    this.workflow?.session.update('minimumBalanceForWithdrawalClaim', minimum);
+    this.workflow?.session.setValue(
+      'minimumBalanceForWithdrawalClaim',
+      minimum
+    );
 
     this.workflow!.emit('visible-postables-will-change');
     this.isComplete = true;

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.ts
@@ -23,26 +23,28 @@ class CardPayWithdrawalWorkflowTokenClaimComponent extends Component<WorkflowCar
   walletProviders = walletProviders;
   @service declare layer1Network: Layer1Network;
   @reads('layer1Network.walletProvider') declare walletProvider: WalletProvider;
-  @reads('args.workflowSession.state.withdrawalToken')
-  declare tokenSymbol: BridgeableSymbol;
+
+  get tokenSymbol(): BridgeableSymbol {
+    return this.args.workflowSession.getValue('withdrawalToken')!;
+  }
 
   @tracked isConfirming = false;
   @tracked txnHash: string | undefined;
   @tracked errorMessage = '';
 
   get bridgeValidationResult(): BridgeValidationResult {
-    if (!this.args.workflowSession.state.bridgeValidationResult) {
+    let bridgeValidationResult =
+      this.args.workflowSession.getValue<BridgeValidationResult>(
+        'bridgeValidationResult'
+      );
+    if (!bridgeValidationResult) {
       throw new Error('missing bridgeValidationResult in workflow session');
     }
-    return this.args.workflowSession.state
-      .bridgeValidationResult as BridgeValidationResult;
+    return bridgeValidationResult;
   }
 
   get withdrawalAmount(): BN {
-    if (!this.args.workflowSession.state.withdrawnAmount) {
-      return new BN('0');
-    }
-    return new BN(this.args.workflowSession.state.withdrawnAmount);
+    return this.args.workflowSession.getValue('withdrawnAmount') ?? new BN('0');
   }
 
   get tokenSymbolForConversion(): BridgeableSymbol {
@@ -82,7 +84,7 @@ class CardPayWithdrawalWorkflowTokenClaimComponent extends Component<WorkflowCar
           onTxnHash: (txnHash: string) => (this.txnHash = txnHash),
         }
       );
-      this.args.workflowSession.update('claimTokensTxnHash', this.txnHash);
+      this.args.workflowSession.setValue('claimTokensTxnHash', this.txnHash);
       this.args.onComplete?.();
     } catch (e) {
       console.error(e);

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
@@ -39,11 +39,12 @@ class CardPayWithdrawalWorkflowTransactionAmountComponent extends Component<Work
   // assumption is these are always set by cards before it. They should be defined by the time
   // it gets to this part of the workflow
   get currentSafe(): Safe {
-    return this.args.workflowSession.state.withdrawalSafe;
+    return this.args.workflowSession.state.withdrawalSafe as Safe;
   }
 
   get currentTokenSymbol(): BridgedTokenSymbol {
-    return this.args.workflowSession.state.withdrawalToken;
+    return this.args.workflowSession.state
+      .withdrawalToken as BridgedTokenSymbol;
   }
 
   get currentTokenSymbolWithdrawalLimits() {
@@ -131,7 +132,6 @@ class CardPayWithdrawalWorkflowTransactionAmountComponent extends Component<Work
     } else {
       Sentry.captureException('Unable to validate withdrawal limits');
     }
-
     this.validationMessage = validateTokenInput(this.amount, validationOptions);
   }
 
@@ -156,7 +156,7 @@ class CardPayWithdrawalWorkflowTransactionAmountComponent extends Component<Work
       let layer1Address = this.layer1Network.walletInfo.firstAddress;
       this.isConfirmed = true;
       let { currentTokenSymbol } = this;
-      let withdrawnAmount = this.amountAsBigNumber.toString();
+      let withdrawnAmount = this.amountAsBigNumber;
 
       assertBridgedTokenSymbol(currentTokenSymbol);
 
@@ -164,13 +164,13 @@ class CardPayWithdrawalWorkflowTransactionAmountComponent extends Component<Work
         this.currentSafe.address,
         layer1Address!,
         getUnbridgedSymbol(currentTokenSymbol),
-        withdrawnAmount
+        withdrawnAmount.toString()
       );
       let layer2BlockHeight = yield this.layer2Network.getBlockHeight();
 
       this.txnHash = transactionHash;
 
-      this.args.workflowSession.updateMany({
+      this.args.workflowSession.setValue({
         withdrawnAmount,
         layer2BlockHeightBeforeBridging: layer2BlockHeight,
         relayTokensTxnHash: transactionHash,

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-confirmed/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-confirmed/index.hbs
@@ -8,7 +8,7 @@
       @isLayer2={{true}}
       @link={{this.blockscoutUrl}}
       @token={{this.withdrawToken}}
-      @amount={{format-wei-amount this.withdrawAmount}}
+      @amount={{format-wei-amount this.withdrawnAmount}}
       @preposition="from"
       @walletAddress={{this.layer2Network.walletInfo.firstAddress}}
       @depotAddress={{this.depotAddress}}
@@ -35,7 +35,7 @@
       @isLayer1={{true}}
       @link={{this.withdrawTxnViewerUrl}}
       @token={{this.receivedToken}}
-      @amount={{format-wei-amount this.withdrawAmount}}
+      @amount={{format-wei-amount this.withdrawnAmount}}
       @preposition="in"
       @walletAddress={{this.layer1Network.walletInfo.firstAddress}}
       data-test-withdrawal-transaction-confirmed-to

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-confirmed/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-confirmed/index.ts
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import { reads } from 'macro-decorators';
 import { inject as service } from '@ember/service';
 import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
@@ -10,16 +9,20 @@ import {
   TokenDisplayInfo,
   TokenSymbol,
 } from '@cardstack/web-client/utils/token';
+import { TransactionHash } from '@cardstack/web-client/utils/web3-strategies/types';
 
 class CardPayWithdrawalWorkflowTransactionConfirmedComponent extends Component<WorkflowCardComponentArgs> {
   @service declare layer1Network: Layer1Network;
   @service declare layer2Network: Layer2Network;
-  @reads('args.workflowSession.state.withdrawalToken')
-  declare tokenSymbol: TokenSymbol;
-  @reads('args.workflowSession.state.relayTokensTxnHash')
-  declare relayTokensTxnHash: string;
-  @reads('args.workflowSession.state.claimTokensTxnHash')
-  declare claimTokensTxnHash: string;
+  get tokenSymbol(): TokenSymbol {
+    return this.args.workflowSession.getValue('withdrawalToken')!;
+  }
+  get relayTokensTxnHash(): TransactionHash | null {
+    return this.args.workflowSession.getValue('relayTokensTxnHash');
+  }
+  get claimTokensTxnHash(): TransactionHash | null {
+    return this.args.workflowSession.getValue('claimTokensTxnHash');
+  }
 
   constructor(owner: unknown, args: WorkflowCardComponentArgs) {
     super(owner, args);
@@ -40,22 +43,22 @@ class CardPayWithdrawalWorkflowTransactionConfirmedComponent extends Component<W
     }
   }
 
-  get withdrawAmount(): BN {
-    return new BN(this.args.workflowSession.state.withdrawnAmount);
+  get withdrawnAmount(): BN {
+    return this.args.workflowSession.getValue('withdrawnAmount')!;
   }
 
   get bridgeExplorerUrl(): string | undefined {
+    if (!this.relayTokensTxnHash) return undefined;
     return this.layer2Network.bridgeExplorerUrl(this.relayTokensTxnHash);
   }
 
-  get blockscoutUrl(): string {
-    return (
-      this.args.workflowSession.state.relayTokensTxnHash &&
-      this.layer2Network.blockExplorerUrl(this.relayTokensTxnHash)
-    );
+  get blockscoutUrl(): string | undefined {
+    if (!this.relayTokensTxnHash) return undefined;
+    return this.layer2Network.blockExplorerUrl(this.relayTokensTxnHash);
   }
 
   get withdrawTxnViewerUrl(): string | undefined {
+    if (!this.claimTokensTxnHash) return undefined;
     return this.layer1Network.blockExplorerUrl(this.claimTokensTxnHash);
   }
 

--- a/packages/web-client/app/helpers/format-amount.ts
+++ b/packages/web-client/app/helpers/format-amount.ts
@@ -7,7 +7,7 @@ import Helper from '@ember/component/helper';
 type FormatAmountHelperParams = [number | string, number];
 
 export function formatAmount(
-  amount: number | string,
+  amount: number | string | null | undefined,
   minDecimals: number = 0
 ): string {
   if (amount == null || amount === undefined) {

--- a/packages/web-client/app/models/workflow.ts
+++ b/packages/web-client/app/models/workflow.ts
@@ -19,7 +19,7 @@ export {
 export { default as NetworkAwareWorkflowCard } from './workflow/network-aware-card';
 export { Participant, WorkflowPostable } from './workflow/workflow-postable';
 export {
-  ArbitraryDictionary,
+  WorkflowSessionDictionary,
   default as WorkflowSession,
 } from './workflow/workflow-session';
 export { SessionAwareWorkflowMessage } from './workflow/session-aware-workflow-message';
@@ -100,10 +100,10 @@ export abstract class Workflow {
     return this.completedMilestoneCount === this.milestones.length;
   }
 
-  cancel(reason?: string) {
+  cancel(reason?: string | null) {
     const cancelationReason = reason || 'UNKNOWN';
 
-    this.session.updateMany({
+    this.session.setValue({
       isCancelled: true,
       cancelationReason: cancelationReason,
     });
@@ -189,7 +189,7 @@ export abstract class Workflow {
     this.session.restoreFromStorage();
 
     const [lastCompletedCardName] = (
-      this.session.state.completedCardNames || []
+      this.session.getValue<Array<string>>('completedCardNames') || []
     ).slice(-1);
 
     if (lastCompletedCardName) {
@@ -206,11 +206,11 @@ export abstract class Workflow {
     }
 
     if (
-      this.session.state.isCancelled &&
-      this.session.state.cancelationReason
+      this.session.getValue('isCancelled') &&
+      this.session.getValue('cancelationReason')
     ) {
       next(this, () => {
-        this.cancel(this.session.state.cancelationReason);
+        this.cancel(this.session.getValue('cancelationReason'));
       });
     }
   }

--- a/packages/web-client/app/models/workflow/session-aware-workflow-message.ts
+++ b/packages/web-client/app/models/workflow/session-aware-workflow-message.ts
@@ -1,21 +1,21 @@
 import {
-  ArbitraryDictionary,
   IWorkflowMessage,
   Participant,
   WorkflowPostable,
+  WorkflowSession,
 } from '@cardstack/web-client/models/workflow';
 
 interface SessionAwareWorkflowMessageOptions {
   author: Participant;
   includeIf: (this: WorkflowPostable) => boolean;
-  template: (session: ArbitraryDictionary) => string;
+  template: (session: WorkflowSession) => string;
 }
 
 export class SessionAwareWorkflowMessage
   extends WorkflowPostable
   implements IWorkflowMessage
 {
-  private template: (session: ArbitraryDictionary) => string;
+  private template: (session: WorkflowSession) => string;
   isComplete = true;
 
   constructor(options: SessionAwareWorkflowMessageOptions) {
@@ -24,6 +24,9 @@ export class SessionAwareWorkflowMessage
   }
 
   get message() {
-    return this.template(this.workflow?.session.state!);
+    if (!this.workflow) {
+      return '';
+    }
+    return this.template(this.workflow.session);
   }
 }

--- a/packages/web-client/app/models/workflow/workflow-card.ts
+++ b/packages/web-client/app/models/workflow/workflow-card.ts
@@ -52,8 +52,8 @@ export class WorkflowCard extends WorkflowPostable {
   get session(): WorkflowSession | undefined {
     return this.workflow?.session;
   }
-  get completedCardNames(): Array<String> {
-    return this.session?.state.completedCardNames ?? [];
+  get completedCardNames(): Array<string> {
+    return this.session?.getValue<Array<string>>('completedCardNames') ?? [];
   }
 
   @action async onComplete() {
@@ -69,7 +69,7 @@ export class WorkflowCard extends WorkflowPostable {
 
     if (this.isComplete && this.cardName) {
       if (!this.completedCardNames.includes(this.cardName)) {
-        this.session?.updateMany({
+        this.session?.setValue({
           completedCardNames: [...this.completedCardNames, this.cardName],
           completedMilestonesCount: this.workflow?.completedMilestoneCount,
           milestonesCount: this.workflow?.milestones.length,
@@ -84,7 +84,7 @@ export class WorkflowCard extends WorkflowPostable {
     if (this.cardName && this.completedCardNames.length > 0) {
       const resetToIndex = this.completedCardNames.indexOf(this.cardName);
 
-      this.session?.updateMany({
+      this.session?.setValue({
         completedCardNames: this.completedCardNames.slice(0, resetToIndex),
         completedMilestonesCount: this.workflow?.completedMilestoneCount,
         milestonesCount: this.workflow?.milestones.length,

--- a/packages/web-client/app/models/workflow/workflow-session.ts
+++ b/packages/web-client/app/models/workflow/workflow-session.ts
@@ -1,57 +1,111 @@
+/* eslint-disable no-dupe-class-members */
+import {
+  BridgeValidationResult,
+  Safe,
+  TokenInfo,
+} from '@cardstack/cardpay-sdk';
 import { isPresent } from '@ember/utils';
 import { tracked } from '@glimmer/tracking';
+import BN from 'bn.js';
+import { TransactionReceipt } from 'web3-core';
 
-export interface ArbitraryDictionary {
-  [key: string]: any;
+export interface WorkflowSessionDictionary {
+  [key: string]: SupportedType;
+}
+
+type JSONSerializable =
+  | string
+  | number
+  | boolean
+  | null
+  | BridgeValidationResult
+  | Safe
+  | TokenInfo
+  | TransactionReceipt
+  | JSONSerializable[];
+export type SupportedType =
+  | JSONSerializable
+  | Record<string, JSONSerializable>
+  | Date
+  | BN
+  | undefined;
+
+function stateProxyHandler(workflowSession: WorkflowSession) {
+  return {
+    get(_target: unknown, key: string | symbol) {
+      if (key.toString() in workflowSession._state) {
+        return workflowSession.getValue(key.toString());
+      }
+      return undefined;
+    },
+    set(_target: unknown, key: string | symbol, value: SupportedType) {
+      workflowSession.setValue(key.toString(), value);
+      return true;
+    },
+    deleteProperty(_target: unknown, key: string | symbol) {
+      return delete workflowSession._state[key.toString()];
+    },
+    ownKeys: function (_target: unknown) {
+      return Object.keys(workflowSession._state);
+    },
+    has(_target: unknown, key: string | symbol) {
+      return key in workflowSession._state;
+    },
+    defineProperty: function (
+      _target: unknown,
+      _key: string | symbol,
+      _desc: unknown
+    ) {
+      throw new Error('Unsupported operation');
+    },
+    getOwnPropertyDescriptor: function (
+      _target: unknown,
+      key: string | symbol
+    ) {
+      let value = workflowSession.getValue(key.toString());
+      return value
+        ? {
+            value,
+            writable: true,
+            enumerable: true,
+            configurable: true,
+          }
+        : undefined;
+    },
+  };
 }
 
 export default class WorkflowSession {
   workflow: any;
-
+  _stateProxy: any;
   constructor(workflow?: any) {
     this.workflow = workflow;
+    this._stateProxy = new Proxy({}, stateProxyHandler(this));
   }
 
-  @tracked state: ArbitraryDictionary = {};
+  @tracked _state: Record<string, string> = {};
+
+  delete(key: string) {
+    delete this._state[key];
+    // eslint-disable-next-line no-self-assign
+    this._state = this._state; // for reactivity
+
+    this.persistToStorage();
+  }
+
+  get state(): Record<string, SupportedType> {
+    return this._stateProxy;
+  }
 
   get hasPersistence() {
     return isPresent(this.workflow?.workflowPersistenceId);
   }
 
-  update(key: string, val: any) {
-    this.state[key] = val;
-    // eslint-disable-next-line no-self-assign
-    this.state = this.state; // for reactivity
-
-    this.persistToStorage();
-  }
-
-  updateMany(hash: Record<string, any>) {
-    for (const key in hash) {
-      this.state[key] = hash[key];
-    }
-    // eslint-disable-next-line no-self-assign
-    this.state = this.state; // for reactivity
-
-    this.persistToStorage();
-  }
-
-  delete(key: string) {
-    delete this.state[key];
-    // eslint-disable-next-line no-self-assign
-    this.state = this.state; // for reactivity
-
-    this.persistToStorage();
-  }
-
   restoreFromStorage(): void {
     if (!this.hasPersistence) return;
 
-    const persistedData = this.getPersistedData();
-
-    if (persistedData?.state) {
-      this.state = persistedData.state;
-    }
+    let persistedData = this.getPersistedData();
+    this._state = persistedData?.state || {};
   }
 
   getPersistedData(): any {
@@ -60,12 +114,98 @@ export default class WorkflowSession {
     );
   }
 
+  getValue<T extends SupportedType>(key: string): T | null {
+    const data: string | null = this._state[key];
+    if (data !== null && data !== undefined) {
+      let json = JSON.parse(data);
+      if (json.type === 'Date') {
+        return new Date(json.value) as T;
+      } else if (json.type === 'BN') {
+        return new BN(json.value) as T;
+      } else {
+        return json.value;
+      }
+    }
+    return null;
+  }
+
+  getValues(): WorkflowSessionDictionary {
+    let result: WorkflowSessionDictionary = {};
+    for (const key in this._state) {
+      const data: string | null = this._state[key];
+      if (data !== null && data !== undefined) {
+        let json = JSON.parse(data);
+        if (json.type === 'Date') {
+          result[key] = new Date(json.value);
+        } else if (json.type === 'BN') {
+          result[key] = new BN(json.value);
+        } else {
+          result[key] = json.value;
+        }
+      }
+    }
+    return result;
+  }
+
+  setValue(key: string, value: SupportedType): void;
+  setValue(hash: Record<string, SupportedType>): void;
+  setValue(
+    hashOrKey: Record<string, SupportedType> | string,
+    value?: SupportedType
+  ): void {
+    if (typeof hashOrKey === 'string') {
+      this.setStateProperty(hashOrKey, value!);
+    } else {
+      for (const key in hashOrKey) {
+        this.setStateProperty(key, hashOrKey[key]);
+      }
+    }
+    // eslint-disable-next-line no-self-assign
+    this._state = this._state; // for reactivity
+    this.persistToStorage();
+  }
+
+  private setStateProperty(key: string, value: SupportedType) {
+    serializeToState(this._state, key, value);
+  }
+
   private persistToStorage(): void {
     if (!this.hasPersistence) return;
 
     this.workflow?.workflowPersistence.persistData(
       this.workflow.workflowPersistenceId,
-      { name: this.workflow.name, state: this.state }
+      { name: this.workflow.name, state: this._state }
     );
   }
+}
+
+export function serializeToState(
+  state: Record<string, string>,
+  key: string,
+  value: SupportedType
+) {
+  if (value instanceof Date) {
+    state[key] = JSON.stringify({
+      value: value.toISOString(),
+      type: 'Date',
+    });
+  } else if (value instanceof BN) {
+    state[key] = JSON.stringify({
+      value: value.toString(),
+      type: 'BN',
+    });
+  } else {
+    state[key] = JSON.stringify({ value });
+  }
+}
+
+// A useful util for tests
+export function buildState(
+  data: Record<string, SupportedType>
+): Record<string, any> {
+  let result = {};
+  for (let key in data) {
+    serializeToState(result, key, data[key]);
+  }
+  return result;
 }

--- a/packages/web-client/app/models/workflow/workflow-session.ts
+++ b/packages/web-client/app/models/workflow/workflow-session.ts
@@ -77,10 +77,10 @@ function stateProxyHandler(workflowSession: WorkflowSession) {
 
 export default class WorkflowSession {
   workflow: any;
-  _stateProxy: any;
+  #stateProxy: any;
   constructor(workflow?: any) {
     this.workflow = workflow;
-    this._stateProxy = new Proxy({}, stateProxyHandler(this));
+    this.#stateProxy = new Proxy({}, stateProxyHandler(this));
   }
 
   @tracked _state: Record<string, string> = {};
@@ -94,7 +94,7 @@ export default class WorkflowSession {
   }
 
   get state(): Record<string, SupportedType> {
-    return this._stateProxy;
+    return this.#stateProxy;
   }
 
   get hasPersistence() {

--- a/packages/web-client/app/services/card-customization.ts
+++ b/packages/web-client/app/services/card-customization.ts
@@ -8,19 +8,19 @@ import HubAuthentication from './hub-authentication';
 import { getResolver } from '@cardstack/did-resolver';
 import { Resolver } from 'did-resolver';
 
-export interface ColorCustomizationOption {
+export type ColorCustomizationOption = {
   background: string;
   textColor: string;
   patternColor: string;
   id: string;
   description?: string;
-}
+};
 
-export interface PatternCustomizationOption {
+export type PatternCustomizationOption = {
   patternUrl: string | null;
   id: string;
   description?: string;
-}
+};
 
 export interface PrepaidCardCustomization {
   did: string;

--- a/packages/web-client/tests/acceptance/create-merchant-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/create-merchant-persistence-test.ts
@@ -7,12 +7,14 @@ import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/
 import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';
 import { MerchantSafe, PrepaidCardSafe } from '@cardstack/cardpay-sdk';
 import { buildState } from '@cardstack/web-client/models/workflow/workflow-session';
+import { setupHubAuthenticationToken } from '../helpers/setup';
 
 interface Context extends MirageTestContext {}
 
 module('Acceptance | create merchant persistence', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupHubAuthenticationToken(hooks);
   let workflowPersistenceService: WorkflowPersistence;
   let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
   const prepaidCardAddress = '0x81c89274Dc7C9BAcE082d2ca00697d2d2857D2eE';
@@ -49,7 +51,6 @@ module('Acceptance | create merchant persistence', function (hooks) {
   };
 
   hooks.beforeEach(async function () {
-    window.TEST__AUTH_TOKEN = 'abc123--def456--ghi789';
     let layer2Service = this.owner.lookup('service:layer2-network')
       .strategy as Layer2TestWeb3Strategy;
     layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
@@ -108,10 +109,6 @@ module('Acceptance | create merchant persistence', function (hooks) {
     );
 
     workflowPersistenceService.storage.clear();
-  });
-
-  hooks.afterEach(async function () {
-    delete window.TEST__AUTH_TOKEN;
   });
 
   test('Generates a flow uuid query parameter used as a persistence identifier', async function (this: Context, assert) {

--- a/packages/web-client/tests/acceptance/create-merchant-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/create-merchant-persistence-test.ts
@@ -6,6 +6,7 @@ import { MirageTestContext } from 'ember-cli-mirage/test-support';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
 import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';
 import { MerchantSafe, PrepaidCardSafe } from '@cardstack/cardpay-sdk';
+import { buildState } from '@cardstack/web-client/models/workflow/workflow-session';
 
 interface Context extends MirageTestContext {}
 
@@ -109,6 +110,10 @@ module('Acceptance | create merchant persistence', function (hooks) {
     workflowPersistenceService.storage.clear();
   });
 
+  hooks.afterEach(async function () {
+    delete window.TEST__AUTH_TOKEN;
+  });
+
   test('Generates a flow uuid query parameter used as a persistence identifier', async function (this: Context, assert) {
     await visit('/card-pay/merchant-services');
     await click('[data-test-workflow-button="create-merchant"]');
@@ -123,14 +128,14 @@ module('Acceptance | create merchant persistence', function (hooks) {
 
   module('Restoring from a previously saved state', function () {
     test('it restores an unfinished workflow', async function (this: Context, assert) {
-      const state = {
+      let state = buildState({
         completedCardNames: ['LAYER2_CONNECT', 'MERCHANT_CUSTOMIZATION'],
         merchantName,
         merchantId,
         merchantBgColor,
         merchantRegistrationFee,
         prepaidCardChoice: prepaidCard,
-      };
+      });
 
       workflowPersistenceService.persistData('abc123', {
         name: 'MERCHANT_CREATION',
@@ -157,7 +162,7 @@ module('Acceptance | create merchant persistence', function (hooks) {
     });
 
     test('it restores a finished workflow', async function (this: Context, assert) {
-      const state = {
+      const state = buildState({
         completedCardNames: [
           'LAYER2_CONNECT',
           'MERCHANT_CUSTOMIZATION',
@@ -174,7 +179,7 @@ module('Acceptance | create merchant persistence', function (hooks) {
         txnHash:
           '0x8bcc3e419d09a0403d1491b5bb8ac8bee7c67f85cc37e6e17ef8eb77f946497b',
         merchantSafe,
-      };
+      });
 
       workflowPersistenceService.persistData('abc123', {
         name: 'MERCHANT_CREATION',
@@ -207,7 +212,7 @@ module('Acceptance | create merchant persistence', function (hooks) {
     });
 
     test('it restores a cancelled workflow', async function (this: Context, assert) {
-      const state = {
+      const state = buildState({
         cancelationReason: 'DISCONNECTED',
         completedCardNames: ['LAYER2_CONNECT', 'MERCHANT_CUSTOMIZATION'],
         merchantName,
@@ -218,7 +223,7 @@ module('Acceptance | create merchant persistence', function (hooks) {
         completedMilestonesCount: 2,
         isCancelled: true,
         milestonesCount: 3,
-      };
+      });
 
       workflowPersistenceService.persistData('abc123', {
         name: 'MERCHANT_CREATION',
@@ -249,13 +254,13 @@ module('Acceptance | create merchant persistence', function (hooks) {
     });
 
     test('it cancels a persisted flow when trying to restore while unauthenticated', async function (this: Context, assert) {
-      const state = {
+      const state = buildState({
         completedCardNames: ['LAYER2_CONNECT', 'MERCHANT_CUSTOMIZATION'],
         merchantName,
         merchantId,
         merchantBgColor,
         merchantRegistrationFee,
-      };
+      });
 
       workflowPersistenceService.persistData('abc123', {
         name: 'MERCHANT_CREATION',
@@ -293,7 +298,7 @@ module('Acceptance | create merchant persistence', function (hooks) {
     });
 
     test('it should reset the persisted card names when editing one of the previous steps', async function (this: Context, assert) {
-      const state = {
+      const state = buildState({
         completedCardNames: ['LAYER2_CONNECT', 'MERCHANT_CUSTOMIZATION'],
         merchantName,
         merchantId,
@@ -303,7 +308,7 @@ module('Acceptance | create merchant persistence', function (hooks) {
         txnHash:
           '0x8bcc3e419d09a0403d1491b5bb8ac8bee7c67f85cc37e6e17ef8eb77f946497b',
         merchantSafe,
-      };
+      });
 
       workflowPersistenceService.persistData('abc123', {
         name: 'MERCHANT_CREATION',
@@ -330,14 +335,14 @@ module('Acceptance | create merchant persistence', function (hooks) {
     });
 
     test('it cancels a persisted flow when card wallet address is different', async function (this: Context, assert) {
-      const state = {
+      const state = buildState({
         completedCardNames: ['LAYER2_CONNECT', 'MERCHANT_CUSTOMIZATION'],
         merchantName,
         merchantId,
         merchantBgColor,
         merchantRegistrationFee,
         layer2WalletAddress: '0xaaaaaaaaaaaaaaa', // Differs from layer2AccountAddress set in beforeEach
-      };
+      });
 
       workflowPersistenceService.persistData('abc123', {
         name: 'MERCHANT_CREATION',
@@ -359,13 +364,13 @@ module('Acceptance | create merchant persistence', function (hooks) {
     });
 
     test('it allows interactivity after restoring previously saved state', async function (this: Context, assert) {
-      const state = {
+      const state = buildState({
         completedCardNames: ['LAYER2_CONNECT'],
         merchantName,
         merchantId,
         merchantBgColor,
         merchantRegistrationFee,
-      };
+      });
 
       workflowPersistenceService.persistData('abc123', {
         name: 'MERCHANT_CREATION',

--- a/packages/web-client/tests/acceptance/deposit-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-persistence-test.ts
@@ -16,6 +16,7 @@ import {
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
 import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
 import { BN } from 'bn.js';
+import { buildState } from '@cardstack/web-client/models/workflow/workflow-session';
 
 interface Context extends MirageTestContext {}
 
@@ -62,11 +63,11 @@ module('Acceptance | deposit persistence', function (hooks) {
 
   module('Restoring from a previously saved state', function () {
     test('it restores an unfinished workflow', async function (this: Context, assert) {
-      const state = {
+      const state = buildState({
         completedCardNames: ['LAYER1_CONNECT', 'LAYER2_CONNECT', 'TXN_SETUP'],
         depositSourceToken: 'DAI',
-        depositedAmount: '10000000000000000000',
-      };
+        depositedAmount: new BN('10000000000000000000'),
+      });
       workflowPersistenceService.persistData('abc123', {
         name: 'RESERVE_POOL_DEPOSIT',
         state,
@@ -85,10 +86,10 @@ module('Acceptance | deposit persistence', function (hooks) {
     });
 
     test('it restores a workflow partway through the deposit/unlock 2-step process', async function (this: Context, assert) {
-      const state = {
+      const state = buildState({
         completedCardNames: ['LAYER1_CONNECT', 'LAYER2_CONNECT', 'TXN_SETUP'],
         depositSourceToken: 'DAI',
-        depositedAmount: '1000000000000000000',
+        depositedAmount: new BN('10000000000000000000'),
         unlockTxnHash: '0xABC',
         unlockTxnReceipt: {
           status: true,
@@ -106,7 +107,7 @@ module('Acceptance | deposit persistence', function (hooks) {
           events: {},
         },
         relayTokensTxnHash: '0xDEF',
-      };
+      });
       workflowPersistenceService.persistData('abc123', {
         name: 'RESERVE_POOL_DEPOSIT',
         state,
@@ -135,7 +136,7 @@ module('Acceptance | deposit persistence', function (hooks) {
     });
 
     test('it restores a workflow partway through the layer 2 bridging', async function (this: Context, assert) {
-      const state = {
+      const state = buildState({
         completedCardNames: [
           'LAYER1_CONNECT',
           'LAYER2_CONNECT',
@@ -143,7 +144,7 @@ module('Acceptance | deposit persistence', function (hooks) {
           'TXN_AMOUNT',
         ],
         depositSourceToken: 'DAI',
-        depositedAmount: '1000000000000000000',
+        depositedAmount: new BN('10000000000000000000'),
         unlockTxnHash: '0xABC',
         unlockTxnReceipt: {
           status: true,
@@ -177,7 +178,7 @@ module('Acceptance | deposit persistence', function (hooks) {
           events: {},
         },
         layer2BlockHeightBeforeBridging: '1234',
-      };
+      });
       workflowPersistenceService.persistData('abc123', {
         name: 'RESERVE_POOL_DEPOSIT',
         state,
@@ -214,7 +215,7 @@ module('Acceptance | deposit persistence', function (hooks) {
     });
 
     test('it restores a finished workflow', async function (this: Context, assert) {
-      const state = {
+      const state = buildState({
         completedCardNames: [
           'LAYER1_CONNECT',
           'LAYER2_CONNECT',
@@ -223,7 +224,7 @@ module('Acceptance | deposit persistence', function (hooks) {
           'TXN_STATUS',
         ],
         depositSourceToken: 'DAI',
-        depositedAmount: '1000000000000000000',
+        depositedAmount: new BN('10000000000000000000'),
         unlockTxnHash: '0xABC',
         unlockTxnReceipt: {
           status: true,
@@ -272,7 +273,7 @@ module('Acceptance | deposit persistence', function (hooks) {
           logsBloom: '',
           events: {},
         },
-      };
+      });
       workflowPersistenceService.persistData('abc123', {
         name: 'RESERVE_POOL_DEPOSIT',
         state,
@@ -296,13 +297,13 @@ module('Acceptance | deposit persistence', function (hooks) {
     });
 
     test('it restores a cancelled workflow', async function (this: Context, assert) {
-      const state = {
+      const state = buildState({
         isCancelled: true,
         cancelationReason: 'DISCONNECTED',
         completedCardNames: ['LAYER1_CONNECT', 'LAYER2_CONNECT', 'TXN_SETUP'],
         depositSourceToken: 'DAI',
-        depositedAmount: '10000000000000000000',
-      };
+        depositedAmount: new BN('10000000000000000000'),
+      });
       workflowPersistenceService.persistData('abc123', {
         name: 'RESERVE_POOL_DEPOSIT',
         state,
@@ -326,11 +327,11 @@ module('Acceptance | deposit persistence', function (hooks) {
     });
 
     test('it should reset the persisted card names when editing one of the previous steps', async function (this: Context, assert) {
-      const state = {
+      const state = buildState({
         completedCardNames: ['LAYER1_CONNECT', 'LAYER2_CONNECT', 'TXN_SETUP'],
         depositSourceToken: 'DAI',
-        depositedAmount: '10000000000000000000',
-      };
+        depositedAmount: new BN('10000000000000000000'),
+      });
       workflowPersistenceService.persistData('abc123', {
         name: 'RESERVE_POOL_DEPOSIT',
         state,
@@ -354,7 +355,7 @@ module('Acceptance | deposit persistence', function (hooks) {
     });
 
     test('it cancels a persisted flow when Layer 1 wallet address is different', async function (this: Context, assert) {
-      const state = {
+      const state = buildState({
         completedCardNames: [
           'LAYER1_CONNECT',
           'LAYER2_CONNECT',
@@ -362,9 +363,9 @@ module('Acceptance | deposit persistence', function (hooks) {
           'TXN_AMOUNT',
         ],
         depositSourceToken: 'DAI',
-        depositedAmount: '1000000000000000000',
+        depositedAmount: new BN('10000000000000000000'),
         layer1WalletAddress: '0xaaaaaaaaaaaaaaa', // Differs from layer1WalletAddress set in beforeEach
-      };
+      });
       workflowPersistenceService.persistData('abc123', {
         name: 'RESERVE_POOL_DEPOSIT',
         state,
@@ -381,7 +382,7 @@ module('Acceptance | deposit persistence', function (hooks) {
     });
 
     test('it cancels a persisted flow when card wallet address is different', async function (this: Context, assert) {
-      const state = {
+      const state = buildState({
         completedCardNames: [
           'LAYER1_CONNECT',
           'LAYER2_CONNECT',
@@ -389,9 +390,9 @@ module('Acceptance | deposit persistence', function (hooks) {
           'TXN_AMOUNT',
         ],
         depositSourceToken: 'DAI',
-        depositedAmount: '1000000000000000000',
+        depositedAmount: new BN('10000000000000000000'),
         layer2WalletAddress: '0xaaaaaaaaaaaaaaa', // Differs from layer2WalletAddress set in beforeEach
-      };
+      });
       workflowPersistenceService.persistData('abc123', {
         name: 'RESERVE_POOL_DEPOSIT',
         state,
@@ -408,11 +409,11 @@ module('Acceptance | deposit persistence', function (hooks) {
     });
 
     test('it allows interactivity after restoring previously saved state', async function (this: Context, assert) {
-      const state = {
+      const state = buildState({
         completedCardNames: ['LAYER1_CONNECT', 'LAYER2_CONNECT', 'TXN_SETUP'],
         depositSourceToken: 'DAI',
-        depositedAmount: '10000000000000000000',
-      };
+        depositedAmount: new BN('10000000000000000000'),
+      });
       workflowPersistenceService.persistData('abc123', {
         name: 'RESERVE_POOL_DEPOSIT',
         state,

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-persistence-test.ts
@@ -14,6 +14,7 @@ import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/
 import { toWei } from 'web3-utils';
 
 import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';
+import { buildState } from '@cardstack/web-client/models/workflow/workflow-session';
 
 interface Context extends MirageTestContext {}
 
@@ -63,6 +64,10 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
     workflowPersistenceService.storage.clear();
   });
 
+  hooks.afterEach(async function () {
+    delete window.TEST__AUTH_TOKEN;
+  });
+
   test('Generates a flow uuid query parameter used as a persistence identifier', async function (this: Context, assert) {
     await visit('/card-pay');
     await click('[data-test-workflow-button="issue-prepaid-card"]');
@@ -77,7 +82,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
 
   module('Restoring from a previously saved state', function () {
     test('it restores an unfinished workflow', async function (this: Context, assert) {
-      const state = {
+      let state = buildState({
         completedCardNames: [
           'LAYER2_CONNECT',
           'LAYOUT_CUSTOMIZATION',
@@ -102,7 +107,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
         prepaidCardAddress: '0xaeFbA62A2B3e90FD131209CC94480E722704E1F8',
         reloadable: true,
         transferrable: true,
-      };
+      });
 
       workflowPersistenceService.persistData('abc123', {
         name: 'PREPAID_CARD_ISSUANCE',
@@ -130,7 +135,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
     });
 
     test('it restores a finished workflow', async function (this: Context, assert) {
-      const state = {
+      let state = buildState({
         completedCardNames: [
           'LAYER2_CONNECT',
           'LAYOUT_CUSTOMIZATION',
@@ -167,7 +172,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
           spendFaceValue: 500,
           transferrable: true,
         },
-      };
+      });
 
       workflowPersistenceService.persistData('abc123', {
         name: 'Prepaid Card Issuance',
@@ -195,7 +200,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
     });
 
     test('it restores a cancelled workflow', async function (this: Context, assert) {
-      const state = {
+      let state = buildState({
         cancelationReason: 'DISCONNECTED',
         colorScheme: {
           patternColor: 'black',
@@ -221,7 +226,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
         },
         prepaidFundingToken: 'DAI.CPXD',
         spendFaceValue: 500,
-      };
+      });
 
       workflowPersistenceService.persistData('abc123', {
         name: 'Prepaid Card Issuance',
@@ -254,7 +259,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
     });
 
     test('it cancels a persisted flow when trying to restore while unauthenticated', async function (this: Context, assert) {
-      const state = {
+      let state = buildState({
         completedCardNames: [
           'LAYER2_CONNECT',
           'LAYOUT_CUSTOMIZATION',
@@ -279,7 +284,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
         prepaidCardAddress: '0xaeFbA62A2B3e90FD131209CC94480E722704E1F8',
         reloadable: true,
         transferrable: true,
-      };
+      });
 
       workflowPersistenceService.persistData('abc123', {
         name: 'PREPAID_CARD_ISSUANCE',
@@ -316,7 +321,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
     });
 
     test('it should reset the persisted card names when editing one of the previous steps', async function (this: Context, assert) {
-      const state = {
+      let state = buildState({
         completedCardNames: [
           'LAYER2_CONNECT',
           'LAYOUT_CUSTOMIZATION',
@@ -352,7 +357,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
           spendFaceValue: 500,
           transferrable: true,
         },
-      };
+      });
 
       workflowPersistenceService.persistData('abc123', {
         name: 'PREPAID_CARD_ISSUANCE',
@@ -378,7 +383,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
     });
 
     test('it cancels a persisted flow when card wallet address is different', async function (this: Context, assert) {
-      const state = {
+      let state = buildState({
         completedCardNames: [
           'LAYER2_CONNECT',
           'LAYOUT_CUSTOMIZATION',
@@ -404,7 +409,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
         reloadable: true,
         transferrable: true,
         layer2WalletAddress: '0xaaaaaaaaaaaaaaa', // Differs from layer2AccountAddress set in beforeEach
-      };
+      });
 
       workflowPersistenceService.persistData('abc123', {
         name: 'PREPAID_CARD_ISSUANCE',
@@ -425,7 +430,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
     });
 
     test('it allows interactivity after restoring previously saved state', async function (this: Context, assert) {
-      const state = {
+      let state = buildState({
         completedCardNames: ['LAYER2_CONNECT', 'LAYOUT_CUSTOMIZATION'],
         issuerName: 'Vitalik',
         pattern: {
@@ -439,7 +444,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
           background: '#37EB77',
           id: '4f219852-33ee-4e4c-81f7-76318630a423',
         },
-      };
+      });
 
       workflowPersistenceService.persistData('abc123', {
         name: 'Prepaid Card Issuance',

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-persistence-test.ts
@@ -15,12 +15,14 @@ import { toWei } from 'web3-utils';
 
 import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';
 import { buildState } from '@cardstack/web-client/models/workflow/workflow-session';
+import { setupHubAuthenticationToken } from '../helpers/setup';
 
 interface Context extends MirageTestContext {}
 
 module('Acceptance | issue prepaid card persistence', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupHubAuthenticationToken(hooks);
   let workflowPersistenceService: WorkflowPersistence;
 
   hooks.beforeEach(async function (this: Context) {
@@ -28,7 +30,6 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
       prepaidCardColorSchemes,
       prepaidCardPatterns,
     });
-    window.TEST__AUTH_TOKEN = 'abc123--def456--ghi789';
     let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
     const MIN_AMOUNT_TO_PASS = new BN(
       toWei(`${Math.ceil(Math.min(...faceValueOptions) / 100)}`)
@@ -62,10 +63,6 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
     );
 
     workflowPersistenceService.storage.clear();
-  });
-
-  hooks.afterEach(async function () {
-    delete window.TEST__AUTH_TOKEN;
   });
 
   test('Generates a flow uuid query parameter used as a persistence identifier', async function (this: Context, assert) {

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -23,6 +23,7 @@ import { faceValueOptions } from '@cardstack/web-client/components/card-pay/issu
 
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
 import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';
+import { setupHubAuthenticationToken } from '../helpers/setup';
 
 interface Context extends MirageTestContext {}
 
@@ -570,9 +571,9 @@ module('Acceptance | issue prepaid card', function (hooks) {
   module('Tests with the layer 2 wallet already connected', function (hooks) {
     let layer2Service: Layer2TestWeb3Strategy;
     let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
+    setupHubAuthenticationToken(hooks);
 
     hooks.beforeEach(async function () {
-      window.TEST__AUTH_TOKEN = 'abc123--def456--ghi789';
       layer2Service = this.owner.lookup('service:layer2-network')
         .strategy as Layer2TestWeb3Strategy;
       layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
@@ -598,10 +599,6 @@ module('Acceptance | issue prepaid card', function (hooks) {
         ],
       };
       await layer2Service.test__simulateDepot(testDepot as DepotSafe);
-    });
-
-    hooks.afterEach(async function () {
-      delete window.TEST__AUTH_TOKEN;
     });
 
     test('Disconnecting Layer 2 from within the workflow', async function (assert) {

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -534,56 +534,33 @@ module('Acceptance | issue prepaid card', function (hooks) {
 
     assert.equal(persistedData.name, 'PREPAID_CARD_ISSUANCE');
     let persistedState = persistedData.state;
-    delete persistedState.prepaidCardSafe.createdAt;
+    persistedState.prepaidCardSafe = persistedState.prepaidCardSafe.replace(
+      /"createdAt":[\d.]+,/,
+      ''
+    );
 
     assert.deepEqual(persistedState, {
-      colorScheme: {
-        background: '#37EB77',
-        id: '4f219852-33ee-4e4c-81f7-76318630a423',
-        patternColor: 'white',
-        textColor: 'black',
-      },
-      completedCardNames: [
-        'LAYER2_CONNECT',
-        'HUB_AUTH',
-        'LAYOUT_CUSTOMIZATION',
-        'FUNDING_SOURCE',
-        'FACE_VALUE',
-        'PREVIEW',
-        'CONFIRMATION',
-        'EPILOGUE_LAYER_TWO_CONNECT_CARD',
-      ],
-      completedMilestonesCount: 4,
-      did: 'did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e',
-      issuerName: 'JJ',
-      layer2WalletAddress: '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44',
-      milestonesCount: 4,
-      pattern: {
-        id: '80cb8f99-c5f7-419e-9c95-2e87a9d8db32',
-        patternUrl:
-          '/assets/images/prepaid-card-customizations/pattern-3-be5bfc96d028c4ed55a5aafca645d213.svg',
-      },
-      prepaidCardAddress: '0xaeFbA62A2B3e90FD131209CC94480E722704E1F8',
-      prepaidCardSafe: {
-        address: '0xaeFbA62A2B3e90FD131209CC94480E722704E1F8',
-        customizationDID:
-          'did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e',
-        hasBeenUsed: false,
-        issuer: '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44',
-        issuingToken: '0xTOKEN',
-        owners: ['0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44'],
-        prepaidCardOwner: '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44',
-        reloadable: true,
-        spendFaceValue: 10000,
-        tokens: [],
-        transferrable: true,
-        type: 'prepaid-card',
-      },
-      prepaidFundingToken: 'DAI.CPXD',
-      reloadable: true,
-      spendFaceValue: 10000,
-      transferrable: true,
-      txnHash: 'exampleTxnHash',
+      colorScheme:
+        '{"value":{"patternColor":"white","textColor":"black","background":"#37EB77","id":"4f219852-33ee-4e4c-81f7-76318630a423"}}',
+      completedCardNames:
+        '{"value":["LAYER2_CONNECT","HUB_AUTH","LAYOUT_CUSTOMIZATION","FUNDING_SOURCE","FACE_VALUE","PREVIEW","CONFIRMATION","EPILOGUE_LAYER_TWO_CONNECT_CARD"]}',
+      completedMilestonesCount: '{"value":4}',
+      did: '{"value":"did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e"}',
+      issuerName: '{"value":"JJ"}',
+      layer2WalletAddress:
+        '{"value":"0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44"}',
+      milestonesCount: '{"value":4}',
+      pattern:
+        '{"value":{"patternUrl":"/assets/images/prepaid-card-customizations/pattern-3-be5bfc96d028c4ed55a5aafca645d213.svg","id":"80cb8f99-c5f7-419e-9c95-2e87a9d8db32"}}',
+      prepaidCardAddress:
+        '{"value":"0xaeFbA62A2B3e90FD131209CC94480E722704E1F8"}',
+      prepaidCardSafe:
+        '{"value":{"type":"prepaid-card","address":"0xaeFbA62A2B3e90FD131209CC94480E722704E1F8","tokens":[],"owners":["0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44"],"issuingToken":"0xTOKEN","spendFaceValue":10000,"prepaidCardOwner":"0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44","hasBeenUsed":false,"issuer":"0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44","reloadable":true,"transferrable":true,"customizationDID":"did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e"}}',
+      prepaidFundingToken: '{"value":"DAI.CPXD"}',
+      reloadable: '{"value":true}',
+      spendFaceValue: '{"value":10000}',
+      transferrable: '{"value":true}',
+      txnHash: '{"value":"exampleTxnHash"}',
     });
   });
 
@@ -623,8 +600,8 @@ module('Acceptance | issue prepaid card', function (hooks) {
       await layer2Service.test__simulateDepot(testDepot as DepotSafe);
     });
 
-    hooks.afterEach(function () {
-      window.TEST__AUTH_TOKEN = undefined;
+    hooks.afterEach(async function () {
+      delete window.TEST__AUTH_TOKEN;
     });
 
     test('Disconnecting Layer 2 from within the workflow', async function (assert) {

--- a/packages/web-client/tests/helpers/setup.ts
+++ b/packages/web-client/tests/helpers/setup.ts
@@ -1,0 +1,8 @@
+export function setupHubAuthenticationToken(hooks: any) {
+  hooks.beforeEach(function () {
+    window.TEST__AUTH_TOKEN = 'abc123--def456--ghi789';
+  });
+  hooks.afterEach(function () {
+    delete window.TEST__AUTH_TOKEN;
+  });
+}

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/merchant-customization-test.ts
@@ -257,10 +257,10 @@ module(
     });
 
     test('It updates the workflow session when saved', async function (assert) {
-      assert.notOk(workflowSession.state.merchantName);
-      assert.notOk(workflowSession.state.merchantId);
-      assert.notOk(workflowSession.state.merchantBgColor);
-      assert.notOk(workflowSession.state.merchantTextColor);
+      assert.notOk(workflowSession.getValue('merchantName'));
+      assert.notOk(workflowSession.getValue('merchantId'));
+      assert.notOk(workflowSession.getValue('merchantBgColor'));
+      assert.notOk(workflowSession.getValue('merchantTextColor'));
 
       let merchantNameInput = `${MERCHANT_NAME_FIELD} input`;
       await fillIn(merchantNameInput, 'HELLO!');
@@ -275,10 +275,10 @@ module(
 
       await click(SAVE_DETAILS_BUTTON);
 
-      assert.equal(workflowSession.state.merchantName, 'HELLO!');
-      assert.equal(workflowSession.state.merchantId, VALID_ID);
-      assert.ok(workflowSession.state.merchantBgColor);
-      assert.ok(workflowSession.state.merchantTextColor);
+      assert.equal(workflowSession.getValue<string>('merchantName'), 'HELLO!');
+      assert.equal(workflowSession.getValue<string>('merchantId'), VALID_ID);
+      assert.ok(workflowSession.getValue<string>('merchantBgColor'));
+      assert.ok(workflowSession.getValue<string>('merchantTextColor'));
     });
 
     test('It displays the memorialized state correctly', async function (assert) {
@@ -295,8 +295,8 @@ module(
 
       await click(SAVE_DETAILS_BUTTON);
 
-      let bgColor = workflowSession.state.merchantBgColor;
-      let textColor = workflowSession.state.merchantTextColor;
+      let bgColor = workflowSession.getValue<string>('merchantBgColor')!;
+      let textColor = workflowSession.getValue<string>('merchantTextColor')!;
 
       assert.dom(COMPLETED_SELECTOR).exists();
       assert.dom(EDIT_BUTTON).exists();

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
@@ -78,7 +78,7 @@ module(
       ]);
 
       let workflowSession = new WorkflowSession();
-      workflowSession.updateMany({
+      workflowSession.setValue({
         merchantName: 'Mandello',
         merchantId: 'mandello1',
         merchantBgColor: '#ff5050',

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
@@ -25,7 +25,7 @@ module(
       layer2Strategy.test__simulateAccountsChanged([layer2AccountAddress]);
 
       const session = new WorkflowSession();
-      session.update('depositSourceToken', 'DAI');
+      session.setValue('depositSourceToken', 'DAI');
       layer1Service = this.owner.lookup('service:layer1-network').strategy;
 
       const startDaiAmountString = '5.111111111111111110';

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-setup-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-setup-test.ts
@@ -103,7 +103,7 @@ module(
         card: new BN('10000000000000000000000'),
       });
 
-      session.update('depositSourceToken', 'DAI');
+      session.setValue('depositSourceToken', 'DAI');
 
       this.setProperties({
         session,

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-status-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-status-test.ts
@@ -7,6 +7,7 @@ import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/
 import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 import sinon from 'sinon';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
+import { TransactionReceipt } from 'web3-core';
 
 module(
   'Integration | Component | card-pay/deposit-workflow/transaction-status',
@@ -16,13 +17,13 @@ module(
     test('It shows a blockscout button if bridging succeeds', async function (assert) {
       let onComplete = sinon.spy();
       let workflowSession = new WorkflowSession();
-      workflowSession.updateMany({
+      workflowSession.setValue({
         depositSourceToken: 'DAI',
         layer2BlockHeightBeforeBridging: '0',
         relayTokensTxnReceipt: {
           transactionHash: 'RelayTokensTransactionHash',
           blockNumber: 1,
-        },
+        } as TransactionReceipt,
       });
       const layer1Service = this.owner.lookup('service:layer1-network')
         .strategy as Layer1TestWeb3Strategy;
@@ -114,13 +115,13 @@ module(
 
       let onComplete = sinon.spy();
       let workflowSession = new WorkflowSession();
-      workflowSession.updateMany({
+      workflowSession.setValue({
         depositSourceToken: 'DAI',
         layer2BlockHeightBeforeBridging: '0',
         relayTokensTxnReceipt: {
           transactionHash: 'RelayTokensTransactionHash',
           blockNumber: 1,
-        },
+        } as TransactionReceipt,
       });
 
       sinon
@@ -167,13 +168,13 @@ module(
 
       let onComplete = sinon.spy();
       let workflowSession = new WorkflowSession();
-      workflowSession.updateMany({
+      workflowSession.setValue({
         depositSourceToken: 'DAI',
         layer2BlockHeightBeforeBridging: '0',
         relayTokensTxnReceipt: {
           transactionHash: 'RelayTokensTransactionHash',
           blockNumber: 1,
-        },
+        } as TransactionReceipt,
       });
 
       sinon

--- a/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
@@ -45,7 +45,7 @@ module(
       ) as CardCustomization;
 
       let workflowSession = new WorkflowSession();
-      workflowSession.updateMany({
+      workflowSession.setValue({
         spendFaceValue: 100000,
         issuerName: 'Some name',
         colorScheme: {

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/choose-balance-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/choose-balance-test.ts
@@ -6,7 +6,7 @@ import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
 import BN from 'bn.js';
 
-import { DepotSafe } from '@cardstack/cardpay-sdk/sdk/safes';
+import { DepotSafe, Safe } from '@cardstack/cardpay-sdk/sdk/safes';
 import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 
 module(
@@ -194,12 +194,12 @@ module(
 
       await click('[data-test-boxel-action-chin] [data-test-boxel-button]');
       assert.equal(
-        session.state.withdrawalToken,
+        session.getValue('withdrawalToken'),
         'CARD.CPXD',
         'workflow session withdrawal token updated'
       );
       assert.equal(
-        session.state.withdrawalSafe.address,
+        session.getValue<Safe>('withdrawalSafe')?.address,
         merchantAddress,
         'workflow session withdrawal safe updated'
       );

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-confirmed-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-confirmed-test.ts
@@ -49,11 +49,8 @@ module(
         ],
       };
       await layer2Service.test__simulateDepot(testDepot as DepotSafe);
-      this.set('session.state.withdrawalToken', 'DAI.CPXD');
-      this.set(
-        'session.state.withdrawnAmount',
-        new BN('123456000000000000000')
-      );
+      session.setValue('withdrawalToken', 'DAI.CPXD');
+      session.setValue('withdrawnAmount', new BN('123456000000000000000'));
 
       await render(hbs`
         <CardPay::WithdrawalWorkflow::TransactionConfirmed

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
@@ -18,7 +18,7 @@ module(
 
     hooks.beforeEach(async function () {
       let workflowSession = new WorkflowSession();
-      workflowSession.updateMany({
+      workflowSession.setValue({
         layer2BlockHeightBeforeBridging: 1234,
         relayTokensTxnHash: 'relay',
         withdrawalToken: 'CARD.CPXD',

--- a/packages/web-client/tests/unit/models/workflow/workflow-session-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/workflow-session-test.ts
@@ -1,18 +1,577 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import WorkflowSession from '@cardstack/web-client/models/workflow/workflow-session';
+import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';
+import Ember from 'ember';
+import BN from 'bn.js';
+
+const { track, valueForTag, validateTag } =
+  // @ts-ignore digging
+  Ember.__loader.require('@glimmer/validator');
 
 module('Unit | WorkflowSession model', function (hooks) {
   setupTest(hooks);
 
+  const ID = 'abc123';
+
   test('state starts off as empty', function (assert) {
     let subject = new WorkflowSession();
-    assert.deepEqual(subject.state, {});
+    assert.deepEqual(subject._state, {});
   });
 
-  test('when update is called, state is updated', function (assert) {
-    let subject = new WorkflowSession();
-    subject.update('depositSourceToken', 'dai');
-    assert.equal(subject.state['depositSourceToken'], 'dai');
+  test('get string value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {
+        myKey: '{ "value": "myValue" }',
+      },
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+    assert.equal(subject.getValue<string>('myKey'), 'myValue');
   });
+
+  test('get un-set string value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {},
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+    assert.equal(subject.getValue<string>('myKey'), null);
+  });
+
+  test('set string value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {},
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+
+    const tag = track(() => {
+      subject._state.myKey;
+    });
+    let snapshot = valueForTag(tag);
+    assert.ok(validateTag(tag, snapshot), 'tag should be valid to start');
+
+    subject.setValue('myKey', 'myValue');
+
+    assert.strictEqual(
+      validateTag(tag, snapshot),
+      false,
+      'tag is invalidated after property is set'
+    );
+
+    assert.equal(subject.getValue<string>('myKey'), 'myValue');
+
+    let data = workflowPersistence.getPersistedData(ID);
+    assert.deepEqual(data, {
+      state: {
+        myKey: '{"value":"myValue"}',
+      },
+    });
+  });
+
+  test('set optional string value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {},
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+
+    const tag = track(() => {
+      subject._state.myKey;
+    });
+    let snapshot = valueForTag(tag);
+    assert.ok(validateTag(tag, snapshot), 'tag should be valid to start');
+
+    let s: string | undefined;
+    subject.setValue('myKey', s);
+
+    assert.strictEqual(
+      validateTag(tag, snapshot),
+      false,
+      'tag is invalidated after property is set'
+    );
+
+    assert.equal(subject.getValue<string | undefined>('myKey'), null);
+
+    let data = workflowPersistence.getPersistedData(ID);
+    assert.deepEqual(data, {
+      state: {
+        myKey: '{}',
+      },
+    });
+  });
+
+  test('get number value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {
+        myKey: '{ "value": 42 }',
+      },
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+    assert.equal(subject.getValue<number>('myKey'), 42);
+  });
+
+  test('get un-set number value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {},
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+    assert.equal(subject.getValue<number>('myKey'), null);
+  });
+
+  test('set number value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {},
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+
+    const tag = track(() => {
+      subject._state.myKey;
+    });
+    let snapshot = valueForTag(tag);
+    assert.ok(validateTag(tag, snapshot), 'tag should be valid to start');
+
+    subject.setValue('myKey', 42);
+
+    assert.strictEqual(
+      validateTag(tag, snapshot),
+      false,
+      'tag is invalidated after property is set'
+    );
+
+    assert.equal(subject.getValue<number>('myKey'), 42);
+
+    let data = workflowPersistence.getPersistedData(ID);
+    assert.deepEqual(data, {
+      state: {
+        myKey: '{"value":42}',
+      },
+    });
+  });
+
+  test('set multiple keys at once with a hash', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {},
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+
+    const tag = track(() => {
+      subject._state.myNumberKey;
+      subject._state.myStringKey;
+    });
+    let snapshot = valueForTag(tag);
+    assert.ok(validateTag(tag, snapshot), 'tag should be valid to start');
+
+    subject.setValue({
+      myNumberKey: 42,
+      myStringKey: 'myValue',
+    });
+
+    assert.strictEqual(
+      validateTag(tag, snapshot),
+      false,
+      'tag is invalidated after property is set'
+    );
+
+    assert.equal(subject.getValue<number>('myNumberKey'), 42);
+    assert.equal(subject.getValue<string>('myStringKey'), 'myValue');
+
+    let data = workflowPersistence.getPersistedData(ID);
+    assert.deepEqual(data, {
+      state: {
+        myNumberKey: '{"value":42}',
+        myStringKey: '{"value":"myValue"}',
+      },
+    });
+  });
+
+  test('get all keys at once as a hash', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {
+        myNumberKey: '{ "value": 42 }',
+        myStringKey: '{ "value": "myValue" }',
+      },
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+
+    assert.deepEqual(subject.getValues(), {
+      myNumberKey: 42,
+      myStringKey: 'myValue',
+    });
+  });
+
+  test('state is a proxy allowing access to values', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {
+        myNumberKey: '{ "value": 42 }',
+        myStringKey: '{ "value": "myValue" }',
+        myBNKey: '{ "value": "42", "type": "BN" }',
+      },
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+    assert.equal(subject.state.myNumberKey, 42);
+    assert.equal(subject.state.myStringKey, 'myValue');
+    assert.ok(subject.state.noSuchKey === undefined);
+    assert.ok(new BN('42').eq(subject.state.myBNKey as BN));
+
+    subject.state.myNumberKey = 43;
+
+    assert.equal(subject.state.myNumberKey, 43);
+    assert.equal(subject.getValue<number>('myNumberKey'), 43);
+
+    delete subject.state.myNumberKey;
+
+    assert.ok(subject.state.myNumberKey === undefined);
+    assert.deepEqual(Object.keys(subject.state), ['myStringKey', 'myBNKey']);
+  });
+
+  test('get boolean value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {
+        myKey: '{ "value": false }',
+      },
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+    assert.equal(subject.getValue<boolean>('myKey'), false);
+  });
+
+  test('get un-set boolean value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {},
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+    assert.equal(subject.getValue<boolean>('myKey'), null);
+  });
+
+  test('set boolean value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {},
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+
+    const tag = track(() => {
+      subject._state.myKey;
+    });
+    let snapshot = valueForTag(tag);
+    assert.ok(validateTag(tag, snapshot), 'tag should be valid to start');
+
+    subject.setValue('myKey', false);
+
+    assert.strictEqual(
+      validateTag(tag, snapshot),
+      false,
+      'tag is invalidated after property is set'
+    );
+
+    assert.equal(subject.getValue<boolean>('myKey'), false);
+
+    let data = workflowPersistence.getPersistedData(ID);
+    assert.deepEqual(data, {
+      state: {
+        myKey: '{"value":false}',
+      },
+    });
+  });
+
+  test('get BigNumber value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {
+        myKey: '{ "value": "42", "type": "BN" }',
+      },
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+    assert.ok(
+      subject.getValue<BN>('myKey')?.eq(new BN('42')),
+      'returns correct BN'
+    );
+  });
+
+  test('get un-set BigNumber value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {},
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+    assert.equal(subject.getValue<BN>('myKey'), null);
+  });
+
+  test('set BiugNumber value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {},
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+
+    const tag = track(() => {
+      subject._state.myKey;
+    });
+    let snapshot = valueForTag(tag);
+    assert.ok(validateTag(tag, snapshot), 'tag should be valid to start');
+
+    subject.setValue('myKey', new BN(42));
+
+    assert.strictEqual(
+      validateTag(tag, snapshot),
+      false,
+      'tag is invalidated after property is set'
+    );
+
+    assert.ok(
+      subject.getValue<BN>('myKey')?.eq(new BN('42')),
+      'returns correct BN'
+    );
+
+    let data = workflowPersistence.getPersistedData(ID);
+    assert.deepEqual(data, {
+      state: {
+        myKey: '{"value":"42","type":"BN"}',
+      },
+    });
+  });
+
+  test('get Date value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {
+        myKey: '{ "value": "2020-09-22T20:50:18.491Z", "type": "Date" }',
+      },
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+    assert.equal(
+      subject.getValue<Date>('myKey')?.getTime(),
+      Date.UTC(2020, 8, 22, 20, 50, 18, 491),
+      'returns correct Date'
+    );
+  });
+
+  test('get un-set Date value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {},
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+    assert.equal(subject.getValue<Date>('myKey'), null);
+  });
+
+  test('set Date value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {},
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+
+    const tag = track(() => {
+      subject._state.myKey;
+    });
+    let snapshot = valueForTag(tag);
+    assert.ok(validateTag(tag, snapshot), 'tag should be valid to start');
+
+    subject.setValue('myKey', new Date(Date.UTC(2020, 8, 22, 20, 50, 18, 491)));
+
+    assert.strictEqual(
+      validateTag(tag, snapshot),
+      false,
+      'tag is invalidated after property is set'
+    );
+
+    assert.equal(
+      subject.getValue<Date>('myKey')?.getTime(),
+      Date.UTC(2020, 8, 22, 20, 50, 18, 491),
+      'returns correct Date'
+    );
+
+    let data = workflowPersistence.getPersistedData(ID);
+    assert.deepEqual(data, {
+      state: {
+        myKey: '{"value":"2020-09-22T20:50:18.491Z","type":"Date"}',
+      },
+    });
+  });
+
+  test('set string array value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {},
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+
+    const tag = track(() => {
+      subject._state.myKey;
+    });
+    let snapshot = valueForTag(tag);
+    assert.ok(validateTag(tag, snapshot), 'tag should be valid to start');
+
+    subject.setValue('myKey', ['a', 'b', 'c']);
+
+    assert.strictEqual(
+      validateTag(tag, snapshot),
+      false,
+      'tag is invalidated after property is set'
+    );
+
+    assert.deepEqual(subject.getValue<Array<string>>('myKey'), ['a', 'b', 'c']);
+
+    let data = workflowPersistence.getPersistedData(ID);
+    assert.deepEqual(data, {
+      state: {
+        myKey: '{"value":["a","b","c"]}',
+      },
+    });
+  });
+
+  test('set string record value', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData(ID, {
+      name: 'EXAMPLE',
+      state: {},
+    });
+    let subject = new WorkflowSession({
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    });
+    subject.restoreFromStorage();
+
+    const tag = track(() => {
+      subject._state.myKey;
+    });
+    let snapshot = valueForTag(tag);
+    assert.ok(validateTag(tag, snapshot), 'tag should be valid to start');
+
+    subject.setValue('myKey', { a: 'A', b: 'B', c: 'C' });
+
+    assert.strictEqual(
+      validateTag(tag, snapshot),
+      false,
+      'tag is invalidated after property   is set'
+    );
+
+    assert.deepEqual(subject.getValue<Record<string, string>>('myKey'), {
+      a: 'A',
+      b: 'B',
+      c: 'C',
+    });
+
+    let data = workflowPersistence.getPersistedData(ID);
+    assert.deepEqual(data, {
+      state: {
+        myKey: '{"value":{"a":"A","b":"B","c":"C"}}',
+      },
+    });
+  });
+
+  //TODO tests for DepotSafe type
+  //TODO tests for MerchantSafe type
+  //TODO tests for PrepaidCardSafe type
+  //TODO tests for TransactionReceipt type
 });

--- a/packages/web-client/tests/unit/models/workflow/workflow-session-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/workflow-session-test.ts
@@ -381,7 +381,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     assert.equal(subject.getValue<BN>('myKey'), null);
   });
 
-  test('set BiugNumber value', function (assert) {
+  test('set BigNumber value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
       name: 'EXAMPLE',

--- a/packages/web-client/tests/unit/services/hub-authentication-test.ts
+++ b/packages/web-client/tests/unit/services/hub-authentication-test.ts
@@ -21,6 +21,10 @@ module('Unit | Service | HubAuthentication', function (hooks) {
     layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
   });
 
+  hooks.afterEach(async function () {
+    delete window.TEST__AUTH_TOKEN;
+  });
+
   // Test initialization
   test('it can initialize with an authenticated state', async function (assert) {
     hubAuthentication = this.owner.lookup('service:hub-authentication');


### PR DESCRIPTION
This adds an explicit set of supported types that we are allowed to save to a WorkflowSession so as to guarantee that we can round-trip these values to localstorage. The set of allowed values consists of naturally JSON-serializable values along with BN and Date instances.

The PR uses a Proxy to preserve the `@workflowSession.state.*` access pattern that is convenient in templates.