### PR TITLE
Subgraph break prevention

### DIFF
--- a/packages/cardpay-subgraph/subgraph-template.yaml
+++ b/packages/cardpay-subgraph/subgraph-template.yaml
@@ -640,36 +640,38 @@ dataSources:
           handler: handleRewardeeRegistrationFee
       file: ./src/mappings/register-rewardee-handler.ts
 
-  - kind: ethereum/contract
-    name: RewardPool
-    network: {NETWORK}
-    source:
-      address: "{REWARD_POOL_ADDRESS}"
-      abi: RewardPool
-      startBlock: {CARDPAY_GENESIS_BLOCK}
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.4
-      language: wasm/assemblyscript
-      entities:
-        - RewardeeClaim
-      abis:
-        - name: RewardPool
-          file: ./abis/generated/RewardPool.json
-        - name: ERC20
-          file: ./abis/ERC20.json
-        - name: ERC20SymbolBytes
-          file: ./abis/ERC20SymbolBytes.json
-        - name: ERC20NameBytes
-          file: ./abis/ERC20NameBytes.json
-        - name: GnosisSafe
-          file: ./abis/GnosisSafe.json
-      eventHandlers:
-        - event: RewardeeClaim(address,address,address,uint256)
-          handler: handleRewardeeClaim
-        - event: RewardTokensAdded(address,address,address,uint256)
-          handler: handleRewardTokensAdded
-      file: ./src/mappings/reward-pool.ts
+  # The shape of Rewardee claim changed in 0.8.2--commenting this out to prevent breaking index
+
+  # - kind: ethereum/contract
+  #   name: RewardPool
+  #   network: {NETWORK}
+  #   source:
+  #     address: "{REWARD_POOL_ADDRESS}"
+  #     abi: RewardPool
+  #     startBlock: {CARDPAY_GENESIS_BLOCK}
+  #   mapping:
+  #     kind: ethereum/events
+  #     apiVersion: 0.0.4
+  #     language: wasm/assemblyscript
+  #     entities:
+  #       - RewardeeClaim
+  #     abis:
+  #       - name: RewardPool
+  #         file: ./abis/generated/RewardPool.json
+  #       - name: ERC20
+  #         file: ./abis/ERC20.json
+  #       - name: ERC20SymbolBytes
+  #         file: ./abis/ERC20SymbolBytes.json
+  #       - name: ERC20NameBytes
+  #         file: ./abis/ERC20NameBytes.json
+  #       - name: GnosisSafe
+  #         file: ./abis/GnosisSafe.json
+  #     eventHandlers:
+  #       - event: RewardeeClaim(address,address,address,uint256)
+  #         handler: handleRewardeeClaim
+  #       - event: RewardTokensAdded(address,address,address,uint256)
+  #         handler: handleRewardTokensAdded
+  #     file: ./src/mappings/reward-pool.ts
 
 templates:
   - kind: ethereum/contract

--- a/packages/cardpay-subgraph/subgraph-template.yaml
+++ b/packages/cardpay-subgraph/subgraph-template.yaml
@@ -640,7 +640,9 @@ dataSources:
           handler: handleRewardeeRegistrationFee
       file: ./src/mappings/register-rewardee-handler.ts
 
-  # The shape of Rewardee claim changed in 0.8.2--commenting this out to prevent breaking index
+  # The shape of Rewardee claim changed in 0.8.2
+  # (https://github.com/cardstack/card-pay-protocol/pull/103) commenting this
+  # out to prevent breaking index
 
   # - kind: ethereum/contract
   #   name: RewardPool


### PR DESCRIPTION
The PR https://github.com/cardstack/card-pay-protocol/pull/103 introduced a change in the shape to an event that we are indexing in the subgraph, but the subgraph has not yet been updated to accommodate this new shape. The subgraph will need to be enhanced so that it recognizes this new event shape, and either ignores the older shaped events or includes a data source specifically to index the older shaped events.