### PR TITLE
Workflow selector fix cs 2042

### DIFF
--- a/packages/web-client/app/components/card-pay/header/workflow-tracker/dropdown-list/index.hbs
+++ b/packages/web-client/app/components/card-pay/header/workflow-tracker/dropdown-list/index.hbs
@@ -1,5 +1,5 @@
-<aside tabindex="0" {{did-insert this.setEventListeners}} class='workflow-tracker' {{on-click-outside @close ignoreSelector="[data-workflow-tracker-toggle]"}}>
-  <header class={{cn "workflow-tracker__heading" workflow-tracker__heading--scrolled=this.isScrolled}} aria-label="Active workflows"> {{!-- label is because of linter --}}
+<aside tabindex="0" class='workflow-tracker' {{on-click-outside @close ignoreSelector="[data-workflow-tracker-toggle]"}}>
+  <header class="workflow-tracker__heading" aria-label="Active workflows">
     {{svg-jar 'task-active' class='workflow-tracker__heading-icon'}}
     Active workflows
     <span

--- a/packages/web-client/app/components/card-pay/header/workflow-tracker/dropdown-list/index.ts
+++ b/packages/web-client/app/components/card-pay/header/workflow-tracker/dropdown-list/index.ts
@@ -3,51 +3,15 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 
 import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';
-import { tracked } from '@glimmer/tracking';
 
 interface CardPayHeaderWorkflowTrackerDropdownListArgs {}
 
 export default class CardPayHeaderWorkflowTrackerDropdownList extends Component<CardPayHeaderWorkflowTrackerDropdownListArgs> {
   @service declare workflowPersistence: WorkflowPersistence;
 
-  initialPosition?: number;
-  @tracked currentPosition?: number;
-
   @action clearCompletedWorkflows() {
     this.workflowPersistence.completedWorkflows.forEach((workflowAndId) => {
       this.workflowPersistence.clearWorkflowWithId(workflowAndId.id);
     });
-  }
-
-  @action setEventListeners(element: HTMLElement) {
-    let item =
-      document.getElementById('workflow-tracker-active-list')
-        ?.firstElementChild ??
-      document.getElementById('workflow-tracker-completed-list')
-        ?.firstElementChild;
-
-    this.initialPosition = item?.getBoundingClientRect().top;
-
-    element.onscroll = () => {
-      this.currentPosition = item?.getBoundingClientRect().top;
-    };
-    element.onfocus = this._lockBodyScroll;
-    element.onblur = this._unlockBodyScroll;
-    element.onmouseover = this._lockBodyScroll;
-    element.onmouseout = this._unlockBodyScroll;
-  }
-
-  get isScrolled() {
-    return Boolean(
-      this.currentPosition && this.currentPosition !== this.initialPosition
-    );
-  }
-
-  _lockBodyScroll() {
-    document.body.classList.add('has-modal');
-  }
-
-  _unlockBodyScroll() {
-    document.body.classList.remove('has-modal');
   }
 }

--- a/packages/web-client/app/components/card-pay/header/workflow-tracker/index.css
+++ b/packages/web-client/app/components/card-pay/header/workflow-tracker/index.css
@@ -12,7 +12,7 @@
   max-width: var(--workflow-tracker-max-width);
   min-height: var(--workflow-tracker-max-width);
   max-height: var(--workflow-tracker-max-height);
-  position: fixed;
+  position: absolute;
   top: 6rem;
   right: var(--boxel-sp-lg);
   background-color: var(--workflow-tracker-background);


### PR DESCRIPTION
Ticket: [CS-2042](https://linear.app/cardstack/issue/CS-2042/polish-workflow-tracker-scrolling-interaction)

This PR changes the following:

1. Makes the dropdown stick to the opener button

- I did this change because I feel that dropdowns should stick to their opener button

Previously (the dropdown follows you while you scroll the page):

![image](https://user-images.githubusercontent.com/273660/136161709-39628176-103d-4db4-b485-a3930f3dca9d.png)


After the change (the dropdown will stay anchored to the top while scrolling down):

![image](https://user-images.githubusercontent.com/273660/136161782-32227ed3-6a87-4b17-bdec-179efedbcfa2.png)


2. Fixes the scrollbar jumping behaviour

- Video of the bug is here: https://www.loom.com/share/d10e9e7e04e04e808f1298d942ba3e97
- The reason for the body scrollbar appearing/disappearing is the scroll locking code which is adding and removing `has-modal` to the body, which is removing the body scrollbar
- In my opinion, the scroll locking logic isn't needed anymore. Not sure if this is a remnant of a previous design implementation, but now it seems the scrolling works perfectly fine. Here's the video of this PR: https://www.loom.com/share/314ba6290fd34c05b4d01a5c92f5494a. The bonus of removing this logic is that it also fixes the scrollbar bug described above.

