### PR TITLE
web: Remove superfluous action invocation argument

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -192,7 +192,6 @@ jobs:
           SENTRY_DSN: ${{ secrets.WEB_CLIENT_SENTRY_DSN }}
         with:
           environment: staging
-          sentry_url_prefix: https://app-staging.stack.cards
       - name: Send success notification to Discord
         if: ${{ success() }}
         uses: ./.github/actions/discord-message


### PR DESCRIPTION
I missed this in #2118, it produces [warnings](https://github.com/cardstack/cardstack/actions/runs/1283241852).