### PR TITLE
Adjust copy + add refresh page cta

### DIFF
--- a/packages/web-client/app/components/card-pay/network-problem-modal/index.hbs
+++ b/packages/web-client/app/components/card-pay/network-problem-modal/index.hbs
@@ -29,7 +29,10 @@
       <div data-test-network-problem-modal-body>
         {{@body}}
       </div>
-      <Boxel::Button @kind="primary" {{on "click" (optional @action)}} data-test-network-problem-modal-action>{{@actionText}}</Boxel::Button>
+      <div>
+        <Boxel::Button @kind="primary" {{on "click" (optional @action)}} data-test-network-problem-modal-action>{{@actionText}}</Boxel::Button>
+        <Boxel::Button @kind="secondary" {{on "click" this.openDiscord}}>Contact Cardstack Support</Boxel::Button>
+      </div>
     </Boxel::CardContainer>
   </div>
 </Boxel::Modal>

--- a/packages/web-client/app/components/card-pay/network-problem-modal/index.ts
+++ b/packages/web-client/app/components/card-pay/network-problem-modal/index.ts
@@ -1,0 +1,9 @@
+import config from '@cardstack/web-client/config/environment';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+
+export default class NetworkProblemModalComponent extends Component {
+  @action openDiscord() {
+    window.open(config.urls.discordSupportChannelUrl, '_blank');
+  }
+}

--- a/packages/web-client/app/controllers/card-pay.ts
+++ b/packages/web-client/app/controllers/card-pay.ts
@@ -5,7 +5,6 @@ import Layer1Network from '@cardstack/web-client/services/layer1-network';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { tracked } from '@glimmer/tracking';
 import { currentNetworkDisplayInfo as c } from '../utils/web3-strategies/network-display-info';
-import config from '../config/environment';
 
 interface NetworkProblemModalOptions {
   title: string;
@@ -49,10 +48,10 @@ export default class CardPayController extends Controller {
     if (this.networkProblemModalOptions) return;
     this.showNetworkProblemModal({
       title: `Disconnected from ${c[network].fullName}`,
-      body: `Sorry! Card Pay is disconnected from ${c[network].fullName}. You can restore the connection by refreshing the page.`,
+      body: `An unexpected error happened and the connection with ${c[network].fullName} was lost. To restore the connection and resume your work, please refresh the page.`,
       onClose: this.hideNetworkProblemModal,
-      action: () => window.open(config.urls.discordSupportChannelUrl, '_blank'),
-      actionText: 'Contact Cardstack Support',
+      action: () => window.location.reload(),
+      actionText: 'Refresh Page',
       dismissable: true,
     });
   }

--- a/packages/web-client/tests/acceptance/network-problems-test.ts
+++ b/packages/web-client/tests/acceptance/network-problems-test.ts
@@ -78,9 +78,9 @@ module('Acceptance | network-problems', function (hooks) {
     assert
       .dom(MODAL_BODY)
       .containsText(
-        'Sorry! Card Pay is disconnected from L2 test chain. You can restore the connection by refreshing the page.'
+        'An unexpected error happened and the connection with L2 test chain was lost. To restore the connection and resume your work, please refresh the page.'
       );
-    assert.dom(MODAL_ACTION).containsText('Contact Cardstack Support');
+    assert.dom(MODAL_ACTION).containsText('Refresh Page');
     assert.dom(MODAL).hasAttribute(MODAL_IS_DISMISSABLE_ATTRIBUTE);
   });
 
@@ -93,9 +93,9 @@ module('Acceptance | network-problems', function (hooks) {
     assert
       .dom(MODAL_BODY)
       .containsText(
-        'Sorry! Card Pay is disconnected from L1 test chain. You can restore the connection by refreshing the page.'
+        'An unexpected error happened and the connection with L1 test chain was lost. To restore the connection and resume your work, please refresh the page.'
       );
-    assert.dom(MODAL_ACTION).containsText('Contact Cardstack Support');
+    assert.dom(MODAL_ACTION).containsText('Refresh Page');
     assert.dom(MODAL).hasAttribute(MODAL_IS_DISMISSABLE_ATTRIBUTE);
   });
 });


### PR DESCRIPTION
Ticket: [CS-2556](https://linear.app/cardstack/issue/CS-2556/add-a-refresh-button-to-the-disconnection-error-pop-up)

![image](https://user-images.githubusercontent.com/273660/142192676-217f0fb9-2de7-41ae-b3c3-a3f17e028ddb.png)
