### PR TITLE
add claimTokensTxnHash back to withdrawal workflow

### DIFF
--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.ts
@@ -31,7 +31,7 @@ class CardPayWithdrawalWorkflowTokenClaimComponent extends Component<WorkflowCar
 
   @tracked isConfirming = false;
   get txnHash(): TransactionHash | null {
-    return this.args.workflowSession.getValue('txnHash');
+    return this.args.workflowSession.getValue('claimTokensTxnHash');
   }
   @tracked errorMessage = '';
 
@@ -103,7 +103,7 @@ class CardPayWithdrawalWorkflowTokenClaimComponent extends Component<WorkflowCar
           this.bridgeValidationResult,
           {
             onTxnHash: (txnHash: string) => {
-              this.args.workflowSession.setValue('txnHash', txnHash);
+              this.args.workflowSession.setValue('claimTokensTxnHash', txnHash);
             },
           }
         );


### PR DESCRIPTION
The link "View on Etherscan" will not have a url without being able to access the transaction hash from the workflow session.

![image](https://user-images.githubusercontent.com/39579264/136399226-f74d1f56-e708-44c0-b187-ef9f883b547a.png)
