### PR TITLE
Allow completed flows to be restored via tracker UI

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.ts
@@ -56,7 +56,11 @@ class CardPayDepositWorkflowTransactionStatusComponent extends Component<Workflo
 
   constructor(owner: unknown, args: WorkflowCardComponentArgs) {
     super(owner, args);
-    if (!this.completedLayer2TxnReceipt) {
+    if (this.completedLayer2TxnReceipt) {
+      this.completedStepCount = 3;
+      this.blockCount = this.totalBlockCount;
+      this.args.onComplete?.();
+    } else {
       taskFor(this.waitForBlockConfirmationsTask)
         .perform()
         .catch((e) => {

--- a/packages/web-client/app/components/card-pay/header/workflow-tracker/item/index.hbs
+++ b/packages/web-client/app/components/card-pay/header/workflow-tracker/item/index.hbs
@@ -1,7 +1,6 @@
 <button
   class='workflow-tracker-item'
   type='button'
-  disabled={{if this.isComplete 'disabled'}}
   {{on 'click' this.visit}}
   ...attributes
 >

--- a/packages/web-client/tests/acceptance/persistence-view-restore-test.ts
+++ b/packages/web-client/tests/acceptance/persistence-view-restore-test.ts
@@ -188,10 +188,6 @@ module('Acceptance | persistence view and restore', function () {
         .containsText('Complete');
 
       assert
-        .dom('[data-test-completed-workflow] button')
-        .isDisabled('expected a completed workflow button to be disabled');
-
-      assert
         .dom('[data-test-completed-workflow] .boxel-progress-icon--complete')
         .exists();
 

--- a/packages/web-client/tests/acceptance/withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-test.ts
@@ -389,7 +389,6 @@ module('Acceptance | withdrawal', function (hooks) {
     });
     await waitFor(`${post} [data-test-balance="ETH"]`);
     await waitFor(milestoneCompletedSel(0));
-    assert.dom(milestoneCompletedSel(0));
 
     await waitUntil(() => {
       return document

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-status-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-status-test.ts
@@ -9,6 +9,13 @@ import sinon from 'sinon';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
 import { TransactionReceipt } from 'web3-core';
 
+const depositSourceToken = 'DAI';
+const stepTitles = {
+  deposit: `Deposit tokens into reserve pool on ${c.layer1.fullName}`,
+  bridge: `Bridge tokens from ${c.layer1.fullName} to ${c.layer2.fullName}`,
+  mint: `Mint tokens on ${c.layer2.shortName}: ${depositSourceToken}.CPXD`,
+};
+
 module(
   'Integration | Component | card-pay/deposit-workflow/transaction-status',
   function (hooks) {
@@ -18,7 +25,7 @@ module(
       let onComplete = sinon.spy();
       let workflowSession = new WorkflowSession();
       workflowSession.setValue({
-        depositSourceToken: 'DAI',
+        depositSourceToken,
         layer2BlockHeightBeforeBridging: '0',
         relayTokensTxnReceipt: {
           transactionHash: 'RelayTokensTransactionHash',
@@ -53,11 +60,14 @@ module(
 
       assert
         .dom(`[data-test-token-bridge-step="0"][data-test-completed]`)
-        .exists();
+        .containsText(stepTitles.deposit);
       assert.dom(`[data-test-etherscan-button]`).exists();
       assert
         .dom(`[data-test-token-bridge-step][data-test-completed]`)
         .exists({ count: 1 });
+      assert
+        .dom(`[data-test-token-bridge-step="1"]`)
+        .containsText(stepTitles.bridge);
       assert
         .dom(`[data-test-token-bridge-step-status="1"]`)
         .hasText(`0 of ${blockCount} blocks confirmed`);
@@ -101,7 +111,7 @@ module(
       );
       assert
         .dom(`[data-test-token-bridge-step="2"][data-test-completed]`)
-        .exists();
+        .containsText(stepTitles.mint);
       assert.dom('[data-test-blockscout-button]').exists();
       assert.dom('[data-test-deposit-minting-step-failed]').doesNotExist();
       assert.dom('[data-test-deposit-transaction-status-error]').doesNotExist();
@@ -113,7 +123,7 @@ module(
       let onComplete = sinon.spy();
       let workflowSession = new WorkflowSession();
       workflowSession.setValue({
-        depositSourceToken: 'DAI',
+        depositSourceToken,
         layer2BlockHeightBeforeBridging: '0',
         relayTokensTxnReceipt: {
           transactionHash: 'RelayTokensTransactionHash',
@@ -145,15 +155,15 @@ module(
 
       assert
         .dom(`[data-test-token-bridge-step="0"][data-test-completed]`)
-        .exists();
+        .containsText(stepTitles.deposit);
       assert.dom(`[data-test-etherscan-button]`).exists();
       assert
         .dom(`[data-test-token-bridge-step="1"][data-test-completed]`)
-        .exists();
+        .containsText(stepTitles.bridge);
       assert.dom(`[data-test-bridge-explorer-button]`).exists();
       assert
         .dom(`[data-test-token-bridge-step="2"][data-test-completed]`)
-        .exists();
+        .containsText(stepTitles.mint);
       assert.dom('[data-test-blockscout-button]').exists();
 
       assert.ok(onComplete.called);
@@ -166,7 +176,7 @@ module(
       let onComplete = sinon.spy();
       let workflowSession = new WorkflowSession();
       workflowSession.setValue({
-        depositSourceToken: 'DAI',
+        depositSourceToken,
         layer2BlockHeightBeforeBridging: '0',
         relayTokensTxnReceipt: {
           transactionHash: 'RelayTokensTransactionHash',
@@ -219,7 +229,7 @@ module(
       let onComplete = sinon.spy();
       let workflowSession = new WorkflowSession();
       workflowSession.setValue({
-        depositSourceToken: 'DAI',
+        depositSourceToken,
         layer2BlockHeightBeforeBridging: '0',
         relayTokensTxnReceipt: {
           transactionHash: 'RelayTokensTransactionHash',


### PR DESCRIPTION
Tried restoring all 4 completed workflows, I think the deposit workflow's transaction status card was the only one which needed fixing.