### PR TITLE
Add reward subgraph events

### DIFF
--- a/packages/cardpay-sdk/contracts/abi/v0.8.0/register-reward-program-handler.ts
+++ b/packages/cardpay-sdk/contracts/abi/v0.8.0/register-reward-program-handler.ts
@@ -1,0 +1,281 @@
+export default [
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'previousOwner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnershipTransferred',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'prepaidCard',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'issuingToken',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'issuingTokenAmount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'spendAmount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'admin',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+    ],
+    name: 'RewardProgramRegistrationFee',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [],
+    name: 'Setup',
+    type: 'event',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'actionDispatcher',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'cardpayVersion',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    payable: false,
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'exchangeAddress',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+    ],
+    name: 'initialize',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'isOwner',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'owner',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [],
+    name: 'renounceOwnership',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'rewardManagerAddress',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'tokenManagerAddress',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'transferOwnership',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_actionDispatcher',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_exchangeAddress',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_tokenManagerAddress',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_rewardManagerAddress',
+        type: 'address',
+      },
+    ],
+    name: 'setup',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address payable',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes',
+        name: 'data',
+        type: 'bytes',
+      },
+    ],
+    name: 'onTokenTransfer',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+];

--- a/packages/cardpay-sdk/contracts/abi/v0.8.0/register-rewardee-handler.ts
+++ b/packages/cardpay-sdk/contracts/abi/v0.8.0/register-rewardee-handler.ts
@@ -1,0 +1,295 @@
+export default [
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'previousOwner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnershipTransferred',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'prepaidCard',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'issuingToken',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'issuingTokenAmount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'spendAmount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'rewardProgramID',
+        type: 'address',
+      },
+    ],
+    name: 'RewardeeRegistrationFee',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [],
+    name: 'Setup',
+    type: 'event',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'actionDispatcher',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'cardpayVersion',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    payable: false,
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'exchangeAddress',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+    ],
+    name: 'initialize',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'isOwner',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'owner',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'prepaidCardManager',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [],
+    name: 'renounceOwnership',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'rewardManagerAddress',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'tokenManagerAddress',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'transferOwnership',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_actionDispatcher',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_prepaidCardManager',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_exchangeAddress',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_tokenManagerAddress',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_rewardManagerAddress',
+        type: 'address',
+      },
+    ],
+    name: 'setup',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address payable',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes',
+        name: 'data',
+        type: 'bytes',
+      },
+    ],
+    name: 'onTokenTransfer',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+];

--- a/packages/cardpay-sdk/contracts/addresses.ts
+++ b/packages/cardpay-sdk/contracts/addresses.ts
@@ -95,6 +95,9 @@ const XDAI = {
   uniswapV2Router: '0x1C232F01118CB8B424793ae03F870aa7D0ac7f77', // This is the UniswapV2Router02
   uniswapV2Factory: '0xA818b4F111Ccac7AA31D0BCc0806d64F2E0737D7',
   rewardPool: '0x42628325845B3e01EfdD6ce4b3665453dC6c9A13',
+  // rewardManager: '',
+  // registerRewardProgramHandler: '',
+  // registerRewardeeHandler: '',
   deprecatedMerchantManager_v0_6_7: '0x3C29B2A563F4bB9D625175bE823c528A4Ddd1107', // eslint-disable-line @typescript-eslint/naming-convention
   oracles: {
     DAI: '0x36698BF676c40be119b0Fe4f964f4527943258F2', // eslint-disable-line @typescript-eslint/naming-convention

--- a/packages/cardpay-sdk/contracts/addresses.ts
+++ b/packages/cardpay-sdk/contracts/addresses.ts
@@ -53,6 +53,8 @@ const SOKOL = {
   uniswapV2Factory: '0x6b67f08F08B715B162aa09239488318A660F24BF',
   rewardPool: '0x2D23acfEA32492911E8DF12E697AF0013B8D4E7b',
   rewardManager: '0x9A89A110238201c12568f3a4a02BE5Ae63284497',
+  registerRewardProgramHandler: '0xaF5B2869Be9Eb9c45cc0501F17B145A3229dD2C0',
+  registerRewardeeHandler: '0x0B793A280F2E47997432a9047073F5e634A9A731',
   deprecatedMerchantManager_v0_6_7: '0xA113ECa0Af275e1906d1fe1B7Bef1dDB033113E2', // eslint-disable-line @typescript-eslint/naming-convention
   oracles: {
     DAI: '0x74beF86c9d4a5b96B81D8d8e44157DFd35Eda5fB', // eslint-disable-line @typescript-eslint/naming-convention

--- a/packages/cardpay-sdk/contracts/addresses.ts
+++ b/packages/cardpay-sdk/contracts/addresses.ts
@@ -95,9 +95,6 @@ const XDAI = {
   uniswapV2Router: '0x1C232F01118CB8B424793ae03F870aa7D0ac7f77', // This is the UniswapV2Router02
   uniswapV2Factory: '0xA818b4F111Ccac7AA31D0BCc0806d64F2E0737D7',
   rewardPool: '0x42628325845B3e01EfdD6ce4b3665453dC6c9A13',
-  rewardManager: '',
-  registerRewardProgramHandler: '',
-  registerRewardeeHandler: '',
   deprecatedMerchantManager_v0_6_7: '0x3C29B2A563F4bB9D625175bE823c528A4Ddd1107', // eslint-disable-line @typescript-eslint/naming-convention
   oracles: {
     DAI: '0x36698BF676c40be119b0Fe4f964f4527943258F2', // eslint-disable-line @typescript-eslint/naming-convention

--- a/packages/cardpay-sdk/contracts/addresses.ts
+++ b/packages/cardpay-sdk/contracts/addresses.ts
@@ -91,6 +91,9 @@ const XDAI = {
   uniswapV2Router: '0x1C232F01118CB8B424793ae03F870aa7D0ac7f77', // This is the UniswapV2Router02
   uniswapV2Factory: '0xA818b4F111Ccac7AA31D0BCc0806d64F2E0737D7',
   rewardPool: '0x42628325845B3e01EfdD6ce4b3665453dC6c9A13',
+  rewardManager: '',
+  registerRewardProgramHandler: '',
+  registerRewardeeHandler: '',
   deprecatedMerchantManager_v0_6_7: '0x3C29B2A563F4bB9D625175bE823c528A4Ddd1107', // eslint-disable-line @typescript-eslint/naming-convention
   oracles: {
     DAI: '0x36698BF676c40be119b0Fe4f964f4527943258F2', // eslint-disable-line @typescript-eslint/naming-convention

--- a/packages/cardpay-sdk/contracts/addresses.ts
+++ b/packages/cardpay-sdk/contracts/addresses.ts
@@ -95,9 +95,9 @@ const XDAI = {
   uniswapV2Router: '0x1C232F01118CB8B424793ae03F870aa7D0ac7f77', // This is the UniswapV2Router02
   uniswapV2Factory: '0xA818b4F111Ccac7AA31D0BCc0806d64F2E0737D7',
   rewardPool: '0x42628325845B3e01EfdD6ce4b3665453dC6c9A13',
-  // rewardManager: '',
-  // registerRewardProgramHandler: '',
-  // registerRewardeeHandler: '',
+  rewardManager: '',
+  registerRewardProgramHandler: '',
+  registerRewardeeHandler: '',
   deprecatedMerchantManager_v0_6_7: '0x3C29B2A563F4bB9D625175bE823c528A4Ddd1107', // eslint-disable-line @typescript-eslint/naming-convention
   oracles: {
     DAI: '0x36698BF676c40be119b0Fe4f964f4527943258F2', // eslint-disable-line @typescript-eslint/naming-convention

--- a/packages/cardpay-sdk/contracts/addresses.ts
+++ b/packages/cardpay-sdk/contracts/addresses.ts
@@ -12,6 +12,8 @@ import SplitPrepaidCardHandlerABI from './abi/v0.8.0/split-prepaid-card-handler'
 import SpendABI from './abi/v0.8.0/spend';
 import MerchantManagerABI from './abi/v0.8.0/merchant-manager';
 import DeprecatedMerchantManagerABI_0_6_7 from './abi/v0.8.0/deprecated-merchant-manager-0_6_7';
+import RegisterRewardProgramHandlerABI from './abi/v0.8.0/register-reward-program-handler';
+import RegisterRewardeeHandlerABI from './abi/v0.8.0/register-rewardee-handler';
 function consumeModule(_module: any) {}
 consumeModule(PayMerchantHandlerABI);
 consumeModule(RegisterMerchantHandlerABI);
@@ -21,6 +23,8 @@ consumeModule(SpendABI);
 consumeModule(MerchantManagerABI);
 // we include this because we are still interested in indexing events from this contract
 consumeModule(DeprecatedMerchantManagerABI_0_6_7);
+consumeModule(RegisterRewardProgramHandlerABI);
+consumeModule(RegisterRewardeeHandlerABI);
 
 const KOVAN = {
   cardToken: '0xd6E34821F508e4247Db359CFceE0cb5e8050972a',

--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -187,7 +187,7 @@ export default class RewardPool {
     let from = contractOptions?.from ?? (await this.layer2Web3.eth.getAccounts())[0];
     let token = new this.layer2Web3.eth.Contract(ERC677ABI as AbiItem[], tokenAddress);
     let symbol = await token.methods.symbol().call();
-    let balance = new BN(toWei(await token.methods.balanceOf(safeAddress).call()));
+    let balance = new BN(await token.methods.balanceOf(safeAddress).call());
     let weiAmount = new BN(toWei(amount));
     if (balance.lt(weiAmount)) {
       throw new Error(

--- a/packages/cardpay-sdk/sdk/safes/base.ts
+++ b/packages/cardpay-sdk/sdk/safes/base.ts
@@ -117,7 +117,7 @@ const safeQueryFields = `
     rewardee {
       id
     }
-}
+  }
 `;
 
 const safeQuery = `
@@ -185,7 +185,7 @@ export default class Safes {
           result.push(safeResult);
         } else if (safeResult.type === 'prepaid-card' && safeResult.spendFaceValue > 0) {
           result.push(safeResult);
-        } else if (safeResult.type === 'merchant' || safeResult.type === 'depot') {
+        } else if (safeResult.type === 'merchant' || safeResult.type === 'depot' || safeResult.type === 'reward') {
           result.push(safeResult);
         }
       }

--- a/packages/cardpay-sdk/sdk/safes/base.ts
+++ b/packages/cardpay-sdk/sdk/safes/base.ts
@@ -12,7 +12,7 @@ import { TransactionReceipt } from 'web3-core';
 import { TransactionOptions, waitUntilTransactionMined, isTransactionHash } from '../utils/general-utils';
 const { fromWei } = Web3.utils;
 
-export type Safe = DepotSafe | PrepaidCardSafe | MerchantSafe | ExternalSafe;
+export type Safe = DepotSafe | PrepaidCardSafe | MerchantSafe | RewardSafe | ExternalSafe;
 interface BaseSafe {
   address: string;
   createdAt: number;
@@ -29,6 +29,12 @@ export interface MerchantSafe extends BaseSafe {
   merchant: string;
   infoDID?: string;
 }
+
+export interface RewardSafe extends BaseSafe {
+  type: 'reward';
+  rewardProgramId: string;
+}
+
 export interface ExternalSafe extends BaseSafe {
   type: 'external';
 }
@@ -105,6 +111,13 @@ const safeQueryFields = `
       id
     }
   }
+  reward {
+    id
+    rewardProgramID
+    rewardee {
+      id
+    }
+}
 `;
 
 const safeQuery = `
@@ -398,6 +411,13 @@ interface GraphQLSafeResult {
       id: string;
     };
   };
+  reward: {
+    id: string;
+    rewardProgramId: string;
+    rewardee: {
+      id: string;
+    };
+  };
 }
 
 function processSafeResult(safe: GraphQLSafeResult): Safe | undefined {
@@ -467,6 +487,16 @@ function processSafeResult(safe: GraphQLSafeResult): Safe | undefined {
       owners,
     };
     return prepaidCard;
+  } else if (safe.reward) {
+    let reward: RewardSafe = {
+      type: 'reward',
+      address: safe.reward.id,
+      rewardProgramId: safe.reward.rewardProgramId,
+      tokens,
+      createdAt,
+      owners,
+    };
+    return reward;
   } else {
     let externalSafe: ExternalSafe = {
       type: 'external',

--- a/packages/cardpay-sdk/sdk/safes/base.ts
+++ b/packages/cardpay-sdk/sdk/safes/base.ts
@@ -113,7 +113,6 @@ const safeQueryFields = `
   }
   reward {
     id
-    rewardProgramID
     rewardee {
       id
     }

--- a/packages/cardpay-subgraph/etc/pre-codegen.js
+++ b/packages/cardpay-subgraph/etc/pre-codegen.js
@@ -65,6 +65,10 @@ let abis = {
   SupplierManager: getAbi(join(sourceAbiDir, 'supplier-manager.ts')),
   Exchange: getAbi(join(sourceAbiDir, 'exchange.ts')),
   DeprecatedMerchantManager_v0_6_7: getAbi(join(sourceAbiDir, 'deprecated-merchant-manager-0_6_7.ts')),
+  RewardPool: getAbi(join(sourceAbiDir, 'reward-pool.ts')),
+  RewardManager: getAbi(join(sourceAbiDir, 'reward-manager.ts')),
+  RegisterRewardProgramHandler: getAbi(join(sourceAbiDir, 'register-reward-program-handler.ts')),
+  RegisterRewardeeHandler: getAbi(join(sourceAbiDir, 'register-rewardee-handler')),
 };
 
 removeSync(abiDir);
@@ -103,7 +107,11 @@ let subgraph = readFileSync(subgraphTemplateFile, { encoding: 'utf8' })
   .replace(
     /{DEPRECATED_MERCHANT_MANAGER_v0_6_7_ADDRESS}/g,
     getAddress('deprecatedMerchantManager_v0_6_7', cleanNetwork)
-  );
+  )
+  .replace(/{REWARD_POOL_ADDRESS}/g, getAddress('rewardPool', cleanNetwork))
+  .replace(/{REWARD_MANAGER_ADDRESS}/g, getAddress('rewardManager', cleanNetwork))
+  .replace(/{REGISTER_REWARD_PROGRAM_HANDLER_ADDRESS}/g, getAddress('registerRewardProgramHandler', cleanNetwork))
+  .replace(/{REGISTER_REWARDEE_HANDLER_ADDRESS}/g, getAddress('registerRewardeeHandler', cleanNetwork));
 
 removeSync(subgraphFile);
 writeFileSync(subgraphFile, subgraph);

--- a/packages/cardpay-subgraph/etc/pre-codegen.js
+++ b/packages/cardpay-subgraph/etc/pre-codegen.js
@@ -68,7 +68,7 @@ let abis = {
   RewardPool: getAbi(join(sourceAbiDir, 'reward-pool.ts')),
   RewardManager: getAbi(join(sourceAbiDir, 'reward-manager.ts')),
   RegisterRewardProgramHandler: getAbi(join(sourceAbiDir, 'register-reward-program-handler.ts')),
-  RegisterRewardeeHandler: getAbi(join(sourceAbiDir, 'register-rewardee-handler')),
+  RegisterRewardeeHandler: getAbi(join(sourceAbiDir, 'register-rewardee-handler.ts')),
 };
 
 removeSync(abiDir);

--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -397,6 +397,7 @@ type Transaction @entity {
   spendAccumulations: [SpendAccumulation]!         @derivedFrom(field: "transaction")
   merchantFeePayments: [MerchantFeePayment]!       @derivedFrom(field: "transaction")
   merchantClaims: [MerchantClaim]!                 @derivedFrom(field: "transaction")
+  rewardClaims: [RewardeeClaim]!                   @derivedFrom(field: "transaction")
   merchantRevenueEvents: [MerchantRevenueEvent]!   @derivedFrom(field: "transaction")
   tokenSwaps: [TokenSwap]!                         @derivedFrom(field: "transaction")
   prepaidCardInventoryEvents: [PrepaidCardInventoryEvent]! @derivedFrom(field: "transaction")

--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -312,7 +312,7 @@ type Safe @entity {
   safeTxns: [SafeTransaction]!              @derivedFrom(field: "safe")
   depot: Depot                              @derivedFrom(field: "safe")
   merchant: MerchantSafe                    @derivedFrom(field: "safe")
-  rewardee: RewardSafe                      @derivedFrom(field: "safe")
+  reward: RewardSafe                      @derivedFrom(field: "safe")
   prepaidCard: PrepaidCard                  @derivedFrom(field: "safe")
   tokens: [TokenHolder]!                    @derivedFrom(field: "safe")
   sentBridgedTokens: [BridgeToLayer1Event]! @derivedFrom(field: "safe")
@@ -465,7 +465,7 @@ type RewardProgramRegistrationPayment @entity {
   admin: Account!
   transaction: Transaction!
   createdAt: BigInt!
-  prepaidCardPayment: PrepaidCardPayment! #remember to add bang here
+  prepaidCardPayment: PrepaidCardPayment!
 }
 
 type RewardeeRegistrationPayment @entity {
@@ -474,7 +474,7 @@ type RewardeeRegistrationPayment @entity {
   rewardee: Account!
   transaction: Transaction!
   createdAt: BigInt!
-  prepaidCardPayment: PrepaidCardPayment! #remember to add bang here
+  prepaidCardPayment: PrepaidCardPayment!
 }
 
 type RewardSafe @entity {
@@ -488,7 +488,7 @@ type RewardeeClaim @entity {
   id: ID!
   rewardProgramID: String!
   rewardee: Account!
-  rewardSafe: RewardSafe! #remember to add bang here
+  rewardSafe: RewardSafe!
   amount: BigInt!
   transaction: Transaction!
   timestamp: BigInt!

--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -460,8 +460,17 @@ type TokenPair @entity {
 
 type RewardProgramRegistrationPayment @entity {
   id: ID!
-  admin: Account!
   rewardProgramID: String!
+  admin: Account!
+  transaction: Transaction!
+  createdAt: BigInt!
+  prepaidCardPayment: PrepaidCardPayment #remember to add bang here
+}
+
+type RewardeeRegistrationPayment @entity {
+  id: ID!
+  rewardProgramID: String!
+  rewardee: Account!
   transaction: Transaction!
   createdAt: BigInt!
   prepaidCardPayment: PrepaidCardPayment #remember to add bang here

--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -103,6 +103,7 @@ type PrepaidCardPayment @entity {
   historicPrepaidCardIssuingTokenBalance: BigInt!
   merchantRegistrationPayments: [MerchantRegistrationPayment]! @derivedFrom(field: "prepaidCardPayment")
   rewardProgramRegistrationPayments: [RewardProgramRegistrationPayment]! @derivedFrom(field: "prepaidCardPayment")
+  rewardeeRegistrationPayments: [RewardeeRegistrationPayment]! @derivedFrom(field: "prepaidCardPayment")
 }
 
 type PrepaidCardSplit @entity {

--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -101,6 +101,7 @@ type PrepaidCardPayment @entity {
   historicPrepaidCardFaceValue: BigInt!
   historicPrepaidCardIssuingTokenBalance: BigInt!
   merchantRegistrationPayments: [MerchantRegistrationPayment]! @derivedFrom(field: "prepaidCardPayment")
+  rewardProgramRegistrationPayments: [RewardProgramRegistrationPayment]! @derivedFrom(field: "prepaidCardPayment")
 }
 
 type PrepaidCardSplit @entity {
@@ -456,3 +457,13 @@ type TokenPair @entity {
   token1: Token!
   swaps: [TokenSwap]!             @derivedFrom(field: "tokenPair")
 }
+
+type RewardProgramRegistrationPayment @entity {
+  id: ID!
+  admin: Account!
+  transaction: Transaction!
+  createdAt: BigInt!
+  prepaidCardPayment: PrepaidCardPayment
+  paidWith: PrepaidCard
+}
+

--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -312,6 +312,7 @@ type Safe @entity {
   safeTxns: [SafeTransaction]!              @derivedFrom(field: "safe")
   depot: Depot                              @derivedFrom(field: "safe")
   merchant: MerchantSafe                    @derivedFrom(field: "safe")
+  rewardee: RewardSafe                      @derivedFrom(field: "safe")
   prepaidCard: PrepaidCard                  @derivedFrom(field: "safe")
   tokens: [TokenHolder]!                    @derivedFrom(field: "safe")
   sentBridgedTokens: [BridgeToLayer1Event]! @derivedFrom(field: "safe")
@@ -464,7 +465,7 @@ type RewardProgramRegistrationPayment @entity {
   admin: Account!
   transaction: Transaction!
   createdAt: BigInt!
-  prepaidCardPayment: PrepaidCardPayment #remember to add bang here
+  prepaidCardPayment: PrepaidCardPayment! #remember to add bang here
 }
 
 type RewardeeRegistrationPayment @entity {
@@ -473,7 +474,7 @@ type RewardeeRegistrationPayment @entity {
   rewardee: Account!
   transaction: Transaction!
   createdAt: BigInt!
-  prepaidCardPayment: PrepaidCardPayment #remember to add bang here
+  prepaidCardPayment: PrepaidCardPayment! #remember to add bang here
 }
 
 type RewardSafe @entity {
@@ -481,4 +482,14 @@ type RewardSafe @entity {
   rewardProgramID: String!
   rewardee: Account!
   safe: Safe!
+}
+
+type RewardeeClaim @entity {
+  id: ID!
+  rewardProgramID: String!
+  rewardee: Account!
+  rewardSafe: RewardSafe! #remember to add bang here
+  amount: BigInt!
+  transaction: Transaction!
+  timestamp: BigInt!
 }

--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -8,6 +8,7 @@ type Account @entity {
   createdPrepaidCards: [PrepaidCardCreation]!      @derivedFrom(field: "issuer")
   splitPrepaidCards: [PrepaidCardSplit]!           @derivedFrom(field: "issuer")
   createdMerchants: [MerchantCreation]!            @derivedFrom(field: "merchant")
+  createdRewardSafes: [RewardSafe]!                @derivedFrom(field: "rewardee")
   receivedPrepaidCards: [PrepaidCardTransfer]!     @derivedFrom(field: "to")
   provisionedPrepaidCards: [PrepaidCardProvisionedEvent]! @derivedFrom(field: "customer")
   sentPrepaidCards: [PrepaidCardTransfer]!         @derivedFrom(field: "from")
@@ -461,7 +462,7 @@ type TokenPair @entity {
 
 type RewardProgramRegistrationPayment @entity {
   id: ID!
-  rewardProgramID: String!
+  rewardProgram: RewardProgram!
   admin: Account!
   transaction: Transaction!
   createdAt: BigInt!
@@ -470,23 +471,32 @@ type RewardProgramRegistrationPayment @entity {
 
 type RewardeeRegistrationPayment @entity {
   id: ID!
-  rewardProgramID: String!
+  rewardProgram: RewardProgram!
   rewardee: Account!
   transaction: Transaction!
   createdAt: BigInt!
   prepaidCardPayment: PrepaidCardPayment!
 }
 
+type RewardProgram @entity {
+  id: ID!
+  admin: Account!
+  rewardSafe: [RewardSafe]! @derivedFrom(field: "rewardProgram")
+  tokenAddEvents: [RewardTokensAdd]! @derivedFrom(field: "rewardProgram")
+  rewardClaimEvents: [RewardeeClaim]! @derivedFrom(field: "rewardProgram")
+}
+
 type RewardSafe @entity {
   id: ID!
-  rewardProgramID: String!
+  rewardProgram: RewardProgram!
   rewardee: Account!
   safe: Safe!
+  claims: [RewardeeClaim]! @derivedFrom(field: "rewardSafe")
 }
 
 type RewardeeClaim @entity {
   id: ID!
-  rewardProgramID: String!
+  rewardProgram: RewardProgram!
   rewardee: Account!
   rewardSafe: RewardSafe!
   amount: BigInt!
@@ -496,7 +506,7 @@ type RewardeeClaim @entity {
 
 type RewardTokensAdd @entity {
   id: ID!
-  rewardProgramID: String!
+  rewardProgram: RewardProgram!
   safe: Safe!
   token: Token!
   amount: BigInt!

--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -461,9 +461,8 @@ type TokenPair @entity {
 type RewardProgramRegistrationPayment @entity {
   id: ID!
   admin: Account!
+  rewardProgramID: String!
   transaction: Transaction!
   createdAt: BigInt!
-  prepaidCardPayment: PrepaidCardPayment
-  paidWith: PrepaidCard
+  prepaidCardPayment: PrepaidCardPayment #remember to add bang here
 }
-

--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -483,7 +483,7 @@ type RewardeeRegistrationPayment @entity {
 type RewardProgram @entity {
   id: ID!
   admin: Account!
-  rewardSafe: [RewardSafe]! @derivedFrom(field: "rewardProgram")
+  rewardSafes: [RewardSafe]! @derivedFrom(field: "rewardProgram")
   tokenAddEvents: [RewardTokensAdd]! @derivedFrom(field: "rewardProgram")
   rewardClaimEvents: [RewardeeClaim]! @derivedFrom(field: "rewardProgram")
 }

--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -493,3 +493,13 @@ type RewardeeClaim @entity {
   transaction: Transaction!
   timestamp: BigInt!
 }
+
+type RewardTokensAdd @entity {
+  id: ID!
+  rewardProgramID: String!
+  safe: Safe!
+  token: Token!
+  amount: BigInt!
+  transaction: Transaction!
+  timestamp: BigInt!
+}

--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -475,3 +475,10 @@ type RewardeeRegistrationPayment @entity {
   createdAt: BigInt!
   prepaidCardPayment: PrepaidCardPayment #remember to add bang here
 }
+
+type RewardSafe @entity {
+  id: ID!
+  rewardProgramID: String!
+  rewardee: Account!
+  safe: Safe!
+}

--- a/packages/cardpay-subgraph/src/mappings/depot.ts
+++ b/packages/cardpay-subgraph/src/mappings/depot.ts
@@ -1,14 +1,7 @@
 import { SupplierSafeCreated, SupplierInfoDIDUpdated } from '../../generated/Depot/SupplierManager';
 import { TokensBridgedToSafe, TokensBridgingInitiated } from '../../generated/TokenBridge/HomeMultiAMBErc20ToErc677';
-import {
-  Depot,
-  Account,
-  BridgeToLayer1Event,
-  BridgeToLayer2Event,
-  SupplierInfoDIDUpdate,
-  Safe,
-} from '../../generated/schema';
-import { makeToken, makeEOATransaction, toChecksumAddress, makeEOATransactionForSafe } from '../utils';
+import { Depot, BridgeToLayer1Event, BridgeToLayer2Event, SupplierInfoDIDUpdate, Safe } from '../../generated/schema';
+import { makeToken, makeEOATransaction, toChecksumAddress, makeEOATransactionForSafe, makeAccount } from '../utils';
 import { log, BigInt, Address } from '@graphprotocol/graph-ts';
 import { GnosisSafe } from '../../generated/Gnosis/GnosisSafe';
 
@@ -55,13 +48,11 @@ export function handleSentBridgedTokens(event: TokensBridgingInitiated): void {
     let safeContract = GnosisSafe.bind(Address.fromString(safe.id));
     let owners = safeContract.getOwners();
     if (owners.length > 0) {
-      let account = new Account(toChecksumAddress(owners[0]));
-      account.save();
+      let account = makeAccount(toChecksumAddress(owners[0]));
       bridgeEventEntity.account = account.id;
     }
   } else {
-    let account = new Account(sender);
-    account.save();
+    makeAccount(sender);
     bridgeEventEntity.account = sender;
     makeEOATransaction(event, sender);
   }
@@ -74,8 +65,7 @@ export function handleSetInfoDID(event: SupplierInfoDIDUpdated): void {
 
   let infoDID = event.params.infoDID;
 
-  let accountEntity = new Account(supplier);
-  accountEntity.save();
+  makeAccount(supplier);
 
   let updateEntity = new SupplierInfoDIDUpdate(event.transaction.hash.toHex());
   updateEntity.timestamp = event.block.timestamp;
@@ -86,8 +76,7 @@ export function handleSetInfoDID(event: SupplierInfoDIDUpdated): void {
 }
 
 function makeDepot(safe: string, supplier: string, timestamp: BigInt): void {
-  let accountEntity = new Account(supplier);
-  accountEntity.save();
+  makeAccount(supplier);
 
   let depotEntity = new Depot(safe);
   depotEntity.safe = safe;

--- a/packages/cardpay-subgraph/src/mappings/gnosis-proxy-factory.ts
+++ b/packages/cardpay-subgraph/src/mappings/gnosis-proxy-factory.ts
@@ -1,8 +1,8 @@
 import { ProxyCreation } from '../../generated/Gnosis/GnosisProxyFactory';
 import { GnosisSafe } from '../../generated/Gnosis/GnosisSafe';
 import { GnosisSafe as GnosisSafeTemplate } from '../../generated/templates';
-import { Safe, Account, SafeOwner } from '../../generated/schema';
-import { toChecksumAddress } from '../utils';
+import { Safe, SafeOwner } from '../../generated/schema';
+import { toChecksumAddress, makeAccount } from '../utils';
 import { log } from '@graphprotocol/graph-ts';
 
 export function handleProxyCreation(event: ProxyCreation): void {
@@ -15,8 +15,7 @@ export function handleProxyCreation(event: ProxyCreation): void {
 
   for (let i = 0; i < owners.length; i++) {
     let ownerAddress = toChecksumAddress(owners[i]);
-    let ownerEntity = new Account(ownerAddress);
-    ownerEntity.save();
+    makeAccount(ownerAddress);
 
     let safeOwnerId = safeAddress + '-' + ownerAddress;
     let safeOwnerEntity = new SafeOwner(safeOwnerId);

--- a/packages/cardpay-subgraph/src/mappings/merchant-manager.ts
+++ b/packages/cardpay-subgraph/src/mappings/merchant-manager.ts
@@ -1,7 +1,7 @@
 import { BigInt } from '@graphprotocol/graph-ts';
 import { MerchantCreation as MerchantCreationEvent } from '../../generated/Merchant/MerchantManager';
-import { Account, MerchantSafe, MerchantCreation } from '../../generated/schema';
-import { makeEOATransaction, toChecksumAddress } from '../utils';
+import { MerchantSafe, MerchantCreation } from '../../generated/schema';
+import { makeEOATransaction, toChecksumAddress, makeAccount } from '../utils';
 
 export function handleMerchantCreation(event: MerchantCreationEvent): void {
   let merchant = toChecksumAddress(event.params.merchant);
@@ -10,8 +10,7 @@ export function handleMerchantCreation(event: MerchantCreationEvent): void {
   let merchantSafe = toChecksumAddress(event.params.merchantSafe);
   let infoDID = event.params.infoDID;
 
-  let accountEntity = new Account(merchant);
-  accountEntity.save();
+  makeAccount(merchant);
 
   let merchantSafeEntity = new MerchantSafe(merchantSafe);
   merchantSafeEntity.safe = merchantSafe;

--- a/packages/cardpay-subgraph/src/mappings/prepaid-card-market.ts
+++ b/packages/cardpay-subgraph/src/mappings/prepaid-card-market.ts
@@ -7,7 +7,6 @@ import {
 } from '../../generated/Market/PrepaidCardMarket';
 import { ethereum, BigInt, store } from '@graphprotocol/graph-ts';
 import {
-  Account,
   PrepaidCardAsk,
   PrepaidCardAskSetEvent,
   PrepaidCardInventoryAddEvent,
@@ -18,7 +17,7 @@ import {
   SKU,
   SKUInventory,
 } from '../../generated/schema';
-import { makeToken, makeEOATransaction, toChecksumAddress } from '../utils';
+import { makeToken, makeEOATransaction, toChecksumAddress, makeAccount } from '../utils';
 import { log } from '@graphprotocol/graph-ts';
 
 export function handleProvisionedPrepaidCard(event: ProvisionedPrepaidCard): void {
@@ -28,8 +27,7 @@ export function handleProvisionedPrepaidCard(event: ProvisionedPrepaidCard): voi
   let customer = toChecksumAddress(event.params.customer);
   let sku = event.params.sku.toHex();
   let askPrice = event.params.askPrice;
-  let accountEntity = new Account(customer);
-  accountEntity.save();
+  makeAccount(customer);
 
   makeEOATransaction(event, customer);
   let itemId = sku + '-' + prepaidCard;
@@ -64,8 +62,7 @@ export function handleItemSet(event: ItemSet): void {
   let prepaidCard = toChecksumAddress(event.params.prepaidCard);
   let issuer = toChecksumAddress(event.params.issuer);
   let sku = event.params.sku.toHex();
-  let accountEntity = new Account(issuer);
-  accountEntity.save();
+  makeAccount(issuer);
 
   makeEOATransaction(event, issuer);
   let issuingToken = makeToken(event.params.issuingToken);
@@ -93,8 +90,7 @@ export function handleAskSet(event: AskSet): void {
   let askPrice = event.params.askPrice;
   let sku = event.params.sku.toHex();
   let issuer = toChecksumAddress(event.params.issuer);
-  let accountEntity = new Account(issuer);
-  accountEntity.save();
+  makeAccount(issuer);
 
   let inventoryEntity = SKUInventory.load(sku);
   if (inventoryEntity == null) {
@@ -130,8 +126,7 @@ export function handleItemRemoved(event: ItemRemoved): void {
   let prepaidCard = toChecksumAddress(event.params.prepaidCard);
   let issuer = toChecksumAddress(event.params.issuer);
   let sku = event.params.sku.toHex();
-  let accountEntity = new Account(issuer);
-  accountEntity.save();
+  makeAccount(issuer);
 
   makeEOATransaction(event, issuer);
   let itemId = sku + '-' + prepaidCard;

--- a/packages/cardpay-subgraph/src/mappings/prepaid-card.ts
+++ b/packages/cardpay-subgraph/src/mappings/prepaid-card.ts
@@ -5,7 +5,6 @@ import {
   PrepaidCardSend,
 } from '../../generated/PrepaidCard/PrepaidCardManager';
 import {
-  Account,
   Depot,
   PrepaidCard,
   PrepaidCardCreation,
@@ -19,6 +18,7 @@ import {
   makeTransaction,
   getPrepaidCardFaceValue,
   makeEOATransactionForSafe,
+  makeAccount,
 } from '../utils';
 import { log } from '@graphprotocol/graph-ts';
 
@@ -33,8 +33,7 @@ export function handleCreatePrepaidCard(event: CreatePrepaidCard): void {
   } else {
     makeEOATransaction(event, issuer);
   }
-  let accountEntity = new Account(issuer);
-  accountEntity.save();
+  makeAccount(issuer);
 
   let prepaidCardMgr = PrepaidCardManager.bind(event.address);
   let cardInfo = prepaidCardMgr.cardDetails(event.params.card);

--- a/packages/cardpay-subgraph/src/mappings/register-reward-program-handler.ts
+++ b/packages/cardpay-subgraph/src/mappings/register-reward-program-handler.ts
@@ -25,10 +25,10 @@ export function handleRewardProgramRegistrationFee(event: RewardProgramRegistrat
     event.params.spendAmount
   );
   let entity = new RewardProgramRegistrationPayment(txnHash);
+  entity.rewardProgramID = rewardProgramID;
   entity.admin = admin;
   entity.transaction = txnHash;
   entity.createdAt = event.block.timestamp;
   entity.prepaidCardPayment = txnHash;
-  entity.rewardProgramID = rewardProgramID;
   entity.save();
 }

--- a/packages/cardpay-subgraph/src/mappings/register-reward-program-handler.ts
+++ b/packages/cardpay-subgraph/src/mappings/register-reward-program-handler.ts
@@ -1,0 +1,33 @@
+import { RewardProgramRegistrationFee } from '../../generated/RewardProgram/RegisterRewardProgramHandler';
+import { log } from '@graphprotocol/graph-ts';
+
+import { RewardProgramRegistrationPayment } from '../../generated/schema';
+import { toChecksumAddress, makePrepaidCardPayment, makeToken, makeTransaction } from '../utils';
+
+export function handleRewardProgramRegistrationFee(event: RewardProgramRegistrationFee): void {
+  makeTransaction(event);
+  let prepaidCard = toChecksumAddress(event.params.prepaidCard);
+  let admin = toChecksumAddress(event.params.admin);
+  let rewardProgramID = toChecksumAddress(event.params.rewardProgramID);
+  let issuingToken = makeToken(event.params.issuingToken);
+  let txnHash = event.transaction.hash.toHex();
+  log.info('====prepaidCard {}', [prepaidCard]);
+  log.info('====admin {}', [admin]);
+  log.info('====rewardProgramID {}', [rewardProgramID]);
+
+  makePrepaidCardPayment(
+    event,
+    prepaidCard,
+    null,
+    issuingToken,
+    event.params.issuingTokenAmount,
+    event.params.spendAmount
+  );
+  let entity = new RewardProgramRegistrationPayment(rewardProgramID);
+  entity.admin = admin;
+  entity.transaction = txnHash;
+  entity.createdAt = event.block.timestamp;
+  entity.prepaidCardPayment = txnHash;
+  entity.paidWith = prepaidCard;
+  entity.save();
+}

--- a/packages/cardpay-subgraph/src/mappings/register-reward-program-handler.ts
+++ b/packages/cardpay-subgraph/src/mappings/register-reward-program-handler.ts
@@ -2,7 +2,7 @@ import { RewardProgramRegistrationFee } from '../../generated/RegisterRewardProg
 import { log } from '@graphprotocol/graph-ts';
 
 import { RewardProgramRegistrationPayment } from '../../generated/schema';
-import { toChecksumAddress, makePrepaidCardPayment, makeToken, makeTransaction, makeAccount } from '../utils';
+import { toChecksumAddress, makePrepaidCardPayment, makeToken, makeAccount } from '../utils';
 
 export function handleRewardProgramRegistrationFee(event: RewardProgramRegistrationFee): void {
   let txnHash = event.transaction.hash.toHex();

--- a/packages/cardpay-subgraph/src/mappings/register-reward-program-handler.ts
+++ b/packages/cardpay-subgraph/src/mappings/register-reward-program-handler.ts
@@ -1,5 +1,4 @@
 import { RewardProgramRegistrationFee } from '../../generated/RegisterRewardProgram/RegisterRewardProgramHandler';
-import { log } from '@graphprotocol/graph-ts';
 
 import { RewardProgramRegistrationPayment } from '../../generated/schema';
 import { toChecksumAddress, makePrepaidCardPayment, makeToken, makeAccount } from '../utils';
@@ -10,10 +9,6 @@ export function handleRewardProgramRegistrationFee(event: RewardProgramRegistrat
   let admin = toChecksumAddress(event.params.admin);
   let rewardProgramID = toChecksumAddress(event.params.rewardProgramID);
   let issuingToken = makeToken(event.params.issuingToken);
-
-  log.info('====prepaidCard {}', [prepaidCard]);
-  log.info('====admin {}', [admin]);
-  log.info('====rewardProgramID {}', [rewardProgramID]);
 
   makeAccount(admin);
   makePrepaidCardPayment(

--- a/packages/cardpay-subgraph/src/mappings/register-reward-program-handler.ts
+++ b/packages/cardpay-subgraph/src/mappings/register-reward-program-handler.ts
@@ -1,6 +1,6 @@
 import { RewardProgramRegistrationFee } from '../../generated/RegisterRewardProgram/RegisterRewardProgramHandler';
 
-import { RewardProgramRegistrationPayment } from '../../generated/schema';
+import { RewardProgramRegistrationPayment, RewardProgram } from '../../generated/schema';
 import { toChecksumAddress, makePrepaidCardPayment, makeToken, makeAccount } from '../utils';
 
 export function handleRewardProgramRegistrationFee(event: RewardProgramRegistrationFee): void {
@@ -19,8 +19,13 @@ export function handleRewardProgramRegistrationFee(event: RewardProgramRegistrat
     event.params.issuingTokenAmount,
     event.params.spendAmount
   );
+
+  let rewardProgramEntity = new RewardProgram(rewardProgramID);
+  rewardProgramEntity.admin = admin;
+  rewardProgramEntity.save();
+
   let entity = new RewardProgramRegistrationPayment(txnHash);
-  entity.rewardProgramID = rewardProgramID;
+  entity.rewardProgram = rewardProgramID;
   entity.admin = admin;
   entity.transaction = txnHash;
   entity.createdAt = event.block.timestamp;

--- a/packages/cardpay-subgraph/src/mappings/register-rewardee-handler.ts
+++ b/packages/cardpay-subgraph/src/mappings/register-rewardee-handler.ts
@@ -1,13 +1,7 @@
 import { RewardeeRegistrationFee } from '../../generated/RegisterRewardee/RegisterRewardeeHandler';
 import { log } from '@graphprotocol/graph-ts';
 import { RewardeeRegistrationPayment } from '../../generated/schema';
-import {
-  toChecksumAddress,
-  makePrepaidCardPayment,
-  makeToken,
-  makeAccount,
-  getPrepaidCardOwner,
-} from '../utils';
+import { toChecksumAddress, makePrepaidCardPayment, makeToken, makeAccount, getPrepaidCardOwner } from '../utils';
 
 export function handleRewardeeRegistrationFee(event: RewardeeRegistrationFee): void {
   let txnHash = event.transaction.hash.toHex();
@@ -18,7 +12,7 @@ export function handleRewardeeRegistrationFee(event: RewardeeRegistrationFee): v
   log.info('====prepaidCard {}', [prepaidCard]);
   log.info('====rewardProgramID {}', [rewardProgramID]);
 
-  let rewardee = getPrepaidCardOwner(prepaidCard).toString();
+  let rewardee = toChecksumAddress(getPrepaidCardOwner(prepaidCard));
   makeAccount(rewardee);
   log.info('====rewardee {}', [rewardee]);
   makePrepaidCardPayment(

--- a/packages/cardpay-subgraph/src/mappings/register-rewardee-handler.ts
+++ b/packages/cardpay-subgraph/src/mappings/register-rewardee-handler.ts
@@ -1,21 +1,26 @@
-import { RewardProgramRegistrationFee } from '../../generated/RegisterRewardProgram/RegisterRewardProgramHandler';
+import { RewardeeRegistrationFee } from '../../generated/RegisterRewardee/RegisterRewardeeHandler';
 import { log } from '@graphprotocol/graph-ts';
+import { RewardeeRegistrationPayment } from '../../generated/schema';
+import {
+  toChecksumAddress,
+  makePrepaidCardPayment,
+  makeToken,
+  makeAccount,
+  getPrepaidCardOwner,
+} from '../utils';
 
-import { RewardProgramRegistrationPayment } from '../../generated/schema';
-import { toChecksumAddress, makePrepaidCardPayment, makeToken, makeTransaction, makeAccount } from '../utils';
-
-export function handleRewardProgramRegistrationFee(event: RewardProgramRegistrationFee): void {
+export function handleRewardeeRegistrationFee(event: RewardeeRegistrationFee): void {
   let txnHash = event.transaction.hash.toHex();
   let prepaidCard = toChecksumAddress(event.params.prepaidCard);
-  let admin = toChecksumAddress(event.params.admin);
   let rewardProgramID = toChecksumAddress(event.params.rewardProgramID);
   let issuingToken = makeToken(event.params.issuingToken);
 
   log.info('====prepaidCard {}', [prepaidCard]);
-  log.info('====admin {}', [admin]);
   log.info('====rewardProgramID {}', [rewardProgramID]);
 
-  makeAccount(admin);
+  let rewardee = getPrepaidCardOwner(prepaidCard).toString();
+  makeAccount(rewardee);
+  log.info('====rewardee {}', [rewardee]);
   makePrepaidCardPayment(
     event,
     prepaidCard,
@@ -24,11 +29,12 @@ export function handleRewardProgramRegistrationFee(event: RewardProgramRegistrat
     event.params.issuingTokenAmount,
     event.params.spendAmount
   );
-  let entity = new RewardProgramRegistrationPayment(txnHash);
-  entity.admin = admin;
+  let entity = new RewardeeRegistrationPayment(txnHash);
   entity.transaction = txnHash;
+  entity.rewardee = rewardee;
   entity.createdAt = event.block.timestamp;
   entity.prepaidCardPayment = txnHash;
   entity.rewardProgramID = rewardProgramID;
+
   entity.save();
 }

--- a/packages/cardpay-subgraph/src/mappings/register-rewardee-handler.ts
+++ b/packages/cardpay-subgraph/src/mappings/register-rewardee-handler.ts
@@ -1,5 +1,4 @@
 import { RewardeeRegistrationFee } from '../../generated/RegisterRewardee/RegisterRewardeeHandler';
-import { log } from '@graphprotocol/graph-ts';
 import { RewardeeRegistrationPayment } from '../../generated/schema';
 import { toChecksumAddress, makePrepaidCardPayment, makeToken, makeAccount, getPrepaidCardOwner } from '../utils';
 
@@ -9,12 +8,8 @@ export function handleRewardeeRegistrationFee(event: RewardeeRegistrationFee): v
   let rewardProgramID = toChecksumAddress(event.params.rewardProgramID);
   let issuingToken = makeToken(event.params.issuingToken);
 
-  log.info('====prepaidCard {}', [prepaidCard]);
-  log.info('====rewardProgramID {}', [rewardProgramID]);
-
   let rewardee = toChecksumAddress(getPrepaidCardOwner(prepaidCard));
   makeAccount(rewardee);
-  log.info('====rewardee {}', [rewardee]);
   makePrepaidCardPayment(
     event,
     prepaidCard,

--- a/packages/cardpay-subgraph/src/mappings/register-rewardee-handler.ts
+++ b/packages/cardpay-subgraph/src/mappings/register-rewardee-handler.ts
@@ -1,14 +1,23 @@
 import { RewardeeRegistrationFee } from '../../generated/RegisterRewardee/RegisterRewardeeHandler';
-import { RewardeeRegistrationPayment } from '../../generated/schema';
+import { RewardeeRegistrationPayment, RewardProgram } from '../../generated/schema';
 import { toChecksumAddress, makePrepaidCardPayment, makeToken, makeAccount, getPrepaidCardOwner } from '../utils';
+import { log } from '@graphprotocol/graph-ts';
 
 export function handleRewardeeRegistrationFee(event: RewardeeRegistrationFee): void {
   let txnHash = event.transaction.hash.toHex();
   let prepaidCard = toChecksumAddress(event.params.prepaidCard);
   let rewardProgramID = toChecksumAddress(event.params.rewardProgramID);
   let issuingToken = makeToken(event.params.issuingToken);
-
   let rewardee = toChecksumAddress(getPrepaidCardOwner(prepaidCard));
+
+  let rewardProgramEntity = RewardProgram.load(rewardProgramID);
+  if (rewardProgramEntity == null) {
+    log.warning(
+      'Cannot process tokens added txn {}: Reward program entity does not exist for safe address {}. This is likely due to the subgraph having a startBlock that is higher than the block the safe was created in.',
+      [txnHash, rewardProgramID]
+    );
+    return;
+  }
   makeAccount(rewardee);
   makePrepaidCardPayment(
     event,
@@ -23,7 +32,6 @@ export function handleRewardeeRegistrationFee(event: RewardeeRegistrationFee): v
   entity.rewardee = rewardee;
   entity.createdAt = event.block.timestamp;
   entity.prepaidCardPayment = txnHash;
-  entity.rewardProgramID = rewardProgramID;
-
+  entity.rewardProgram = rewardProgramID;
   entity.save();
 }

--- a/packages/cardpay-subgraph/src/mappings/reward-manager.ts
+++ b/packages/cardpay-subgraph/src/mappings/reward-manager.ts
@@ -1,7 +1,6 @@
 import { RewardeeRegistered } from '../../generated/RewardManager/RewardManager';
 import { RewardSafe } from '../../generated/schema';
 import { toChecksumAddress, makeEOATransaction, makeAccount } from '../utils';
-import { log } from '@graphprotocol/graph-ts';
 
 // To track creation of reward safe
 export function handleRewardeeRegistration(event: RewardeeRegistered): void {
@@ -10,7 +9,6 @@ export function handleRewardeeRegistration(event: RewardeeRegistered): void {
   let rewardSafe = toChecksumAddress(event.params.rewardSafe);
   makeAccount(rewardee);
   makeEOATransaction(event, rewardee);
-  log.info('=============== bobba {}', [rewardSafe]);
   let entity = new RewardSafe(rewardSafe);
   entity.rewardProgramID = rewardProgramID;
   entity.rewardee = rewardee;

--- a/packages/cardpay-subgraph/src/mappings/reward-manager.ts
+++ b/packages/cardpay-subgraph/src/mappings/reward-manager.ts
@@ -1,0 +1,18 @@
+import { RewardeeRegistered } from '../../generated/RewardManager/RewardManager';
+import { RewardSafe } from '../../generated/schema';
+import { toChecksumAddress, makeEOATransaction } from '../utils';
+import { log } from '@graphprotocol/graph-ts';
+
+// To track creation of reward safe
+export function handleRewardeeRegistration(event: RewardeeRegistered): void {
+  let rewardProgramID = toChecksumAddress(event.params.rewardProgramID);
+  let rewardee = toChecksumAddress(event.params.rewardee);
+  let rewardSafe = toChecksumAddress(event.params.rewardSafe);
+  makeEOATransaction(event, rewardee);
+  log.info('====rewardSafe {}', [rewardSafe]);
+  let entity = new RewardSafe(rewardSafe);
+  entity.rewardProgramID = rewardProgramID;
+  entity.rewardee = rewardee;
+  entity.safe = rewardSafe;
+  entity.save();
+}

--- a/packages/cardpay-subgraph/src/mappings/reward-manager.ts
+++ b/packages/cardpay-subgraph/src/mappings/reward-manager.ts
@@ -1,16 +1,29 @@
 import { RewardeeRegistered } from '../../generated/RewardManager/RewardManager';
-import { RewardSafe } from '../../generated/schema';
+import { RewardSafe, RewardProgram } from '../../generated/schema';
 import { toChecksumAddress, makeEOATransaction, makeAccount } from '../utils';
+import { log } from '@graphprotocol/graph-ts';
 
 // To track creation of reward safe
 export function handleRewardeeRegistration(event: RewardeeRegistered): void {
+  let txnHash = event.transaction.hash.toHex();
   let rewardProgramID = toChecksumAddress(event.params.rewardProgramID);
   let rewardee = toChecksumAddress(event.params.rewardee);
   let rewardSafe = toChecksumAddress(event.params.rewardSafe);
+
+  let rewardProgramEntity = RewardProgram.load(rewardProgramID);
+  if (rewardProgramEntity == null) {
+    log.warning(
+      'Cannot process tokens added txn {}: Reward program entity does not exist for safe address {}. This is likely due to the subgraph having a startBlock that is higher than the block the safe was created in.',
+      [txnHash, rewardProgramID]
+    );
+    return;
+  }
+
   makeAccount(rewardee);
   makeEOATransaction(event, rewardee);
+
   let entity = new RewardSafe(rewardSafe);
-  entity.rewardProgramID = rewardProgramID;
+  entity.rewardProgram = rewardProgramID;
   entity.rewardee = rewardee;
   entity.safe = rewardSafe;
   entity.save();

--- a/packages/cardpay-subgraph/src/mappings/reward-manager.ts
+++ b/packages/cardpay-subgraph/src/mappings/reward-manager.ts
@@ -1,6 +1,6 @@
 import { RewardeeRegistered } from '../../generated/RewardManager/RewardManager';
 import { RewardSafe } from '../../generated/schema';
-import { toChecksumAddress, makeEOATransaction } from '../utils';
+import { toChecksumAddress, makeEOATransaction, makeAccount } from '../utils';
 import { log } from '@graphprotocol/graph-ts';
 
 // To track creation of reward safe
@@ -8,8 +8,9 @@ export function handleRewardeeRegistration(event: RewardeeRegistered): void {
   let rewardProgramID = toChecksumAddress(event.params.rewardProgramID);
   let rewardee = toChecksumAddress(event.params.rewardee);
   let rewardSafe = toChecksumAddress(event.params.rewardSafe);
+  makeAccount(rewardee);
   makeEOATransaction(event, rewardee);
-  log.info('====rewardSafe {}', [rewardSafe]);
+  log.info('=============== bobba {}', [rewardSafe]);
   let entity = new RewardSafe(rewardSafe);
   entity.rewardProgramID = rewardProgramID;
   entity.rewardee = rewardee;

--- a/packages/cardpay-subgraph/src/mappings/reward-pool.ts
+++ b/packages/cardpay-subgraph/src/mappings/reward-pool.ts
@@ -1,0 +1,35 @@
+import { RewardeeClaim as RewardeeClaimEvent } from '../../generated/RewardPool/RewardPool';
+import { RewardeeClaim, RewardSafe } from '../../generated/schema';
+import { toChecksumAddress, makeEOATransactionForSafe, makeAccount } from '../utils';
+import { log } from '@graphprotocol/graph-ts';
+// To track creation of reward safe
+export function handleRewardeeClaim(event: RewardeeClaimEvent): void {
+  let txnHash = event.transaction.hash.toHex();
+  let rewardProgramID = toChecksumAddress(event.params.rewardProgramID);
+  let rewardee = toChecksumAddress(event.params.rewardee);
+  let rewardSafe = toChecksumAddress(event.params.rewardSafe);
+  let amount = event.params.amount;
+
+  let rewardSafeEntity = RewardSafe.load(rewardSafe);
+  if (rewardSafeEntity == null) {
+    log.warning(
+      'Cannot process rewardee claim txn {}: RewardSafe entity does not exist for safe address {}. This is likely due to the subgraph having a startBlock that is higher than the block the safe was created in.',
+      [txnHash, rewardSafe]
+    );
+    return;
+  }
+  makeAccount(rewardee);
+  makeEOATransactionForSafe(event, rewardSafe);
+
+  log.info('=====================Tom Cardy {}', [rewardSafe]);
+
+  log.info('====rewardSafe {}', [rewardSafe]);
+  let entity = new RewardeeClaim(txnHash);
+  entity.rewardProgramID = rewardProgramID;
+  entity.rewardee = rewardee;
+  entity.amount = amount;
+  entity.rewardSafe = rewardSafe;
+  entity.transaction = txnHash;
+  entity.timestamp = event.block.timestamp;
+  entity.save();
+}

--- a/packages/cardpay-subgraph/src/mappings/reward-pool.ts
+++ b/packages/cardpay-subgraph/src/mappings/reward-pool.ts
@@ -1,6 +1,7 @@
-import { RewardeeClaim as RewardeeClaimEvent } from '../../generated/RewardPool/RewardPool';
-import { RewardeeClaim, RewardSafe } from '../../generated/schema';
-import { toChecksumAddress, makeEOATransactionForSafe, makeAccount } from '../utils';
+import { RewardeeClaim as RewardeeClaimEvent, RewardTokensAdded } from '../../generated/RewardPool/RewardPool';
+import { RewardeeClaim, RewardSafe, RewardTokensAdd } from '../../generated/schema';
+import { toChecksumAddress, makeEOATransactionForSafe, makeAccount, makeToken } from '../utils';
+import { log } from '@graphprotocol/graph-ts';
 
 export function handleRewardeeClaim(event: RewardeeClaimEvent): void {
   let txnHash = event.transaction.hash.toHex();
@@ -28,4 +29,21 @@ export function handleRewardeeClaim(event: RewardeeClaimEvent): void {
   entity.transaction = txnHash;
   entity.timestamp = event.block.timestamp;
   entity.save();
+}
+
+export function handleRewardTokensAdded(event: RewardTokensAdded): void {
+  let txnHash = event.transaction.hash.toHex();
+  let rewardProgramID = toChecksumAddress(event.params.rewardProgramID);
+  let safe = toChecksumAddress(event.params.sender);
+  let token = makeToken(event.params.tokenAddress);
+  let amount = event.params.amount;
+
+  makeEOATransactionForSafe(event, safe);
+  let entity = new RewardTokensAdd(txnHash);
+  entity.rewardProgramID = rewardProgramID;
+  entity.safe = safe;
+  entity.token = token;
+  entity.amount = amount;
+  entity.transaction = txnHash;
+  entity.timestamp = event.block.timestamp;
 }

--- a/packages/cardpay-subgraph/src/mappings/reward-pool.ts
+++ b/packages/cardpay-subgraph/src/mappings/reward-pool.ts
@@ -1,8 +1,7 @@
 import { RewardeeClaim as RewardeeClaimEvent } from '../../generated/RewardPool/RewardPool';
 import { RewardeeClaim, RewardSafe } from '../../generated/schema';
 import { toChecksumAddress, makeEOATransactionForSafe, makeAccount } from '../utils';
-import { log } from '@graphprotocol/graph-ts';
-// To track creation of reward safe
+
 export function handleRewardeeClaim(event: RewardeeClaimEvent): void {
   let txnHash = event.transaction.hash.toHex();
   let rewardProgramID = toChecksumAddress(event.params.rewardProgramID);
@@ -21,9 +20,6 @@ export function handleRewardeeClaim(event: RewardeeClaimEvent): void {
   makeAccount(rewardee);
   makeEOATransactionForSafe(event, rewardSafe);
 
-  log.info('=====================Tom Cardy {}', [rewardSafe]);
-
-  log.info('====rewardSafe {}', [rewardSafe]);
   let entity = new RewardeeClaim(txnHash);
   entity.rewardProgramID = rewardProgramID;
   entity.rewardee = rewardee;

--- a/packages/cardpay-subgraph/src/mappings/reward-pool.ts
+++ b/packages/cardpay-subgraph/src/mappings/reward-pool.ts
@@ -46,4 +46,5 @@ export function handleRewardTokensAdded(event: RewardTokensAdded): void {
   entity.amount = amount;
   entity.transaction = txnHash;
   entity.timestamp = event.block.timestamp;
+  entity.save();
 }

--- a/packages/cardpay-subgraph/src/utils.ts
+++ b/packages/cardpay-subgraph/src/utils.ts
@@ -159,6 +159,11 @@ export function makePrepaidCardPayment(
   }
 }
 
+export function makeAccount(address: string): void {
+  let accountEntity = new Account(address);
+  accountEntity.save();
+}
+
 export function getPrepaidCardFaceValue(prepaidCard: string): BigInt {
   let prepaidCardMgr = PrepaidCardManager.bind(Address.fromString(addresses.get('prepaidCardManager') as string));
   let cardDetails = prepaidCardMgr.cardDetails(Address.fromString(prepaidCard));

--- a/packages/cardpay-subgraph/src/utils.ts
+++ b/packages/cardpay-subgraph/src/utils.ts
@@ -174,6 +174,11 @@ export function getPrepaidCardFaceValue(prepaidCard: string): BigInt {
   return faceValue;
 }
 
+export function getPrepaidCardOwner(prepaidCard: string): Address {
+  let prepaidCardMgr = PrepaidCardManager.bind(Address.fromString(addresses.get('prepaidCardManager') as string));
+  return prepaidCardMgr.getPrepaidCardOwner(Address.fromString(prepaidCard));
+}
+
 export function toChecksumAddress(address: Address): string {
   let lowerCaseAddress = address.toHex().slice(2);
   let hash = crypto

--- a/packages/cardpay-subgraph/src/utils.ts
+++ b/packages/cardpay-subgraph/src/utils.ts
@@ -46,8 +46,7 @@ export function makeTransaction(event: ethereum.Event): void {
 
 export function makeEOATransaction(event: ethereum.Event, address: string, safe: string | null = null): void {
   makeTransaction(event);
-  let accountEntity = new Account(address);
-  accountEntity.save();
+  makeAccount(address);
 
   let txnHash = event.transaction.hash.toHex();
   let entity = new EOATransaction(txnHash + '-' + address);
@@ -159,9 +158,10 @@ export function makePrepaidCardPayment(
   }
 }
 
-export function makeAccount(address: string): void {
+export function makeAccount(address: string): Account {
   let accountEntity = new Account(address);
   accountEntity.save();
+  return accountEntity;
 }
 
 export function getPrepaidCardFaceValue(prepaidCard: string): BigInt {

--- a/packages/cardpay-subgraph/src/utils.ts
+++ b/packages/cardpay-subgraph/src/utils.ts
@@ -100,7 +100,7 @@ export function makePrepaidCardPayment(
     prepaidCardEntity.save();
   } else {
     log.warning(
-      'Cannot process merchant payment txn {}: PrepaidCard entity does not exist for prepaid card {}. This is likely due to the subgraph having a startBlock that is higher than the block the prepaid card was created in.',
+      'Cannot process payment txn {}: PrepaidCard entity does not exist for prepaid card {}. This is likely due to the subgraph having a startBlock that is higher than the block the prepaid card was created in.',
       [txnHash, prepaidCard]
     );
     return;

--- a/packages/cardpay-subgraph/subgraph-template.yaml
+++ b/packages/cardpay-subgraph/subgraph-template.yaml
@@ -667,6 +667,8 @@ dataSources:
       eventHandlers:
         - event: RewardeeClaim(address,address,address,uint256)
           handler: handleRewardeeClaim
+        - event: RewardTokensAdded(address,address,address,uint256)
+          handler: handleRewardTokensAdded
       file: ./src/mappings/reward-pool.ts
 
 templates:

--- a/packages/cardpay-subgraph/subgraph-template.yaml
+++ b/packages/cardpay-subgraph/subgraph-template.yaml
@@ -640,6 +640,34 @@ dataSources:
           handler: handleRewardeeRegistrationFee
       file: ./src/mappings/register-rewardee-handler.ts
 
+  - kind: ethereum/contract
+    name: RewardPool
+    network: {NETWORK}
+    source:
+      address: "{REWARD_POOL_ADDRESS}"
+      abi: RewardPool
+      startBlock: {CARDPAY_GENESIS_BLOCK}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      entities:
+        - RewardeeClaim
+      abis:
+        - name: RewardPool
+          file: ./abis/generated/RewardPool.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: ERC20SymbolBytes
+          file: ./abis/ERC20SymbolBytes.json
+        - name: ERC20NameBytes
+          file: ./abis/ERC20NameBytes.json
+        - name: GnosisSafe
+          file: ./abis/GnosisSafe.json
+      eventHandlers:
+        - event: RewardeeClaim(address,address,address,uint256)
+          handler: handleRewardeeClaim
+      file: ./src/mappings/reward-pool.ts
 
 templates:
   - kind: ethereum/contract

--- a/packages/cardpay-subgraph/subgraph-template.yaml
+++ b/packages/cardpay-subgraph/subgraph-template.yaml
@@ -545,7 +545,7 @@ dataSources:
           handler: handleTransfer
       file: ./src/mappings/token.ts
   - kind: ethereum/contract
-    name: RewardProgram
+    name: RegisterRewardProgram
     network: {NETWORK}
     source:
       address: "{REGISTER_REWARD_PROGRAM_HANDLER_ADDRESS}"
@@ -556,7 +556,7 @@ dataSources:
       apiVersion: 0.0.4
       language: wasm/assemblyscript
       entities:
-        - RewardProgram
+        - RewardProgramRegistrationPayment
       abis:
         - name: RegisterRewardProgramHandler
           file: ./abis/generated/RegisterRewardProgramHandler.json
@@ -576,6 +576,38 @@ dataSources:
         - event: RewardProgramRegistrationFee(address,address,uint256,uint256,address,address)
           handler: handleRewardProgramRegistrationFee
       file: ./src/mappings/register-reward-program-handler.ts
+  - kind: ethereum/contract
+    name: RegisterRewardee
+    network: {NETWORK}
+    source:
+      address: "{REGISTER_REWARDEE_HANDLER_ADDRESS}"
+      abi: RegisterRewardeeHandler
+      startBlock: {CARDPAY_GENESIS_BLOCK}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      entities:
+        - RewardeeRegistrationPayment
+      abis:
+        - name: RegisterRewardeeHandler
+          file: ./abis/generated/RegisterRewardeeHandler.json
+        - name: PrepaidCardManager
+          file: ./abis/generated/PrepaidCardManager.json
+        - name: Exchange
+          file: ./abis/generated/Exchange.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: ERC20SymbolBytes
+          file: ./abis/ERC20SymbolBytes.json
+        - name: ERC20NameBytes
+          file: ./abis/ERC20NameBytes.json
+        - name: GnosisSafe
+          file: ./abis/GnosisSafe.json
+      eventHandlers:
+        - event: RewardeeRegistrationFee(address,address,uint256,uint256,address)
+          handler: handleRewardeeRegistrationFee
+      file: ./src/mappings/register-rewardee-handler.ts
 
 
 templates:

--- a/packages/cardpay-subgraph/subgraph-template.yaml
+++ b/packages/cardpay-subgraph/subgraph-template.yaml
@@ -544,6 +544,36 @@ dataSources:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
       file: ./src/mappings/token.ts
+
+  - kind: ethereum/contract
+    name: RewardManager
+    network: {NETWORK}
+    source:
+      address: "{REWARD_MANAGER_ADDRESS}"
+      abi: RewardManager
+      startBlock: {CARDPAY_GENESIS_BLOCK}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      entities:
+        - RewardSafe
+      abis:
+        - name: RewardManager
+          file: ./abis/generated/RewardManager.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: ERC20SymbolBytes
+          file: ./abis/ERC20SymbolBytes.json
+        - name: ERC20NameBytes
+          file: ./abis/ERC20NameBytes.json
+        - name: GnosisSafe
+          file: ./abis/GnosisSafe.json
+      eventHandlers:
+        - event: RewardeeRegistered(address,address,address)
+          handler: handleRewardeeRegistration
+      file: ./src/mappings/reward-manager.ts
+
   - kind: ethereum/contract
     name: RegisterRewardProgram
     network: {NETWORK}
@@ -576,6 +606,7 @@ dataSources:
         - event: RewardProgramRegistrationFee(address,address,uint256,uint256,address,address)
           handler: handleRewardProgramRegistrationFee
       file: ./src/mappings/register-reward-program-handler.ts
+
   - kind: ethereum/contract
     name: RegisterRewardee
     network: {NETWORK}

--- a/packages/cardpay-subgraph/subgraph-template.yaml
+++ b/packages/cardpay-subgraph/subgraph-template.yaml
@@ -544,6 +544,38 @@ dataSources:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
       file: ./src/mappings/token.ts
+  - kind: ethereum/contract
+    name: RewardProgram
+    network: {NETWORK}
+    source:
+      address: "{REGISTER_REWARD_PROGRAM_HANDLER_ADDRESS}"
+      abi: RegisterRewardProgramHandler
+      startBlock: {CARDPAY_GENESIS_BLOCK}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      entities:
+        - RewardProgram
+      abis:
+        - name: RegisterRewardProgramHandler
+          file: ./abis/generated/RegisterRewardProgramHandler.json
+        - name: PrepaidCardManager
+          file: ./abis/generated/PrepaidCardManager.json
+        - name: Exchange
+          file: ./abis/generated/Exchange.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: ERC20SymbolBytes
+          file: ./abis/ERC20SymbolBytes.json
+        - name: ERC20NameBytes
+          file: ./abis/ERC20NameBytes.json
+        - name: GnosisSafe
+          file: ./abis/GnosisSafe.json
+      eventHandlers:
+        - event: RewardProgramRegistrationFee(address,address,uint256,uint256,address,address)
+          handler: handleRewardProgramRegistrationFee
+      file: ./src/mappings/register-reward-program-handler.ts
 
 
 templates:


### PR DESCRIPTION
**Data Sources <> Events**
- RewardManager
  - RewardeeRegistered
- RewardPool
  - RewardeeClaim
  - RewardTokensAdded
- RegisterRewardeeHandler
  - RewardeeRegistrationFee
- RegisterRewardProgram
  - RewardProgramRegistrationFee

Note: 
- There is a [change](https://github.com/cardstack/card-pay-protocol/pull/103) here that I want to include in the subgraph. But, will include it only after a card protocol deploy.
- Also note I added a utils `makeAccount` which required me to make changes to other handlers. Since subgraph is so fragile just want to point that out.