### PR TITLE
CS-2425 Add merchant safe deposit and withdraw to merchant revenue subgraph

### DIFF
--- a/packages/cardpay-subgraph/etc/pre-codegen.js
+++ b/packages/cardpay-subgraph/etc/pre-codegen.js
@@ -140,6 +140,7 @@ writeFileSync(
 export let addresses = new Map<string, string>();
 addresses.set("prepaidCardManager", "${getAddress('prepaidCardManager', cleanNetwork)}");
 addresses.set("relay", "${getAddress('relay', cleanNetwork)}");
+addresses.set("revenuePool", "${getAddress('revenuePool', cleanNetwork)}");
 `
 );
 

--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -232,6 +232,24 @@ type MerchantClaim @entity {
   amount: BigInt!
 }
 
+type MerchantWithdraw @entity {
+  id: ID!
+  timestamp: BigInt!
+  transaction: Transaction!
+  merchantSafe: MerchantSafe!
+  token: Token!
+  amount: BigInt!
+}
+
+type MerchantDeposit @entity {
+  id: ID!
+  timestamp: BigInt!
+  transaction: Transaction!
+  merchantSafe: MerchantSafe!
+  token: Token!
+  amount: BigInt!
+}
+
 type MerchantRevenueEvent @entity {
   id: ID!
   transaction: Transaction!
@@ -241,6 +259,8 @@ type MerchantRevenueEvent @entity {
   merchantRevenue: MerchantRevenue!
   prepaidCardPayment: PrepaidCardPayment
   merchantClaim: MerchantClaim
+  merchantWithdraw: MerchantWithdraw
+  MerchantDeposit: MerchantDeposit
 }
 
 type SpendAccumulation @entity {

--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -260,7 +260,7 @@ type MerchantRevenueEvent @entity {
   prepaidCardPayment: PrepaidCardPayment
   merchantClaim: MerchantClaim
   merchantWithdraw: MerchantWithdraw
-  MerchantDeposit: MerchantDeposit
+  merchantDeposit: MerchantDeposit
 }
 
 type SpendAccumulation @entity {

--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -239,6 +239,7 @@ type MerchantWithdraw @entity {
   merchantSafe: MerchantSafe!
   token: Token!
   amount: BigInt!
+  to: String!
 }
 
 type MerchantDeposit @entity {
@@ -248,6 +249,7 @@ type MerchantDeposit @entity {
   merchantSafe: MerchantSafe!
   token: Token!
   amount: BigInt!
+  from: String!
 }
 
 type MerchantRevenueEvent @entity {

--- a/packages/cardpay-subgraph/src/mappings/token.ts
+++ b/packages/cardpay-subgraph/src/mappings/token.ts
@@ -17,6 +17,7 @@ export function handleTransfer(event: TransferEvent): void {
     let receiverSafe = Safe.load(to);
     if (receiverSafe != null) {
       makeEOATransactionForSafe(event, receiverSafe.id);
+      // TODO handle merchant deposit
     } else {
       makeEOATransaction(event, to);
     }
@@ -26,6 +27,7 @@ export function handleTransfer(event: TransferEvent): void {
     let senderSafe = Safe.load(from);
     if (senderSafe != null) {
       makeEOATransactionForSafe(event, senderSafe.id);
+      // TODO handle merchant withdraw
     } else {
       makeEOATransaction(event, from);
     }
@@ -98,3 +100,5 @@ function makeAccount(address: Address): string {
   entity.save();
   return account;
 }
+
+function makeMerchantRevenueEvent(merchantSafe: string, token: string) {}

--- a/packages/cardpay-subgraph/src/mappings/token.ts
+++ b/packages/cardpay-subgraph/src/mappings/token.ts
@@ -16,6 +16,7 @@ import {
   MerchantRevenueEvent,
   MerchantDeposit,
   MerchantWithdraw,
+  MerchantSafe,
 } from '../../generated/schema';
 import { ZERO_ADDRESS } from '@protofire/subgraph-toolkit';
 import { Transfer as TransferEvent, ERC20 } from '../erc-20/ERC20';
@@ -39,7 +40,7 @@ export function handleTransfer(event: TransferEvent): void {
       let revenuePoolAddress = addresses.get('revenuePool') as string;
       // token transfers from the revenue pool are actually claims, so don't include
       // those as MerchantDeposits
-      if (receiverSafe.merchant != null && from != revenuePoolAddress) {
+      if (MerchantSafe.load(to) != null && from != revenuePoolAddress) {
         let merchantDepositEntity = new MerchantDeposit(txnHash);
         merchantDepositEntity.timestamp = event.block.timestamp;
         merchantDepositEntity.transaction = txnHash;
@@ -64,7 +65,7 @@ export function handleTransfer(event: TransferEvent): void {
       makeEOATransactionForSafe(event, senderSafe.id);
 
       // don't count gas payments as merchant withdrawals
-      if (senderSafe.merchant != null && to != relayFunder) {
+      if (MerchantSafe.load(from) != null && to != relayFunder) {
         let merchantWithdrawEntity = new MerchantWithdraw(txnHash);
         merchantWithdrawEntity.timestamp = event.block.timestamp;
         merchantWithdrawEntity.transaction = txnHash;

--- a/packages/cardpay-subgraph/src/mappings/token.ts
+++ b/packages/cardpay-subgraph/src/mappings/token.ts
@@ -35,7 +35,10 @@ export function handleTransfer(event: TransferEvent): void {
     if (receiverSafe != null) {
       makeEOATransactionForSafe(event, receiverSafe.id);
 
-      if (receiverSafe.merchant != null) {
+      let revenuePoolAddress = addresses.get('revenuePool') as string;
+      // token transfers from the revenue pool are actually claims, so don't include
+      // those as MerchantDeposits
+      if (receiverSafe.merchant != null && from != revenuePoolAddress) {
         let merchantDepositEntity = new MerchantDeposit(txnHash);
         merchantDepositEntity.timestamp = event.block.timestamp;
         merchantDepositEntity.transaction = txnHash;

--- a/packages/cardpay-subgraph/subgraph-template.yaml
+++ b/packages/cardpay-subgraph/subgraph-template.yaml
@@ -507,6 +507,8 @@ dataSources:
           file: ./abis/ERC20NameBytes.json
         - name: GnosisSafe
           file: ./abis/GnosisSafe.json
+        - name: RevenuePool
+          file: ./abis/generated/RevenuePool.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
@@ -540,6 +542,8 @@ dataSources:
           file: ./abis/ERC20NameBytes.json
         - name: GnosisSafe
           file: ./abis/GnosisSafe.json
+        - name: RevenuePool
+          file: ./abis/generated/RevenuePool.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer

--- a/packages/cardpay-subgraph/subgraph-template.yaml
+++ b/packages/cardpay-subgraph/subgraph-template.yaml
@@ -498,6 +498,9 @@ dataSources:
         - TokenHistory
         - Transaction
         - EOATransaction
+        - MerchantDeposit
+        - MerchantWithdraw
+        - MerchantRevenueEvent
       abis:
         - name: ERC20
           file: ./abis/ERC20.json
@@ -533,6 +536,9 @@ dataSources:
         - TokenHistory
         - Transaction
         - EOATransaction
+        - MerchantDeposit
+        - MerchantWithdraw
+        - MerchantRevenueEvent
       abis:
         - name: ERC20
           file: ./abis/ERC20.json


### PR DESCRIPTION
This adds the edges `merchantWithdraw` and `merchantDeposit` to the `merchantRevenueEvent` subgraph to aid in the constructions of the merchant activity history for the wallet app.