### PR TITLE
add options for websocket autoreconnecting as used in cardwallet

### DIFF
--- a/packages/web-client/app/utils/wc-provider.ts
+++ b/packages/web-client/app/utils/wc-provider.ts
@@ -62,9 +62,14 @@ class WalletConnectProvider extends ExtendedProviderEngine {
   constructor(opts: ICardstackWalletConnectProviderOptions) {
     super({
       blockTracker: new BlockTracker({
-        provider: new WebsocketProvider(
-          opts.rpcWss[opts.chainId!]
-        ) as unknown as Provider,
+        provider: new WebsocketProvider(opts.rpcWss[opts.chainId!], {
+          reconnect: {
+            auto: true,
+            delay: 1000,
+            onTimeout: true,
+            maxAttempts: 10,
+          },
+        }) as unknown as Provider,
       }),
     });
     let rpcWss: IRPCMap = opts.rpcWss || null;

--- a/packages/web-client/app/utils/wc-provider.ts
+++ b/packages/web-client/app/utils/wc-provider.ts
@@ -37,8 +37,6 @@ export interface ICardstackWalletConnectProviderOptions
   rpcWss: IRPCMap;
 }
 
-const MIN_RECONNECTION_INTERVAL = 5000;
-
 class WalletConnectProvider extends ExtendedProviderEngine {
   public bridge = 'https://bridge.walletconnect.org';
   public qrcode = true;
@@ -57,7 +55,6 @@ class WalletConnectProvider extends ExtendedProviderEngine {
   public websocketProvider!: TypedWebsocketProviderWithConstructor;
   public networkId!: number;
   public infuraId?: string;
-  private lastReconnection = -Infinity;
 
   constructor(opts: ICardstackWalletConnectProviderOptions) {
     super({
@@ -529,28 +526,6 @@ class WalletConnectProvider extends ExtendedProviderEngine {
     this.websocketProvider.on('connect', this.onWebsocketConnect.bind(this));
   }
 
-  async maybeReconnect() {
-    // setTimeout is needed to delay execution of this code until the
-    // websocket provider has finished the callback for its close event,
-    // because part of that callback includes clearing all event listeners attached to it.
-    // We need to reattach the event listeners after that completes.
-    setTimeout(() => {
-      try {
-        console.log('attempting websocket reconnection');
-        if (Date.now() - this.lastReconnection < MIN_RECONNECTION_INTERVAL) {
-          this.emit('websocket-disconnected');
-          return;
-        }
-        this.lastReconnection = Date.now();
-        this.websocketProvider.reset();
-        this.bindSocketListeners();
-        this.websocketProvider.connect();
-      } catch (e) {
-        this.emit('websocket-disconnected');
-      }
-    }, 0);
-  }
-
   async onWebsocketConnect() {
     console.log('websocket connected', this.websocketProvider.connection.url);
     Sentry.addBreadcrumb({
@@ -582,7 +557,7 @@ class WalletConnectProvider extends ExtendedProviderEngine {
         ? Sentry.Severity.Info
         : Sentry.Severity.Error,
     });
-    this.maybeReconnect();
+    this.emit('websocket-disconnected');
   }
 }
 


### PR DESCRIPTION
see https://github.com/cardstack/cardwallet/blob/9c8dcb6c777f15de63938ce6a1cfc7aa6915bf04/cardstack/src/models/web3-provider.ts

I missed `reconnect.auto` when working on this the first time and tried this out after looking at card wallet's approach to use it in the notifications work. It works to reconnect for the main case of websocket disconnection we want to prevent, which is a disconnection after idling for a few minutes.