### PR TITLE
Push notification registrations 

### DIFF
--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -33,7 +33,7 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
 
 
 --
--- Name: EXTENSION pgcrypto; Type: COMMENT; Schema: -; Owner: 
+-- Name: EXTENSION pgcrypto; Type: COMMENT; Schema: -; Owner:
 --
 
 COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
@@ -834,6 +834,21 @@ CREATE TABLE public.prepaid_card_patterns (
 ALTER TABLE public.prepaid_card_patterns OWNER TO postgres;
 
 --
+-- Name: push_notification_registrations; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.push_notification_registrations (
+    id uuid NOT NULL,
+    owner_address text NOT NULL,
+    push_client_id text NOT NULL,
+    disabled_at timestamp without time zone,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.push_notification_registrations OWNER TO postgres;
+
+--
 -- Name: reservations; Type: TABLE; Schema: public; Owner: postgres
 --
 
@@ -1039,6 +1054,14 @@ ALTER TABLE ONLY public.prepaid_card_patterns
 
 
 --
+-- Name: push_notification_registrations push_notification_registrations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.push_notification_registrations
+    ADD CONSTRAINT push_notification_registrations_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: reservations reservations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
@@ -1096,6 +1119,13 @@ CREATE INDEX discord_bots_bot_type_status_index ON public.discord_bots USING btr
 --
 
 CREATE UNIQUE INDEX merchant_infos_slug_unique_index ON public.merchant_infos USING btree (slug);
+
+
+--
+-- Name: push_notification_registrations_owner_address_push_client_id_un; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX push_notification_registrations_owner_address_push_client_id_un ON public.push_notification_registrations USING btree (owner_address, push_client_id);
 
 
 --
@@ -1289,21 +1319,21 @@ COPY graphile_worker.migrations (id, ts) FROM stdin;
 --
 
 COPY public.pgmigrations (id, name, run_on) FROM stdin;
-1	20210527151505645_create-prepaid-card-tables	2021-11-29 17:02:42.091944
-2	20210614080132698_create-prepaid-card-customizations-table	2021-11-29 17:02:42.091944
-3	20210623052200757_create-graphile-worker-schema	2021-11-29 17:02:42.091944
-4	20210809113449561_merchant-infos	2021-11-29 17:02:42.091944
-5	20210817184105100_wallet-orders	2021-11-29 17:02:42.091944
-6	20210920142313915_prepaid-card-reservations	2021-11-29 17:02:42.091944
-7	20210924200122612_order-indicies	2021-11-29 17:02:42.091944
-8	20211006090701108_create-card-spaces	2021-11-29 17:02:42.091944
-9	20211013155536724_card-index	2021-11-29 17:02:42.091944
-10	20211013173917696_beta-testers	2021-11-29 17:02:42.091944
-11	20211014131843187_add-fields-to-card-spaces	2021-11-29 17:02:42.091944
-12	20211020231214235_discord-bots	2021-11-29 17:02:42.091944
-13	20211105180905492_wyre-price-service	2021-11-29 17:02:42.091944
-14	20211110210324178_card-index-part-duex	2021-11-29 17:02:42.091944
-15	20211118084217151_create-uploads	2021-11-29 17:02:42.091944
+1	20210527151505645_create-prepaid-card-tables	2021-08-02 16:26:07.752752
+2	20210614080132698_create-prepaid-card-customizations-table	2021-08-02 16:26:07.752752
+3	20210623052200757_create-graphile-worker-schema	2021-08-02 16:26:07.752752
+5	20210809113449561_merchant-infos	2021-08-12 09:52:27.790806
+6	20210817184105100_wallet-orders	2021-08-25 08:15:41.07505
+7	20210920142313915_prepaid-card-reservations	2021-10-06 14:32:47.039161
+8	20210924200122612_order-indicies	2021-10-06 14:32:47.039161
+13	20211006090701108_create-card-spaces	2021-10-14 10:38:51.140793
+21	20211020231214235_discord-bots	2021-11-18 11:18:35.492811
+22	20211105180905492_wyre-price-service	2021-11-18 11:18:35.492811
+33	20211118084217151_create-uploads	2021-11-29 09:21:50.978293
+14	20211013155536724_card-index	2021-10-18 09:59:34.440379
+19	20211013173917696_beta-testers	2021-11-18 11:18:35.492811
+20	20211014131843187_add-fields-to-card-spaces	2021-11-18 11:18:35.492811
+41	20211129083801382_create-push-notification-registrations	2021-11-30 11:02:14.267117
 \.
 
 

--- a/packages/hub/db/migrations/20211129083801382_create-push-notification-registrations.js
+++ b/packages/hub/db/migrations/20211129083801382_create-push-notification-registrations.js
@@ -1,0 +1,17 @@
+const PUSH_NOTIFICATION_REGISTRATIONS_TABLE = 'push_notification_registrations';
+
+exports.up = (pgm) => {
+  pgm.createTable(PUSH_NOTIFICATION_REGISTRATIONS_TABLE, {
+    id: { type: 'uuid', primaryKey: true },
+    owner_address: { type: 'string', notNull: true },
+    push_client_id: { type: 'string', notNull: true },
+    disabled_at: { type: 'timestamp' },
+    created_at: { type: 'timestamp', notNull: true, default: pgm.func('current_timestamp') },
+  });
+
+  pgm.createIndex(PUSH_NOTIFICATION_REGISTRATIONS_TABLE, ['owner_address', 'push_client_id'], { unique: true });
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable(PUSH_NOTIFICATION_REGISTRATIONS_TABLE);
+};

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -78,6 +78,9 @@ import HubDmChannelsDbGateway from './services/discord-bots/dm-channels-db-gatew
 import { SearchIndex } from './services/search-index';
 import Web3Storage from './services/web3-storage';
 import UploadRouter from './routes/upload';
+import PushNotificationRegistrationSerializer from './services/serializers/push-notification-registration-serializer';
+import PushNotificationRegistrationQueries from './services/queries/push-notification-registration';
+import PushNotificationRegistrationsRoute from './routes/push_notification_registrations';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -125,6 +128,9 @@ export function createRegistry(): Registry {
   registry.register('card-space-validator', CardSpaceValidator);
   registry.register('card-space-queries', CardSpaceQueries);
   registry.register('card-spaces-route', CardSpacesRoute);
+  registry.register('push-notification-registrations-route', PushNotificationRegistrationsRoute);
+  registry.register('push-notification-registration-serializer', PushNotificationRegistrationSerializer);
+  registry.register('push-notification-registration-queries', PushNotificationRegistrationQueries);
   registry.register('relay', RelayService);
   registry.register('reserved-words', ReservedWords);
   registry.register('reservations-route', ReservationsRoute);

--- a/packages/hub/node-tests/routes/push-notification-registrations-test.ts
+++ b/packages/hub/node-tests/routes/push-notification-registrations-test.ts
@@ -1,0 +1,200 @@
+import shortUuid from 'short-uuid';
+import { registry, setupHub } from '../helpers/server';
+
+const stubNonce = 'abc:123';
+let stubAuthToken = 'def--456';
+let stubTimestamp = process.hrtime.bigint();
+
+class StubAuthenticationUtils {
+  generateNonce() {
+    return stubNonce;
+  }
+  buildAuthToken() {
+    return stubAuthToken;
+  }
+  extractVerifiedTimestamp(_nonce: string) {
+    return stubTimestamp;
+  }
+
+  validateAuthToken(encryptedAuthToken: string) {
+    return handleValidateAuthToken(encryptedAuthToken);
+  }
+}
+
+let stubUserAddress = '0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13';
+function handleValidateAuthToken(encryptedString: string) {
+  expect(encryptedString).to.equal('abc123--def456--ghi789');
+  return stubUserAddress;
+}
+
+describe('POST /api/push-notification-registrations', async function () {
+  this.beforeEach(function () {
+    registry(this).register('authentication-utils', StubAuthenticationUtils);
+  });
+  let { request, getContainer } = setupHub(this);
+
+  it('returns 401 without bearer token', async function () {
+    await request()
+      .post('/api/push-notification-registrations')
+      .send({})
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(401)
+      .expect({
+        errors: [
+          {
+            status: '401',
+            title: 'No valid auth token',
+          },
+        ],
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('persists push notification registration', async function () {
+    let payload = {
+      data: {
+        type: 'push-notification-registration',
+        attributes: {
+          'push-client-id': 'FIREBASE_USER_ID',
+        },
+      },
+    };
+
+    await request()
+      .post('/api/push-notification-registrations')
+      .send(payload)
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(201)
+      .expect(function (res) {
+        res.body.data.id = 'id';
+      })
+      .expect({
+        data: {
+          id: 'id',
+          type: 'push-notification-registration',
+          attributes: {
+            'owner-address': stubUserAddress,
+            'push-client-id': 'FIREBASE_USER_ID',
+            'disabled-at': null,
+          },
+        },
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+
+    let pushNotificationRegistrationQueries = await getContainer().lookup('push-notification-registration-queries');
+    let records = await pushNotificationRegistrationQueries.query({
+      ownerAddress: stubUserAddress,
+      pushClientId: 'FIREBASE_USER_ID',
+    });
+
+    expect(records.length).to.equal(1);
+    expect(records[0].ownerAddress).to.equal(stubUserAddress);
+    expect(records[0].pushClientId).to.equal('FIREBASE_USER_ID');
+  });
+
+  it('does not fail when registration is already present + it reenables the existing one', async function () {
+    let pushNotificationRegistrationQueries = await getContainer().lookup('push-notification-registration-queries');
+
+    await pushNotificationRegistrationQueries.insert({
+      id: shortUuid.uuid(),
+      ownerAddress: stubUserAddress,
+      pushClientId: 'FIREBASE_USER_ID',
+      disabledAt: '2021-12-01 10:00:00',
+    });
+
+    let payload = {
+      data: {
+        type: 'push-notification-registration',
+        attributes: {
+          'push-client-id': 'FIREBASE_USER_ID',
+        },
+      },
+    };
+
+    await request()
+      .post('/api/push-notification-registrations')
+      .send(payload)
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(201)
+      .expect(function (res) {
+        res.body.data.id = 'id';
+      })
+      .expect({
+        data: {
+          id: 'id',
+          type: 'push-notification-registration',
+          attributes: {
+            'owner-address': stubUserAddress,
+            'push-client-id': 'FIREBASE_USER_ID',
+            'disabled-at': null,
+          },
+        },
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+
+    let records = await pushNotificationRegistrationQueries.query({
+      ownerAddress: stubUserAddress,
+      pushClientId: 'FIREBASE_USER_ID',
+    });
+
+    expect(records.length).to.equal(1);
+    expect(records[0].ownerAddress).to.equal(stubUserAddress);
+    expect(records[0].pushClientId).to.equal('FIREBASE_USER_ID');
+  });
+});
+
+describe('DELETE /api/push-notification-registrations', function () {
+  this.beforeEach(function () {
+    registry(this).register('authentication-utils', StubAuthenticationUtils);
+  });
+  let { request, getContainer } = setupHub(this);
+
+  it('returns 401 without bearer token', async function () {
+    await request()
+      .post('/api/push-notification-registrations')
+      .send({})
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(401)
+      .expect({
+        errors: [
+          {
+            status: '401',
+            title: 'No valid auth token',
+          },
+        ],
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('deletes push notification registration', async function () {
+    let pushNotificationRegistrationQueries = await getContainer().lookup('push-notification-registration-queries');
+
+    await pushNotificationRegistrationQueries.insert({
+      id: shortUuid.uuid(),
+      ownerAddress: stubUserAddress,
+      pushClientId: 'FIREBASE_USER_ID',
+      disabledAt: null,
+    });
+
+    await request()
+      .delete(`/api/push-notification-registrations/FIREBASE_USER_ID`)
+      .send({})
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(200);
+
+    let records = await pushNotificationRegistrationQueries.query({
+      ownerAddress: stubUserAddress,
+      pushClientId: 'FIREBASE_USER_ID',
+    });
+
+    expect(records.length).to.equal(0);
+  });
+});

--- a/packages/hub/routes/push_notification_registrations.ts
+++ b/packages/hub/routes/push_notification_registrations.ts
@@ -1,0 +1,93 @@
+import Koa from 'koa';
+import autoBind from 'auto-bind';
+import DatabaseManager from '@cardstack/db';
+import { inject } from '@cardstack/di';
+
+import { ensureLoggedIn } from './utils/auth';
+
+import PushNotificationRegistrationSerializer from '../services/serializers/push-notification-registration-serializer';
+import PushNotificationRegistrationQueries from '../services/queries/push-notification-registration';
+import shortUuid from 'short-uuid';
+
+export interface PushNotificationRegistration {
+  id: string;
+  ownerAddress: string;
+  pushClientId: string;
+  disabledAt: string | null;
+}
+
+export default class PushNotificationRegistrationsRoute {
+  databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
+  pushNotificationRegistrationSerialier: PushNotificationRegistrationSerializer = inject(
+    'push-notification-registration-serializer',
+    {
+      as: 'pushNotificationRegistrationSerialier',
+    }
+  );
+  pushNotificationRegistrationQueries: PushNotificationRegistrationQueries = inject(
+    'push-notification-registration-queries',
+    {
+      as: 'pushNotificationRegistrationQueries',
+    }
+  );
+
+  constructor() {
+    autoBind(this);
+  }
+
+  async post(ctx: Koa.Context) {
+    if (!ensureLoggedIn(ctx)) {
+      return;
+    }
+
+    let existingPushNotificationRegistration = (
+      await this.pushNotificationRegistrationQueries.query({
+        ownerAddress: ctx.state.userAddress,
+        pushClientId: ctx.request.body.data.attributes['push-client-id'],
+      })
+    )[0];
+
+    let pushNotificationRegistration: PushNotificationRegistration;
+
+    if (existingPushNotificationRegistration) {
+      pushNotificationRegistration = existingPushNotificationRegistration;
+      pushNotificationRegistration.disabledAt = null;
+      await this.pushNotificationRegistrationQueries.update(pushNotificationRegistration);
+    } else {
+      pushNotificationRegistration = {
+        id: shortUuid.uuid(),
+        ownerAddress: ctx.state.userAddress,
+        pushClientId: ctx.request.body.data.attributes['push-client-id'],
+        disabledAt: null,
+      };
+
+      await this.pushNotificationRegistrationQueries.insert(pushNotificationRegistration);
+    }
+
+    let serialized = await this.pushNotificationRegistrationSerialier.serialize(pushNotificationRegistration);
+
+    ctx.status = 201;
+    ctx.body = serialized;
+    ctx.type = 'application/vnd.api+json';
+  }
+
+  async delete(ctx: Koa.Context) {
+    if (!ensureLoggedIn(ctx)) {
+      return;
+    }
+
+    await this.pushNotificationRegistrationQueries.delete({
+      ownerAddress: ctx.state.userAddress,
+      pushClientId: ctx.params.push_client_id,
+    } as PushNotificationRegistration);
+
+    ctx.status = 200;
+    ctx.type = 'application/vnd.api+json';
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'push-notification-registrations-route': PushNotificationRegistrationsRoute;
+  }
+}

--- a/packages/hub/services/api-router.ts
+++ b/packages/hub/services/api-router.ts
@@ -26,6 +26,9 @@ export default class APIRouter {
   cardSpacesRoute = inject('card-spaces-route', {
     as: 'cardSpacesRoute',
   });
+  pushNotificationRegistrationsRoute = inject('push-notification-registrations-route', {
+    as: 'pushNotificationRegistrationsRoute',
+  });
   custodialWalletRoute = inject('custodial-wallet-route', { as: 'custodialWalletRoute' });
   ordersRoute = inject('orders-route', { as: 'ordersRoute' });
   reservationsRoute = inject('reservations-route', { as: 'reservationsRoute' });
@@ -46,6 +49,7 @@ export default class APIRouter {
       inventoryRoute,
       cardSpacesRoute,
       wyrePricesRoute,
+      pushNotificationRegistrationsRoute,
     } = this;
     let apiSubrouter = new Router();
     apiSubrouter.get('/boom', boomRoute.get);
@@ -67,6 +71,12 @@ export default class APIRouter {
     apiSubrouter.post('/card-spaces/validate-profile-name', parseBody, cardSpacesRoute.postProfileNameValidation);
     apiSubrouter.post('/card-spaces/validate-url', parseBody, cardSpacesRoute.postUrlValidation);
     apiSubrouter.put('/card-spaces/:id', parseBody, cardSpacesRoute.put);
+    apiSubrouter.post('/push-notification-registrations', parseBody, pushNotificationRegistrationsRoute.post);
+    apiSubrouter.delete(
+      '/push-notification-registrations/:push_client_id',
+      parseBody,
+      pushNotificationRegistrationsRoute.delete
+    );
     apiSubrouter.get('/wyre-prices', parseBody, wyrePricesRoute.get);
     apiSubrouter.all('/(.*)', notFound);
 

--- a/packages/hub/services/queries/push-notification-registration.ts
+++ b/packages/hub/services/queries/push-notification-registration.ts
@@ -1,0 +1,64 @@
+import DatabaseManager from '@cardstack/db';
+import { inject } from '@cardstack/di';
+import { PushNotificationRegistration } from '../../routes/push_notification_registrations';
+import { buildConditions } from '../../utils/queries';
+
+interface PushNotificationRegistrationQueriesFilter {
+  ownerAddress: string;
+  pushClientId: string;
+}
+
+export default class PushNotificationRegistrationQueries {
+  databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
+
+  async query(filter: PushNotificationRegistrationQueriesFilter): Promise<PushNotificationRegistration[]> {
+    let db = await this.databaseManager.getClient();
+
+    const conditions = buildConditions(filter);
+
+    const query = `SELECT id, owner_address, push_client_id, disabled_at FROM push_notification_registrations WHERE ${conditions.where}`;
+    const queryResult = await db.query(query, conditions.values);
+
+    return queryResult.rows.map((row) => {
+      return {
+        id: row['id'],
+        ownerAddress: row['owner_address'],
+        pushClientId: row['push_client_id'],
+        disabledAt: row['disabled_at'],
+      };
+    });
+  }
+
+  async insert(model: PushNotificationRegistration) {
+    let db = await this.databaseManager.getClient();
+
+    await db.query(
+      'INSERT INTO push_notification_registrations (id, owner_address, push_client_id, disabled_at) VALUES($1, $2, $3, $4)',
+      [model.id, model.ownerAddress, model.pushClientId, model.disabledAt]
+    );
+  }
+
+  async update(model: PushNotificationRegistration) {
+    let db = await this.databaseManager.getClient();
+
+    await db.query(
+      'UPDATE push_notification_registrations SET disabled_at = $1 WHERE owner_address = $2 AND push_client_id = $3',
+      [model.disabledAt, model.ownerAddress, model.pushClientId]
+    );
+  }
+
+  async delete(model: PushNotificationRegistration) {
+    let db = await this.databaseManager.getClient();
+
+    await db.query('DELETE FROM push_notification_registrations WHERE owner_address = $1 AND push_client_id = $2', [
+      model.ownerAddress,
+      model.pushClientId,
+    ]);
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'push-notification-registration-queries': PushNotificationRegistrationQueries;
+  }
+}

--- a/packages/hub/services/serializers/push-notification-registration-serializer.ts
+++ b/packages/hub/services/serializers/push-notification-registration-serializer.ts
@@ -1,0 +1,30 @@
+import { PushNotificationRegistration } from '../../routes/push_notification_registrations';
+
+interface JSONAPIDocument {
+  data: any;
+  included?: any[];
+}
+
+export default class PushNotificationRegistrationSerializer {
+  serialize(model: PushNotificationRegistration): JSONAPIDocument {
+    const result = {
+      data: {
+        id: model.id,
+        type: 'push-notification-registration',
+        attributes: {
+          'owner-address': model.ownerAddress,
+          'push-client-id': model.pushClientId,
+          'disabled-at': model.disabledAt,
+        },
+      },
+    };
+
+    return result as JSONAPIDocument;
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'push-notification-registration-serializer': PushNotificationRegistrationSerializer;
+  }
+}

--- a/packages/hub/utils/queries.ts
+++ b/packages/hub/utils/queries.ts
@@ -1,3 +1,5 @@
+const camelToSnakeCase = (str: string) => str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+
 // Takes an object with keys and values for querying and transforms them into parts
 // suitable for passing into `db.query()` (DatabaseManager).
 //
@@ -6,7 +8,7 @@
 
 export function buildConditions(params: any) {
   let conditions = Object.keys(params).map((key, index) => {
-    return `${key}=$${index + 1}`;
+    return `${camelToSnakeCase(key)}=$${index + 1}`;
   });
 
   let values = Object.values(params);


### PR DESCRIPTION
Tickets: [CS-2613](https://linear.app/cardstack/issue/CS-2613/hub-api-endpoint-to-record-a-push-notification-registration-map-of-eoa), [CS-2614](https://linear.app/cardstack/issue/CS-2614/hub-api-endpoint-to-remove-a-push-notification-registration)

POST and DELETE api/push-notification-registrations endpoints were added so that the mobile app will be able to register and unregister push notifications coming from the hub.

Questions:
1. Should we also add a GET endpoint? I think it might be useful for the mobile app to first see if the registration already exists before attempting to register. 
2. Given `push-notification-registrations` routes don't actually accept an ID (because the registration is tied to `ctx.state.userAddress`, and there is only one registration per owner address), these route definitions don't quite conform to classic REST definitions. I'm thinking if it would be better to rename the routes from a plural to a singular resource naming (`POST push-notification-registration` and `DELETE push-notification-registration`)