### PR TITLE
Fix thread body z-index

### DIFF
--- a/packages/boxel/addon/components/boxel/thread/index.css
+++ b/packages/boxel/addon/components/boxel/thread/index.css
@@ -19,6 +19,7 @@
 .boxel-thread__scroll-wrapper {
   padding-bottom: var(--boxel-sp-lg);
   overflow-y: auto;
+  z-index: 0;
 }
 
 .boxel-thread__scroll-wrapper:focus {


### PR DESCRIPTION
Fixes the disappearance of thread header shadow upon overlap with a card. No ticket for this, just something small that was annoying.

Before:
<img width="802" alt="before" src="https://user-images.githubusercontent.com/16160806/134968329-6457ec48-1217-4384-b73f-6394e54355bc.png">

After:
<img width="807" alt="after" src="https://user-images.githubusercontent.com/16160806/134968351-badcd3de-5552-4612-adca-98eddf02bba5.png">

