### PR TITLE
use exchange rates in merchant payments to display appropriate amount of SPEND + validate min amount

### DIFF
--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -34,11 +34,13 @@ The app uses a Postgresql-based background task queue built on [graphile/worker]
 
 Below is a list of the most common environment variables that the Hub accepts:
 
+- `SERVER_SECRET` (required) - to generate one for your machine, run `node --eval="console.log(crypto.randomBytes(32).toString('base64'))"`
+- `FIXER_API_KEY` (required for `/api/exchange-rates`) - API key for currency exchange rates, we use https://fixer.io/
+- `EXCHANGE_RATES_ALLOWED_DOMAINS` - domains from which a request to `/api/exchange-rates` is allowed
 - `HUB_AWS_ACCESS_KEY_ID`
 - `HUB_AWS_SECRET_ACCESS_KEY`
 - `HUB_AWS_REGION`
 - `AWS_PROFILE` - if none of the HUB_AWS_* variables are defined, no credentials or region will be passed to the aws-sdk. This will make the aws-sdk's default behavior take effect, which includes using an AWS_PROFILE env var if it is set
-- `SERVER_SECRET` (required) - to generate one for your machine, run `node --eval="console.log(crypto.randomBytes(32).toString('base64'))"`
 - `DATABASE_URL` - defaults in development to postgres://postgres:postgres@localhost:5432/hub_development
 - `LOG_LEVELS` - defaults to `*=info`
 
@@ -148,6 +150,8 @@ Run the command, open a postgres client, and connect to localhost, port 55432 wi
 ## Provided APIs
 
 APIs conform to the [JSON API specification](https://jsonapi.org/).
+
+### GET /api/exchange-rates
 
 ### GET /api/prepaid-card-patterns
 

--- a/packages/hub/config/custom-environment-variables.json
+++ b/packages/hub/config/custom-environment-variables.json
@@ -26,6 +26,10 @@
   "web3": {
     "network": "NETWORK"
   },
+  "exchangeRates": {
+    "allowedDomains": "EXCHANGE_RATES_ALLOWED_DOMAINS",
+    "apiKey": "FIXER_API_KEY"
+  },
   "relay": {
     "provisionerSecret": "PROVISIONER_SECRET"
   },

--- a/packages/hub/config/default.json
+++ b/packages/hub/config/default.json
@@ -35,6 +35,10 @@
     "callbackUrl": null,
     "url": "https://api.testwyre.com"
   },
+  "exchangeRates": {
+    "allowedDomains": ["https://wallet-staging.stack.cards", "https://wallet.cardstack.com"],
+    "apiKey": null
+  },
   "relay": {
     "provisionerSecret": null
   },

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -16,6 +16,7 @@ import DevelopmentConfig from './services/development-config';
 import DevelopmentProxyMiddleware from './services/development-proxy-middleware';
 import WyreService from './services/wyre';
 import BoomRoute from './routes/boom';
+import ExchangeRatesRoute from './routes/exchange-rates';
 import SessionRoute from './routes/session';
 import PrepaidCardColorSchemesRoute from './routes/prepaid-card-color-schemes';
 import PrepaidCardColorSchemeSerializer from './services/serializers/prepaid-card-color-scheme-serializer';
@@ -48,6 +49,7 @@ import s3PutJson from './tasks/s3-put-json';
 import { CardstackError } from './utils/error';
 import { environment, httpLogging } from './middleware';
 import cors from '@koa/cors';
+import ExchangeRatesService from './services/exchange-rates';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -72,6 +74,8 @@ export function wireItUp(registryCallback?: RegistryCallback): Container {
   registry.register('database-manager', DatabaseManager);
   registry.register('development-config', DevelopmentConfig);
   registry.register('development-proxy-middleware', DevelopmentProxyMiddleware);
+  registry.register('exchange-rates', ExchangeRatesService);
+  registry.register('exchange-rates-route', ExchangeRatesRoute);
   registry.register('health-check', HealthCheck);
   registry.register('inventory-route', InventoryRoute);
   registry.register('merchant-infos-route', MerchantInfosRoute);

--- a/packages/hub/node-tests/routes/exchange-rates-test.ts
+++ b/packages/hub/node-tests/routes/exchange-rates-test.ts
@@ -1,0 +1,175 @@
+import supertest, { Test } from 'supertest';
+import { HubServer } from '../../main';
+import { Registry } from '../../di/dependency-injection';
+import ExchangeRatesService, { FixerFailureResponse, FixerSuccessResponse } from '../../services/exchange-rates';
+import config from 'config';
+
+const allowedDomains = config.get('exchangeRates.allowedDomains');
+function isValidAllowedDomainConfig(object: unknown): object is string[] {
+  return Array.isArray(object) && object.every((v) => typeof v === 'string') && object.length > 0;
+}
+if (!isValidAllowedDomainConfig(allowedDomains)) {
+  throw new Error('Exchange rate allowed domain config is invalid');
+}
+const allowedDomain = allowedDomains[0];
+
+const mockExchangeRatesResponse = {
+  success: true,
+  timestamp: Math.floor(Date.now() / 1000),
+  date: '2021-09-30',
+  base: 'USD',
+  rates: {
+    GBP: 1, // eslint-disable-line @typescript-eslint/naming-convention
+    CAD: 3, // eslint-disable-line @typescript-eslint/naming-convention
+  },
+} as FixerSuccessResponse;
+
+class StubExchangeRatesService {
+  fetchExchangeRates() {
+    return Promise.resolve(mockExchangeRatesResponse);
+  }
+}
+
+describe('GET /api/exchange-rates', function () {
+  let server: HubServer;
+  let request: supertest.SuperTest<Test>;
+
+  this.afterEach(async function () {
+    server?.teardown();
+  });
+
+  it('does not fetch exchange rates for an incorrect origin', async function () {
+    server = await HubServer.create({
+      registryCallback(registry: Registry) {
+        registry.register('exchange-rates', StubExchangeRatesService);
+      },
+    });
+    request = supertest(server.app.callback());
+    await request
+      .get(`/api/exchange-rates`)
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .set('Origin', 'https://google.com')
+      .expect(403)
+      .expect({
+        errors: [
+          {
+            status: '403',
+            title: 'Not allowed',
+          },
+        ],
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('fetches exchange rates for an accepted origin', async function () {
+    server = await HubServer.create({
+      registryCallback(registry: Registry) {
+        registry.register('exchange-rates', StubExchangeRatesService);
+      },
+    });
+    request = supertest(server.app.callback());
+    await request
+      .get(`/api/exchange-rates`)
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .set('Origin', allowedDomain)
+      .expect(200)
+      .expect({
+        data: {
+          type: 'exchange-rates',
+          attributes: {
+            base: mockExchangeRatesResponse.base,
+            rates: mockExchangeRatesResponse.rates,
+          },
+        },
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('Returns 502 for falsey result being fetched', async function () {
+    class FalseyReturnExchangeRatesService extends ExchangeRatesService {
+      async fetchExchangeRates() {
+        return undefined;
+      }
+    }
+    server = await HubServer.create({
+      registryCallback(registry: Registry) {
+        registry.register('exchange-rates', FalseyReturnExchangeRatesService);
+      },
+    });
+    request = supertest(server.app.callback());
+    await request
+      .get(`/api/exchange-rates`)
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .set('Origin', allowedDomain)
+      .expect(502)
+      .expect({
+        errors: [
+          {
+            status: '502',
+            title: 'Bad Gateway',
+            detail: 'Failed to fetch exchange rates for unknown reason',
+          },
+        ],
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('Returns 502 for failure result from Fixer', async function () {
+    class FailingExchangeRatesService extends ExchangeRatesService {
+      async fetchExchangeRates(): Promise<FixerFailureResponse> {
+        return {
+          success: false,
+          error: {
+            code: -1,
+            info: 'readable info about the error',
+          },
+        };
+      }
+    }
+    server = await HubServer.create({
+      registryCallback(registry: Registry) {
+        registry.register('exchange-rates', FailingExchangeRatesService);
+      },
+    });
+    request = supertest(server.app.callback());
+    await request
+      .get(`/api/exchange-rates`)
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .set('Origin', allowedDomain)
+      .expect(502)
+      .expect({
+        errors: [
+          {
+            status: '502',
+            title: 'Bad Gateway',
+            detail: '-1: readable info about the error',
+          },
+        ],
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('Allows errors from the exchange rate service through', async function () {
+    class CrashingExchangeRatesService extends ExchangeRatesService {
+      async fetchExchangeRates(): Promise<FixerFailureResponse> {
+        throw new Error('An error that might occur in caching or fetching');
+      }
+    }
+    server = await HubServer.create({
+      registryCallback(registry: Registry) {
+        registry.register('exchange-rates', CrashingExchangeRatesService);
+      },
+    });
+    request = supertest(server.app.callback());
+    await request
+      .get(`/api/exchange-rates`)
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .set('Origin', allowedDomain)
+      .expect(500);
+  });
+});

--- a/packages/hub/node-tests/services/exchange-rates-test.ts
+++ b/packages/hub/node-tests/services/exchange-rates-test.ts
@@ -1,0 +1,178 @@
+import ExchangeRatesService, { FixerFailureResponse, FixerSuccessResponse } from '../../services/exchange-rates';
+
+describe('ExchangeRatesService', function () {
+  it('hits the cache if the cache is valid', async function () {
+    let mockCachedValue: FixerSuccessResponse = {
+      success: true,
+      timestamp: Math.floor(Number(new Date()) / 1000),
+      base: 'USD',
+      date: '2021-10-05',
+      rates: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        JPY: 4,
+      },
+    };
+
+    class PatchedExchangeRatesService extends ExchangeRatesService {
+      interval = 1000;
+      cachedValue = mockCachedValue;
+
+      async requestExchangeRatesFromFixer(): Promise<FixerSuccessResponse> {
+        return {
+          success: true,
+          timestamp: Math.floor(Number(new Date()) / 1000),
+          base: 'USD',
+          date: '2021-10-02',
+          rates: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            GBP: 4,
+          },
+        };
+      }
+
+      get cacheIsValid() {
+        return true;
+      }
+    }
+
+    let subject = new PatchedExchangeRatesService();
+    let result = await subject.fetchExchangeRates();
+
+    expect(result).deep.equal(mockCachedValue);
+  });
+
+  it('does not hit the cache if the cache is invalid', async function () {
+    let freshFetches = 0;
+    let mockCachedValue: FixerSuccessResponse = {
+      success: true,
+      timestamp: Math.floor(Number(new Date()) / 1000),
+      base: 'USD',
+      date: '2021-10-05',
+      rates: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        JPY: 4,
+      },
+    };
+    let mockFreshValue: FixerSuccessResponse = {
+      success: true,
+      timestamp: Math.floor(Number(new Date()) / 1000),
+      base: 'USD',
+      date: '2021-10-02',
+      rates: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        GBP: 4,
+      },
+    };
+
+    class PatchedExchangeRatesService extends ExchangeRatesService {
+      interval = 1000;
+      cachedValue = mockCachedValue;
+
+      async requestExchangeRatesFromFixer(): Promise<FixerSuccessResponse> {
+        freshFetches += 1;
+        return mockFreshValue;
+      }
+
+      get cacheIsValid() {
+        return false;
+      }
+    }
+
+    let subject = new PatchedExchangeRatesService();
+    let result = await subject.fetchExchangeRates();
+
+    expect(freshFetches).equal(1);
+    expect(result).deep.equal(mockFreshValue);
+  });
+
+  it('invalidates the cache if it has been too long since last fetch', async function () {
+    let duration = 2000;
+    let mockCachedValue: FixerSuccessResponse = {
+      success: true,
+      timestamp: Math.floor(Number(new Date()) / 1000),
+      base: 'USD',
+      date: '2021-10-05',
+      rates: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        JPY: 4,
+      },
+    };
+    class PatchedExchangeRatesService extends ExchangeRatesService {
+      lastFetched = Number(new Date());
+      cachedValue = mockCachedValue;
+      interval = duration;
+
+      async requestExchangeRatesFromFixer(): Promise<FixerSuccessResponse> {
+        return {
+          success: true,
+          timestamp: Math.floor(Number(new Date()) / 1000),
+          base: 'USD',
+          date: '2021-10-02',
+          rates: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            GBP: 4,
+          },
+        };
+      }
+    }
+
+    let subject = new PatchedExchangeRatesService();
+    expect(subject.cacheIsValid).equal(true);
+    subject.lastFetched = Number(new Date()) - duration * 2;
+    expect(subject.cacheIsValid).equal(false);
+  });
+
+  it('clears the cache after an error', async function () {
+    let mockCachedValue: FixerSuccessResponse = {
+      success: true,
+      timestamp: Math.floor(Number(new Date()) / 1000),
+      base: 'USD',
+      date: '2021-10-05',
+      rates: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        JPY: 4,
+      },
+    };
+
+    class PatchedExchangeRatesService extends ExchangeRatesService {
+      interval = 1000;
+      cachedValue = mockCachedValue;
+
+      async requestExchangeRatesFromFixer(): Promise<FixerSuccessResponse> {
+        throw new Error('This error should clear the cache and reset last fetched timer');
+      }
+    }
+
+    let subject = new PatchedExchangeRatesService();
+    subject.lastFetched = Number(new Date());
+    expect(subject.cacheIsValid).equal(true);
+    subject.lastFetched = Number(new Date()) - 2000;
+    await expect(subject.fetchExchangeRates()).rejectedWith(
+      'This error should clear the cache and reset last fetched timer'
+    );
+    expect(subject.cachedValue).equal(undefined);
+    expect(subject.lastFetched).equal(0);
+  });
+
+  it('returns a failure response from Fixer', async function () {
+    let mockFailureResponse = {
+      success: false,
+      error: {
+        code: -1,
+        info: 'Some info about the error',
+      },
+    } as FixerFailureResponse;
+
+    class PatchedExchangeRatesService extends ExchangeRatesService {
+      interval = 1000;
+
+      async requestExchangeRatesFromFixer(): Promise<FixerFailureResponse> {
+        return mockFailureResponse;
+      }
+    }
+
+    let subject = new PatchedExchangeRatesService();
+
+    expect(await subject.fetchExchangeRates()).deep.equal(mockFailureResponse);
+  });
+});

--- a/packages/hub/routes/exchange-rates.ts
+++ b/packages/hub/routes/exchange-rates.ts
@@ -1,0 +1,75 @@
+import Koa from 'koa';
+import autoBind from 'auto-bind';
+import { inject } from '../di/dependency-injection';
+import ExchangeRatesService from '../services/exchange-rates';
+import config from 'config';
+
+const allowedDomains: string[] = config.get('exchangeRates.allowedDomains');
+function isValidAllowedDomainConfig(object: unknown): object is string[] {
+  return Array.isArray(object) && object.every((v) => typeof v === 'string') && object.length > 0;
+}
+if (!isValidAllowedDomainConfig(allowedDomains)) {
+  throw new Error('Exchange rate allowed domain config is invalid');
+}
+
+/**
+ * Provides exchange rate information for converting from USD to other currencies
+ */
+export default class ExchangeRatesRoute {
+  exchangeRatesService: ExchangeRatesService = inject('exchange-rates', { as: 'exchangeRatesService' });
+
+  constructor() {
+    autoBind(this);
+  }
+
+  async get(ctx: Koa.Context) {
+    if (ctx.environment === 'development' || (ctx.headers.origin && allowedDomains.includes(ctx.headers.origin))) {
+      let exchangeRates = await this.exchangeRatesService.fetchExchangeRates();
+      if (!exchangeRates?.success) {
+        let detail = exchangeRates?.error
+          ? `${exchangeRates.error.code}: ${exchangeRates.error.info}`
+          : 'Failed to fetch exchange rates for unknown reason';
+        ctx.status = 502;
+        ctx.body = {
+          errors: [
+            {
+              status: '502',
+              title: 'Bad Gateway',
+              detail,
+            },
+          ],
+        };
+        ctx.type = 'application/vnd.api+json';
+      } else {
+        ctx.status = 200;
+        ctx.body = {
+          data: {
+            type: 'exchange-rates',
+            attributes: {
+              base: exchangeRates.base,
+              rates: exchangeRates.rates,
+            },
+          },
+        };
+        ctx.type = 'application/vnd.api+json';
+      }
+    } else {
+      ctx.status = 403;
+      ctx.body = {
+        errors: [
+          {
+            status: '403',
+            title: 'Not allowed',
+          },
+        ],
+      };
+      ctx.type = 'application/vnd.api+json';
+    }
+  }
+}
+
+declare module '@cardstack/hub/di/dependency-injection' {
+  interface KnownServices {
+    'exchange-rates-route': ExchangeRatesRoute;
+  }
+}

--- a/packages/hub/services/api-router.ts
+++ b/packages/hub/services/api-router.ts
@@ -5,6 +5,7 @@ import Koa from 'koa';
 import mimeMatch from 'mime-match';
 import { CardstackError } from '../utils/error';
 import BoomRoute from '../routes/boom';
+import ExchangeRatesRoute from '../routes/exchange-rates';
 import SessionRoute from '../routes/session';
 import PrepaidCardColorSchemesRoute from '../routes/prepaid-card-color-schemes';
 import PrepaidCardPatternsRoute from '../routes/prepaid-card-patterns';
@@ -19,6 +20,7 @@ import { parseBody } from '../middleware';
 
 export default class APIRouter {
   boomRoute: BoomRoute = inject('boom-route', { as: 'boomRoute' });
+  exchangeRatesRoute: ExchangeRatesRoute = inject('exchange-rates-route', { as: 'exchangeRatesRoute' });
   sessionRoute: SessionRoute = inject('session-route', { as: 'sessionRoute' });
   prepaidCardColorSchemesRoute: PrepaidCardColorSchemesRoute = inject('prepaid-card-color-schemes-route', {
     as: 'prepaidCardColorSchemesRoute',
@@ -39,6 +41,7 @@ export default class APIRouter {
   routes() {
     let {
       boomRoute,
+      exchangeRatesRoute,
       prepaidCardColorSchemesRoute,
       prepaidCardPatternsRoute,
       prepaidCardCustomizationsRoute,
@@ -51,6 +54,7 @@ export default class APIRouter {
     } = this;
     let apiSubrouter = new Router();
     apiSubrouter.get('/boom', boomRoute.get);
+    apiSubrouter.get('/exchange-rates', exchangeRatesRoute.get);
     apiSubrouter.get('/session', sessionRoute.get);
     apiSubrouter.post('/session', parseBody, sessionRoute.post);
     apiSubrouter.get('/prepaid-card-color-schemes', prepaidCardColorSchemesRoute.get);

--- a/packages/hub/services/exchange-rates.ts
+++ b/packages/hub/services/exchange-rates.ts
@@ -35,7 +35,7 @@ export default class ExchangeRatesService {
   }
 
   /**
-   * Sample response
+   * Example of a successful request
    * ```
    * {
    *   success: true,
@@ -43,18 +43,19 @@ export default class ExchangeRatesService {
    *   base: 'USD',
    *   date: '2021-09-30',
    *   rates: {
-   *     EUR: 1,
-   *     GBP: 0.860246,
-   *     AUD: 1.602961,
-   *     CNY: 7.463258,
-   *     KRW: 1370.453432,
-   *     RUB: 84.171385,
-   *     INR: 85.915208,
-   *     JPY: 129.027569,
-   *     TRY: 10.291685,
-   *     CAD: 1.468866,
-   *     NZD: 1.679484,
-   *     ZAR: 17.450637
+   *     USD: 1,
+   *     EUR: 0.859735,
+   *     GBP: 0.734635,
+   *     AUD: 1.370802,
+   *     CNY: 6.4467,
+   *     KRW: 1179.593505,
+   *     RUB: 72.672501,
+   *     INR: 74.264596,
+   *     JPY: 111.124504,
+   *     TRY: 8.855645,
+   *     CAD: 1.2588,
+   *     NZD: 1.433345,
+   *     ZAR: 14.94734
    *   }
    * }
    * ```
@@ -87,7 +88,7 @@ export default class ExchangeRatesService {
         }
         return result;
       } catch (e) {
-        Sentry.captureException(e ?? 'Fetching exchange rates returned a falsey value');
+        Sentry.captureException(e);
         this.invalidateCache();
         throw e;
       }

--- a/packages/hub/services/exchange-rates.ts
+++ b/packages/hub/services/exchange-rates.ts
@@ -1,9 +1,9 @@
 /* global fetch */
 import config from 'config';
-import supportedNativeCurrencies from '@cardstack/cardpay-sdk/sdk/native-currencies';
+import { nativeCurrencies, NativeCurrency } from '@cardstack/cardpay-sdk/sdk/currencies';
 import * as Sentry from '@sentry/node';
 
-const currencySymbols = Object.keys(supportedNativeCurrencies);
+const currencySymbols = Object.keys(nativeCurrencies) as NativeCurrency[];
 const INTERVAL = 1000 * 60 * 60;
 
 // these results are from fixer.

--- a/packages/hub/services/exchange-rates.ts
+++ b/packages/hub/services/exchange-rates.ts
@@ -1,0 +1,117 @@
+/* global fetch */
+import config from 'config';
+import supportedNativeCurrencies from '@cardstack/cardpay-sdk/sdk/native-currencies';
+import * as Sentry from '@sentry/node';
+
+const currencySymbols = Object.keys(supportedNativeCurrencies);
+const INTERVAL = 1000 * 60 * 60;
+
+// these results are from fixer.
+export interface FixerSuccessResponse {
+  success: true;
+  timestamp: number;
+  base: string;
+  date: string;
+  rates: {
+    [currencyCode: string]: number;
+  };
+}
+
+export interface FixerFailureResponse {
+  success: false;
+  error: {
+    code: number;
+    info: string;
+  };
+}
+
+export default class ExchangeRatesService {
+  interval: number = INTERVAL;
+  lastFetched = 0;
+  cachedValue: FixerSuccessResponse | undefined = undefined;
+
+  private get apiKey() {
+    return config.get('exchangeRates.apiKey') as string;
+  }
+
+  /**
+   * Sample response
+   * ```
+   * {
+   *   success: true,
+   *   timestamp: 1633018143,
+   *   base: 'USD',
+   *   date: '2021-09-30',
+   *   rates: {
+   *     EUR: 1,
+   *     GBP: 0.860246,
+   *     AUD: 1.602961,
+   *     CNY: 7.463258,
+   *     KRW: 1370.453432,
+   *     RUB: 84.171385,
+   *     INR: 85.915208,
+   *     JPY: 129.027569,
+   *     TRY: 10.291685,
+   *     CAD: 1.468866,
+   *     NZD: 1.679484,
+   *     ZAR: 17.450637
+   *   }
+   * }
+   * ```
+   *
+   * Example of a failed request:
+   * ```
+   * {
+   *   "success": false,
+   *   "error": {
+   *     "code": 104,
+   *     "info": "Your monthly API request volume has been reached. Please upgrade your plan."
+   *   }
+   * }
+   * ```
+   */
+  async fetchExchangeRates(): Promise<FixerSuccessResponse | FixerFailureResponse | undefined> {
+    if (this.cacheIsValid) {
+      return this.cachedValue;
+    } else {
+      try {
+        // this approach has a risk of sending multiple requests when the cache is invalidated
+        // since it does not handle simultaneous requests
+        let result = await this.requestExchangeRatesFromFixer();
+        if (result?.success) {
+          this.cachedValue = result;
+          this.lastFetched = result.timestamp * 1000;
+        } else {
+          Sentry.captureException(result ?? 'Fetching exchange rates returned a falsey value');
+          this.invalidateCache();
+        }
+        return result;
+      } catch (e) {
+        Sentry.captureException(e ?? 'Fetching exchange rates returned a falsey value');
+        this.invalidateCache();
+        throw e;
+      }
+    }
+  }
+
+  invalidateCache() {
+    this.cachedValue = undefined;
+    this.lastFetched = 0;
+  }
+
+  async requestExchangeRatesFromFixer(): Promise<FixerSuccessResponse | FixerFailureResponse | undefined> {
+    return await (
+      await fetch(`http://data.fixer.io/api/latest?access_key=${this.apiKey}&base=USD&symbols=${currencySymbols}`)
+    ).json();
+  }
+
+  get cacheIsValid() {
+    return Boolean(Number(new Date()) - this.lastFetched <= this.interval && this.cachedValue);
+  }
+}
+
+declare module '@cardstack/hub/di/dependency-injection' {
+  interface KnownServices {
+    'exchange-rates': ExchangeRatesService;
+  }
+}

--- a/packages/web-client/app/controllers/pay.ts
+++ b/packages/web-client/app/controllers/pay.ts
@@ -78,14 +78,30 @@ export default class CardPayMerchantServicesController extends Controller {
         },
       };
     } else {
-      let amount = Number(
-        roundAmountToNativeCurrencyDecimals(this.amount, this.currency)
-      );
+      let rate = this.model.exchangeRates?.[this.currency];
+      let amount: number;
+      let formattedSpendAmount: string | undefined;
+      if (rate) {
+        let minAmount = minUsdAmount * rate;
+        amount = Number(
+          roundAmountToNativeCurrencyDecimals(
+            Math.max(this.amount, minAmount),
+            this.currency
+          )
+        );
+        formattedSpendAmount = `§${formatAmount(usdToSpend(amount / rate))}`;
+      } else {
+        amount = Number(
+          roundAmountToNativeCurrencyDecimals(this.amount, this.currency)
+        );
+        formattedSpendAmount = undefined;
+      }
+
       return {
         amount,
         displayed: {
           amount: convertAmountToNativeDisplay(amount, this.currency),
-          secondaryAmount: '',
+          secondaryAmount: formattedSpendAmount,
         },
       };
     }

--- a/packages/web-client/app/controllers/pay.ts
+++ b/packages/web-client/app/controllers/pay.ts
@@ -41,7 +41,7 @@ export default class CardPayMerchantServicesController extends Controller {
         },
       };
     } else if (
-      !(isSupportedCurrency(this.currency) || this.currency === 'SPD') ||
+      !isSupportedCurrency(this.currency) ||
       this.currency === 'DAI' ||
       this.currency === 'CARD' ||
       this.currency === 'ETH'

--- a/packages/web-client/mirage/config.js
+++ b/packages/web-client/mirage/config.js
@@ -2,9 +2,24 @@ import {
   getFilenameFromDid,
   defaultCreatedPrepaidCardDID,
 } from '@cardstack/web-client/utils/test-factories';
+import supportedNativeCurrencies from '@cardstack/cardpay-sdk/sdk/native-currencies';
 
 export default function () {
   this.namespace = 'api';
+
+  this.get('/exchange-rates', function () {
+    return {
+      data: {
+        type: 'exchange-rates',
+        attributes: {
+          base: 'USD',
+          rates: Object.fromEntries(
+            Object.keys(supportedNativeCurrencies).map((k) => [k, 2])
+          ),
+        },
+      },
+    };
+  });
 
   this.post('/merchant-infos');
 

--- a/packages/web-client/mirage/config.js
+++ b/packages/web-client/mirage/config.js
@@ -2,7 +2,7 @@ import {
   getFilenameFromDid,
   defaultCreatedPrepaidCardDID,
 } from '@cardstack/web-client/utils/test-factories';
-import supportedNativeCurrencies from '@cardstack/cardpay-sdk/sdk/native-currencies';
+import { nativeCurrencies } from '@cardstack/cardpay-sdk/sdk/currencies';
 
 export default function () {
   this.namespace = 'api';
@@ -14,7 +14,7 @@ export default function () {
         attributes: {
           base: 'USD',
           rates: Object.fromEntries(
-            Object.keys(supportedNativeCurrencies).map((k) => [k, 2])
+            Object.keys(nativeCurrencies).map((k) => [k, 2])
           ),
         },
       },

--- a/packages/web-client/tests/acceptance/pay-test.ts
+++ b/packages/web-client/tests/acceptance/pay-test.ts
@@ -7,9 +7,11 @@ import sinon from 'sinon';
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
 import {
   convertAmountToNativeDisplay,
+  formatCurrencyAmount,
   generateMerchantPaymentUrl,
   roundAmountToNativeCurrencyDecimals,
   spendToUsd,
+  usdToSpend,
 } from '@cardstack/cardpay-sdk';
 import config from '@cardstack/web-client/config/environment';
 import { MIN_PAYMENT_AMOUNT_IN_SPEND } from '@cardstack/cardpay-sdk/sdk/do-not-use-on-chain-constants';
@@ -17,6 +19,7 @@ import {
   createMerchantSafe,
   getFilenameFromDid,
 } from '@cardstack/web-client/utils/test-factories';
+import { Response as MirageResponse } from 'ember-cli-mirage';
 
 // selectors
 const MERCHANT = '[data-test-merchant]';
@@ -33,10 +36,12 @@ const DEEP_LINK = '[data-test-payment-request-deep-link]';
 const PAYMENT_URL = '[data-test-payment-request-url]';
 
 // fixed data
+const mirageConversionRate = 2; // mirage is hardcoded to provide 1:2 conversion from USD to any other currency
 const universalLinkDomain = config.universalLinkDomain;
 const exampleDid = 'did:cardstack:1moVYMRNGv6E5Ca3t7aXVD2Yb11e4e91103f084a';
 const spendSymbol = 'SPD';
 const usdSymbol = 'USD';
+const jpySymbol = 'JPY';
 const invalidCurrencySymbol = 'WUT';
 const network = 'sokol';
 const merchantName = 'Mandello';
@@ -261,11 +266,12 @@ module('Acceptance | pay', function (hooks) {
 
   test('it renders correctly if currency is non-USD and non-SPEND', async function (assert) {
     const jpyAmount = 300.335;
-    const jpySymbol = 'JPY';
     const roundedJpyAmount = roundAmountToNativeCurrencyDecimals(
       jpyAmount,
       jpySymbol
     );
+    const roundedJpyAmountInUsd =
+      Number(roundedJpyAmount) / mirageConversionRate;
 
     await visit(
       `/pay/${network}/${merchantSafe.address}?amount=${jpyAmount}&currency=${jpySymbol}`
@@ -274,7 +280,11 @@ module('Acceptance | pay', function (hooks) {
     assert
       .dom(AMOUNT)
       .containsText(convertAmountToNativeDisplay(roundedJpyAmount, jpySymbol));
-    assert.dom(SECONDARY_AMOUNT).doesNotExist();
+    assert
+      .dom(SECONDARY_AMOUNT)
+      .containsText(
+        `§${formatCurrencyAmount(usdToSpend(roundedJpyAmountInUsd)!, 0)}`
+      );
 
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,
@@ -282,6 +292,59 @@ module('Acceptance | pay', function (hooks) {
       merchantSafeID: merchantSafe.address,
       currency: jpySymbol,
       amount: Number(roundedJpyAmount),
+    });
+    assert.dom(QR_CODE).hasAttribute('data-test-styled-qr-code', expectedUrl);
+    assert.dom(PAYMENT_URL).containsText(expectedUrl);
+  });
+
+  test('it rounds amount up to min spend amount if currency is non-USD and non-SPEND', async function (assert) {
+    const minJpyAmount = minUsdAmount * mirageConversionRate;
+    const jpyAmount = minJpyAmount - 0.1;
+    const convertedMinSpendAmount = usdToSpend(
+      minJpyAmount / mirageConversionRate
+    );
+
+    await visit(
+      `/pay/${network}/${merchantSafe.address}?amount=${jpyAmount}&currency=${jpySymbol}`
+    );
+
+    assert
+      .dom(AMOUNT)
+      .containsText(convertAmountToNativeDisplay(minJpyAmount, jpySymbol));
+    assert.dom(SECONDARY_AMOUNT).containsText(`§${convertedMinSpendAmount}`);
+
+    let expectedUrl = generateMerchantPaymentUrl({
+      domain: universalLinkDomain,
+      network,
+      merchantSafeID: merchantSafe.address,
+      currency: jpySymbol,
+      amount: minJpyAmount,
+    });
+    assert.dom(QR_CODE).hasAttribute('data-test-styled-qr-code', expectedUrl);
+    assert.dom(PAYMENT_URL).containsText(expectedUrl);
+  });
+
+  test('it handles errors in fetching exchange rates gracefully', async function (this: MirageTestContext, assert) {
+    this.server.get('/exchange-rates', function () {
+      return new MirageResponse(502, {}, '');
+    });
+
+    const jpyAmount = 300;
+
+    await visit(
+      `/pay/${network}/${merchantSafe.address}?amount=${jpyAmount}&currency=${jpySymbol}`
+    );
+
+    assert
+      .dom(AMOUNT)
+      .containsText(convertAmountToNativeDisplay(jpyAmount, jpySymbol));
+
+    let expectedUrl = generateMerchantPaymentUrl({
+      domain: universalLinkDomain,
+      network,
+      merchantSafeID: merchantSafe.address,
+      currency: jpySymbol,
+      amount: jpyAmount,
     });
     assert.dom(QR_CODE).hasAttribute('data-test-styled-qr-code', expectedUrl);
     assert.dom(PAYMENT_URL).containsText(expectedUrl);

--- a/packages/web-client/tests/acceptance/pay-test.ts
+++ b/packages/web-client/tests/acceptance/pay-test.ts
@@ -338,6 +338,7 @@ module('Acceptance | pay', function (hooks) {
     assert
       .dom(AMOUNT)
       .containsText(convertAmountToNativeDisplay(jpyAmount, jpySymbol));
+    assert.dom(SECONDARY_AMOUNT).doesNotExist();
 
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,


### PR DESCRIPTION
- [x] Add caching?
- [x] Try out with the merchant payment request page
- [x] Documentation for new env vars
- [x] Get API key, update fetching code to accept base=USD
- [ ] add secret, communicate to others for dev purposes
