### PR TITLE
Preselect prepaid card if there is only 1; disable low-balance cards

### DIFF
--- a/packages/web-client/app/components/card-pay/card-picker/index.css
+++ b/packages/web-client/app/components/card-pay/card-picker/index.css
@@ -81,11 +81,16 @@
   border-top: 1px solid var(--boxel-light-400);
 }
 
-.card-picker-dropdown__option:hover {
+.card-picker-dropdown__option:hover:not(.card-picker-dropdown__option--disabled) {
   background-color: var(--boxel-purple-100);
   cursor: pointer;
 }
 
 .ember-power-select-selected-item .card-picker-dropdown__option:hover {
   background-color: initial;
+}
+
+.card-picker-dropdown__option--disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }

--- a/packages/web-client/app/components/card-pay/card-picker/index.hbs
+++ b/packages/web-client/app/components/card-pay/card-picker/index.hbs
@@ -1,6 +1,6 @@
 <PowerSelect
   class={{cn "card-picker-dropdown" card-picker-dropdown--selected=@selectedCard}}
-  @options={{@cards}}
+  @options={{@options}}
   @selected={{@selectedCard}}
   @selectedItemComponent="card-pay/card-picker/selected-item"
   @placeholder="Select card"
@@ -9,13 +9,15 @@
   @eventType="click"
   @verticalPosition="below"
   data-test-card-picker-dropdown
-as |card|>
+as |option|>
   <CardPay::CardPicker::CardOption
     class={{cn
       "card-picker-dropdown__option"
-      card-picker-dropdown__option--selected=(eq card.address @selectedCard.address)
+      card-picker-dropdown__option--selected=(eq option.card.address @selectedCard.address)
+      card-picker-dropdown__option--disabled=(eq option.disabled true)
     }}
-    @card={{card}}
-    data-test-card-picker-dropdown-option={{card.address}}
+    @card={{option.card}}
+    data-test-card-picker-dropdown-option={{option.card.address}}
+    data-test-card-picker-dropdown-option-disabled={{option.disabled}}
   />
 </PowerSelect>

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
@@ -37,7 +37,7 @@
           />
           {{#if (eq this.creationState "default")}}
             <CardPay::CardPicker
-              @cards={{this.prepaidCards}}
+              @options={{this.prepaidCardsForDropdown}}
               @chooseCard={{this.choosePrepaidCard}}
               @selectedCard={{this.selectedPrepaidCard}}
             />
@@ -45,7 +45,7 @@
         </div>
       {{else}}
         <CardPay::CardPicker
-          @cards={{this.prepaidCards}}
+          @options={{this.prepaidCardsForDropdown}}
           @chooseCard={{this.choosePrepaidCard}}
           @selectedCard={{this.selectedPrepaidCard}}
         />

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
@@ -32,6 +32,11 @@ interface CardPayCreateMerchantWorkflowPrepaidCardChoiceComponentArgs {
   isComplete: boolean;
 }
 
+interface DropdownOption {
+  card: PrepaidCardSafe;
+  disabled: boolean;
+}
+
 const A_WHILE = config.environment === 'test' ? 500 : 1000 * 10;
 
 export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent extends Component<CardPayCreateMerchantWorkflowPrepaidCardChoiceComponentArgs> {
@@ -66,6 +71,13 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
 
     if (prepaidCardChoice) {
       this.selectedPrepaidCard = prepaidCardChoice;
+    } else {
+      let availableCards = this.prepaidCards.filter(
+        (c) => c.spendFaceValue >= this.merchantRegistrationFee
+      );
+      if (availableCards.length === 1) {
+        this.selectedPrepaidCard = availableCards[0];
+      }
     }
   }
 
@@ -86,8 +98,22 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
     ) as PrepaidCardSafe[];
   }
 
-  @action choosePrepaidCard(card: PrepaidCardSafe) {
-    this.selectedPrepaidCard = card;
+  get prepaidCardsForDropdown() {
+    let cards: DropdownOption[] = [];
+    if (this.prepaidCards.length) {
+      this.prepaidCards.forEach((c) => {
+        let option: DropdownOption = {
+          card: c,
+          disabled: c.spendFaceValue < this.merchantRegistrationFee,
+        };
+        cards.push(option);
+      });
+    }
+    return cards;
+  }
+
+  @action choosePrepaidCard(option: DropdownOption) {
+    this.selectedPrepaidCard = option.card;
   }
 
   @action createMerchant() {

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
@@ -100,16 +100,24 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
 
   get prepaidCardsForDropdown() {
     let cards: DropdownOption[] = [];
+    let lowBalCards: DropdownOption[] = [];
+
     if (this.prepaidCards.length) {
       this.prepaidCards.forEach((c) => {
+        let isLowBal = c.spendFaceValue < this.merchantRegistrationFee;
         let option: DropdownOption = {
           card: c,
-          disabled: c.spendFaceValue < this.merchantRegistrationFee,
+          disabled: isLowBal,
         };
-        cards.push(option);
+        if (isLowBal) {
+          lowBalCards.push(option);
+        } else {
+          cards.push(option);
+        }
       });
     }
-    return cards;
+
+    return [...cards, ...lowBalCards];
   }
 
   @action choosePrepaidCard(option: DropdownOption) {

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-card-picker-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-card-picker-test.ts
@@ -29,13 +29,13 @@ module(
           type: 'prepaid-card',
           createdAt: Date.now() / 1000,
 
-          address: prepaidCardAddress,
+          address: prepaidCardAddress2,
 
           tokens: [],
           owners: [layer2AccountAddress],
 
           issuingToken: '0xTOKEN',
-          spendFaceValue: 2324,
+          spendFaceValue: 500,
           prepaidCardOwner: layer2AccountAddress,
           hasBeenUsed: false,
           issuer: layer2AccountAddress,
@@ -46,13 +46,13 @@ module(
           type: 'prepaid-card',
           createdAt: Date.now() / 1000,
 
-          address: prepaidCardAddress2,
+          address: prepaidCardAddress,
 
           tokens: [],
           owners: [layer2AccountAddress],
 
           issuingToken: '0xTOKEN',
-          spendFaceValue: 500,
+          spendFaceValue: 2324,
           prepaidCardOwner: layer2AccountAddress,
           hasBeenUsed: false,
           issuer: layer2AccountAddress,

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-card-picker-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-card-picker-test.ts
@@ -1,0 +1,138 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render, waitFor } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
+import { WorkflowSession } from '@cardstack/web-client/models/workflow';
+
+module(
+  'Integration | Component | card-pay/create-merchant/prepaid-card-choice-card-picker edge cases',
+  function (hooks) {
+    let layer2Service: Layer2TestWeb3Strategy;
+    let prepaidCardAddress: string;
+    let prepaidCardAddress2: string;
+
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(async function (this) {
+      layer2Service = this.owner.lookup('service:layer2-network')
+        .strategy as Layer2TestWeb3Strategy;
+
+      let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
+      prepaidCardAddress = '0x123400000000000000000000000000000000abcd';
+      prepaidCardAddress2 = '0x432100000000000000000000000000000000dbca';
+
+      layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
+
+      layer2Service.test__simulateAccountSafes(layer2AccountAddress, [
+        {
+          type: 'prepaid-card',
+          createdAt: Date.now() / 1000,
+
+          address: prepaidCardAddress,
+
+          tokens: [],
+          owners: [layer2AccountAddress],
+
+          issuingToken: '0xTOKEN',
+          spendFaceValue: 2324,
+          prepaidCardOwner: layer2AccountAddress,
+          hasBeenUsed: false,
+          issuer: layer2AccountAddress,
+          reloadable: false,
+          transferrable: false,
+        },
+        {
+          type: 'prepaid-card',
+          createdAt: Date.now() / 1000,
+
+          address: prepaidCardAddress2,
+
+          tokens: [],
+          owners: [layer2AccountAddress],
+
+          issuingToken: '0xTOKEN',
+          spendFaceValue: 500,
+          prepaidCardOwner: layer2AccountAddress,
+          hasBeenUsed: false,
+          issuer: layer2AccountAddress,
+          reloadable: false,
+          transferrable: false,
+        },
+      ]);
+
+      let workflowSession = new WorkflowSession();
+      workflowSession.setValue({
+        merchantName: 'Mandello',
+        merchantId: 'mandello1',
+        merchantBgColor: '#ff5050',
+        merchantTextColor: '#fff',
+        merchantRegistrationFee: 1000,
+      });
+
+      this.setProperties({
+        onComplete: () => {},
+        onIncomplete: () => {},
+        isComplete: false,
+        frozen: false,
+        workflowSession,
+      });
+
+      await render(hbs`
+        <CardPay::CreateMerchantWorkflow::PrepaidCardChoice
+          @onComplete={{this.onComplete}}
+          @isComplete={{this.isComplete}}
+          @onIncomplete={{this.onIncomplete}}
+          @workflowSession={{this.workflowSession}}
+          @frozen={{this.frozen}}
+        />
+      `);
+    });
+
+    test('it preselects prepaid card if there is only one valid option', async function (assert) {
+      assert
+        .dom(
+          `[data-test-prepaid-card-choice-selected-card] [data-test-prepaid-card="${prepaidCardAddress}"]`
+        )
+        .exists();
+
+      await click(`[data-test-card-picker-dropdown] > [role="button"]`);
+      await waitFor(
+        `[data-test-card-picker-dropdown-option="${prepaidCardAddress}"]`
+      );
+
+      assert
+        .dom(`[data-test-card-picker-dropdown-option]`)
+        .exists({ count: 2 });
+      assert
+        .dom(
+          `[data-test-card-picker-dropdown-option="${prepaidCardAddress2}"][data-test-card-picker-dropdown-option-disabled]`
+        )
+        .hasClass('card-picker-dropdown__option--disabled');
+    });
+
+    test('it disables and fades out cards with insufficient balance', async function (assert) {
+      await click(`[data-test-card-picker-dropdown] > [role="button"]`);
+      await waitFor(
+        `[data-test-card-picker-dropdown-option="${prepaidCardAddress}"]`
+      );
+
+      assert
+        .dom(`[data-test-card-picker-dropdown-option]`)
+        .exists({ count: 2 });
+      assert
+        .dom(`[data-test-card-picker-dropdown-option-disabled]`)
+        .exists({ count: 1 });
+      assert
+        .dom(
+          `[data-test-card-picker-dropdown] li:nth-of-type(2)[aria-disabled="true"]`
+        )
+        .exists();
+      assert
+        .dom(
+          `[data-test-card-picker-dropdown-option="${prepaidCardAddress2}"][data-test-card-picker-dropdown-option-disabled]`
+        )
+        .hasClass('card-picker-dropdown__option--disabled');
+    });
+  }
+);


### PR DESCRIPTION
CS-1896

Prepaid card selection card-picker:
- If the user only has 1 card (with sufficient balance), preselect that card
- Disable and fade out low balance cards