### PR TITLE
Open Card Space details form in a modal

### DIFF
--- a/packages/web-client/app/components/card-space/create-space-workflow/details/index.hbs
+++ b/packages/web-client/app/components/card-space/create-space-workflow/details/index.hbs
@@ -12,7 +12,7 @@
   >
     <:default as |d|>
       <d.ActionButton
-        {{on "click" @onComplete}}
+        {{on "click" this.toggleDetailsForm}}
         data-test-card-space-details-start-button
       >
         Get Started
@@ -21,10 +21,23 @@
     <:memorialized as |m|>
       <m.ActionButton
         data-test-card-space-details-edit-button
-        {{on "click" @onIncomplete}}
+        {{on "click" this.toggleDetailsForm}}
       >
         Edit
       </m.ActionButton>
     </:memorialized>
   </Boxel::ActionChin>
+
+  {{#in-element this.detailsModalElement}}
+    <Boxel::Modal
+      style={{css-var boxel-modal-max-width="60rem"}}
+      @isOpen={{this.detailsModalShown}}
+      @onClose={{this.toggleDetailsForm}}
+    >
+      <CardSpace::EditDetails
+        @workflowSession={{this.workflow.session}}
+        @onSave={{this.onSave}}
+      />
+    </Boxel::Modal>
+  {{/in-element}}
 </ActionCardContainer>

--- a/packages/web-client/app/components/card-space/create-space-workflow/details/index.ts
+++ b/packages/web-client/app/components/card-space/create-space-workflow/details/index.ts
@@ -1,0 +1,23 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
+import { tracked } from '@glimmer/tracking';
+
+class CreateSpaceWorkflowDetailsComponent extends Component<WorkflowCardComponentArgs> {
+  detailsModalElement = document.getElementById('create-space-workflow-modal');
+  @tracked detailsModalShown: boolean = false;
+
+  @action toggleDetailsForm() {
+    if (this.args.isComplete) {
+      this.args.onIncomplete?.();
+    }
+    this.detailsModalShown = !this.detailsModalShown;
+  }
+
+  @action onSave() {
+    this.detailsModalShown = false;
+    this.args.onComplete?.();
+  }
+}
+
+export default CreateSpaceWorkflowDetailsComponent;

--- a/packages/web-client/app/components/card-space/create-space-workflow/index.hbs
+++ b/packages/web-client/app/components/card-space/create-space-workflow/index.hbs
@@ -4,6 +4,9 @@
     @workflow={{this.workflow}}
   />
 {{/if}}
+
+<div id="create-space-workflow-modal"></div>
+
 <Listener
   @emitter={{this.layer2Network}}
   @event="disconnect"

--- a/packages/web-client/app/components/card-space/create-space-workflow/index.ts
+++ b/packages/web-client/app/components/card-space/create-space-workflow/index.ts
@@ -249,6 +249,7 @@ class CreateSpaceWorkflowComponent extends Component {
   @service declare router: RouterService;
 
   @tracked workflow: CreateSpaceWorkflow | null = null;
+  @tracked detailsEditFormShown: boolean = true;
 
   constructor(owner: unknown, args: {}) {
     super(owner, args);

--- a/packages/web-client/app/components/card-space/edit-details/index.hbs
+++ b/packages/web-client/app/components/card-space/edit-details/index.hbs
@@ -1,0 +1,18 @@
+<ActionCardContainer
+  @header="Card Space Setup"
+>
+  <ActionCardContainer::Section @title="Edit your Card Space details">
+  </ActionCardContainer::Section>
+
+  <Boxel::ActionChin
+  >
+    <:default as |d|>
+      <d.ActionButton
+        {{on "click" @onSave}}
+        data-test-card-space-edit-details-save-button
+      >
+        Save Choices
+      </d.ActionButton>
+    </:default>
+  </Boxel::ActionChin>
+</ActionCardContainer>

--- a/packages/web-client/tests/acceptance/create-card-space-test.ts
+++ b/packages/web-client/tests/acceptance/create-card-space-test.ts
@@ -108,6 +108,8 @@ module('Acceptance | create card space', function (hooks) {
       .containsText(`Fill out the Card Space details`);
 
     await click('[data-test-card-space-details-start-button]');
+    await click('[data-test-card-space-edit-details-save-button]');
+
     assert.dom('[data-test-card-space-details-is-complete]').exists();
 
     await waitFor(milestoneCompletedSel(2));


### PR DESCRIPTION
Ticket: [CS-2187](https://linear.app/cardstack/issue/CS-2187/card-space-details-popup)

There's a [design on Zeplin](https://app.zeplin.io/project/6155e6cbf246d4b15e5baa22/screen/6155e874c6a900ae5c8336ad) where the Card Space setup workflow opens another modal where the user can edit details such as url, button text, category, etc. 

This PR implements this modal as a placeholder for the upcoming form controls.

I did some research on where to render this 2nd modal stacked on top of the first one. My reasoning is that the modal should belong to the "edit card" so I first tried to render it there but was faced with a bunch of z-index issues 😬 So I decided to render it elsewhere, in the workflow component. That worked ok without any CSS modifications. I used Ember's `in-element` – I know we use `<ToElsewhere />` in some other place but this unfortunately did not work in my case (with the `Boxel::Modal` and `CardSpace::EditDetails` composition, nothing got rendered).

This is how it looks like:
![image](https://user-images.githubusercontent.com/273660/138072438-9b4c25cc-aaf5-45cf-9498-f0ca0190703d.png)

