### PR TITLE
use our own corde command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,7 +52,7 @@
       "type": "node",
       "request": "launch",
       "name": "Bot tests",
-      "program": "${workspaceRoot}/node_modules/.bin/corde",
+      "program": "${workspaceRoot}/packages/hub/bin/corde",
       "cwd": "${workspaceRoot}/packages/hub",
       "console": "integratedTerminal",
       "args": ["--files", "./bot-tests/services/discord-bots/hub-bot/**/*.ts"],

--- a/packages/hub/bin/corde
+++ b/packages/hub/bin/corde
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+/* eslint-disable node/shebang */
+
+// we use this because corde tries to use esm to run this command and that has problems
+// with optional chaining: https://github.com/standard-things/esm/issues/866
+// running this assumes that we are in a node environment >= 14
+require('corde/lib/src/cli/cli');

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -18,7 +18,7 @@
     "test": "npm-run-all test:*",
     "test:node": "NODE_ENV=test mocha -r @cardstack/test-support/prepare-node-tests 'node-tests/**/*-test.js' --timeout 60000",
     "test:remove-ts-artifacts-for-corde": "find ./bot-tests \\( -name \"*.d.ts\" -or -name \"*.js\" -or -name \"*.js.map\" \\) -exec rm -f {} \\;",
-    "test:bot": "yarn test:remove-ts-artifacts-for-corde && corde",
+    "test:bot": "yarn test:remove-ts-artifacts-for-corde && bin/corde",
     "autotest": "NODE_ENV=test mocha -w --reporter=min mocha -r @cardstack/test-support/prepare-node-tests 'node-tests/**/*-test.js' --timeout 60000"
   },
   "dependencies": {


### PR DESCRIPTION
Attempt to help https://github.com/cardstack/cardstack/pull/2397 pass CI - tests on that branch pass locally with this change