### PR TITLE
web: Add guard to ignore task cancelation

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.ts
@@ -13,6 +13,7 @@ import { TransactionReceipt } from 'web3-core';
 import { task } from 'ember-concurrency-decorators';
 import { taskFor } from 'ember-concurrency-ts';
 import {
+  didCancel,
   race,
   rawTimeout,
   TaskGenerator,
@@ -106,10 +107,12 @@ class CardPayDepositWorkflowTransactionStatusComponent extends Component<Workflo
       taskFor(this.waitForBlockConfirmationsTask)
         .perform()
         .catch((e) => {
-          console.error('Failed to complete block confirmations');
-          console.error(e);
-          Sentry.captureException(e);
-          this.blockCountError = true;
+          if (!didCancel(e)) {
+            console.error('Failed to complete block confirmations');
+            console.error(e);
+            Sentry.captureException(e);
+            this.blockCountError = true;
+          }
         }),
       taskFor(this.timerTask).perform(),
     ]);


### PR DESCRIPTION
Task cancelation results in promise rejection, but we don’t
want to treat cancelation (from the component being closed
by clicking out of the workflow, for instance) as a failure.

Since this was a bug report about a console warning, it’s not
covered by testing, but I hacked the component test to
allow me to arbitrarily destroy the component:

![image](https://user-images.githubusercontent.com/43280/140417501-aa025f40-619e-4c83-92a2-f35fbdf3fe9a.png)

Before this change, destroying the component produced the warning:

![screencast 2021-11-04 15-48-06](https://user-images.githubusercontent.com/43280/140417982-6cde4497-c276-4a3d-910c-af75bf821ebd.gif)

Afterward, no warning:

![screencast 2021-11-04 15-49-32](https://user-images.githubusercontent.com/43280/140418000-ac3a4b09-143f-4588-94ed-4740a1461762.gif)
