### PR TITLE
web: Change workflow versions to be integers

### DIFF
--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
@@ -45,7 +45,7 @@ export const MILESTONE_TITLES = [
   'Save merchant details',
   'Create merchant',
 ];
-export const WORKFLOW_VERSION = 1.1;
+export const WORKFLOW_VERSION = 2;
 
 class CreateMerchantWorkflow extends Workflow {
   name = 'MERCHANT_CREATION' as WorkflowName;

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -51,7 +51,7 @@ export const MILESTONE_TITLES = [
   'Confirm transaction',
 ];
 
-export const WORKFLOW_VERSION = 1.1;
+export const WORKFLOW_VERSION = 2;
 
 class IssuePrepaidCardWorkflow extends Workflow {
   @service declare router: RouterService;

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
@@ -51,7 +51,7 @@ export const MILESTONE_TITLES = [
   `Claim tokens on ${c.layer1.conversationalName}`,
 ];
 
-export const WORKFLOW_VERSION = 1.1;
+export const WORKFLOW_VERSION = 2;
 
 class CheckBalanceWorkflowMessage
   extends WorkflowPostable

--- a/packages/web-client/tests/acceptance/withdrawal-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-persistence-test.ts
@@ -271,7 +271,7 @@ module('Acceptance | withdrawal persistence', function (hooks) {
         name: 'WITHDRAWAL',
         state,
       });
-      await visit('/card-pay/token-suppliers?flow=deposit&flow-id=abc123');
+      await visit('/card-pay/token-suppliers?flow=withdrawal&flow-id=abc123');
       assert.dom('[data-test-milestone="0"]').doesNotExist();
       assert.dom('[data-test-milestone="1"]').doesNotExist();
       assert.dom('[data-test-milestone="2"]').doesNotExist();
@@ -303,7 +303,7 @@ module('Acceptance | withdrawal persistence', function (hooks) {
         name: 'WITHDRAWAL',
         state,
       });
-      await visit('/card-pay/token-suppliers?flow=deposit&flow-id=abc123');
+      await visit('/card-pay/token-suppliers?flow=withdrawal&flow-id=abc123');
       assert.dom('[data-test-milestone="0"]').doesNotExist();
       assert.dom('[data-test-milestone="1"]').doesNotExist();
       assert.dom('[data-test-milestone="2"]').doesNotExist();
@@ -400,7 +400,7 @@ module('Acceptance | withdrawal persistence', function (hooks) {
         name: 'WITHDRAWAL',
         state,
       });
-      await visit('/card-pay/token-suppliers?flow=deposit&flow-id=abc123');
+      await visit('/card-pay/token-suppliers?flow=withdrawal&flow-id=abc123');
       assert.dom('[data-test-milestone="0"]').doesNotExist();
       assert.dom('[data-test-milestone="1"]').doesNotExist();
       assert.dom('[data-test-milestone="2"]').doesNotExist();


### PR DESCRIPTION
Always incrementing by one saves us having to think in the
semver-esque “is this a minor or major update?” way that’s
ultimately irrelevant because all that matters for
invalidation is that the version is higher.

We could have linting for this if necessary but hopefully it
becomes obvious as the numbers climb.