### PR TITLE
Reduce workflow boilerplate

### DIFF
--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
@@ -6,7 +6,7 @@ import {
   spendToUsd,
 } from '@cardstack/cardpay-sdk';
 import {
-  cardbot,
+  conditionalCancelationMessage,
   IWorkflowSession,
   Milestone,
   PostableCollection,
@@ -18,6 +18,7 @@ import {
   WorkflowMessage,
   WorkflowName,
   UNSUPPORTED_WORKFLOW_STATE_VERSION,
+  defaultCancelationCard,
 } from '@cardstack/web-client/models/workflow';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { action } from '@ember/object';
@@ -28,7 +29,6 @@ import RouterService from '@ember/routing/router-service';
 import WorkflowPersistence from '@cardstack/web-client/services/workflow-persistence';
 import { formatAmount } from '@cardstack/web-client/helpers/format-amount';
 import { tracked } from '@glimmer/tracking';
-import { isPresent } from '@ember/utils';
 
 const FAILURE_REASONS = {
   UNAUTHENTICATED: 'UNAUTHENTICATED',
@@ -62,16 +62,13 @@ class CreateMerchantWorkflow extends Workflow {
       title: MILESTONE_TITLES[0],
       postables: [
         new WorkflowMessage({
-          author: cardbot,
           message: `Hello, nice to see you!`,
         }),
         new WorkflowMessage({
-          author: cardbot,
           message: `To receive payment through Card Pay, you need to create a merchant account.
           All you need is to choose a name for your merchant account and sign a transaction to create your merchant on the ${c.layer2.fullName}.`,
         }),
         new NetworkAwareWorkflowMessage({
-          author: cardbot,
           message: `Looks like you’ve already connected your ${c.layer2.fullName} wallet, which you can see below.
           Please continue with the next step of this workflow.`,
           includeIf() {
@@ -79,14 +76,12 @@ class CreateMerchantWorkflow extends Workflow {
           },
         }),
         new NetworkAwareWorkflowMessage({
-          author: cardbot,
           message: `To get started, connect your ${c.layer2.fullName} wallet via your Card Wallet mobile app. If you don’t have the app installed, please do so now.`,
           includeIf() {
             return !this.hasLayer2Account;
           },
         }),
         new NetworkAwareWorkflowMessage({
-          author: cardbot,
           message: `Once you have installed the app, open the app and add an existing wallet/account or create a new account. Scan this QR code with your account, which will connect your account with Cardstack.`,
           includeIf() {
             return !this.hasLayer2Account;
@@ -94,7 +89,6 @@ class CreateMerchantWorkflow extends Workflow {
         }),
         new WorkflowCard({
           cardName: 'LAYER2_CONNECT',
-          author: cardbot,
           componentName: 'card-pay/layer-two-connect-card',
           async check() {
             let { layer2Network } = this.workflow as CreateMerchantWorkflow;
@@ -147,7 +141,6 @@ class CreateMerchantWorkflow extends Workflow {
       title: MILESTONE_TITLES[1],
       postables: [
         new NetworkAwareWorkflowMessage({
-          author: cardbot,
           message: `To store data in the Cardstack Hub, you need to authenticate using your Card Wallet.
           You only need to do this once per browser/device.`,
           includeIf() {
@@ -156,19 +149,16 @@ class CreateMerchantWorkflow extends Workflow {
         }),
         new NetworkAwareWorkflowCard({
           cardName: 'HUB_AUTH',
-          author: cardbot,
           componentName: 'card-pay/hub-authentication',
           includeIf(this: NetworkAwareWorkflowCard) {
             return !this.isHubAuthenticated;
           },
         }),
         new WorkflowMessage({
-          author: cardbot,
           message: 'Let’s create a new merchant account.',
         }),
         new WorkflowCard({
           cardName: 'MERCHANT_CUSTOMIZATION',
-          author: cardbot,
           componentName:
             'card-pay/create-merchant-workflow/merchant-customization',
         }),
@@ -179,17 +169,14 @@ class CreateMerchantWorkflow extends Workflow {
       title: MILESTONE_TITLES[2],
       postables: [
         new WorkflowMessage({
-          author: cardbot,
           message: 'Looking great!',
         }),
         new WorkflowMessage({
-          author: cardbot,
           message: `On the next step: You need to pay a small protocol fee to create your merchant.
           Please select a prepaid card and balance from your ${c.layer2.fullName} wallet`,
         }),
         new WorkflowCard({
           cardName: 'PREPAID_CARD_CHOICE',
-          author: cardbot,
           componentName:
             'card-pay/create-merchant-workflow/prepaid-card-choice',
         }),
@@ -199,40 +186,27 @@ class CreateMerchantWorkflow extends Workflow {
   ];
   epilogue = new PostableCollection([
     new WorkflowMessage({
-      author: cardbot,
       message: `Congratulations! You have created a merchant.`,
     }),
     new WorkflowCard({
       cardName: 'EPILOGUE_NEXT_STEPS',
-      author: cardbot,
       componentName: 'card-pay/create-merchant-workflow/next-steps',
     }),
   ]);
   cancelationMessages = new PostableCollection([
     // if we disconnect from layer 2
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.DISCONNECTED,
       message: `It looks like your ${c.layer2.fullName} wallet got disconnected. If you still want to create a merchant, please start again by connecting your wallet.`,
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason === FAILURE_REASONS.DISCONNECTED
-        );
-      },
     }),
     // cancelation for changing accounts
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.ACCOUNT_CHANGED,
       message:
         'It looks like you changed accounts in the middle of this workflow. If you still want to create a merchant, please restart the workflow.',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason === FAILURE_REASONS.ACCOUNT_CHANGED
-        );
-      },
     }),
     // cancelation for not having prepaid card
     new SessionAwareWorkflowMessage({
-      author: cardbot,
       template: (session: IWorkflowSession) =>
         `It looks like you don’t have a prepaid card in your wallet. You will need one to pay the ${formatAmount(
           session.getValue('merchantRegistrationFee')
@@ -248,7 +222,6 @@ class CreateMerchantWorkflow extends Workflow {
     }),
     // cancelation for insufficient balance
     new SessionAwareWorkflowMessage({
-      author: cardbot,
       template: (session: IWorkflowSession) =>
         `It looks like you don’t have a prepaid card with enough funds to pay the ${formatAmount(
           session.getValue('merchantRegistrationFee')
@@ -263,66 +236,31 @@ class CreateMerchantWorkflow extends Workflow {
         );
       },
     }),
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.UNAUTHENTICATED,
       message: 'You are no longer authenticated. Please restart the workflow.',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason === FAILURE_REASONS.UNAUTHENTICATED
-        );
-      },
     }),
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.RESTORATION_UNAUTHENTICATED,
       message:
         'You attempted to restore an unfinished workflow, but you are no longer authenticated. Please restart the workflow.',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason ===
-          FAILURE_REASONS.RESTORATION_UNAUTHENTICATED
-        );
-      },
     }),
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.RESTORATION_L2_ACCOUNT_CHANGED,
       message:
         'You attempted to restore an unfinished workflow, but you changed your Card Wallet address. Please restart the workflow.',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason ===
-          FAILURE_REASONS.RESTORATION_L2_ACCOUNT_CHANGED
-        );
-      },
     }),
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.RESTORATION_L2_DISCONNECTED,
       message:
         'You attempted to restore an unfinished workflow, but your Card Wallet got disconnected. Please restart the workflow.',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason ===
-          FAILURE_REASONS.RESTORATION_L2_DISCONNECTED
-        );
-      },
     }),
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.UNSUPPORTED_WORKFLOW_STATE_VERSION,
       message:
         'You attempted to restore an unfinished workflow, but the workflow has been upgraded by the Cardstack development team since then, so you will need to start again. Sorry about that!',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason ===
-          FAILURE_REASONS.UNSUPPORTED_WORKFLOW_STATE_VERSION
-        );
-      },
     }),
-    new WorkflowCard({
-      author: cardbot,
-      componentName: 'workflow-thread/default-cancelation-cta',
-      includeIf() {
-        return isPresent(this.workflow?.cancelationReason);
-      },
-    }),
+    defaultCancelationCard(),
   ]);
 
   constructor(owner: unknown, workflowPersistenceId: string) {

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -11,7 +11,6 @@ import BN from 'bn.js';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
 import HubAuthentication from '@cardstack/web-client/services/hub-authentication';
 import {
-  cardbot,
   IWorkflowSession,
   Milestone,
   NetworkAwareWorkflowCard,
@@ -23,6 +22,8 @@ import {
   WorkflowMessage,
   WorkflowName,
   UNSUPPORTED_WORKFLOW_STATE_VERSION,
+  conditionalCancelationMessage,
+  defaultCancelationCard,
 } from '@cardstack/web-client/models/workflow';
 
 import { tracked } from '@glimmer/tracking';
@@ -67,15 +68,12 @@ class IssuePrepaidCardWorkflow extends Workflow {
       title: MILESTONE_TITLES[0],
       postables: [
         new WorkflowMessage({
-          author: cardbot,
           message: `Hello, it’s nice to see you!`,
         }),
         new WorkflowMessage({
-          author: cardbot,
           message: `Let’s issue a prepaid card.`,
         }),
         new NetworkAwareWorkflowMessage({
-          author: cardbot,
           message: `Looks like you’ve already connected your ${c.layer2.fullName} wallet, which you can see below.
           Please continue with the next step of this workflow.`,
           includeIf() {
@@ -83,21 +81,18 @@ class IssuePrepaidCardWorkflow extends Workflow {
           },
         }),
         new NetworkAwareWorkflowMessage({
-          author: cardbot,
           message: `Before we get started, please connect your ${c.layer2.fullName} wallet via your Card Wallet mobile app. If you don’t have the app installed, please do so now.`,
           includeIf() {
             return !this.hasLayer2Account;
           },
         }),
         new NetworkAwareWorkflowMessage({
-          author: cardbot,
           message: `Once you have installed the app, open the app and add an existing wallet/account or create a new wallet/account. Use your account to scan this QR code, which will connect your account with Card Pay.`,
           includeIf() {
             return !this.hasLayer2Account;
           },
         }),
         new WorkflowCard({
-          author: cardbot,
           cardName: 'LAYER2_CONNECT',
           componentName: 'card-pay/layer-two-connect-card',
           async check() {
@@ -147,7 +142,6 @@ class IssuePrepaidCardWorkflow extends Workflow {
       title: MILESTONE_TITLES[1],
       postables: [
         new NetworkAwareWorkflowMessage({
-          author: cardbot,
           message: `To store card customization data in the Cardstack Hub, you need to authenticate using your Card Wallet.
           You only need to do this once per browser/device.`,
           includeIf() {
@@ -156,20 +150,17 @@ class IssuePrepaidCardWorkflow extends Workflow {
         }),
         new NetworkAwareWorkflowCard({
           cardName: 'HUB_AUTH',
-          author: cardbot,
           componentName: 'card-pay/hub-authentication',
           includeIf(this: NetworkAwareWorkflowCard) {
             return !this.isHubAuthenticated;
           },
         }),
         new WorkflowMessage({
-          author: cardbot,
           message:
             'Let’s get started! First, you can choose the look and feel of your card, so that your customers and other users recognize that this prepaid card came from you.',
         }),
         new WorkflowCard({
           cardName: 'LAYOUT_CUSTOMIZATION',
-          author: cardbot,
           componentName:
             'card-pay/issue-prepaid-card-workflow/layout-customization',
         }),
@@ -180,27 +171,22 @@ class IssuePrepaidCardWorkflow extends Workflow {
       title: MILESTONE_TITLES[2],
       postables: [
         new WorkflowMessage({
-          author: cardbot,
           message: 'Nice choice!',
         }),
         new WorkflowMessage({
-          author: cardbot,
           message: `On to the next step: How do you want to fund your prepaid card? Please select a depot and balance from your ${c.layer2.fullName} wallet.`,
         }),
         new WorkflowCard({
           cardName: 'FUNDING_SOURCE',
-          author: cardbot,
           componentName: 'card-pay/issue-prepaid-card-workflow/funding-source',
         }),
         new WorkflowMessage({
-          author: cardbot,
           message: `When you choose the face value of your prepaid card, you may want to consider creating one card with a larger balance,
             as opposed to several cards with smaller balances (which would require a separate transaction, incl. fees, for each card).
             After you have created your card, you can split it up into multiple cards with smaller balances to transfer to your customers.`,
         }),
         new WorkflowCard({
           cardName: 'FACE_VALUE',
-          author: cardbot,
           componentName: 'card-pay/issue-prepaid-card-workflow/face-value',
         }),
       ],
@@ -210,13 +196,11 @@ class IssuePrepaidCardWorkflow extends Workflow {
       title: MILESTONE_TITLES[3],
       postables: [
         new WorkflowMessage({
-          author: cardbot,
           message: `This is what your prepaid card will look like.
             Now, we just need your confirmation to create the card.`,
         }),
         new WorkflowCard({
           cardName: 'PREVIEW',
-          author: cardbot,
           componentName: 'card-pay/issue-prepaid-card-workflow/preview',
         }),
       ],
@@ -225,43 +209,32 @@ class IssuePrepaidCardWorkflow extends Workflow {
   ];
   epilogue = new PostableCollection([
     new WorkflowMessage({
-      author: cardbot,
       message: `Congratulations, you have created a prepaid card! This prepaid card has been added to your ${c.layer2.fullName} wallet.`,
     }),
     new WorkflowCard({
       cardName: 'CONFIRMATION',
-      author: cardbot,
       componentName: 'card-pay/issue-prepaid-card-workflow/confirmation',
     }),
     new WorkflowMessage({
-      author: cardbot,
       message: `This is the remaining balance in your ${c.layer2.fullName} wallet:`,
     }),
     new WorkflowCard({
       cardName: 'EPILOGUE_LAYER_TWO_CONNECT_CARD',
-      author: cardbot,
       componentName: 'card-pay/layer-two-connect-card',
     }),
     new WorkflowCard({
       cardName: 'EPILOGUE_NEXT_STEPS',
-      author: cardbot,
       componentName: 'card-pay/issue-prepaid-card-workflow/next-steps',
     }),
   ]);
   cancelationMessages = new PostableCollection([
     // if we disconnect from layer 2
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.DISCONNECTED,
       message: `It looks like your ${c.layer2.fullName} wallet got disconnected. If you still want to create a prepaid card, please start again by connecting your wallet.`,
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason === FAILURE_REASONS.DISCONNECTED
-        );
-      },
     }),
     // if we don't have enough balance (50 USD equivalent)
     new SessionAwareWorkflowMessage({
-      author: cardbot,
       template: (session: IWorkflowSession) =>
         `Looks like there’s not enough balance in your ${
           c.layer2.fullName
@@ -283,7 +256,6 @@ class IssuePrepaidCardWorkflow extends Workflow {
       },
     }),
     new WorkflowCard({
-      author: cardbot,
       componentName:
         'card-pay/issue-prepaid-card-workflow/insufficient-funds-cta',
       includeIf() {
@@ -294,85 +266,36 @@ class IssuePrepaidCardWorkflow extends Workflow {
       },
     }),
     // cancelation for changing accounts
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.ACCOUNT_CHANGED,
       message:
         'It looks like you changed accounts in the middle of this workflow. If you still want to create a prepaid card, please restart the workflow.',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason === FAILURE_REASONS.ACCOUNT_CHANGED
-        );
-      },
     }),
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.UNAUTHENTICATED,
       message: 'You are no longer authenticated. Please restart the workflow.',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason === FAILURE_REASONS.UNAUTHENTICATED
-        );
-      },
     }),
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.RESTORATION_UNAUTHENTICATED,
       message:
         'You attempted to restore an unfinished workflow, but you are no longer authenticated. Please restart the workflow.',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason ===
-          FAILURE_REASONS.RESTORATION_UNAUTHENTICATED
-        );
-      },
     }),
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.RESTORATION_L2_ACCOUNT_CHANGED,
       message:
         'You attempted to restore an unfinished workflow, but you changed your Card Wallet address. Please restart the workflow.',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason ===
-          FAILURE_REASONS.RESTORATION_L2_ACCOUNT_CHANGED
-        );
-      },
     }),
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.RESTORATION_L2_DISCONNECTED,
       message:
         'You attempted to restore an unfinished workflow, but your Card Wallet got disconnected. Please restart the workflow.',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason ===
-          FAILURE_REASONS.RESTORATION_L2_DISCONNECTED
-        );
-      },
     }),
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.UNSUPPORTED_WORKFLOW_STATE_VERSION,
       message:
         'You attempted to restore an unfinished workflow, but the workflow has been upgraded by the Cardstack development team since then, so you will need to start again. Sorry about that!',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason ===
-          FAILURE_REASONS.UNSUPPORTED_WORKFLOW_STATE_VERSION
-        );
-      },
     }),
-    new WorkflowCard({
-      author: cardbot,
-      componentName: 'workflow-thread/default-cancelation-cta',
-      includeIf() {
-        return (
-          [
-            FAILURE_REASONS.DISCONNECTED,
-            FAILURE_REASONS.ACCOUNT_CHANGED,
-            FAILURE_REASONS.UNAUTHENTICATED,
-            FAILURE_REASONS.RESTORATION_UNAUTHENTICATED,
-            FAILURE_REASONS.RESTORATION_L2_ACCOUNT_CHANGED,
-            FAILURE_REASONS.RESTORATION_L2_DISCONNECTED,
-          ] as String[]
-        ).includes(String(this.workflow?.cancelationReason));
-      },
-    }),
+    defaultCancelationCard(),
   ]);
 
   constructor(owner: unknown, workflowPersistenceId?: string) {

--- a/packages/web-client/app/components/card-space/create-space-workflow/index.ts
+++ b/packages/web-client/app/components/card-space/create-space-workflow/index.ts
@@ -9,7 +9,6 @@ import WorkflowPersistence from '@cardstack/web-client/services/workflow-persist
 import HubAuthentication from '@cardstack/web-client/services/hub-authentication';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
 import {
-  cardbot,
   Milestone,
   NetworkAwareWorkflowCard,
   NetworkAwareWorkflowMessage,
@@ -19,6 +18,8 @@ import {
   WorkflowMessage,
   WorkflowName,
   UNSUPPORTED_WORKFLOW_STATE_VERSION,
+  conditionalCancelationMessage,
+  defaultCancelationCard,
 } from '@cardstack/web-client/models/workflow';
 
 const FAILURE_REASONS = {
@@ -53,11 +54,9 @@ class CreateSpaceWorkflow extends Workflow {
       title: MILESTONE_TITLES[0],
       postables: [
         new WorkflowMessage({
-          author: cardbot,
           message: `Hello, welcome to Card Space, we're happy to see you!`,
         }),
         new NetworkAwareWorkflowMessage({
-          author: cardbot,
           message: `Looks like you’ve already connected your ${c.layer2.fullName} wallet, which you can see below.
           Please continue with the next step of this workflow.`,
           includeIf() {
@@ -65,21 +64,18 @@ class CreateSpaceWorkflow extends Workflow {
           },
         }),
         new NetworkAwareWorkflowMessage({
-          author: cardbot,
           message: `To get started, connect your ${c.layer2.fullName} wallet via your Card Wallet mobile app. If you don’t have the app installed, please do so now.`,
           includeIf() {
             return !this.hasLayer2Account;
           },
         }),
         new NetworkAwareWorkflowMessage({
-          author: cardbot,
           message: `Once you have installed the app, open the app and add an existing wallet/account or create a new account. Scan this QR code with your account, which will connect it with Card Space.`,
           includeIf() {
             return !this.hasLayer2Account;
           },
         }),
         new WorkflowCard({
-          author: cardbot,
           cardName: 'LAYER2_CONNECT',
           componentName: 'card-pay/layer-two-connect-card',
         }),
@@ -91,16 +87,13 @@ class CreateSpaceWorkflow extends Workflow {
       postables: [
         // TODO
         // new WorkflowMessage({
-        //   author: cardbot,
         //   message: `It looks like you don’t have a prepaid card in your account. You will need one to pay the **100 SPEND ($1 USD)** Card Space creation fee. Please buy a prepaid card before you continue with this workflow.`,
         // }),
         // new WorkflowCard({
-        //   author: cardbot,
         //   cardName: 'PREPAID_CARD_PURCHASE_INSTRUCTIONS',
         //   componentName: 'card-pay/prepaid-card-purchase-instructions',
         // }),
         new NetworkAwareWorkflowMessage({
-          author: cardbot,
           message: `To store data in the Cardstack Hub, you need to authenticate using your Card Wallet.
           You only need to do this once per browser/device.`,
           includeIf() {
@@ -109,18 +102,15 @@ class CreateSpaceWorkflow extends Workflow {
         }),
         new NetworkAwareWorkflowCard({
           cardName: 'HUB_AUTH',
-          author: cardbot,
           componentName: 'card-pay/hub-authentication',
           includeIf(this: NetworkAwareWorkflowCard) {
             return !this.isHubAuthenticated;
           },
         }),
         new WorkflowMessage({
-          author: cardbot,
           message: `Please pick a username for your account. This is the name that will be shown to others when you communicate with them. If you like, you can upload a profile picture too.`,
         }),
         new WorkflowCard({
-          author: cardbot,
           cardName: 'CARD_SPACE_USERNAME',
           componentName: 'card-space/create-space-workflow/username',
         }),
@@ -131,15 +121,12 @@ class CreateSpaceWorkflow extends Workflow {
       title: MILESTONE_TITLES[2],
       postables: [
         new WorkflowMessage({
-          author: cardbot,
           message: `Nice choice!`,
         }),
         new WorkflowMessage({
-          author: cardbot,
           message: `Now it's time to set up your space. The preview shows you how your space will be displayed to users who visit the Card Space org.`,
         }),
         new WorkflowCard({
-          author: cardbot,
           cardName: 'CARD_SPACE_DETAILS',
           componentName: 'card-space/create-space-workflow/details',
         }),
@@ -150,25 +137,20 @@ class CreateSpaceWorkflow extends Workflow {
       title: MILESTONE_TITLES[3],
       postables: [
         new WorkflowMessage({
-          author: cardbot,
           message: `We have sent your URL reservation badge to your connected account (just check your Card Wallet mobile app).`,
         }),
         new WorkflowCard({
-          author: cardbot,
           cardName: 'CARD_SPACE_BADGE',
           componentName: 'card-space/create-space-workflow/badge',
         }),
         new WorkflowMessage({
-          author: cardbot,
           message: `On to the next step: You need to pay a small protocol fee to create your Card Space. Please select a prepaid card with a spendable balance from your ${c.layer2.fullName} wallet.`,
         }),
         new WorkflowCard({
-          author: cardbot,
           cardName: 'CARD_SPACE_CONFIRM',
           componentName: 'card-space/create-space-workflow/confirm',
         }),
         new WorkflowMessage({
-          author: cardbot,
           message: `Thank you for your payment.`,
         }),
       ],
@@ -177,117 +159,58 @@ class CreateSpaceWorkflow extends Workflow {
   ];
   epilogue = new PostableCollection([
     new WorkflowMessage({
-      author: cardbot,
       message: `This is the remaining balance on your prepaid card:`,
     }),
     // TODO
     // new WorkflowCard({
-    //   author: cardbot,
     //   cardName: 'EPILOGUE_PREPAID_CARD_BALANCE',
     //   componentName: 'card-pay/prepaid-card-balance',
     // }),
     new WorkflowMessage({
-      author: cardbot,
       message: `Congrats, you have created your Card Space!`,
     }),
     new WorkflowCard({
       cardName: 'EPILOGUE_NEXT_STEPS',
-      author: cardbot,
       componentName: 'card-space/create-space-workflow/next-steps',
     }),
   ]);
   cancelationMessages = new PostableCollection([
     // if we disconnect from layer 2
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.L2_DISCONNECTED,
       message: `It looks like your ${c.layer2.fullName} wallet got disconnected. If you still want to create a Card Space, please start again by connecting your wallet.`,
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason === FAILURE_REASONS.L2_DISCONNECTED
-        );
-      },
     }),
     // cancelation for changing accounts
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.L2_ACCOUNT_CHANGED,
       message:
         'It looks like you changed accounts in the middle of this workflow. If you still want to create a Card Space, please restart the workflow.',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason ===
-          FAILURE_REASONS.L2_ACCOUNT_CHANGED
-        );
-      },
     }),
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.UNAUTHENTICATED,
       message: 'You are no longer authenticated. Please restart the workflow.',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason === FAILURE_REASONS.UNAUTHENTICATED
-        );
-      },
     }),
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.RESTORATION_UNAUTHENTICATED,
       message:
         'You attempted to restore an unfinished workflow, but you are no longer authenticated. Please restart the workflow.',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason ===
-          FAILURE_REASONS.RESTORATION_UNAUTHENTICATED
-        );
-      },
     }),
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.RESTORATION_L2_ACCOUNT_CHANGED,
       message:
         'You attempted to restore an unfinished workflow, but you changed your Card Wallet address. Please restart the workflow.',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason ===
-          FAILURE_REASONS.RESTORATION_L2_ACCOUNT_CHANGED
-        );
-      },
     }),
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.RESTORATION_L2_DISCONNECTED,
       message:
         'You attempted to restore an unfinished workflow, but your Card Wallet got disconnected. Please restart the workflow.',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason ===
-          FAILURE_REASONS.RESTORATION_L2_DISCONNECTED
-        );
-      },
     }),
-    new WorkflowMessage({
-      author: cardbot,
+    conditionalCancelationMessage({
+      forReason: FAILURE_REASONS.UNSUPPORTED_WORKFLOW_STATE_VERSION,
       message:
         'You attempted to restore an unfinished workflow, but the workflow has been upgraded by the Cardstack development team since then, so you will need to start again. Sorry about that!',
-      includeIf() {
-        return (
-          this.workflow?.cancelationReason ===
-          FAILURE_REASONS.UNSUPPORTED_WORKFLOW_STATE_VERSION
-        );
-      },
     }),
-    new WorkflowCard({
-      author: cardbot,
-      componentName: 'workflow-thread/default-cancelation-cta',
-      includeIf() {
-        return (
-          [
-            FAILURE_REASONS.L2_DISCONNECTED,
-            FAILURE_REASONS.L2_ACCOUNT_CHANGED,
-            FAILURE_REASONS.UNAUTHENTICATED,
-            FAILURE_REASONS.RESTORATION_L2_DISCONNECTED,
-            FAILURE_REASONS.RESTORATION_L2_ACCOUNT_CHANGED,
-            FAILURE_REASONS.RESTORATION_UNAUTHENTICATED,
-          ] as String[]
-        ).includes(String(this.workflow?.cancelationReason));
-      },
-    }),
+    defaultCancelationCard(),
   ]);
 
   constructor(owner: unknown, workflowPersistenceId?: string) {

--- a/packages/web-client/app/models/workflow.ts
+++ b/packages/web-client/app/models/workflow.ts
@@ -23,6 +23,11 @@ export {
   default as WorkflowSession,
 } from './workflow/workflow-session';
 export { SessionAwareWorkflowMessage } from './workflow/session-aware-workflow-message';
+export {
+  conditionalCancelationMessage,
+  defaultCancelationCard,
+} from './workflow/cancelation-helpers';
+
 interface PostableIndices {
   isInMilestone: boolean;
   isInEpilogue: boolean;

--- a/packages/web-client/app/models/workflow/cancelation-helpers.ts
+++ b/packages/web-client/app/models/workflow/cancelation-helpers.ts
@@ -1,0 +1,29 @@
+import { WorkflowMessage } from './workflow-message';
+import { WorkflowCard } from './workflow-card';
+import { isPresent } from '@ember/utils';
+
+interface CancelationMessageArgs {
+  forReason: string;
+  message: string;
+}
+
+export function conditionalCancelationMessage({
+  forReason: reason,
+  message,
+}: CancelationMessageArgs): WorkflowMessage {
+  return new WorkflowMessage({
+    message,
+    includeIf() {
+      return this.workflow?.cancelationReason === reason;
+    },
+  });
+}
+
+export function defaultCancelationCard(): WorkflowCard {
+  return new WorkflowCard({
+    componentName: 'workflow-thread/default-cancelation-cta',
+    includeIf() {
+      return isPresent(this.workflow?.cancelationReason);
+    },
+  });
+}

--- a/packages/web-client/app/models/workflow/session-aware-workflow-message.ts
+++ b/packages/web-client/app/models/workflow/session-aware-workflow-message.ts
@@ -6,7 +6,7 @@ import {
 } from '@cardstack/web-client/models/workflow';
 
 interface SessionAwareWorkflowMessageOptions {
-  author: Participant;
+  author?: Participant;
   includeIf: (this: WorkflowPostable) => boolean;
   template: (session: IWorkflowSession) => string;
 }

--- a/packages/web-client/app/models/workflow/workflow-card.ts
+++ b/packages/web-client/app/models/workflow/workflow-card.ts
@@ -36,7 +36,7 @@ export class WorkflowCard extends WorkflowPostable {
   };
 
   constructor(options: Partial<WorkflowCardOptions>) {
-    super(options.author!, options.includeIf);
+    super(options.author, options.includeIf);
     this.componentName = options.componentName!;
     this.cardName = options.cardName || '';
 

--- a/packages/web-client/app/models/workflow/workflow-message.ts
+++ b/packages/web-client/app/models/workflow/workflow-message.ts
@@ -17,7 +17,7 @@ export class WorkflowMessage
   message: string;
 
   constructor(options: Partial<WorkflowMessageOptions>) {
-    super(options.author!, options.includeIf);
+    super(options.author, options.includeIf);
     this.message = options.message!;
     this.isComplete = true;
   }

--- a/packages/web-client/app/models/workflow/workflow-postable.ts
+++ b/packages/web-client/app/models/workflow/workflow-postable.ts
@@ -1,5 +1,5 @@
 import { tracked } from '@glimmer/tracking';
-import { Workflow } from '../workflow';
+import { cardbot, Workflow } from '../workflow';
 
 export interface Participant {
   name: string;
@@ -13,10 +13,10 @@ export class WorkflowPostable {
   }
   @tracked isComplete: boolean = false;
   constructor(
-    author: Participant,
+    author?: Participant,
     includeIf: ((this: WorkflowPostable) => boolean) | undefined = undefined
   ) {
-    this.author = author;
+    this.author = author || cardbot;
     this.includeIf = includeIf;
   }
   includeIf: (() => boolean) | undefined;


### PR DESCRIPTION
For your consideration. I felt the workflow definition was getting a bit verbose and explored a couple of ways to reduce the boilerplate. This PR does this in two ways:

- wraps the conditional cancelation message pattern in a function
- assumes postable author is cardbot by default