### PR TITLE
Use retry UI (over cancel) for deposit workflow

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -57,17 +57,17 @@
       * The actual value depends on the current exchange rate and is determined at the time of authorization.
     </div>
     {{#if (and this.errorMessage this.depositTaskRetriable)}}
-      <CardPay::ErrorMessage as |supportURL|>
+      <CardPay::ErrorMessage data-test-deposit-error-message as |supportURL|>
         {{this.errorMessage}}
         Please try again if you want to continue with this workflow. If you haven't received a signing request, click on "Resend signing request" below, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack Support</a>
       </CardPay::ErrorMessage>
     {{else if this.errorMessage}}
-      <CardPay::ErrorMessage as |supportURL|>
+      <CardPay::ErrorMessage data-test-deposit-error-message as |supportURL|>
         {{this.errorMessage}}
         Please try again if you want to continue with this workflow, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
       </CardPay::ErrorMessage>
     {{else if this.depositTaskRetriable}}
-      <CardPay::ErrorMessage as |supportURL|>
+      <CardPay::ErrorMessage data-test-deposit-error-message as |supportURL|>
         If you haven't received a signing request, make sure to check your connected {{network-display-info "layer1" "fullName"}} wallet. You can also try to click on "Resend signing request" below, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack Support</a>.
       </CardPay::ErrorMessage>
     {{/if}}

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -59,7 +59,7 @@
     {{#if (and this.errorMessage this.depositTaskRetriable)}}
       <CardPay::ErrorMessage data-test-deposit-error-message as |supportURL|>
         {{this.errorMessage}}
-        Please try again if you want to continue with this workflow. If you haven't received a signing request, click on "Resend signing request" below, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack Support</a>
+        Please try again if you want to continue with this workflow. If you haven't received a signing request, click on "Resend Signing Request" below, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack Support</a>
       </CardPay::ErrorMessage>
     {{else if this.errorMessage}}
       <CardPay::ErrorMessage data-test-deposit-error-message as |supportURL|>
@@ -68,7 +68,7 @@
       </CardPay::ErrorMessage>
     {{else if this.depositTaskRetriable}}
       <CardPay::ErrorMessage data-test-deposit-error-message as |supportURL|>
-        If you haven't received a signing request, make sure to check your connected {{network-display-info "layer1" "fullName"}} wallet. You can also try to click on "Resend signing request" below, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack Support</a>.
+        If you haven't received a signing request, make sure to check your connected {{network-display-info "layer1" "fullName"}} wallet. You can also try to click on "Resend Signing Request" below, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack Support</a>.
       </CardPay::ErrorMessage>
     {{/if}}
   </ActionCardContainer::Section>
@@ -120,7 +120,7 @@
       </i.ActionButton>
       {{#if this.depositTaskRetriable}}
         <i.CancelButton {{on "click" this.retryDeposit}} data-test-deposit-retry-button>
-          Resend signing request
+          Resend Signing Request
         </i.CancelButton>
       {{/if}}
       {{#if this.depositTxnViewerUrl}}

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -53,14 +53,24 @@
         </CardPay::LabeledValue>
       {{/unless}}
     </div>
-    {{#if this.errorMessage}}
-      <CardPay::ErrorMessage as |supportURL|>
-        {{this.errorMessage}} Please try again if you want to continue with this workflow, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
-      </CardPay::ErrorMessage>
-    {{/if}}
     <div class="transaction-amount__footnote">
       * The actual value depends on the current exchange rate and is determined at the time of authorization.
     </div>
+    {{#if (and this.errorMessage this.depositTaskRetriable)}}
+      <CardPay::ErrorMessage as |supportURL|>
+        {{this.errorMessage}}
+        Please try again if you want to continue with this workflow. If you haven't received a signing request, click on "Resend signing request" below, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack Support</a>
+      </CardPay::ErrorMessage>
+    {{else if this.errorMessage}}
+      <CardPay::ErrorMessage as |supportURL|>
+        {{this.errorMessage}}
+        Please try again if you want to continue with this workflow, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
+      </CardPay::ErrorMessage>
+    {{else if this.depositTaskRetriable}}
+      <CardPay::ErrorMessage as |supportURL|>
+        If you haven't received a signing request, make sure to check your connected {{network-display-info "layer1" "fullName"}} wallet. You can also try to click on "Resend signing request" below, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack Support</a>.
+      </CardPay::ErrorMessage>
+    {{/if}}
   </ActionCardContainer::Section>
   <Boxel::ActionChin @stepNumber={{1}} @state={{this.unlockCtaState}} @disabled={{or @frozen this.unlockCtaDisabled}}>
     <:default as |a|>
@@ -110,7 +120,7 @@
       </i.ActionButton>
       {{#if this.depositTaskRetriable}}
         <i.CancelButton {{on "click" this.retryDeposit}} data-test-deposit-retry-button>
-          Retry
+          Resend signing request
         </i.CancelButton>
       {{/if}}
       {{#if this.depositTxnViewerUrl}}

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -108,9 +108,9 @@
       <i.ActionButton data-test-deposit-button>
         Depositing
       </i.ActionButton>
-      {{#if this.depositTaskCancelable}}
-        <i.CancelButton {{on "click" this.cancelDeposit}} data-test-deposit-cancel-button>
-          Cancel
+      {{#if this.depositTaskRetriable}}
+        <i.CancelButton {{on "click" this.retryDeposit}} data-test-deposit-retry-button>
+          Retry
         </i.CancelButton>
       {{/if}}
       {{#if this.depositTxnViewerUrl}}

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.hbs
@@ -56,7 +56,7 @@
     <div class="transaction-amount__footnote">
       * The actual value depends on the current exchange rate and is determined at the time of authorization.
     </div>
-    {{#if (and this.errorMessage this.depositTaskRetriable)}}
+    {{#if (and this.errorMessage this.depositTaskRetryable)}}
       <CardPay::ErrorMessage data-test-deposit-error-message as |supportURL|>
         {{this.errorMessage}}
         Please try again if you want to continue with this workflow. If you haven't received a signing request, click on "Resend Signing Request" below, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack Support</a>
@@ -66,7 +66,7 @@
         {{this.errorMessage}}
         Please try again if you want to continue with this workflow, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
       </CardPay::ErrorMessage>
-    {{else if this.depositTaskRetriable}}
+    {{else if this.depositTaskRetryable}}
       <CardPay::ErrorMessage data-test-deposit-error-message as |supportURL|>
         If you haven't received a signing request, make sure to check your connected {{network-display-info "layer1" "fullName"}} wallet. You can also try to click on "Resend Signing Request" below, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack Support</a>.
       </CardPay::ErrorMessage>
@@ -118,7 +118,7 @@
       <i.ActionButton data-test-deposit-button>
         Depositing
       </i.ActionButton>
-      {{#if this.depositTaskRetriable}}
+      {{#if this.depositTaskRetryable}}
         <i.CancelButton {{on "click" this.retryDeposit}} data-test-deposit-retry-button>
           Resend Signing Request
         </i.CancelButton>

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
@@ -82,7 +82,7 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<Workflo
     });
   }
 
-  get depositTaskRetriable() {
+  get depositTaskRetryable() {
     return (
       !this.relayTokensTxnHash &&
       this.depositTaskRunningForAWhile &&

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
@@ -78,7 +78,7 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<Workflo
     });
   }
 
-  get depositTaskCancelable() {
+  get depositTaskRetriable() {
     return !this.relayTokensTxnHash && this.depositTaskRunningForAWhile;
   }
 
@@ -213,7 +213,7 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<Workflo
     }
   }
 
-  @action cancelDeposit() {
+  @action retryDeposit() {
     taskFor(this.depositTask).cancelAll();
     this.depositTaskRunningForAWhile = false;
   }

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
@@ -248,7 +248,6 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<Workflo
           this.cancelDepositsOtherThan(uid);
         }
       );
-      session.setValue('setting task', uid);
       this.depositTaskMap[uid] = task;
 
       let transactionReceipt = yield task;

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
@@ -222,6 +222,8 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<Workflo
     this.errorMessage = '';
     let session = this.args.workflowSession;
     try {
+      session.setValue('depositedAmount', this.amountAsBigNumber);
+
       let transactionReceipt;
       if (this.relayTokensTxnHash) {
         transactionReceipt = yield this.layer1Network.resumeRelayTokens(
@@ -248,7 +250,6 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<Workflo
         ]);
       }
       session.setValue('relayTokensTxnReceipt', transactionReceipt);
-      session.setValue('depositedAmount', this.amountAsBigNumber);
       this.args.onComplete?.();
     } catch (e) {
       console.error(e);

--- a/packages/web-client/app/utils/web3-strategies/test-layer1.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer1.ts
@@ -97,7 +97,7 @@ export default class TestLayer1Web3Strategy implements Layer1Web3Strategy {
     _destinationAddress: string,
     _amountInWei: BN,
     { onTxnHash }: RelayTokensOptions
-  ) {
+  ): Promise<TransactionReceipt> {
     this.#depositOnTxnHash = onTxnHash;
     this.#depositDeferred = RSVP.defer();
     return this.#depositDeferred.promise;

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
@@ -135,12 +135,12 @@ module(
       assert.dom('[data-test-deposit-retry-button]').isVisible();
       assert
         .dom('[data-test-deposit-retry-button]')
-        .containsText('Resend signing request');
+        .containsText('Resend Signing Request');
       assert.dom('[data-test-deposit-retry-button]').isEnabled();
       assert
         .dom('[data-test-deposit-error-message]')
         .containsText(
-          `If you haven't received a signing request, make sure to check your connected L1 test chain wallet. You can also try to click on "Resend signing request" below, or contact Cardstack Support.`
+          `If you haven't received a signing request, make sure to check your connected L1 test chain wallet. You can also try to click on "Resend Signing Request" below, or contact Cardstack Support.`
         );
 
       await click('[data-test-deposit-retry-button]');

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
@@ -347,12 +347,12 @@ module(
         });
 
         await render(hbs`
-        <CardPay::DepositWorkflow::TransactionAmount
-          @workflowSession={{this.session}}
-          @onComplete={{this.onComplete}}
-          @onIncomplete={{noop}}
-        />
-      `);
+          <CardPay::DepositWorkflow::TransactionAmount
+            @workflowSession={{this.session}}
+            @onComplete={{this.onComplete}}
+            @onIncomplete={{noop}}
+          />
+        `);
 
         await layer1Service.test__simulateUnlock();
 

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
@@ -133,8 +133,15 @@ module(
       await new Promise((resolve) => setTimeout(() => resolve(true), 500));
 
       assert.dom('[data-test-deposit-retry-button]').isVisible();
+      assert
+        .dom('[data-test-deposit-retry-button]')
+        .containsText('Resend signing request');
       assert.dom('[data-test-deposit-retry-button]').isEnabled();
-      // additional assertions on the error message
+      assert
+        .dom('[data-test-deposit-error-message]')
+        .containsText(
+          `If you haven't received a signing request, make sure to check your connected L1 test chain wallet. You can also try to click on "Resend signing request" below, or contact Cardstack Support.`
+        );
 
       await click('[data-test-deposit-retry-button]');
 
@@ -364,7 +371,7 @@ module(
         assert
           .dom('[data-test-deposit-error-message]')
           .containsText(
-            'Please try again if you want to continue with this workflow, or contact Cardstack support.'
+            'There was a problem initiating the bridging of your tokens to the L2 test chain. This may be due to a network issue, or perhaps you canceled the request in your wallet. Please try again if you want to continue with this workflow, or contact Cardstack support.'
           );
       });
 

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
@@ -7,6 +7,7 @@ import {
   click,
   settled,
   waitFor,
+  find,
 } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
@@ -15,6 +16,9 @@ import { WorkflowSession } from '@cardstack/web-client/models/workflow';
 import BN from 'bn.js';
 import { toWei } from 'web3-utils';
 import sinon from 'sinon';
+import { TransactionReceipt } from 'web3-core';
+import { RelayTokensOptions } from '@cardstack/web-client/utils/web3-strategies/types';
+import RSVP, { defer } from 'rsvp';
 
 let layer1Service: Layer1TestWeb3Strategy;
 let session: WorkflowSession;
@@ -104,10 +108,12 @@ module(
       assert.ok(completed);
     });
 
-    test('its deposit step can be canceled if there is no deposit transaction hash', async function (assert) {
+    test('its deposit step can be retried if there is no deposit transaction hash', async function (assert) {
       session.setValue('unlockTxnHash', 'unlockTokensTxnHash');
       session.setValue('depositSourceToken', 'DAI');
       session.setValue('depositedAmount', new BN(toWei('5')));
+
+      let relayTokensSpy = sinon.spy(layer1Service, 'relayTokens');
 
       await render(hbs`
       <CardPay::DepositWorkflow::TransactionAmount
@@ -120,19 +126,22 @@ module(
       await layer1Service.test__simulateUnlock();
 
       await click('[data-test-deposit-button]');
+
       assert.dom('[data-test-deposit-button]').containsText('Depositing');
+      assert.ok(relayTokensSpy.calledOnce);
 
       await new Promise((resolve) => setTimeout(() => resolve(true), 500));
-      assert.dom('[data-test-deposit-cancel-button]').isVisible();
-      assert.dom('[data-test-deposit-cancel-button]').isEnabled();
 
-      await click('[data-test-deposit-cancel-button]');
+      assert.dom('[data-test-deposit-retry-button]').isVisible();
+      assert.dom('[data-test-deposit-retry-button]').isEnabled();
+      // additional assertions on the error message
 
-      assert.dom('[data-test-deposit-button]').containsText('Deposit');
-      assert.dom('[data-test-deposit-button]').isEnabled();
+      await click('[data-test-deposit-retry-button]');
+
+      assert.ok(relayTokensSpy.calledTwice);
     });
 
-    test('its deposit step can not be canceled if there is a deposit transaction hash', async function (assert) {
+    test('its deposit step can not be retried if there is a deposit transaction hash', async function (assert) {
       session.setValue('unlockTxnHash', 'unlockTokensTxnHash');
       session.setValue('depositSourceToken', 'DAI');
       session.setValue('depositedAmount', new BN(toWei('5')));
@@ -152,8 +161,7 @@ module(
       await click('[data-test-deposit-button]');
 
       await new Promise((resolve) => setTimeout(() => resolve(true), 500));
-      assert.dom('[data-test-deposit-button]').containsText('Depositing');
-      assert.dom('[data-test-deposit-cancel-button]').doesNotExist();
+      assert.dom('[data-test-deposit-retry-button]').doesNotExist();
     });
 
     test('It disables the unlock button when amount entered is more than balance (18-decimal floating point)', async function (assert) {
@@ -282,6 +290,125 @@ module(
       assert
         .dom('[data-test-boxel-input-error-message]')
         .containsText('Amount must be above 0.00 DAI');
+    });
+
+    module('it can resolve retries correctly', function (hooks) {
+      let attempt1: RSVP.Deferred<void>;
+      let attempt2: RSVP.Deferred<void>;
+      let isComplete = false;
+      let onComplete: Function;
+
+      hooks.beforeEach(async function () {
+        session.setValue('unlockTxnHash', 'unlockTokensTxnHash');
+        session.setValue('depositSourceToken', 'DAI');
+        session.setValue('depositedAmount', new BN(toWei('5')));
+
+        isComplete = false;
+        onComplete = () => (isComplete = true);
+        this.set('onComplete', onComplete);
+
+        let relayTokensStub = sinon.stub(layer1Service, 'relayTokens');
+
+        let attempts = 0;
+        // resolving attempt1 will cause the transaction hash to be resolved with
+        // "attempt 1 hash", and attempt2 with "attempt 2 hash"
+        attempt1 = defer();
+        attempt2 = defer();
+
+        relayTokensStub.callsFake(async function (
+          _token: string,
+          _destinationAddress: string,
+          _amountInWei: BN,
+          options: RelayTokensOptions
+        ) {
+          attempts += 1;
+          let currentAttempt = attempts;
+          let hash: string;
+          if (currentAttempt === 1) {
+            hash = 'attempt 1 hash';
+            await attempt1.promise;
+          } else if (currentAttempt === 2) {
+            hash = 'attempt 2 hash';
+            await attempt2.promise;
+          }
+
+          options.onTxnHash?.(hash!);
+
+          return {
+            blockNumber: 0,
+          } as TransactionReceipt;
+        });
+
+        await render(hbs`
+        <CardPay::DepositWorkflow::TransactionAmount
+          @workflowSession={{this.session}}
+          @onComplete={{this.onComplete}}
+          @onIncomplete={{noop}}
+        />
+      `);
+
+        await layer1Service.test__simulateUnlock();
+
+        await click('[data-test-deposit-button]');
+        await waitFor('[data-test-deposit-retry-button]');
+        await click('[data-test-deposit-retry-button]');
+      });
+
+      test('it resets if we reject both attempts', async function (assert) {
+        attempt1.reject();
+        attempt2.reject();
+
+        await settled();
+
+        assert.notOk(isComplete, 'onComplete was not called');
+        assert
+          .dom('[data-test-deposit-error-message]')
+          .containsText(
+            'Please try again if you want to continue with this workflow, or contact Cardstack support.'
+          );
+      });
+
+      test('it completes successfully if we reject the first attempt and resolve the second', async function (assert) {
+        attempt1.reject();
+        attempt2.resolve();
+
+        await settled();
+
+        assert.ok(isComplete, 'onComplete was called');
+        assert.ok(
+          find('[data-test-deposit-etherscan-button]')
+            ?.getAttribute('href')
+            ?.includes('attempt 2 hash')
+        );
+      });
+
+      test('it completes successfully if we resolve the first attempt and reject the second', async function (assert) {
+        attempt1.resolve();
+        attempt2.reject();
+
+        await settled();
+
+        assert.ok(isComplete, 'onComplete was called');
+        assert.ok(
+          find('[data-test-deposit-etherscan-button]')
+            ?.getAttribute('href')
+            ?.includes('attempt 1 hash')
+        );
+      });
+
+      test('it completes successfully if we resolve both attempts', async function (assert) {
+        attempt1.resolve();
+        attempt2.resolve();
+
+        await settled();
+
+        assert.ok(isComplete, 'onComplete was called');
+        assert.ok(
+          find('[data-test-deposit-etherscan-button]')
+            ?.getAttribute('href')
+            ?.includes('attempt 1 hash')
+        );
+      });
     });
   }
 );


### PR DESCRIPTION
Modifies the deposit workflow to use a retry UI that allows us to keep track of every deposit signing request sent, until one returns with a transaction hash, and then we continue following only that one. The reason for this is that we don't reliably have a way to cancel transactions via nonce. 

![image](https://user-images.githubusercontent.com/39579264/142471740-ab478c53-dcb8-4c00-b8ec-72ac0c5b56ad.png)

Here's a loom of it in action (there have been some copy changes since - see above, but the retry mechanism is still the same): https://www.loom.com/share/779d508328b64ee78635cb6442a7346f

### Some stuff I'm not sure about
- Is "Resend Signing Request" the right button text? Is there a better way to phrase it? Should it be "Resend Signature Request"?

### Some work that could/should follow:
- Rename Action Chin's Cancel button to something that encompasses retry and cancel
- Add retry UI to the withdrawal flow's claim step

### Some edge cases that this does not cover
- User clicks deposit and refreshes the page, hence "disconnecting" our JS and the signing request in the user's layer 1 wallet
- Transactions that fail after a transaction hash is returned (to investigate in https://linear.app/cardstack/issue/CS-2502/investigate-how-the-dapp-handles-transactions-that-fail-after)