### PR TITLE
Introduce a version property to workflow session's meta state

### DIFF
--- a/packages/web-client/app/components/card-pay/header/workflow-tracker/item/index.hbs
+++ b/packages/web-client/app/components/card-pay/header/workflow-tracker/item/index.hbs
@@ -1,6 +1,7 @@
 <button
   class={{cn "workflow-tracker-item" workflow-tracker-item--completed=this.isComplete}}
   type='button'
+  data-test-workflow-tracker-item={{this.workflowId}}
   {{on 'click' this.visit}}
   ...attributes
 >

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -22,6 +22,7 @@ import {
   WorkflowCard,
   WorkflowMessage,
   WorkflowName,
+  UNSUPPORTED_WORKFLOW_STATE_VERSION,
 } from '@cardstack/web-client/models/workflow';
 
 import { tracked } from '@glimmer/tracking';
@@ -41,6 +42,7 @@ export const FAILURE_REASONS = {
   RESTORATION_UNAUTHENTICATED: 'RESTORATION_UNAUTHENTICATED',
   RESTORATION_L2_ACCOUNT_CHANGED: 'RESTORATION_L2_ACCOUNT_CHANGED',
   RESTORATION_L2_DISCONNECTED: 'RESTORATION_L2_DISCONNECTED',
+  UNSUPPORTED_WORKFLOW_STATE_VERSION: UNSUPPORTED_WORKFLOW_STATE_VERSION,
 } as const;
 
 export const MILESTONE_TITLES = [
@@ -50,12 +52,15 @@ export const MILESTONE_TITLES = [
   'Confirm transaction',
 ];
 
+export const WORKFLOW_VERSION = 1;
+
 class IssuePrepaidCardWorkflow extends Workflow {
   @service declare router: RouterService;
   @service declare layer2Network: Layer2Network;
   @service declare hubAuthentication: HubAuthentication;
 
   name = 'PREPAID_CARD_ISSUANCE' as WorkflowName;
+  version = WORKFLOW_VERSION;
 
   milestones = [
     new Milestone({
@@ -341,6 +346,17 @@ class IssuePrepaidCardWorkflow extends Workflow {
         );
       },
     }),
+    new WorkflowMessage({
+      author: cardbot,
+      message:
+        'You attempted to restore an unfinished workflow, but the workflow has been upgraded by the Cardstack development team since then, so you will need to start again. Sorry about that!',
+      includeIf() {
+        return (
+          this.workflow?.cancelationReason ===
+          FAILURE_REASONS.UNSUPPORTED_WORKFLOW_STATE_VERSION
+        );
+      },
+    }),
     new WorkflowCard({
       author: cardbot,
       componentName: 'workflow-thread/default-cancelation-cta',
@@ -362,13 +378,11 @@ class IssuePrepaidCardWorkflow extends Workflow {
   constructor(owner: unknown, workflowPersistenceId?: string) {
     super(owner, workflowPersistenceId);
     this.attachWorkflow();
-    this.restore();
   }
 
   restorationErrors() {
     let { hubAuthentication, layer2Network } = this;
-
-    let errors = [];
+    let errors = super.restorationErrors();
 
     if (!layer2Network.isConnected) {
       errors.push(FAILURE_REASONS.RESTORATION_L2_DISCONNECTED);

--- a/packages/web-client/app/models/workflow/workflow-session.ts
+++ b/packages/web-client/app/models/workflow/workflow-session.ts
@@ -26,6 +26,7 @@ export interface IWorkflowSession {
 export interface WorkflowMeta {
   updatedAt: string | undefined;
   createdAt: string | undefined;
+  version: number;
   completedCardNames: string[] | undefined;
   completedMilestonesCount: number | undefined;
   milestonesCount: number | undefined;
@@ -209,7 +210,10 @@ export default class WorkflowSession implements IWorkflowSession {
     let createdAt = this.getMeta()?.createdAt || updatedAt;
 
     // persist must be false to avoid infinite recursion
-    this.setMeta({ updatedAt, createdAt }, false);
+    this.setMeta(
+      { updatedAt, createdAt, version: this.workflow.version },
+      false
+    );
 
     this.workflow.workflowPersistence.persistData(
       this.workflow.workflowPersistenceId,

--- a/packages/web-client/tests/acceptance/create-card-space-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/create-card-space-persistence-test.ts
@@ -6,6 +6,7 @@ import WorkflowPersistence from '@cardstack/web-client/services/workflow-persist
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
 import { buildState } from '@cardstack/web-client/models/workflow/workflow-session';
 import { setupHubAuthenticationToken } from '../helpers/setup';
+import { WORKFLOW_VERSION } from '@cardstack/web-client/components/card-space/create-space-workflow';
 
 interface Context extends MirageTestContext {}
 
@@ -52,6 +53,7 @@ module('Acceptance | create card space persistence', function (hooks) {
     test('it restores an unfinished workflow', async function (this: Context, assert) {
       let state = buildState({
         meta: {
+          version: WORKFLOW_VERSION,
           completedCardNames: ['LAYER2_CONNECT', 'CARD_SPACE_USERNAME'],
         },
       });
@@ -73,6 +75,7 @@ module('Acceptance | create card space persistence', function (hooks) {
     test('it restores a finished workflow', async function (this: Context, assert) {
       let state = buildState({
         meta: {
+          version: WORKFLOW_VERSION,
           completedCardNames: [
             'LAYER2_CONNECT',
             'CARD_SPACE_USERNAME',
@@ -101,6 +104,7 @@ module('Acceptance | create card space persistence', function (hooks) {
     test('it restores a cancelled workflow', async function (this: Context, assert) {
       const state = buildState({
         meta: {
+          version: WORKFLOW_VERSION,
           completedCardNames: ['LAYER2_CONNECT', 'CARD_SPACE_USERNAME'],
           isCanceled: true,
           cancelationReason: 'L2_DISCONNECTED',
@@ -134,6 +138,7 @@ module('Acceptance | create card space persistence', function (hooks) {
     test('it cancels a persisted flow when trying to restore while unauthenticated', async function (this: Context, assert) {
       const state = buildState({
         meta: {
+          version: WORKFLOW_VERSION,
           completedCardNames: ['LAYER2_CONNECT', 'CARD_SPACE_USERNAME'],
         },
       });
@@ -172,6 +177,7 @@ module('Acceptance | create card space persistence', function (hooks) {
     test('it should reset the persisted card names when editing one of the previous steps', async function (this: Context, assert) {
       const state = buildState({
         meta: {
+          version: WORKFLOW_VERSION,
           completedCardNames: ['LAYER2_CONNECT', 'CARD_SPACE_USERNAME'],
         },
       });
@@ -196,6 +202,7 @@ module('Acceptance | create card space persistence', function (hooks) {
     test('it cancels a persisted flow when card wallet address is different', async function (this: Context, assert) {
       const state = buildState({
         meta: {
+          version: WORKFLOW_VERSION,
           completedCardNames: ['LAYER2_CONNECT', 'CARD_SPACE_USERNAME'],
         },
         layer2WalletAddress: '0xaaaaaaaaaaaaaaa', // Differs from layer2AccountAddress set in beforeEach
@@ -220,6 +227,7 @@ module('Acceptance | create card space persistence', function (hooks) {
     test('it allows interactivity after restoring previously saved state', async function (this: Context, assert) {
       const state = buildState({
         meta: {
+          version: WORKFLOW_VERSION,
           completedCardNames: ['LAYER2_CONNECT'],
         },
       });
@@ -239,6 +247,31 @@ module('Acceptance | create card space persistence', function (hooks) {
 
       await click('[data-test-card-space-username-save-button]');
       assert.dom(milestoneCompletedSel(1)).exists();
+    });
+
+    test('it cancels a persisted flow when state version is old', async function (this: Context, assert) {
+      const state = buildState({
+        meta: {
+          version: WORKFLOW_VERSION - 1,
+          completedCardNames: ['LAYER2_CONNECT', 'CARD_SPACE_USERNAME'],
+        },
+        layer2WalletAddress: '0xaaaaaaaaaaaaaaa', // Differs from layer2AccountAddress set in beforeEach
+      });
+
+      workflowPersistenceService.persistData('abc123', {
+        name: 'CARD_SPACE_CREATION',
+        state,
+      });
+
+      await visit('/card-space?flow=create-space&flow-id=abc123');
+
+      assert.dom(milestoneCompletedSel(0)).doesNotExist();
+      assert.dom(milestoneCompletedSel(1)).doesNotExist();
+      assert
+        .dom('[data-test-cancelation]')
+        .includesText(
+          'You attempted to restore an unfinished workflow, but the workflow has been upgraded by the Cardstack development team since then, so you will need to start again. Sorry about that!'
+        );
     });
   });
 });

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -18,7 +18,10 @@ import prepaidCardColorSchemes from '../../mirage/fixture-data/prepaid-card-colo
 import prepaidCardPatterns from '../../mirage/fixture-data/prepaid-card-patterns';
 import { timeout } from 'ember-concurrency';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
-import { faceValueOptions } from '@cardstack/web-client/components/card-pay/issue-prepaid-card-workflow/index';
+import {
+  faceValueOptions,
+  WORKFLOW_VERSION,
+} from '@cardstack/web-client/components/card-pay/issue-prepaid-card-workflow/index';
 
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
 import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';
@@ -569,6 +572,7 @@ module('Acceptance | issue prepaid card', function (hooks) {
       transferrable: true,
       txnHash: 'exampleTxnHash',
       meta: {
+        version: WORKFLOW_VERSION,
         completedCardNames: [
           'LAYER2_CONNECT',
           'HUB_AUTH',

--- a/packages/web-client/tests/acceptance/persistence-view-restore-test.ts
+++ b/packages/web-client/tests/acceptance/persistence-view-restore-test.ts
@@ -24,6 +24,12 @@ import {
   createPrepaidCardSafe,
   createSafeToken,
 } from '@cardstack/web-client/utils/test-factories';
+import { WORKFLOW_VERSION as WITHDRAWAL_WORKFLOW_VERSION } from '@cardstack/web-client/components/card-pay/withdrawal-workflow';
+import { WORKFLOW_VERSION as MERCHANT_CREATION_WORKFLOW_VERSION } from '@cardstack/web-client/components/card-pay/create-merchant-workflow';
+import { WORKFLOW_VERSION as PREPAID_CARD_ISSUANCE_WORKFLOW_VERSION } from '@cardstack/web-client/components/card-pay/issue-prepaid-card-workflow';
+import { WORKFLOW_VERSION as CARD_SPACE_CREATION_WORKFLOW_VERSION } from '@cardstack/web-client/components/card-space/create-space-workflow';
+import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
+import BN from 'bn.js';
 
 interface Context extends MirageTestContext {}
 
@@ -75,6 +81,7 @@ module('Acceptance | persistence view and restore', function () {
         name: 'MERCHANT_CREATION',
         state: buildState({
           meta: {
+            version: MERCHANT_CREATION_WORKFLOW_VERSION,
             completedCardNames: ['LAYER2_CONNECT', 'MERCHANT_CUSTOMIZATION'],
             completedMilestonesCount: 1,
             milestonesCount: 3,
@@ -89,6 +96,7 @@ module('Acceptance | persistence view and restore', function () {
           name: `PREPAID_CARD_ISSUANCE`,
           state: buildState({
             meta: {
+              version: PREPAID_CARD_ISSUANCE_WORKFLOW_VERSION,
               completedCardNames: [
                 'LAYER2_CONNECT',
                 'HUB_AUTH',
@@ -107,6 +115,7 @@ module('Acceptance | persistence view and restore', function () {
         name: 'PREPAID_CARD_ISSUANCE',
         state: buildState({
           meta: {
+            version: PREPAID_CARD_ISSUANCE_WORKFLOW_VERSION,
             completedCardNames: [
               'LAYER2_CONNECT',
               'HUB_AUTH',
@@ -137,6 +146,7 @@ module('Acceptance | persistence view and restore', function () {
         name: `PREPAID_CARD_ISSUANCE`,
         state: buildState({
           meta: {
+            version: PREPAID_CARD_ISSUANCE_WORKFLOW_VERSION,
             completedCardNames: [
               'LAYER2_CONNECT',
               'HUB_AUTH',
@@ -156,6 +166,7 @@ module('Acceptance | persistence view and restore', function () {
         name: 'CARD_SPACE_CREATION',
         state: buildState({
           meta: {
+            version: CARD_SPACE_CREATION_WORKFLOW_VERSION,
             completedCardNames: ['LAYER2_CONNECT'],
             completedMilestonesCount: 1,
             milestonesCount: 4,
@@ -170,6 +181,7 @@ module('Acceptance | persistence view and restore', function () {
           name: 'CARD_SPACE_CREATION',
           state: buildState({
             meta: {
+              version: CARD_SPACE_CREATION_WORKFLOW_VERSION,
               completedCardNames: [
                 'LAYER2_CONNECT',
                 'CARD_SPACE_USERNAME',
@@ -190,6 +202,7 @@ module('Acceptance | persistence view and restore', function () {
           name: 'CARD_SPACE_CREATION',
           state: buildState({
             meta: {
+              version: CARD_SPACE_CREATION_WORKFLOW_VERSION,
               completedCardNames: ['LAYER2_CONNECT'],
               completedMilestonesCount: 1,
               milestonesCount: 4,
@@ -250,6 +263,7 @@ module('Acceptance | persistence view and restore', function () {
         name: 'MERCHANT_CREATION',
         state: buildState({
           meta: {
+            version: MERCHANT_CREATION_WORKFLOW_VERSION,
             completedCardNames: ['LAYER2_CONNECT', 'MERCHANT_CUSTOMIZATION'],
             completedMilestonesCount: 1,
             milestonesCount: 3,
@@ -272,6 +286,7 @@ module('Acceptance | persistence view and restore', function () {
         name: 'MERCHANT_CREATION',
         state: buildState({
           meta: {
+            version: MERCHANT_CREATION_WORKFLOW_VERSION,
             completedCardNames: ['LAYER2_CONNECT', 'MERCHANT_CUSTOMIZATION'],
             completedMilestonesCount: 1,
             milestonesCount: 3,
@@ -283,6 +298,7 @@ module('Acceptance | persistence view and restore', function () {
         name: 'PREPAID_CARD_ISSUANCE',
         state: buildState({
           meta: {
+            version: PREPAID_CARD_ISSUANCE_WORKFLOW_VERSION,
             completedCardNames: [
               'LAYER2_CONNECT',
               'HUB_AUTH',
@@ -381,37 +397,43 @@ module('Acceptance | persistence view and restore', function () {
   module(
     'when workflows have been persisted before the application loads',
     function (hooks) {
-      window.TEST__MOCK_LOCAL_STORAGE_INIT = {};
+      hooks.beforeEach(function () {
+        window.TEST__MOCK_LOCAL_STORAGE_INIT = {};
 
-      for (let i = 0; i < 2; i++) {
+        for (let i = 0; i < 2; i++) {
+          window.TEST__MOCK_LOCAL_STORAGE_INIT[
+            constructStorageKey(`persisted-${i}`)
+          ] = JSON.stringify({
+            name: `PREPAID_CARD_ISSUANCE`,
+            state: buildState({
+              meta: {
+                completedCardNames: ['LAYER2_CONNECT', 'HUB_AUTH'],
+                completedMilestonesCount: 1,
+                milestonesCount: 4,
+              },
+            }),
+          });
+        }
+
         window.TEST__MOCK_LOCAL_STORAGE_INIT[
-          constructStorageKey(`persisted-${i}`)
+          constructStorageKey(`persisted-card-space-wf`)
         ] = JSON.stringify({
-          name: `PREPAID_CARD_ISSUANCE`,
+          name: `CARD_SPACE_CREATION`,
           state: buildState({
             meta: {
-              completedCardNames: ['LAYER2_CONNECT', 'HUB_AUTH'],
+              completedCardNames: ['LAYER2_CONNECT'],
               completedMilestonesCount: 1,
               milestonesCount: 4,
             },
           }),
         });
-      }
 
-      window.TEST__MOCK_LOCAL_STORAGE_INIT[
-        constructStorageKey(`persisted-card-space-wf`)
-      ] = JSON.stringify({
-        name: `CARD_SPACE_CREATION`,
-        state: buildState({
-          meta: {
-            completedCardNames: ['LAYER2_CONNECT'],
-            completedMilestonesCount: 1,
-            milestonesCount: 4,
-          },
-        }),
+        window.TEST__MOCK_LOCAL_STORAGE_INIT['unrelated'] = 'hello';
       });
 
-      window.TEST__MOCK_LOCAL_STORAGE_INIT['unrelated'] = 'hello';
+      hooks.afterEach(function () {
+        delete window.TEST__MOCK_LOCAL_STORAGE_INIT;
+      });
 
       setupApplicationTest(hooks);
       setupMirage(hooks);
@@ -422,8 +444,74 @@ module('Acceptance | persistence view and restore', function () {
         assert.dom('[data-test-workflow-tracker-count]').containsText('2');
       });
 
-      hooks.afterEach(function () {
-        delete window.TEST__MOCK_LOCAL_STORAGE_INIT;
+      test('clicking a workflow persisted with an old version opens the flow and cancels immediately', async function (this: Context, assert) {
+        // @ts-ignore - defined in beforeEach
+        window.TEST__MOCK_LOCAL_STORAGE_INIT[
+          constructStorageKey(`persisted-old`)
+        ] = JSON.stringify({
+          name: `WITHDRAWAL`,
+          state: buildState({
+            meta: {
+              version: WITHDRAWAL_WORKFLOW_VERSION - 1,
+              completedCardNames: ['LAYER1_CONNECT', 'CHECK_BALANCE'],
+              completedMilestonesCount: 2,
+              milestonesCount: 6,
+            },
+          }),
+        });
+
+        let layer1AccountAddress =
+          '0xaCD5f5534B756b856ae3B2CAcF54B3321dd6654Fb6';
+        let layer1Service = this.owner.lookup('service:layer1-network')
+          .strategy as Layer1TestWeb3Strategy;
+        layer1Service.test__simulateAccountsChanged(
+          [layer1AccountAddress],
+          'metamask'
+        );
+        layer1Service.test__simulateBalances({
+          defaultToken: new BN('2141100000000000000'),
+          dai: new BN('250500000000000000000'),
+          card: new BN('10000000000000000000000'),
+        });
+
+        let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
+
+        let layer2Service = this.owner.lookup('service:layer2-network')
+          .strategy as Layer2TestWeb3Strategy;
+        layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
+        let testDepot = createDepotSafe({
+          address: '0xB236ca8DbAB0644ffCD32518eBF4924ba8666666',
+          tokens: [createSafeToken('CARD', '500000000000000000000')],
+        });
+
+        await layer2Service.test__simulateDepot(testDepot);
+
+        let merchantRegistrationFee = await this.owner
+          .lookup('service:layer2-network')
+          .strategy.fetchMerchantRegistrationFee();
+
+        layer2Service.test__simulateAccountSafes(layer2AccountAddress, [
+          createPrepaidCardSafe({
+            address: '0x123400000000000000000000000000000000abcd',
+            owners: [layer2AccountAddress],
+            spendFaceValue: merchantRegistrationFee,
+            prepaidCardOwner: layer2AccountAddress,
+            issuer: layer2AccountAddress,
+            transferrable: false,
+          }),
+        ]);
+
+        await visit('/card-pay/');
+        assert.dom('[data-test-workflow-tracker-count]').containsText('3');
+        await click('[data-test-workflow-tracker-toggle]');
+        await click('[data-test-workflow-tracker-item]');
+
+        assert
+          .dom('[data-test-cancelation]')
+          .includesText(
+            'You attempted to restore an unfinished workflow, but the workflow has been upgraded by the Cardstack development team since then, so you will need to start again. Sorry about that!'
+          );
+        assert.dom('[data-test-workflow-tracker-count]').containsText('2');
       });
     }
   );

--- a/packages/web-client/tests/stubs/workflow.ts
+++ b/packages/web-client/tests/stubs/workflow.ts
@@ -2,10 +2,8 @@ import { Workflow, WorkflowName } from '@cardstack/web-client/models/workflow';
 
 export class WorkflowStub extends Workflow {
   name = 'WITHDRAWAL' as WorkflowName;
+  version = 1;
 
-  restorationErrors() {
-    return [];
-  }
   beforeRestorationChecks() {
     return [];
   }

--- a/packages/web-client/tests/unit/models/workflow/workflow-session-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/workflow-session-test.ts
@@ -9,6 +9,7 @@ import Ember from 'ember';
 import BN from 'bn.js';
 import { default as sinon, SinonFakeTimers } from 'sinon';
 import { Workflow } from '@cardstack/web-client/models/workflow';
+import { WORKFLOW_VERSION } from '@cardstack/web-client/components/card-pay/issue-prepaid-card-workflow';
 
 const { track, valueForTag, validateTag } =
   // @ts-ignore digging
@@ -31,6 +32,7 @@ module('Unit | WorkflowSession model', function (hooks) {
       value: {
         updatedAt: startDateString,
         createdAt: startDateString,
+        version: WORKFLOW_VERSION,
       },
     });
   });
@@ -50,6 +52,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -65,6 +68,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -80,6 +84,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -119,6 +124,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -161,6 +167,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -176,6 +183,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -191,6 +199,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -230,6 +239,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -278,6 +288,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -301,6 +312,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -335,6 +347,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -350,6 +363,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -365,6 +379,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -406,6 +421,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -424,6 +440,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -439,6 +456,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -483,6 +501,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -502,6 +521,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -517,6 +537,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -560,6 +581,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -599,6 +621,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -647,6 +670,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -671,6 +695,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -723,6 +748,7 @@ module('Unit | WorkflowSession model', function (hooks) {
           completedMilestonesCount: 1,
           updatedAt: startDateString,
           createdAt: startDateString,
+          version: WORKFLOW_VERSION,
         },
       }),
       'State is persisted when persist=false is not specified'
@@ -737,6 +763,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -778,6 +805,7 @@ module('Unit | WorkflowSession model', function (hooks) {
     });
     let subject = new WorkflowSession({
       name: 'PREPAID_CARD_ISSUANCE',
+      version: WORKFLOW_VERSION,
       workflowPersistence,
       workflowPersistenceId: ID,
     } as Workflow);
@@ -800,5 +828,22 @@ module('Unit | WorkflowSession model', function (hooks) {
       updatedDateString,
       `Updated date has an updated ISO date string: ${updatedDateString}`
     );
+  });
+
+  test('it can return worklow version', function (assert) {
+    let workflowPersistence = new WorkflowPersistence();
+    workflowPersistence.persistData('workflow-id-1', {
+      name: 'PREPAID_CARD_ISSUANCE',
+      state: {},
+    });
+    let subject = new WorkflowSession({
+      name: 'PREPAID_CARD_ISSUANCE',
+      version: 2,
+      workflowPersistence,
+      workflowPersistenceId: ID,
+    } as Workflow);
+    subject.setMeta({});
+
+    assert.equal(subject.getMeta().version, 2);
   });
 });


### PR DESCRIPTION
When a workflow is restored, we check the version persisted to the session and if it is older than the current workflow version, the flow is canceled and we show a message.