### PR TITLE
remove symbolic link

### DIFF
--- a/packages/cardpay-sdk/contracts/abi/v0.8.5/latest
+++ b/packages/cardpay-sdk/contracts/abi/v0.8.5/latest
@@ -1,1 +1,0 @@
-/Users/tintinthong/Documents/GitHub/cardstack/packages/cardpay-sdk/contracts/abi/latest


### PR DESCRIPTION
Mistakenly added symbolic link within `0.8.5` directory that causes lint errors.

```
Error: ELOOP: too many symbolic links encountered, stat '/Users/tintinthong/Documents/GitHub/cardstack/packages/cardpay-sdk/contracts/abi/v0.8.5/latest/latest/latest/latest/latest/latest/latest/latest/latest/latest/latest/latest/latest/latest/latest/latest/latest'
```