### PR TITLE
[CS-2279]: Add merchant uni link domain to network constants

### DIFF
--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -33,6 +33,7 @@ const SOKOL = {
   relayServiceURL: 'https://relay-staging.stack.cards/api',
   subgraphURL: 'https://graph-staging.stack.cards/subgraphs/name/habdelra/cardpay-sokol',
   tallyServiceURL: 'https://tally-service-staging.stack.cards/api/v1',
+  merchantUniLinkDomain: MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,
 };
 const KOVAN = {
   apiBaseUrl: 'https://api-kovan.etherscan.io/api',
@@ -81,6 +82,7 @@ const XDAI = {
   rpcWssNode: 'wss://rpc.xdaichain.com/wss',
   relayServiceURL: 'https://relay.cardstack.com/api',
   subgraphURL: 'https://graph.cardstack.com/subgraphs/name/habdelra/cardpay-xdai',
+  merchantUniLinkDomain: MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME,
 };
 
 type ConstantKeys = keyof typeof SOKOL | keyof typeof KOVAN | keyof typeof MAINNET | keyof typeof XDAI;


### PR DESCRIPTION
Adds merchant uni link domain to network constants on `SOKOL` and `XDAI` so we can retrieve the right domain on the mobile app.