### PR TITLE
Workflow cancellation bug

### DIFF
--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
@@ -340,7 +340,7 @@ class CreateMerchantWorkflow extends Workflow {
       layer2Network.isConnected &&
       persistedState.layer2WalletAddress &&
       layer2Network.walletInfo.firstAddress !==
-        persistedState.layer2WalletAddress
+        JSON.parse(persistedState.layer2WalletAddress).value
     ) {
       errors.push(FAILURE_REASONS.RESTORATION_L2_ACCOUNT_CHANGED);
     }

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import config from '@cardstack/web-client/config/environment';
-import { WorkflowSession } from '@cardstack/web-client/models/workflow';
+import { IWorkflowSession } from '@cardstack/web-client/models/workflow';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import MerchantInfoService from '@cardstack/web-client/services/merchant-info';
 import { isLayer2UserRejectionError } from '@cardstack/web-client/utils/is-user-rejection-error';
@@ -27,7 +27,7 @@ import {
 import BN from 'bn.js';
 
 interface CardPayCreateMerchantWorkflowPrepaidCardChoiceComponentArgs {
-  workflowSession: WorkflowSession;
+  workflowSession: IWorkflowSession;
   onComplete: () => void;
   isComplete: boolean;
 }

--- a/packages/web-client/app/components/card-pay/deposit-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/index.ts
@@ -262,7 +262,7 @@ class DepositWorkflow extends Workflow {
     this.attachWorkflow();
   }
 
-  restorationErrors(persistedState: any) {
+  restorationErrors() {
     let { layer1Network, layer2Network } = this;
 
     let errors = [];
@@ -271,11 +271,13 @@ class DepositWorkflow extends Workflow {
       errors.push(FAILURE_REASONS.RESTORATION_L1_DISCONNECTED);
     }
 
+    let persistedLayer1Address = this.session.getValue<string>(
+      'layer1WalletAddress'
+    );
     if (
       layer1Network.isConnected &&
-      persistedState.layer1WalletAddress &&
-      layer1Network.walletInfo.firstAddress !==
-        JSON.parse(persistedState.layer1WalletAddress).value
+      persistedLayer1Address &&
+      layer1Network.walletInfo.firstAddress !== persistedLayer1Address
     ) {
       errors.push(FAILURE_REASONS.RESTORATION_L1_ADDRESS_CHANGED);
     }
@@ -284,11 +286,13 @@ class DepositWorkflow extends Workflow {
       errors.push(FAILURE_REASONS.RESTORATION_L2_DISCONNECTED);
     }
 
+    let persistedLayer2Address = this.session.getValue<string>(
+      'layer2WalletAddress'
+    );
     if (
       layer2Network.isConnected &&
-      persistedState.layer2WalletAddress &&
-      layer2Network.walletInfo.firstAddress !==
-        JSON.parse(persistedState.layer2WalletAddress).value
+      persistedLayer2Address &&
+      layer2Network.walletInfo.firstAddress !== persistedLayer2Address
     ) {
       errors.push(FAILURE_REASONS.RESTORATION_L2_ADDRESS_CHANGED);
     }
@@ -306,18 +310,18 @@ class DepositWorkflowComponent extends Component {
   constructor(owner: unknown, args: {}) {
     super(owner, args);
     let workflow = new DepositWorkflow(getOwner(this));
-    let persistedState = workflow.session.getPersistedData()?.state ?? {};
-    let willRestore = Object.keys(persistedState).length > 0;
+    let willRestore = workflow.session.hasPersistedState();
 
     if (willRestore) {
-      taskFor(this.restoreTask).perform(workflow, persistedState);
+      workflow.session.restoreFromStorage();
+      taskFor(this.restoreTask).perform(workflow);
     } else {
       this.workflow = workflow;
     }
   }
 
-  @task *restoreTask(workflow: DepositWorkflow, state: any) {
-    let errors = workflow.restorationErrors(state);
+  @task *restoreTask(workflow: DepositWorkflow) {
+    let errors = workflow.restorationErrors();
     if (errors.length > 0) {
       next(this, () => {
         workflow.cancel(errors[0]);

--- a/packages/web-client/app/components/card-pay/deposit-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/index.ts
@@ -275,7 +275,7 @@ class DepositWorkflow extends Workflow {
       layer1Network.isConnected &&
       persistedState.layer1WalletAddress &&
       layer1Network.walletInfo.firstAddress !==
-        persistedState.layer1WalletAddress
+        JSON.parse(persistedState.layer1WalletAddress).value
     ) {
       errors.push(FAILURE_REASONS.RESTORATION_L1_ADDRESS_CHANGED);
     }
@@ -288,7 +288,7 @@ class DepositWorkflow extends Workflow {
       layer2Network.isConnected &&
       persistedState.layer2WalletAddress &&
       layer2Network.walletInfo.firstAddress !==
-        persistedState.layer2WalletAddress
+        JSON.parse(persistedState.layer2WalletAddress).value
     ) {
       errors.push(FAILURE_REASONS.RESTORATION_L2_ADDRESS_CHANGED);
     }

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -329,7 +329,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
     this.attachWorkflow();
   }
 
-  restorationErrors(persistedState: any) {
+  restorationErrors() {
     let { hubAuthentication, layer2Network } = this;
 
     let errors = [];
@@ -342,11 +342,13 @@ class IssuePrepaidCardWorkflow extends Workflow {
       errors.push(FAILURE_REASONS.RESTORATION_L2_DISCONNECTED);
     }
 
+    let persistedLayer2Address = this.session.getValue<string>(
+      'layer2WalletAddress'
+    );
     if (
       layer2Network.isConnected &&
-      persistedState.layer2WalletAddress &&
-      layer2Network.walletInfo.firstAddress !==
-        JSON.parse(persistedState.layer2WalletAddress).value
+      persistedLayer2Address &&
+      layer2Network.walletInfo.firstAddress !== persistedLayer2Address
     ) {
       errors.push(FAILURE_REASONS.RESTORATION_L2_ACCOUNT_CHANGED);
     }
@@ -366,18 +368,18 @@ class IssuePrepaidCardWorkflowComponent extends Component {
     super(owner, args);
 
     let workflow = new IssuePrepaidCardWorkflow(getOwner(this));
-    let persistedState = workflow.session.getPersistedData()?.state ?? {};
-    let willRestore = Object.keys(persistedState).length > 0;
+    let willRestore = workflow.session.hasPersistedState();
 
     if (willRestore) {
-      taskFor(this.restoreTask).perform(workflow, persistedState);
+      workflow.session.restoreFromStorage();
+      taskFor(this.restoreTask).perform(workflow);
     } else {
       this.workflow = workflow;
     }
   }
 
-  @task *restoreTask(workflow: IssuePrepaidCardWorkflow, state: any) {
-    let errors = workflow.restorationErrors(state);
+  @task *restoreTask(workflow: IssuePrepaidCardWorkflow) {
+    let errors = workflow.restorationErrors();
     if (errors.length > 0) {
       next(this, () => {
         workflow.cancel(errors[0]);

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -346,7 +346,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
       layer2Network.isConnected &&
       persistedState.layer2WalletAddress &&
       layer2Network.walletInfo.firstAddress !==
-        persistedState.layer2WalletAddress
+        JSON.parse(persistedState.layer2WalletAddress).value
     ) {
       errors.push(FAILURE_REASONS.RESTORATION_L2_ACCOUNT_CHANGED);
     }

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { taskFor } from 'ember-concurrency-ts';
 import { reads } from 'macro-decorators';
-import { WorkflowSession } from '@cardstack/web-client/models/workflow';
+import { IWorkflowSession } from '@cardstack/web-client/models/workflow';
 import {
   task,
   TaskGenerator,
@@ -28,7 +28,7 @@ import {
 } from '../../../../services/card-customization';
 
 interface CardPayPrepaidCardWorkflowPreviewComponentArgs {
-  workflowSession: WorkflowSession;
+  workflowSession: IWorkflowSession;
   onComplete: () => void;
   isComplete: boolean;
 }

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
@@ -44,11 +44,12 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
     super(owner, args);
     if (this.isConnected) {
       next(this, () => {
-        this.persistWalletAddress();
+        this.persistWalletAddressIfInWorkflow();
         this.args.onComplete?.();
       });
     }
   }
+
   get connectedWalletProvider(): WalletProvider | undefined {
     if (!this.isConnected) return undefined;
     else
@@ -62,8 +63,8 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
     else return '';
   }
 
-  persistWalletAddress() {
-    this.args?.workflowSession?.setValue(
+  persistWalletAddressIfInWorkflow() {
+    this.args.workflowSession?.setValue(
       'layer1WalletAddress',
       this.layer1Network.walletInfo.firstAddress
     );
@@ -133,7 +134,7 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
     yield timeout(500); // allow time for strategy to verify connected chain -- it might not accept the connection
     if (this.isConnected) {
       this.args.onConnect?.();
-      this.persistWalletAddress();
+      this.persistWalletAddressIfInWorkflow();
       this.args.onComplete?.();
     }
   }

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
@@ -63,7 +63,7 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
   }
 
   persistWalletAddress() {
-    this.args.workflowSession.setValue(
+    this.args?.workflowSession?.setValue(
       'layer1WalletAddress',
       this.layer1Network.walletInfo.firstAddress
     );

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
@@ -44,6 +44,7 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
     super(owner, args);
     if (this.isConnected) {
       next(this, () => {
+        this.persistWalletAddress();
         this.args.onComplete?.();
       });
     }
@@ -59,6 +60,13 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
   get connectedWalletLogo(): string {
     if (this.connectedWalletProvider) return this.connectedWalletProvider.logo;
     else return '';
+  }
+
+  persistWalletAddress() {
+    this.args.workflowSession.setValue(
+      'layer1WalletAddress',
+      this.layer1Network.walletInfo.firstAddress
+    );
   }
 
   get cardState(): string {
@@ -125,6 +133,7 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
     yield timeout(500); // allow time for strategy to verify connected chain -- it might not accept the connection
     if (this.isConnected) {
       this.args.onConnect?.();
+      this.persistWalletAddress();
       this.args.onComplete?.();
     }
   }

--- a/packages/web-client/app/components/card-pay/layer-two-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-two-connect-card/index.ts
@@ -37,7 +37,7 @@ class CardPayLayerTwoConnectCardComponent extends Component<CardPayLayerTwoConne
     super(owner, args);
     if (this.isConnected) {
       next(this, () => {
-        this.persistWalletAddress();
+        this.persistWalletAddressIfInWorkflow();
         this.args.onComplete?.();
       });
     }
@@ -64,13 +64,13 @@ class CardPayLayerTwoConnectCardComponent extends Component<CardPayLayerTwoConne
     yield timeout(500); // allow time for strategy to verify connected chain -- it might not accept the connection
     if (this.isConnected) {
       this.args.onConnect?.();
-      this.persistWalletAddress();
+      this.persistWalletAddressIfInWorkflow();
       this.args.onComplete?.();
     }
   }
 
-  persistWalletAddress() {
-    this.args.workflowSession.setValue(
+  persistWalletAddressIfInWorkflow() {
+    this.args.workflowSession?.setValue(
       'layer2WalletAddress',
       this.layer2Network.walletInfo.firstAddress
     );

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
@@ -378,7 +378,7 @@ with Card Pay.`,
       layer1Network.isConnected &&
       persistedState.layer1WalletAddress &&
       layer1Network.walletInfo.firstAddress !==
-        persistedState.layer1WalletAddress
+        JSON.parse(persistedState.layer1WalletAddress).value
     ) {
       errors.push(FAILURE_REASONS.RESTORATION_L1_ADDRESS_CHANGED);
     }
@@ -391,7 +391,7 @@ with Card Pay.`,
       layer2Network.isConnected &&
       persistedState.layer2WalletAddress &&
       layer2Network.walletInfo.firstAddress !==
-        persistedState.layer2WalletAddress
+        JSON.parse(persistedState.layer2WalletAddress).value
     ) {
       errors.push(FAILURE_REASONS.RESTORATION_L2_ADDRESS_CHANGED);
     }

--- a/packages/web-client/app/models/workflow.ts
+++ b/packages/web-client/app/models/workflow.ts
@@ -1,7 +1,7 @@
 import { Milestone } from './workflow/milestone';
 import PostableCollection from './workflow/postable-collection';
 import { WorkflowPostable } from './workflow/workflow-postable';
-import WorkflowSession from './workflow/workflow-session';
+import WorkflowSession, { IWorkflowSession } from './workflow/workflow-session';
 import { tracked } from '@glimmer/tracking';
 import { SimpleEmitter } from '../utils/events';
 import { next } from '@ember/runloop';
@@ -20,6 +20,7 @@ export { default as NetworkAwareWorkflowCard } from './workflow/network-aware-ca
 export { Participant, WorkflowPostable } from './workflow/workflow-postable';
 export {
   WorkflowSessionDictionary,
+  IWorkflowSession,
   default as WorkflowSession,
 } from './workflow/workflow-session';
 export { SessionAwareWorkflowMessage } from './workflow/session-aware-workflow-message';
@@ -43,7 +44,7 @@ export abstract class Workflow {
   cancelationMessages: PostableCollection = new PostableCollection();
   @tracked isCanceled = false;
   @tracked cancelationReason: null | string = null;
-  session: WorkflowSession;
+  session: IWorkflowSession;
   owner: any;
   simpleEmitter = new SimpleEmitter();
   isRestored = false;

--- a/packages/web-client/app/models/workflow/session-aware-workflow-message.ts
+++ b/packages/web-client/app/models/workflow/session-aware-workflow-message.ts
@@ -1,21 +1,21 @@
 import {
   IWorkflowMessage,
+  IWorkflowSession,
   Participant,
   WorkflowPostable,
-  WorkflowSession,
 } from '@cardstack/web-client/models/workflow';
 
 interface SessionAwareWorkflowMessageOptions {
   author: Participant;
   includeIf: (this: WorkflowPostable) => boolean;
-  template: (session: WorkflowSession) => string;
+  template: (session: IWorkflowSession) => string;
 }
 
 export class SessionAwareWorkflowMessage
   extends WorkflowPostable
   implements IWorkflowMessage
 {
-  private template: (session: WorkflowSession) => string;
+  private template: (session: IWorkflowSession) => string;
   isComplete = true;
 
   constructor(options: SessionAwareWorkflowMessageOptions) {

--- a/packages/web-client/app/models/workflow/workflow-card.ts
+++ b/packages/web-client/app/models/workflow/workflow-card.ts
@@ -1,9 +1,9 @@
 import { action } from '@ember/object';
 import { Participant, WorkflowPostable } from './workflow-postable';
-import WorkflowSession from './workflow-session';
+import { IWorkflowSession } from './workflow-session';
 
 export interface WorkflowCardComponentArgs {
-  workflowSession: WorkflowSession;
+  workflowSession: IWorkflowSession;
   onComplete: (() => void) | undefined;
   onIncomplete: (() => void) | undefined;
   isComplete: boolean;
@@ -49,9 +49,10 @@ export class WorkflowCard extends WorkflowPostable {
       this.check = options.check;
     }
   }
-  get session(): WorkflowSession | undefined {
+  get session(): IWorkflowSession | undefined {
     return this.workflow?.session;
   }
+
   get completedCardNames(): Array<string> {
     return this.session?.getMeta()?.completedCardNames ?? [];
   }

--- a/packages/web-client/tests/unit/models/workflow/workflow-session-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/workflow-session-test.ts
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import WorkflowSession, {
   buildState,
+  WorkflowMeta,
 } from '@cardstack/web-client/models/workflow/workflow-session';
 import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';
 import Ember from 'ember';
@@ -643,10 +644,10 @@ module('Unit | WorkflowSession model', function (hooks) {
     } as Workflow);
     let initialMeta = subject.getMeta();
 
-    assert.equal(
+    assert.deepEqual(
       initialMeta,
-      null,
-      'There is no meta when session is instantiated'
+      {} as WorkflowMeta,
+      'There is an empty meta when session is instantiated'
     );
 
     subject.setMeta(


### PR DESCRIPTION
cs-1982

- JSON wasn't parsed, so persisted state wallet address didn't match the current address and workflows got cancelled
- persist layer 1 address