### PR TITLE
Add sdk for withdraw from reward safe

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -223,7 +223,7 @@
         "sokol",
         // Hassan's testing mnemonic feel free to use your own
         "--mnemonic",
-        "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
+        "fortune reduce accuse famous fetch waste debate alcohol notice salmon wish okay"
       ]
     },
     {
@@ -694,7 +694,7 @@
         "reward-balances",
         "0x159ADe032073d930E85f95AbBAB9995110c43C71", //owner address
         "--rewardProgramId",
-        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94",
+        "0x2E3C67B93082CC9EA68334f1eb0259E822973115",
         "--network",
         "sokol",
         "--mnemonic",
@@ -710,7 +710,7 @@
       "env": {},
       "args": [
         "register-reward-program",
-        "0x95864b14c7AEa30cf741B921130003e2323aA2FE",  //prepaid card
+        "0xE4EA6a40a91F424428c599AAbAb4D06579DbC027", //prepaid card
         "0x159ADe032073d930E85f95AbBAB9995110c43C71",  //reward program
         "--network",
         "sokol",
@@ -727,8 +727,8 @@
       "env": {},
       "args": [
         "register-rewardee",
-        "0x95864b14c7AEa30cf741B921130003e2323aA2FE", //prepaid card 
-        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94", //reward program
+        "0xE4EA6a40a91F424428c599AAbAb4D06579DbC027", //prepaid card
+        "0x2E3C67B93082CC9EA68334f1eb0259E822973115", //reward program
         "--network",
         "sokol",
         "--mnemonic",
@@ -745,7 +745,7 @@
       "args": [
         "add-reward-tokens",
         "0x906B5c2877dEad3c5565b042094d182b7575ADdE", //single owner safe
-        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94", //reward program
+        "0x2E3C67B93082CC9EA68334f1eb0259E822973115", //reward program
         "0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee", //token address
         "5",
         "--network",
@@ -763,7 +763,7 @@
       "env": {},
       "args": [
         "reward-pool-balance",
-        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94", //reward program
+        "0x2E3C67B93082CC9EA68334f1eb0259E822973115", //reward program id
         "0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee", //token address
         "--network",
         "sokol",
@@ -780,10 +780,10 @@
       "env": {},
       "args": [
         "claim-rewards",
-        "0x908630DFdE60552DAF5291C7081cF2fD475CB368", //reward safe
-        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94", //reward program id
+        "0x7f4B3963E6B65Fb09445C0E62993d9343eb55434", //reward safe
+        "0x2E3C67B93082CC9EA68334f1eb0259E822973115", //reward program id
         "0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee", //token address
-        "0x00000000000000000000000000000000000000000000000000000000000001b80000000000000000000000000000000000000000000000001bc16d674ec800008ec764e890f688e09100fed014087bfc81101b03d3b37ddf0bcd2bcb2d46c491", //proof
+        "0x00000000000000000000000000000000000000000000000000000000000001cd0000000000000000000000000000000000000000000000000de0b6b3a7640000",
         // "--amount",
         // "1",
         "--network",
@@ -802,8 +802,8 @@
       "args": [
         "claimable-reward-proofs",
         "0x159ADe032073d930E85f95AbBAB9995110c43C71", //owner address
-        // "--rewardProgramId",
-        // "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94",
+        "--rewardProgramId",
+        "0x2E3C67B93082CC9EA68334f1eb0259E822973115",
         // "--tokenAddress",
         // "0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee",
         "--network",
@@ -822,7 +822,7 @@
       "args": [
         "lock-reward-program",
         "0x95864b14c7AEa30cf741B921130003e2323aA2FE", //prepaid card
-        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94", //reward program
+        "0x2E3C67B93082CC9EA68334f1eb0259E822973115", //reward program
         "--network",
         "sokol",
         "--mnemonic",
@@ -838,7 +838,7 @@
       "env": {},
       "args": [
         "is-reward-program-locked",
-        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94", //reward program
+        "0x2E3C67B93082CC9EA68334f1eb0259E822973115", //reward program
         "--network",
         "sokol",
         "--mnemonic",
@@ -855,7 +855,7 @@
       "args": [
         "update-reward-program-admin",
         "0x95864b14c7AEa30cf741B921130003e2323aA2FE", //prepaid card
-        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94", //reward program
+        "0x2E3C67B93082CC9EA68334f1eb0259E822973115", //reward program
         "0x372f9d2a25F4255dCc4d1922EB548E02ab427310", //new admin (some random address)
         "--network",
         "sokol",
@@ -872,7 +872,7 @@
       "env": {},
       "args": [
         "reward-program-admin",
-        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94", //reward program
+        "0x2E3C67B93082CC9EA68334f1eb0259E822973115", //reward program
         "--network",
         "sokol",
         "--mnemonic",
@@ -888,10 +888,11 @@
       "env": {},
       "args": [
         "withdraw-reward-safe",
-        "0x908630DFdE60552DAF5291C7081cF2fD475CB368", //reward safe
+        "0x7f4B3963E6B65Fb09445C0E62993d9343eb55434", //reward safe
+        // "0x908630DFdE60552DAF5291C7081cF2fD475CB368", //reward safe
         "0x159ADe032073d930E85f95AbBAB9995110c43C71", //recipient (justin's depot)
         "0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee", //token address
-        "8", // amount (in ether units)
+        "1", // amount (in ether units)
         "--network",
         "sokol",
         "--mnemonic",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -692,9 +692,9 @@
       "env": {},
       "args": [
         "reward-balances",
-        "0x159ADe032073d930E85f95AbBAB9995110c43C71", // Justin's address
+        "0x159ADe032073d930E85f95AbBAB9995110c43C71", //owner address
         "--rewardProgramId",
-        "0x4767D0D74356433d54880Fcd7f083751d64388aF",
+        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94",
         "--network",
         "sokol",
         "--mnemonic",
@@ -710,8 +710,8 @@
       "env": {},
       "args": [
         "register-reward-program",
-        "0x36731EC6C6c10d99f09580820b8D30607A383288",
-        "0x159ADe032073d930E85f95AbBAB9995110c43C71",
+        "0x95864b14c7AEa30cf741B921130003e2323aA2FE",  //prepaid card
+        "0x159ADe032073d930E85f95AbBAB9995110c43C71",  //reward program
         "--network",
         "sokol",
         "--mnemonic",
@@ -727,8 +727,8 @@
       "env": {},
       "args": [
         "register-rewardee",
-        "0x36731EC6C6c10d99f09580820b8D30607A383288",
-        "0x22593fefedddafbf5b0d92ac026138f4da1e707f",
+        "0x95864b14c7AEa30cf741B921130003e2323aA2FE", //prepaid card 
+        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94", //reward program
         "--network",
         "sokol",
         "--mnemonic",
@@ -744,9 +744,9 @@
       "env": {},
       "args": [
         "add-reward-tokens",
-        "0x906B5c2877dEad3c5565b042094d182b7575ADdE",
-        "0x63cbD6f839c54635c73235Fd3d0CC8Cb52B7B127",
-        "0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee",
+        "0x906B5c2877dEad3c5565b042094d182b7575ADdE", //single owner safe
+        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94", //reward program
+        "0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee", //token address
         "5",
         "--network",
         "sokol",
@@ -763,8 +763,8 @@
       "env": {},
       "args": [
         "reward-pool-balance",
-        "0x63cbD6f839c54635c73235Fd3d0CC8Cb52B7B127",
-        "0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee",
+        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94", //reward program
+        "0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee", //token address
         "--network",
         "sokol",
         "--mnemonic",
@@ -780,12 +780,12 @@
       "env": {},
       "args": [
         "claim-rewards",
-        "0xcfE8a7eEeFa2182a91a86dB3C08ff6229899A50B",
-        "0x4767D0D74356433d54880Fcd7f083751d64388aF", //default reward program id
-        "0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee",
-        "0x00000000000000000000000000000000000000000000000000000000000000070000000000000000000000000000000000000000000000008ac7230489e80000ded2d0791a20d9d7fa1c9aa2ca7fec46f27cfcea42ce1d151f33e6e9cdd52f8b8ec7fea33ce953aa1933e444f8d4862a2878b08cd14862c9d5f928c5292b4811e04490b4c7bf89e4d50417d8ba6f982f6c7323a550c07e57e38feb0ce08d5d5bcc13be6aef2c87b9ddffe4e5dc827260850a398512deaccb11c0f3515c6ea9c373e766e12b90202a8e6ce04264fb355a8f8a37960eb86c09a8710ffb5e23356c", //proof
-        "--amount",
-        "1",
+        "0x908630DFdE60552DAF5291C7081cF2fD475CB368", //reward safe
+        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94", //reward program id
+        "0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee", //token address
+        "0x00000000000000000000000000000000000000000000000000000000000001b80000000000000000000000000000000000000000000000001bc16d674ec800008ec764e890f688e09100fed014087bfc81101b03d3b37ddf0bcd2bcb2d46c491", //proof
+        // "--amount",
+        // "1",
         "--network",
         "sokol",
         "--mnemonic",
@@ -801,9 +801,9 @@
       "env": {},
       "args": [
         "claimable-reward-proofs",
-        "0x159ADe032073d930E85f95AbBAB9995110c43C71", // Justin's address
+        "0x159ADe032073d930E85f95AbBAB9995110c43C71", //owner address
         // "--rewardProgramId",
-        // "0x4767D0D74356433d54880Fcd7f083751d64388aF",
+        // "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94",
         // "--tokenAddress",
         // "0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee",
         "--network",
@@ -821,8 +821,8 @@
       "env": {},
       "args": [
         "lock-reward-program",
-        "0xb284f51Ac8dc7df9D7DAedEf485092dc4D41B8A8", //prepaid card
-        "0x1c20cB9A77aCd795636E97c639DadBb8f168D288", //reward program
+        "0x95864b14c7AEa30cf741B921130003e2323aA2FE", //prepaid card
+        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94", //reward program
         "--network",
         "sokol",
         "--mnemonic",
@@ -838,7 +838,7 @@
       "env": {},
       "args": [
         "is-reward-program-locked",
-        "0x1c20cB9A77aCd795636E97c639DadBb8f168D288", //reward program
+        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94", //reward program
         "--network",
         "sokol",
         "--mnemonic",
@@ -854,8 +854,8 @@
       "env": {},
       "args": [
         "update-reward-program-admin",
-        "0xb284f51Ac8dc7df9D7DAedEf485092dc4D41B8A8", //prepaid card
-        "0x1c20cB9A77aCd795636E97c639DadBb8f168D288", //reward program
+        "0x95864b14c7AEa30cf741B921130003e2323aA2FE", //prepaid card
+        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94", //reward program
         "0x372f9d2a25F4255dCc4d1922EB548E02ab427310", //new admin (some random address)
         "--network",
         "sokol",
@@ -872,7 +872,26 @@
       "env": {},
       "args": [
         "reward-program-admin",
-        "0x1c20cB9A77aCd795636E97c639DadBb8f168D288", //reward program
+        "0xf8808F5FB73777F0999EFc5939Bb7E44Aa2eaE94", //reward program
+        "--network",
+        "sokol",
+        "--mnemonic",
+        "fortune reduce accuse famous fetch waste debate alcohol notice salmon wish okay"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Cardpay testnet: Withdraw From Reward Safe",
+      "program": "${workspaceFolder}/packages/cardpay-cli/cardpay.js",
+      "console": "integratedTerminal",
+      "env": {},
+      "args": [
+        "withdraw-reward-safe",
+        "0x908630DFdE60552DAF5291C7081cF2fD475CB368", //reward safe
+        "0x159ADe032073d930E85f95AbBAB9995110c43C71", //recipient (justin's depot)
+        "0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee", //token address
+        "8", // amount (in ether units)
         "--network",
         "sokol",
         "--mnemonic",

--- a/packages/cardpay-cli/index.ts
+++ b/packages/cardpay-cli/index.ts
@@ -28,6 +28,7 @@ import {
   isRewardProgramLocked,
   updateRewardProgramAdmin,
   rewardProgramAdmin,
+  withdraw,
 } from './reward-manager';
 import { ethToUsdPrice, priceOracleUpdatedAt as layer1PriceOracleUpdatedAt } from './layer-one-oracle';
 import {
@@ -104,7 +105,8 @@ type Commands =
   | 'lockRewardProgram'
   | 'isRewardProgramLocked'
   | 'updateRewardProgramAdmin'
-  | 'rewardProgramAdmin';
+  | 'rewardProgramAdmin'
+  | 'withdrawRewardSafe';
 
 let command: Commands | undefined;
 interface Options {
@@ -889,6 +891,29 @@ let {
     });
     command = 'rewardProgramAdmin';
   })
+  .command(
+    'withdraw-reward-safe <rewardSafe> <recipient> <tokenAddress> <amount>',
+    'Withdraw from reward safe',
+    (yargs) => {
+      yargs.positional('rewardSafe', {
+        type: 'string',
+        description: 'The address of the rewardSafe that already contains rewards',
+      });
+      yargs.positional('recipient', {
+        type: 'string',
+        description: "The token recipient's address",
+      });
+      yargs.positional('tokenAddress', {
+        type: 'string',
+        description: 'The address of the tokens that are being transferred from reward safe',
+      });
+      yargs.positional('amount', {
+        type: 'string',
+        description: 'The amount of tokens to transfer (not in units of wei, but in eth)',
+      });
+      command = 'withdrawRewardSafe';
+    }
+  )
   .options({
     network: {
       alias: 'n',
@@ -1307,6 +1332,25 @@ if (!command) {
         return;
       }
       await rewardProgramAdmin(network, rewardProgramId, mnemonic);
+      break;
+    case 'withdrawRewardSafe':
+      if (recipient == null) {
+        showHelpAndExit('recipient is a required value');
+        return;
+      }
+      if (rewardSafe == null) {
+        showHelpAndExit('rewardSafe is a required value');
+        return;
+      }
+      if (tokenAddress == null) {
+        showHelpAndExit('tokenAddress is a required value');
+        return;
+      }
+      if (amount == null) {
+        showHelpAndExit('amount is a required value');
+        return;
+      }
+      await withdraw(network, rewardSafe, recipient, tokenAddress, amount, mnemonic);
       break;
     default:
       assertNever(command);

--- a/packages/cardpay-cli/reward-manager.ts
+++ b/packages/cardpay-cli/reward-manager.ts
@@ -79,3 +79,21 @@ export async function rewardProgramAdmin(network: string, rewardProgramId: strin
   const admin = await rewardManager.getRewardProgramAdmin(rewardProgramId);
   console.log(`Reward program admin of ${rewardProgramId} is ${admin}`);
 }
+
+export async function withdraw(
+  network: string,
+  rewardSafe: string,
+  to: string,
+  tokenAddress: string,
+  amount: string,
+  mnemonic?: string
+): Promise<void> {
+  let web3 = await getWeb3(network, mnemonic);
+  let rewardManagerAPI = await getSDK('RewardManager', web3);
+  let blockExplorer = await getConstant('blockExplorer', web3);
+  await rewardManagerAPI.withdraw(rewardSafe, to, tokenAddress, amount, {
+    onTxnHash: (txnHash: string) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),
+  });
+  console.log(`Withdraw ${amount} of ${tokenAddress} out of ${rewardSafe} to ${to}`);
+  console.log('done');
+}

--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -730,7 +730,7 @@ let balanceForAllTokens = await rewardPool.rewardTokenBalances(address, rewardPr
 
 ## `RewardPool.addRewardTokens`
 
-The `AddRewardTokens` API is used to refill the reward pool for a particular reward program with any single owner safe. Currently, we are using single-owner safe like depot safe or merchant safe to send funds, but, in the future we will use prepaid cards to pay. If a reward program doesn't have any funds inside of the pool rewardees will be unable to claim. Anyone can call this api not only the rewardProgramAdmin.
+The `AddRewardTokens` API is used to refill the reward pool for a particular reward program with any single owner safe. Currently, the sdk supports using single-owner safe like depot safe or merchant safe to send funds (the protocol supports prepaid card payments too). If a reward program doesn't have any funds inside of the pool rewardees will be unable to claim. Anyone can call this function not only the rewardProgramAdmin.
 
 ```js
 let rewardPool = await getSDK('RewardPool', web3);
@@ -743,11 +743,9 @@ The `Claim` API is used by the rewardee to claim rewards for a reward program id
 
 Pre-requisite for this action:
 - reward program has to be registered
-- rewardee has to register and create safe for that particular reward program
-- rewardee must get an existing proof from tally api  -- look at `rewardPool.getProofs`
+- rewardee has to register and create safe for that particular reward program. The funds will be claimed into this safe -- reward safe
+- rewardee must get an existing proof from tally api  -- look at `rewardPool.getProofs` or `rewardPool.getProofsWithBalance`
 - reward pool has to be filled with reward token for that reward program
-
-This claim action is similar to `RevenuePool.claim` in that a pre-flight check is used to check that the rewards claimed will be able to cover that gas for the transaction.
 
 ```js
 let rewardPool = await getSDK('RewardPool', web3);
@@ -760,20 +758,48 @@ The `RewardManager` API is used to interact to manage reward program. Those inte
 
 ## `RewardManager.registerRewardProgram`
 
-The `RegisterRewardProgram` API is used to register a reward program using a prepaid card. The call can specify an EOA admin account -- it defaults to the owner of the prepaid card itself. The reward program admin will then be able to manage the reward program using other api functions like`lockRewardProgram`, `addRewardRule`, etc. A fee of 500 spend is charged when registering a reward program. Currently, tally only gives rewards to a single reward program (sokol: "0x4767D0D74356433d54880Fcd7f083751d64388aF").
+The `RegisterRewardProgram` API is used to register a reward program using a prepaid card. The call can specify an EOA admin account -- it defaults to the owner of the prepaid card itself. The reward program admin will then be able to manage the reward program using other api functions like`lockRewardProgram`, `addRewardRule`, `updateRewardProgramAdmin`. A fee of 500 spend is charged when registering a reward program. Currently, tally only gives rewards to a single reward program (sokol: "0x4767D0D74356433d54880Fcd7f083751d64388aF").
 
 ```js
-let prepaidCardAPI = await getSDK('PrepaidCard', web3);
-await prepaidCardAPI.registerRewardProgram(prepaidCard, admin)
+let rewardManagerAPI = await getSDK('RewardManager', web3);
+await rewardManagerAPI.registerRewardProgram(prepaidCard, admin)
 ```
 
 ## `RewardManager.registerRewardee`
 
-The `RegistereRewardee` API is used to register a rewardee for a reward program using a prepaid card. The purpose of registering is not to "be considered to receive rewards" rather to "be able to claim rewards that have been given". By registering, the owner of the prepaid card is given ownership of a reward safe that will be used to retrieve rewards from the reward pool. A rewardee/eoa is eligible to only have one reward safe for each reward program; any attempts to re-register will result in a revert error. A fee of 500 spend is charged when registering a rewardee.
+The `RegisterRewardee` API is used to register a rewardee for a reward program using a prepaid card. The purpose of registering is not to "be considered to receive rewards" rather to "be able to claim rewards that have been given". By registering, the owner of the prepaid card is given ownership of a reward safe that will be used to retrieve rewards from the reward pool. A rewardee/eoa is eligible to only have one reward safe for each reward program; any attempts to re-register will result in a revert error. There is no fee in registering a reward safe, the prepaid card will pay the gas fees to execute the transaction. 
 
 ```js
-let prepaidCardAPI = await getSDK('PrepaidCard', web3);
-await prepaidCardAPI.registerRewardee(prepaidCard , rewardProgramId)
+let rewardManagerAPI = await getSDK(RewardManager, web3);
+await rewardManagerAPI.registerRewardee(prepaidCard , rewardProgramId)
+```
+
+## `RewardManager.lockRewardProgram`
+
+The `LockRewardProgram` API is used to to lock a reward program using a prepaid card. When a reward program is locked, tally will choose to stop calculating rewards for reward reward program from that point forward. This doesn't stop the unclaimed rewards from being claimed, i.e. unused proofs. The prepaid card will pay for the gas fees to execute the transaction. Only the reward program admin can call this function. Executing this function again will unlock the reward program, which will allow tally to restart calculating rewards. 
+
+
+```js
+let rewardManagerAPI = await getSDK(RewardManager, web3);
+await rewardManagerAPI.lockRewardProgram(prepaidCard , rewardProgramId)
+```
+
+## `RewardManager.updateRewardProgramAdmin`
+
+The `UpdateRewardProgramAdmin` API is used to update the reward program admin of a reward program using a prepaid card. The prepaid card will pay for the gas fees to execute the transaction. Only the reward program admin can call this function.
+
+```js
+let rewardManagerAPI = await getSDK(RewardManager, web3);
+await rewardManagerAPI.updateRewardProgramAdmin(prepaidCard , rewardProgramId, newAdmin)
+```
+
+## `RewardManager.withdraw`
+
+The `Withdraw` API is used to withdraw ERC677 tokens earned in a reward safe to any other destination address -- it is simlar to a transfer function. The funds in the withdrawal will pay for the gas fees to execute the transaction. 
+
+```js
+let rewardManagerAPI = await getSDK(RewardManager, web3);
+await rewardManagerAPI.withdraw(rewardSafe , to, token, amount)
 ```
 
 ## `LayerOneOracle`

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -32,7 +32,7 @@ const SOKOL = {
   rpcNode: 'https://sokol.poa.network',
   rpcArchiveNode: 'https://sokol-archive.blockscout.com',
   rpcWssNode: 'wss://sokol.poa.network/wss',
-  relayServiceURL: 'https://relay-staging.stack.cards/api',
+  relayServiceURL: 'http://localhost:8000/api',
   subgraphURL: 'https://graph-staging.stack.cards/subgraphs/name/habdelra/cardpay-sokol',
   tallyServiceURL: 'https://tally-service-staging.stack.cards/api/v1',
   merchantUniLinkDomain: MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -32,7 +32,7 @@ const SOKOL = {
   rpcNode: 'https://sokol.poa.network',
   rpcArchiveNode: 'https://sokol-archive.blockscout.com',
   rpcWssNode: 'wss://sokol.poa.network/wss',
-  relayServiceURL: 'http://localhost:8000/api',
+  relayServiceURL: 'https://relay-staging.stack.cards/api',
   subgraphURL: 'https://graph-staging.stack.cards/subgraphs/name/habdelra/cardpay-sokol',
   tallyServiceURL: 'https://tally-service-staging.stack.cards/api/v1',
   merchantUniLinkDomain: MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -531,7 +531,7 @@ export default class RewardManager {
     }
 
     let rewardManager = await getSDK('RewardManager', this.layer2Web3);
-    let rewardManagerAddress = await this.address()
+    let rewardManagerAddress = await this.address();
 
     let from = contractOptions?.from ?? (await this.layer2Web3.eth.getAccounts())[0];
     let rewardSafeOwner = await rewardManager.getRewardSafeOwner(safeAddress);

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -2,10 +2,9 @@ import Web3 from 'web3';
 import RewardManagerABI from '../../contracts/abi/v0.8.5/reward-manager';
 import { Contract, ContractOptions } from 'web3-eth-contract';
 import { getAddress } from '../../contracts/addresses';
-import { AbiItem, randomHex, toChecksumAddress } from 'web3-utils';
+import { AbiItem, randomHex, toChecksumAddress, fromWei, toWei } from 'web3-utils';
 import { isTransactionHash, TransactionOptions, waitForSubgraphIndexWithTxnReceipt } from '../utils/general-utils';
 import { getSDK } from '../version-resolver';
-import { ContractOptions } from 'web3-eth-contract';
 import { TransactionReceipt } from 'web3-core';
 import {
   EventABI,
@@ -20,7 +19,6 @@ import {
   executeTransaction,
 } from '../utils/safe-utils';
 import { Signature, signPrepaidCardSendTx } from '../utils/signing-utils';
-import { getSDK } from '../version-resolver';
 import BN from 'bn.js';
 import ERC20ABI from '../../contracts/abi/erc-20';
 import { signRewardSafe, fullSignatureTxAsBytes, createEIP1271VerifyingData } from '../utils/signing-utils';
@@ -521,7 +519,7 @@ export default class RewardManager {
   ): Promise<TransactionReceipt> {
     if (isTransactionHash(safeAddressOrTxnHash)) {
       let txnHash = safeAddressOrTxnHash;
-      return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+      return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     }
     if (!safeAddressOrTxnHash) {
       throw new Error('safeAddress is required');
@@ -664,7 +662,7 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
     if (typeof onTxnHash === 'function') {
       await onTxnHash(gnosisTxn.ethereumTx.txHash);
     }
-    return await waitUntilTransactionMined(this.layer2Web3, gnosisTxn.ethereumTx.txHash);
+    return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, gnosisTxn.ethereumTx.txHash);
   }
 
   async address(): Promise<string> {

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -21,7 +21,7 @@ import {
 import { Signature, signPrepaidCardSendTx } from '../utils/signing-utils';
 import BN from 'bn.js';
 import ERC20ABI from '../../contracts/abi/erc-20';
-import { signRewardSafe, fullSignatureTxAsBytes, createEIP1271VerifyingData } from '../utils/signing-utils';
+import { signRewardSafe, signEIP1271SafeTxAsBytes, createEIP1271VerifyingData } from '../utils/signing-utils';
 import { ZERO_ADDRESS } from '../constants';
 import GnosisSafeABI from '../../contracts/abi/gnosis-safe';
 
@@ -581,7 +581,7 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
       tokenAddress
     );
 
-    let fullSignatureInnerExec = await fullSignatureTxAsBytes(
+    let fullSignatureInnerExec = await signEIP1271SafeTxAsBytes(
       this.layer2Web3,
       tokenAddress,
       0,
@@ -599,7 +599,7 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
     // for nested gnosis executions, gasEstimate() call will fail if we sign for incremented nonce within the inner gnosis execution
     // therefore, we intentionally sign for a NON-incremented  nonce so the relayer can return a gas estimate
 
-    let fullSignatureInnerExecNonIncrementingNonce = await fullSignatureTxAsBytes(
+    let fullSignatureInnerExecNonIncrementingNonce = await signEIP1271SafeTxAsBytes(
       this.layer2Web3,
       tokenAddress,
       0,

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -1,6 +1,5 @@
 import Web3 from 'web3';
 import RewardManagerABI from '../../contracts/abi/v0.8.5/reward-manager';
-import { Contract } from 'web3-eth-contract';
 import { Contract, ContractOptions } from 'web3-eth-contract';
 import { getAddress } from '../../contracts/addresses';
 import { AbiItem, randomHex, toChecksumAddress } from 'web3-utils';
@@ -17,12 +16,13 @@ import {
   executeSendWithRateLock,
   GnosisExecTx,
   executeSend,
+  gasEstimate,
+  executeTransaction,
 } from '../utils/safe-utils';
 import { Signature, signPrepaidCardSendTx } from '../utils/signing-utils';
 import { getSDK } from '../version-resolver';
 import BN from 'bn.js';
 import ERC20ABI from '../../contracts/abi/erc-20';
-import { gasEstimate, executeTransaction, getNextNonceFromEstimate } from '../utils/safe-utils';
 import { signRewardSafe, fullSignatureTxAsBytes, createEIP1271VerifyingData } from '../utils/signing-utils';
 import { ZERO_ADDRESS } from '../constants';
 import GnosisSafeABI from '../../contracts/abi/gnosis-safe';
@@ -500,6 +500,7 @@ export default class RewardManager {
 
   async getRewardProgramAdmin(rewardProgramId: string): Promise<string> {
     return await (await this.getRewardManager()).methods.rewardProgramAdmins(rewardProgramId).call();
+  }
 
   async withdraw(txnHash: string): Promise<TransactionReceipt>;
   async withdraw(

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -21,7 +21,7 @@ import {
 import { Signature, signPrepaidCardSendTx } from '../utils/signing-utils';
 import BN from 'bn.js';
 import ERC20ABI from '../../contracts/abi/erc-20';
-import { signRewardSafe, signEIP1271SafeTxAsBytes, createEIP1271VerifyingData } from '../utils/signing-utils';
+import { signRewardSafe, signSafeTxWithEIP1271AsBytes, createEIP1271VerifyingData } from '../utils/signing-utils';
 import { ZERO_ADDRESS } from '../constants';
 import GnosisSafeABI from '../../contracts/abi/gnosis-safe';
 
@@ -581,7 +581,7 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
       tokenAddress
     );
 
-    let fullSignatureInnerExec = await signEIP1271SafeTxAsBytes(
+    let fullSignatureInnerExec = await signSafeTxWithEIP1271AsBytes(
       this.layer2Web3,
       tokenAddress,
       0,
@@ -599,7 +599,7 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
     // for nested gnosis executions, gasEstimate() call will fail if we sign for incremented nonce within the inner gnosis execution
     // therefore, we intentionally sign for a NON-incremented  nonce so the relayer can return a gas estimate
 
-    let fullSignatureInnerExecNonIncrementingNonce = await signEIP1271SafeTxAsBytes(
+    let fullSignatureInnerExecNonIncrementingNonce = await signSafeTxWithEIP1271AsBytes(
       this.layer2Web3,
       tokenAddress,
       0,

--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -377,7 +377,7 @@ The reward program ${rewardProgramId} has balance equals ${fromWei(
       .encodeABI();
     let estimate = await gasEstimate(this.layer2Web3, safeAddress, rewardPoolAddress, '0', payload, 0, tokenAddress);
 
-    let gasCost = new BN(estimate.dataGas).add(new BN(estimate.baseGas)).mul(new BN(estimate.gasPrice));
+    let gasCost = new BN(estimate.safeTxGas).add(new BN(estimate.baseGas)).mul(new BN(estimate.gasPrice));
     if (weiAmount.lt(gasCost)) {
       throw new Error(
         `Reward safe does not have enough to pay for gas when claiming rewards. The reward safe ${safeAddress} unclaimed balance for token ${tokenAddress} is ${fromWei(

--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -87,8 +87,8 @@ export default class RewardPool {
 
   async getProofs(
     address: string,
-    tokenAddress?: string,
     rewardProgramId?: string,
+    tokenAddress?: string,
     offset?: number,
     limit?: number
   ): Promise<Proof[]> {
@@ -124,7 +124,7 @@ export default class RewardPool {
     tokenAddress?: string
   ): Promise<ProofWithBalance[]> {
     let rewardPool = await this.getRewardPool();
-    let proofs = await this.getProofs(address, tokenAddress, rewardProgramId);
+    let proofs = await this.getProofs(address, rewardProgramId, tokenAddress);
     const tokenAddresses = [...new Set(proofs.map((item) => item.tokenAddress))];
     let tokenMapping = await this.tokenSymbolMapping(tokenAddresses);
     return await Promise.all(
@@ -165,7 +165,7 @@ export default class RewardPool {
     }
     const tokenContract = new this.layer2Web3.eth.Contract(ERC20ABI as AbiItem[], tokenAddress);
     let tokenSymbol = await tokenContract.methods.symbol().call();
-    let proofs = await this.getProofs(address, tokenAddress, rewardProgramId);
+    let proofs = await this.getProofs(address, rewardProgramId, tokenAddress);
 
     let rewardPool = await this.getRewardPool();
     let ungroupedTokenBalance = await Promise.all(

--- a/packages/cardpay-sdk/sdk/utils/signing-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/signing-utils.ts
@@ -135,7 +135,7 @@ export async function signSafeTxAsBytes(
   return [await signTypedData(web3, owner, typedData)];
 }
 
-export async function signEIP1271SafeTxAsBytes(
+export async function signSafeTxWithEIP1271AsBytes(
   web3: Web3,
   to: string,
   value: number,

--- a/packages/cardpay-sdk/sdk/utils/signing-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/signing-utils.ts
@@ -135,7 +135,7 @@ export async function signSafeTxAsBytes(
   return [await signTypedData(web3, owner, typedData)];
 }
 
-export async function fullSignatureTxAsBytes(
+export async function signEIP1271SafeTxAsBytes(
   web3: Web3,
   to: string,
   value: number,


### PR DESCRIPTION
- sdk to withdraw funds to safe owner
   - handles tricky thing of signing with a non-incremented nonce purely for gas estimation
   - relies on [change in relayer](https://github.com/cardstack/card-protocol-relay-service/pull/43)
   -  **Context of main problem:** `CannotEstimateGas` error occured due to failing gas esimate calls on the relayer -- the calls which use `requiredTxGas`. The `requiredTxGas` failed bcos it ran a simulation call which is different from the outer execution of the gnosis safe. The incremented nonce signed for the inner execution was not valid because there was NO outer execution of the gnosis safe, ie there was no outer execution to simulate the increase of the nonce.