### PR TITLE
Fix/websocket stuff

### DIFF
--- a/packages/web-client/app/components/card-pay/network-problem-modal/index.css
+++ b/packages/web-client/app/components/card-pay/network-problem-modal/index.css
@@ -1,20 +1,20 @@
-.chain-change-modal {
-  --chain-change-modal-max-width: 36.25rem; /* 580px */
+.network-problem-modal {
+  --network-problem-modal-max-width: 36.25rem; /* 580px */
   --boxel-modal-max-width: unset;
   /* stylelint-disable-next-line length-zero-no-unit */
   --boxel-modal-offset-top: 0px; /* Do not remove the px here. It would break the `calc` calculation for the scroll. */
 }
 
-.chain-change-modal > div {
+.network-problem-modal > div {
   width: auto;
   display: flex;
   align-items: center;
   margin: 0 var(--boxel-sp-lg);
 }
 
-.chain-change-modal__scroll-wrapper {
+.network-problem-modal__scroll-wrapper {
   width: 100%;
-  max-width: var(--chain-change-modal-max-width);
+  max-width: var(--network-problem-modal-max-width);
   height: auto;
   max-height: 100%;
   margin: auto;
@@ -24,12 +24,12 @@
 }
 
 @media screen and (max-width: 40rem) {
-  .chain-change-modal__scroll-wrapper {
+  .network-problem-modal__scroll-wrapper {
     min-width: unset;
   }
 }
 
-.chain-change-modal__card {
+.network-problem-modal__card {
   position: relative;
   padding: var(--boxel-sp-xxl) var(--boxel-sp-lg);
   display: flex;
@@ -40,7 +40,7 @@
   outline-style: solid;
 }
 
-.chain-change-modal__card-title {
+.network-problem-modal__card-title {
   font: 700 1.125rem/calc(24 / 18) var(--boxel-font-family);
   letter-spacing: 0;
   display: flex;
@@ -48,11 +48,11 @@
   flex-flow: row nowrap;
 }
 
-.chain-change-modal__card-title-content {
+.network-problem-modal__card-title-content {
   flex-grow: 1;
 }
 
-.chain-change-modal__card-title-icon {
+.network-problem-modal__card-title-icon {
   margin-right: var(--boxel-sp-sm);
   flex-shrink: 0;
 }

--- a/packages/web-client/app/components/card-pay/network-problem-modal/index.hbs
+++ b/packages/web-client/app/components/card-pay/network-problem-modal/index.hbs
@@ -1,11 +1,11 @@
 <Boxel::Modal
-  class="chain-change-modal"
+  class="network-problem-modal"
   @isOpen={{@isOpen}}
   @onClose={{@onClose}}
   @layer="urgent"
 >
   <div
-    class="chain-change-modal__scroll-wrapper"
+    class="network-problem-modal__scroll-wrapper"
     {{focus-trap
       focusTrapOptions=(hash
         allowOutsideClick=@dismissable
@@ -14,12 +14,12 @@
     }}
   >
     <Boxel::CardContainer
-      class="chain-change-modal__card"
+      class="network-problem-modal__card"
       tabindex="-1"
     >
-      <header class="chain-change-modal__card-title">
-          {{svg-jar "warning" class="chain-change-modal__card-title-icon" width="30" height="30"}}
-          <div class="chain-change-modal__card-title-content">
+      <header class="network-problem-modal__card-title">
+          {{svg-jar "warning" class="network-problem-modal__card-title-icon" width="30" height="30"}}
+          <div class="network-problem-modal__card-title-content">
             {{@title}}
           </div>
       </header>

--- a/packages/web-client/app/components/card-pay/network-problem-modal/index.hbs
+++ b/packages/web-client/app/components/card-pay/network-problem-modal/index.hbs
@@ -3,6 +3,8 @@
   @isOpen={{@isOpen}}
   @onClose={{@onClose}}
   @layer="urgent"
+  data-test-network-problem-modal
+  data-test-network-problem-modal-dismissable={{@dismissable}}
 >
   <div
     class="network-problem-modal__scroll-wrapper"
@@ -19,12 +21,14 @@
     >
       <header class="network-problem-modal__card-title">
           {{svg-jar "warning" class="network-problem-modal__card-title-icon" width="30" height="30"}}
-          <div class="network-problem-modal__card-title-content">
+          <div class="network-problem-modal__card-title-content" data-test-network-problem-modal-title>
             {{@title}}
           </div>
       </header>
-      {{@body}}
-      <Boxel::Button @kind="primary" {{on "click" (optional @action)}}>{{@actionText}}</Boxel::Button>
+      <div data-test-network-problem-modal-body>
+        {{@body}}
+      </div>
+      <Boxel::Button @kind="primary" {{on "click" (optional @action)}} data-test-network-problem-modal-action>{{@actionText}}</Boxel::Button>
     </Boxel::CardContainer>
   </div>
 </Boxel::Modal>

--- a/packages/web-client/app/controllers/card-pay.ts
+++ b/packages/web-client/app/controllers/card-pay.ts
@@ -7,7 +7,7 @@ import { tracked } from '@glimmer/tracking';
 import { currentNetworkDisplayInfo as c } from '../utils/web3-strategies/network-display-info';
 import config from '../config/environment';
 
-interface ChainChangeModalOptions {
+interface NetworkProblemModalOptions {
   title: string;
   body: string;
   actionText: string;
@@ -23,7 +23,7 @@ export default class CardPayController extends Controller {
   @tracked isShowingLayer1ConnectModal = false;
   @tracked isShowingLayer2ConnectModal = false;
   @tracked needsReload = false;
-  @tracked chainChangeModalOptions: ChainChangeModalOptions | null = null;
+  @tracked networkProblemModalOptions: NetworkProblemModalOptions | null = null;
 
   constructor() {
     super(...arguments);
@@ -46,11 +46,11 @@ export default class CardPayController extends Controller {
   }
 
   @action showNetworkUnstableModal(network: keyof typeof c) {
-    if (this.chainChangeModalOptions) return;
-    this.showChainChangeModal({
+    if (this.networkProblemModalOptions) return;
+    this.showNetworkProblemModal({
       title: `Disconnected from ${c[network].fullName}`,
       body: `Sorry! Card Pay is disconnected from ${c[network].fullName}. You can restore the connection by refreshing the page.`,
-      onClose: this.hideChainChangeModal,
+      onClose: this.hideNetworkProblemModal,
       action: () => window.open(config.urls.discordSupportChannelUrl, '_blank'),
       actionText: 'Contact Cardstack Support',
       dismissable: true,
@@ -60,7 +60,7 @@ export default class CardPayController extends Controller {
   @action
   onLayer1Incorrect() {
     this.needsReload = true;
-    this.showChainChangeModal({
+    this.showNetworkProblemModal({
       title: `Please connect to ${c.layer1.fullName}`,
       body: `Card Pay uses ${c.layer1.fullName} as its Layer 1 network. To ensure the safety of your assets and transactions, this page will reload as soon as you change your wallet’s network to ${c.layer1.fullName} or disconnect your wallet.`,
       onClose: () => {},
@@ -73,12 +73,12 @@ export default class CardPayController extends Controller {
   @action
   onLayer2Incorrect() {
     // don't allow layer 2 modal options to override layer 1
-    if (this.chainChangeModalOptions) return;
-    this.showChainChangeModal({
+    if (this.networkProblemModalOptions) return;
+    this.showNetworkProblemModal({
       title: `Please connect to ${c.layer2.fullName}`,
       body: `Card Pay uses ${c.layer2.fullName} as its Layer 2 network. To ensure the safety of your assets and transactions, we’ve disconnected your wallet. You can restart any incomplete workflows after reconnecting with ${c.layer2.fullName}.`,
-      onClose: this.hideChainChangeModal,
-      action: this.hideChainChangeModal,
+      onClose: this.hideNetworkProblemModal,
+      action: this.hideNetworkProblemModal,
       actionText: 'Dismiss',
       dismissable: true,
     });
@@ -94,13 +94,13 @@ export default class CardPayController extends Controller {
   }
 
   @action
-  showChainChangeModal(options: ChainChangeModalOptions) {
-    this.chainChangeModalOptions = options;
+  showNetworkProblemModal(options: NetworkProblemModalOptions) {
+    this.networkProblemModalOptions = options;
   }
 
   @action
-  hideChainChangeModal() {
-    this.chainChangeModalOptions = null;
+  hideNetworkProblemModal() {
+    this.networkProblemModalOptions = null;
   }
 
   @action transitionTo(routeName: string) {

--- a/packages/web-client/app/controllers/card-pay.ts
+++ b/packages/web-client/app/controllers/card-pay.ts
@@ -5,6 +5,7 @@ import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { tracked } from '@glimmer/tracking';
 import { currentNetworkDisplayInfo as c } from '../utils/web3-strategies/network-display-info';
+import config from '../config/environment';
 
 interface ChainChangeModalOptions {
   title: string;
@@ -14,17 +15,6 @@ interface ChainChangeModalOptions {
   onClose: Function;
   dismissable: boolean;
 }
-
-const networkCorrectionMessages = {
-  layer1: {
-    title: `Please connect to ${c.layer1.fullName}`,
-    body: `Card Pay uses ${c.layer1.fullName} as its Layer 1 network. To ensure the safety of your assets and transactions, this page will reload as soon as you change your wallet’s network to ${c.layer1.fullName} or disconnect your wallet.`,
-  },
-  layer2: {
-    title: `Please connect to ${c.layer2.fullName}`,
-    body: `Card Pay uses ${c.layer2.fullName} as its Layer 2 network. To ensure the safety of your assets and transactions, we’ve disconnected your wallet. You can restart any incomplete workflows after reconnecting with ${c.layer2.fullName}.`,
-  },
-};
 
 export default class CardPayController extends Controller {
   cardPayLogo = '/images/icons/card-pay-logo.svg';
@@ -41,19 +31,38 @@ export default class CardPayController extends Controller {
     this.layer1Network.on('correct-chain', this.maybeReload);
     this.layer1Network.on('disconnect', this.maybeReload);
     this.layer1Network.on('incorrect-chain', this.onLayer1Incorrect);
+    this.layer1Network.on('websocket-disconnected', () =>
+      this.showNetworkUnstableModal('layer1')
+    );
 
     this.layer2Network.on('incorrect-chain', this.onLayer2Incorrect);
+    this.layer2Network.on('websocket-disconnected', () =>
+      this.showNetworkUnstableModal('layer2')
+    );
   }
 
   @action disconnectLayer1() {
     this.layer1Network.disconnect();
   }
 
+  @action showNetworkUnstableModal(network: keyof typeof c) {
+    if (this.chainChangeModalOptions) return;
+    this.showChainChangeModal({
+      title: `Disconnected from ${c[network].fullName}`,
+      body: `Sorry! Card Pay is disconnected from ${c[network].fullName}. You can restore the connection by refreshing the page.`,
+      onClose: this.hideChainChangeModal,
+      action: () => window.open(config.urls.discordSupportChannelUrl, '_blank'),
+      actionText: 'Contact Cardstack Support',
+      dismissable: true,
+    });
+  }
+
   @action
   onLayer1Incorrect() {
     this.needsReload = true;
     this.showChainChangeModal({
-      ...networkCorrectionMessages.layer1,
+      title: `Please connect to ${c.layer1.fullName}`,
+      body: `Card Pay uses ${c.layer1.fullName} as its Layer 1 network. To ensure the safety of your assets and transactions, this page will reload as soon as you change your wallet’s network to ${c.layer1.fullName} or disconnect your wallet.`,
       onClose: () => {},
       action: this.disconnectLayer1,
       actionText: 'Disconnect and Reload',
@@ -66,7 +75,8 @@ export default class CardPayController extends Controller {
     // don't allow layer 2 modal options to override layer 1
     if (this.chainChangeModalOptions) return;
     this.showChainChangeModal({
-      ...networkCorrectionMessages.layer2,
+      title: `Please connect to ${c.layer2.fullName}`,
+      body: `Card Pay uses ${c.layer2.fullName} as its Layer 2 network. To ensure the safety of your assets and transactions, we’ve disconnected your wallet. You can restart any incomplete workflows after reconnecting with ${c.layer2.fullName}.`,
       onClose: this.hideChainChangeModal,
       action: this.hideChainChangeModal,
       actionText: 'Dismiss',

--- a/packages/web-client/app/controllers/card-pay.ts
+++ b/packages/web-client/app/controllers/card-pay.ts
@@ -32,12 +32,12 @@ export default class CardPayController extends Controller {
     this.layer1Network.on('disconnect', this.maybeReload);
     this.layer1Network.on('incorrect-chain', this.onLayer1Incorrect);
     this.layer1Network.on('websocket-disconnected', () =>
-      this.showNetworkUnstableModal('layer1')
+      this.showWebsocketDisconnectedModal('layer1')
     );
 
     this.layer2Network.on('incorrect-chain', this.onLayer2Incorrect);
     this.layer2Network.on('websocket-disconnected', () =>
-      this.showNetworkUnstableModal('layer2')
+      this.showWebsocketDisconnectedModal('layer2')
     );
   }
 
@@ -45,7 +45,7 @@ export default class CardPayController extends Controller {
     this.layer1Network.disconnect();
   }
 
-  @action showNetworkUnstableModal(network: keyof typeof c) {
+  @action showWebsocketDisconnectedModal(network: keyof typeof c) {
     if (this.networkProblemModalOptions) return;
     this.showNetworkProblemModal({
       title: `Disconnected from ${c[network].fullName}`,

--- a/packages/web-client/app/services/layer1-network.ts
+++ b/packages/web-client/app/services/layer1-network.ts
@@ -68,6 +68,7 @@ export default class Layer1Network
     this.strategy.on('account-changed', this.onAccountChanged);
     this.strategy.on('incorrect-chain', this.onIncorrectChain);
     this.strategy.on('correct-chain', this.onCorrectChain);
+    this.strategy.on('websocket-disconnected', this.onWebsocketDisconnected);
   }
 
   connect(walletProvider: WalletProvider) {
@@ -85,6 +86,10 @@ export default class Layer1Network
 
   @action onIncorrectChain() {
     this.simpleEmitter.emit('incorrect-chain');
+  }
+
+  @action onWebsocketDisconnected() {
+    this.simpleEmitter.emit('websocket-disconnected');
   }
 
   @action onCorrectChain() {

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -88,6 +88,7 @@ export default class Layer2Network
     this.strategy.on('disconnect', this.onDisconnect);
     this.strategy.on('incorrect-chain', this.onIncorrectChain);
     this.strategy.on('account-changed', this.onAccountChanged);
+    this.strategy.on('websocket-disconnected', this.onWebsocketDisconnected);
 
     taskFor(this.strategy.initializeTask)
       .perform()
@@ -227,6 +228,10 @@ export default class Layer2Network
 
   @action onAccountChanged() {
     this.simpleEmitter.emit('account-changed');
+  }
+
+  @action onWebsocketDisconnected() {
+    this.simpleEmitter.emit('websocket-disconnected');
   }
 
   on(event: Layer2ChainEvent, cb: Function): UnbindEventListener {

--- a/packages/web-client/app/templates/card-pay.hbs
+++ b/packages/web-client/app/templates/card-pay.hbs
@@ -45,15 +45,15 @@
   @isLayerConnected={{this.layer2Network.isConnected}}
 />
 
-{{#if this.chainChangeModalOptions}}
-  <CardPay::ChainChangeModal
+{{#if this.networkProblemModalOptions}}
+  <CardPay::NetworkProblemModal
     @isOpen={{true}}
-    @title={{this.chainChangeModalOptions.title}}
-    @body={{this.chainChangeModalOptions.body}}
-    @actionText={{this.chainChangeModalOptions.actionText}}
-    @action={{this.chainChangeModalOptions.action}}
-    @onClose={{this.chainChangeModalOptions.onClose}}
-    @dismissable={{this.chainChangeModalOptions.dismissable}}
+    @title={{this.networkProblemModalOptions.title}}
+    @body={{this.networkProblemModalOptions.body}}
+    @actionText={{this.networkProblemModalOptions.actionText}}
+    @action={{this.networkProblemModalOptions.action}}
+    @onClose={{this.networkProblemModalOptions.onClose}}
+    @dismissable={{this.networkProblemModalOptions.dismissable}}
   />
 {{/if}}
 

--- a/packages/web-client/app/utils/wc-provider.ts
+++ b/packages/web-client/app/utils/wc-provider.ts
@@ -525,6 +525,10 @@ class WalletConnectProvider extends ExtendedProviderEngine {
   }
 
   async maybeReconnect() {
+    // setTimeout is needed to delay execution of this code until the
+    // websocket provider has finished the callback for its close event,
+    // because part of that callback includes clearing all event listeners attached to it.
+    // We need to reattach the event listeners after that completes.
     setTimeout(() => {
       try {
         console.log('attempting websocket reconnection');

--- a/packages/web-client/app/utils/wc-provider.ts
+++ b/packages/web-client/app/utils/wc-provider.ts
@@ -37,6 +37,8 @@ export interface ICardstackWalletConnectProviderOptions
   rpcWss: IRPCMap;
 }
 
+const MIN_RECONNECTION_INTERVAL = 5000;
+
 class WalletConnectProvider extends ExtendedProviderEngine {
   public bridge = 'https://bridge.walletconnect.org';
   public qrcode = true;
@@ -55,6 +57,7 @@ class WalletConnectProvider extends ExtendedProviderEngine {
   public websocketProvider!: TypedWebsocketProviderWithConstructor;
   public networkId!: number;
   public infuraId?: string;
+  private lastReconnection = -Infinity;
 
   constructor(opts: ICardstackWalletConnectProviderOptions) {
     super({
@@ -81,8 +84,7 @@ class WalletConnectProvider extends ExtendedProviderEngine {
     this.rpcWss = rpcWss;
     this.chainId = chainId;
     this.websocketProvider = websocketProvider;
-    this.websocketProvider.on('close', this.onWebsocketClose.bind(this));
-    this.websocketProvider.on('connect', this.onWebsocketConnect.bind(this));
+    this.bindSocketListeners();
     this.bridge = opts.connector
       ? opts.connector.bridge
       : opts.bridge || 'https://bridge.walletconnect.org';
@@ -517,6 +519,29 @@ class WalletConnectProvider extends ExtendedProviderEngine {
     };
   }
 
+  bindSocketListeners() {
+    this.websocketProvider.on('close', this.onWebsocketClose.bind(this));
+    this.websocketProvider.on('connect', this.onWebsocketConnect.bind(this));
+  }
+
+  async maybeReconnect() {
+    setTimeout(() => {
+      try {
+        console.log('attempting websocket reconnection');
+        if (Date.now() - this.lastReconnection < MIN_RECONNECTION_INTERVAL) {
+          this.emit('websocket-disconnected');
+          return;
+        }
+        this.lastReconnection = Date.now();
+        this.websocketProvider.reset();
+        this.bindSocketListeners();
+        this.websocketProvider.connect();
+      } catch (e) {
+        this.emit('websocket-disconnected');
+      }
+    }, 0);
+  }
+
   async onWebsocketConnect() {
     console.log('websocket connected', this.websocketProvider.connection.url);
     Sentry.addBreadcrumb({
@@ -548,6 +573,7 @@ class WalletConnectProvider extends ExtendedProviderEngine {
         ? Sentry.Severity.Info
         : Sentry.Severity.Error,
     });
+    this.maybeReconnect();
   }
 }
 

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -26,7 +26,8 @@ interface ConnectionManagerOptions {
 type ConnectionManagerWalletEvent =
   | 'connected'
   | 'disconnected'
-  | 'chain-changed';
+  | 'chain-changed'
+  | 'websocket-disconnected';
 
 type ConnectionManagerCrossTabEvent = 'cross-tab-connection';
 
@@ -142,6 +143,7 @@ export class ConnectionManager {
     this.strategy.on('connected', this.onConnect);
     this.strategy.on('disconnected', this.onDisconnect);
     this.strategy.on('chain-changed', this.onChainChanged);
+    this.strategy.on('websocket-disconnected', this.onWebsocketDisconnected);
     await this.strategy.setup(session);
   }
 
@@ -207,6 +209,10 @@ export class ConnectionManager {
 
   @action onChainChanged(chainId: number) {
     this.emit('chain-changed', chainId);
+  }
+
+  @action onWebsocketDisconnected() {
+    this.emit('websocket-disconnected');
   }
 }
 
@@ -452,6 +458,7 @@ class WalletConnectConnectionStrategy extends ConnectionStrategy {
     });
 
     provider.on('websocket-disconnected', () => {
+      this.emit('websocket-disconnected');
       this.disconnect();
     });
 

--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -451,6 +451,10 @@ class WalletConnectConnectionStrategy extends ConnectionStrategy {
       this.onDisconnect(false);
     });
 
+    provider.on('websocket-disconnected', () => {
+      this.disconnect();
+    });
+
     this.provider = provider;
     return;
   }

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -83,6 +83,10 @@ export default abstract class Layer1ChainWeb3Strategy
       'cross-tab-connection',
       this.onCrossTabConnection
     );
+    this.connectionManager.on(
+      'websocket-disconnected',
+      this.onWebsocketDisconnected
+    );
     this.nativeTokenSymbol = getConstantByNetwork(
       'nativeTokenSymbol',
       this.networkSymbol
@@ -150,6 +154,11 @@ export default abstract class Layer1ChainWeb3Strategy
       this.simpleEmitter.emit('disconnect');
     }
     this.cleanupConnectionState();
+  }
+
+  @action
+  private onWebsocketDisconnected() {
+    this.simpleEmitter.emit('websocket-disconnected');
   }
 
   async reconnect() {

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -171,8 +171,8 @@ export default abstract class Layer2ChainWeb3Strategy
     });
 
     this.provider.on('websocket-disconnected', () => {
+      this.simpleEmitter.emit('websocket-disconnected');
       this.disconnect();
-      // this.simpleEmitter.emit('websocket-disconnected');
     });
 
     this.web3.setProvider(this.provider as any);

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -169,6 +169,12 @@ export default abstract class Layer2ChainWeb3Strategy
       },
       connector: new CustomStorageWalletConnect(connectorOptions, this.chainId),
     });
+
+    this.provider.on('websocket-disconnected', () => {
+      this.disconnect();
+      // this.simpleEmitter.emit('websocket-disconnected');
+    });
+
     this.web3.setProvider(this.provider as any);
 
     this.connector.on('display_uri', (err, payload) => {

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -24,12 +24,14 @@ export type Layer1ChainEvent =
   | 'disconnect'
   | 'incorrect-chain'
   | 'correct-chain'
-  | 'account-changed';
+  | 'account-changed'
+  | 'websocket-disconnected';
 export type Layer2ChainEvent =
   | 'disconnect'
   | 'incorrect-chain'
   | 'correct-chain'
-  | 'account-changed';
+  | 'account-changed'
+  | 'websocket-disconnected';
 
 export interface Web3Strategy {
   isConnected: boolean;

--- a/packages/web-client/tests/acceptance/network-problems-test.ts
+++ b/packages/web-client/tests/acceptance/network-problems-test.ts
@@ -1,0 +1,101 @@
+import { module, test } from 'qunit';
+import { settled, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
+import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
+
+import { createDepotSafe } from '@cardstack/web-client/utils/test-factories';
+
+const MODAL = '[data-test-network-problem-modal]';
+const MODAL_TITLE = '[data-test-network-problem-modal-title]';
+const MODAL_BODY = '[data-test-network-problem-modal-body]';
+const MODAL_ACTION = '[data-test-network-problem-modal-action]';
+
+const MODAL_IS_DISMISSABLE_ATTRIBUTE =
+  'data-test-network-problem-modal-dismissable';
+
+module('Acceptance | network-problems', function (hooks) {
+  setupApplicationTest(hooks);
+  let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
+  let layer2Service: Layer2TestWeb3Strategy;
+  let layer1Service: Layer1TestWeb3Strategy;
+
+  hooks.beforeEach(async function () {
+    layer2Service = this.owner.lookup('service:layer2-network')
+      .strategy as Layer2TestWeb3Strategy;
+    layer2Service.test__simulateRemoteAccountSafes(layer2AccountAddress, [
+      createDepotSafe({}),
+    ]);
+    await layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
+
+    let layer1AccountAddress = '0xaCD5f5534B756b856ae3B2CAcF54B3321dd6654Fb6';
+    layer1Service = this.owner.lookup('service:layer1-network')
+      .strategy as Layer1TestWeb3Strategy;
+    layer1Service.test__simulateAccountsChanged(
+      [layer1AccountAddress],
+      'metamask'
+    );
+
+    await visit('/card-pay/balances');
+  });
+
+  test('Layer 2 incorrect chain event triggers the showing of a modal', async function (assert) {
+    layer2Service.simpleEmitter.emit('incorrect-chain');
+
+    await settled();
+
+    assert.dom(MODAL_TITLE).containsText('Please connect to L2 test chain');
+    assert
+      .dom(MODAL_BODY)
+      .containsText(
+        'Card Pay uses L2 test chain as its Layer 2 network. To ensure the safety of your assets and transactions, we’ve disconnected your wallet. You can restart any incomplete workflows after reconnecting with L2 test chain.'
+      );
+    assert.dom(MODAL_ACTION).containsText('Dismiss');
+    assert.dom(MODAL).hasAttribute(MODAL_IS_DISMISSABLE_ATTRIBUTE);
+  });
+
+  test('Layer 1 incorrect chain event triggers the showing of a non-dismissable modal', async function (assert) {
+    layer1Service.simpleEmitter.emit('incorrect-chain');
+
+    await settled();
+
+    assert.dom(MODAL_TITLE).containsText('Please connect to L1 test chain');
+    assert
+      .dom(MODAL_BODY)
+      .containsText(
+        'Card Pay uses L1 test chain as its Layer 1 network. To ensure the safety of your assets and transactions, this page will reload as soon as you change your wallet’s network to L1 test chain or disconnect your wallet.'
+      );
+    assert.dom(MODAL_ACTION).containsText('Disconnect and Reload');
+    assert.dom(MODAL).doesNotHaveAttribute(MODAL_IS_DISMISSABLE_ATTRIBUTE);
+  });
+
+  test('Layer 2 websocket disconnected event triggers the showing of a modal', async function (assert) {
+    layer2Service.simpleEmitter.emit('websocket-disconnected');
+
+    await settled();
+
+    assert.dom(MODAL_TITLE).containsText('Disconnected from L2 test chain');
+    assert
+      .dom(MODAL_BODY)
+      .containsText(
+        'Sorry! Card Pay is disconnected from L2 test chain. You can restore the connection by refreshing the page.'
+      );
+    assert.dom(MODAL_ACTION).containsText('Contact Cardstack Support');
+    assert.dom(MODAL).hasAttribute(MODAL_IS_DISMISSABLE_ATTRIBUTE);
+  });
+
+  test('Layer 1 websocket disconnected event triggers the showing of a modal', async function (assert) {
+    layer1Service.simpleEmitter.emit('websocket-disconnected');
+
+    await settled();
+
+    assert.dom(MODAL_TITLE).containsText('Disconnected from L1 test chain');
+    assert
+      .dom(MODAL_BODY)
+      .containsText(
+        'Sorry! Card Pay is disconnected from L1 test chain. You can restore the connection by refreshing the page.'
+      );
+    assert.dom(MODAL_ACTION).containsText('Contact Cardstack Support');
+    assert.dom(MODAL).hasAttribute(MODAL_IS_DISMISSABLE_ATTRIBUTE);
+  });
+});


### PR DESCRIPTION
Try to reconnect to websockets if they disconnect. If that fails, we disconnect and display an error message.

![image](https://user-images.githubusercontent.com/39579264/140777270-e764693e-2682-4f07-8482-f1659132950b.png)

Coincidentally found out that this change should also fix the occasional issue with the DApp not responding when Card Wallet scans the Layer 2 QR code to connect - it happens when the websocket is disconnected, which happens after ~2 mins of inactivity.

https://github.com/cardstack/cardstack/pull/2359/commits/c0679fdc1731b902a0c972494f9a89dd08d3a03f is for removal, it provides a way to access one WalletConnect websocket via the console as `window.wsref`, in order to trigger closing of a websocket via `window.wsref.close()`. The implementation makes it hard to try this with Layer 1 and 2 connected via WalletConnect.

TODO:
- [x] tests - will try to fire the events to trigger websocket disconnection. 
- [ ] think about appropriate reconnection interval