### PR TITLE
depositing can be canceled if user has not confirmed the transaction

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -108,6 +108,11 @@
       <i.ActionButton data-test-deposit-button>
         Depositing
       </i.ActionButton>
+      {{#if this.cancelable}}
+        <i.CancelButton {{on "click" this.cancelDeposit}} data-test-deposit-cancel-button>
+          Cancel
+        </i.CancelButton>
+      {{/if}}
       {{#if this.depositTxnViewerUrl}}
         <i.InfoArea>
           <Boxel::Button @as="anchor" @kind="secondary-dark" @size="extra-small" @href={{this.depositTxnViewerUrl}} target="_blank" rel="noopener" data-test-deposit-etherscan-button>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
@@ -68,6 +68,10 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<Workflo
     });
   }
 
+  get cancelable() {
+    return !this.relayTokensTxnHash;
+  }
+
   get currentTokenDetails(): TokenDisplayInfo<BridgeableSymbol> | undefined {
     if (this.currentTokenSymbol) {
       return new TokenDisplayInfo(this.currentTokenSymbol);
@@ -190,6 +194,10 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<Workflo
       this.errorMessage =
         'There was a problem unlocking your tokens for deposit. This may be due to a network issue, or perhaps you canceled the request in your wallet.';
     }
+  }
+
+  @action cancelDeposit() {
+    taskFor(this.depositTask).cancelAll();
   }
 
   @task *depositTask(): TaskGenerator<void> {

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
@@ -1,6 +1,13 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn, typeIn, click, settled } from '@ember/test-helpers';
+import {
+  render,
+  fillIn,
+  typeIn,
+  click,
+  settled,
+  waitFor,
+} from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
@@ -10,6 +17,7 @@ import { toWei } from 'web3-utils';
 import sinon from 'sinon';
 
 let layer1Service: Layer1TestWeb3Strategy;
+let session: WorkflowSession;
 
 module(
   'Integration | Component | card-pay/deposit-workflow/transaction-amount',
@@ -24,7 +32,7 @@ module(
       let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
       layer2Strategy.test__simulateAccountsChanged([layer2AccountAddress]);
 
-      const session = new WorkflowSession();
+      session = new WorkflowSession();
       session.setValue('depositSourceToken', 'DAI');
       layer1Service = this.owner.lookup('service:layer1-network').strategy;
 
@@ -40,19 +48,124 @@ module(
       this.setProperties({
         session,
       });
+    });
+
+    test('it can go through with unlock and deposit', async function (assert) {
+      let completed = false;
+      this.set('onComplete', () => {
+        completed = true;
+      });
+      await render(hbs`
+      <CardPay::DepositWorkflow::TransactionAmount
+        @workflowSession={{this.session}}
+        @onComplete={{this.onComplete}}
+        @onIncomplete={{noop}}
+      />
+    `);
+
+      const daiToSend = '5';
+      // const daiToSendInWei = '5000000000000000000';
+
+      await fillIn('[data-test-token-amount-input]', daiToSend);
+      assert.dom('[data-test-deposit-button]').isDisabled();
+      assert.dom('[data-test-unlock-button]').isNotDisabled();
+
+      await click('[data-test-unlock-button]');
+      layer1Service.test__simulateUnlockTxnHash();
+      await waitFor('[data-test-unlock-etherscan-button]');
+
+      assert
+        .dom('[data-test-unlock-etherscan-button]')
+        .containsText('View on Etherscan')
+        .hasAttribute('href', /.+/);
+
+      layer1Service.test__simulateUnlock();
+      await settled();
+
+      assert.dom('[data-test-deposit-button]').isEnabled();
+
+      await click('[data-test-deposit-button]');
+
+      assert.dom('[data-test-deposit-button]').containsText('Depositing');
+
+      layer1Service.test__simulateDepositTxnHash();
+      await waitFor('[data-test-deposit-etherscan-button]');
+
+      assert
+        .dom('[data-test-deposit-etherscan-button]')
+        .containsText('View on Etherscan')
+        .hasAttribute('href', /.+/);
+
+      layer1Service.test__simulateDeposit();
+      await settled();
+
+      assert
+        .dom('[data-test-deposit-success-message]')
+        .containsText('Deposited');
+      assert.ok(completed);
+    });
+
+    test('its deposit step can be canceled if there is no deposit transaction hash', async function (assert) {
+      session.setValue('unlockTxnHash', 'unlockTokensTxnHash');
+      session.setValue('depositSourceToken', 'DAI');
+      session.setValue('depositedAmount', new BN(toWei('5')));
 
       await render(hbs`
-          <CardPay::DepositWorkflow::TransactionAmount
-            @workflowSession={{this.session}}
-            @onComplete={{noop}}
-            @onIncomplete={{noop}}
-          />
-        `);
+      <CardPay::DepositWorkflow::TransactionAmount
+        @workflowSession={{this.session}}
+        @onComplete={{noop}}
+        @onIncomplete={{noop}}
+      />
+    `);
+
+      await layer1Service.test__simulateUnlock();
+
+      await click('[data-test-deposit-button]');
+      assert.dom('[data-test-deposit-button]').containsText('Depositing');
+
+      assert.dom('[data-test-deposit-cancel-button]').isVisible();
+      assert.dom('[data-test-deposit-cancel-button]').isEnabled();
+
+      await click('[data-test-deposit-cancel-button]');
+
+      assert.dom('[data-test-deposit-button]').containsText('Deposit');
+      assert.dom('[data-test-deposit-button]').isEnabled();
+    });
+
+    test('its deposit step can not be canceled if there is a deposit transaction hash', async function (assert) {
+      session.setValue('unlockTxnHash', 'unlockTokensTxnHash');
+      session.setValue('depositSourceToken', 'DAI');
+      session.setValue('depositedAmount', new BN(toWei('5')));
+
+      await render(hbs`
+      <CardPay::DepositWorkflow::TransactionAmount
+        @workflowSession={{this.session}}
+        @onComplete={{noop}}
+        @onIncomplete={{noop}}
+      />
+    `);
+
+      await layer1Service.test__simulateUnlock();
+
+      session.setValue('relayTokensTxnHash', 'relayTokensTxnHash');
+
+      await click('[data-test-deposit-button]');
+
+      assert.dom('[data-test-deposit-button]').containsText('Depositing');
+      assert.dom('[data-test-deposit-cancel-button]').doesNotExist();
     });
 
     test('It disables the unlock button when amount entered is more than balance (18-decimal floating point)', async function (assert) {
       const daiInBalance = '5.111111111111111110';
       const moreDaiThanBalance = '5.111111111111111111';
+
+      await render(hbs`
+      <CardPay::DepositWorkflow::TransactionAmount
+        @workflowSession={{this.session}}
+        @onComplete={{noop}}
+        @onIncomplete={{noop}}
+      />
+    `);
 
       assert.dom('[data-test-unlock-button]').isDisabled();
       await fillIn('[data-test-token-amount-input]', moreDaiThanBalance);
@@ -68,6 +181,14 @@ module(
     test('It accurately sends the amount to be handled by layer 1 (18-decimal floating point)', async function (assert) {
       const daiToSend = '5.111111111111111110';
       const daiToSendInWei = '5111111111111111110';
+
+      await render(hbs`
+      <CardPay::DepositWorkflow::TransactionAmount
+        @workflowSession={{this.session}}
+        @onComplete={{noop}}
+        @onIncomplete={{noop}}
+      />
+    `);
 
       let approveSpy = sinon.spy(layer1Service, 'approve');
 
@@ -91,6 +212,14 @@ module(
       const invalidDai3 = '  1'; /* has space */
       const invalidDai4 = '12/'; /* invalid char */
       let startDaiAmount = toWei(startDaiString);
+
+      await render(hbs`
+      <CardPay::DepositWorkflow::TransactionAmount
+        @workflowSession={{this.session}}
+        @onComplete={{noop}}
+        @onIncomplete={{noop}}
+      />
+    `);
 
       layer1Service.test__simulateBalances({
         defaultToken: new BN('0'),
@@ -139,6 +268,14 @@ module(
     });
 
     test('it rejects a value of zero', async function (assert) {
+      await render(hbs`
+      <CardPay::DepositWorkflow::TransactionAmount
+        @workflowSession={{this.session}}
+        @onComplete={{noop}}
+        @onIncomplete={{noop}}
+      />
+    `);
+
       await fillIn('input', '0');
       assert.dom('input').hasAria('invalid', 'true');
       assert


### PR DESCRIPTION
Double depositing should not happen because of needing to approve the amount beforehand. However, users who leave the page after canceling in the DApp, and later approve on their wallet will not be able to continue the workflow properly on the DApp later.