### PR TITLE
Add min validation to dapp merchant payment page for SPEND and USD

### DIFF
--- a/packages/cardpay-sdk/sdk/do-not-use-on-chain-constants.ts
+++ b/packages/cardpay-sdk/sdk/do-not-use-on-chain-constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Do not use this constant where possible, instead use PrepaidCard.getPaymentLimits
+ * This constant is here because it is used in a page where PrepaidCard.getPaymentLimits cannot
+ * be called as there is no web3 connection
+ */
+export const MIN_PAYMENT_AMOUNT_IN_SPEND = 50;

--- a/packages/web-client/app/controllers/pay.ts
+++ b/packages/web-client/app/controllers/pay.ts
@@ -14,6 +14,10 @@ import { useResource } from 'ember-resources';
 import { MerchantInfo } from '../resources/merchant-info';
 import config from '@cardstack/web-client/config/environment';
 import { formatAmount } from '../helpers/format-amount';
+import { MIN_PAYMENT_AMOUNT_IN_SPEND } from '@cardstack/cardpay-sdk/sdk/do-not-use-on-chain-constants';
+
+const minSpendAmount = MIN_PAYMENT_AMOUNT_IN_SPEND;
+const minUsdAmount = spendToUsd(minSpendAmount)!;
 
 export default class CardPayMerchantServicesController extends Controller {
   @service('is-ios') declare isIOSService: IsIOS;
@@ -50,7 +54,7 @@ export default class CardPayMerchantServicesController extends Controller {
         },
       };
     } else if (this.currency === 'SPD') {
-      let amount = Math.ceil(this.amount);
+      let amount = Math.max(Math.ceil(this.amount), minSpendAmount);
       return {
         amount,
         displayed: {
@@ -62,8 +66,9 @@ export default class CardPayMerchantServicesController extends Controller {
         },
       };
     } else if (this.currency === 'USD') {
-      let amount = Number(
-        roundAmountToNativeCurrencyDecimals(this.amount, 'USD')
+      let amount = Math.max(
+        Number(roundAmountToNativeCurrencyDecimals(this.amount, 'USD')),
+        minUsdAmount
       );
       return {
         amount,

--- a/packages/web-client/tests/acceptance/pay-test.ts
+++ b/packages/web-client/tests/acceptance/pay-test.ts
@@ -94,10 +94,9 @@ module('Acceptance | pay', function (hooks) {
     });
   });
 
-  test('it renders correctly with SPD as currency', async function (assert) {
-    await visit(
-      `/pay/${network}/${merchantSafe.address}?amount=${spendAmount}&currency=${spendSymbol}`
-    );
+  test('It displays merchant info correctly in a non-iOS environment', async function (assert) {
+    await visit(`/pay/${network}/${merchantSafe.address}`);
+
     await waitFor(MERCHANT);
 
     assert.dom(MERCHANT).hasAttribute('data-test-merchant', merchantName);
@@ -111,6 +110,33 @@ module('Acceptance | pay', function (hooks) {
         'data-test-merchant-logo-text-color',
         merchantInfoTextColor
       );
+  });
+
+  test('It displays merchant info correctly on iOS', async function (assert) {
+    let isIOSService = this.owner.lookup('service:is-ios');
+    sinon.stub(isIOSService, 'isIOS').returns(true);
+
+    await visit(`/pay/${network}/${merchantSafe.address}`);
+    await waitFor(MERCHANT);
+
+    assert.dom(MERCHANT).hasAttribute('data-test-merchant', merchantName);
+    assert
+      .dom(MERCHANT_LOGO)
+      .hasAttribute(
+        'data-test-merchant-logo-background',
+        merchantInfoBackground
+      )
+      .hasAttribute(
+        'data-test-merchant-logo-text-color',
+        merchantInfoTextColor
+      );
+  });
+
+  test('it renders correctly with SPD as currency', async function (assert) {
+    await visit(
+      `/pay/${network}/${merchantSafe.address}?amount=${spendAmount}&currency=${spendSymbol}`
+    );
+
     assert.dom(AMOUNT).containsText(`§${spendAmount}`);
     assert
       .dom(SECONDARY_AMOUNT)
@@ -318,19 +344,6 @@ module('Acceptance | pay', function (hooks) {
     await visit(
       `/pay/${network}/${merchantSafe.address}?amount=${spendAmount}&currrency=${spendSymbol}`
     );
-    await waitFor(MERCHANT);
-
-    assert.dom(MERCHANT).hasAttribute('data-test-merchant', merchantName);
-    assert
-      .dom(MERCHANT_LOGO)
-      .hasAttribute(
-        'data-test-merchant-logo-background',
-        merchantInfoBackground
-      )
-      .hasAttribute(
-        'data-test-merchant-logo-text-color',
-        merchantInfoTextColor
-      );
 
     assert.dom(AMOUNT).containsText(`§${spendAmount}`);
     assert

--- a/packages/web-client/tests/acceptance/pay-test.ts
+++ b/packages/web-client/tests/acceptance/pay-test.ts
@@ -135,19 +135,7 @@ module('Acceptance | pay', function (hooks) {
     await visit(
       `/pay/${network}/${merchantSafe.address}?amount=${floatingSpendAmount}&currency=${spendSymbol}`
     );
-    await waitFor(MERCHANT);
 
-    assert.dom(MERCHANT).hasAttribute('data-test-merchant', merchantName);
-    assert
-      .dom(MERCHANT_LOGO)
-      .hasAttribute(
-        'data-test-merchant-logo-background',
-        merchantInfoBackground
-      )
-      .hasAttribute(
-        'data-test-merchant-logo-text-color',
-        merchantInfoTextColor
-      );
     assert.dom(AMOUNT).containsText(`§${roundedSpendAmount}`);
     assert
       .dom(SECONDARY_AMOUNT)
@@ -173,19 +161,7 @@ module('Acceptance | pay', function (hooks) {
     await visit(
       `/pay/${network}/${merchantSafe.address}?amount=${lessThanMinSpendAmount}&currency=${spendSymbol}`
     );
-    await waitFor(MERCHANT);
 
-    assert.dom(MERCHANT).hasAttribute('data-test-merchant', merchantName);
-    assert
-      .dom(MERCHANT_LOGO)
-      .hasAttribute(
-        'data-test-merchant-logo-background',
-        merchantInfoBackground
-      )
-      .hasAttribute(
-        'data-test-merchant-logo-text-color',
-        merchantInfoTextColor
-      );
     assert.dom(AMOUNT).containsText(`§${minSpendAmount}`);
     assert
       .dom(SECONDARY_AMOUNT)
@@ -206,19 +182,7 @@ module('Acceptance | pay', function (hooks) {
     await visit(
       `/pay/${network}/${merchantSafe.address}?amount=${spendAmount}`
     );
-    await waitFor(MERCHANT);
 
-    assert.dom(MERCHANT).hasAttribute('data-test-merchant', merchantName);
-    assert
-      .dom(MERCHANT_LOGO)
-      .hasAttribute(
-        'data-test-merchant-logo-background',
-        merchantInfoBackground
-      )
-      .hasAttribute(
-        'data-test-merchant-logo-text-color',
-        merchantInfoTextColor
-      );
     assert.dom(AMOUNT).containsText(`§${spendAmount}`);
     assert
       .dom(SECONDARY_AMOUNT)
@@ -240,19 +204,7 @@ module('Acceptance | pay', function (hooks) {
     await visit(
       `/pay/${network}/${merchantSafe.address}?amount=${usdAmount}&currency=${usdSymbol}`
     );
-    await waitFor(MERCHANT);
 
-    assert.dom(MERCHANT).hasAttribute('data-test-merchant', merchantName);
-    assert
-      .dom(MERCHANT_LOGO)
-      .hasAttribute(
-        'data-test-merchant-logo-background',
-        merchantInfoBackground
-      )
-      .hasAttribute(
-        'data-test-merchant-logo-text-color',
-        merchantInfoTextColor
-      );
     assert
       .dom(AMOUNT)
       .containsText(
@@ -274,19 +226,7 @@ module('Acceptance | pay', function (hooks) {
     await visit(
       `/pay/${network}/${merchantSafe.address}?amount=${lessThanMinUsdAmount}&currency=${usdSymbol}`
     );
-    await waitFor(MERCHANT);
 
-    assert.dom(MERCHANT).hasAttribute('data-test-merchant', merchantName);
-    assert
-      .dom(MERCHANT_LOGO)
-      .hasAttribute(
-        'data-test-merchant-logo-background',
-        merchantInfoBackground
-      )
-      .hasAttribute(
-        'data-test-merchant-logo-text-color',
-        merchantInfoTextColor
-      );
     assert
       .dom(AMOUNT)
       .containsText(convertAmountToNativeDisplay(minUsdAmount, 'USD'));
@@ -313,19 +253,6 @@ module('Acceptance | pay', function (hooks) {
     await visit(
       `/pay/${network}/${merchantSafe.address}?amount=${jpyAmount}&currency=${jpySymbol}`
     );
-    await waitFor(MERCHANT);
-
-    assert.dom(MERCHANT).hasAttribute('data-test-merchant', merchantName);
-    assert
-      .dom(MERCHANT_LOGO)
-      .hasAttribute(
-        'data-test-merchant-logo-background',
-        merchantInfoBackground
-      )
-      .hasAttribute(
-        'data-test-merchant-logo-text-color',
-        merchantInfoTextColor
-      );
 
     assert
       .dom(AMOUNT)
@@ -347,19 +274,6 @@ module('Acceptance | pay', function (hooks) {
     await visit(
       `/pay/${network}/${merchantSafe.address}?amount=300&currency=${invalidCurrencySymbol}`
     );
-    await waitFor(MERCHANT);
-
-    assert.dom(MERCHANT).hasAttribute('data-test-merchant', merchantName);
-    assert
-      .dom(MERCHANT_LOGO)
-      .hasAttribute(
-        'data-test-merchant-logo-background',
-        merchantInfoBackground
-      )
-      .hasAttribute(
-        'data-test-merchant-logo-text-color',
-        merchantInfoTextColor
-      );
 
     assert.dom(AMOUNT).doesNotExist();
     assert.dom(SECONDARY_AMOUNT).doesNotExist();
@@ -382,19 +296,6 @@ module('Acceptance | pay', function (hooks) {
     await visit(
       `/pay/${network}/${merchantSafe.address}?amount=30a&currency=${spendSymbol}`
     );
-    await waitFor(MERCHANT);
-
-    assert.dom(MERCHANT).hasAttribute('data-test-merchant', merchantName);
-    assert
-      .dom(MERCHANT_LOGO)
-      .hasAttribute(
-        'data-test-merchant-logo-background',
-        merchantInfoBackground
-      )
-      .hasAttribute(
-        'data-test-merchant-logo-text-color',
-        merchantInfoTextColor
-      );
 
     assert.dom(AMOUNT).doesNotExist();
     assert.dom(SECONDARY_AMOUNT).doesNotExist();


### PR DESCRIPTION
Adds an on-chain constant that is unlikely to change anytime soon, uses said constant in the `pay` page to set USD and SPEND amounts to the minimum amount if they are less than the minimum.