### PR TITLE
Add block confirm to withdraw flow

### DIFF
--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
@@ -51,7 +51,7 @@ export const MILESTONE_TITLES = [
   `Claim tokens on ${c.layer1.conversationalName}`,
 ];
 
-export const WORKFLOW_VERSION = 4;
+export const WORKFLOW_VERSION = 5;
 
 class CheckBalanceWorkflowMessage
   extends WorkflowPostable

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
@@ -92,7 +92,7 @@
           class="withdrawal-transaction-amount__loading-indicator"
           @color="var(--boxel-light)"
         />
-        <div class="withdrawal-transaction-amount__loading-message">
+        <div data-test-withdrawal-transaction-amount-in-progress class="withdrawal-transaction-amount__loading-message">
           Waiting for you to confirm on your Card Wallet mobile app...
         </div>
       </i.ActionStatusArea>

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.hbs
@@ -23,7 +23,7 @@
         {{progressStep.title}}
       </span>
 
-      <span class="transaction-status__step-status">
+      <span class="transaction-status__step-status" data-test-token-bridge-step-status={{progressStep.index}} data-test-withdrawal-bridging-block-count={{this.blockCount}}>
         {{#if (eq progressStep.index 0)}}
           <Boxel::Button @as="anchor" @size="extra-small" @href={{this.blockscoutUrl}} target="_blank" rel="noopener" data-test-blockscout-button>
             View on Blockscout
@@ -32,6 +32,8 @@
         {{#if (eq progressStep.index 1)}}
           {{#if this.error}}
             <span data-test-withdrawal-bridging-failed>Failed</span>
+          {{else if this.showBridgingSubstate}}
+            {{this.bridgingSubstate}} <Boxel::LoadingIndicator class="transaction-status__spinner" />
           {{else}}
             <Boxel::Button @as="anchor" @size="extra-small" @href={{this.bridgeExplorerUrl}} target="_blank" rel="noopener" data-test-bridge-explorer-button>
               View in Bridge Explorer

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -7,6 +7,7 @@ import {
   Layer2ChainEvent,
   Layer2Web3Strategy,
   TransactionHash,
+  TxnBlockNumber,
   WithdrawalLimits,
 } from '../utils/web3-strategies/types';
 import {
@@ -236,6 +237,10 @@ export default class Layer2Network
 
   on(event: Layer2ChainEvent, cb: Function): UnbindEventListener {
     return this.simpleEmitter.on(event, cb);
+  }
+
+  async getBlockConfirmation(blockNumber: TxnBlockNumber): Promise<void> {
+    return this.strategy.getBlockConfirmation(blockNumber);
   }
 
   getBlockHeight() {

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -37,6 +37,7 @@ import { taskFor } from 'ember-concurrency-ts';
 import { UsdConvertibleSymbol } from './token-to-usd';
 import { TransactionOptions } from '@cardstack/cardpay-sdk';
 import { Safes } from '../resources/safes';
+import { TransactionReceipt } from 'web3-core';
 export default class Layer2Network
   extends Service
   implements Emitter<Layer2ChainEvent>
@@ -271,14 +272,20 @@ export default class Layer2Network
     safeAddress: string,
     receiverAddress: string,
     tokenSymbol: BridgedTokenSymbol,
-    amount: string
-  ): Promise<TransactionHash> {
+    amount: string,
+    options: TransactionOptions
+  ): Promise<TransactionReceipt> {
     return this.strategy.bridgeToLayer1(
       safeAddress,
       receiverAddress,
       tokenSymbol,
-      amount
+      amount,
+      options
     );
+  }
+
+  async resumeBridgeToLayer1(txnHash: string) {
+    return this.strategy.resumeBridgeToLayer1(txnHash);
   }
 
   async awaitBridgedToLayer1(fromBlock: BN, transactionHash: TransactionHash) {

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -25,6 +25,7 @@ import {
   Layer2NetworkSymbol,
   Layer2ChainEvent,
   WithdrawalLimits,
+  TxnBlockNumber,
 } from './types';
 import {
   networkIds,
@@ -39,6 +40,7 @@ import {
   PrepaidCardSafe,
   Safe,
   TransactionOptions,
+  waitUntilBlock,
 } from '@cardstack/cardpay-sdk';
 import { taskFor } from 'ember-concurrency-ts';
 import config from '../../config/environment';
@@ -458,6 +460,12 @@ export default abstract class Layer2ChainWeb3Strategy
       'blockExplorer',
       this.networkSymbol
     )}/tx/${txnHash}`;
+  }
+
+  async getBlockConfirmation(blockNumber: TxnBlockNumber): Promise<void> {
+    if (!this.web3)
+      throw new Error('Cannot get block confirmations without web3');
+    return await waitUntilBlock(this.web3, blockNumber);
   }
 
   async getBlockHeight(): Promise<BN> {

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -511,26 +511,26 @@ export default abstract class Layer2ChainWeb3Strategy
     safeAddress: string,
     receiverAddress: string,
     tokenSymbol: BridgedTokenSymbol,
-    amountInWei: string
-  ): Promise<TransactionHash> {
+    amountInWei: string,
+    options: TransactionOptions
+  ): Promise<TransactionReceipt> {
     let tokenBridge = await getSDK('TokenBridgeHomeSide', this.web3);
     let tokenAddress = new TokenContractInfo(tokenSymbol, this.networkSymbol)!
       .address;
 
-    // in this case we don't want to wait for mining to complete. there is a
-    // purpose built await in the SDK for the bridge validators that is
-    // performed after this action--we can just rely on that for the timing
+    return await tokenBridge.relayTokens(
+      safeAddress,
+      tokenAddress,
+      receiverAddress,
+      amountInWei,
+      options
+    );
+  }
 
-    let transactionHash = await new Promise<TransactionHash>((res, reject) => {
-      tokenBridge
-        .relayTokens(safeAddress, tokenAddress, receiverAddress, amountInWei, {
-          onTxnHash: (txnHash) => res(txnHash),
-        })
-        .catch((e) => {
-          reject(e);
-        });
-    });
-    return transactionHash;
+  async resumeBridgeToLayer1(txnHash: string) {
+    let tokenBridge = await getSDK('TokenBridgeHomeSide', this.web3);
+
+    return await tokenBridge.relayTokens(txnHash);
   }
 
   async awaitBridgedToLayer1(

--- a/packages/web-client/app/utils/web3-strategies/test-layer2.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer2.ts
@@ -154,21 +154,30 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
     return this.bridgingToLayer2Deferred.promise as Promise<TransactionReceipt>;
   }
 
-  bridgeToLayer1(
+  async bridgeToLayer1(
     safeAddress: string,
     receiverAddress: string,
     tokenSymbol: BridgedTokenSymbol,
-    amountInWei: string
-  ): Promise<TransactionHash> {
+    amountInWei: string,
+    options: TransactionOptions
+  ): Promise<TransactionReceipt> {
     this.bridgeToLayer1Requests.push({
       safeAddress,
       receiverAddress,
       tokenSymbol,
       amountInWei,
     });
-    this.bridgingToLayer1HashDeferred = defer<TransactionHash>();
     this.bridgingToLayer1Deferred = defer<BridgeValidationResult>();
-    return this.bridgingToLayer1HashDeferred.promise;
+    options.onTxnHash?.('exampleTxnHash');
+    return {
+      blockNumber: this.test__blockNumber,
+    } as TransactionReceipt;
+  }
+
+  async resumeBridgeToLayer1(_txnHash: string) {
+    return {
+      blockNumber: this.test__blockNumber,
+    } as TransactionReceipt;
   }
 
   awaitBridgedToLayer1(

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -128,8 +128,10 @@ export interface Layer2Web3Strategy
     safeAddress: string,
     receiverAddress: string,
     tokenSymbol: BridgedTokenSymbol,
-    amountInWei: string
-  ): Promise<TransactionHash>;
+    amountInWei: string,
+    options: TransactionOptions
+  ): Promise<TransactionReceipt>;
+  resumeBridgeToLayer1(txnHash: string): Promise<TransactionReceipt>;
   awaitBridgedToLayer1(
     fromBlock: BN,
     txnHash: TransactionHash

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -115,6 +115,7 @@ export interface Layer2Web3Strategy
     symbolsToUpdate: UsdConvertibleSymbol[]
   ): Promise<Record<UsdConvertibleSymbol, ConversionFunction>>;
   blockExplorerUrl(txnHash: TransactionHash): string;
+  getBlockConfirmation(blockNumber: number): Promise<void>;
   getBlockHeight(): Promise<BN>;
   awaitBridgedToLayer2(
     fromBlock: BN,

--- a/packages/web-client/tests/acceptance/withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-test.ts
@@ -246,16 +246,7 @@ module('Acceptance | withdrawal', function (hooks) {
     await click(
       `${post} [data-test-withdrawal-transaction-amount] [data-test-boxel-button]`
     );
-    layer2Service.bridgingToLayer1HashDeferred.resolve('abc123');
-    assert
-      .dom(
-        `${post} [data-test-withdrawal-transaction-amount] [data-test-boxel-button]`
-      )
-      .doesNotExist();
-    assert
-      .dom('[data-test-withdrawal-transaction-amount]')
-      .containsText('Waiting for you to confirm');
-    await waitFor('[data-test-withdrawal-transaction-amount-is-complete]');
+
     assert
       .dom('[data-test-withdrawal-transaction-amount]')
       .containsText('Confirmed');

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
@@ -88,6 +88,12 @@ module(
         .dom(`[data-test-blockscout-button]`)
         .hasAttribute('href', /relay$/);
 
+      assert
+        .dom(`[data-test-token-bridge-step="1"]`)
+        .containsText(
+          `Bridge tokens from ${c.layer2.fullName} to ${c.layer1.fullName}`
+        );
+
       for (let i = 1; i <= layer1Service.bridgeConfirmationBlockCount; i++) {
         await waitFor(`[data-test-withdrawal-bridging-block-count="${i}"]`);
 
@@ -97,12 +103,6 @@ module(
 
         layer2Service.test__simulateBlockConfirmation();
       }
-
-      assert
-        .dom(`[data-test-token-bridge-step="1"]:not([data-test-completed])`)
-        .containsText(
-          `Bridge tokens from ${c.layer2.fullName} to ${c.layer1.fullName}`
-        );
 
       await waitFor('[data-test-bridge-explorer-button]');
 

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
@@ -29,6 +29,9 @@ module(
       workflowSession.setValue({
         layer2BlockHeightBeforeBridging: 1234,
         relayTokensTxnHash: 'relay',
+        relayTokensTxnReceipt: {
+          blockNumber: 0,
+        },
         withdrawalToken: 'CARD.CPXD',
         withdrawalSafe: safeAddress,
       });
@@ -57,7 +60,10 @@ module(
         '0xsource',
         '0xdestination',
         'DAI.CPXD',
-        '20'
+        '20',
+        {
+          onTxnHash: () => {},
+        }
       );
     });
 

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-status-test.ts
@@ -1,12 +1,13 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { find, render, settled } from '@ember/test-helpers';
+import { find, render, settled, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
 
 import sinon from 'sinon';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
+import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
 import {
   createDepotSafe,
   generateMockAddress,
@@ -61,6 +62,10 @@ module(
     });
 
     test('It renders transaction status and links', async function (assert) {
+      let layer1Service = this.owner.lookup('service:layer1-network')
+        .strategy as Layer1TestWeb3Strategy;
+      layer2Service.test__autoResolveBlockConfirmations = false;
+
       await render(hbs`
         <CardPay::WithdrawalWorkflow::TransactionStatus
           @onComplete={{this.onComplete}}
@@ -83,11 +88,24 @@ module(
         .dom(`[data-test-blockscout-button]`)
         .hasAttribute('href', /relay$/);
 
+      for (let i = 1; i <= layer1Service.bridgeConfirmationBlockCount; i++) {
+        await waitFor(`[data-test-withdrawal-bridging-block-count="${i}"]`);
+
+        assert
+          .dom(`[data-test-token-bridge-step-status="1"]`)
+          .hasText(`${i} of 5 blocks confirmed`);
+
+        layer2Service.test__simulateBlockConfirmation();
+      }
+
       assert
         .dom(`[data-test-token-bridge-step="1"]:not([data-test-completed])`)
         .containsText(
           `Bridge tokens from ${c.layer2.fullName} to ${c.layer1.fullName}`
         );
+
+      await waitFor('[data-test-bridge-explorer-button]');
+
       assert
         .dom(`[data-test-bridge-explorer-button]`)
         .hasAttribute('href', /relay$/);


### PR DESCRIPTION
Main changes:
1. Modified `transaction-amount` to wait for and save a receipt that signifies that the transaction has been mined, and contains the block number to let us know where to start the block count in `transaction-status`. This also requires `transaction-amount` to be able to resume with a transaction hash.
2. `transaction-status` now counts blocks to wait for finalization before checking for bridge validation.

![image](https://user-images.githubusercontent.com/39579264/142038519-361c5a62-426a-4d5a-bee1-c68f715e1cf3.png)

TODO:
- [x] Get the transaction receipt in the transaction-amount card instead, remove receipt utility added to layer 2