### PR TITLE
add workflow name to workflow session test

### DIFF
--- a/packages/web-client/app/models/workflow.ts
+++ b/packages/web-client/app/models/workflow.ts
@@ -37,7 +37,7 @@ export type WorkflowName =
   | 'MERCHANT_CREATION';
 
 export abstract class Workflow {
-  name!: WorkflowName;
+  abstract name: WorkflowName;
   milestones: Milestone[] = [];
   epilogue: PostableCollection = new PostableCollection();
   cancelationMessages: PostableCollection = new PostableCollection();

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
@@ -5,6 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
 import {
   Workflow,
+  WorkflowName,
   WorkflowSession,
 } from '@cardstack/web-client/models/workflow';
 import sinon from 'sinon';
@@ -282,7 +283,9 @@ module(
       });
 
       test('it cancels the workflow if hub authentication fails', async function (assert) {
-        class ConcreteWorkflow extends Workflow {}
+        class ConcreteWorkflow extends Workflow {
+          name = 'WITHDRAWAL' as WorkflowName;
+        }
         let workflow = new ConcreteWorkflow(this.owner);
         workflow.attachWorkflow();
         this.set('workflowSession.workflow', workflow);

--- a/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/issue-prepaid-card-workflow/preview-test.ts
@@ -5,6 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
 import {
   Workflow,
+  WorkflowName,
   WorkflowSession,
 } from '@cardstack/web-client/models/workflow';
 import sinon from 'sinon';
@@ -96,7 +97,9 @@ module(
       });
 
       test('it cancels the workflow if hub authentication fails', async function (assert) {
-        class ConcreteWorkflow extends Workflow {}
+        class ConcreteWorkflow extends Workflow {
+          name = 'WITHDRAWAL' as WorkflowName;
+        }
         let workflow = new ConcreteWorkflow(this.owner);
         workflow.attachWorkflow();
         this.set('workflowSession.workflow', workflow);

--- a/packages/web-client/tests/integration/components/workflow-thread-test.ts
+++ b/packages/web-client/tests/integration/components/workflow-thread-test.ts
@@ -9,12 +9,15 @@ import {
   WorkflowMessage,
   WorkflowPostable,
   WorkflowCard,
+  WorkflowName,
 } from '@cardstack/web-client/models/workflow';
 
 module('Integration | Component | workflow-thread', function (hooks) {
   setupRenderingTest(hooks);
 
-  class ConcreteWorkflow extends Workflow {}
+  class ConcreteWorkflow extends Workflow {
+    name = 'WITHDRAWAL' as WorkflowName;
+  }
 
   test('it renders before-content named block', async function (assert) {
     this.set('workflow', new ConcreteWorkflow(this.owner));

--- a/packages/web-client/tests/unit/models/workflow-test.ts
+++ b/packages/web-client/tests/unit/models/workflow-test.ts
@@ -6,13 +6,16 @@ import {
   Workflow,
   WorkflowCard,
   WorkflowMessage,
+  WorkflowName,
   WorkflowPostable,
 } from '@cardstack/web-client/models/workflow';
 
 module('Unit | Workflow model', function (hooks) {
   setupTest(hooks);
 
-  class ConcreteWorkflow extends Workflow {}
+  class ConcreteWorkflow extends Workflow {
+    name = 'WITHDRAWAL' as WorkflowName;
+  }
 
   let exampleMilestone: Milestone;
   let exampleMessage: WorkflowMessage;

--- a/packages/web-client/tests/unit/models/workflow/milestone-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/milestone-test.ts
@@ -4,6 +4,7 @@ import {
   Milestone,
   Participant,
   Workflow,
+  WorkflowName,
   WorkflowPostable,
 } from '@cardstack/web-client/models/workflow';
 
@@ -79,7 +80,9 @@ module('Unit | Milestone model', function (hooks) {
       assert.ok(subject.isComplete);
     });
 
-    class ConcreteWorkflow extends Workflow {}
+    class ConcreteWorkflow extends Workflow {
+      name = 'WITHDRAWAL' as WorkflowName;
+    }
 
     test('setWorkflow does exactly that', function (assert) {
       let workflow = new ConcreteWorkflow(this.owner);

--- a/packages/web-client/tests/unit/models/workflow/workflow-card-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/workflow-card-test.ts
@@ -7,6 +7,7 @@ import {
   WorkflowCard,
   Participant,
   WorkflowPostable,
+  WorkflowName,
 } from '@cardstack/web-client/models/workflow';
 
 module('Unit | WorkflowCard model', function (hooks) {
@@ -22,7 +23,9 @@ module('Unit | WorkflowCard model', function (hooks) {
       author: participant,
       componentName: 'foo/bar',
     });
-    class StubWorkflow extends Workflow {}
+    class StubWorkflow extends Workflow {
+      name = 'WITHDRAWAL' as WorkflowName;
+    }
     let wf = new StubWorkflow(this.owner);
     subject.setWorkflow(wf);
     assert.equal(subject.session, wf.session);
@@ -59,6 +62,7 @@ module('Unit | WorkflowCard model', function (hooks) {
     });
 
     class StubWorkflow extends Workflow {
+      name = 'WITHDRAWAL' as WorkflowName;
       milestones = [
         new Milestone({
           title: 'mock. should not be completed',
@@ -83,6 +87,7 @@ module('Unit | WorkflowCard model', function (hooks) {
       componentName: 'foo/bar',
     });
     class StubWorkflow extends Workflow {
+      name = 'WITHDRAWAL' as WorkflowName;
       resetTo(postable: WorkflowPostable) {
         postable.isComplete = false; // simplified version of actual implementation
       }

--- a/packages/web-client/tests/unit/models/workflow/workflow-postable-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/workflow-postable-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { Workflow } from '@cardstack/web-client/models/workflow';
+import { Workflow, WorkflowName } from '@cardstack/web-client/models/workflow';
 import {
   Participant,
   WorkflowPostable,
@@ -9,7 +9,9 @@ import {
 module('Unit | WorkflowPostable model', function (hooks) {
   setupTest(hooks);
 
-  class ConcreteWorkflow extends Workflow {}
+  class ConcreteWorkflow extends Workflow {
+    name = 'WITHDRAWAL' as WorkflowName;
+  }
 
   let participant: Participant;
   hooks.beforeEach(function () {

--- a/packages/web-client/tests/unit/models/workflow/workflow-session-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/workflow-session-test.ts
@@ -42,12 +42,13 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('get string value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {
         myKey: '{ "value": "myValue" }',
       },
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -58,10 +59,11 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('get un-set string value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -72,10 +74,11 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('set string value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -99,7 +102,7 @@ module('Unit | WorkflowSession model', function (hooks) {
 
     let data = workflowPersistence.getPersistedData(ID);
     assert.deepEqual(data, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {
         meta,
         myKey: '{"value":"myValue"}',
@@ -110,10 +113,11 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('set optional string value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -138,7 +142,7 @@ module('Unit | WorkflowSession model', function (hooks) {
 
     let data = workflowPersistence.getPersistedData(ID);
     assert.deepEqual(data, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {
         meta,
         myKey: '{}',
@@ -149,12 +153,13 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('get number value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {
         myKey: '{ "value": 42 }',
       },
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -165,10 +170,11 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('get un-set number value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -179,10 +185,11 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('set number value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -206,7 +213,7 @@ module('Unit | WorkflowSession model', function (hooks) {
 
     let data = workflowPersistence.getPersistedData(ID);
     assert.deepEqual(data, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {
         meta,
         myKey: '{"value":42}',
@@ -217,10 +224,11 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('set multiple keys at once with a hash', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -249,7 +257,7 @@ module('Unit | WorkflowSession model', function (hooks) {
 
     let data = workflowPersistence.getPersistedData(ID);
     assert.deepEqual(data, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {
         meta,
         myNumberKey: '{"value":42}',
@@ -261,13 +269,14 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('get all keys at once as a hash', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {
         myNumberKey: '{ "value": 42 }',
         myStringKey: '{ "value": "myValue" }',
       },
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -282,7 +291,7 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('state is a proxy allowing access to values', async function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {
         myNumberKey: '{ "value": 42 }',
         myStringKey: '{ "value": "myValue" }',
@@ -290,6 +299,7 @@ module('Unit | WorkflowSession model', function (hooks) {
       },
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -317,12 +327,13 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('get boolean value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {
         myKey: '{ "value": false }',
       },
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -333,10 +344,11 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('get un-set boolean value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -347,10 +359,11 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('set boolean value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -374,7 +387,7 @@ module('Unit | WorkflowSession model', function (hooks) {
 
     let data = workflowPersistence.getPersistedData(ID);
     assert.deepEqual(data, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {
         meta,
         myKey: '{"value":false}',
@@ -385,12 +398,13 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('get BigNumber value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {
         myKey: '{ "value": "42", "type": "BN" }',
       },
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -404,10 +418,11 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('get un-set BigNumber value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -418,10 +433,11 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('set BigNumber value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -448,7 +464,7 @@ module('Unit | WorkflowSession model', function (hooks) {
 
     let data = workflowPersistence.getPersistedData(ID);
     assert.deepEqual(data, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {
         meta,
         myKey: '{"value":"42","type":"BN"}',
@@ -459,12 +475,13 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('get Date value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {
         myKey: '{ "value": "2020-09-22T20:50:18.491Z", "type": "Date" }',
       },
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -479,10 +496,11 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('get un-set Date value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -493,10 +511,11 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('set Date value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -524,7 +543,7 @@ module('Unit | WorkflowSession model', function (hooks) {
 
     let data = workflowPersistence.getPersistedData(ID);
     assert.deepEqual(data, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {
         meta,
         myKey: '{"value":"2020-09-22T20:50:18.491Z","type":"Date"}',
@@ -535,10 +554,11 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('set string array value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -562,7 +582,7 @@ module('Unit | WorkflowSession model', function (hooks) {
 
     let data = workflowPersistence.getPersistedData(ID);
     assert.deepEqual(data, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {
         meta,
         myKey: '{"value":["a","b","c"]}',
@@ -573,10 +593,11 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('set string record value', function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -604,7 +625,7 @@ module('Unit | WorkflowSession model', function (hooks) {
 
     let data = workflowPersistence.getPersistedData(ID);
     assert.deepEqual(data, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {
         meta,
         myKey: '{"value":{"a":"A","b":"B","c":"C"}}',
@@ -620,10 +641,11 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('it throws if meta is updated via the setValues method', async function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -643,10 +665,11 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('it can update meta properly, preserving earlier properties', async function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -708,10 +731,11 @@ module('Unit | WorkflowSession model', function (hooks) {
   test('it stores information about updated and created date when persisting data for the first time', async function (assert) {
     let workflowPersistence = new WorkflowPersistence();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -748,10 +772,11 @@ module('Unit | WorkflowSession model', function (hooks) {
     let workflowPersistence = new WorkflowPersistence();
     let startDateString = new Date().toISOString();
     workflowPersistence.persistData(ID, {
-      name: 'EXAMPLE',
+      name: 'PREPAID_CARD_ISSUANCE',
       state: {},
     });
     let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);


### PR DESCRIPTION
The name persisted when `WorkflowSession.persistToStorage` is called is taken from a workflow session's workflow.

Alternatively, we could cast the expected persisted state to `WorkflowPersistencePersistedData`.