### PR TITLE
web: Fix display of restored withdrawal source

### DIFF
--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/choose-balance/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/choose-balance/index.ts
@@ -27,7 +27,11 @@ class CardPayWithdrawalWorkflowChooseBalanceComponent extends Component<Workflow
 
   constructor(owner: unknown, args: WorkflowCardComponentArgs) {
     super(owner, args);
-    this.selectedSafe = this.layer2Network.depotSafe;
+    let withdrawalSafeAddress =
+      this.args.workflowSession.getValue<string>('withdrawalSafe');
+    this.selectedSafe = withdrawalSafeAddress
+      ? this.layer2Network.safes.getByAddress(withdrawalSafeAddress)
+      : this.layer2Network.depotSafe;
     this.selectedTokenSymbol =
       this.tokens.find((t) => t.symbol === this.withdrawalToken)
         ?.tokenDisplayInfo.symbol ?? this.tokens[0].tokenDisplayInfo.symbol;


### PR DESCRIPTION
The default value for the selected safe was being used
even when was already persisted in the workflow:

![screencast 2021-10-15 10-07-16](https://user-images.githubusercontent.com/43280/137515089-195c59ff-7997-43ae-86a9-0d238030d876.gif)

What other subtleties like this might exist 😳