### PR TITLE
web: Change merchant logo to be capitalised

### DIFF
--- a/packages/web-client/app/components/card-pay/merchant-logo/index.hbs
+++ b/packages/web-client/app/components/card-pay/merchant-logo/index.hbs
@@ -10,6 +10,6 @@
     data-test-merchant-logo-text-color={{@logoTextColor}}
     ...attributes
   >
-    {{first-char @name}}
+    {{capitalize (first-char @name)}}
   </div>
 {{/if}}

--- a/packages/web-client/tests/acceptance/pay-test.ts
+++ b/packages/web-client/tests/acceptance/pay-test.ts
@@ -45,7 +45,7 @@ const usdSymbol = 'USD';
 const jpySymbol = 'JPY';
 const invalidCurrencySymbol = 'WUT';
 const network = 'sokol';
-const merchantName = 'Mandello';
+const merchantName = 'mandello';
 const merchantInfoBackground = '#00ffcc';
 const merchantInfoTextColor = '#000000';
 const nonexistentMerchantId = 'nonexistentmerchant';
@@ -103,6 +103,7 @@ module('Acceptance | pay', function (hooks) {
     assert.dom(MERCHANT).hasAttribute('data-test-merchant', merchantName);
     assert
       .dom(MERCHANT_LOGO)
+      .containsText(merchantName.substr(0, 1).toUpperCase())
       .hasAttribute(
         'data-test-merchant-logo-background',
         merchantInfoBackground


### PR DESCRIPTION
This has been a discrepancy between presentation here
vs Card Wallet. There was no test directly exercising
this so I put it in the pay test, which uses the logo…
I could make a specific test if that seems preferable.