### PR TITLE
throw json rpc errors that come up instead of silencing them

### DIFF
--- a/packages/web-client/app/utils/wc-provider.ts
+++ b/packages/web-client/app/utils/wc-provider.ts
@@ -431,8 +431,8 @@ class WalletConnectProvider extends ExtendedProviderEngine {
     this.addProvider({
       handleRequest: async (payload: IJsonRpcRequest, _next: any, end: any) => {
         try {
-          const { result } = await this.handleRequest(payload);
-          end(undefined, result);
+          const { error, result } = (await this.handleRequest(payload)) as any;
+          end(error, result);
         } catch (error) {
           end(error);
         }


### PR DESCRIPTION
Misleading typescript strikes again 😩. This fixes JSON RPC errors being interpreted by the DApp as successful calls with a return value of `undefined`.

To mock a JSON RPC error sent via websocket, try replacing `WebsocketProvider.prototype._onMessage` in `node_modules/web3-providers-ws/lib/index.js` with:

```
WebsocketProvider.prototype._onMessage = function (e) {
  var _this = this;
  
  // this try catch block conditionally rewrites calls to the eth json rpc with an error
  try {
    const { id } = JSON.parse(e.data);
    const request = _this.responseQueue.get(id);
    if (
      request.payload &&
      request.payload.method === "eth_call" &&
      request.payload.params &&
      request.payload.params[0] &&
      // replace address for contracts that you want to mock an error for
      // based on `packages/cardpay-sdk/contracts/addresses.ts`
      // the current address makes any methods of the homeBridge contract on Sokol error
      request.payload.params[0].to ===
        "0x16a80598DD2f143CFBf091638CE3fB02c9135528".toLowerCase()
    ) {
      console.log("messing up", request.payload.params);
      e = {
        data: JSON.stringify({
          jsonrpc: "2.0",
          error: {
            code: -32017,
            message: "Timeout",
            data: "Nethermind.JsonRpc.Modules.ModuleRentalTimeoutException: Unable to rent an instance of IEthRpcModule. Too many concurrent requests.\n   at Nethermind.JsonRpc.Modules.BoundedModulePool`1.SlowPath() in /src/Nethermind/Nethermind.JsonRpc/Modules/BoundedModulePool.cs:line 58\n   at Nethermind.JsonRpc.Modules.RpcModuleProvider.<>c__DisplayClass15_0`1.<<Register>b__0>d.MoveNext() in /src/Nethermind/Nethermind.JsonRpc/Modules/RpcModuleProvider.cs:line 74\n--- End of stack trace from previous location ---\n   at Nethermind.JsonRpc.JsonRpcService.ExecuteAsync(JsonRpcRequest request, String methodName, ValueTuple`2 method, JsonRpcContext context) in /src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs:line 161\n   at Nethermind.JsonRpc.JsonRpcService.ExecuteRequestAsync(JsonRpcRequest rpcRequest, JsonRpcContext context) in /src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs:line 114\n   at Nethermind.JsonRpc.JsonRpcService.SendRequestAsync(JsonRpcRequest rpcRequest, JsonRpcContext context) in /src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs:line 104",
          },
          id: id,
        }),
      };
    }
  } catch (e) {
    console.log("oops failed to rewrite");
  }
  
  this._parseResponse(typeof e.data === "string" ? e.data : "").forEach(
    function (result) {
      if (result.method && result.method.indexOf("_subscription") !== -1) {
        _this.emit(_this.DATA, result);
        return;
      }
      var id = result.id;
      // get the id which matches the returned id
      if (Array.isArray(result)) {
        id = result[0].id;
      }
      if (_this.responseQueue.has(id)) {
        if (_this.responseQueue.get(id).callback !== undefined) {
          _this.responseQueue.get(id).callback(false, result);
        }
        _this.responseQueue.delete(id);
      }
    }
  );
};

```