### PR TITLE
༼ ༎ຶ ෴ ༎ຶ༽  auto-run "tsc --watch" in VS code (opt-in)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,7 +15,10 @@
         "panel": "new"
       },
       "group": "build",
-      "isBackground": true
+      "isBackground": true,
+      "runOptions": {
+        "runOn":"folderOpen"
+      }
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,6 +4,7 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "tsc --watch",
       "type": "typescript",
       "tsconfig": "tsconfig.json",
       "option": "watch",


### PR DESCRIPTION
To prevent the never ending `tsc --watch` not running troll, this PR adds an opt-in auto run task such that when your mono repo folder is opened tsc watch will run automatically.

The next time you open your mono repo (File -> Open Recent -> <mono repo project folder>), you should be prompted if you want to allow auto run tasks. Select "yes". Alternatively you can go to Command-P, ">", Tasks, Task: Manage Automatic Tasks in Folder, and select "Allow Automatic Tasks in Folder".
<img width="1412" alt="Screen Shot 2021-09-25 at 8 56 44 AM" src="https://user-images.githubusercontent.com/61075/134772421-009dfede-6dd7-4cf0-8bc0-ab2e755b21c6.png">
 