### PR TITLE
More robust workflow state comparison

### DIFF
--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -24,7 +24,10 @@ import { faceValueOptions } from '@cardstack/web-client/components/card-pay/issu
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
 import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';
 import { setupHubAuthenticationToken } from '../helpers/setup';
-import { buildState } from '@cardstack/web-client/models/workflow/workflow-session';
+import {
+  deserializeState,
+  WorkflowMeta,
+} from '@cardstack/web-client/models/workflow/workflow-session';
 
 interface Context extends MirageTestContext {}
 
@@ -541,65 +544,67 @@ module('Acceptance | issue prepaid card', function (hooks) {
       ''
     );
 
-    assert.deepEqual(
-      {
-        ...persistedState,
-        meta: persistedState.meta
-          .replace(/"createdAt":".+?",/, '')
-          .replace(/"updatedAt":".+?",/, ''),
+    let deserializedState = deserializeState({
+      ...persistedState,
+    });
+    // We don't have a good way to control the date properties in an acceptance test yet
+    // sinon.useFakeTimers will mess up a couple of browser apis + ember concurrency
+    if (deserializedState.meta) {
+      delete (deserializedState.meta as WorkflowMeta)?.createdAt;
+      delete (deserializedState.meta as WorkflowMeta)?.updatedAt;
+    }
+
+    assert.deepEqual(deserializedState, {
+      colorScheme: {
+        patternColor: 'white',
+        textColor: 'black',
+        background: '#37EB77',
+        id: '4f219852-33ee-4e4c-81f7-76318630a423',
       },
-      buildState({
-        colorScheme: {
-          patternColor: 'white',
-          textColor: 'black',
-          background: '#37EB77',
-          id: '4f219852-33ee-4e4c-81f7-76318630a423',
-        },
-        did: 'did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e',
-        issuerName: 'JJ',
-        layer2WalletAddress: '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44',
-        pattern: {
-          patternUrl:
-            '/assets/images/prepaid-card-customizations/pattern-3-be5bfc96d028c4ed55a5aafca645d213.svg',
-          id: '80cb8f99-c5f7-419e-9c95-2e87a9d8db32',
-        },
-        prepaidCardAddress: '0xaeFbA62A2B3e90FD131209CC94480E722704E1F8',
-        prepaidCardSafe: {
-          type: 'prepaid-card',
-          address: '0xaeFbA62A2B3e90FD131209CC94480E722704E1F8',
-          tokens: [],
-          owners: ['0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44'],
-          issuingToken: '0xTOKEN',
-          spendFaceValue: 10000,
-          prepaidCardOwner: '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44',
-          hasBeenUsed: false,
-          issuer: '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44',
-          reloadable: true,
-          transferrable: true,
-          customizationDID:
-            'did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e',
-        },
-        prepaidFundingToken: 'DAI.CPXD',
-        reloadable: true,
+      did: 'did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e',
+      issuerName: 'JJ',
+      layer2WalletAddress: '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44',
+      pattern: {
+        patternUrl:
+          '/assets/images/prepaid-card-customizations/pattern-3-be5bfc96d028c4ed55a5aafca645d213.svg',
+        id: '80cb8f99-c5f7-419e-9c95-2e87a9d8db32',
+      },
+      prepaidCardAddress: '0xaeFbA62A2B3e90FD131209CC94480E722704E1F8',
+      prepaidCardSafe: {
+        type: 'prepaid-card',
+        address: '0xaeFbA62A2B3e90FD131209CC94480E722704E1F8',
+        tokens: [],
+        owners: ['0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44'],
+        issuingToken: '0xTOKEN',
         spendFaceValue: 10000,
+        prepaidCardOwner: '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44',
+        hasBeenUsed: false,
+        issuer: '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44',
+        reloadable: true,
         transferrable: true,
-        txnHash: 'exampleTxnHash',
-        meta: {
-          completedCardNames: [
-            'LAYER2_CONNECT',
-            'HUB_AUTH',
-            'LAYOUT_CUSTOMIZATION',
-            'FUNDING_SOURCE',
-            'FACE_VALUE',
-            'PREVIEW',
-            'CONFIRMATION',
-            'EPILOGUE_LAYER_TWO_CONNECT_CARD',
-          ],
-          completedMilestonesCount: 4,
-          milestonesCount: 4,
-        },
-      })
-    );
+        customizationDID:
+          'did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e',
+      },
+      prepaidFundingToken: 'DAI.CPXD',
+      reloadable: true,
+      spendFaceValue: 10000,
+      transferrable: true,
+      txnHash: 'exampleTxnHash',
+      meta: {
+        completedCardNames: [
+          'LAYER2_CONNECT',
+          'HUB_AUTH',
+          'LAYOUT_CUSTOMIZATION',
+          'FUNDING_SOURCE',
+          'FACE_VALUE',
+          'PREVIEW',
+          'CONFIRMATION',
+          'EPILOGUE_LAYER_TWO_CONNECT_CARD',
+        ],
+        completedMilestonesCount: 4,
+        milestonesCount: 4,
+      },
+    });
   });
 
   // test('Initiating workflow with layer 2 wallet already connected', async function (assert) {

--- a/packages/web-client/tests/acceptance/withdrawal-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-persistence-test.ts
@@ -105,7 +105,7 @@ module('Acceptance | withdrawal persistence', function (hooks) {
             'TRANSACTION_AMOUNT',
             'TRANSACTION_STATUS',
           ],
-          createdAt: 1627908405,
+          createdAt: '1627908405',
         },
       });
 

--- a/packages/web-client/tests/unit/models/workflow/workflow-session-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/workflow-session-test.ts
@@ -7,6 +7,7 @@ import WorkflowPersistence from '@cardstack/web-client/services/workflow-persist
 import Ember from 'ember';
 import BN from 'bn.js';
 import { default as sinon, SinonFakeTimers } from 'sinon';
+import { Workflow } from '@cardstack/web-client/models/workflow';
 
 const { track, valueForTag, validateTag } =
   // @ts-ignore digging
@@ -49,7 +50,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
     assert.equal(subject.getValue<string>('myKey'), 'myValue');
   });
@@ -63,7 +64,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
     assert.equal(subject.getValue<string>('myKey'), null);
   });
@@ -77,7 +78,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
 
     const tag = track(() => {
@@ -114,7 +115,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
 
     const tag = track(() => {
@@ -154,7 +155,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
     assert.equal(subject.getValue<number>('myKey'), 42);
   });
@@ -168,7 +169,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
     assert.equal(subject.getValue<number>('myKey'), null);
   });
@@ -182,7 +183,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
 
     const tag = track(() => {
@@ -219,7 +220,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
 
     const tag = track(() => {
@@ -265,7 +266,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
 
     assert.deepEqual(subject.getValues(), {
@@ -287,7 +288,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
     assert.equal(subject.state.myNumberKey, 42);
     assert.equal(subject.state.myStringKey, 'myValue');
@@ -320,7 +321,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
     assert.equal(subject.getValue<boolean>('myKey'), false);
   });
@@ -334,7 +335,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
     assert.equal(subject.getValue<boolean>('myKey'), null);
   });
@@ -348,7 +349,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
 
     const tag = track(() => {
@@ -387,7 +388,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
     assert.ok(
       subject.getValue<BN>('myKey')?.eq(new BN('42')),
@@ -404,7 +405,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
     assert.equal(subject.getValue<BN>('myKey'), null);
   });
@@ -418,7 +419,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
 
     const tag = track(() => {
@@ -460,7 +461,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
     assert.equal(
       subject.getValue<Date>('myKey')?.getTime(),
@@ -478,7 +479,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
     assert.equal(subject.getValue<Date>('myKey'), null);
   });
@@ -492,7 +493,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
 
     const tag = track(() => {
@@ -533,7 +534,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
 
     const tag = track(() => {
@@ -570,7 +571,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     subject.restoreFromStorage();
 
     const tag = track(() => {
@@ -616,13 +617,17 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     assert.throws(() => {
       subject.setValue('meta', 'something');
     }, 'Please use setMeta to set meta values');
 
     assert.throws(() => {
-      subject.setValue({ meta: 'something-else' });
+      subject.setValue({
+        meta: {
+          updatedAt: '3',
+        },
+      });
     }, 'Please use setMeta to set meta values');
   });
 
@@ -635,7 +640,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     let initialMeta = subject.getMeta();
 
     assert.equal(
@@ -700,7 +705,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
     let initialMeta = subject.getMeta();
     assert.equal(
       initialMeta?.createdAt,
@@ -740,7 +745,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     let subject = new WorkflowSession({
       workflowPersistence,
       workflowPersistenceId: ID,
-    });
+    } as Workflow);
 
     subject.setValue('arbitrary-key', 'arbitrary-value');
 


### PR DESCRIPTION
- `WorkflowSession` recognizes `Workflow` in Typescript
- Deserializes actual state to `Record<string, SupportedType>` rather than serializing the expected state so that `deepEqual` will not be affected by the order of properties specified, or string formatting.