### PR TITLE
web: Add truncation for merchant names

### DIFF
--- a/packages/web-client/app/components/card-pay/merchant-card/index.css
+++ b/packages/web-client/app/components/card-pay/merchant-card/index.css
@@ -63,6 +63,10 @@
 
 .merchant-card__value {
   font: 700 var(--boxel-font-sm);
+  max-width: 12rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .merchant-card__manager-icon {

--- a/packages/web-client/app/components/card-pay/merchant-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/merchant-card/index.hbs
@@ -15,7 +15,7 @@
     <div class="merchant-card__info">
       <div>
         <div class="merchant-card__label">Business ID</div>
-        <div class="merchant-card__value">{{@id}}</div>
+        <div class="merchant-card__value" title={{@id}}>{{@id}}</div>
       </div>
       <div>
         <span class="merchant-card__value">{{@managerCount}}</span>

--- a/packages/web-client/app/components/card-pay/merchant/index.css
+++ b/packages/web-client/app/components/card-pay/merchant/index.css
@@ -17,6 +17,10 @@
 .merchant__name {
   font: 700 var(--boxel-font);
   letter-spacing: var(--boxel-lsp-xs);
+  max-width: 20rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .merchant__name--lg {

--- a/packages/web-client/app/components/card-pay/merchant/index.hbs
+++ b/packages/web-client/app/components/card-pay/merchant/index.hbs
@@ -11,7 +11,7 @@
     @logoTextColor={{@logoTextColor}}
   />
   <div>
-    <div class={{cn "merchant__name" merchant__name--lg=(eq @size "large")}}>
+    <div class={{cn "merchant__name" merchant__name--lg=(eq @size "large")}} title={{@name}}>
       {{@name}}
     </div>
     {{#if @address}}

--- a/packages/web-client/app/components/card-pay/safe-balances/index.css
+++ b/packages/web-client/app/components/card-pay/safe-balances/index.css
@@ -67,11 +67,17 @@
   align-items: center;
 }
 
+.card-pay-safe-balances__title-and-link {
+  min-width: 0; /* Allow text-overflow to work */
+}
+
 .card-pay-safe-balances__title {
   font-size: 1.625rem;
   font-weight: 600;
   letter-spacing: 0;
-  line-height: var(--boxel-font-size-lg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .card-pay-safe-balances__logo {

--- a/packages/web-client/app/components/card-pay/safe-balances/index.hbs
+++ b/packages/web-client/app/components/card-pay/safe-balances/index.hbs
@@ -30,8 +30,8 @@
           @logoTextColor={{this.data.info.textColor}}
         />
       {{/if}}
-      <div>
-        <h3 class='card-pay-safe-balances__title'>
+      <div class='card-pay-safe-balances__title-and-link'>
+        <h3 class='card-pay-safe-balances__title' title={{this.data.info.name}}>
           {{this.data.info.name}}
         </h3>
         {{#if this.data.info.id}}


### PR DESCRIPTION
This is a brute force approach to addressing the unbounded text problem in merchant names. Maybe we should restrict length and get better design feedback, but in the interim, this will do, IMO.

Before and afters:

![image](https://user-images.githubusercontent.com/43280/143133528-1305c8d1-aa9a-425b-a1cd-b3f6f9b09ea0.png)

![image](https://user-images.githubusercontent.com/43280/143133670-f6df6d05-b490-4be8-9801-129f456e1f94.png)
