### PR TITLE
web: Fix CSS cascade to allow overrides to Boxel

### DIFF
--- a/packages/web-client/app/index.html
+++ b/packages/web-client/app/index.html
@@ -11,13 +11,13 @@
 
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/@cardstack/web-client.css">
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/app-components.css" />
     <link href="{{rootURL}}images/icon-apple-256x256.png" rel="apple-touch-icon">
     <link href="{{rootURL}}images/icon-favicon-32x32.png" rel="shortcut icon" type="image/x-icon">
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/app-components.css" />
 
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/@cardstack/web-client.js"></script>


### PR DESCRIPTION
The Boxel CSS is being imported in `{{content-for "body"}}` now when it used to be in `vendor.css`. The misordering is causing overrides on Boxel fields to be lower-priority, resulting in visual errors like this (as reported by @topwebtek7):

![image](https://user-images.githubusercontent.com/43280/138770687-0267b73c-d011-474a-afa3-64a9ee066f7c.png)

There’s a new CSS `link` in `body` in production right now:

![image](https://user-images.githubusercontent.com/43280/138770297-68624084-ce63-4b0e-93a1-5e470f8604dc.png)

In the past there was no CSS `link` in `body`:

![image](https://user-images.githubusercontent.com/43280/138770359-db5e4971-b4f5-42fa-ac05-a0ed5e3ab8e9.png)

This PR moves the component CSS to be after it so it takes priority. I think it would be preferable to have Boxel CSS return to being in `vendor.css` but I have been struggling with narrowing this down locally. Any @cardstack/web-client people have ideas, or @ef4 maybe?