### PR TITLE
Timeout after 1 minute when trying to authenticate with the hub

### DIFF
--- a/packages/web-client/app/components/card-pay/hub-authentication/index.hbs
+++ b/packages/web-client/app/components/card-pay/hub-authentication/index.hbs
@@ -12,7 +12,13 @@
           style={{css-var status-icon-size="2.5rem"}}
           data-test-failed
         >
-          Authentication failed or was canceled.
+          {{#if (eq this.error.message "AUTH_TIMEOUT")}}
+            <span>
+              Authentication with Card Wallet timed out. If you didn't receive a confirmation request on your device, try again, or contact <a href={{this.supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
+            </span>
+          {{else}}
+            Authentication failed or was canceled.
+          {{/if}}
         </d.ActionStatusArea>
         <d.InfoArea>
           <Boxel::Button

--- a/packages/web-client/tests/integration/components/card-pay/hub-authentication-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/hub-authentication-test.ts
@@ -125,5 +125,22 @@ module(
           .containsText('Authenticated with Hub');
       });
     });
+
+    test('It shows a message on timeout', async function (assert) {
+      let deferred = RSVP.defer<void>();
+      sinon
+        .stub(hubAuthentication, 'ensureAuthenticated')
+        .returns(deferred.promise);
+
+      await click('[data-test-authentication-button]');
+
+      await waitFor('[data-test-failed]');
+
+      assert
+        .dom('[data-test-failed]')
+        .containsText(
+          "Authentication with Card Wallet timed out. If you didn't receive a confirmation request on your device, try again, or contact Cardstack support"
+        );
+    });
   }
 );


### PR DESCRIPTION
Ticket: [cs-2295](https://linear.app/cardstack/issue/CS-2295/bug-card-issuance-hangs-at-hub-authen)

I haven't been able to reproduce this bug, but Kiel's idea about introducing a timeout makes a lot of sense. In case something we can't control goes wrong or hangs, the user gets notified and can retry after 1 minute.