### PR TITLE
web: Add guard against missing account address

### DIFF
--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -328,6 +328,10 @@ export default abstract class Layer2ChainWeb3Strategy
   @task *viewSafesTask(
     account: string = this.walletInfo.firstAddress!
   ): TaskGenerator<ViewSafesResult> {
+    if (!account) {
+      return { blockNumber: 0, safes: [] };
+    }
+
     return yield this.#safesApi.view(account);
   }
 


### PR DESCRIPTION
This fixes an edge case where the viewSafesTask would run
forever because the SDK’s Safes.view was being called with
an undefined address. It doesn’t make sense to call that
function without an address.

Adapted steps to reproduce thanks to @jurgenwerk; compare on
app.cardstack.com vs this branch:

1. Go to https://app.cardstack.com/card-pay/deposit-withdrawal
2. Connect MetaMask, Card wallet in the nav bar
3. Disconnect Card wallet in the nav bar
4. Click deposit tokens. The flow will take you to the wallet connect prompt. 
5. Connect card wallet
6. You should see the never ending loading spinners now