### PR TITLE
Allow dashboard panel to collapse if card wallet is connected

### DIFF
--- a/packages/web-client/app/components/card-pay/dashboard-panel/index.css
+++ b/packages/web-client/app/components/card-pay/dashboard-panel/index.css
@@ -14,7 +14,6 @@
 }
 
 .dashboard-details-container__summary {
-  display: none; /* when there's no other on the dashboard */
   position: relative;
   min-height: 5rem;
 }
@@ -23,6 +22,10 @@
 .dashboard-details-container__summary::-webkit-details-marker {
   display: none;
   content: '';
+}
+
+.dashboard-details-container--no-collapse .dashboard-details-container__summary {
+  display: none;
 }
 
 .dashboard-details-container__marker::before {

--- a/packages/web-client/app/components/card-pay/dashboard-panel/index.hbs
+++ b/packages/web-client/app/components/card-pay/dashboard-panel/index.hbs
@@ -1,6 +1,7 @@
 <details
   class={{cn "dashboard-details-container" dashboard-details-container--no-collapse=@noCollapse}}
   ...attributes
+  open={{if @noCollapse true @open}}
 >
   <summary class="dashboard-details-container__summary">
     <div class="dashboard-panel__summary-hero" style={{css-url "background-image" @panel.summaryHeroImageUrl}} />

--- a/packages/web-client/app/components/card-pay/dashboard-panel/index.hbs
+++ b/packages/web-client/app/components/card-pay/dashboard-panel/index.hbs
@@ -1,4 +1,7 @@
-<details open class="dashboard-details-container" ...attributes>
+<details
+  class={{cn "dashboard-details-container" dashboard-details-container--no-collapse=@noCollapse}}
+  ...attributes
+>
   <summary class="dashboard-details-container__summary">
     <div class="dashboard-panel__summary-hero" style={{css-url "background-image" @panel.summaryHeroImageUrl}} />
     <div class="dashboard-details-container__summary-content">

--- a/packages/web-client/app/css/card-pay/balances.css
+++ b/packages/web-client/app/css/card-pay/balances.css
@@ -30,13 +30,13 @@
 }
 
 .card-pay-dashboard__balances-section-header-button-icon {
-  margin-left: var(--boxel-sp-xs);
+  --icon-color: var(--boxel-highlight);
 
-  --icon-color: var(--boxel-cyan);
+  margin-left: var(--boxel-sp-xs);
 }
 
 .card-pay-dashboard__balances-section-title {
-  font-weight: normal;
+  font-weight: 400;
 }
 
 .card-pay-dashboard__balances-count {

--- a/packages/web-client/app/css/card-pay/merchant-services.css
+++ b/packages/web-client/app/css/card-pay/merchant-services.css
@@ -12,15 +12,26 @@
   margin-top: var(--boxel-sp-xxl);
 }
 
-.card-pay-dashboard__merchants-title {
+.card-pay-dashboard__merchants-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: var(--boxel-sp-xxl);
+}
+
+.card-pay-dashboard__merchants-title {
   font: 600 var(--boxel-font-lg);
   letter-spacing: var(--boxel-lsp-xs);
+}
+
+.card-pay-dashboard__merchants-section-header-button-icon {
+  --icon-color: var(--boxel-highlight);
+
+  margin-left: var(--boxel-sp-xs);
 }
 
 .card-pay-dashboard__merchants-cards {
   display: grid;
   gap: var(--boxel-sp-xl) var(--boxel-sp);
   grid-template-columns: repeat(auto-fill, 22.75rem);
-  margin-top: var(--boxel-sp);
 }

--- a/packages/web-client/app/templates/card-pay/balances.hbs
+++ b/packages/web-client/app/templates/card-pay/balances.hbs
@@ -1,7 +1,7 @@
 {{page-title "Card Balances"}}
 
 <section class="card-pay-dashboard__balances" role="tabpanel" aria-labelledby="card-pay.balances">
-  <CardPay::DashboardPanel @panel={{@model.panel}}>
+  <CardPay::DashboardPanel @panel={{@model.panel}} @noCollapse={{not this.layer2Network.isConnected}} open={{not this.layer2Network.isConnected}}>
     {{#each @model.panel.sections as |section|}}
       <CardPay::DashboardPanel::Section @section={{section}}>
         <:cta>

--- a/packages/web-client/app/templates/card-pay/balances.hbs
+++ b/packages/web-client/app/templates/card-pay/balances.hbs
@@ -1,7 +1,7 @@
 {{page-title "Card Balances"}}
 
 <section class="card-pay-dashboard__balances" role="tabpanel" aria-labelledby="card-pay.balances">
-  <CardPay::DashboardPanel @panel={{@model.panel}} @noCollapse={{not this.layer2Network.isConnected}} open={{not this.layer2Network.isConnected}}>
+  <CardPay::DashboardPanel @panel={{@model.panel}} @noCollapse={{not this.layer2Network.isConnected}}>
     {{#each @model.panel.sections as |section|}}
       <CardPay::DashboardPanel::Section @section={{section}}>
         <:cta>

--- a/packages/web-client/app/templates/card-pay/merchant-services.hbs
+++ b/packages/web-client/app/templates/card-pay/merchant-services.hbs
@@ -1,7 +1,7 @@
 {{page-title "Merchant Services"}}
 
 <section class="card-pay-dashboard__merchants" role="tabpanel" aria-labelledby="card-pay.merchant-services">
-  <CardPay::DashboardPanel @panel={{@model.panel}} @noCollapse={{not this.layer2Network.isConnected}} open={{not this.layer2Network.isConnected}}>
+  <CardPay::DashboardPanel @panel={{@model.panel}} @noCollapse={{not this.layer2Network.isConnected}}>
     {{#each @model.panel.sections as |section|}}
       <CardPay::DashboardPanel::Section @section={{section}}>
         <:cta>

--- a/packages/web-client/app/templates/card-pay/merchant-services.hbs
+++ b/packages/web-client/app/templates/card-pay/merchant-services.hbs
@@ -1,7 +1,7 @@
 {{page-title "Merchant Services"}}
 
 <section class="card-pay-dashboard__merchants" role="tabpanel" aria-labelledby="card-pay.merchant-services">
-  <CardPay::DashboardPanel @panel={{@model.panel}}>
+  <CardPay::DashboardPanel @panel={{@model.panel}} @noCollapse={{not this.layer2Network.isConnected}} open={{not this.layer2Network.isConnected}}>
     {{#each @model.panel.sections as |section|}}
       <CardPay::DashboardPanel::Section @section={{section}}>
         <:cta>
@@ -26,8 +26,26 @@
 
   {{#if this.layer2Network.isConnected}}
     <section data-test-merchants-section>
-      <h3 class="card-pay-dashboard__merchants-title">Merchant Services</h3>
-      <div class="card-pay-dashboard__merchants-cards">
+      <header class="card-pay-dashboard__merchants-section-header">
+        <h3 class="card-pay-dashboard__merchants-title">Merchant Services</h3>
+        {{#let @model.panel.sections.[0] as |section|}}
+          <Boxel::Button
+            {{on "click" (fn this.transitionToWorkflow section.workflow)}}
+            @kind="secondary-dark"
+            @size="small"
+            @disabled={{section.isCtaDisabled}}
+            @route="card-pay.balances"
+            data-test-workflow-button={{section.workflow}}
+          >
+            <span>{{section.cta}}</span>
+            {{svg-jar "plus"
+              class="card-pay-dashboard__merchants-section-header-button-icon"
+              role="presentation"
+            }}
+          </Boxel::Button>
+        {{/let}}
+      </header>
+      <section class="card-pay-dashboard__merchants-cards">
         {{#each this.merchantSafes as |merchantSafe|}}
           <CardPay::MerchantSafe
             @safe={{merchantSafe}}
@@ -35,7 +53,7 @@
             data-test-merchant-dashboard-card
           />
         {{/each}}
-      </div>
+      </section>
     </section>
   {{/if}}
 </section>

--- a/packages/web-client/app/templates/card-pay/token-suppliers.hbs
+++ b/packages/web-client/app/templates/card-pay/token-suppliers.hbs
@@ -1,7 +1,7 @@
 {{page-title "Token Suppliers"}}
 
 <section class="card-pay-dashboard__token-suppliers" role="tabpanel" aria-labelledby="card-pay.token-suppliers">
-  <CardPay::DashboardPanel @panel={{@model.panel}}>
+  <CardPay::DashboardPanel @panel={{@model.panel}} @noCollapse={{true}} open>
     {{#each @model.panel.sections as |section|}}
       <CardPay::DashboardPanel::Section @section={{section}}>
         <:cta>

--- a/packages/web-client/app/templates/card-pay/token-suppliers.hbs
+++ b/packages/web-client/app/templates/card-pay/token-suppliers.hbs
@@ -1,7 +1,7 @@
 {{page-title "Token Suppliers"}}
 
 <section class="card-pay-dashboard__token-suppliers" role="tabpanel" aria-labelledby="card-pay.token-suppliers">
-  <CardPay::DashboardPanel @panel={{@model.panel}} @noCollapse={{true}} open>
+  <CardPay::DashboardPanel @panel={{@model.panel}} @noCollapse={{true}}>
     {{#each @model.panel.sections as |section|}}
       <CardPay::DashboardPanel::Section @section={{section}}>
         <:cta>


### PR DESCRIPTION
- Collapse info panels when L2 is connected
- Did not collapse the one on token-suppliers tab since there's no other content
- Added CTA on merchants tab

<img width="1431" alt="balances-collapsed" src="https://user-images.githubusercontent.com/16160806/137021750-2f00ab39-63c6-4a39-880c-7a17fe5a5ad5.png">

<img width="1433" alt="merchant-services-collapsed" src="https://user-images.githubusercontent.com/16160806/137021768-300bde78-473a-48af-8ad5-eaa3dca3ba0e.png">