### PR TITLE
show url to block explorer while withdrawal is in progress

### DIFF
--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.hbs
@@ -96,9 +96,13 @@
           Waiting for you to confirm on your Card Wallet mobile app...
         </div>
       </i.ActionStatusArea>
-      <i.InfoArea>
-        Only visible to you
-      </i.InfoArea>
+      {{#if this.txViewerUrl}}
+        <i.InfoArea>
+          <Boxel::Button @as="anchor" @kind="secondary-dark" @size="extra-small" @href={{this.txViewerUrl}} target="_blank" rel="noopener">
+            View on Blockscout
+          </Boxel::Button>
+        </i.InfoArea>
+      {{/if}}
     </:in-progress>
     <:memorialized as |m|>
       <m.ActionStatusArea>


### PR DESCRIPTION
Show a link to the block explorer once the transaction returns a hash so that users can track their transactions' progress externally.

![image](https://user-images.githubusercontent.com/39579264/142825688-0764f276-00c8-4cbf-994c-fcf5b42c6671.png)
