### PR TITLE
temporarily remove rewards from query

### DIFF
--- a/packages/cardpay-sdk/sdk/safes/base.ts
+++ b/packages/cardpay-sdk/sdk/safes/base.ts
@@ -111,12 +111,6 @@ const safeQueryFields = `
       id
     }
   }
-  reward {
-    id
-    rewardee {
-      id
-    }
-  }
 `;
 
 const safeQuery = `


### PR DESCRIPTION
Probably dont need #2187, had a look and I think we can just not add this field to the query for now, and add it back on later after subgraph deploy.