### PR TITLE
CS:2261 Stop using the archive node in the SDK

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -423,7 +423,7 @@
       "args": [
         "pay-merchant",
         "0x3e6C2b2c3a842b6492F9F43349D77A40568e3d7E", // safe for Hassan's merchant (whose address the correlates with the mnemenoic 0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13)
-        "0x483F081bB0C25A5B216D1A4BD9CE0196092A0575", // Hassan's prepaid card --feel free to use your own
+        "0xF9b61C39C0c74C9BE637a0298244d2ca3f3cd509", // Hassan's prepaid card --feel free to use your own
         "100",
         "--network",
         "sokol",

--- a/packages/cardpay-cli/utils.ts
+++ b/packages/cardpay-cli/utils.ts
@@ -26,8 +26,10 @@ export async function getWeb3(network: string, mnemonic?: string): Promise<Web3>
         name: 'Cardstack - Cardpay CLI',
       },
       rpc: {
-        // we can't use OpenEthereum nodes as it was issues with modern web3 providers
-        [networkIds[network]]: getConstantByNetwork('rpcNodeNethermind', network),
+        // we can't use OpenEthereum nodes as it was issues with modern web3
+        // providers (specifically the xdai archive node that POA hosts falls
+        // into this category)
+        [networkIds[network]]: getConstantByNetwork('rpcNode', network),
       },
       bridge: BRIDGE,
     });

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -27,9 +27,8 @@ const SOKOL = {
   nativeTokenSymbol: 'SPOA',
   nativeTokenName: 'SPOA',
   name: 'Sokol',
-  // this needs to be an "archive" node
-  rpcNode: 'https://sokol-archive.blockscout.com',
-  rpcNodeNethermind: 'https://sokol-archive.blockscout.com',
+  rpcNode: 'https://sokol.poa.network',
+  rpcArchiveNode: 'https://sokol-archive.blockscout.com',
   rpcWssNode: 'wss://sokol.poa.network/wss',
   relayServiceURL: 'https://relay-staging.stack.cards/api',
   subgraphURL: 'https://graph-staging.stack.cards/subgraphs/name/habdelra/cardpay-sokol',
@@ -78,9 +77,8 @@ const XDAI = {
   nativeTokenSymbol: 'DAI',
   nativeTokenName: 'xDai',
   name: 'xDai Chain',
-  // this needs to be an "archive" node
-  rpcNode: 'https://xdai-archive.blockscout.com',
-  rpcNodeNethermind: 'https://rpc.xdaichain.com',
+  rpcNode: 'https://rpc.xdaichain.com',
+  rpcArchiveNode: 'https://xdai-archive.blockscout.com', // warning this is an OpenEthereum node which has issues with modern web3 providers
   rpcWssNode: 'wss://rpc.xdaichain.com/wss',
   relayServiceURL: 'https://relay.cardstack.com/api',
   subgraphURL: 'https://graph.cardstack.com/subgraphs/name/habdelra/cardpay-xdai',


### PR DESCRIPTION
This change will eliminate the use of the archive node in the SDK. This could have negative ramifications, though, specifically in the SDK's `waitUntilTransactionMined()` function. this function will no longer be able to handle txn hashes that are older (I'm thinking 100,000 blocks old). probably that's ok. If this does blow up, we should understand which SDK APIs cause a problem and switch to using our subgraph to wait for txn's and/or look up event logs (aka prepaid cards) that were involved in the txn from the subgraph.