### PR TITLE
web: Add timeout message for deposit delay

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.css
@@ -36,3 +36,11 @@
   align-items: center;
   justify-content: center;
 }
+
+.transaction-status__delay {
+  color: #707070;
+}
+
+.transaction-status__delay a {
+  text-decoration: underline;
+}

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.hbs
@@ -55,7 +55,7 @@
       <p class='transaction-status__delay' data-test-deposit-transaction-status-delay>
         Due to network conditions this transaction is taking longer to confirm,
         you can check the status of the transaction
-        <a href={{this.bridgeExplorerUrl}} target="_blank" rel="noopener noreferrer">here</a>.
+        <a href={{this.slowBridgingUrl}} target="_blank" rel="noopener noreferrer">here</a>.
       </p>
     {{/if}}
     {{#if (or this.bridgeError this.blockCountError)}}

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.hbs
@@ -51,6 +51,13 @@
         {{/if}}
       </div>
     </Boxel::ProgressSteps>
+    {{#if this.showSlowBridgingMessage}}
+      <p class='transaction-status__delay' data-test-deposit-transaction-status-delay>
+        Due to network conditions this transaction is taking longer to confirm,
+        you can check the status of the transaction
+        <a href={{this.bridgeExplorerUrl}} target="_blank" rel="noopener noreferrer">here</a>.
+      </p>
+    {{/if}}
     {{#if (or this.bridgeError this.blockCountError)}}
       <CardPay::ErrorMessage data-test-deposit-transaction-status-error as |supportURL|>
         There was a problem completing the bridging of your tokens to {{network-display-info "layer2" "fullName"}}. Please contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a> so that we can investigate and resolve this issue for you.

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.ts
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import BN from 'bn.js';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/browser';
+import config from '@cardstack/web-client/config/environment';
 import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { TokenSymbol } from '@cardstack/web-client/utils/token';
@@ -11,7 +12,14 @@ import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3
 import { TransactionReceipt } from 'web3-core';
 import { task } from 'ember-concurrency-decorators';
 import { taskFor } from 'ember-concurrency-ts';
-import { TaskGenerator } from 'ember-concurrency';
+import {
+  race,
+  rawTimeout,
+  TaskGenerator,
+  waitForProperty,
+} from 'ember-concurrency';
+
+const A_WHILE = config.environment === 'test' ? 1 : 1000 * 60 * 2;
 
 class CardPayDepositWorkflowTransactionStatusComponent extends Component<WorkflowCardComponentArgs> {
   @service declare layer1Network: Layer1Network;
@@ -35,6 +43,8 @@ class CardPayDepositWorkflowTransactionStatusComponent extends Component<Workflo
   @tracked bridgeError = false;
   @tracked blockCountError = false;
   @tracked blockCount = 0;
+
+  @tracked showSlowBridgingMessage = false;
 
   get totalBlockCount(): number {
     return this.layer1Network.strategy.bridgeConfirmationBlockCount;
@@ -61,14 +71,7 @@ class CardPayDepositWorkflowTransactionStatusComponent extends Component<Workflo
       this.blockCount = this.totalBlockCount;
       this.args.onComplete?.();
     } else {
-      taskFor(this.waitForBlockConfirmationsTask)
-        .perform()
-        .catch((e) => {
-          console.error('Failed to complete block confirmations');
-          console.error(e);
-          Sentry.captureException(e);
-          this.blockCountError = true;
-        });
+      taskFor(this.awaitTimerTask).perform();
     }
   }
 
@@ -86,6 +89,20 @@ class CardPayDepositWorkflowTransactionStatusComponent extends Component<Workflo
     }
   }
 
+  @task *awaitTimerTask(): TaskGenerator<void> {
+    yield race([
+      taskFor(this.waitForBlockConfirmationsTask)
+        .perform()
+        .catch((e) => {
+          console.error('Failed to complete block confirmations');
+          console.error(e);
+          Sentry.captureException(e);
+          this.blockCountError = true;
+        }),
+      taskFor(this.timerTask).perform(),
+    ]);
+  }
+
   @task *waitForBlockConfirmationsTask(): TaskGenerator<void> {
     let blockNumber = this.relayTokensTxnReceipt.blockNumber;
     while (this.blockCount <= this.totalBlockCount + 1) {
@@ -94,6 +111,13 @@ class CardPayDepositWorkflowTransactionStatusComponent extends Component<Workflo
     }
     this.completedStepCount++;
     this.waitForBridgingToComplete();
+  }
+
+  @task *timerTask(): TaskGenerator<void> {
+    this.showSlowBridgingMessage = false;
+    yield rawTimeout(A_WHILE);
+    this.showSlowBridgingMessage = true;
+    yield waitForProperty(this, 'showSlowBridgingMessage', false);
   }
 
   async waitForBridgingToComplete() {
@@ -111,6 +135,7 @@ class CardPayDepositWorkflowTransactionStatusComponent extends Component<Workflo
         transactionReceipt
       );
       this.completedStepCount++;
+      this.showSlowBridgingMessage = false;
       this.args.onComplete?.();
     } catch (e) {
       console.error('Failed to complete bridging to layer 2');

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.ts
@@ -162,6 +162,16 @@ class CardPayDepositWorkflowTransactionStatusComponent extends Component<Workflo
       this.completedLayer2TxnReceipt!.transactionHash
     );
   }
+
+  get slowBridgingUrl() {
+    if (this.completedStepCount === 1) {
+      return this.depositTxnViewerUrl;
+    } else if (this.completedStepCount === 2) {
+      return this.bridgeExplorerUrl;
+    } else {
+      return this.blockscoutUrl;
+    }
+  }
 }
 
 export default CardPayDepositWorkflowTransactionStatusComponent;

--- a/packages/web-client/app/utils/web3-strategies/test-layer1.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer1.ts
@@ -113,11 +113,11 @@ export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
   }
 
   blockExplorerUrl(txnHash: TransactionHash): string {
-    return `https://www.youtube.com/watch?v=xvFZjo5PgG0&txnHash=${txnHash}`;
+    return `https://www.youtube.com/watch?v=xvFZjo5PgG0&q=BlockExplorer&txnHash=${txnHash}`;
   }
 
   bridgeExplorerUrl(txnHash: TransactionHash): string {
-    return `https://www.youtube.com/watch?v=xvFZjo5PgG0&txnHash=${txnHash}`;
+    return `https://www.youtube.com/watch?v=xvFZjo5PgG0&q=BridgeExplorer&txnHash=${txnHash}`;
   }
 
   test__simulateWalletConnectUri() {

--- a/packages/web-client/app/utils/web3-strategies/test-layer2.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer2.ts
@@ -170,11 +170,11 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
   }
 
   blockExplorerUrl(txnHash: TransactionHash): string {
-    return `https://www.youtube.com/watch?v=xvFZjo5PgG0&txnHash=${txnHash}`;
+    return `https://www.youtube.com/watch?v=xvFZjo5PgG0&q=BlockExplorer&txnHash=${txnHash}`;
   }
 
   bridgeExplorerUrl(txnHash: TransactionHash): string {
-    return `https://www.youtube.com/watch?v=xvFZjo5PgG0&txnHash=${txnHash}`;
+    return `https://www.youtube.com/watch?v=xvFZjo5PgG0&q=BridgeExplorer&txnHash=${txnHash}`;
   }
 
   get isConnected() {

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-status-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-status-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, waitFor } from '@ember/test-helpers';
+import { find, render, settled, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
@@ -58,6 +58,8 @@ module(
           />
         `);
 
+      assert.dom('[data-test-deposit-transaction-status-delay]').doesNotExist();
+
       assert
         .dom(`[data-test-token-bridge-step="0"][data-test-completed]`)
         .containsText(stepTitles.deposit);
@@ -72,7 +74,14 @@ module(
         .dom(`[data-test-token-bridge-step-status="1"]`)
         .hasText(`0 of ${blockCount} blocks confirmed`);
 
-      assert.dom('[data-test-deposit-transaction-status-delay]').doesNotExist();
+      await settled();
+
+      let etherscanHref = find('[data-test-etherscan-button]')?.getAttribute(
+        'href'
+      )!;
+      assert
+        .dom('[data-test-deposit-transaction-status-delay] a')
+        .hasAttribute('href', etherscanHref);
 
       layer1Service.test__simulateBlockConfirmation();
       await waitFor(
@@ -97,6 +106,13 @@ module(
         .dom(`[data-test-token-bridge-step="2"][data-test-completed]`)
         .doesNotExist();
       assert.dom(`[data-test-blockscout-button]`).doesNotExist();
+
+      let bridgeExplorerHerf = find(
+        '[data-test-bridge-explorer-button]'
+      )?.getAttribute('href')!;
+      assert
+        .dom('[data-test-deposit-transaction-status-delay] a')
+        .hasAttribute('href', bridgeExplorerHerf);
 
       assert
         .dom('[data-test-deposit-transaction-status-delay]')
@@ -123,6 +139,7 @@ module(
       assert.dom('[data-test-blockscout-button]').exists();
       assert.dom('[data-test-deposit-minting-step-failed]').doesNotExist();
       assert.dom('[data-test-deposit-transaction-status-error]').doesNotExist();
+      assert.dom('[data-test-deposit-transaction-status-delay]').doesNotExist();
 
       assert.ok(onComplete.called);
     });

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-status-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-status-test.ts
@@ -72,6 +72,8 @@ module(
         .dom(`[data-test-token-bridge-step-status="1"]`)
         .hasText(`0 of ${blockCount} blocks confirmed`);
 
+      assert.dom('[data-test-deposit-transaction-status-delay]').doesNotExist();
+
       layer1Service.test__simulateBlockConfirmation();
       await waitFor(
         `[data-test-token-bridge-step-block-count="${blockCount}"]`
@@ -95,6 +97,12 @@ module(
         .dom(`[data-test-token-bridge-step="2"][data-test-completed]`)
         .doesNotExist();
       assert.dom(`[data-test-blockscout-button]`).doesNotExist();
+
+      assert
+        .dom('[data-test-deposit-transaction-status-delay]')
+        .containsText(
+          'Due to network conditions this transaction is taking longer to confirm'
+        );
 
       // bridging should also refresh layer 2 balances so we want to ensure that here
       layer2Service.balancesRefreshed = false;


### PR DESCRIPTION
This adds a message to the deposit transaction status card that shows after two minutes. It contains a link that updates as the card progresses, so it always links to the same place as the most-recently-displayed transaction status button.

![image](https://user-images.githubusercontent.com/43280/139710336-8e8c0f97-e6a5-410a-bca3-031a7bd94941.png)
