### PR TITLE
Workflow cancellation refactor

### DIFF
--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
@@ -27,6 +27,7 @@ import RouterService from '@ember/routing/router-service';
 import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';
 import { formatAmount } from '@cardstack/web-client/helpers/format-amount';
 import { tracked } from '@glimmer/tracking';
+import { isPresent } from '@ember/utils';
 
 const FAILURE_REASONS = {
   UNAUTHENTICATED: 'UNAUTHENTICATED',
@@ -300,22 +301,12 @@ class CreateMerchantWorkflow extends Workflow {
         );
       },
     }),
+
     new WorkflowCard({
       author: cardbot,
       componentName: 'workflow-thread/default-cancelation-cta',
       includeIf() {
-        return (
-          [
-            FAILURE_REASONS.UNAUTHENTICATED,
-            FAILURE_REASONS.DISCONNECTED,
-            FAILURE_REASONS.ACCOUNT_CHANGED,
-            FAILURE_REASONS.NO_PREPAID_CARD,
-            FAILURE_REASONS.INSUFFICIENT_PREPAID_CARD_BALANCE,
-            FAILURE_REASONS.RESTORATION_UNAUTHENTICATED,
-            FAILURE_REASONS.RESTORATION_L2_ACCOUNT_CHANGED,
-            FAILURE_REASONS.RESTORATION_L2_DISCONNECTED,
-          ] as String[]
-        ).includes(String(this.workflow?.cancelationReason));
+        return isPresent(this.workflow?.cancelationReason);
       },
     }),
   ]);

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
@@ -31,6 +31,7 @@ import {
 import { task } from 'ember-concurrency-decorators';
 import { formatWeiAmount } from '@cardstack/web-client/helpers/format-wei-amount';
 import { action } from '@ember/object';
+import { isPresent } from '@ember/utils';
 const FAILURE_REASONS = {
   DISCONNECTED: 'DISCONNECTED',
   ACCOUNT_CHANGED: 'ACCOUNT_CHANGED',
@@ -326,7 +327,6 @@ with Card Pay.`,
         );
       },
     }),
-    // cancelation for changing accounts
     new WorkflowMessage({
       author: cardbot,
       message:
@@ -359,13 +359,33 @@ with Card Pay.`,
         );
       },
     }),
+    new WorkflowMessage({
+      author: cardbot,
+      message:
+        'You attempted to restore an unfinished workflow, but your Card wallet got disconnected. Please restart the workflow.',
+      includeIf() {
+        return (
+          this.workflow?.cancelationReason ===
+          FAILURE_REASONS.RESTORATION_L2_DISCONNECTED
+        );
+      },
+    }),
+    new WorkflowMessage({
+      author: cardbot,
+      message:
+        'You attempted to restore an unfinished workflow, but your Layer 1 wallet got disconnected. Please restart the workflow.',
+      includeIf() {
+        return (
+          this.workflow?.cancelationReason ===
+          FAILURE_REASONS.RESTORATION_L1_DISCONNECTED
+        );
+      },
+    }),
     new WorkflowCard({
       author: cardbot,
       componentName: 'workflow-thread/default-cancelation-cta',
       includeIf() {
-        return (Object.values(FAILURE_REASONS) as String[]).includes(
-          String(this.workflow?.cancelationReason)
-        );
+        return isPresent(this.workflow?.cancelationReason);
       },
     }),
   ]);

--- a/packages/web-client/app/models/workflow.ts
+++ b/packages/web-client/app/models/workflow.ts
@@ -126,7 +126,7 @@ export abstract class Workflow {
     const cancelationReason = reason || 'UNKNOWN';
 
     this.session.setMeta({
-      isCancelled: true,
+      isCanceled: true,
       cancelationReason: cancelationReason,
     });
 
@@ -228,7 +228,7 @@ export abstract class Workflow {
     }
 
     if (
-      this.session.getMeta().isCancelled &&
+      this.session.getMeta().isCanceled &&
       this.session.getMeta().cancelationReason
     ) {
       this.cancel(this.session.getMeta().cancelationReason);

--- a/packages/web-client/app/models/workflow/workflow-session.ts
+++ b/packages/web-client/app/models/workflow/workflow-session.ts
@@ -29,7 +29,7 @@ export interface WorkflowMeta {
   completedCardNames: string[] | undefined;
   completedMilestonesCount: number | undefined;
   milestonesCount: number | undefined;
-  isCancelled: boolean | undefined;
+  isCanceled: boolean | undefined;
   cancelationReason: string | undefined;
 }
 

--- a/packages/web-client/app/services/workflow-persistence.ts
+++ b/packages/web-client/app/services/workflow-persistence.ts
@@ -96,7 +96,9 @@ export default class WorkflowPersistence extends Service {
 
   get activeWorkflows() {
     return this.allValidWorkflows.filter(
-      (meta) => meta.completedMilestonesCount! < meta.milestonesCount!
+      (meta) =>
+        meta.completedMilestonesCount! < meta.milestonesCount! &&
+        !meta.isCanceled
     );
   }
 

--- a/packages/web-client/tests/acceptance/create-merchant-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/create-merchant-persistence-test.ts
@@ -177,13 +177,13 @@ module('Acceptance | create merchant persistence', function (hooks) {
       assert.dom('[data-test-workflow-thread]').doesNotExist();
     });
 
-    test('it restores a cancelled workflow', async function (this: Context, assert) {
+    test('it restores a canceled workflow', async function (this: Context, assert) {
       const state = buildState({
         meta: {
           completedCardNames: ['LAYER2_CONNECT', 'MERCHANT_CUSTOMIZATION'],
           milestonesCount: 3,
           completedMilestonesCount: 2,
-          isCancelled: true,
+          isCanceled: true,
           cancelationReason: 'DISCONNECTED',
         },
         merchantName,

--- a/packages/web-client/tests/acceptance/deposit-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-persistence-test.ts
@@ -304,11 +304,11 @@ module('Acceptance | deposit persistence', function (hooks) {
       assert.dom('[data-test-milestone="3"]').doesNotExist(); // Receive
     });
 
-    test('it restores a cancelled workflow', async function (this: Context, assert) {
+    test('it restores a canceled workflow', async function (this: Context, assert) {
       const state = buildState({
         meta: {
           completedCardNames: ['LAYER1_CONNECT', 'LAYER2_CONNECT', 'TXN_SETUP'],
-          isCancelled: true,
+          isCanceled: true,
           cancelationReason: 'DISCONNECTED',
         },
         depositSourceToken: 'DAI',

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-persistence-test.ts
@@ -192,7 +192,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
       assert.dom('[data-test-milestone="2"]').doesNotExist(); // Choose funding source
     });
 
-    test('it restores a cancelled workflow', async function (this: Context, assert) {
+    test('it restores a canceled workflow', async function (this: Context, assert) {
       let state = buildState({
         colorScheme: {
           patternColor: 'black',
@@ -210,7 +210,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
           ],
           milestonesCount: 4,
           completedMilestonesCount: 3,
-          isCancelled: true,
+          isCanceled: true,
           cancelationReason: 'DISCONNECTED',
         },
         issuerName: 'Peter',

--- a/packages/web-client/tests/acceptance/persistence-view-restore-test.ts
+++ b/packages/web-client/tests/acceptance/persistence-view-restore-test.ts
@@ -134,9 +134,18 @@ module('Acceptance | persistence view and restore', function () {
       });
 
       workflowPersistenceService.persistData('canceled', {
-        name: 'PREPAID_CARD_ISSUANCE',
+        name: `PREPAID_CARD_ISSUANCE`,
         state: buildState({
           meta: {
+            completedCardNames: [
+              'LAYER2_CONNECT',
+              'HUB_AUTH',
+              'LAYOUT_CUSTOMIZATION',
+              'FUNDING_SOURCE',
+            ],
+            completedMilestonesCount: 1,
+            milestonesCount: 4,
+            updatedAt: Date.UTC(2020, 10, 22, 20, 50, 18, 491).toString(),
             isCanceled: true,
             cancelationReason: 'RESTORATION_UNAUTHENTICATED',
           },

--- a/packages/web-client/tests/acceptance/persistence-view-restore-test.ts
+++ b/packages/web-client/tests/acceptance/persistence-view-restore-test.ts
@@ -137,7 +137,7 @@ module('Acceptance | persistence view and restore', function () {
         name: 'PREPAID_CARD_ISSUANCE',
         state: buildState({
           meta: {
-            isCancelled: true,
+            isCanceled: true,
             cancelationReason: 'RESTORATION_UNAUTHENTICATED',
           },
         }),

--- a/packages/web-client/tests/acceptance/withdrawal-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-persistence-test.ts
@@ -190,7 +190,7 @@ module('Acceptance | withdrawal persistence', function (hooks) {
       assert.dom('[data-test-withdrawal-next-step="new-withdrawal"]').exists();
     });
 
-    test('it restores a cancelled workflow', async function (this: Context, assert) {
+    test('it restores a canceled workflow', async function (this: Context, assert) {
       const state = buildState({
         withdrawalToken: 'DAI.CPXD',
         withdrawnAmount: new BN('1000000000000000000'),
@@ -222,7 +222,7 @@ module('Acceptance | withdrawal persistence', function (hooks) {
             'TRANSACTION_AMOUNT',
             'TRANSACTION_STATUS',
           ],
-          isCancelled: true,
+          isCanceled: true,
           cancelationReason: 'DISCONNECTED',
         },
       });


### PR DESCRIPTION
This PR:

1. Adds restoration cancellation messages (more context [here in discord](https://discord.com/channels/584043165066199050/855105564643819530/894502990361296916))
2. Renames occurrences of "cancelled" to "canceled"
3. Filters out canceled workflows from the active workflow selector

QUESTION ⁉️ 🚨: There is a potential bug introduced in (2) but we can decide to ignore it. The problem is that the currently persisted workflows have the property written as `isCancelled` while now we use `isCanceled`. This means the currently saved workflows that are canceled will still be shown in the workflow selector UI. Can someone give us an idea to what extent this feature has been exercised on staging and production? If we want to 100% support this filter for historically persisted canceled workflows then we can add another check (to support both `isCancelled` and `isCanceled`). 