### PR TITLE
Ensure hub db init-test is run with NODE_ENV=test

### DIFF
--- a/packages/hub/cli/db/init-test.ts
+++ b/packages/hub/cli/db/init-test.ts
@@ -12,7 +12,9 @@ export async function handler(_argv: Argv) {
   const dbConfig = config.get<any>('db');
   let dbUrl = dbConfig.url as string;
   let dbName = dbUrl.split('/').reverse()[0];
-
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error('This subcommand is designed to be called with NODE_ENV set to "test" only');
+  }
   if (!process.env.CI) {
     try {
       console.log(`Dropping ${dbName} db...`);


### PR DESCRIPTION
Brought you by the guy who just accidentally wiped his development database