### PR TITLE
web: Replace original depot icon

### DIFF
--- a/packages/web-client/app/components/card-pay/safe-balances/index.ts
+++ b/packages/web-client/app/components/card-pay/safe-balances/index.ts
@@ -45,7 +45,7 @@ export default class CardPaySafeBalancesComponent extends Component<CardPaySafeB
       };
     } else if (this.args.safe.type === 'depot') {
       return {
-        icon: 'depot-arrows',
+        icon: 'depot',
         info: {
           name: 'Depot',
         },

--- a/packages/web-client/public/images/icons/depot-arrows.svg
+++ b/packages/web-client/public/images/icons/depot-arrows.svg
@@ -1,1 +1,0 @@
-<svg viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg"><circle cx="40" cy="40" fill="#f8f7fa" r="40"/><g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.5"><path d="m23.8 30.67h34.08"/><path d="m49.71 22.5 8.17 8.17-8.17 8.16"/><path d="m57.17 49.33h-34.08"/><path d="m31.26 57.5-8.17-8.17 8.17-8.16"/></g></svg>

--- a/packages/web-client/public/images/icons/depot.svg
+++ b/packages/web-client/public/images/icons/depot.svg
@@ -1,1 +1,1 @@
-<svg height="40" viewBox="0 0 40 40" width="40" xmlns="http://www.w3.org/2000/svg"><circle cx="20" cy="20" r="20"/><g fill="#fff"><circle cx="20" cy="20" r="6"/><path d="m23 19h12v2h-12z"/></g></svg>
+<svg viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg"><circle cx="40" cy="40" fill="#f8f7fa" r="40"/><g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.5"><path d="m23.8 30.67h34.08"/><path d="m49.71 22.5 8.17 8.17-8.17 8.16"/><path d="m57.17 49.33h-34.08"/><path d="m31.26 57.5-8.17-8.17 8.17-8.16"/></g></svg>

--- a/packages/web-client/tests/integration/components/card-pay/safe-balances-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/safe-balances-test.ts
@@ -72,7 +72,7 @@ module('Integration | Component | card-pay/safe-balances', function (hooks) {
     assert.dom('[data-test-safe-balances-type]').containsText('Depot');
 
     assert.dom('[data-test-safe-balances-title]').containsText('Depot');
-    assert.dom('[data-test-safe-balances-logo=depot-arrows]').exists();
+    assert.dom('[data-test-safe-balances-logo=depot]').exists();
     assert.dom('[data-test-safe-balances-link]').doesNotExist();
 
     assert


### PR DESCRIPTION
This applies the arrows-based depot icon in places that
formerly used the Gnosis Safe icon.