### PR TITLE
reverting the fine tuning--flew too close to the sun

### DIFF
--- a/packages/cardpay-sdk/sdk/token-bridge-foreign-side.ts
+++ b/packages/cardpay-sdk/sdk/token-bridge-foreign-side.ts
@@ -48,7 +48,7 @@ export interface ITokenBridgeForeignSide {
 // the new tokens require for transfer which will effect this value. Ultimately
 // this value reflects the gas limit that the token bridge is configured with
 // for performing withdrawals.
-const CLAIM_BRIDGED_TOKENS_GAS_LIMIT = 300000;
+const CLAIM_BRIDGED_TOKENS_GAS_LIMIT = 350000;
 
 // Note:  To accommodate the fix for infura block mismatch errors (made in
 // CS-2391), we are waiting one extra block for all layer 1 transactions.


### PR DESCRIPTION
the fine tuning that I attempted to perform was a cut too deep and the token bridge rejected this gas limit