### PR TITLE
log websocket events to Sentry

### DIFF
--- a/packages/web-client/app/utils/wc-provider.ts
+++ b/packages/web-client/app/utils/wc-provider.ts
@@ -15,6 +15,7 @@ import {
   IWalletConnectProviderOptions,
   IQRCodeModalOptions,
 } from '@walletconnect/types';
+import * as Sentry from '@sentry/browser';
 
 import CacheSubprovider from 'web3-provider-engine/subproviders/cache';
 import FixtureSubprovider from 'web3-provider-engine/subproviders/fixture';
@@ -80,6 +81,8 @@ class WalletConnectProvider extends ExtendedProviderEngine {
     this.rpcWss = rpcWss;
     this.chainId = chainId;
     this.websocketProvider = websocketProvider;
+    this.websocketProvider.on('close', this.onWebsocketClose.bind(this));
+    this.websocketProvider.on('connect', this.onWebsocketConnect.bind(this));
     this.bridge = opts.connector
       ? opts.connector.bridge
       : opts.bridge || 'https://bridge.walletconnect.org';
@@ -512,6 +515,39 @@ class WalletConnectProvider extends ExtendedProviderEngine {
         }
       },
     };
+  }
+
+  async onWebsocketConnect() {
+    console.log('websocket connected', this.websocketProvider.connection.url);
+    Sentry.addBreadcrumb({
+      type: 'debug',
+      message: 'Websocket connected',
+      data: {
+        url: this.websocketProvider.connection.url,
+      },
+      level: Sentry.Severity.Info,
+    });
+  }
+
+  async onWebsocketClose(event: CloseEvent) {
+    console.log('websocket closed', this.websocketProvider.connection.url);
+    Sentry.addBreadcrumb({
+      type: 'debug',
+      message: 'Websocket connection closed',
+      data: {
+        code: event.code,
+        reason: event.reason,
+        wasClean: event.wasClean,
+        url: this.websocketProvider.connection.url,
+      },
+      // unsure about 1001 since this could also happen due to server failure
+      // but also can happen due to closing the tab normally
+      // unlike other codes which will only get here after the websocket provider
+      // fails to reconnect, 1000 and 1001 will get here immediately if the closing was clean
+      level: [1000, 1001].includes(event.code)
+        ? Sentry.Severity.Info
+        : Sentry.Severity.Error,
+    });
   }
 }
 


### PR DESCRIPTION
Currently the bug in CS-1800 does not affect a large amount of users and there is little useful information in Sentry on the root cause of this issue. This PR adds some logging about websocket status changes, in hopes that we get more information about what we're trying to fix.