### PR TITLE
Prevent Boxel CI from deploying previews and posting a comment for root package changes (eg. yarn.lock).

### DIFF
--- a/.github/workflows/pr-boxel.yml
+++ b/.github/workflows/pr-boxel.yml
@@ -56,13 +56,30 @@ jobs:
         run: yarn test:boxel:try $EMBER_TRY_SCENARIO
         timeout-minutes: 10
 
+  check-if-requires-preview:
+    name: Check if a preview deploy is required
+    runs-on: ubuntu-latest
+    needs: try-scenarios
+    outputs:
+      boxel-files-changed: ${{ steps.boxel-files-that-changed.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get boxel files that changed
+        id: boxel-files-that-changed
+        uses: tj-actions/changed-files@v1.1.2
+        with:
+          files: |
+            ^packages/boxel
+
   deploy-boxel-preview:
     name: Deploy a preview to S3
     runs-on: ubuntu-latest
     # github.event.pull_request.head.repo.full_name == github.repository: true if pr is from the original repo, false if it's from a fork
     # github.head_ref: the branch that the pull request is from. only appears on pull_request events
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref
-    needs: try-scenarios
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref && needs.check-if-requires-preview.outputs.boxel-files-changed == 'true'
+    needs: check-if-requires-preview
     env:
       S3_PREVIEW_INDEX_BUCKET_NAME: boxel-preview.cardstack.com
       S3_PREVIEW_ASSET_BUCKET_NAME: boxel-preview-assets.cardstack.com


### PR DESCRIPTION
It will only deploy a preview and post if something inside Boxel has changed. This does mean we still post a preview when releasing a new version (possible to refine further, I think).