### PR TITLE
Add flag to allow testing of alternate Layer 2 RPC Websocket connection

### DIFF
--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -88,6 +88,8 @@ const XDAI = {
   rpcArchiveNode:
     'https://apis.ankr.com/eaf28986bda44bfe95354b64c666a8fa/00f97db34d49dd3b0beb288e7542365d/xdai/fast/main',
   rpcWssNode: 'wss://rpc.xdaichain.com/wss',
+  rpcWssNodeNext:
+    'wss://apis.ankr.com/wss/eaf28986bda44bfe95354b64c666a8fa/00f97db34d49dd3b0beb288e7542365d/xdai/fast/main',
   relayServiceURL: 'https://relay.cardstack.com/api',
   subgraphURL: 'https://graph.cardstack.com/subgraphs/name/habdelra/cardpay-xdai',
   merchantUniLinkDomain: MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME,

--- a/packages/web-client/app/utils/features.ts
+++ b/packages/web-client/app/utils/features.ts
@@ -1,0 +1,10 @@
+import { getConstantByNetwork } from '@cardstack/cardpay-sdk';
+import { Layer2NetworkSymbol } from './web3-strategies/types';
+
+export function getLayer2RpcWssNodeUrl(networkSymbol: Layer2NetworkSymbol) {
+  if (window.localStorage.getItem('layer2RpcWssNode') === 'next') {
+    return getConstantByNetwork('rpcWssNodeNext', networkSymbol);
+  } else {
+    return getConstantByNetwork('rpcWssNode', networkSymbol);
+  }
+}

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -54,6 +54,7 @@ import { IAssets } from '@cardstack/cardpay-sdk';
 import { PrepaidCard } from '@cardstack/cardpay-sdk';
 import { ViewSafesResult } from '@cardstack/cardpay-sdk';
 import { faceValueOptions } from '@cardstack/web-client/components/card-pay/issue-prepaid-card-workflow';
+import { getLayer2RpcWssNodeUrl } from '../features';
 
 const BROADCAST_CHANNEL_MESSAGES = {
   CONNECTED: 'CONNECTED',
@@ -155,6 +156,8 @@ export default abstract class Layer2ChainWeb3Strategy
       };
     }
     this.web3 = new Web3();
+
+    let rpcWss = getLayer2RpcWssNodeUrl(this.networkSymbol);
     this.provider = new WalletConnectProvider({
       chainId: this.chainId,
       rpc: {
@@ -164,10 +167,7 @@ export default abstract class Layer2ChainWeb3Strategy
         ),
       },
       rpcWss: {
-        [networkIds[this.networkSymbol]]: getConstantByNetwork(
-          'rpcWssNode',
-          this.networkSymbol
-        ),
+        [networkIds[this.networkSymbol]]: rpcWss,
       },
       connector: new CustomStorageWalletConnect(connectorOptions, this.chainId),
     });


### PR DESCRIPTION
- In localstorage, if layer2RpcWssNode is set to "next", the SDKs layer2RpcWssNodeNext constant will be used instead of layer2RpcWssNode. Clear that localstorage key to revert to normal behavior