### PR TITLE
Use boxel::modal component in cardhost

### DIFF
--- a/packages/cardhost/app/components/card-container/index.css
+++ b/packages/cardhost/app/components/card-container/index.css
@@ -1,0 +1,8 @@
+.card-container__content {
+  padding: var(--boxel-sp-lg);
+}
+
+.card-container__action-chin {
+  display: flex;
+  padding: var(--boxel-sp-lg);
+}

--- a/packages/cardhost/app/components/card-container/index.hbs
+++ b/packages/cardhost/app/components/card-container/index.hbs
@@ -1,15 +1,18 @@
 <Boxel::CardContainer @displayBoundaries={{true}} style="margin:1vw 2vw;overflow:hidden;">
-  <Boxel::Header @editable={{@editable}} @editAction={{perform this.modal.editCardTask @card}}>
+  <Boxel::Header @header="Layout">
     {{#if @editable}}
       <button data-test-edit-button {{on 'click' (perform this.modal.editCardTask @card)}}>Edit</button>
       <button data-test-new-button-server {{on 'click' (perform this.modal.newCardTask @card this.REALM)}}>New (Server)</button>
       <button data-test-new-button-local {{on 'click' (perform this.modal.newCardTask @card this.LOCAL_REALM)}}>New (Local)</button>
     {{/if}}
+    {{yield to="header"}}
   </Boxel::Header>
 
-  {{yield}}
+  <section class="card-container__content">
+    {{yield}}
+  </section>
 
-  <div style="background-color: lightgray">
+  <footer class="card-container__action-chin">
     {{yield to="action-chin"}}
-  </div>
+  </footer>
 </Boxel::CardContainer>

--- a/packages/cardhost/app/components/card-container/index.ts
+++ b/packages/cardhost/app/components/card-container/index.ts
@@ -4,6 +4,7 @@ import ModalService from 'cardhost/services/modal';
 import type RouterService from '@ember/routing/router-service';
 import CardModel from '@cardstack/core/src/card-model';
 import { LOCAL_REALM, DEMO_REALM } from 'cardhost/lib/builder';
+import './index.css';
 
 interface CardContainerArgs {
   card?: CardModel;

--- a/packages/cardhost/app/components/card-modal/index.css
+++ b/packages/cardhost/app/components/card-modal/index.css
@@ -6,3 +6,11 @@
   display: block;
   text-transform: capitalize;
 }
+
+.card-modal__action-chin-button {
+  margin-left: auto;
+}
+
+.card-modal__action-chin-button + .card-modal__action-chin-button {
+  margin-left: var(--boxel-sp-sm);
+}

--- a/packages/cardhost/app/components/card-modal/index.hbs
+++ b/packages/cardhost/app/components/card-modal/index.hbs
@@ -1,36 +1,51 @@
-{{#if this.modal.isShowing}}
-  <div class={{cn "modal" this.modal.state.format}} style="border:5px red dashed; margin: 5vw;padding:1vw" data-test-modal>
-    <div>
-      <button data-test-modal-close {{on 'click' this.close}}>Close Modal</button>
-    </div>
-
-    {{#if this.modal.isLoading}}
-      <h1>LOADING!!!</h1>
-    {{else}}
-      {{#if (eq this.modal.state.format 'edit')}}
-        <CardContainer
-          @selected={{true}}
-        >
-          <:default>
-            <this.modal.cardComponent />
-          </:default>
-
-          <:action-chin>
-            <button data-test-modal-save {{on 'click' this.modal.save}}>Save</button>
-            <button data-test-modal-cancel {{on 'click' this.modal.close}}>Cancel</button>
-          </:action-chin>
-        </CardContainer>
-      {{else}}
-        <CardContainer
-          @card={{this.modal.card}}
-          @editable={{true}}
-        >
+<Boxel::Modal @isOpen={{this.modal.isShowing}} @onClose={{this.close}} data-test-modal>
+  {{#if this.modal.isLoading}}
+    <CardContainer>
+      <h1>Loading...</h1>
+    </CardContainer>
+  {{else}}
+    {{#if (eq this.modal.state.format 'edit')}}
+      <CardContainer class={{cn "modal" this.modal.state.format}}>
+        <:default>
           <this.modal.cardComponent />
-        </CardContainer>
-      {{/if}}
+        </:default>
+
+        <:action-chin>
+          <Boxel::Button
+            {{on "click" this.modal.close}}
+            class="card-modal__action-chin-button"
+            @kind="secondary"
+            data-test-modal-cancel
+          >
+            Cancel
+          </Boxel::Button>
+          <Boxel::Button
+            {{on "click" this.modal.save}}
+            class="card-modal__action-chin-button"
+            @kind="primary"
+            data-test-modal-save
+          >
+            Save
+          </Boxel::Button>
+        </:action-chin>
+      </CardContainer>
+    {{else}}
+      <CardContainer
+        class={{cn "modal" this.modal.state.format}}
+        @card={{this.modal.card}}
+        @editable={{true}}
+      >
+        <:header>
+          <button data-test-modal-close {{on "click" this.close}}>Close</button>
+        </:header>
+
+        <:default>
+          <this.modal.cardComponent />
+        </:default>
+      </CardContainer>
     {{/if}}
-  </div>
-{{/if}}
+  {{/if}}
+</Boxel::Modal>
 
 <div
   class="CardModal-urlWatcher"

--- a/packages/cardhost/app/routes/application.ts
+++ b/packages/cardhost/app/routes/application.ts
@@ -13,6 +13,7 @@ import '@cardstack/boxel/components/boxel/field/view/index.css';
 import '@cardstack/boxel/components/boxel/field/edit/index.css';
 import '@cardstack/boxel/components/boxel/header/index.css';
 import '@cardstack/boxel/components/boxel/input/index.css';
+import '@cardstack/boxel/components/boxel/modal/index.css';
 import '@cardstack/boxel/components/boxel/select-button/index.css';
 
 export default class ApplicationRoute extends Route {}


### PR DESCRIPTION
Breaking up the `cards-continued` branch into smaller PRs. This one uses the Boxel::Modal component in cardhost. 
#CS-2181