### PR TITLE
update canadian dollar sign

### DIFF
--- a/packages/cardpay-sdk/sdk/native-currencies.ts
+++ b/packages/cardpay-sdk/sdk/native-currencies.ts
@@ -163,7 +163,7 @@ export default {
     mask: '[099999999999]{.}[00]',
     placeholder: '0.00',
     smallThreshold: 1,
-    symbol: 'CA$',
+    symbol: 'CAN$',
   },
   NZD: {
     alignment: 'left',


### PR DESCRIPTION
This PR should fix formatting of the canadian dollar sign. `native-currencies.ts` seems like it was taken from:

https://github.com/cardstack/cardwallet/blob/develop/src/references/native-currencies.json

Could we consolidate these? My understanding is, right now any additions* in the reference file in cardwallet should require a change in `native-currencies.ts` for the sake of the `convertAmountToNativeDisplay` utility and other utilities that use it.