### PR TITLE
CS-2571 Adding ability to filter safe results by type

### DIFF
--- a/packages/cardpay-cli/README.md
+++ b/packages/cardpay-cli/README.md
@@ -55,7 +55,7 @@ yarn cardpay safes-view --walletConnect
   - [`cardpay claim-revenue <MERCHANT_SAFE> <TOKEN_ADDRESS> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#cardpay-claim-revenue-merchant_safe-token_address-amount---networknetwork---mnemonicmnemonic---walletconnect)
   - [`cardpay claim-revenue-gas-estimate <MERCHANT_SAFE> <TOKEN_ADDRESS> <AMOUNT> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#cardpay-claim-revenue-gas-estimate-merchant_safe-token_address-amount---networknetwork---mnemonicmnemonic---walletconnect)
   - [`cardpay new-prepaidcard-gas-fee <TOKEN_ADDRESS> --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#cardpay-new-prepaidcard-gas-fee-token_address---networknetwork---mnemonicmnemonic---walletconnect)
-  - [`cardpay safes-view [ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#cardpay-safes-view-address---networknetwork---mnemonicmnemonic---walletconnect)
+  - [`cardpay safes-view [ADDRESS] [SAFE_TYPE] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#cardpay-safes-view-address-safe_type---networknetwork---mnemonicmnemonic---walletconnect)
   - [`cardpay safe-view [SAFE_ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#cardpay-safe-view-safe_address---networknetwork---mnemonicmnemonic---walletconnect)
   - [`cardpay safe-transfer-tokens [SAFE_ADDRESS] [TOKEN_ADDRESS] [RECIPIENT] [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#cardpay-safe-transfer-tokens-safe_address-token_address-recipient-amount---networknetwork---mnemonicmnemonic---walletconnect)
   - [`cardpay safe-transfer-tokens-gas-estimate [SAFE_ADDRESS] [TOKEN_ADDRESS] [RECIPIENT] [AMOUNT] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`](#cardpay-safe-transfer-tokens-gas-estimate-safe_address-token_address-recipient-amount---networknetwork---mnemonicmnemonic---walletconnect)
@@ -459,16 +459,17 @@ ARGUMENTS
   MNEMONIC           (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
   WALLET_CONNECT     (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet
 ```
-## `cardpay safes-view [ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
+## `cardpay safes-view [ADDRESS] [SAFE_TYPE] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]`
 
 View safes that your wallet is the owner of
 
 ```
 USAGE
-  $ cardpay safes-view [ADDRESS] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
+  $ cardpay safes-view [ADDRESS] [SAFE_TYPE] --network=NETWORK [--mnemonic=MNEMONIC] [--walletConnect]
 
 ARGUMENTS
   ADDRESS         (Optional) an address of an owner whose safes you wish to view (defaults to the wallet's default account)
+  SAFE_TYPE       (Optional) The type of safe to view: 'depot', 'merchant', 'prepaid-card', 'reward'
   NETWORK         The network to use ("sokol" or "xdai")
   MNEMONIC        (Optional) Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE
   WALLET_CONNECT  (Optional) A flag that indicates that you wish to use wallet connect (and hence the card wallet app) for your wallet

--- a/packages/cardpay-cli/index.ts
+++ b/packages/cardpay-cli/index.ts
@@ -53,6 +53,7 @@ import {
   removeFromInventory as removePrepaidCardInventory,
   addToInventory as addPrepaidCardInventory,
 } from './prepaid-card-market.js';
+import { Safe } from '@cardstack/cardpay-sdk';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -146,6 +147,7 @@ interface Options {
   rewardSafe?: string;
   newAdmin?: string;
   force?: string;
+  safeType?: Exclude<Safe['type'], 'external'>;
 }
 let {
   network,
@@ -186,6 +188,7 @@ let {
   rewardSafe,
   newAdmin,
   force,
+  safeType,
 } = yargs(process.argv.slice(2))
   .scriptName('cardpay')
   .usage('Usage: $0 <command> [options]')
@@ -285,12 +288,16 @@ let {
     }
   )
   .command(
-    'safes-view [address]',
+    'safes-view [address] [safeType]',
     'View contents of the safes owned by the specified address (or default wallet account)',
     (yargs) => {
       yargs.positional('address', {
         type: 'string',
         description: "The address of the safe owner. This defaults to your wallet's default account when not provided",
+      });
+      yargs.positional('safeType', {
+        type: 'string',
+        description: "The type of safe to view: 'depot', 'merchant', 'prepaid-card', 'reward'",
       });
       command = 'safesView';
     }
@@ -971,7 +978,7 @@ if (!command) {
       await claimLayer1BridgedTokens(network, messageId, encodedData, signatures, mnemonic);
       break;
     case 'safesView':
-      await viewSafes(network, address, mnemonic);
+      await viewSafes(network, address, safeType, mnemonic);
       break;
     case 'safeView':
       if (safeAddress == null) {

--- a/packages/cardpay-cli/safe.ts
+++ b/packages/cardpay-cli/safe.ts
@@ -1,7 +1,6 @@
 import Web3 from 'web3';
-import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
+import { getConstant, getSDK, Safe } from '@cardstack/cardpay-sdk';
 import { getWeb3 } from './utils';
-import { Safe } from '@cardstack/cardpay-sdk/sdk/safes';
 
 const { toWei, fromWei } = Web3.utils;
 
@@ -21,15 +20,21 @@ export async function viewSafe(network: string, address: string, mnemonic?: stri
   console.log();
 }
 
-export async function viewSafes(network: string, address: string | undefined, mnemonic?: string): Promise<void> {
+export async function viewSafes(
+  network: string,
+  address: string | undefined,
+  type: Exclude<Safe['type'], 'external'> | undefined,
+  mnemonic?: string
+): Promise<void> {
   let web3 = await getWeb3(network, mnemonic);
+  address = address || undefined;
 
   let safesApi = await getSDK('Safes', web3);
-  console.log('Getting safes...');
+  console.log(`Getting ${type ? type + ' ' : ''}safes...`);
   console.log();
-  let safes = (await safesApi.view(address)).safes.filter((safe) => safe.type !== 'external');
+  let safes = (await safesApi.view(address, { type })).safes.filter((safe) => safe.type !== 'external');
   if (safes.length === 0) {
-    console.log('You have no safes (not counting safes external to the cardpay protocol)');
+    console.log('Found no safes (not counting safes external to the cardpay protocol)');
   }
   safes.forEach((safe) => {
     displaySafe(safe.address, safe);

--- a/packages/cardpay-sdk/sdk/utils/graphql.ts
+++ b/packages/cardpay-sdk/sdk/utils/graphql.ts
@@ -6,17 +6,17 @@ import { getConstant } from '../constants';
 export async function query(
   network: string,
   graphQLQuery: string,
-  variables?: { [varName: string]: string | number }
+  variables?: { [varName: string]: string | number | null }
 ): Promise<{ data: any }>;
 export async function query(
   web3: Web3,
   graphQLQuery: string,
-  variables?: { [varName: string]: string | number }
+  variables?: { [varName: string]: string | number | null }
 ): Promise<{ data: any }>;
 export async function query(
   networkOrWeb3: string | Web3,
   graphQLQuery: string,
-  variables?: { [varName: string]: string | number }
+  variables?: { [varName: string]: string | number | null }
 ): Promise<{ data: any }> {
   let subgraphURL: string;
   if (typeof networkOrWeb3 === 'string') {

--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -410,6 +410,7 @@ type SafeOwner @entity {
   id: ID!               # Set to safe.id-owner.id
   owner: Account!
   safe: Safe!
+  type: String
   createdAt: BigInt!
   ownershipChangedAt: BigInt!
 }

--- a/packages/cardpay-subgraph/src/mappings/depot.ts
+++ b/packages/cardpay-subgraph/src/mappings/depot.ts
@@ -1,7 +1,14 @@
 import { SupplierSafeCreated, SupplierInfoDIDUpdated } from '../../generated/Depot/SupplierManager';
 import { TokensBridgedToSafe, TokensBridgingInitiated } from '../../generated/TokenBridge/HomeMultiAMBErc20ToErc677';
 import { Depot, BridgeToLayer1Event, BridgeToLayer2Event, SupplierInfoDIDUpdate, Safe } from '../../generated/schema';
-import { makeToken, makeEOATransaction, toChecksumAddress, makeEOATransactionForSafe, makeAccount } from '../utils';
+import {
+  makeToken,
+  makeEOATransaction,
+  toChecksumAddress,
+  makeEOATransactionForSafe,
+  makeAccount,
+  setSafeType,
+} from '../utils';
 import { log, BigInt, Address } from '@graphprotocol/graph-ts';
 import { GnosisSafe } from '../../generated/Gnosis/GnosisSafe';
 
@@ -28,6 +35,8 @@ export function handleReceivedBridgedTokens(event: TokensBridgedToSafe): void {
   bridgeEventEntity.token = makeToken(event.params.token);
   bridgeEventEntity.amount = event.params.value;
   bridgeEventEntity.save();
+
+  setSafeType(safe, 'depot');
   log.debug('created bridge event entity {} for depot {}', [bridgeEventEntity.id, bridgeEventEntity.depot]);
 }
 

--- a/packages/cardpay-subgraph/src/mappings/merchant-manager.ts
+++ b/packages/cardpay-subgraph/src/mappings/merchant-manager.ts
@@ -1,7 +1,7 @@
 import { BigInt } from '@graphprotocol/graph-ts';
 import { MerchantCreation as MerchantCreationEvent } from '../../generated/Merchant/MerchantManager';
 import { MerchantSafe, MerchantCreation } from '../../generated/schema';
-import { makeEOATransaction, toChecksumAddress, makeAccount } from '../utils';
+import { makeEOATransaction, toChecksumAddress, makeAccount, setSafeType } from '../utils';
 
 export function handleMerchantCreation(event: MerchantCreationEvent): void {
   let merchant = toChecksumAddress(event.params.merchant);
@@ -25,4 +25,6 @@ export function handleMerchantCreation(event: MerchantCreationEvent): void {
   creationEntity.merchantSafe = merchantSafe;
   creationEntity.merchant = merchant;
   creationEntity.save();
+
+  setSafeType(merchantSafe, 'merchant');
 }

--- a/packages/cardpay-subgraph/src/mappings/prepaid-card.ts
+++ b/packages/cardpay-subgraph/src/mappings/prepaid-card.ts
@@ -19,6 +19,7 @@ import {
   getPrepaidCardFaceValue,
   makeEOATransactionForSafe,
   makeAccount,
+  setSafeType,
 } from '../utils';
 import { log } from '@graphprotocol/graph-ts';
 
@@ -65,6 +66,8 @@ export function handleCreatePrepaidCard(event: CreatePrepaidCard): void {
   creationEntity.spendAmount = event.params.spendAmount;
   creationEntity.creationGasFeeCollected = event.params.gasFeeCollected;
   creationEntity.save();
+
+  setSafeType(prepaidCard, 'prepaid-card');
 }
 
 export function handleTransferPrepaidCard(event: TransferredPrepaidCard): void {

--- a/packages/cardpay-subgraph/src/mappings/reward-manager.ts
+++ b/packages/cardpay-subgraph/src/mappings/reward-manager.ts
@@ -1,6 +1,6 @@
 import { RewardeeRegistered } from '../../generated/RewardManager/RewardManager';
 import { RewardSafe, RewardProgram } from '../../generated/schema';
-import { toChecksumAddress, makeEOATransaction, makeAccount } from '../utils';
+import { toChecksumAddress, makeEOATransaction, makeAccount, setSafeType } from '../utils';
 import { log } from '@graphprotocol/graph-ts';
 
 // To track creation of reward safe
@@ -27,4 +27,6 @@ export function handleRewardeeRegistration(event: RewardeeRegistered): void {
   entity.rewardee = rewardee;
   entity.safe = rewardSafe;
   entity.save();
+
+  setSafeType(rewardSafe, 'reward');
 }


### PR DESCRIPTION
This introduces a new field in our subgraph that allows us to filter safes by type. This filtering capability is exposed in the `Safes.view()` API as a `type` field in the options for this API call. So that if you want to retrieve just the prepaid cards, you can call:
```js
let prepaidCards = Safes.view({ type: 'prepaid-card'});
```