### PR TITLE
Support to get versioned ABI from SDK

### DIFF
--- a/packages/cardpay-sdk/contracts/addresses.ts
+++ b/packages/cardpay-sdk/contracts/addresses.ts
@@ -16,6 +16,8 @@ import RegisterRewardProgramHandlerABI from './abi/v0.8.6/register-reward-progra
 import RegisterRewardeeHandlerABI from './abi/v0.8.6/register-rewardee-handler';
 import SupplierManagerABI from './abi/v0.8.6/supplier-manager';
 
+export const protocolVersions = ['v0.8.6', 'v0.8.5'];
+
 function consumeModule(_module: any) {}
 consumeModule(PayMerchantHandlerABI);
 consumeModule(RegisterMerchantHandlerABI);
@@ -64,6 +66,7 @@ const SOKOL = {
   rewardManager: '0xaC47B293f836F3a64eb4AEF02Cb7d1428dCe815f',
   registerRewardProgramHandler: '0xaF5B2869Be9Eb9c45cc0501F17B145A3229dD2C0',
   registerRewardeeHandler: '0xD46f5eE431eAA309ABeC7a3561E06586450171b0',
+  versionManager: '0xBbF3aad37298C997a485E270bD465ec3e6aCD2a7',
   deprecatedMerchantManager_v0_6_7: '0xA113ECa0Af275e1906d1fe1B7Bef1dDB033113E2',
   oracles: {
     'DAI.CPXD': '0x74beF86c9d4a5b96B81D8d8e44157DFd35Eda5fB',
@@ -108,6 +111,7 @@ const XDAI = {
   rewardManager: '0x3B6bedcA6EC78fCd33aFeB385B192056de639403',
   registerRewardProgramHandler: '0x8e0A60912C56F4436396C636f0ED500ef27af4e0',
   registerRewardeeHandler: '0x198ea3D257715Fb2e9025c061BE96e56AE611A9f',
+  versionManager: '0xd900133f96F85939335ADb9786ea9f2e07Bdf8c0',
   deprecatedMerchantManager_v0_6_7: '0x3C29B2A563F4bB9D625175bE823c528A4Ddd1107',
   oracles: {
     'DAI.CPXD': '0x36698BF676c40be119b0Fe4f964f4527943258F2',

--- a/packages/cardpay-sdk/index.ts
+++ b/packages/cardpay-sdk/index.ts
@@ -42,7 +42,7 @@ export * from './sdk/currency-utils';
 export * from './sdk/currencies';
 export { query as gqlQuery } from './sdk/utils/graphql';
 export { validateMerchantId, generateMerchantPaymentUrl, isValidMerchantPaymentUrl } from './sdk/utils/merchant';
-export { getSDK } from './sdk/version-resolver';
+export { getSDK, getABI } from './sdk/version-resolver';
 
 export { default as ERC20ABI } from './contracts/abi/erc-20';
 export { default as ERC677ABI } from './contracts/abi/erc-677';

--- a/packages/cardpay-sdk/sdk/version-resolver.ts
+++ b/packages/cardpay-sdk/sdk/version-resolver.ts
@@ -100,7 +100,7 @@ export async function getABI(contractName: string, web3: Web3): Promise<AbiItem[
   let protocolVersion = await versionManager.methods.version().call();
   let versionMap: { [version: string]: AbiItem[] } = {};
   for (let version of protocolVersions) {
-    versionMap[version.replace('v', '')] = (await import(`../contracts/abi/${version}/${contractName}`)).default;
+    versionMap[version.replace('v', '')] = (await import(`../contracts/abi/${version}/${contractName}.js`)).default;
   }
   let abi = getAPIVersion(versionMap, protocolVersion);
   return abi;

--- a/packages/cardpay-sdk/sdk/version-resolver.ts
+++ b/packages/cardpay-sdk/sdk/version-resolver.ts
@@ -1,5 +1,5 @@
 import Web3 from 'web3';
-import { AddressKeys, getAddress } from '../contracts/addresses';
+import { AddressKeys, getAddress, protocolVersions } from '../contracts/addresses';
 import { AbiItem } from 'web3-utils';
 import { satisfies } from 'semver';
 import mapKeys from 'lodash/mapKeys';
@@ -77,6 +77,34 @@ const cardPayVersionABI: AbiItem[] = [
     type: 'function',
   },
 ];
+const VersionManagerABI: AbiItem[] = [
+  {
+    constant: true,
+    inputs: [],
+    name: 'version',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+export async function getABI(contractName: string, web3: Web3): Promise<AbiItem[]> {
+  let versionManager = new web3.eth.Contract(VersionManagerABI, await getAddress('versionManager', web3));
+  let protocolVersion = await versionManager.methods.version().call();
+  let versionMap: { [version: string]: AbiItem[] } = {};
+  for (let version of protocolVersions) {
+    versionMap[version.replace('v', '')] = (await import(`../contracts/abi/${version}/${contractName}`)).default;
+  }
+  let abi = getAPIVersion(versionMap, protocolVersion);
+  return abi;
+}
 
 export async function getSDK<T extends SDK>(sdk: T, ...args: any[]): Promise<MapReturnType<T>> {
   let [web3] = args;

--- a/packages/cardpay-sdk/tsconfig.json
+++ b/packages/cardpay-sdk/tsconfig.json
@@ -2,10 +2,10 @@
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,
-    "module": "es6",
+    "module": "es2020",
     "moduleResolution": "Node",
     "pretty": true,
-    "target": "ES6",
+    "target": "es2020",
     "strict": true,
     "sourceMap": true,
     "experimentalDecorators": true,

--- a/packages/web-client/tsconfig.json
+++ b/packages/web-client/tsconfig.json
@@ -18,7 +18,7 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": ".",
-    "module": "es6",
+    "module": "es2020",
     "experimentalDecorators": true,
     "skipLibCheck": true,
     "paths": {


### PR DESCRIPTION
@backspace This PR will allow you to retrieve a versioned ABI from the SDK. To call it just ask for any of the contract names in the packages/cardpay-sdk/contracts/abi/<version> folder. for example:
```js
let abi = await getABI("price-oracle", web3); 
```
will return current price oracle contract ABI for the current protocol version
