### PR TITLE
Replace placeholder error message with a real one

### DIFF
--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
@@ -66,8 +66,7 @@
     {{#if this.error}}
       <CardPay::ErrorMessage data-test-prepaid-card-choice-error-message as |supportURL|>
         {{#if (eq this.error.message "INSUFFICIENT_FUNDS")}}
-          {{!-- TODO: This should be accompanied by canceling the workflow CS-1620 --}}
-          TODO insufficient funds message
+          It looks like your prepaid card doesn't have enough funds to pay the {{format-amount this.merchantRegistrationFee 0}} SPEND ({{format-usd (spend-to-usd this.merchantRegistrationFee)}}) merchant creation fee. Please try another prepaid card, or buy one in Card Wallet.
         {{else if (eq this.error.message "TIMEOUT")}}
           There was a problem creating your merchant. Please contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a> to find out the status of your transaction.
         {{else if (eq this.error.message "USER_REJECTION")}}

--- a/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/create-merchant-workflow/prepaid-card-choice-test.ts
@@ -18,7 +18,7 @@ const USER_REJECTION_ERROR_MESSAGE =
   'It looks like you have canceled the request in your wallet. Please try again if you want to continue with this workflow.';
 const TIMEOUT_ERROR_MESSAGE =
   'There was a problem creating your merchant. Please contact Cardstack support to find out the status of your transaction.';
-const INSUFFICIENT_FUNDS_ERROR_MESSAGE = 'TODO insufficient funds message';
+const INSUFFICIENT_FUNDS_ERROR_MESSAGE = `It looks like your prepaid card doesn't have enough funds to pay the 100 SPEND ($1.00 USD) merchant creation fee. Please try another prepaid card, or buy one in Card Wallet.`;
 const DEFAULT_ERROR_MESSAGE =
   'There was a problem creating your merchant. This may be due to a network issue, or perhaps you canceled the request in your wallet. Please try again if you want to continue with this workflow, or contact Cardstack support.';
 


### PR DESCRIPTION
I didn't realise there was this TODO when canceling CS-1620. Canceling workflows from within a card is something we still haven't implemented - would be good for this component + the prepaid card creation preview card.