### PR TITLE
CS-2524 updating SDK to wait until txn's are indexed by subgraph before resolving API promises

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -126,8 +126,9 @@
 
         // Kovan DAI Bridge args
         "bridge-to-l2",
-        "10",
+        "200",
         "0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa", // Kovan DAI
+        "0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13", // L2 wallet EOA
         "--network",
         "kovan",
         // Hassan's testing mnemonic feel free to use your own
@@ -424,7 +425,7 @@
       "args": [
         "pay-merchant",
         "0x3e6C2b2c3a842b6492F9F43349D77A40568e3d7E", // safe for Hassan's merchant (whose address the correlates with the mnemenoic 0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13)
-        "0x9972D7972130E1Ba9E87d39C7e7229F56dC82e4e", // Hassan's prepaid card --feel free to use your own
+        "0x70fdd952d8b4DC0E3E91d2e7392bdb600d637b40", // Hassan's prepaid card --feel free to use your own
         "100",
         "--network",
         "sokol",
@@ -567,7 +568,7 @@
         "claim-revenue",
         "0x3e6C2b2c3a842b6492F9F43349D77A40568e3d7E", // safe for Hassan's merchant (whose address the correlates with the mnemenoic 0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13)
         "0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1", // DAI.CPXD
-        "5",
+        "1",
         "--network",
         "sokol",
         // Hassan's testing mnemonic feel free to use your own

--- a/packages/cardpay-sdk/sdk/prepaid-card-market/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card-market/base.ts
@@ -6,7 +6,7 @@ import PrepaidCardManagerABI from '../../contracts/abi/v0.8.5/prepaid-card-manag
 import GnosisSafeABI from '../../contracts/abi/gnosis-safe';
 import { TransactionReceipt } from 'web3-core';
 import { ContractOptions } from 'web3-eth-contract';
-import { isTransactionHash, TransactionOptions, waitUntilTransactionMined } from '../utils/general-utils';
+import { isTransactionHash, TransactionOptions, waitForSubgraphIndexWithTxnReceipt } from '../utils/general-utils';
 import {
   EventABI,
   executeSend,
@@ -91,7 +91,7 @@ export default class PrepaidCardMarket {
   ): Promise<TransactionReceipt> {
     if (isTransactionHash(fundingPrepaidCardOrTxnHash)) {
       let txnHash = fundingPrepaidCardOrTxnHash;
-      return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+      return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     }
     if (!prepaidCardToAdd) {
       throw new Error('prepaidCardToAdd must be provided');
@@ -163,7 +163,7 @@ export default class PrepaidCardMarket {
     if (typeof onTxnHash === 'function') {
       await onTxnHash(txnHash);
     }
-    return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+    return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
 
   async removeFromInventory(txnHash: string): Promise<TransactionReceipt>;
@@ -183,7 +183,7 @@ export default class PrepaidCardMarket {
   ): Promise<TransactionReceipt> {
     if (isTransactionHash(fundingPrepaidCardOrTxnHash)) {
       let txnHash = fundingPrepaidCardOrTxnHash;
-      return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+      return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     }
     if (!prepaidCardAddresses) {
       throw new Error('prepaidCardAddresses must be provided');
@@ -230,7 +230,7 @@ export default class PrepaidCardMarket {
     if (typeof onTxnHash === 'function') {
       await onTxnHash(txnHash);
     }
-    return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+    return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
 
   async setAsk(txnHash: string): Promise<TransactionReceipt>;
@@ -252,7 +252,7 @@ export default class PrepaidCardMarket {
   ): Promise<TransactionReceipt> {
     if (isTransactionHash(prepaidCardOrTxnHash)) {
       let txnHash = prepaidCardOrTxnHash;
-      return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+      return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     }
     if (!sku) {
       throw new Error('sku is required');
@@ -297,12 +297,12 @@ export default class PrepaidCardMarket {
     if (typeof onTxnHash === 'function') {
       await onTxnHash(txnHash);
     }
-    return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+    return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
 
   async getPrepaidCardFromProvisionTxnHash(txnHash: string, marketAddress?: string): Promise<PrepaidCardSafe> {
     let prepaidCardAPI = await getSDK('PrepaidCard', this.layer2Web3);
-    let txnReceipt = await waitUntilTransactionMined(this.layer2Web3, txnHash);
+    let txnReceipt = await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     marketAddress = marketAddress ?? (await getAddress('prepaidCardMarket', this.layer2Web3));
     let [event] = getParamsFromEvent(
       this.layer2Web3,

--- a/packages/cardpay-sdk/sdk/prepaid-card/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card/base.ts
@@ -23,7 +23,7 @@ import {
   getNextNonceFromEstimate,
   executeSendWithRateLock,
 } from '../utils/safe-utils';
-import { isTransactionHash, TransactionOptions, waitUntilTransactionMined } from '../utils/general-utils';
+import { isTransactionHash, TransactionOptions, waitForSubgraphIndexWithTxnReceipt } from '../utils/general-utils';
 import { Signature, signSafeTxAsBytes, signPrepaidCardSendTx, signSafeTx } from '../utils/signing-utils';
 import { PrepaidCardSafe } from '../safes';
 import { TransactionReceipt } from 'web3-core';
@@ -104,7 +104,7 @@ export default class PrepaidCard {
   ): Promise<TransactionReceipt> {
     if (isTransactionHash(merchantSafeOrTxnHash)) {
       let txnHash = merchantSafeOrTxnHash;
-      return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+      return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     }
     if (!prepaidCardAddress) {
       throw new Error('prepaidCardAddress is required');
@@ -161,7 +161,7 @@ export default class PrepaidCard {
       await onTxnHash(txnHash);
     }
 
-    return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+    return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
 
   async transfer(txnHash: string): Promise<TransactionReceipt>;
@@ -179,7 +179,7 @@ export default class PrepaidCard {
   ): Promise<TransactionReceipt> {
     if (isTransactionHash(prepaidCardAddressOrTxnHash)) {
       let txnHash = prepaidCardAddressOrTxnHash;
-      return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+      return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     }
     let prepaidCardAddress = prepaidCardAddressOrTxnHash;
     if (!newOwner) {
@@ -253,7 +253,7 @@ export default class PrepaidCard {
       await onTxnHash(txnHash);
     }
 
-    return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+    return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
 
   async split(
@@ -277,7 +277,7 @@ export default class PrepaidCard {
   ): Promise<{ prepaidCards: PrepaidCardSafe[]; sku: string; txReceipt: TransactionReceipt }> {
     if (isTransactionHash(prepaidCardAddressOrTxnHash)) {
       let txnHash = prepaidCardAddressOrTxnHash;
-      let txReceipt = await waitUntilTransactionMined(this.layer2Web3, txnHash);
+      let txReceipt = await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
       return {
         txReceipt,
         prepaidCards: await this.resolvePrepaidCards(await this.getPrepaidCardsFromTxn(txnHash)),
@@ -368,7 +368,7 @@ export default class PrepaidCard {
     }
 
     let prepaidCardAddresses = await this.getPrepaidCardsFromTxn(gnosisResult.ethereumTx.txHash);
-    let txReceipt = await waitUntilTransactionMined(this.layer2Web3, gnosisResult.ethereumTx.txHash);
+    let txReceipt = await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, gnosisResult.ethereumTx.txHash);
 
     return {
       txReceipt,
@@ -402,7 +402,7 @@ export default class PrepaidCard {
       let txnHash = safeAddressOrTxnHash;
       return {
         prepaidCards: await this.resolvePrepaidCards(await this.getPrepaidCardsFromTxn(txnHash)),
-        txnReceipt: await waitUntilTransactionMined(this.layer2Web3, txnHash),
+        txnReceipt: await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash),
       };
     }
     let safeAddress = safeAddressOrTxnHash;
@@ -496,7 +496,7 @@ export default class PrepaidCard {
 
     return {
       prepaidCards: await this.resolvePrepaidCards(prepaidCardAddresses),
-      txnReceipt: await waitUntilTransactionMined(this.layer2Web3, gnosisTxn.ethereumTx.txHash),
+      txnReceipt: await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, gnosisTxn.ethereumTx.txHash),
     };
   }
 
@@ -583,7 +583,7 @@ export default class PrepaidCard {
 
   private async getPrepaidCardsFromTxn(txnHash: string): Promise<string[]> {
     let prepaidCardMgrAddress = await getAddress('prepaidCardManager', this.layer2Web3);
-    let txnReceipt = await waitUntilTransactionMined(this.layer2Web3, txnHash);
+    let txnReceipt = await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     return getParamsFromEvent(this.layer2Web3, txnReceipt, this.createPrepaidCardEventABI(), prepaidCardMgrAddress).map(
       (createCardLog) => createCardLog.card
     );

--- a/packages/cardpay-sdk/sdk/revenue-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/revenue-pool/base.ts
@@ -16,7 +16,7 @@ import {
   getNextNonceFromEstimate,
   executeSendWithRateLock,
 } from '../utils/safe-utils';
-import { TransactionOptions, waitUntilTransactionMined, isTransactionHash } from '../utils/general-utils';
+import { TransactionOptions, waitForSubgraphIndexWithTxnReceipt, isTransactionHash } from '../utils/general-utils';
 import { Signature, signPrepaidCardSendTx, signSafeTx } from '../utils/signing-utils';
 import { getSDK } from '../version-resolver';
 import BN from 'bn.js';
@@ -114,7 +114,7 @@ export default class RevenuePool {
   ): Promise<TransactionReceipt> {
     if (isTransactionHash(merchantSafeAddressOrTxnHash)) {
       let txnHash = merchantSafeAddressOrTxnHash;
-      return waitUntilTransactionMined(this.layer2Web3, txnHash);
+      return waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     }
     let merchantSafeAddress = merchantSafeAddressOrTxnHash;
     if (!tokenAddress) {
@@ -173,7 +173,7 @@ export default class RevenuePool {
     if (typeof onTxnHash === 'function') {
       await onTxnHash(txnHash);
     }
-    return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+    return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
 
   async registerMerchant(txnHash: string): Promise<{ merchantSafe: MerchantSafe; txReceipt: TransactionReceipt }>;
@@ -194,7 +194,7 @@ export default class RevenuePool {
       let merchantSafeAddress = await this.getMerchantSafeFromTxn(txnHash);
       return {
         merchantSafe: await this.resolveMerchantSafe(merchantSafeAddress),
-        txReceipt: await waitUntilTransactionMined(this.layer2Web3, txnHash),
+        txReceipt: await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash),
       };
     }
     let prepaidCardAddress = prepaidCardAddressOrTxnHash;
@@ -249,7 +249,7 @@ export default class RevenuePool {
     let merchantSafeAddress = await this.getMerchantSafeFromTxn(txnHash);
     return {
       merchantSafe: await this.resolveMerchantSafe(merchantSafeAddress),
-      txReceipt: await waitUntilTransactionMined(this.layer2Web3, txnHash),
+      txReceipt: await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash),
     };
   }
 
@@ -266,7 +266,7 @@ export default class RevenuePool {
 
   private async getMerchantSafeFromTxn(txnHash: string): Promise<string> {
     let merchantManager = await getAddress('merchantManager', this.layer2Web3);
-    let txnReceipt = await waitUntilTransactionMined(this.layer2Web3, txnHash);
+    let txnReceipt = await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     return getParamsFromEvent(this.layer2Web3, txnReceipt, this.createMerchantEventABI(), merchantManager)[0]
       ?.merchantSafe;
   }

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -3,7 +3,7 @@ import RewardManagerABI from '../../contracts/abi/v0.8.5/reward-manager';
 import { Contract } from 'web3-eth-contract';
 import { getAddress } from '../../contracts/addresses';
 import { AbiItem, randomHex, toChecksumAddress } from 'web3-utils';
-import { isTransactionHash, TransactionOptions, waitUntilTransactionMined } from '../utils/general-utils';
+import { isTransactionHash, TransactionOptions, waitForSubgraphIndexWithTxnReceipt } from '../utils/general-utils';
 import { getSDK } from '../version-resolver';
 import { ContractOptions } from 'web3-eth-contract';
 import { TransactionReceipt } from 'web3-core';
@@ -45,7 +45,7 @@ export default class RewardManager {
       let txnHash = prepaidCardAddressOrTxnHash;
       return {
         rewardProgramId,
-        txReceipt: await waitUntilTransactionMined(this.layer2Web3, txnHash),
+        txReceipt: await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash),
       };
     }
     if (!prepaidCardAddressOrTxnHash) {
@@ -110,7 +110,7 @@ export default class RewardManager {
 
     return {
       rewardProgramId,
-      txReceipt: await waitUntilTransactionMined(this.layer2Web3, txnHash),
+      txReceipt: await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash),
     };
   }
 
@@ -131,7 +131,7 @@ export default class RewardManager {
       let txnHash = prepaidCardAddressOrTxnHash;
       return {
         rewardSafe: await this.getRewardSafeFromTxn(txnHash),
-        txReceipt: await waitUntilTransactionMined(this.layer2Web3, txnHash),
+        txReceipt: await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash),
       };
     }
     if (!prepaidCardAddressOrTxnHash) {
@@ -176,7 +176,7 @@ export default class RewardManager {
 
     return {
       rewardSafe: await this.getRewardSafeFromTxn(gnosisResult.ethereumTx.txHash),
-      txReceipt: await waitUntilTransactionMined(this.layer2Web3, txnHash),
+      txReceipt: await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash),
     };
   }
 
@@ -195,7 +195,7 @@ export default class RewardManager {
   ): Promise<TransactionReceipt> {
     if (isTransactionHash(prepaidCardAddressOrTxnHash)) {
       let txnHash = prepaidCardAddressOrTxnHash;
-      return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+      return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     }
     if (!prepaidCardAddressOrTxnHash) {
       throw new Error('prepaidCardAddress is required');
@@ -236,7 +236,7 @@ export default class RewardManager {
     if (typeof onTxnHash === 'function') {
       await onTxnHash(txnHash);
     }
-    return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+    return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
 
   async updateRewardProgramAdmin(txnHash: string): Promise<TransactionReceipt>;
@@ -256,7 +256,7 @@ export default class RewardManager {
   ): Promise<TransactionReceipt> {
     if (isTransactionHash(prepaidCardAddressOrTxnHash)) {
       let txnHash = prepaidCardAddressOrTxnHash;
-      return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+      return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     }
     if (!prepaidCardAddressOrTxnHash) {
       throw new Error('prepaidCardAddress is required');
@@ -306,7 +306,7 @@ export default class RewardManager {
     if (typeof onTxnHash === 'function') {
       await onTxnHash(txnHash);
     }
-    return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+    return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
   private async getRegisterRewardProgramPayload(
     prepaidCardAddress: string,
@@ -458,7 +458,7 @@ export default class RewardManager {
   }
   private async getRewardSafeFromTxn(txnHash: string): Promise<any> {
     let rewardMgrAddress = await getAddress('rewardManager', this.layer2Web3);
-    let txnReceipt = await waitUntilTransactionMined(this.layer2Web3, txnHash);
+    let txnReceipt = await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     return getParamsFromEvent(this.layer2Web3, txnReceipt, this.rewardeeRegisteredABI(), rewardMgrAddress)[0]
       .rewardSafe;
   }

--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -12,7 +12,7 @@ import BN from 'bn.js';
 import ERC20ABI from '../../contracts/abi/erc-20';
 import ERC677ABI from '../../contracts/abi/erc-677';
 import { gasEstimate, executeTransaction, getNextNonceFromEstimate } from '../utils/safe-utils';
-import { isTransactionHash, TransactionOptions, waitUntilTransactionMined } from '../utils/general-utils';
+import { isTransactionHash, TransactionOptions, waitForSubgraphIndexWithTxnReceipt } from '../utils/general-utils';
 import { TransactionReceipt } from 'web3-core';
 interface Proof {
   rootHash: string;
@@ -247,7 +247,7 @@ export default class RewardPool {
   ): Promise<TransactionReceipt> {
     if (isTransactionHash(safeAddressOrTxnHash)) {
       let txnHash = safeAddressOrTxnHash;
-      return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+      return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     }
     let safeAddress = safeAddressOrTxnHash;
     if (!rewardProgramId) {
@@ -300,7 +300,7 @@ export default class RewardPool {
     if (typeof onTxnHash === 'function') {
       await onTxnHash(gnosisTxn.ethereumTx.txHash);
     }
-    return await waitUntilTransactionMined(this.layer2Web3, gnosisTxn.ethereumTx.txHash);
+    return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, gnosisTxn.ethereumTx.txHash);
   }
 
   async claim(txnHash: string): Promise<TransactionReceipt>;
@@ -324,7 +324,7 @@ export default class RewardPool {
   ): Promise<TransactionReceipt> {
     if (isTransactionHash(safeAddressOrTxnHash)) {
       let txnHash = safeAddressOrTxnHash;
-      return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+      return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     }
     let safeAddress = safeAddressOrTxnHash;
     if (!rewardProgramId) {
@@ -434,7 +434,7 @@ The reward program ${rewardProgramId} has balance equals ${fromWei(
     if (typeof onTxnHash === 'function') {
       await onTxnHash(gnosisTxn.ethereumTx.txHash);
     }
-    return await waitUntilTransactionMined(this.layer2Web3, gnosisTxn.ethereumTx.txHash);
+    return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, gnosisTxn.ethereumTx.txHash);
   }
 
   async balance(rewardProgramId: string, tokenAddress: string): Promise<RewardTokenBalance> {

--- a/packages/cardpay-sdk/sdk/safes/base.ts
+++ b/packages/cardpay-sdk/sdk/safes/base.ts
@@ -9,7 +9,7 @@ import { signSafeTx } from '../utils/signing-utils';
 import BN from 'bn.js';
 import { query } from '../utils/graphql';
 import { TransactionReceipt } from 'web3-core';
-import { TransactionOptions, waitUntilTransactionMined, isTransactionHash } from '../utils/general-utils';
+import { TransactionOptions, waitForSubgraphIndexWithTxnReceipt, isTransactionHash } from '../utils/general-utils';
 const { fromWei } = Web3.utils;
 
 export type Safe = DepotSafe | PrepaidCardSafe | MerchantSafe | RewardSafe | ExternalSafe;
@@ -270,7 +270,7 @@ export default class Safes {
   ): Promise<TransactionReceipt> {
     if (isTransactionHash(safeAddressOrTxnHash)) {
       let txnHash = safeAddressOrTxnHash;
-      return waitUntilTransactionMined(this.layer2Web3, txnHash);
+      return waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     }
     let safeAddress = safeAddressOrTxnHash;
     if (!tokenAddress) {
@@ -326,7 +326,7 @@ export default class Safes {
     if (typeof onTxnHash === 'function') {
       await onTxnHash(txnHash);
     }
-    return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+    return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
 
   async setSupplierInfoDID(txnHash: string): Promise<TransactionReceipt>;
@@ -346,7 +346,7 @@ export default class Safes {
   ): Promise<TransactionReceipt> {
     if (isTransactionHash(safeAddressOrTxnHash)) {
       let txnHash = safeAddressOrTxnHash;
-      return waitUntilTransactionMined(this.layer2Web3, txnHash);
+      return waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     }
     let safeAddress = safeAddressOrTxnHash;
     if (infoDID == null) {
@@ -381,7 +381,7 @@ export default class Safes {
     if (typeof onTxnHash === 'function') {
       await onTxnHash(txnHash);
     }
-    return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+    return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
 
   private transferTokenPayload(tokenAddress: string, recipient: string, amount: string): string {

--- a/packages/cardpay-sdk/sdk/token-bridge-home-side.ts
+++ b/packages/cardpay-sdk/sdk/token-bridge-home-side.ts
@@ -10,7 +10,7 @@ import { executeTransaction, gasEstimate, getNextNonceFromEstimate } from './uti
 import { AbiItem, fromWei, toBN } from 'web3-utils';
 import { signSafeTx } from './utils/signing-utils';
 import { query } from './utils/graphql';
-import { TransactionOptions, waitUntilTransactionMined, isTransactionHash } from './utils/general-utils';
+import { TransactionOptions, waitForSubgraphIndexWithTxnReceipt, isTransactionHash } from './utils/general-utils';
 
 // The TokenBridge is created between 2 networks, referred to as a Native (or Home) Network and a Foreign network.
 // The Native or Home network has fast and inexpensive operations. All bridge operations to collect validator confirmations are performed on this side of the bridge.
@@ -79,7 +79,7 @@ export default class TokenBridgeHomeSide implements ITokenBridgeHomeSide {
     let { nonce, onNonce, onTxnHash } = txnOptions ?? {};
     if (isTransactionHash(safeAddressOrTxnHash)) {
       let txnHash = safeAddressOrTxnHash;
-      return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+      return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
     }
     let safeAddress = safeAddressOrTxnHash;
     if (!tokenAddress) {
@@ -132,7 +132,7 @@ export default class TokenBridgeHomeSide implements ITokenBridgeHomeSide {
     if (typeof onTxnHash === 'function') {
       await onTxnHash(txnHash);
     }
-    return await waitUntilTransactionMined(this.layer2Web3, txnHash);
+    return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
 
   async waitForBridgingValidation(fromBlock: string, bridgingTxnHash: string): Promise<BridgeValidationResult> {

--- a/packages/cardpay-sdk/sdk/utils/general-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/general-utils.ts
@@ -161,13 +161,23 @@ export async function waitForSubgraphIndex(
       await new Promise<void>((res) => setTimeout(() => res(), POLL_INTERVAL));
     }
     queryResults = await gqlQuery(network, transactionQuery, { txnHash });
-  } while (!queryResults.data.transaction == null && Date.now() < start + duration);
+  } while (queryResults.data.transaction == null && Date.now() < start + duration);
 
   if (!queryResults.data.transaction) {
     throw new Error(`Timed out waiting for txnHash to be indexed ${txnHash}`);
   }
 
   return;
+}
+
+export async function waitForSubgraphIndexWithTxnReceipt(
+  web3: Web3,
+  txnHash: string,
+  duration = 60 * 10 * 1000
+): Promise<TransactionReceipt> {
+  let txnReceipt = await waitUntilTransactionMined(web3, txnHash, duration);
+  await waitForSubgraphIndex(txnHash, web3, duration);
+  return txnReceipt;
 }
 
 // because BN does not handle floating point, and the numbers from ethereum


### PR DESCRIPTION
With this change, it means that after any of the API's complete in the SDK, the results in the subgraph should be consistent with the actions takes by the API (i.e. we'll be able to read our writes from the subgraph).