### PR TITLE
default to HUB_ENVIRONMENT for the config env

### DIFF
--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -98,6 +98,7 @@ export function wireItUp(registryCallback?: RegistryCallback): Container {
 }
 
 const LOGGER = logger('hub/server');
+process.env.NODE_CONFIG_ENV = process.env.HUB_ENVIRONMENT || process.env.NODE_ENV;
 
 // Empty for now
 const DEFAULT_CONFIG: ServerConfig = {};


### PR DESCRIPTION
Based on the docs here: https://github.com/lorenwest/node-config/wiki/Environment-Variables#node_config_env
if you wish to use an env that is different from the NODE_ENV, you can set the NODE_CONFIG_ENV. I have defaulted this to the HUB_ENVIRONMENT env var which we set in waypoint to "production" and "staging", respectively.