### PR TITLE
always fetch latest safe values?

### DIFF
--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -128,8 +128,8 @@ export default class Layer2Network
     return txnHash ? this.strategy.bridgeExplorerUrl(txnHash) : undefined;
   }
 
-  @task *viewSafeTask(address: string): TaskGenerator<Safe> {
-    return yield this.strategy.viewSafe(address);
+  @task *viewSafeTask(address: string, latest = false): TaskGenerator<Safe> {
+    return yield this.strategy.viewSafe(address, latest);
   }
 
   @task *issuePrepaidCardTask(

--- a/packages/web-client/app/utils/web3-strategies/test-layer2.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer2.ts
@@ -201,7 +201,7 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
     return await this.test__simulateConvertFromSpend(symbol, amount);
   }
 
-  async viewSafe(address: string): Promise<Safe | undefined> {
+  async viewSafe(address: string, _latest = false): Promise<Safe | undefined> {
     return Promise.resolve(
       [...this.accountSafes.values()]
         .flat()

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -125,7 +125,7 @@ export interface Layer2Web3Strategy
     fromBlock: BN,
     txnHash: TransactionHash
   ): Promise<BridgeValidationResult>;
-  viewSafe(address: string): Promise<Safe | undefined>;
+  viewSafe(address: string, latest?: boolean): Promise<Safe | undefined>;
   viewSafesTask(account: string): TaskGenerator<Safe[]>;
   checkHubAuthenticationValid(authToken: string): Promise<boolean>;
   authenticate(): Promise<string>;


### PR DESCRIPTION
Prototype. Aiming to make it easy to get the latest values for merchant and prepaid card safes on demand for read-after-write consistency. 

~~not TODO: should sync the safe's value in the `Safes` resource, possibly by detaching the `Safes` resource's value from `viewSafesTask.last` and mutating it...~~

The above approach does mean that any action that refreshes/refetches safes will overwrite it, so overall trying to fetch only one safe's latest value seems like a bad idea.

Leaning towards always fetching latest data for all safes, and modifying this method to update a single safe in the safes resource instead, so that any subsequent safe fetches are consistent.