### PR TITLE
update DApp tokens' displayed decimals

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/confirmation/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/confirmation/index.hbs
@@ -8,7 +8,7 @@
       @isLayer1={{true}}
       @link={{this.depositTxnViewerUrl}}
       @token={{this.depositedToken}}
-      @amount={{format-wei-amount this.depositedAmount}}
+      @amount={{format-wei-amount this.depositedAmount false}}
       @preposition="from"
       @walletAddress={{this.layer1Network.walletInfo.firstAddress}}
       data-test-deposit-confirmation-from
@@ -35,7 +35,7 @@
       @isLayer2={{true}}
       @link={{this.blockscoutUrl}}
       @token={{this.receivedToken}}
-      @amount={{format-wei-amount this.depositedAmount}}
+      @amount={{format-wei-amount this.depositedAmount false}}
       @preposition="in"
       @walletAddress={{this.layer2Network.walletInfo.firstAddress}}
       @depotAddress={{this.depotAddress}}

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -31,7 +31,7 @@
             class="transaction-amount__token"
             @size="large"
             @icon={{this.currentTokenDetails.icon}}
-            @balance={{format-wei-amount this.amountAsBigNumber}}
+            @balance={{format-wei-amount this.amountAsBigNumber false}}
             @symbol={{this.currentTokenSymbol}}
             @text={{concat (format-usd (token-to-usd this.currentTokenSymbol this.amountAsBigNumber)) "*"}}
             data-test-deposit-amount-entered

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/check-balance/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/check-balance/index.hbs
@@ -45,7 +45,7 @@
         <CardPay::BalanceDisplay
           @size="large"
           @icon={{this.nativeTokenDisplayInfo.icon}}
-          @balance={{format-wei-amount this.minimumBalanceForWithdrawalClaim}}
+          @balance={{format-wei-amount this.minimumBalanceForWithdrawalClaim false}}
           @symbol={{this.nativeTokenDisplayInfo.symbol}}
           @usdBalance={{token-to-usd 'ETH' this.minimumBalanceForWithdrawalClaim}}
         />

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
@@ -104,17 +104,20 @@ class CheckBalanceWorkflowMessage
       } in your account on ${
         c.layer1.fullName
       } to perform the last step of this withdrawal workflow, which requires ~${formatWeiAmount(
-        minimumBalanceForWithdrawalClaim
+        minimumBalanceForWithdrawalClaim,
+        false
       )} ${c.layer1.nativeTokenSymbol}.`;
     } else {
       return `Checking your balance...
 
       The last step of this withdrawal requires that you have at least **~${formatWeiAmount(
-        minimumBalanceForWithdrawalClaim
+        minimumBalanceForWithdrawalClaim,
+        false
       )} ${c.layer1.nativeTokenSymbol}**.
-      You only have **${formatWeiAmount(layer1Network.defaultTokenBalance)} ${
-        c.layer1.nativeTokenSymbol
-      }**. You will need to deposit more
+      You only have **${formatWeiAmount(
+        layer1Network.defaultTokenBalance,
+        false
+      )} ${c.layer1.nativeTokenSymbol}**. You will need to deposit more
       ${
         c.layer1.nativeTokenSymbol
       } to your account shown below to continue the withdrawal.`;

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.hbs
@@ -13,7 +13,7 @@
         class="token-claim__balance-display"
         @size="large"
         @icon={{this.tokenDetails.icon}}
-        @balance={{format-wei-amount this.withdrawalAmount}}
+        @balance={{format-wei-amount this.withdrawalAmount false}}
         @symbol={{this.tokenSymbol}}
         @text={{concat (format-usd (token-to-usd this.tokenSymbol this.withdrawalAmount)) "*"}}
         data-test-withdrawal-token-claim-amount

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
@@ -34,7 +34,7 @@
             class="withdrawal-transaction-amount__token"
             @size="large"
             @icon={{this.currentTokenDetails.icon}}
-            @balance={{format-wei-amount this.amountAsBigNumber}}
+            @balance={{format-wei-amount this.amountAsBigNumber false}}
             @symbol={{this.currentTokenSymbol}}
             @text={{concat (format-usd (token-to-usd this.currentTokenSymbol this.amountAsBigNumber)) "*"}}
             data-test-amount-entered

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-confirmed/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-confirmed/index.hbs
@@ -8,7 +8,7 @@
       @isLayer2={{true}}
       @link={{this.blockscoutUrl}}
       @token={{this.withdrawToken}}
-      @amount={{format-wei-amount this.withdrawnAmount}}
+      @amount={{format-wei-amount this.withdrawnAmount false}}
       @preposition="from"
       @walletAddress={{this.layer2Network.walletInfo.firstAddress}}
       @depotAddress={{this.depotAddress}}
@@ -35,7 +35,7 @@
       @isLayer1={{true}}
       @link={{this.withdrawTxnViewerUrl}}
       @token={{this.receivedToken}}
-      @amount={{format-wei-amount this.withdrawnAmount}}
+      @amount={{format-wei-amount this.withdrawnAmount false}}
       @preposition="in"
       @walletAddress={{this.layer1Network.walletInfo.firstAddress}}
       data-test-withdrawal-transaction-confirmed-to

--- a/packages/web-client/app/helpers/format-wei-amount.ts
+++ b/packages/web-client/app/helpers/format-wei-amount.ts
@@ -19,14 +19,17 @@ export function formatWeiAmount(
 
   const minDecimals = 2;
 
-  let result: string | number = Number(fromWei(amountInSmallestUnit));
+  let result: string = fromWei(amountInSmallestUnit);
   if (!round) {
-    // return the exact same amount of decimal places if truncation should not occur
+    // return the exact same amount of decimal places if rounding should not occur
     return formatCurrencyAmount(
       result,
       Math.max(countDecimalPlaces(result), minDecimals)
     );
-  } else if (Math.abs(result) > 0.0001 && Math.abs(result) < 1) {
+  } else if (
+    Math.abs(Number(result)) > 0.0001 &&
+    Math.abs(Number(result)) < 1
+  ) {
     result = handleSignificantDecimals(result, 2, 2);
     return formatCurrencyAmount(
       result,

--- a/packages/web-client/app/helpers/format-wei-amount.ts
+++ b/packages/web-client/app/helpers/format-wei-amount.ts
@@ -27,11 +27,17 @@ export function formatWeiAmount(
     valueInEther = initialValueInEther;
     decimals = Math.max(countDecimalPlaces(valueInEther), minDecimals);
   } else if (
-    // does not handle negative numbers currently.
-    Number(initialValueInEther) > 0.0001 &&
-    Number(initialValueInEther) < 1
+    Math.abs(Number(initialValueInEther)) > 0.0001 &&
+    Math.abs(Number(initialValueInEther)) < 1
   ) {
-    valueInEther = handleSignificantDecimals(initialValueInEther, 2, 2);
+    // handleSignificantDecimals doesn't work properly with numbers that are less than 0 && greater than -1
+    // There is a way to fix this in the SDK, but am being cautious about any "bug as a feature" use of this function
+    // This hack is temporary, until we address that
+    let isNegative = Number(initialValueInEther) < 0;
+    valueInEther = isNegative
+      ? '-' +
+        handleSignificantDecimals(initialValueInEther.replace(/^-/, ''), 2, 2)
+      : handleSignificantDecimals(initialValueInEther, 2, 2);
     decimals = Math.max(countDecimalPlaces(valueInEther), minDecimals);
   } else {
     valueInEther = initialValueInEther;

--- a/packages/web-client/app/helpers/format-wei-amount.ts
+++ b/packages/web-client/app/helpers/format-wei-amount.ts
@@ -19,26 +19,26 @@ export function formatWeiAmount(
 
   const minDecimals = 2;
 
-  let result: string = fromWei(amountInSmallestUnit);
+  let initialValueInEther: string = fromWei(amountInSmallestUnit);
+  let valueInEther: string;
+  let decimals: number;
+
   if (!round) {
-    // return the exact same amount of decimal places if rounding should not occur
-    return formatCurrencyAmount(
-      result,
-      Math.max(countDecimalPlaces(result), minDecimals)
-    );
+    valueInEther = initialValueInEther;
+    decimals = Math.max(countDecimalPlaces(valueInEther), minDecimals);
   } else if (
-    Math.abs(Number(result)) > 0.0001 &&
-    Math.abs(Number(result)) < 1
+    // does not handle negative numbers currently.
+    Number(initialValueInEther) > 0.0001 &&
+    Number(initialValueInEther) < 1
   ) {
-    result = handleSignificantDecimals(result, 2, 2);
-    return formatCurrencyAmount(
-      result,
-      Math.max(countDecimalPlaces(result), minDecimals)
-    );
+    valueInEther = handleSignificantDecimals(initialValueInEther, 2, 2);
+    decimals = Math.max(countDecimalPlaces(valueInEther), minDecimals);
   } else {
-    // by default, just truncate to 2 decimal places
-    return formatCurrencyAmount(result, minDecimals);
+    valueInEther = initialValueInEther;
+    decimals = minDecimals;
   }
+
+  return formatCurrencyAmount(valueInEther, decimals);
 }
 
 class FormatWeiAmountHelper extends Helper {

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -85,7 +85,7 @@ module('Acceptance | deposit', function (hooks) {
     });
 
     await waitFor(`${post} [data-test-balance="ETH"]`);
-    assert.dom(`${post} [data-test-balance="ETH"]`).containsText('2.1411');
+    assert.dom(`${post} [data-test-balance="ETH"]`).containsText('2.14');
     assert.dom(`${post} [data-test-balance="DAI"]`).containsText('250.50');
     assert.dom(`${post} [data-test-balance="CARD"]`).containsText('10,000.00');
 
@@ -324,7 +324,7 @@ module('Acceptance | deposit', function (hooks) {
     await waitFor(`${epiloguePostableSel(3)} [data-test-balance="ETH"]`);
     assert
       .dom(`${epiloguePostableSel(3)} [data-test-balance="ETH"]`)
-      .containsText('2.1411');
+      .containsText('2.14');
     assert
       .dom(`${epiloguePostableSel(3)} [data-test-balance="DAI"]`)
       .containsText('0.50');
@@ -735,7 +735,7 @@ module('Acceptance | deposit', function (hooks) {
     assert
       .dom(postableSel(2, 0))
       .containsText('choose the asset you would like to deposit');
-    assert.dom('[data-test-layer-2-wallet-card]').containsText('0.1422');
+    assert.dom('[data-test-layer-2-wallet-card]').containsText('0.14');
     assert
       .dom(
         '[data-test-layer-2-wallet-card] [data-test-layer-2-wallet-disconnect-button]'
@@ -820,7 +820,7 @@ module('Acceptance | deposit', function (hooks) {
     assert
       .dom(postableSel(2, 0))
       .containsText('choose the asset you would like to deposit');
-    assert.dom('[data-test-layer-2-wallet-card]').containsText('0.1422');
+    assert.dom('[data-test-layer-2-wallet-card]').containsText('0.14');
     assert
       .dom(
         '[data-test-layer-2-wallet-card] [data-test-layer-2-wallet-disconnect-button]'

--- a/packages/web-client/tests/acceptance/deposit-withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-withdrawal-test.ts
@@ -60,10 +60,10 @@ module('Acceptance | deposit and withdrawal', function (hooks) {
       .containsText(`$116.41 USD`);
     assert
       .dom('[data-test-card-pay-depot-token="DAI.CPXD"]')
-      .containsText('14.1422987 DAI.CPXD');
+      .containsText('14.14 DAI.CPXD');
     assert
       .dom('[data-test-card-pay-depot-token="CARD.CPXD"]')
-      .containsText('567.8991 CARD.CPXD');
+      .containsText('567.90 CARD.CPXD');
     assert
       .dom('[data-test-card-pay-depot-token="DAI.CPXD"]')
       .containsText('$2.83 USD');

--- a/packages/web-client/tests/acceptance/withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-test.ts
@@ -76,7 +76,7 @@ module('Acceptance | withdrawal', function (hooks) {
       card: new BN('10000000000000000000000'),
     });
     await waitFor(`${post} [data-test-balance="ETH"]`);
-    assert.dom(`${post} [data-test-balance="ETH"]`).containsText('2.1411');
+    assert.dom(`${post} [data-test-balance="ETH"]`).containsText('2.14');
     assert.dom(`${post} [data-test-balance="DAI"]`).containsText('150.50');
     assert.dom(`${post} [data-test-balance="CARD"]`).containsText('10,000.00');
     await settled();

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-amount-test.ts
@@ -78,7 +78,7 @@ module(
       assert.dom('[data-test-withdrawal-source]').containsText(depotAddress);
       assert
         .dom('[data-test-withdrawal-balance]')
-        .containsText(`${startDaiAmountString} DAI.CPXD`);
+        .containsText(`100.11 DAI.CPXD`);
     });
 
     test('the amount is marked invalid when a value is entered and then cleared', async function (assert) {

--- a/packages/web-client/tests/integration/components/layer-one-connect-card-test.ts
+++ b/packages/web-client/tests/integration/components/layer-one-connect-card-test.ts
@@ -64,7 +64,7 @@ module('Integration | Component | layer-one-connect-card', function (hooks) {
         <CardPay::LayerOneConnectCard/>
       `);
 
-    assert.dom('[data-test-balance="ETH"]').containsText('2.1411');
+    assert.dom('[data-test-balance="ETH"]').containsText('2.14');
     assert.dom('[data-test-balance="DAI"]').containsText('0.50');
     assert.dom('[data-test-balance="CARD"]').containsText('10,000.00');
 

--- a/packages/web-client/tests/integration/components/layer-two-connect-card-test.ts
+++ b/packages/web-client/tests/integration/components/layer-two-connect-card-test.ts
@@ -42,7 +42,7 @@ module('Integration | Component | layer-two-connect-card', function (hooks) {
       <CardPay::LayerTwoConnectCard @workflowSession={{this.session}} />
     `);
 
-    assert.dom('[data-test-balance="DAI.CPXD"]').containsText('2.1411');
+    assert.dom('[data-test-balance="DAI.CPXD"]').containsText('2.14');
     assert.dom('[data-test-balance="CARD.CPXD"]').doesNotExist();
 
     layer2Service.test__simulateRemoteAccountSafes('address', [
@@ -57,7 +57,7 @@ module('Integration | Component | layer-two-connect-card', function (hooks) {
     await layer2Service.safes.fetch();
     await waitFor('[data-test-balance="CARD.CPXD"]');
 
-    assert.dom('[data-test-balance="DAI.CPXD"]').containsText('2.1411');
+    assert.dom('[data-test-balance="DAI.CPXD"]').containsText('2.14');
     assert.dom('[data-test-balance="CARD.CPXD"]').containsText('2.99');
 
     layer2Service.test__simulateRemoteAccountSafes('address', [

--- a/packages/web-client/tests/integration/helpers/format-wei-amount-test.ts
+++ b/packages/web-client/tests/integration/helpers/format-wei-amount-test.ts
@@ -8,49 +8,43 @@ import BN from 'bn.js';
 module('Integration | Helper | format-wei-amount', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('It should by default return values with exactly 2 decimal places if they are > 1 or < -1', async function (assert) {
-    this.set('inputValue', toWei(new BN('1')));
-    this.set('round', false);
-    await render(hbs`{{format-wei-amount this.inputValue this.round}}`);
-    assert.dom(this.element).hasText('1.00');
+  for (let round of [true, false]) {
+    test(`${
+      round ? 'rounded' : 'not rounded'
+    }: it should return values with at least 2 decimal places`, async function (assert) {
+      this.set('inputValue', toWei(new BN('1')));
+      this.set('round', round);
 
-    this.set('round', true);
-    assert.dom(this.element).hasText('1.00');
+      await render(hbs`{{format-wei-amount this.inputValue this.round}}`);
+      assert.dom(this.element).hasText('1.00');
 
-    this.set('inputValue', toWei(new BN('11')).div(new BN('10')));
-    assert.dom(this.element).hasText('1.10');
+      this.set('inputValue', toWei(new BN('11')).div(new BN('10')));
+      assert.dom(this.element).hasText('1.10');
+    });
 
-    this.set('inputValue', toWei(new BN('111')).div(new BN('100')));
-    assert.dom(this.element).hasText('1.11');
+    test(`${
+      round ? 'rounded' : 'not rounded'
+    }: it should return values with separators`, async function (assert) {
+      this.set('inputValue', toWei(new BN('1000')));
+      this.set('round', round);
 
-    this.set('inputValue', toWei(new BN('-11')).div(new BN('10')));
-    assert.dom(this.element).hasText('-1.10');
+      await render(hbs`{{format-wei-amount this.inputValue this.round}}`);
+      assert.dom(this.element).hasText('1,000.00');
+    });
+  }
 
-    this.set('inputValue', toWei(new BN('-111')).div(new BN('100')));
-    assert.dom(this.element).hasText('-1.11');
-  });
-
-  test('It should return a precise value up to 18 decimals if round is false', async function (assert) {
+  test('not rounded: It should return a precise value up to 18 decimals', async function (assert) {
     this.set('inputValue', new BN('123456789123456789'));
     this.set('round', false);
     await render(hbs`{{format-wei-amount this.inputValue this.round}}`);
     assert.dom(this.element).hasText('0.123456789123456789');
   });
 
-  test('It should have a minDecimals of 2 if an invalid minDecimals is provided', async function (assert) {
-    this.set('inputValue', toWei(new BN('1')));
-    this.set('minDecimals', 'beep');
-    await render(hbs`{{format-wei-amount this.inputValue this.minDecimals}}`);
+  test('rounded: It should return a value with 2 significant digits for small but significant numbers (> 0.0001)', async function (assert) {
+    this.set('inputValue', new BN('123000000000000'));
+    this.set('round', true);
 
-    assert.dom(this.element).hasText('1.00');
-
-    this.set('minDecimals', -30);
-    assert.dom(this.element).hasText('1.00');
-  });
-
-  test('It should render separator commas if amount is 1000 or greater', async function (assert) {
-    this.set('inputValue', toWei(new BN('1000')));
-    await render(hbs`{{format-wei-amount this.inputValue}}`);
-    assert.dom(this.element).hasText('1,000.00');
+    await render(hbs`{{format-wei-amount this.inputValue this.round}}`);
+    assert.dom(this.element).hasText('0.00012');
   });
 });

--- a/packages/web-client/tests/integration/helpers/format-wei-amount-test.ts
+++ b/packages/web-client/tests/integration/helpers/format-wei-amount-test.ts
@@ -8,39 +8,33 @@ import BN from 'bn.js';
 module('Integration | Helper | format-wei-amount', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('It should return a precise value up to 18 decimals', async function (assert) {
-    this.set('inputValue', new BN('123456789123456789'));
-    await render(hbs`{{format-wei-amount this.inputValue}}`);
-    assert.dom(this.element).hasText('0.123456789123456789');
-  });
-
-  test('It should add zeros to fulfil the required precision', async function (assert) {
+  test('It should by default return values with exactly 2 decimal places if they are > 1 or < -1', async function (assert) {
     this.set('inputValue', toWei(new BN('1')));
-    this.set('minDecimals', 1);
-    await render(hbs`{{format-wei-amount this.inputValue this.minDecimals}}`);
-    assert.dom(this.element).hasText('1.0');
-
-    this.set('minDecimals', 2);
+    this.set('round', false);
+    await render(hbs`{{format-wei-amount this.inputValue this.round}}`);
     assert.dom(this.element).hasText('1.00');
-  });
 
-  test('It should respect existing non-zero floating decimals when adding zeros', async function (assert) {
-    // 1.1
+    this.set('round', true);
+    assert.dom(this.element).hasText('1.00');
+
     this.set('inputValue', toWei(new BN('11')).div(new BN('10')));
-    this.set('minDecimals', 3);
-    await render(hbs`{{format-wei-amount this.inputValue this.minDecimals}}`);
-    assert.dom(this.element).hasText('1.100');
+    assert.dom(this.element).hasText('1.10');
 
-    // 1.11
     this.set('inputValue', toWei(new BN('111')).div(new BN('100')));
-    assert.dom(this.element).hasText('1.110');
+    assert.dom(this.element).hasText('1.11');
+
+    this.set('inputValue', toWei(new BN('-11')).div(new BN('10')));
+    assert.dom(this.element).hasText('-1.10');
+
+    this.set('inputValue', toWei(new BN('-111')).div(new BN('100')));
+    assert.dom(this.element).hasText('-1.11');
   });
 
-  test('It should have a minDecimals of 2 by default', async function (assert) {
-    this.set('inputValue', toWei(new BN('1')));
-    await render(hbs`{{format-wei-amount this.inputValue}}`);
-
-    assert.dom(this.element).hasText('1.00');
+  test('It should return a precise value up to 18 decimals if round is false', async function (assert) {
+    this.set('inputValue', new BN('123456789123456789'));
+    this.set('round', false);
+    await render(hbs`{{format-wei-amount this.inputValue this.round}}`);
+    assert.dom(this.element).hasText('0.123456789123456789');
   });
 
   test('It should have a minDecimals of 2 if an invalid minDecimals is provided', async function (assert) {
@@ -52,13 +46,6 @@ module('Integration | Helper | format-wei-amount', function (hooks) {
 
     this.set('minDecimals', -30);
     assert.dom(this.element).hasText('1.00');
-  });
-
-  test('It should not add floating zeros if minDecimals is 0', async function (assert) {
-    this.set('inputValue', toWei(new BN('1')));
-    this.set('minDecimals', 0);
-    await render(hbs`{{format-wei-amount this.inputValue this.minDecimals}}`);
-    assert.dom(this.element).hasText('1');
   });
 
   test('It should render separator commas if amount is 1000 or greater', async function (assert) {

--- a/packages/web-client/tests/integration/helpers/format-wei-amount-test.ts
+++ b/packages/web-client/tests/integration/helpers/format-wei-amount-test.ts
@@ -20,6 +20,12 @@ module('Integration | Helper | format-wei-amount', function (hooks) {
 
       this.set('inputValue', toWei(new BN('11')).div(new BN('10')));
       assert.dom(this.element).hasText('1.10');
+
+      this.set('inputValue', toWei(new BN('-1')));
+      assert.dom(this.element).hasText('-1.00');
+
+      this.set('inputValue', toWei(new BN('-11')).div(new BN('10')));
+      assert.dom(this.element).hasText('-1.10');
     });
 
     test(`${
@@ -30,6 +36,9 @@ module('Integration | Helper | format-wei-amount', function (hooks) {
 
       await render(hbs`{{format-wei-amount this.inputValue this.round}}`);
       assert.dom(this.element).hasText('1,000.00');
+
+      this.set('inputValue', toWei(new BN('-1000')));
+      assert.dom(this.element).hasText('-1,000.00');
     });
   }
 
@@ -38,6 +47,9 @@ module('Integration | Helper | format-wei-amount', function (hooks) {
     this.set('round', false);
     await render(hbs`{{format-wei-amount this.inputValue this.round}}`);
     assert.dom(this.element).hasText('0.123456789123456789');
+
+    this.set('inputValue', new BN('-123456789123456789'));
+    assert.dom(this.element).hasText('-0.123456789123456789');
   });
 
   test('rounded: It should return a value with 2 significant digits for small but significant numbers (> 0.0001)', async function (assert) {
@@ -46,5 +58,8 @@ module('Integration | Helper | format-wei-amount', function (hooks) {
 
     await render(hbs`{{format-wei-amount this.inputValue this.round}}`);
     assert.dom(this.element).hasText('0.00012');
+
+    this.set('inputValue', new BN('-123000000000000'));
+    assert.dom(this.element).hasText('-0.00012');
   });
 });


### PR DESCRIPTION
With this change,`format-wei-amount` will, in addition to adding separator commas: 

- round any amounts > 1 to 2 decimal places
- round amounts < 1 and > 0.0001 to 2 significant digits
- round amounts < 0.0001 to 0

(units are in ether)

This behaviour can be turned off by providing `false` as a second argument to `format-wei-amount`, in which case `format-wei-amount` simply serves to provide a minimum of 2 decimal places and add separator commas.