### PR TITLE
web: Add timeout message for withdrawal tracking

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.css
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-status/index.css
@@ -38,7 +38,7 @@
 }
 
 .transaction-status__delay {
-  color: #707070;
+  color: var(--boxel-purple-500);
 }
 
 .transaction-status__delay a {

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.hbs
@@ -39,6 +39,13 @@
         {{/if}}
       </span>
     </Boxel::ProgressSteps>
+    {{#if this.showSlowBridgingMessage}}
+      <p class='transaction-status__delay' data-test-withdrawal-transaction-status-delay>
+        Due to network conditions this transaction is taking longer to confirm,
+        you can check the status of the transaction
+        <a href={{this.bridgeExplorerUrl}} target="_blank" rel="noopener noreferrer">here</a>.
+      </p>
+    {{/if}}
     {{#if this.error}}
       <CardPay::ErrorMessage data-test-withdrawal-transaction-status-error as |supportURL|>
         There was a problem completing the bridging of your tokens to {{network-display-info "layer1" "fullName"}}. Please contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a> so that we can investigate and resolve this issue for you.

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled } from '@ember/test-helpers';
+import { find, render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
@@ -72,6 +72,9 @@ module(
       `);
 
       assert.dom('[data-test-action-card-title-icon-name="clock"]').exists();
+      assert
+        .dom('[data-test-withdrawal-transaction-status-delay]')
+        .doesNotExist();
 
       assert
         .dom(`[data-test-token-bridge-step="0"][data-test-completed]`)
@@ -88,6 +91,20 @@ module(
       assert
         .dom(`[data-test-bridge-explorer-button]`)
         .hasAttribute('href', /relay$/);
+
+      await settled();
+
+      let bridgeExplorerHref = find(
+        '[data-test-bridge-explorer-button]'
+      )?.getAttribute('href')!;
+      assert
+        .dom('[data-test-withdrawal-transaction-status-delay] a')
+        .hasAttribute('href', bridgeExplorerHref);
+      assert
+        .dom('[data-test-withdrawal-transaction-status-delay]')
+        .containsText(
+          'Due to network conditions this transaction is taking longer to confirm'
+        );
     });
 
     test('It completes when the bridged transaction completes', async function (assert) {


### PR DESCRIPTION
This is the withdrawal equivalent of #2295, though it’s simpler
because there are only two steps and the first is always complete
when the component renders.

This also changes the text colour [as suggested by @Aierie](https://github.com/cardstack/cardstack/pull/2295/files#r741135185) since
these components use the same CSS 🙃
