### PR TITLE
web: Add Card Space button text chooser

### DIFF
--- a/packages/web-client/app/components/card-space/edit-details/button-text/index.css
+++ b/packages/web-client/app/components/card-space/edit-details/button-text/index.css
@@ -1,0 +1,37 @@
+.card-space-button-text-field__option {
+  display: grid;
+  grid-template-columns: auto 1fr 1fr;
+  align-items: center;
+  gap: var(--boxel-sp);
+  padding: var(--boxel-sp-lg) var(--boxel-sp);
+  border-radius: var(--boxel-border-radius);
+  box-shadow: 0 0 0 1px var(--boxel-light-400);
+  transition: box-shadow var(--boxel-transition);
+}
+
+.card-space-button-text-field__option + .card-space-button-text-field__option {
+  margin-top: var(--boxel-sp);
+}
+
+.card-space-button-text-field--checked,
+.card-space-button-text-field__option:focus,
+.card-space-button-text-field__option:focus-within {
+  box-shadow: 0 0 0 2px var(--boxel-highlight);
+  outline: 1px solid transparent;
+}
+
+.card-space-button-text-field__input {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 1rem;
+  height: 1rem;
+  margin: 0;
+  border: 1.5px solid var(--boxel-dark);
+  border-radius: 100px;
+  background-color: transparent;
+}
+
+.card-space-button-text-field__input--checked {
+  background-color: var(--boxel-highlight);
+  border-width: 3px;
+}

--- a/packages/web-client/app/components/card-space/edit-details/button-text/index.hbs
+++ b/packages/web-client/app/components/card-space/edit-details/button-text/index.hbs
@@ -1,0 +1,24 @@
+<div class="card-space-url-form">
+  <CardPay::LabeledValue
+    @fieldMode="edit"
+    @label="Button Text"
+    data-test-card-space-button-text-field
+  >
+    <div data-test-button-text-options>
+      {{#each this.options as |option|}}
+        <label class={{cn 'card-space-button-text-field__option' card-space-button-text-field__option--checked=@checked}} data-test-button-text-option>
+          {{#let (eq this.buttonTextValue option) as |checked|}}
+            <Input
+              name="deposit-token"
+              class={{cn "card-space-button-text-field__input" card-space-button-text-field__input--checked=checked}}
+              @type="radio"
+              @checked={{checked}}
+              {{on 'input' (fn this.setButtonTextValue option)}}
+            />
+            {{option}}
+          {{/let}}
+        </label>
+      {{/each}}
+    </div>
+  </CardPay::LabeledValue>
+</div>

--- a/packages/web-client/app/components/card-space/edit-details/button-text/index.ts
+++ b/packages/web-client/app/components/card-space/edit-details/button-text/index.ts
@@ -1,0 +1,24 @@
+import Component from '@glimmer/component';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
+import { action } from '@ember/object';
+
+export const OPTIONS = [
+  'Visit this Space',
+  'Visit this Business',
+  'Visit this Creator',
+  'Visit this Person',
+];
+
+class CardSpaceEditDetailsButtonTextComponent extends Component<WorkflowCardComponentArgs> {
+  options = OPTIONS;
+
+  get buttonTextValue() {
+    return this.args.workflowSession.getValue<string>('buttonText');
+  }
+
+  @action setButtonTextValue(val: string) {
+    this.args.workflowSession.setValue('buttonText', val);
+  }
+}
+
+export default CardSpaceEditDetailsButtonTextComponent;

--- a/packages/web-client/app/components/card-space/edit-details/index.hbs
+++ b/packages/web-client/app/components/card-space/edit-details/index.hbs
@@ -5,6 +5,9 @@
     <CardSpace::EditDetails::Url
       @workflowSession={{@workflowSession}}
     />
+    <CardSpace::EditDetails::ButtonText
+      @workflowSession={{@workflowSession}}
+    />
   </ActionCardContainer::Section>
 
   <Boxel::ActionChin

--- a/packages/web-client/tests/integration/components/card-space/details/button-text-card-test.ts
+++ b/packages/web-client/tests/integration/components/card-space/details/button-text-card-test.ts
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { WorkflowSession } from '@cardstack/web-client/models/workflow';
+import { Response as MirageResponse } from 'ember-cli-mirage';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { MirageTestContext } from 'ember-cli-mirage/test-support';
+import { OPTIONS } from '@cardstack/web-client/components/card-space/edit-details/button-text';
+
+interface Context extends MirageTestContext {}
+
+module(
+  'Integration | Component | card-space/edit-details/button-text',
+  function (hooks) {
+    setupRenderingTest(hooks);
+    setupMirage(hooks);
+
+    test('it lists the allowed button texts and persists the choice to the workflow session', async function (this: Context, assert) {
+      this.server.post('/card-spaces/validate-url', function () {
+        return new MirageResponse(200, {}, { errors: [] });
+      });
+
+      let workflowSession = new WorkflowSession();
+      this.set('workflowSession', workflowSession);
+
+      await render(hbs`
+        <CardSpace::EditDetails::ButtonText
+          @workflowSession={{this.workflowSession}}
+        />
+      `);
+
+      OPTIONS.forEach(function (buttonText, index) {
+        assert
+          .dom(`[data-test-button-text-option]:nth-child(${index + 1})`)
+          .hasText(buttonText);
+      });
+
+      await click(`[data-test-button-text-option]:nth-child(2)`);
+
+      assert.equal(workflowSession.getValue<string>('buttonText'), OPTIONS[1]);
+      assert
+        .dom('[data-test-button-text-option]:nth-child(2) input')
+        .isChecked();
+    });
+
+    test('it restores input from session', async function (this: Context, assert) {
+      let workflowSession = new WorkflowSession();
+      this.set('workflowSession', workflowSession);
+      workflowSession.setValue('buttonText', OPTIONS[1]);
+
+      await render(hbs`
+        <CardSpace::EditDetails::ButtonText
+          @workflowSession={{this.workflowSession}}
+        />
+      `);
+
+      assert
+        .dom('[data-test-button-text-option]:nth-child(2) input')
+        .hasClass('card-space-button-text-field__input--checked');
+    });
+  }
+);


### PR DESCRIPTION
This adds a Card Space profile card button text chooser to the existing edit details card:

![screencast 2021-11-18 14-24-59](https://user-images.githubusercontent.com/43280/142491518-99e58600-7d5c-4053-8b44-bc0d0c61aeb0.gif)

This doesn’t attempt to address the duplication of [valid button text options](https://github.com/cardstack/cardstack/blob/15efcdf7f42b66c88ac2f4edc3ca75bc07bea459/packages/hub/services/validators/card-space.ts#L33) in Hub. Maybe a new directory in `packages` for sharing?