### PR TITLE
Update issue prepaid card flow cancelation message for insufficient funds

### DIFF
--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.hbs
@@ -11,7 +11,7 @@
         <span>Prepaid cards are denominated in SPEND:</span>
         <span class="face-value-card__exchange-rate">
           {{svg-jar "spend" width="20" height="20" role="presentation"}}
-          §1 SPEND = {{format-usd this.spendToUsdRate}}
+          §1 SPEND = {{format-usd (spend-to-usd 1)}}
         </span>
       </p>
       <CardPay::LabeledValue @vertical={{true}} @label="Funding From:">

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.ts
@@ -9,7 +9,7 @@ import {
   TokenDisplayInfo,
   TokenSymbol,
 } from '@cardstack/web-client/utils/token';
-import { faceValueOptions, spendToUsdRate } from '../workflow-config';
+import { faceValueOptions, spendToUsdRate } from '../index';
 import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 
 interface FaceValue {

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/face-value/index.ts
@@ -9,7 +9,7 @@ import {
   TokenDisplayInfo,
   TokenSymbol,
 } from '@cardstack/web-client/utils/token';
-import { faceValueOptions, spendToUsdRate } from '../index';
+import { faceValueOptions } from '../index';
 import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 
 interface FaceValue {
@@ -20,7 +20,6 @@ interface FaceValue {
 
 class FaceValueCard extends Component<WorkflowCardComponentArgs> {
   faceValueOptions = faceValueOptions;
-  spendToUsdRate = spendToUsdRate;
 
   @service declare layer2Network: Layer2Network;
   get fundingTokenSymbol(): TokenSymbol {

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -28,7 +28,6 @@ import { tracked } from '@glimmer/tracking';
 import {
   convertAmountToNativeDisplay,
   fromWei,
-  handleSignificantDecimals,
   spendToUsd,
 } from '@cardstack/cardpay-sdk';
 
@@ -265,10 +264,8 @@ class IssuePrepaidCardWorkflow extends Workflow {
           c.layer2.fullName
         } wallet by bridging some tokens from your ${
           c.layer1.fullName
-        } wallet. The minimum balance needed to issue a prepaid card is approximately **${handleSignificantDecimals(
-          fromWei(session.getValue<string>('daiMinValue')!),
-          18,
-          2
+        } wallet. The minimum balance needed to issue a prepaid card is approximately **${Math.ceil(
+          Number(fromWei(session.getValue<string>('daiMinValue')!))
         )} DAI.CPXD (${convertAmountToNativeDisplay(
           spendToUsd(session.getValue<number>('spendMinValue')!)!,
           'USD'

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -29,7 +29,7 @@ import { formatWeiAmount } from '@cardstack/web-client/helpers/format-wei-amount
 
 export const faceValueOptions = [500, 1000, 2500, 5000, 10000, 50000];
 
-const FAILURE_REASONS = {
+export const FAILURE_REASONS = {
   UNAUTHENTICATED: 'UNAUTHENTICATED',
   DISCONNECTED: 'DISCONNECTED',
   INSUFFICIENT_FUNDS: 'INSUFFICIENT_FUNDS',
@@ -92,6 +92,19 @@ class IssuePrepaidCardWorkflow extends Workflow {
           cardName: 'LAYER2_CONNECT',
           componentName: 'card-pay/layer-two-connect-card',
           async check() {
+            let previouslyCanceledForInsufficientFunds =
+              this.workflow?.isCanceled &&
+              this.workflow.cancelationReason ===
+                FAILURE_REASONS.INSUFFICIENT_FUNDS;
+            /**
+             * Use the previous cancelation's daiMinValue
+             */
+            if (previouslyCanceledForInsufficientFunds)
+              return {
+                success: false,
+                reason: FAILURE_REASONS.INSUFFICIENT_FUNDS,
+              };
+
             let { layer2Network } = this.workflow as IssuePrepaidCardWorkflow;
 
             let daiMinValue = new BN(

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -28,7 +28,6 @@ import { tracked } from '@glimmer/tracking';
 import { formatWeiAmount } from '@cardstack/web-client/helpers/format-wei-amount';
 
 export const faceValueOptions = [500, 1000, 2500, 5000, 10000, 50000];
-export const spendToUsdRate = 0.01;
 
 const FAILURE_REASONS = {
   UNAUTHENTICATED: 'UNAUTHENTICATED',

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -268,7 +268,7 @@ class IssuePrepaidCardWorkflow extends Workflow {
         } wallet. The minimum balance needed to issue a prepaid card is approximately **${handleSignificantDecimals(
           fromWei(session.getValue<string>('daiMinValue')!),
           18,
-          5
+          2
         )} DAI.CPXD (${convertAmountToNativeDisplay(
           spendToUsd(session.getValue<number>('spendMinValue')!)!,
           'USD'

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/workflow-config.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/workflow-config.ts
@@ -1,2 +1,0 @@
-export const faceValueOptions = [500, 1000, 2500, 5000, 10000, 50000];
-export const spendToUsdRate = 0.01;

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -109,7 +109,10 @@ export default class Layer2Network
     return this.strategy.updateUsdConverters(symbolsToUpdate);
   }
 
-  async convertFromSpend(symbol: ConvertibleSymbol, amount: number) {
+  async convertFromSpend(
+    symbol: ConvertibleSymbol,
+    amount: number
+  ): Promise<string> {
     return await this.strategy.convertFromSpend(symbol, amount);
   }
 

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -455,7 +455,10 @@ export default abstract class Layer2ChainWeb3Strategy
     return tokenBridge.waitForBridgingValidation(fromBlock.toString(), txnHash);
   }
 
-  async convertFromSpend(symbol: ConvertibleSymbol, amount: number) {
+  async convertFromSpend(
+    symbol: ConvertibleSymbol,
+    amount: number
+  ): Promise<string> {
     let address: string | undefined;
     if (symbol === this.defaultTokenSymbol) {
       address = this.defaultTokenContractAddress;

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -145,7 +145,7 @@ export interface Layer2Web3Strategy
   resumeRegisterMerchantTransaction(txnHash: string): Promise<MerchantSafe>;
   defaultTokenSymbol: ConvertibleSymbol;
   refreshSafesAndBalances(): void;
-  convertFromSpend(symbol: ConvertibleSymbol, amount: number): Promise<any>;
+  convertFromSpend(symbol: ConvertibleSymbol, amount: number): Promise<string>;
 }
 
 export type TransactionHash = string;

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-persistence-test.ts
@@ -21,6 +21,9 @@ import {
   createSafeToken,
 } from '@cardstack/web-client/utils/test-factories';
 
+const MIN_AMOUNT_TO_PASS = new BN(
+  toWei(`${Math.ceil(Math.min(...faceValueOptions) / 100)}`)
+);
 interface Context extends MirageTestContext {}
 
 module('Acceptance | issue prepaid card persistence', function (hooks) {
@@ -35,9 +38,6 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
       prepaidCardPatterns,
     });
     let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
-    const MIN_AMOUNT_TO_PASS = new BN(
-      toWei(`${Math.ceil(Math.min(...faceValueOptions) / 100)}`)
-    );
     let layer2Service = this.owner.lookup('service:layer2-network')
       .strategy as Layer2TestWeb3Strategy;
     layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
@@ -95,6 +95,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
           background: '#37EB77',
           id: '4f219852-33ee-4e4c-81f7-76318630a423',
         },
+        daiMinValue: MIN_AMOUNT_TO_PASS,
         prepaidFundingToken: 'DAI.CPXD',
         spendFaceValue: 10000,
         did: 'did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e',
@@ -151,6 +152,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
           background: '#37EB77',
           id: '4f219852-33ee-4e4c-81f7-76318630a423',
         },
+        daiMinValue: MIN_AMOUNT_TO_PASS,
         prepaidFundingToken: 'DAI.CPXD',
         spendFaceValue: 10000,
         did: 'did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e',
@@ -218,6 +220,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
           patternUrl:
             'https://app.cardstack.com/images/prepaid-card-customizations/pattern-1.svg',
         },
+        daiMinValue: MIN_AMOUNT_TO_PASS,
         prepaidFundingToken: 'DAI.CPXD',
         spendFaceValue: 500,
       });
@@ -274,6 +277,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
           background: '#37EB77',
           id: '4f219852-33ee-4e4c-81f7-76318630a423',
         },
+        daiMinValue: MIN_AMOUNT_TO_PASS,
         prepaidFundingToken: 'DAI.CPXD',
         spendFaceValue: 10000,
         did: 'did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e',
@@ -338,6 +342,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
           background: '#37EB77',
           id: '4f219852-33ee-4e4c-81f7-76318630a423',
         },
+        daiMinValue: MIN_AMOUNT_TO_PASS,
         prepaidFundingToken: 'DAI.CPXD',
         spendFaceValue: 10000,
         did: 'did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e',
@@ -399,6 +404,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
           background: '#37EB77',
           id: '4f219852-33ee-4e4c-81f7-76318630a423',
         },
+        daiMinValue: MIN_AMOUNT_TO_PASS,
         prepaidFundingToken: 'DAI.CPXD',
         spendFaceValue: 10000,
         did: 'did:cardstack:1pfsUmRoNRYTersTVPYgkhWE62b2cd7ce12b578e',
@@ -443,6 +449,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
           background: '#37EB77',
           id: '4f219852-33ee-4e4c-81f7-76318630a423',
         },
+        daiMinValue: MIN_AMOUNT_TO_PASS,
       });
 
       workflowPersistenceService.persistData('abc123', {

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-persistence-test.ts
@@ -8,7 +8,7 @@ import prepaidCardPatterns from '../../mirage/fixture-data/prepaid-card-patterns
 
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
 import { BN } from 'bn.js';
-import { faceValueOptions } from '@cardstack/web-client/components/card-pay/issue-prepaid-card-workflow/workflow-config';
+import { faceValueOptions } from '@cardstack/web-client/components/card-pay/issue-prepaid-card-workflow/index';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
 import { toWei } from 'web3-utils';
 

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-persistence-test.ts
@@ -479,7 +479,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
           } wallet. The minimum balance needed to issue a prepaid card is approximately ${handleSignificantDecimals(
             fromWei(previousMinDaiAmount),
             18,
-            5
+            2
           )} DAI.CPXD (${convertAmountToNativeDisplay(
             spendToUsd(previousSpendAmount)!,
             'USD'

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-persistence-test.ts
@@ -24,7 +24,6 @@ import {
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
 import {
   convertAmountToNativeDisplay,
-  handleSignificantDecimals,
   spendToUsd,
 } from '@cardstack/cardpay-sdk';
 
@@ -476,10 +475,8 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
             c.layer2.fullName
           } wallet by bridging some tokens from your ${
             c.layer1.fullName
-          } wallet. The minimum balance needed to issue a prepaid card is approximately ${handleSignificantDecimals(
-            fromWei(previousMinDaiAmount),
-            18,
-            2
+          } wallet. The minimum balance needed to issue a prepaid card is approximately ${Math.ceil(
+            Number(fromWei(previousMinDaiAmount))
           )} DAI.CPXD (${convertAmountToNativeDisplay(
             spendToUsd(previousSpendAmount)!,
             'USD'

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -18,7 +18,7 @@ import prepaidCardColorSchemes from '../../mirage/fixture-data/prepaid-card-colo
 import prepaidCardPatterns from '../../mirage/fixture-data/prepaid-card-patterns';
 import { timeout } from 'ember-concurrency';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
-import { faceValueOptions } from '@cardstack/web-client/components/card-pay/issue-prepaid-card-workflow/workflow-config';
+import { faceValueOptions } from '@cardstack/web-client/components/card-pay/issue-prepaid-card-workflow/index';
 
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
 import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -33,6 +33,7 @@ import {
   createSafeToken,
   defaultCreatedPrepaidCardDID,
 } from '@cardstack/web-client/utils/test-factories';
+import { formatWeiAmount } from '@cardstack/web-client/helpers/format-wei-amount';
 
 interface Context extends MirageTestContext {}
 
@@ -546,6 +547,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
         background: '#37EB77',
         id: '4f219852-33ee-4e4c-81f7-76318630a423',
       },
+      daiMinValue: MIN_AMOUNT_TO_PASS,
       did: defaultCreatedPrepaidCardDID,
       issuerName: 'JJ',
       layer2WalletAddress: '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44',
@@ -726,7 +728,15 @@ module('Acceptance | issue prepaid card', function (hooks) {
       assert
         .dom(cancelationPostableSel(0))
         .containsText(
-          `Looks like there’s no balance in your ${c.layer2.fullName} wallet to fund a prepaid card. Before you can continue, please add funds to your ${c.layer2.fullName} wallet by bridging some tokens from your ${c.layer1.fullName} wallet.`
+          `Looks like there’s not enough balance in your ${
+            c.layer2.fullName
+          } wallet to fund a prepaid card. Before you can continue, please add funds to your ${
+            c.layer2.fullName
+          } wallet by bridging some tokens from your ${
+            c.layer1.fullName
+          } wallet. The minimum balance needed to issue a prepaid card is ${formatWeiAmount(
+            MIN_AMOUNT_TO_PASS
+          )} DAI.CPXD.`
         );
       assert.dom(cancelationPostableSel(1)).containsText('Workflow canceled');
 

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -743,7 +743,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
           } wallet. The minimum balance needed to issue a prepaid card is approximately ${handleSignificantDecimals(
             fromWei(MIN_AMOUNT_TO_PASS.toString()),
             18,
-            5
+            2
           )} DAI.CPXD (${convertAmountToNativeDisplay(
             spendToUsd(MIN_SPEND_AMOUNT)!,
             'USD'

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -35,7 +35,6 @@ import {
 } from '@cardstack/web-client/utils/test-factories';
 import {
   convertAmountToNativeDisplay,
-  handleSignificantDecimals,
   spendToUsd,
 } from '@cardstack/cardpay-sdk';
 
@@ -740,10 +739,8 @@ module('Acceptance | issue prepaid card', function (hooks) {
             c.layer2.fullName
           } wallet by bridging some tokens from your ${
             c.layer1.fullName
-          } wallet. The minimum balance needed to issue a prepaid card is approximately ${handleSignificantDecimals(
-            fromWei(MIN_AMOUNT_TO_PASS.toString()),
-            18,
-            2
+          } wallet. The minimum balance needed to issue a prepaid card is approximately ${Math.ceil(
+            Number(fromWei(MIN_AMOUNT_TO_PASS.toString()))
           )} DAI.CPXD (${convertAmountToNativeDisplay(
             spendToUsd(MIN_SPEND_AMOUNT)!,
             'USD'


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39579264/136077498-4a07486d-d44d-4030-b8d6-70a26dc8dfe3.png)


Not sure about https://github.com/cardstack/cardstack/pull/2205/commits/9b930cb9aa9be6363c059bc2530895a82d1c2ba2 because of the possibility of evolving schemas / workflow session property names, and also because I'm unsure if being true to the moment of cancelation is better than reflecting the latest value.