### PR TITLE
Card Space Url validation endpoint

### DIFF
--- a/packages/hub/node-tests/routes/card-space-test.ts
+++ b/packages/hub/node-tests/routes/card-space-test.ts
@@ -284,20 +284,19 @@ describe('POST /api/card-spaces', function () {
       server.teardown();
     });
 
-    it('returns urlAvailable = true when url available', async function () {
+    it('returns no url errors when url is available', async function () {
       await request
         .get(`/api/card-spaces/validate-url/satoshi.card.space`)
         .set('Authorization', 'Bearer: abc123--def456--ghi789')
         .set('Content-Type', 'application/vnd.api+json')
         .expect(200)
         .expect({
-          urlAvailable: true,
-          detail: '',
+          errors: [],
         })
         .expect('Content-Type', 'application/vnd.api+json');
     });
 
-    it('returns urlAvailable = false when url already used', async function () {
+    it('returns url errors when url is already used', async function () {
       let dbManager = await server.container.lookup('database-manager');
       let db = await dbManager.getClient();
       await db.query(
@@ -311,8 +310,14 @@ describe('POST /api/card-spaces', function () {
         .set('Content-Type', 'application/vnd.api+json')
         .expect(200)
         .expect({
-          urlAvailable: false,
-          detail: 'Already exists',
+          errors: [
+            {
+              status: '422',
+              title: 'Invalid attribute',
+              source: { pointer: `/data/attributes/url` },
+              detail: 'Already exists',
+            },
+          ],
         })
         .expect('Content-Type', 'application/vnd.api+json');
     });

--- a/packages/hub/node-tests/routes/card-space-test.ts
+++ b/packages/hub/node-tests/routes/card-space-test.ts
@@ -264,4 +264,75 @@ describe('POST /api/card-spaces', function () {
       })
       .expect('Content-Type', 'application/vnd.api+json');
   });
+
+  describe('GET /api/card-spaces/url-validation/:url', async function () {
+    let server: HubServer;
+    let request: supertest.SuperTest<Test>;
+
+    this.beforeEach(async function () {
+      server = await HubServer.create({
+        registryCallback(registry: Registry) {
+          registry.register('authentication-utils', StubAuthenticationUtils);
+          registry.register('worker-client', StubWorkerClient);
+        },
+      });
+
+      request = supertest(server.app.callback());
+    });
+
+    this.afterEach(async function () {
+      server.teardown();
+    });
+
+    it('returns urlAvailable = true when url available', async function () {
+      await request
+        .get(`/api/card-spaces/validate-url/satoshi.card.space`)
+        .set('Authorization', 'Bearer: abc123--def456--ghi789')
+        .set('Content-Type', 'application/vnd.api+json')
+        .expect(200)
+        .expect({
+          urlAvailable: true,
+          detail: '',
+        })
+        .expect('Content-Type', 'application/vnd.api+json');
+    });
+
+    it('returns urlAvailable = false when url already used', async function () {
+      let dbManager = await server.container.lookup('database-manager');
+      let db = await dbManager.getClient();
+      await db.query(
+        'INSERT INTO card_spaces(id, profile_name, url, profile_description, profile_category, profile_button_text, owner_address) VALUES($1, $2, $3, $4, $5, $6, $7)',
+        ['AB70B8D5-95F5-4C20-997C-4DB9013B347C', 'Test', 'satoshi.card.space', 'Test', 'Test', 'Test', '0x0']
+      );
+
+      await request
+        .get(`/api/card-spaces/validate-url/satoshi.card.space`)
+        .set('Authorization', 'Bearer: abc123--def456--ghi789')
+        .set('Content-Type', 'application/vnd.api+json')
+        .expect(200)
+        .expect({
+          urlAvailable: false,
+          detail: 'Already exists',
+        })
+        .expect('Content-Type', 'application/vnd.api+json');
+    });
+
+    it('returns 401 without bearer token', async function () {
+      await request
+        .post('/api/card-spaces')
+        .send({})
+        .set('Accept', 'application/vnd.api+json')
+        .set('Content-Type', 'application/vnd.api+json')
+        .expect(401)
+        .expect({
+          errors: [
+            {
+              status: '401',
+              title: 'No valid auth token',
+            },
+          ],
+        })
+        .expect('Content-Type', 'application/vnd.api+json');
+    });
+  });
 });

--- a/packages/hub/routes/card-spaces.ts
+++ b/packages/hub/routes/card-spaces.ts
@@ -86,6 +86,20 @@ export default class CardSpacesRoute {
     ctx.type = 'application/vnd.api+json';
   }
 
+  async getUrlValidation(ctx: Koa.Context) {
+    if (!ensureLoggedIn(ctx)) {
+      return;
+    }
+
+    let url: string = ctx.params.url;
+    let errors = await this.cardSpaceValidator.validate({ url } as CardSpace);
+    let urlAvailable = !errors.url.includes('Already exists');
+
+    ctx.status = 200;
+    ctx.body = { urlAvailable, detail: errors.url.join(', ') };
+    ctx.type = 'application/vnd.api+json';
+  }
+
   sanitizeText(value: string | unknown): string {
     if (typeof value === 'string') {
       return value.trim().replace(/ +/g, ' ');

--- a/packages/hub/services/api-router.ts
+++ b/packages/hub/services/api-router.ts
@@ -74,6 +74,7 @@ export default class APIRouter {
     apiSubrouter.post('/reservations', parseBody, reservationsRoute.post);
     apiSubrouter.get('/reservations/:reservation_id', reservationsRoute.get);
     apiSubrouter.post('/card-spaces', parseBody, cardSpacesRoute.post);
+    apiSubrouter.get('/card-spaces/validate-url/:url', cardSpacesRoute.getUrlValidation);
     apiSubrouter.all('/(.*)', notFound);
 
     let apiRouter = new Router();


### PR DESCRIPTION
Ticket: [CS-2068](https://linear.app/cardstack/issue/CS-2068/endpoint-for-validating-url-uniqueness)

This PR adds an `/api/card-spaces/url-validation/:url` endpoint (similar to what we already have for the merchant slug) which will support the following feature in the Card Space setup workflow:

![image](https://user-images.githubusercontent.com/273660/137454719-7cfe1dfb-5df8-48ca-8dd9-f7d6a30ef55a.png)
