### PR TITLE
web: Add current card name to workflow persistence

### DIFF
--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/confirmation/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/confirmation/index.hbs
@@ -1,5 +1,5 @@
 <ActionCardContainer
-  @header="Prepaid card"
+  @header={{@displayName}}
   @isComplete={{@isComplete}}
   class="issue-prepaid-card-workflow-confirmation"
 >

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
@@ -1,6 +1,6 @@
 <ActionCardContainer
   class="face-value-card"
-  @header="Prepaid card funding"
+  @header={{@displayName}}
   @isComplete={{@isComplete}}
   {{did-insert this.prepareFaceValueOptions}}
   data-test-face-value-card

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/funding-source/index.hbs
@@ -1,5 +1,5 @@
 <ActionCardContainer
-  @header="Prepaid card funding"
+  @header={{@displayName}}
   @isComplete={{@isComplete}}
   data-test-funding-source-card
 >

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -83,6 +83,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
         new WorkflowCard({
           author: cardbot,
           cardName: 'LAYER2_CONNECT',
+          cardDisplayName: `Wallet - ${c.layer2.fullName}`,
           componentName: 'card-pay/layer-two-connect-card',
           async check() {
             let { layer2Network } = this.workflow as IssuePrepaidCardWorkflow;
@@ -124,6 +125,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
         }),
         new NetworkAwareWorkflowCard({
           cardName: 'HUB_AUTH',
+          cardDisplayName: 'Authenticate',
           author: cardbot,
           componentName: 'card-pay/hub-authentication',
           includeIf(this: NetworkAwareWorkflowCard) {
@@ -137,6 +139,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
         }),
         new WorkflowCard({
           cardName: 'LAYOUT_CUSTOMIZATION',
+          cardDisplayName: 'Layout Customization',
           author: cardbot,
           componentName:
             'card-pay/issue-prepaid-card-workflow/layout-customization',
@@ -157,6 +160,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
         }),
         new WorkflowCard({
           cardName: 'FUNDING_SOURCE',
+          cardDisplayName: 'Prepaid card funding',
           author: cardbot,
           componentName: 'card-pay/issue-prepaid-card-workflow/funding-source',
         }),
@@ -168,6 +172,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
         }),
         new WorkflowCard({
           cardName: 'FACE_VALUE',
+          cardDisplayName: 'Prepaid card funding',
           author: cardbot,
           componentName: 'card-pay/issue-prepaid-card-workflow/face-value',
         }),
@@ -184,6 +189,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
         }),
         new WorkflowCard({
           cardName: 'PREVIEW',
+          cardDisplayName: 'Prepaid card preview',
           author: cardbot,
           componentName: 'card-pay/issue-prepaid-card-workflow/preview',
         }),
@@ -198,6 +204,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
     }),
     new WorkflowCard({
       cardName: 'CONFIRMATION',
+      cardDisplayName: 'Prepaid card',
       author: cardbot,
       componentName: 'card-pay/issue-prepaid-card-workflow/confirmation',
     }),
@@ -207,11 +214,13 @@ class IssuePrepaidCardWorkflow extends Workflow {
     }),
     new WorkflowCard({
       cardName: 'EPILOGUE_LAYER_TWO_CONNECT_CARD',
+      cardDisplayName: `Wallet - ${c.layer2.fullName}`,
       author: cardbot,
       componentName: 'card-pay/layer-two-connect-card',
     }),
     new WorkflowCard({
       cardName: 'EPILOGUE_NEXT_STEPS',
+      cardDisplayName: 'Next steps',
       author: cardbot,
       componentName: 'card-pay/issue-prepaid-card-workflow/next-steps',
     }),

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/layout-customization/index.hbs
@@ -1,5 +1,5 @@
 <ActionCardContainer
-  @header="Layout Customization"
+  @header={{@displayName}}
   @isComplete={{@isComplete}}
   data-test-layout-customization-is-complete={{@isComplete}}
   class="layout-customization"

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.hbs
@@ -1,5 +1,5 @@
 <ActionCardContainer
-  @header="Prepaid card preview"
+  @header={{@displayName}}
   @isComplete={{@isComplete}}
 >
   <ActionCardContainer::Section

--- a/packages/web-client/app/components/card-pay/layer-two-connect-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-two-connect-card/index.hbs
@@ -1,6 +1,6 @@
 <ActionCardContainer
   @suppressHeader={{@suppressHeader}}
-  @header={{concat "Wallet - " (network-display-info "layer2" "fullName")}}
+  @header={{@displayName}}
   @isComplete={{@isComplete}}
   data-test-layer-2-wallet-card
   ...attributes

--- a/packages/web-client/app/components/workflow-thread/postable/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/postable/index.hbs
@@ -38,6 +38,7 @@
     }}>
       {{component
         @postable.componentName
+        displayName=@postable.cardDisplayName
         workflowSession=@postable.session
         frozen=@frozen
         onComplete=(optional @postable.onComplete)

--- a/packages/web-client/app/models/animated-workflow.ts
+++ b/packages/web-client/app/models/animated-workflow.ts
@@ -180,6 +180,10 @@ export default class AnimatedWorkflow {
     while (true) {
       let result = this.revealNext();
 
+      if (result.revealed) {
+        result.postable?.onRevealed();
+      }
+
       // the last card in these things is not completed so isComplete will never
       // be true. We check for completion by making sure all the things we need to
       // show are shown

--- a/packages/web-client/app/models/workflow/network-aware-card.ts
+++ b/packages/web-client/app/models/workflow/network-aware-card.ts
@@ -11,6 +11,7 @@ import { getOwner } from '@ember/application';
 
 interface NetworkAwareWorkflowCardOptions {
   cardName?: string;
+  cardDisplayName: string;
   author: Participant;
   componentName: string; // this should eventually become a card reference
   includeIf(this: NetworkAwareWorkflowCard): boolean;

--- a/packages/web-client/app/models/workflow/workflow-card.ts
+++ b/packages/web-client/app/models/workflow/workflow-card.ts
@@ -22,6 +22,7 @@ export type CheckResult = SuccessCheckResult | FailureCheckResult;
 
 interface WorkflowCardOptions {
   cardName?: string;
+  cardDisplayName: string;
   author: Participant;
   componentName: string; // this should eventually become a card reference
   includeIf(this: WorkflowCard): boolean;
@@ -30,6 +31,7 @@ interface WorkflowCardOptions {
 
 export class WorkflowCard extends WorkflowPostable {
   cardName: string;
+  cardDisplayName: string;
   componentName: string;
   check: (this: WorkflowCard) => Promise<CheckResult> = () => {
     return Promise.resolve({ success: true });
@@ -39,6 +41,7 @@ export class WorkflowCard extends WorkflowPostable {
     super(options.author!, options.includeIf);
     this.componentName = options.componentName!;
     this.cardName = options.cardName || '';
+    this.cardDisplayName = options.cardDisplayName || '';
 
     this.reset = () => {
       if (this.isComplete) {
@@ -57,7 +60,10 @@ export class WorkflowCard extends WorkflowPostable {
   }
 
   onRevealed() {
-    this.session?.update('currentCardName', this.cardName);
+    this.session?.updateMany({
+      currentCardName: this.cardName,
+      currentCardDisplayName: this.cardDisplayName,
+    });
   }
 
   @action async onComplete() {

--- a/packages/web-client/app/models/workflow/workflow-card.ts
+++ b/packages/web-client/app/models/workflow/workflow-card.ts
@@ -56,6 +56,10 @@ export class WorkflowCard extends WorkflowPostable {
     return this.session?.state.completedCardNames ?? [];
   }
 
+  onRevealed() {
+    this.session?.update('currentCardName', this.cardName);
+  }
+
   @action async onComplete() {
     if (this.isComplete) return;
     let checkResult = await this.check();

--- a/packages/web-client/app/models/workflow/workflow-postable.ts
+++ b/packages/web-client/app/models/workflow/workflow-postable.ts
@@ -22,4 +22,5 @@ export class WorkflowPostable {
   includeIf: (() => boolean) | undefined;
   reset: (() => void) | undefined;
   failureReason: string | undefined;
+  onRevealed() {}
 }

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -359,6 +359,20 @@ module('Acceptance | issue prepaid card', function (hooks) {
     await waitFor(milestoneCompletedSel(2));
     assert.dom(milestoneCompletedSel(2)).containsText('Face value chosen');
 
+    let workflowPersistenceService = this.owner.lookup(
+      'service:workflow-persistence'
+    ) as WorkflowPersistence;
+
+    const workflowPersistenceId = new URL(
+      'http://domain.test/' + currentURL()
+    ).searchParams.get('flow-id')!;
+
+    assert.equal(
+      workflowPersistenceService.getPersistedData(workflowPersistenceId).state
+        .currentCardName,
+      'PREVIEW'
+    );
+
     assert
       .dom(postableSel(3, 0))
       .containsText('This is what your prepaid card will look like.');
@@ -504,14 +518,6 @@ module('Acceptance | issue prepaid card', function (hooks) {
 
     await waitFor(epiloguePostableSel(4));
 
-    let workflowPersistenceService = this.owner.lookup(
-      'service:workflow-persistence'
-    ) as WorkflowPersistence;
-
-    const workflowPersistenceId = new URL(
-      'http://domain.test/' + currentURL()
-    ).searchParams.get('flow-id')!;
-
     assert
       .dom(
         `${epiloguePostableSel(
@@ -554,6 +560,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
         'EPILOGUE_LAYER_TWO_CONNECT_CARD',
       ],
       completedMilestonesCount: 4,
+      currentCardName: 'EPILOGUE_NEXT_STEPS',
       did: 'did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e',
       issuerName: 'JJ',
       layer2WalletAddress: '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44',

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -367,11 +367,12 @@ module('Acceptance | issue prepaid card', function (hooks) {
       'http://domain.test/' + currentURL()
     ).searchParams.get('flow-id')!;
 
-    assert.equal(
-      workflowPersistenceService.getPersistedData(workflowPersistenceId).state
-        .currentCardName,
-      'PREVIEW'
-    );
+    let persistedState = workflowPersistenceService.getPersistedData(
+      workflowPersistenceId
+    ).state;
+
+    assert.equal(persistedState.currentCardName, 'PREVIEW');
+    assert.equal(persistedState.currentCardDisplayName, 'Prepaid card preview');
 
     assert
       .dom(postableSel(3, 0))
@@ -539,7 +540,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
     );
 
     assert.equal(persistedData.name, 'PREPAID_CARD_ISSUANCE');
-    let persistedState = persistedData.state;
+    persistedState = persistedData.state;
     delete persistedState.prepaidCardSafe.createdAt;
 
     assert.deepEqual(persistedState, {
@@ -561,6 +562,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
       ],
       completedMilestonesCount: 4,
       currentCardName: 'EPILOGUE_NEXT_STEPS',
+      currentCardDisplayName: 'Next steps',
       did: 'did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e',
       issuerName: 'JJ',
       layer2WalletAddress: '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44',


### PR DESCRIPTION
The design for #2127 workflow restoration includes display names for the persisted workflow and its current card, as well as a progress indicator for how many milestones have been completed. The current persistence scheme includes a `name` and `state.{completedMilestonesCount,milestonesCount}` that are sufficient to render everything but the current card name. At first I tried reconstructing the workflow from the persisted state to calculate the current card but it was brittle and wasteful, so this has `WorkflowCard`s store their names in the session upon `reveal` instead.

I’m unsure whether `onRevealed` makes sense and whether assuming an `AnimatedWorkflow` is okay.

This only stores the internal `name` so far, I’ll be extracting display names from templates… 😯