### PR TITLE
web: Add Return to Dashboard button

### DIFF
--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/index.hbs
@@ -2,6 +2,7 @@
   <WorkflowThread
     class="create-merchant-workflow"
     @workflow={{this.workflow}}
+    @onClose={{@onClose}}
   />
 {{/if}}
 <Listener

--- a/packages/web-client/app/components/card-pay/deposit-workflow/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/index.hbs
@@ -1,5 +1,5 @@
 {{#if this.workflow}}
-  <WorkflowThread class="deposit-workflow" @workflow={{this.workflow}}>
+  <WorkflowThread class="deposit-workflow" @workflow={{this.workflow}} @onClose={{@onClose}}>
     <:before-content>
       <Boxel::ExpandableBanner
         @icon="info"

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.hbs
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.hbs
@@ -1,5 +1,5 @@
 {{#if this.workflow}}
-  <WorkflowThread class="issue-prepaid-card-workflow" @workflow={{this.workflow}}>
+  <WorkflowThread class="issue-prepaid-card-workflow" @workflow={{this.workflow}} @onClose={{@onClose}}>
     <:before-content>
       <Boxel::ExpandableBanner
         @icon="info"

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/index.hbs
@@ -1,5 +1,5 @@
 {{#if this.workflow}}
-  <WorkflowThread class="withdrawal-workflow" @workflow={{this.workflow}}>
+  <WorkflowThread class="withdrawal-workflow" @workflow={{this.workflow}} @onClose={{@onClose}}>
     <:before-content>
       <Boxel::ExpandableBanner
         @icon="info"

--- a/packages/web-client/app/components/card-space/create-space-workflow/index.hbs
+++ b/packages/web-client/app/components/card-space/create-space-workflow/index.hbs
@@ -2,6 +2,7 @@
   <WorkflowThread
     class="create-space-workflow"
     @workflow={{this.workflow}}
+    @onClose={{@onClose}}
   />
 {{/if}}
 

--- a/packages/web-client/app/components/workflow-thread/index.css
+++ b/packages/web-client/app/components/workflow-thread/index.css
@@ -3,6 +3,10 @@
   --outer-max-width: 43.75rem; /* 700px; */
 }
 
+.workflow-thread .boxel-thread-header {
+  grid-template-columns: 1fr auto auto;
+}
+
 .workflow-thread__status {
   color: var(--boxel-dark);
   font: 600 var(--boxel-font-sm);

--- a/packages/web-client/app/components/workflow-thread/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/index.hbs
@@ -9,7 +9,17 @@
   ...attributes
 >
   <:header>
-    <Boxel::ThreadHeader @title={{this.workflow.displayName}} />
+    <Boxel::ThreadHeader @title={{this.workflow.displayName}}>
+      {{#if @onClose}}
+        <Boxel::Button
+          @size='extra-small'
+          {{on 'click' @onClose}}
+          data-test-return-to-dashboard
+        >
+          Return to Dashboard
+        </Boxel::Button>
+      {{/if}}
+    </Boxel::ThreadHeader>
   </:header>
   <:content>
     {{#if (has-block 'before-content')}}

--- a/packages/web-client/app/templates/card-pay/balances.hbs
+++ b/packages/web-client/app/templates/card-pay/balances.hbs
@@ -70,6 +70,6 @@
   @onClose={{this.resetQueryParams}}
 >
   {{#if (is-network-initialized)}}
-    <CardPay::IssuePrepaidCardWorkflow />
+    <CardPay::IssuePrepaidCardWorkflow @onClose={{this.resetQueryParams}} />
   {{/if}}
 </Boxel::Modal>

--- a/packages/web-client/app/templates/card-pay/deposit-withdrawal.hbs
+++ b/packages/web-client/app/templates/card-pay/deposit-withdrawal.hbs
@@ -58,10 +58,10 @@
 >
   {{#if (is-network-initialized)}}
     {{#if (eq this.flow 'deposit')}}
-      <CardPay::DepositWorkflow />
+      <CardPay::DepositWorkflow @onClose={{this.resetQueryParams}} />
     {{/if}}
     {{#if (eq this.flow 'withdrawal')}}
-      <CardPay::WithdrawalWorkflow />
+      <CardPay::WithdrawalWorkflow @onClose={{this.resetQueryParams}} />
     {{/if}}
   {{/if}}
 </Boxel::Modal>

--- a/packages/web-client/app/templates/card-pay/payments.hbs
+++ b/packages/web-client/app/templates/card-pay/payments.hbs
@@ -85,7 +85,7 @@
 >
   {{#if (is-network-initialized)}}
     {{#if (eq this.flow 'create-business')}}
-      <CardPay::CreateMerchantWorkflow />
+      <CardPay::CreateMerchantWorkflow @onClose={{this.resetQueryParams}} />
     {{/if}}
   {{/if}}
 </Boxel::Modal>

--- a/packages/web-client/app/templates/card-space.hbs
+++ b/packages/web-client/app/templates/card-space.hbs
@@ -28,7 +28,7 @@
     @onClose={{this.resetQueryParams}}
   >
     {{#if (is-network-initialized)}}
-      <CardSpace::CreateSpaceWorkflow />
+      <CardSpace::CreateSpaceWorkflow @onClose={{this.resetQueryParams}} />
     {{/if}}
   </Boxel::Modal>
 </main>

--- a/packages/web-client/tests/acceptance/create-card-space-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/create-card-space-persistence-test.ts
@@ -40,7 +40,7 @@ module('Acceptance | create card space persistence', function (hooks) {
     workflowPersistenceService.clear();
   });
 
-  test('Generates a flow uuid query parameter used as a persistence identifier', async function (this: Context, assert) {
+  test('Generates a flow uuid query parameter used as a persistence identifier and can be dismissed via the header button', async function (this: Context, assert) {
     await visit('/card-space');
     await click('[data-test-workflow-button="create-space"]');
 
@@ -50,6 +50,9 @@ module('Acceptance | create card space persistence', function (hooks) {
         .length,
       22
     );
+
+    await click('[data-test-return-to-dashboard]');
+    assert.dom('[data-test-workflow-thread]').doesNotExist();
   });
 
   module('Restoring from a previously saved state', function () {

--- a/packages/web-client/tests/acceptance/create-merchant-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/create-merchant-persistence-test.ts
@@ -73,7 +73,7 @@ module('Acceptance | create merchant persistence', function (hooks) {
     workflowPersistenceService.clear();
   });
 
-  test('Generates a flow uuid query parameter used as a persistence identifier', async function (this: Context, assert) {
+  test('Generates a flow uuid query parameter used as a persistence identifier and can be dismissed via the header button', async function (this: Context, assert) {
     await visit('/card-pay/payments');
     await click('[data-test-workflow-button="create-business"]');
 
@@ -83,6 +83,9 @@ module('Acceptance | create merchant persistence', function (hooks) {
         .length,
       22
     );
+
+    await click('[data-test-return-to-dashboard]');
+    assert.dom('[data-test-workflow-thread]').doesNotExist();
   });
 
   module('Restoring from a previously saved state', function () {

--- a/packages/web-client/tests/acceptance/deposit-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-persistence-test.ts
@@ -55,7 +55,7 @@ module('Acceptance | deposit persistence', function (hooks) {
     workflowPersistenceService.clear();
   });
 
-  test('Generates a flow uuid query parameter used as a persistence identifier', async function (this: Context, assert) {
+  test('Generates a flow uuid query parameter used as a persistence identifier and can be dismissed via the header button', async function (this: Context, assert) {
     await visit('/card-pay/deposit-withdrawal');
     await click('[data-test-workflow-button="deposit"]');
     assert.equal(
@@ -63,6 +63,9 @@ module('Acceptance | deposit persistence', function (hooks) {
         ?.length,
       22
     );
+
+    await click('[data-test-return-to-dashboard]');
+    assert.dom('[data-test-workflow-thread]').doesNotExist();
   });
 
   module('Restoring from a previously saved state', function () {

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-persistence-test.ts
@@ -78,7 +78,7 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
     workflowPersistenceService.clear();
   });
 
-  test('Generates a flow uuid query parameter used as a persistence identifier', async function (this: Context, assert) {
+  test('Generates a flow uuid query parameter used as a persistence identifier and can be dismissed via the header button', async function (this: Context, assert) {
     await visit('/card-pay');
     await click('[data-test-workflow-button="issue-prepaid-card"]');
 
@@ -88,6 +88,9 @@ module('Acceptance | issue prepaid card persistence', function (hooks) {
         .length,
       22
     );
+
+    await click('[data-test-return-to-dashboard]');
+    assert.dom('[data-test-workflow-thread]').doesNotExist();
   });
 
   module('Restoring from a previously saved state', function () {

--- a/packages/web-client/tests/acceptance/withdrawal-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-persistence-test.ts
@@ -65,7 +65,7 @@ module('Acceptance | withdrawal persistence', function (hooks) {
     workflowPersistenceService.clear();
   });
 
-  test('Generates a flow uuid query parameter used as a persistence identifier', async function (this: Context, assert) {
+  test('Generates a flow uuid query parameter used as a persistence identifier and can be dismissed via the header button', async function (this: Context, assert) {
     await visit('/card-pay/deposit-withdrawal');
     await click('[data-test-workflow-button="withdrawal"]');
     assert.equal(
@@ -73,6 +73,9 @@ module('Acceptance | withdrawal persistence', function (hooks) {
         ?.length,
       22
     );
+
+    await click('[data-test-return-to-dashboard]');
+    assert.dom('[data-test-workflow-thread]').doesNotExist();
   });
 
   module('Restoring from a previously saved state', function () {


### PR DESCRIPTION
I’d prefer to be able to accomplish this in a higher-level
way vs having to update every workflow, but I couldn’t
figure out how.

This includes an override to Boxel CSS to add the thread
header button as that is not currently supported in Boxel.