### PR TITLE
Workflow persistence boilerplate refactor

### DIFF
--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/index.hbs
@@ -1,7 +1,9 @@
-<WorkflowThread
-  class="create-merchant-workflow"
-  @workflow={{this.workflow}}
-/>
+{{#if this.workflow}}
+  <WorkflowThread
+    class="create-merchant-workflow"
+    @workflow={{this.workflow}}
+  />
+{{/if}}
 <Listener
   @emitter={{this.layer2Network}}
   @event="disconnect"

--- a/packages/web-client/app/models/workflow.ts
+++ b/packages/web-client/app/models/workflow.ts
@@ -232,9 +232,7 @@ export abstract class Workflow {
       this.session.getMeta().isCancelled &&
       this.session.getMeta().cancelationReason
     ) {
-      next(this, () => {
-        this.cancel(this.session.getMeta().cancelationReason);
-      });
+      this.cancel(this.session.getMeta().cancelationReason);
     }
   }
 }

--- a/packages/web-client/app/models/workflow.ts
+++ b/packages/web-client/app/models/workflow.ts
@@ -6,7 +6,6 @@ import { tracked } from '@glimmer/tracking';
 import { SimpleEmitter } from '../utils/events';
 import WorkflowPersistence from '@cardstack/web-client/app/services/workflow-persistence';
 import { setOwner } from '@ember/application';
-import { next } from '@ember/runloop';
 export { Milestone } from './workflow/milestone';
 export { default as PostableCollection } from './workflow/postable-collection';
 export { WorkflowMessage, IWorkflowMessage } from './workflow/workflow-message';

--- a/packages/web-client/app/models/workflow.ts
+++ b/packages/web-client/app/models/workflow.ts
@@ -4,9 +4,9 @@ import { WorkflowPostable } from './workflow/workflow-postable';
 import WorkflowSession, { IWorkflowSession } from './workflow/workflow-session';
 import { tracked } from '@glimmer/tracking';
 import { SimpleEmitter } from '../utils/events';
-import { next } from '@ember/runloop';
 import WorkflowPersistence from '@cardstack/web-client/app/services/workflow-persistence';
 import { setOwner } from '@ember/application';
+import { next } from '@ember/runloop';
 export { Milestone } from './workflow/milestone';
 export { default as PostableCollection } from './workflow/postable-collection';
 export { WorkflowMessage, IWorkflowMessage } from './workflow/workflow-message';
@@ -52,10 +52,29 @@ export abstract class Workflow {
   workflowPersistence: WorkflowPersistence;
   workflowPersistenceId?: string;
 
-  constructor(owner?: any) {
+  abstract restorationErrors(): string[];
+  abstract beforeRestorationChecks(): Promise<void>[];
+
+  constructor(owner?: any, workflowPersistenceId?: string) {
     setOwner(this, owner);
     this.session = new WorkflowSession(this);
     this.workflowPersistence = owner.lookup('service:workflow-persistence');
+    this.workflowPersistenceId = workflowPersistenceId;
+  }
+
+  async restore() {
+    if (!this.session.hasPersistedState()) {
+      return;
+    }
+    this.session.restoreFromStorage();
+    await Promise.all(this.beforeRestorationChecks());
+    let errors = this.restorationErrors();
+
+    if (errors.length > 0) {
+      this.cancel(errors[0]);
+    } else {
+      this.restoreFromPersistedWorkflow();
+    }
   }
 
   attachWorkflow() {

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
@@ -3,15 +3,13 @@ import { setupRenderingTest } from 'ember-qunit';
 import { click, render, waitFor, waitUntil } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
-import {
-  Workflow,
-  WorkflowSession,
-} from '@cardstack/web-client/models/workflow';
+import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 import sinon from 'sinon';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
 import { Response as MirageResponse } from 'ember-cli-mirage';
 import BN from 'bn.js';
+import { WorkflowStub } from '@cardstack/web-client/tests/stubs/workflow';
 
 interface Context extends MirageTestContext {}
 
@@ -282,8 +280,7 @@ module(
       });
 
       test('it cancels the workflow if hub authentication fails', async function (assert) {
-        class ConcreteWorkflow extends Workflow {}
-        let workflow = new ConcreteWorkflow(this.owner);
+        let workflow = new WorkflowStub(this.owner);
         workflow.attachWorkflow();
         this.set('workflowSession.workflow', workflow);
 

--- a/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
@@ -3,10 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { click, render, waitFor, waitUntil } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
-import {
-  Workflow,
-  WorkflowSession,
-} from '@cardstack/web-client/models/workflow';
+import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 import sinon from 'sinon';
 import CardCustomization from '@cardstack/web-client/services/card-customization';
 import { taskFor } from 'ember-concurrency-ts';
@@ -16,6 +13,7 @@ import prepaidCardColorSchemes from '../../../../../mirage/fixture-data/prepaid-
 import prepaidCardPatterns from '../../../../../mirage/fixture-data/prepaid-card-patterns';
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
 import BN from 'bn.js';
+import { WorkflowStub } from '@cardstack/web-client/tests/stubs/workflow';
 
 const USER_REJECTION_ERROR_MESSAGE =
   'It looks like you have canceled the request in your wallet. Please try again if you want to continue with this workflow.';
@@ -96,8 +94,7 @@ module(
       });
 
       test('it cancels the workflow if hub authentication fails', async function (assert) {
-        class ConcreteWorkflow extends Workflow {}
-        let workflow = new ConcreteWorkflow(this.owner);
+        let workflow = new WorkflowStub(this.owner);
         workflow.attachWorkflow();
         this.set('workflowSession.workflow', workflow);
 

--- a/packages/web-client/tests/integration/components/workflow-thread-test.ts
+++ b/packages/web-client/tests/integration/components/workflow-thread-test.ts
@@ -5,19 +5,17 @@ import hbs from 'htmlbars-inline-precompile';
 import {
   Milestone,
   PostableCollection,
-  Workflow,
   WorkflowMessage,
   WorkflowPostable,
   WorkflowCard,
 } from '@cardstack/web-client/models/workflow';
+import { WorkflowStub } from '@cardstack/web-client/tests/stubs/workflow';
 
 module('Integration | Component | workflow-thread', function (hooks) {
   setupRenderingTest(hooks);
 
-  class ConcreteWorkflow extends Workflow {}
-
   test('it renders before-content named block', async function (assert) {
-    this.set('workflow', new ConcreteWorkflow(this.owner));
+    this.set('workflow', new WorkflowStub(this.owner));
     await render(hbs`
       <WorkflowThread @workflow={{this.workflow}}>
         <:before-content>
@@ -31,7 +29,7 @@ module('Integration | Component | workflow-thread', function (hooks) {
   });
 
   test('it renders date divider before first post and when the date changes', async function (assert) {
-    let workflow = new ConcreteWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     let postable1 = new WorkflowMessage({
       author: { name: 'cardbot' },
       message: 'Hello world',
@@ -79,7 +77,7 @@ module('Integration | Component | workflow-thread', function (hooks) {
   });
 
   test('it uses the appropriate text for milestone statuses', async function (assert) {
-    let workflow = new ConcreteWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     workflow.milestones = [
       new Milestone({
         title: 'First milestone',
@@ -133,7 +131,7 @@ module('Integration | Component | workflow-thread', function (hooks) {
   });
 
   test('it renders epilogue posts after the workflow is complete', async function (assert) {
-    let workflow = new ConcreteWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     let postable1 = new WorkflowPostable({ name: 'cardbot' });
     workflow.milestones = [
       new Milestone({
@@ -162,7 +160,7 @@ module('Integration | Component | workflow-thread', function (hooks) {
   });
 
   test('it renders cancelation posts after the workflow is canceled', async function (assert) {
-    let workflow = new ConcreteWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     workflow.milestones = [
       new Milestone({
         title: 'First milestone',
@@ -206,7 +204,7 @@ module('Integration | Component | workflow-thread', function (hooks) {
         `
     );
 
-    let workflow = new ConcreteWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     let message = () =>
       new WorkflowMessage({
         author: { name: 'cardbot' },

--- a/packages/web-client/tests/stubs/workflow.ts
+++ b/packages/web-client/tests/stubs/workflow.ts
@@ -1,0 +1,12 @@
+import { Workflow, WorkflowName } from '@cardstack/web-client/models/workflow';
+
+export class WorkflowStub extends Workflow {
+  name = 'WITHDRAWAL' as WorkflowName;
+
+  restorationErrors() {
+    return [];
+  }
+  beforeRestorationChecks() {
+    return [];
+  }
+}

--- a/packages/web-client/tests/unit/models/animated-workflow-test.ts
+++ b/packages/web-client/tests/unit/models/animated-workflow-test.ts
@@ -3,17 +3,12 @@ import { setupTest } from 'ember-qunit';
 import {
   Milestone,
   PostableCollection,
-  Workflow,
   WorkflowCard,
   WorkflowMessage,
-  WorkflowName,
 } from '@cardstack/web-client/models/workflow';
 import AnimatedWorkflow from '@cardstack/web-client/models/animated-workflow';
 import { settled } from '@ember/test-helpers';
-
-class MockWorkflow extends Workflow {
-  name = 'WITHDRAWAL' as WorkflowName;
-}
+import { WorkflowStub } from '@cardstack/web-client/tests/stubs/workflow';
 
 let message = (message: string = 'Default message') =>
   new WorkflowMessage({
@@ -42,7 +37,7 @@ module('Unit | AnimatedWorkflow model', function (hooks) {
   });
 
   test("It uses the wrapped workflow's milestones to model its milestones", async function (assert) {
-    let workflow = new MockWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     workflow.milestones = [
       new Milestone({
         title: 'Milestone 1',
@@ -83,7 +78,7 @@ module('Unit | AnimatedWorkflow model', function (hooks) {
   });
 
   test("It reflects the wrapped workflow's isCanceled property", async function (assert) {
-    let workflow = new MockWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     workflow.milestones = [
       new Milestone({
         title: 'Unfinished milestone',
@@ -112,7 +107,7 @@ module('Unit | AnimatedWorkflow model', function (hooks) {
   });
 
   test('It can progress as the underlying workflow progresses through milestones', async function (assert) {
-    let workflow = new MockWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     let target1 = card();
     let target2 = card();
     let target3 = card();
@@ -176,7 +171,7 @@ module('Unit | AnimatedWorkflow model', function (hooks) {
   });
 
   test('It can show an appropriate workflow progress status (milestone, canceled, started)', async function (assert) {
-    let workflow = new MockWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     let target1 = card();
     let target2 = card();
 
@@ -215,7 +210,7 @@ module('Unit | AnimatedWorkflow model', function (hooks) {
   });
 
   test('It makes cancelationMessages visible after the workflow is canceled', async function (assert) {
-    let workflow = new MockWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
 
     workflow.milestones = [
       new Milestone({
@@ -244,7 +239,7 @@ module('Unit | AnimatedWorkflow model', function (hooks) {
   });
 
   test('It makes the epilogue visible after the workflow is completed', async function (assert) {
-    let workflow = new MockWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     let target1 = card();
 
     workflow.milestones = [
@@ -271,7 +266,7 @@ module('Unit | AnimatedWorkflow model', function (hooks) {
   });
 
   test('It can roll back a workflow when the wrapped workflow is rolled back', async function (assert) {
-    let workflow = new MockWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     let target1 = card(true);
 
     workflow.milestones = [

--- a/packages/web-client/tests/unit/models/workflow-test.ts
+++ b/packages/web-client/tests/unit/models/workflow-test.ts
@@ -8,11 +8,10 @@ import {
   WorkflowMessage,
   WorkflowPostable,
 } from '@cardstack/web-client/models/workflow';
+import { WorkflowStub } from '@cardstack/web-client/tests/stubs/workflow';
 
 module('Unit | Workflow model', function (hooks) {
   setupTest(hooks);
-
-  class ConcreteWorkflow extends Workflow {}
 
   let exampleMilestone: Milestone;
   let exampleMessage: WorkflowMessage;
@@ -33,7 +32,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('attachWorkflow sets workflow on milestones', function (assert) {
-    let workflow = new ConcreteWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     workflow.milestones = [exampleMilestone];
     assert.ok(!exampleMilestone.workflow);
     workflow.attachWorkflow();
@@ -41,7 +40,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('attachWorkflow sets workflow on epiloguePostables', function (assert) {
-    let workflow = new ConcreteWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     workflow.milestones = [exampleMilestone];
     workflow.epilogue.postables = [exampleMessage];
     assert.ok(!exampleMessage.workflow);
@@ -50,7 +49,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('attachWorkflow sets workflow on cancelationMessages', function (assert) {
-    let workflow = new ConcreteWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     workflow.milestones = [exampleMilestone];
     workflow.cancelationMessages = new PostableCollection([exampleMessage]);
     assert.ok(!exampleMessage.workflow);
@@ -59,7 +58,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('completedMilestoneCount returns count of milestones with isComplete true', function (assert) {
-    let workflow = new ConcreteWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     let milestone2Postable = new WorkflowPostable({ name: 'cardbot' });
     milestone2Postable.isComplete = false;
 
@@ -78,7 +77,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('visibleMilestones returns milestones up to and including first incomplete milestone', function (assert) {
-    let workflow = new ConcreteWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     let milestone2Postable = new WorkflowPostable({ name: 'cardbot' });
     milestone2Postable.isComplete = false;
 
@@ -105,7 +104,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('progressStatus returns the "completedDetail" of the last complete milestone', function (assert) {
-    let workflow = new ConcreteWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     let milestone2Postable = new WorkflowPostable({ name: 'cardbot' });
     milestone2Postable.isComplete = false;
 
@@ -123,20 +122,20 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('progressStatus returns "Workflow started" when no milestones are complete', function (assert) {
-    let workflow = new ConcreteWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     workflow.milestones = [exampleMilestone];
     assert.equal(workflow.progressStatus, 'Workflow started');
   });
 
   test('progressStatus returns "Workflow canceled" when workflow is canceled', function (assert) {
-    let workflow = new ConcreteWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     workflow.milestones = [exampleMilestone];
     workflow.cancel('TEST');
     assert.equal(workflow.progressStatus, 'Workflow canceled');
   });
 
   test('Incomplete workflow is canceled when workflow.cancel is called', function (assert) {
-    let workflow = new ConcreteWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     workflow.milestones = [exampleMilestone];
     workflow.cancel('TEST');
     assert.equal(workflow.isCanceled, true);
@@ -144,7 +143,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('Workflow cannot be canceled twice', function (assert) {
-    let workflow = new ConcreteWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     workflow.milestones = [exampleMilestone];
     workflow.cancel('FIRST');
     workflow.cancel('SECOND');
@@ -153,7 +152,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('Completed workflow is not canceled when workflow.cancel is called', function (assert) {
-    let workflow = new ConcreteWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     workflow.milestones = [exampleMilestone];
     examplePostable.isComplete = true;
 
@@ -163,7 +162,7 @@ module('Unit | Workflow model', function (hooks) {
   });
 
   test('Workflow.resetTo resets each milestone and its epilogue correctly', function (assert) {
-    const testWorkflow = new ConcreteWorkflow(this.owner);
+    const testWorkflow = new WorkflowStub(this.owner);
     let indicesArray: string[] = [];
 
     class DummyResetFromEpilogue extends PostableCollection {
@@ -253,7 +252,7 @@ module('Unit | Workflow model', function (hooks) {
     let calledIncludeIf: boolean;
 
     hooks.beforeEach(function () {
-      workflow = new ConcreteWorkflow(this.owner);
+      workflow = new WorkflowStub(this.owner);
       calledIncludeIf = false;
       let secondMilestone = new Milestone({
         title: 'Milestone 2',

--- a/packages/web-client/tests/unit/models/workflow/milestone-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/milestone-test.ts
@@ -3,9 +3,9 @@ import { setupTest } from 'ember-qunit';
 import {
   Milestone,
   Participant,
-  Workflow,
   WorkflowPostable,
 } from '@cardstack/web-client/models/workflow';
+import { WorkflowStub } from '@cardstack/web-client/tests/stubs/workflow';
 
 module('Unit | Milestone model', function (hooks) {
   setupTest(hooks);
@@ -79,10 +79,8 @@ module('Unit | Milestone model', function (hooks) {
       assert.ok(subject.isComplete);
     });
 
-    class ConcreteWorkflow extends Workflow {}
-
     test('setWorkflow does exactly that', function (assert) {
-      let workflow = new ConcreteWorkflow(this.owner);
+      let workflow = new WorkflowStub(this.owner);
       subject.setWorkflow(workflow);
       assert.strictEqual(subject.workflow, workflow);
     });

--- a/packages/web-client/tests/unit/models/workflow/workflow-card-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/workflow-card-test.ts
@@ -2,12 +2,12 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { settled } from '@ember/test-helpers';
 import {
-  Milestone,
-  Workflow,
   WorkflowCard,
   Participant,
   WorkflowPostable,
+  Milestone,
 } from '@cardstack/web-client/models/workflow';
+import { WorkflowStub } from '@cardstack/web-client/tests/stubs/workflow';
 
 module('Unit | WorkflowCard model', function (hooks) {
   setupTest(hooks);
@@ -22,8 +22,8 @@ module('Unit | WorkflowCard model', function (hooks) {
       author: participant,
       componentName: 'foo/bar',
     });
-    class StubWorkflow extends Workflow {}
-    let wf = new StubWorkflow(this.owner);
+
+    let wf = new WorkflowStub(this.owner);
     subject.setWorkflow(wf);
     assert.equal(subject.session, wf.session);
   });
@@ -58,7 +58,7 @@ module('Unit | WorkflowCard model', function (hooks) {
       },
     });
 
-    class StubWorkflow extends Workflow {
+    class CustomWorkflowStub extends WorkflowStub {
       milestones = [
         new Milestone({
           title: 'mock. should not be completed',
@@ -67,7 +67,7 @@ module('Unit | WorkflowCard model', function (hooks) {
         }),
       ];
     }
-    let wf = new StubWorkflow(this.owner);
+    let wf = new CustomWorkflowStub(this.owner);
     subject.setWorkflow(wf);
 
     subject.onComplete();
@@ -82,12 +82,12 @@ module('Unit | WorkflowCard model', function (hooks) {
       author: participant,
       componentName: 'foo/bar',
     });
-    class StubWorkflow extends Workflow {
+    class CustomWorkflowStub extends WorkflowStub {
       resetTo(postable: WorkflowPostable) {
         postable.isComplete = false; // simplified version of actual implementation
       }
     }
-    let wf = new StubWorkflow(this.owner);
+    let wf = new CustomWorkflowStub(this.owner);
     subject.setWorkflow(wf);
     subject.onIncomplete();
     assert.equal(subject.isComplete, false);

--- a/packages/web-client/tests/unit/models/workflow/workflow-postable-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/workflow-postable-test.ts
@@ -1,15 +1,13 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { Workflow } from '@cardstack/web-client/models/workflow';
 import {
   Participant,
   WorkflowPostable,
 } from '@cardstack/web-client/models/workflow/workflow-postable';
+import { WorkflowStub } from '@cardstack/web-client/tests/stubs/workflow';
 
 module('Unit | WorkflowPostable model', function (hooks) {
   setupTest(hooks);
-
-  class ConcreteWorkflow extends Workflow {}
 
   let participant: Participant;
   hooks.beforeEach(function () {
@@ -37,7 +35,7 @@ module('Unit | WorkflowPostable model', function (hooks) {
   });
 
   test('setWorkflow does exactly that', function (assert) {
-    let workflow = new ConcreteWorkflow(this.owner);
+    let workflow = new WorkflowStub(this.owner);
     let subject = new WorkflowPostable(participant);
     subject.setWorkflow(workflow);
     assert.strictEqual(subject.workflow, workflow);


### PR DESCRIPTION
This PR:

1. Extracts the restoration logic out of the components and moves it to the `Workflow` model 
2. Moves the responsibility of getting the URL's `flow-id` query param from the `Workflow` model to the component 
3. Delays assigning the workflow to workflow components to the point where the async restoration validation checks and the restoration itself have been finished. This is to avoid unnecessary recomputation on restore, and allows us to remove some of the `next`s that we use  in the restoration flow to mitigate the "recomputation warning"
4. Replaces `MockWorkflow`, `ConcreteWorkflow`, `StubWorkflow` with a `WorkflowStub` so that we don't use so many different names for the same thing 
