### PR TITLE
Update ember-auto-import

### DIFF
--- a/packages/boxel/addon/helpers/css-url.ts
+++ b/packages/boxel/addon/helpers/css-url.ts
@@ -1,0 +1,39 @@
+import { helper } from '@ember/component/helper';
+import { htmlSafe } from '@ember/string';
+import { SafeString } from '@ember/template/-private/handlebars';
+
+export function cssUrl(
+  propertyName: string,
+  url: string
+): SafeString | undefined {
+  if (!/^[-a-zA-Z]+$/.test(propertyName)) {
+    throw new Error(`Potentially unsafe property name ${propertyName}`);
+  }
+  if (!url) {
+    return;
+  }
+
+  // Step 1: Make sure there are no un-encoded double quotes
+  let encodedURL = url.replace(/"/g, '%22');
+
+  // Step 2: if there is a protocol present, whitelist only http and
+  // https. This prevents shenanigans like "javascript://" URLs (which
+  // certain older browsers may execute).
+  let m = /^([^:]+):/.exec(encodedURL);
+  if (m) {
+    let proto = m[1].toLowerCase();
+    if (proto !== 'http' && proto !== 'https') {
+      throw new Error(`disallowed protocol in css url: ${url}`);
+    }
+  }
+
+  // Step 3: Use our own double quotes, which the url cannot break out
+  // of due to Step 1.
+  return htmlSafe(`${propertyName}: url("${encodedURL}")`);
+}
+
+function asHelper(params: [string, string]) {
+  return cssUrl(...params);
+}
+
+export default helper(asHelper);

--- a/packages/boxel/app/helpers/css-url.js
+++ b/packages/boxel/app/helpers/css-url.js
@@ -1,0 +1,1 @@
+export { default } from '@cardstack/boxel/helpers/css-url';

--- a/packages/boxel/package.json
+++ b/packages/boxel/package.json
@@ -45,7 +45,6 @@
     "ember-cli-typescript": "^4.1.0",
     "ember-composable-helpers": "^4.4.1",
     "ember-concurrency-decorators": "^2.0.3",
-    "ember-css-url": "^0.2.1",
     "ember-element-helper": "^0.5.0",
     "ember-event-helpers": "^0.1.1",
     "ember-keyboard": "^6.0.3",

--- a/packages/boxel/package.json
+++ b/packages/boxel/package.json
@@ -37,7 +37,7 @@
     "broccoli-stew": "^3.0.0",
     "dayjs": "^1.10.4",
     "ember-animated": "^0.11.0",
-    "ember-auto-import": "^1.10.1",
+    "ember-auto-import": "^2.2.4",
     "ember-class-names-helper": "^0.2.1",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^5.3.1",
@@ -149,7 +149,8 @@
     "prettier": "^2.3.2",
     "qunit-dom": "^1.6.0",
     "stylelint-config-standard": "^21.0.0",
-    "typescript": "^4.2.3"
+    "typescript": "^4.2.3",
+    "webpack": "^5.64.1"
   },
   "engines": {
     "node": "12.* || >= 14.*"

--- a/packages/boxel/tests/integration/components/boxel/menu-test.js
+++ b/packages/boxel/tests/integration/components/boxel/menu-test.js
@@ -50,7 +50,7 @@ module('Integration | Component | Menu', function (hooks) {
   test('It can render dividers', async function (assert) {
     await render(hbs`
       <Boxel::Menu
-        @closeMenu={{noop}}
+        @closeMenu={{(noop)}}
         @items={{array
           (menu-item 'Top' (noop))
           (menu-item '---')
@@ -64,7 +64,7 @@ module('Integration | Component | Menu', function (hooks) {
   test('It can render variants with appropriate classes', async function (assert) {
     await render(hbs`
       <Boxel::Menu
-        @closeMenu={{noop}}
+        @closeMenu={{(noop)}}
         @items={{array
           (menu-item 'Dangerous' (noop) dangerous=true)
           (menu-item 'Icon' (noop) icon='gear')

--- a/packages/boxel/tests/integration/components/boxel/sort-menu-test.js
+++ b/packages/boxel/tests/integration/components/boxel/sort-menu-test.js
@@ -17,7 +17,7 @@ module('Integration | Component | SortMenu', function (hooks) {
   test('It renders numeric items as an ascending-descending pair', async function (assert) {
     this.set('columns', [{ name: 'Year', sortType: 'numeric' }]);
     await render(
-      hbs`<Boxel::SortMenu @onSort={{noop}} @sortableColumns={{this.columns}}/>`
+      hbs`<Boxel::SortMenu @onSort={{(noop)}} @sortableColumns={{this.columns}}/>`
     );
     assert
       .dom(
@@ -41,7 +41,7 @@ module('Integration | Component | SortMenu', function (hooks) {
   test('It renders alphabetical items as an ascending-descending pair', async function (assert) {
     this.set('columns', [{ name: 'Title', sortType: 'alpha' }]);
     await render(
-      hbs`<Boxel::SortMenu @onSort={{noop}} @sortableColumns={{this.columns}}/>`
+      hbs`<Boxel::SortMenu @onSort={{(noop)}} @sortableColumns={{this.columns}}/>`
     );
     assert
       .dom(
@@ -65,7 +65,7 @@ module('Integration | Component | SortMenu', function (hooks) {
     this.set('sortedColumn', columns[0]);
     this.set('sortedDirection', 'asc');
     await render(
-      hbs`<Boxel::SortMenu @onSort={{noop}} @sortableColumns={{this.sortableColumns}} @sortedColumn={{this.sortedColumn}} @sortedDirection={{this.sortedDirection}}/>`
+      hbs`<Boxel::SortMenu @onSort={{(noop)}} @sortableColumns={{this.sortableColumns}} @sortedColumn={{this.sortedColumn}} @sortedDirection={{this.sortedDirection}}/>`
     );
 
     assert

--- a/packages/boxel/tests/integration/helpers/css-url-test.ts
+++ b/packages/boxel/tests/integration/helpers/css-url-test.ts
@@ -1,0 +1,39 @@
+import { module, test } from 'qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { cssUrl } from '@cardstack/boxel/helpers/css-url';
+
+module('Integration | Helper | css-url', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    this.set('avatar', '/picture.png');
+    await render(
+      hbs`<div class="example" style={{css-url "background-image" this.avatar}}></div>`
+    );
+
+    let style = this.element.querySelector('.example')?.getAttribute('style');
+    assert.equal(style, `background-image: url("/picture.png")`);
+  });
+
+  test('it rejects any funny protocols', async function (assert) {
+    assert.throws(() => {
+      cssUrl('background-image', 'weird://foo');
+    }, /disallowed protocol/);
+  });
+
+  test('it encodes any quotes', function (assert) {
+    assert.equal(
+      cssUrl('background-image', 'foo"bar')?.toString(),
+      'background-image: url("foo%22bar")'
+    );
+  });
+
+  test("it doesn't double-encode URLs that already have encoding", function (assert) {
+    assert.equal(
+      cssUrl('background-image', '/?title=I%20%22Think%22%20So')?.toString(),
+      'background-image: url("/?title=I%20%22Think%22%20So")'
+    );
+  });
+});

--- a/packages/boxel/tests/integration/helpers/dayjs-format-test.js
+++ b/packages/boxel/tests/integration/helpers/dayjs-format-test.js
@@ -12,15 +12,15 @@ module('Integration | Helper | dayjs-format', function (hooks) {
   setupRenderingTest(hooks);
 
   test('one arg (date)', async function (assert) {
-    this.set('date', date(date(0)));
+    this.set('date', '2020-01-02');
     await render(hbs`{{dayjs-format this.date}}`);
-    assert.equal(this.element.textContent.trim(), '1 January, 1970');
+    assert.equal(this.element.textContent.trim(), '2 January, 2020');
   });
 
   test('two args (date, inputFormat)', async function (assert) {
     this.setProperties({
       format: 'MMMM D, YYYY',
-      date: dayjs(Date.parse('2011-10-10')),
+      date: dayjs(new Date(2011, 9, 10)),
     });
 
     await render(hbs`{{dayjs-format this.date this.format}}`);
@@ -41,10 +41,10 @@ module('Integration | Helper | dayjs-format', function (hooks) {
   });
 
   test('works with change in input', async function (assert) {
-    this.set('date', date(0));
+    this.set('date', '2020-01-02');
 
     await render(hbs`{{dayjs-format this.date}}`);
-    assert.equal(this.element.textContent.trim(), '1 January, 1970');
+    assert.equal(this.element.textContent.trim(), '2 January, 2020');
 
     this.set('date', date('5/3/10'));
     assert.equal(this.element.textContent.trim(), '3 May, 2010');

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-amount-test.ts
@@ -63,7 +63,7 @@ module(
       <CardPay::DepositWorkflow::TransactionAmount
         @workflowSession={{this.session}}
         @onComplete={{this.onComplete}}
-        @onIncomplete={{noop}}
+        @onIncomplete={{(noop)}}
       />
     `);
 
@@ -118,8 +118,8 @@ module(
       await render(hbs`
       <CardPay::DepositWorkflow::TransactionAmount
         @workflowSession={{this.session}}
-        @onComplete={{noop}}
-        @onIncomplete={{noop}}
+        @onComplete={{(noop)}}
+        @onIncomplete={{(noop)}}
       />
     `);
 
@@ -156,8 +156,8 @@ module(
       await render(hbs`
       <CardPay::DepositWorkflow::TransactionAmount
         @workflowSession={{this.session}}
-        @onComplete={{noop}}
-        @onIncomplete={{noop}}
+        @onComplete={{(noop)}}
+        @onIncomplete={{(noop)}}
       />
     `);
 
@@ -178,8 +178,8 @@ module(
       await render(hbs`
       <CardPay::DepositWorkflow::TransactionAmount
         @workflowSession={{this.session}}
-        @onComplete={{noop}}
-        @onIncomplete={{noop}}
+        @onComplete={{(noop)}}
+        @onIncomplete={{(noop)}}
       />
     `);
 
@@ -201,8 +201,8 @@ module(
       await render(hbs`
       <CardPay::DepositWorkflow::TransactionAmount
         @workflowSession={{this.session}}
-        @onComplete={{noop}}
-        @onIncomplete={{noop}}
+        @onComplete={{(noop)}}
+        @onIncomplete={{(noop)}}
       />
     `);
 
@@ -232,8 +232,8 @@ module(
       await render(hbs`
       <CardPay::DepositWorkflow::TransactionAmount
         @workflowSession={{this.session}}
-        @onComplete={{noop}}
-        @onIncomplete={{noop}}
+        @onComplete={{(noop)}}
+        @onIncomplete={{(noop)}}
       />
     `);
 
@@ -287,8 +287,8 @@ module(
       await render(hbs`
       <CardPay::DepositWorkflow::TransactionAmount
         @workflowSession={{this.session}}
-        @onComplete={{noop}}
-        @onIncomplete={{noop}}
+        @onComplete={{(noop)}}
+        @onIncomplete={{(noop)}}
       />
     `);
 

--- a/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-setup-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/deposit-workflow/transaction-setup-test.ts
@@ -46,8 +46,8 @@ module(
       await render(hbs`
           <CardPay::DepositWorkflow::TransactionSetup
             @workflowSession={{this.session}}
-            @onComplete={{noop}}
-            @onIncomplete={{noop}}
+            @onComplete={{(noop)}}
+            @onIncomplete={{(noop)}}
           />
         `);
 
@@ -110,8 +110,8 @@ module(
       await render(hbs`
           <CardPay::DepositWorkflow::TransactionSetup
             @workflowSession={{this.session}}
-            @onComplete={{noop}}
-            @onIncomplete={{noop}}
+            @onComplete={{(noop)}}
+            @onIncomplete={{(noop)}}
           />
         `);
 
@@ -155,8 +155,8 @@ module(
           <CardPay::DepositWorkflow::TransactionSetup
             @workflowSession={{this.session}}
             @isComplete={{this.isComplete}}
-            @onComplete={{noop}}
-            @onIncomplete={{noop}}
+            @onComplete={{(noop)}}
+            @onIncomplete={{(noop)}}
           />
         `);
 
@@ -302,8 +302,8 @@ module(
       await render(hbs`
           <CardPay::DepositWorkflow::TransactionSetup
             @workflowSession={{this.session}}
-            @onComplete={{noop}}
-            @onIncomplete={{noop}}
+            @onComplete={{(noop)}}
+            @onIncomplete={{(noop)}}
           />
         `);
 
@@ -339,8 +339,8 @@ module(
       await render(hbs`
           <CardPay::DepositWorkflow::TransactionSetup
             @workflowSession={{this.session}}
-            @onComplete={{noop}}
-            @onIncomplete={{noop}}
+            @onComplete={{(noop)}}
+            @onIncomplete={{(noop)}}
           />
         `);
 
@@ -373,8 +373,8 @@ module(
       await render(hbs`
           <CardPay::DepositWorkflow::TransactionSetup
             @workflowSession={{this.session}}
-            @onComplete={{noop}}
-            @onIncomplete={{noop}}
+            @onComplete={{(noop)}}
+            @onIncomplete={{(noop)}}
           />
         `);
       assert

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-amount-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/transaction-amount-test.ts
@@ -68,8 +68,8 @@ module(
         await render(hbs`
           <CardPay::WithdrawalWorkflow::TransactionAmount
             @workflowSession={{this.session}}
-            @onComplete={{noop}}
-            @onIncomplete={{noop}}
+            @onComplete={{(noop)}}
+            @onIncomplete={{(noop)}}
           />
         `);
       };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5907,6 +5907,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.47.tgz#d7a51db20f0650efec24cd04994f523d93172ed4"
   integrity sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==
 
+"@types/estree@^0.0.50":
+  version "0.0.50"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
+  integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
+
 "@types/eth-sig-util@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/eth-sig-util/-/eth-sig-util-2.1.0.tgz#54497e9c01b5ee3a60475686cce1a20ddccc358b"
@@ -6082,6 +6087,11 @@
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+
+"@types/json-schema@^7.0.8":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
+  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
 "@types/json-stable-stringify@^1.0.32":
   version "1.0.32"
@@ -6880,6 +6890,14 @@
     "@webassemblyjs/helper-numbers" "1.11.0"
     "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
 
+"@webassemblyjs/ast@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"
+  integrity sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==
+  dependencies:
+    "@webassemblyjs/helper-numbers" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -6894,6 +6912,11 @@
   resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.0.tgz#34d62052f453cd43101d72eab4966a022587947c"
   integrity sha512-Q/aVYs/VnPDVYvsCBL/gSgwmfjeCb4LW8+TMrO3cSzJImgv8lxxEPM2JA5jMrivE7LSz3V+PFqtMbls3m1exDA==
 
+"@webassemblyjs/floating-point-hex-parser@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz#f6c61a705f0fd7a6aecaa4e8198f23d9dc179e4f"
+  integrity sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==
+
 "@webassemblyjs/floating-point-hex-parser@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz#3c3d3b271bddfc84deb00f71344438311d52ffb4"
@@ -6904,6 +6927,11 @@
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.0.tgz#aaea8fb3b923f4aaa9b512ff541b013ffb68d2d4"
   integrity sha512-baT/va95eXiXb2QflSx95QGT5ClzWpGaa8L7JnJbgzoYeaA27FCvuBXU758l+KXWRndEmUXjP0Q5fibhavIn8w==
 
+"@webassemblyjs/helper-api-error@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz#1a63192d8788e5c012800ba6a7a46c705288fd16"
+  integrity sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==
+
 "@webassemblyjs/helper-api-error@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz#203f676e333b96c9da2eeab3ccef33c45928b6a2"
@@ -6913,6 +6941,11 @@
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.0.tgz#d026c25d175e388a7dbda9694e91e743cbe9b642"
   integrity sha512-u9HPBEl4DS+vA8qLQdEQ6N/eJQ7gT7aNvMIo8AAWvAl/xMrcOSiI2M0MAnMCy3jIFke7bEee/JwdX1nUpCtdyA==
+
+"@webassemblyjs/helper-buffer@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz#832a900eb444884cde9a7cad467f81500f5e5ab5"
+  integrity sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==
 
 "@webassemblyjs/helper-buffer@1.9.0":
   version "1.9.0"
@@ -6947,10 +6980,24 @@
     "@webassemblyjs/helper-api-error" "1.11.0"
     "@xtuc/long" "4.2.2"
 
+"@webassemblyjs/helper-numbers@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz#64d81da219fbbba1e3bd1bfc74f6e8c4e10a62ae"
+  integrity sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==
+  dependencies:
+    "@webassemblyjs/floating-point-hex-parser" "1.11.1"
+    "@webassemblyjs/helper-api-error" "1.11.1"
+    "@xtuc/long" "4.2.2"
+
 "@webassemblyjs/helper-wasm-bytecode@1.11.0":
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.0.tgz#85fdcda4129902fe86f81abf7e7236953ec5a4e1"
   integrity sha512-MbmhvxXExm542tWREgSFnOVo07fDpsBJg3sIl6fSp9xuu75eGz5lz31q7wTLffwL3Za7XNRCMZy210+tnsUSEA==
+
+"@webassemblyjs/helper-wasm-bytecode@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz#f328241e41e7b199d0b20c18e88429c4433295e1"
+  integrity sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==
 
 "@webassemblyjs/helper-wasm-bytecode@1.9.0":
   version "1.9.0"
@@ -6966,6 +7013,16 @@
     "@webassemblyjs/helper-buffer" "1.11.0"
     "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
     "@webassemblyjs/wasm-gen" "1.11.0"
+
+"@webassemblyjs/helper-wasm-section@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz#21ee065a7b635f319e738f0dd73bfbda281c097a"
+  integrity sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
 
 "@webassemblyjs/helper-wasm-section@1.9.0":
   version "1.9.0"
@@ -6984,6 +7041,13 @@
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
 
+"@webassemblyjs/ieee754@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz#963929e9bbd05709e7e12243a099180812992614"
+  integrity sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==
+  dependencies:
+    "@xtuc/ieee754" "^1.2.0"
+
 "@webassemblyjs/ieee754@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz#15c7a0fbaae83fb26143bbacf6d6df1702ad39e4"
@@ -6998,6 +7062,13 @@
   dependencies:
     "@xtuc/long" "4.2.2"
 
+"@webassemblyjs/leb128@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.1.tgz#ce814b45574e93d76bae1fb2644ab9cdd9527aa5"
+  integrity sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==
+  dependencies:
+    "@xtuc/long" "4.2.2"
+
 "@webassemblyjs/leb128@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.9.0.tgz#f19ca0b76a6dc55623a09cffa769e838fa1e1c95"
@@ -7009,6 +7080,11 @@
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.0.tgz#86e48f959cf49e0e5091f069a709b862f5a2cadf"
   integrity sha512-A/lclGxH6SpSLSyFowMzO/+aDEPU4hvEiooCMXQPcQFPPJaYcPQNKGOCLUySJsYJ4trbpr+Fs08n4jelkVTGVw==
+
+"@webassemblyjs/utf8@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.1.tgz#d1f8b764369e7c6e6bae350e854dec9a59f0a3ff"
+  integrity sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==
 
 "@webassemblyjs/utf8@1.9.0":
   version "1.9.0"
@@ -7028,6 +7104,20 @@
     "@webassemblyjs/wasm-opt" "1.11.0"
     "@webassemblyjs/wasm-parser" "1.11.0"
     "@webassemblyjs/wast-printer" "1.11.0"
+
+"@webassemblyjs/wasm-edit@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz#ad206ebf4bf95a058ce9880a8c092c5dec8193d6"
+  integrity sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/helper-wasm-section" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
+    "@webassemblyjs/wasm-opt" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    "@webassemblyjs/wast-printer" "1.11.1"
 
 "@webassemblyjs/wasm-edit@1.9.0":
   version "1.9.0"
@@ -7054,6 +7144,17 @@
     "@webassemblyjs/leb128" "1.11.0"
     "@webassemblyjs/utf8" "1.11.0"
 
+"@webassemblyjs/wasm-gen@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz#86c5ea304849759b7d88c47a32f4f039ae3c8f76"
+  integrity sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/ieee754" "1.11.1"
+    "@webassemblyjs/leb128" "1.11.1"
+    "@webassemblyjs/utf8" "1.11.1"
+
 "@webassemblyjs/wasm-gen@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz#50bc70ec68ded8e2763b01a1418bf43491a7a49c"
@@ -7074,6 +7175,16 @@
     "@webassemblyjs/helper-buffer" "1.11.0"
     "@webassemblyjs/wasm-gen" "1.11.0"
     "@webassemblyjs/wasm-parser" "1.11.0"
+
+"@webassemblyjs/wasm-opt@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz#657b4c2202f4cf3b345f8a4c6461c8c2418985f2"
+  integrity sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
 
 "@webassemblyjs/wasm-opt@1.9.0":
   version "1.9.0"
@@ -7096,6 +7207,18 @@
     "@webassemblyjs/ieee754" "1.11.0"
     "@webassemblyjs/leb128" "1.11.0"
     "@webassemblyjs/utf8" "1.11.0"
+
+"@webassemblyjs/wasm-parser@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz#86ca734534f417e9bd3c67c7a1c75d8be41fb199"
+  integrity sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-api-error" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/ieee754" "1.11.1"
+    "@webassemblyjs/leb128" "1.11.1"
+    "@webassemblyjs/utf8" "1.11.1"
 
 "@webassemblyjs/wasm-parser@1.9.0":
   version "1.9.0"
@@ -7127,6 +7250,14 @@
   integrity sha512-Fg5OX46pRdTgB7rKIUojkh9vXaVN6sGYCnEiJN1GYkb0RPwShZXp6KTDqmoMdQPKhcroOXh3fEzmkWmCYaKYhQ==
   dependencies:
     "@webassemblyjs/ast" "1.11.0"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/wast-printer@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz#d0c73beda8eec5426f10ae8ef55cee5e7084c2f0"
+  integrity sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/wast-printer@1.9.0":
@@ -7244,6 +7375,11 @@ acorn-globals@^6.0.0:
   dependencies:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
+
+acorn-import-assertions@^1.7.6:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz#ba2b5939ce62c238db6d93d81c9b111b29b855e9"
+  integrity sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==
 
 acorn-jsx-walk@2.0.0:
   version "2.0.0"
@@ -12588,6 +12724,44 @@ ember-auto-import@^2.0.0, ember-auto-import@^2.0.1, ember-auto-import@^2.0.2:
     typescript-memoize "^1.0.0-alpha.3"
     walk-sync "^0.3.3"
 
+ember-auto-import@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-2.2.4.tgz#68c08cb0b7533293024c97387fc449b00561185a"
+  integrity sha512-iXHH+bSMP/uWvJmIhjt+PZz4ymqOLccIxZUouVcUFLKA5EAWE7gamlA684m0pIbSE/V9zKpOul4OfIgKXFprBg==
+  dependencies:
+    "@babel/core" "^7.1.6"
+    "@babel/plugin-proposal-class-properties" "^7.13.0"
+    "@babel/plugin-proposal-decorators" "^7.13.5"
+    "@babel/preset-env" "^7.10.2"
+    "@babel/traverse" "^7.1.6"
+    "@embroider/shared-internals" "^0.40.0"
+    babel-loader "^8.0.6"
+    babel-plugin-ember-modules-api-polyfill "^3.5.0"
+    babel-plugin-htmlbars-inline-precompile "^5.2.1"
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^3.0.8"
+    broccoli-merge-trees "^4.2.0"
+    broccoli-plugin "^4.0.0"
+    broccoli-source "^3.0.0"
+    css-loader "^5.2.0"
+    debug "^4.3.1"
+    ember-cli-babel "^7.0.0"
+    fs-extra "^6.0.1"
+    fs-tree-diff "^2.0.0"
+    handlebars "^4.3.1"
+    js-string-escape "^1.0.1"
+    lodash "^4.17.19"
+    mkdirp "^0.5.1"
+    parse5 "^6.0.1"
+    resolve "^1.20.0"
+    resolve-package-path "^3.1.0"
+    rimraf "^2.6.2"
+    semver "^7.3.4"
+    style-loader "^2.0.0"
+    typescript-memoize "^1.0.0-alpha.3"
+    walk-sync "^0.3.3"
+
 ember-basic-dropdown@^3.0.18, ember-basic-dropdown@^3.0.21:
   version "3.0.21"
   resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-3.0.21.tgz#5711d071966919c9578d2d5ac2c6dcadbb5ea0e0"
@@ -14317,7 +14491,7 @@ engine.io@~3.2.0:
     engine.io-parser "~2.1.0"
     ws "~3.3.1"
 
-enhanced-resolve@5.8.3, enhanced-resolve@^5.7.0:
+enhanced-resolve@5.8.3, enhanced-resolve@^5.7.0, enhanced-resolve@^5.8.3:
   version "5.8.3"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz#6d552d465cce0423f5b3d718511ea53826a7b2f0"
   integrity sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==
@@ -14488,6 +14662,11 @@ es-module-lexer@^0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.4.1.tgz#dda8c6a14d8f340a24e34331e0fab0cb50438e0e"
   integrity sha512-ooYciCUtfw6/d2w56UVeqHPcoCFAiJdz5XOkYpv/Txl1HMUozpXjz/2RIQgqwKdXNDPSF1W7mJCFse3G+HDyAA==
+
+es-module-lexer@^0.9.0:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
+  integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -19238,6 +19417,15 @@ jest-worker@^27.0.2:
   version "27.0.2"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.0.2.tgz#4ebeb56cef48b3e7514552f80d0d80c0129f0b05"
   integrity sha512-EoBdilOTTyOgmHXtw/cPc+ZrCA0KJMrkXzkrPGNwLmnvvlN1nj7MPrxpT7m+otSv2e1TLaVffzDnE/LB14zJMg==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^8.0.0"
+
+jest-worker@^27.0.6:
+  version "27.4.2"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.4.2.tgz#0fb123d50955af1a450267787f340a1bf7e12bc4"
+  integrity sha512-0QMy/zPovLfUPyHuOuuU4E+kGACXXE84nRnq6lBVI9GJg5DCBiA97SATi+ZP8CpiJwEQy1oCPjRBf8AnLjN+Ag==
   dependencies:
     "@types/node" "*"
     merge-stream "^2.0.0"
@@ -25386,6 +25574,15 @@ schema-utils@^3.0.0:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
+schema-utils@^3.1.0, schema-utils@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
+  integrity sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==
+  dependencies:
+    "@types/json-schema" "^7.0.8"
+    ajv "^6.12.5"
+    ajv-keywords "^3.5.2"
+
 scrypt-js@^3.0.0, scrypt-js@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
@@ -25505,6 +25702,13 @@ serialize-javascript@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
   integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+  dependencies:
+    randombytes "^2.1.0"
+
+serialize-javascript@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
+  integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
   dependencies:
     randombytes "^2.1.0"
 
@@ -25989,6 +26193,14 @@ source-map-support@^0.5.19:
   version "0.5.20"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.20.tgz#12166089f8f5e5e8c56926b377633392dd2cb6c9"
   integrity sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@~0.5.20:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -27020,6 +27232,17 @@ terser-webpack-plugin@^5.1.1:
     source-map "^0.6.1"
     terser "^5.7.0"
 
+terser-webpack-plugin@^5.1.3:
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.2.5.tgz#ce65b9880a0c36872555c4874f45bbdb02ee32c9"
+  integrity sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==
+  dependencies:
+    jest-worker "^27.0.6"
+    schema-utils "^3.1.1"
+    serialize-javascript "^6.0.0"
+    source-map "^0.6.1"
+    terser "^5.7.2"
+
 terser@^4.1.2:
   version "4.3.9"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.3.9.tgz#e4be37f80553d02645668727777687dad26bbca8"
@@ -27037,6 +27260,15 @@ terser@^5.3.0, terser@^5.5.1, terser@^5.7.0:
     commander "^2.20.0"
     source-map "~0.7.2"
     source-map-support "~0.5.19"
+
+terser@^5.7.2:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.10.0.tgz#b86390809c0389105eb0a0b62397563096ddafcc"
+  integrity sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.7.2"
+    source-map-support "~0.5.20"
 
 testem@^3.2.0:
   version "3.2.0"
@@ -28288,6 +28520,14 @@ watchpack@^2.2.0:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
+watchpack@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.3.0.tgz#a41bca3da6afaff31e92a433f4c856a0c25ea0c4"
+  integrity sha512-MnN0Q1OsvB/GGHETrFeZPQaOelWh/7O+EiFlj8sM9GPjtQkis7k01aAxrg/18kTfoIVcLL+haEVFlXDaSRwKRw==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
+
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
@@ -28776,6 +29016,11 @@ webpack-sources@^2.3.0:
     source-list-map "^2.0.1"
     source-map "^0.6.1"
 
+webpack-sources@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.2.tgz#d88e3741833efec57c4c789b6010db9977545260"
+  integrity sha512-cp5qdmHnu5T8wRg2G3vZZHoJPN14aqQ89SyQ11NpGH5zEMDCclt49rzo+MaRazk7/UeILhAI+/sEtcM+7Fr0nw==
+
 webpack@^4.43.0:
   version "4.46.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
@@ -28833,6 +29078,36 @@ webpack@^5.0.0, webpack@^5.15.0:
     terser-webpack-plugin "^5.1.1"
     watchpack "^2.2.0"
     webpack-sources "^2.3.0"
+
+webpack@^5.64.1:
+  version "5.64.4"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.64.4.tgz#e1454b6a13009f57cc2c78e08416cd674622937b"
+  integrity sha512-LWhqfKjCLoYJLKJY8wk2C3h77i8VyHowG3qYNZiIqD6D0ZS40439S/KVuc/PY48jp2yQmy0mhMknq8cys4jFMw==
+  dependencies:
+    "@types/eslint-scope" "^3.7.0"
+    "@types/estree" "^0.0.50"
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/wasm-edit" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    acorn "^8.4.1"
+    acorn-import-assertions "^1.7.6"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.8.3"
+    es-module-lexer "^0.9.0"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.4"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.1.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.1.3"
+    watchpack "^2.3.0"
+    webpack-sources "^3.2.2"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
   version "0.7.4"


### PR DESCRIPTION
The ember upgrade PR for boxel is stalled out (https://github.com/cardstack/cardstack/pull/2390). This is an attempt to bring over some smaller commits and get this merged first. It involves updating ember-auto-import as well as handling several deprecations that will effect the ember 4 upgrade