### PR TITLE
depositing can be canceled if user has not confirmed the transaction

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -108,6 +108,11 @@
       <i.ActionButton data-test-deposit-button>
         Depositing
       </i.ActionButton>
+      {{#if this.depositTaskCancelable}}
+        <i.CancelButton {{on "click" this.cancelDeposit}} data-test-deposit-cancel-button>
+          Cancel
+        </i.CancelButton>
+      {{/if}}
       {{#if this.depositTxnViewerUrl}}
         <i.InfoArea>
           <Boxel::Button @as="anchor" @kind="secondary-dark" @size="extra-small" @href={{this.depositTxnViewerUrl}} target="_blank" rel="noopener" data-test-deposit-etherscan-button>


### PR DESCRIPTION
Updated #2297 to allow cancelation for now (with cancel button shown after a delay). Follow-up in https://linear.app/cardstack/issue/CS-2395/add-retry-ui-that-properly-handles-doubled-requests