### PR TITLE
make token bridge eplorer link styles override boxel

### DIFF
--- a/packages/web-client/app/components/card-pay/bridge/index.css
+++ b/packages/web-client/app/components/card-pay/bridge/index.css
@@ -17,7 +17,7 @@
   background: url('/images/backgrounds/bridge-background.svg');
 }
 
-/* 2 selectors because of specificity */
-.card-pay-bridge__button.boxel-button {
+/* many selectors for specificity, excluding disabled/href-less link so that it's clear when the link fails to load */
+a.card-pay-bridge__button.boxel-button[href] {
   --boxel-button-color: var(--boxel-light-300);
 }


### PR DESCRIPTION
I'm a bit hesitant to add yet another button variant before we know if we need it, so am making a judgement call to use an override for now. Also considered using `@kind="primary"`, but decided against it because it deviates from the spec, and feels like it's drawing too much attention to a detail, lmk if you think it's a better solution @burieberry? A bit unsure about how to approach this since we discussed respecting Boxel's constraints over the design spec.

### With href

![image](https://user-images.githubusercontent.com/39579264/141302180-972084b7-be51-4c06-b5e7-dbfbb258b5d7.png)

### No href

![image](https://user-images.githubusercontent.com/39579264/141302244-f87d9164-c156-4874-985f-ac0913d8746d.png)


### `@kind="primary"`

![image](https://user-images.githubusercontent.com/39579264/141303573-8090363e-a0f9-4ddf-8eff-2b0191aa7d5f.png)
