### PR TITLE
hub: Add merchant name to notifications

### DIFF
--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -45,6 +45,7 @@ import WyreCallbackRoute from './routes/wyre-callback';
 import WyrePricesRoute from './routes/wyre-prices';
 import CardSpacesRoute from './routes/card-spaces';
 import MerchantInfoSerializer from './services/serializers/merchant-info-serializer';
+import MerchantInfoService from './services/merchant-info';
 import MerchantInfoQueries from './services/queries/merchant-info';
 import CardSpaceQueries from './services/queries/card-space';
 import CardSpaceSerializer from './services/serializers/card-space-serializer';
@@ -116,6 +117,7 @@ export function createRegistry(): Registry {
   registry.register('inventory-route', InventoryRoute);
   registry.register('merchant-infos-route', MerchantInfosRoute);
   registry.register('merchant-info-serializer', MerchantInfoSerializer);
+  registry.register('merchant-info', MerchantInfoService);
   registry.register('merchant-info-queries', MerchantInfoQueries);
   registry.register('nonce-tracker', NonceTracker);
   registry.register('send-notifications', SendNotificationsTask);

--- a/packages/hub/node-tests/services/merchant-info-test.ts
+++ b/packages/hub/node-tests/services/merchant-info-test.ts
@@ -57,4 +57,22 @@ describe('MerchantInfoService', function () {
 
     expect(result).to.be.null;
   });
+
+  it('returns null when there is no DID', async function () {
+    registry(this).register('merchant-info', MerchantInfoService);
+
+    let subject = await getContainer().lookup('merchant-info');
+    let result = await subject.getMerchantInfo(undefined);
+
+    expect(result).to.be.null;
+  });
+
+  it('returns null the DID is invalid', async function () {
+    registry(this).register('merchant-info', MerchantInfoService);
+
+    let subject = await getContainer().lookup('merchant-info');
+    let result = await subject.getMerchantInfo('did:cardstack:hey');
+
+    expect(result).to.be.null;
+  });
 });

--- a/packages/hub/node-tests/services/merchant-info-test.ts
+++ b/packages/hub/node-tests/services/merchant-info-test.ts
@@ -42,4 +42,19 @@ describe('MerchantInfoService', function () {
       ownerAddress: '0x323B2318F35c6b31113342830204335Dac715AA8',
     });
   });
+
+  it('returns null when the fetch fails', async function () {
+    class PatchedMerchantInfoService extends MerchantInfoService {
+      async fetchMerchantInfo(): Promise<JSONAPIDocument> {
+        throw new Error('Simulated merchant info fetch failure');
+      }
+    }
+
+    registry(this).register('merchant-info', PatchedMerchantInfoService);
+
+    let subject = await getContainer().lookup('merchant-info');
+    let result = await subject.getMerchantInfo('did:cardstack:1m1C1LK4xoVSyybjNRcLB4APbc07954765987f62');
+
+    expect(result).to.be.null;
+  });
 });

--- a/packages/hub/node-tests/services/merchant-info-test.ts
+++ b/packages/hub/node-tests/services/merchant-info-test.ts
@@ -1,0 +1,49 @@
+import MerchantInfoService from '../../services/merchant-info';
+import { registry, setupHub } from '../helpers/server';
+
+interface JSONAPIDocument {
+  data: any;
+  included?: any[];
+}
+
+describe('MerchantInfoService', function () {
+  let { getContainer } = setupHub(this);
+
+  it('returns a MerchantInfo object extracted from a fetched document', async function () {
+    let mockMerchantInfoDocument = {
+      meta: { network: 'sokol' },
+      data: {
+        id: '05074049-be24-45fe-81ba-8e3c1a623aa7',
+        type: 'merchant-infos',
+        attributes: {
+          did: 'did:cardstack:1m1C1LK4xoVSyybjNRcLB4APbc07954765987f62',
+          name: 'a long long long long multi-word name that will cause problems because it is so long it really maybe shouldn’t even be permitted amirite maybe there should be (more of?) a limit',
+          slug: 'longlongmultiword',
+          color: '#fff700',
+          'text-color': '#000000',
+          'owner-address': '0x323B2318F35c6b31113342830204335Dac715AA8',
+        },
+      },
+    };
+
+    class PatchedMerchantInfoService extends MerchantInfoService {
+      async fetchMerchantInfo(): Promise<JSONAPIDocument> {
+        return mockMerchantInfoDocument;
+      }
+    }
+
+    registry(this).register('merchant-info', PatchedMerchantInfoService);
+
+    let subject = await getContainer().lookup('merchant-info');
+    let result = await subject.getMerchantInfo('did:cardstack:1m1C1LK4xoVSyybjNRcLB4APbc07954765987f62');
+
+    expect(result).deep.equal({
+      id: '05074049-be24-45fe-81ba-8e3c1a623aa7',
+      name: 'a long long long long multi-word name that will cause problems because it is so long it really maybe shouldn’t even be permitted amirite maybe there should be (more of?) a limit',
+      slug: 'longlongmultiword',
+      color: '#fff700',
+      textColor: '#000000',
+      ownerAddress: '0x323B2318F35c6b31113342830204335Dac715AA8',
+    });
+  });
+});

--- a/packages/hub/node-tests/services/merchant-info-test.ts
+++ b/packages/hub/node-tests/services/merchant-info-test.ts
@@ -1,5 +1,5 @@
 import MerchantInfoService from '../../services/merchant-info';
-import { JSONAPIDocument } from '../../utils/JSONAPIDocument';
+import { JSONAPIDocument } from '../../utils/jsonapi-document';
 import { registry, setupHub } from '../helpers/server';
 
 describe('MerchantInfoService', function () {

--- a/packages/hub/node-tests/services/merchant-info-test.ts
+++ b/packages/hub/node-tests/services/merchant-info-test.ts
@@ -1,10 +1,6 @@
 import MerchantInfoService from '../../services/merchant-info';
+import { JSONAPIDocument } from '../../utils/JSONAPIDocument';
 import { registry, setupHub } from '../helpers/server';
-
-interface JSONAPIDocument {
-  data: any;
-  included?: any[];
-}
 
 describe('MerchantInfoService', function () {
   let { getContainer } = setupHub(this);

--- a/packages/hub/node-tests/services/web3-socket-test.ts
+++ b/packages/hub/node-tests/services/web3-socket-test.ts
@@ -1,42 +1,10 @@
 import Web3SocketService from '../../services/web3-socket';
 import sentryTestkit from 'sentry-testkit';
 import * as Sentry from '@sentry/node';
+import waitFor from '../utils/wait-for';
 
 const { testkit, sentryTransport } = sentryTestkit();
 const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001';
-
-// based on from https://github.com/TheBrainFamily/wait-for-expect/blob/master/src/index.ts
-const waitForDefaults = {
-  timeout: 1500,
-  interval: 50,
-};
-
-function waitFor(
-  expectation: () => boolean | Promise<boolean>,
-  timeout = waitForDefaults.timeout,
-  interval = waitForDefaults.interval
-) {
-  // eslint-disable-next-line no-param-reassign
-  if (interval < 1) interval = 1;
-  const maxTries = Math.ceil(timeout / interval);
-  let tries = 0;
-  return new Promise<void>((resolve, reject) => {
-    async function rerun() {
-      if (tries > maxTries) {
-        reject(new Error(`Could not meet expectation within ${timeout}ms`));
-      }
-      // eslint-disable-next-line no-use-before-define
-      setTimeout(runExpectation, interval);
-    }
-    async function runExpectation() {
-      tries += 1;
-      let v = await expectation();
-      if (v) resolve();
-      else rerun();
-    }
-    setTimeout(runExpectation, 0);
-  });
-}
 
 describe('Web3Socket', function () {
   it('reports to sentry when web3 initialization fails', async function () {

--- a/packages/hub/node-tests/tasks/notify-customer-payment-test.ts
+++ b/packages/hub/node-tests/tasks/notify-customer-payment-test.ts
@@ -99,7 +99,7 @@ describe('NotifyCustomerPaymentTask', function () {
     expect(lastAddedJobIdentifier).to.equal('send-notifications');
     expect(lastAddedJobPayload).to.deep.equal({
       notifiedAddress: 'eoa-address',
-      message: `Your business Mandello received a payment of §2324`,
+      message: `Mandello received a payment of §2324`,
     });
   });
 
@@ -137,7 +137,7 @@ describe('NotifyCustomerPaymentTask', function () {
     expect(lastAddedJobIdentifier).to.equal('send-notifications');
     expect(lastAddedJobPayload).to.deep.equal({
       notifiedAddress: 'eoa-address',
-      message: `Your business received a payment of §2324`,
+      message: `You received a payment of §2324`,
     });
 
     await waitFor(() => testkit.reports().length > 0);
@@ -173,7 +173,7 @@ describe('NotifyCustomerPaymentTask', function () {
     expect(lastAddedJobIdentifier).to.equal('send-notifications');
     expect(lastAddedJobPayload).to.deep.equal({
       notifiedAddress: 'eoa-address',
-      message: `Your business received a payment of §2324`,
+      message: `You received a payment of §2324`,
     });
   });
 

--- a/packages/hub/node-tests/tasks/notify-customer-payment-test.ts
+++ b/packages/hub/node-tests/tasks/notify-customer-payment-test.ts
@@ -129,6 +129,36 @@ describe('NotifyCustomerPaymentTask', function () {
     });
   });
 
+  it('omits the merchant name when there is no DID', async function () {
+    mockData.value = {
+      prepaidCardOwner: {
+        id: 'prepaid-card-eoa-address',
+      },
+      merchant: {
+        id: 'eoa-address',
+      },
+      merchantSafe: {
+        id: 'merchant-safe-address',
+        infoDid: undefined,
+      },
+      issuingToken: {
+        symbol: 'DAI.CPXD',
+      },
+      spendAmount: '2324',
+      issuingTokenAmount: '23240000000000000000',
+    };
+
+    let task = (await getContainer().lookup('notify-customer-payment')) as NotifyCustomerPayment;
+
+    await task.perform('a');
+
+    expect(lastAddedJobIdentifier).to.equal('send-notifications');
+    expect(lastAddedJobPayload).to.deep.equal({
+      notifiedAddress: 'eoa-address',
+      message: `Your business received a payment of §2324`,
+    });
+  });
+
   it('throws when the transaction is not found on the subgraph', async function () {
     let task = (await getContainer().lookup('notify-customer-payment')) as NotifyCustomerPayment;
 

--- a/packages/hub/node-tests/tasks/notify-customer-payment-test.ts
+++ b/packages/hub/node-tests/tasks/notify-customer-payment-test.ts
@@ -40,10 +40,19 @@ class StubWorkerClient {
   }
 }
 
+class StubMerchantInfo {
+  async getMerchantInfo(_did: string) {
+    return {
+      name: 'Mandello',
+    };
+  }
+}
+
 describe('NotifyCustomerPaymentTask', function () {
   this.beforeEach(function () {
     mockData.value = undefined;
     registry(this).register('cardpay', StubCardPay);
+    registry(this).register('merchant-info', StubMerchantInfo);
     registry(this).register('worker-client', StubWorkerClient);
   });
   let { getContainer } = setupHub(this);
@@ -63,6 +72,7 @@ describe('NotifyCustomerPaymentTask', function () {
       },
       merchantSafe: {
         id: 'merchant-safe-address',
+        infoDid: 'did:cardstack:1m1C1LK4xoVSyybjNRcLB4APbc07954765987f62',
       },
       issuingToken: {
         symbol: 'DAI.CPXD',
@@ -78,7 +88,7 @@ describe('NotifyCustomerPaymentTask', function () {
     expect(lastAddedJobIdentifier).to.equal('send-notifications');
     expect(lastAddedJobPayload).to.deep.equal({
       notifiedAddress: 'eoa-address',
-      message: `Your business received a payment of §2324`,
+      message: `Your business Mandello received a payment of §2324`,
     });
   });
 

--- a/packages/hub/node-tests/tasks/notify-merchant-claim-test.ts
+++ b/packages/hub/node-tests/tasks/notify-merchant-claim-test.ts
@@ -120,6 +120,32 @@ describe('NotifyMerchantClaimTask', function () {
     });
   });
 
+  it('omits the merchant name when there is no DID', async function () {
+    mockData.value = {
+      merchantSafe: {
+        id: 'merchant-safe-address',
+        infoDid: undefined,
+        merchant: {
+          id: 'eoa-address',
+        },
+      },
+      amount: '1155000000000000000000',
+      token: {
+        symbol: 'DAI.CPXD',
+      },
+    };
+
+    let task = (await getContainer().lookup('notify-merchant-claim')) as NotifyMerchantClaim;
+
+    await task.perform('a');
+
+    expect(lastAddedJobIdentifier).to.equal('send-notifications');
+    expect(lastAddedJobPayload).to.deep.equal({
+      notifiedAddress: 'eoa-address',
+      message: `You just claimed 1155 DAI.CPXD from your business account`,
+    });
+  });
+
   it('throws when the transaction is not found on the subgraph', async function () {
     let task = (await getContainer().lookup('notify-merchant-claim')) as NotifyMerchantClaim;
 

--- a/packages/hub/node-tests/tasks/notify-merchant-claim-test.ts
+++ b/packages/hub/node-tests/tasks/notify-merchant-claim-test.ts
@@ -39,10 +39,19 @@ class StubWorkerClient {
   }
 }
 
+class StubMerchantInfo {
+  async getMerchantInfo(_did: string) {
+    return {
+      name: 'Mandello',
+    };
+  }
+}
+
 describe('NotifyMerchantClaimTask', function () {
   this.beforeEach(function () {
     mockData.value = undefined;
     registry(this).register('cardpay', StubCardPay);
+    registry(this).register('merchant-info', StubMerchantInfo);
     registry(this).register('worker-client', StubWorkerClient);
   });
   let { getContainer } = setupHub(this);
@@ -56,6 +65,7 @@ describe('NotifyMerchantClaimTask', function () {
     mockData.value = {
       merchantSafe: {
         id: 'merchant-safe-address',
+        infoDid: 'did:cardstack:1m1C1LK4xoVSyybjNRcLB4APbc07954765987f62',
         merchant: {
           id: 'eoa-address',
         },
@@ -72,7 +82,7 @@ describe('NotifyMerchantClaimTask', function () {
     expect(lastAddedJobIdentifier).to.equal('send-notifications');
     expect(lastAddedJobPayload).to.deep.equal({
       notifiedAddress: 'eoa-address',
-      message: `You just claimed 1155 DAI.CPXD from your business account`,
+      message: `You just claimed 1155 DAI.CPXD from your Mandello business account`,
     });
   });
 

--- a/packages/hub/node-tests/utils/wait-for.ts
+++ b/packages/hub/node-tests/utils/wait-for.ts
@@ -1,0 +1,32 @@
+// based on https://github.com/TheBrainFamily/wait-for-expect/blob/master/src/index.ts
+const waitForDefaults = {
+  timeout: 1500,
+  interval: 50,
+};
+
+export default function waitFor(
+  expectation: () => boolean | Promise<boolean>,
+  timeout = waitForDefaults.timeout,
+  interval = waitForDefaults.interval
+) {
+  // eslint-disable-next-line no-param-reassign
+  if (interval < 1) interval = 1;
+  const maxTries = Math.ceil(timeout / interval);
+  let tries = 0;
+  return new Promise<void>((resolve, reject) => {
+    async function rerun() {
+      if (tries > maxTries) {
+        reject(new Error(`Could not meet expectation within ${timeout}ms`));
+      }
+      // eslint-disable-next-line no-use-before-define
+      setTimeout(runExpectation, interval);
+    }
+    async function runExpectation() {
+      tries += 1;
+      let v = await expectation();
+      if (v) resolve();
+      else rerun();
+    }
+    setTimeout(runExpectation, 0);
+  });
+}

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -51,6 +51,7 @@
     "config": "^3.3.6",
     "corde": "^4.4.1",
     "dag-map": "^2.0.2",
+    "did-resolver": "^3.1.3",
     "dotenv": "^10.0.0",
     "eth-sig-util": "^3.0.1",
     "fast-json-stable-stringify": "^2.1.0",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -51,7 +51,7 @@
     "config": "^3.3.6",
     "corde": "^4.4.1",
     "dag-map": "^2.0.2",
-    "did-resolver": "^3.1.3",
+    "did-resolver": "^3.1.0",
     "dotenv": "^10.0.0",
     "eth-sig-util": "^3.0.1",
     "fast-json-stable-stringify": "^2.1.0",

--- a/packages/hub/services/merchant-info.ts
+++ b/packages/hub/services/merchant-info.ts
@@ -4,7 +4,7 @@ import { inject } from '@cardstack/di';
 import { getResolver } from '@cardstack/did-resolver';
 import { Resolver } from 'did-resolver';
 import { MerchantInfo } from '../routes/merchant-infos';
-import { JSONAPIDocument } from '../utils/JSONAPIDocument';
+import { JSONAPIDocument } from '../utils/jsonapi-document';
 
 export default class MerchantInfoService {
   #didResolver = new Resolver(getResolver());

--- a/packages/hub/services/merchant-info.ts
+++ b/packages/hub/services/merchant-info.ts
@@ -3,6 +3,8 @@ import { inject } from '@cardstack/di';
 
 import { getResolver } from '@cardstack/did-resolver';
 import { Resolver } from 'did-resolver';
+import { MerchantInfo } from '../routes/merchant-infos';
+import { JSONAPIDocument } from '../utils/JSONAPIDocument';
 
 export default class MerchantInfoService {
   #didResolver = new Resolver(getResolver());
@@ -11,12 +13,12 @@ export default class MerchantInfoService {
     as: 'merchantInfoSerializer',
   });
 
-  async getMerchantInfo(did: string): Promise<any> {
+  async getMerchantInfo(did: string): Promise<MerchantInfo> {
     let merchantInfo = await this.fetchMerchantInfo(did);
     return this.merchantInfoSerializer.deserialize(merchantInfo);
   }
 
-  async fetchMerchantInfo(did: string): Promise<any> {
+  async fetchMerchantInfo(did: string): Promise<JSONAPIDocument> {
     let didResult = await this.#didResolver.resolve(did);
     let alsoKnownAs = didResult?.didDocument?.alsoKnownAs;
 

--- a/packages/hub/services/merchant-info.ts
+++ b/packages/hub/services/merchant-info.ts
@@ -5,7 +5,8 @@ import { getResolver } from '@cardstack/did-resolver';
 import { Resolver } from 'did-resolver';
 
 export default class MerchantInfoService {
-  #didResolver = new Resolver(getResolver());
+  // @ts-ignore FIXME what is with this?!?!
+  #didResolver = new Resolver(getResolver().cardstack);
 
   merchantInfoSerializer = inject('merchant-info-serializer', {
     as: 'merchantInfoSerializer',

--- a/packages/hub/services/merchant-info.ts
+++ b/packages/hub/services/merchant-info.ts
@@ -13,9 +13,13 @@ export default class MerchantInfoService {
     as: 'merchantInfoSerializer',
   });
 
-  async getMerchantInfo(did: string): Promise<MerchantInfo> {
-    let merchantInfo = await this.fetchMerchantInfo(did);
-    return this.merchantInfoSerializer.deserialize(merchantInfo);
+  async getMerchantInfo(did: string): Promise<MerchantInfo | null> {
+    try {
+      let merchantInfo = await this.fetchMerchantInfo(did);
+      return this.merchantInfoSerializer.deserialize(merchantInfo);
+    } catch (e) {
+      return null;
+    }
   }
 
   async fetchMerchantInfo(did: string): Promise<JSONAPIDocument> {

--- a/packages/hub/services/merchant-info.ts
+++ b/packages/hub/services/merchant-info.ts
@@ -13,7 +13,11 @@ export default class MerchantInfoService {
     as: 'merchantInfoSerializer',
   });
 
-  async getMerchantInfo(did: string): Promise<MerchantInfo | null> {
+  async getMerchantInfo(did?: string): Promise<MerchantInfo | null> {
+    if (!did) {
+      return null;
+    }
+
     try {
       let merchantInfo = await this.fetchMerchantInfo(did);
       return this.merchantInfoSerializer.deserialize(merchantInfo);

--- a/packages/hub/services/merchant-info.ts
+++ b/packages/hub/services/merchant-info.ts
@@ -5,7 +5,6 @@ import { getResolver } from '@cardstack/did-resolver';
 import { Resolver } from 'did-resolver';
 
 export default class MerchantInfoService {
-  // @ts-ignore FIXME what is with this?!?!
   #didResolver = new Resolver(getResolver());
 
   merchantInfoSerializer = inject('merchant-info-serializer', {

--- a/packages/hub/services/merchant-info.ts
+++ b/packages/hub/services/merchant-info.ts
@@ -1,0 +1,31 @@
+/* global fetch */
+import { inject } from '@cardstack/di';
+
+import { getResolver } from '@cardstack/did-resolver';
+import { Resolver } from 'did-resolver';
+
+export default class MerchantInfoService {
+  #didResolver = new Resolver(getResolver());
+
+  merchantInfoSerializer = inject('merchant-info-serializer', {
+    as: 'merchantInfoSerializer',
+  });
+
+  async getMerchantInfo(did: string): Promise<any> {
+    let merchantInfo = await this.fetchMerchantInfo(did);
+    return this.merchantInfoSerializer.deserialize(merchantInfo);
+  }
+
+  async fetchMerchantInfo(did: string): Promise<any> {
+    let didResult = await this.#didResolver.resolve(did);
+    let alsoKnownAs = didResult?.didDocument?.alsoKnownAs;
+
+    return await (await fetch(alsoKnownAs![0])).json();
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'merchant-info': MerchantInfoService;
+  }
+}

--- a/packages/hub/services/merchant-info.ts
+++ b/packages/hub/services/merchant-info.ts
@@ -6,7 +6,7 @@ import { Resolver } from 'did-resolver';
 
 export default class MerchantInfoService {
   // @ts-ignore FIXME what is with this?!?!
-  #didResolver = new Resolver(getResolver().cardstack);
+  #didResolver = new Resolver(getResolver());
 
   merchantInfoSerializer = inject('merchant-info-serializer', {
     as: 'merchantInfoSerializer',

--- a/packages/hub/services/serializers/card-space-serializer.ts
+++ b/packages/hub/services/serializers/card-space-serializer.ts
@@ -3,11 +3,7 @@ import { inject } from '@cardstack/di';
 import DatabaseManager from '@cardstack/db';
 import { CardSpace } from '../../routes/card-spaces';
 import config from 'config';
-
-interface JSONAPIDocument {
-  data: any;
-  included?: any[];
-}
+import { JSONAPIDocument } from '../../utils/JSONAPIDocument';
 
 export default class CardSpaceSerializer {
   databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });

--- a/packages/hub/services/serializers/card-space-serializer.ts
+++ b/packages/hub/services/serializers/card-space-serializer.ts
@@ -3,7 +3,7 @@ import { inject } from '@cardstack/di';
 import DatabaseManager from '@cardstack/db';
 import { CardSpace } from '../../routes/card-spaces';
 import config from 'config';
-import { JSONAPIDocument } from '../../utils/JSONAPIDocument';
+import { JSONAPIDocument } from '../../utils/jsonapi-document';
 
 export default class CardSpaceSerializer {
   databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });

--- a/packages/hub/services/serializers/merchant-info-serializer.ts
+++ b/packages/hub/services/serializers/merchant-info-serializer.ts
@@ -3,7 +3,7 @@ import { inject } from '@cardstack/di';
 import DatabaseManager from '@cardstack/db';
 import { MerchantInfo } from '../../routes/merchant-infos';
 import config from 'config';
-import { JSONAPIDocument } from '../../utils/JSONAPIDocument';
+import { JSONAPIDocument } from '../../utils/jsonapi-document';
 
 export default class MerchantInfoSerializer {
   databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });

--- a/packages/hub/services/serializers/merchant-info-serializer.ts
+++ b/packages/hub/services/serializers/merchant-info-serializer.ts
@@ -3,11 +3,7 @@ import { inject } from '@cardstack/di';
 import DatabaseManager from '@cardstack/db';
 import { MerchantInfo } from '../../routes/merchant-infos';
 import config from 'config';
-
-interface JSONAPIDocument {
-  data: any;
-  included?: any[];
-}
+import { JSONAPIDocument } from '../../utils/JSONAPIDocument';
 
 export default class MerchantInfoSerializer {
   databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });

--- a/packages/hub/services/serializers/merchant-info-serializer.ts
+++ b/packages/hub/services/serializers/merchant-info-serializer.ts
@@ -35,6 +35,17 @@ export default class MerchantInfoSerializer {
 
     return result as JSONAPIDocument;
   }
+
+  deserialize(json: JSONAPIDocument): MerchantInfo {
+    return {
+      id: json.data.id,
+      name: json.data.attributes['name'],
+      slug: json.data.attributes['slug'],
+      color: json.data.attributes['color'],
+      textColor: json.data.attributes['text-color'],
+      ownerAddress: json.data.attributes['owner-address'],
+    };
+  }
 }
 
 declare module '@cardstack/di' {

--- a/packages/hub/services/serializers/prepaid-card-color-scheme-serializer.ts
+++ b/packages/hub/services/serializers/prepaid-card-color-scheme-serializer.ts
@@ -1,6 +1,6 @@
 import { inject } from '@cardstack/di';
 import DatabaseManager from '@cardstack/db';
-import { JSONAPIDocument } from '../../utils/JSONAPIDocument';
+import { JSONAPIDocument } from '../../utils/jsonapi-document';
 
 interface PrepaidCardColorScheme {
   id: string;

--- a/packages/hub/services/serializers/prepaid-card-color-scheme-serializer.ts
+++ b/packages/hub/services/serializers/prepaid-card-color-scheme-serializer.ts
@@ -1,5 +1,6 @@
 import { inject } from '@cardstack/di';
 import DatabaseManager from '@cardstack/db';
+import { JSONAPIDocument } from '../../utils/JSONAPIDocument';
 
 interface PrepaidCardColorScheme {
   id: string;
@@ -7,10 +8,6 @@ interface PrepaidCardColorScheme {
   patternColor: string;
   textColor: string;
   description: string;
-}
-interface JSONAPIDocument {
-  data: any;
-  included?: any[];
 }
 
 export default class PrepaidCardColorSchemeSerializer {

--- a/packages/hub/services/serializers/prepaid-card-customization-serializer.ts
+++ b/packages/hub/services/serializers/prepaid-card-customization-serializer.ts
@@ -4,7 +4,7 @@ import DatabaseManager from '@cardstack/db';
 import PrepaidCardColorSchemeSerializer from './prepaid-card-color-scheme-serializer';
 import PrepaidCardPatternSerializer from './prepaid-card-pattern-serializer';
 import config from 'config';
-import { JSONAPIDocument } from '../../utils/JSONAPIDocument';
+import { JSONAPIDocument } from '../../utils/jsonapi-document';
 
 interface PrepaidCardCustomization {
   id: string;

--- a/packages/hub/services/serializers/prepaid-card-customization-serializer.ts
+++ b/packages/hub/services/serializers/prepaid-card-customization-serializer.ts
@@ -4,6 +4,7 @@ import DatabaseManager from '@cardstack/db';
 import PrepaidCardColorSchemeSerializer from './prepaid-card-color-scheme-serializer';
 import PrepaidCardPatternSerializer from './prepaid-card-pattern-serializer';
 import config from 'config';
+import { JSONAPIDocument } from '../../utils/JSONAPIDocument';
 
 interface PrepaidCardCustomization {
   id: string;
@@ -14,10 +15,6 @@ interface PrepaidCardCustomization {
 }
 interface PrepaidCardCustomizationSerializationOptions {
   include: PrepaidCardCustomizationRelationship[];
-}
-interface JSONAPIDocument {
-  data: any;
-  included?: any[];
 }
 type PrepaidCardCustomizationRelationship = 'colorScheme' | 'pattern';
 

--- a/packages/hub/services/serializers/prepaid-card-pattern-serializer.ts
+++ b/packages/hub/services/serializers/prepaid-card-pattern-serializer.ts
@@ -1,6 +1,6 @@
 import { inject } from '@cardstack/di';
 import DatabaseManager from '@cardstack/db';
-import { JSONAPIDocument } from '../../utils/JSONAPIDocument';
+import { JSONAPIDocument } from '../../utils/jsonapi-document';
 
 interface PrepaidCardPattern {
   id: string;

--- a/packages/hub/services/serializers/prepaid-card-pattern-serializer.ts
+++ b/packages/hub/services/serializers/prepaid-card-pattern-serializer.ts
@@ -1,16 +1,12 @@
 import { inject } from '@cardstack/di';
 import DatabaseManager from '@cardstack/db';
+import { JSONAPIDocument } from '../../utils/JSONAPIDocument';
 
 interface PrepaidCardPattern {
   id: string;
   patternUrl?: string;
   description: string;
 }
-interface JSONAPIDocument {
-  data: any;
-  included?: any[];
-}
-
 export default class PrepaidCardPatternSerializer {
   databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
 

--- a/packages/hub/services/serializers/push-notification-registration-serializer.ts
+++ b/packages/hub/services/serializers/push-notification-registration-serializer.ts
@@ -1,9 +1,5 @@
 import { PushNotificationRegistration } from '../../routes/push_notification_registrations';
-
-interface JSONAPIDocument {
-  data: any;
-  included?: any[];
-}
+import { JSONAPIDocument } from '../../utils/JSONAPIDocument';
 
 export default class PushNotificationRegistrationSerializer {
   serialize(model: PushNotificationRegistration): JSONAPIDocument {

--- a/packages/hub/services/serializers/push-notification-registration-serializer.ts
+++ b/packages/hub/services/serializers/push-notification-registration-serializer.ts
@@ -1,5 +1,5 @@
 import { PushNotificationRegistration } from '../../routes/push_notification_registrations';
-import { JSONAPIDocument } from '../../utils/JSONAPIDocument';
+import { JSONAPIDocument } from '../../utils/jsonapi-document';
 
 export default class PushNotificationRegistrationSerializer {
   serialize(model: PushNotificationRegistration): JSONAPIDocument {

--- a/packages/hub/tasks/notify-customer-payment.ts
+++ b/packages/hub/tasks/notify-customer-payment.ts
@@ -77,7 +77,7 @@ export default class NotifyCustomerPayment {
         merchantName = ` ${merchantInfo.name}`;
       }
     } catch (e) {
-      // What is to be done? Sentry? Does it matter?
+      // Silently ignore and just show notification without merchant name
     }
 
     let notifiedAddress = result.merchant.id;

--- a/packages/hub/tasks/notify-customer-payment.ts
+++ b/packages/hub/tasks/notify-customer-payment.ts
@@ -12,7 +12,7 @@ export interface PrepaidCardPaymentsQueryResult {
       };
       merchantSafe: {
         id: string;
-        infoDid: string;
+        infoDid: string | undefined;
       };
       merchant: {
         id: string;
@@ -72,8 +72,10 @@ export default class NotifyCustomerPayment {
     let merchantName = '';
 
     try {
-      let merchantInfo = await this.merchantInfo.getMerchantInfo(result.merchantSafe.infoDid);
-      merchantName = ` ${merchantInfo.name}`;
+      if (result.merchantSafe?.infoDid) {
+        let merchantInfo = await this.merchantInfo.getMerchantInfo(result.merchantSafe.infoDid);
+        merchantName = ` ${merchantInfo.name}`;
+      }
     } catch (e) {
       // What is to be done? Sentry? Does it matter?
     }

--- a/packages/hub/tasks/notify-customer-payment.ts
+++ b/packages/hub/tasks/notify-customer-payment.ts
@@ -69,11 +69,18 @@ export default class NotifyCustomerPayment {
       );
     }
 
-    let merchantInfo = await this.merchantInfo.getMerchantInfo(result.merchantSafe.infoDid);
+    let merchantName = '';
+
+    try {
+      let merchantInfo = await this.merchantInfo.getMerchantInfo(result.merchantSafe.infoDid);
+      merchantName = ` ${merchantInfo.name}`;
+    } catch (e) {
+      // What is to be done? Sentry? Does it matter?
+    }
 
     let notifiedAddress = result.merchant.id;
     let spendAmount = result.spendAmount;
-    let message = `Your business ${merchantInfo.name} received a payment of §${spendAmount}`;
+    let message = `Your business${merchantName} received a payment of §${spendAmount}`;
 
     await this.workerClient.addJob('send-notifications', {
       notifiedAddress,

--- a/packages/hub/tasks/notify-customer-payment.ts
+++ b/packages/hub/tasks/notify-customer-payment.ts
@@ -76,7 +76,7 @@ export default class NotifyCustomerPayment {
       if (result.merchantSafe?.infoDid) {
         let merchantInfo = await this.merchantInfo.getMerchantInfo(result.merchantSafe.infoDid);
 
-        if (merchantInfo) {
+        if (merchantInfo?.name) {
           merchantName = ` ${merchantInfo.name}`;
         }
       }

--- a/packages/hub/tasks/notify-customer-payment.ts
+++ b/packages/hub/tasks/notify-customer-payment.ts
@@ -74,7 +74,10 @@ export default class NotifyCustomerPayment {
     try {
       if (result.merchantSafe?.infoDid) {
         let merchantInfo = await this.merchantInfo.getMerchantInfo(result.merchantSafe.infoDid);
-        merchantName = ` ${merchantInfo.name}`;
+
+        if (merchantInfo) {
+          merchantName = ` ${merchantInfo.name}`;
+        }
       }
     } catch (e) {
       // Silently ignore and just show notification without merchant name

--- a/packages/hub/tasks/notify-customer-payment.ts
+++ b/packages/hub/tasks/notify-customer-payment.ts
@@ -70,14 +70,14 @@ export default class NotifyCustomerPayment {
       );
     }
 
-    let merchantName = '';
+    let merchantName = 'You';
 
     try {
       if (result.merchantSafe?.infoDid) {
         let merchantInfo = await this.merchantInfo.getMerchantInfo(result.merchantSafe.infoDid);
 
         if (merchantInfo?.name) {
-          merchantName = ` ${merchantInfo.name}`;
+          merchantName = merchantInfo.name;
         }
       }
     } catch (e) {
@@ -90,7 +90,7 @@ export default class NotifyCustomerPayment {
 
     let notifiedAddress = result.merchant.id;
     let spendAmount = result.spendAmount;
-    let message = `Your business${merchantName} received a payment of §${spendAmount}`;
+    let message = `${merchantName} received a payment of §${spendAmount}`;
 
     await this.workerClient.addJob('send-notifications', {
       notifiedAddress,

--- a/packages/hub/tasks/notify-customer-payment.ts
+++ b/packages/hub/tasks/notify-customer-payment.ts
@@ -3,6 +3,7 @@ import config from 'config';
 import CardpaySDKService from '../services/cardpay-sdk';
 import MerchantInfoService from '../services/merchant-info';
 import WorkerClient from '../services/worker-client';
+import * as Sentry from '@sentry/node';
 
 export interface PrepaidCardPaymentsQueryResult {
   data: {
@@ -80,7 +81,11 @@ export default class NotifyCustomerPayment {
         }
       }
     } catch (e) {
-      // Silently ignore and just show notification without merchant name
+      Sentry.captureException(e, {
+        tags: {
+          action: 'notify-customer-payment',
+        },
+      });
     }
 
     let notifiedAddress = result.merchant.id;

--- a/packages/hub/tasks/notify-merchant-claim.ts
+++ b/packages/hub/tasks/notify-merchant-claim.ts
@@ -10,7 +10,7 @@ export interface MerchantClaimsQueryResult {
     merchantClaims: {
       merchantSafe: {
         id: string;
-        infoDid: string;
+        infoDid: string | undefined;
         merchant: {
           id: string;
         };
@@ -60,8 +60,10 @@ export default class NotifyMerchantClaim {
     let merchantName = '';
 
     try {
-      let merchantInfo = await this.merchantInfo.getMerchantInfo(result.merchantSafe.infoDid);
-      merchantName = ` ${merchantInfo.name}`;
+      if (result.merchantSafe.infoDid) {
+        let merchantInfo = await this.merchantInfo.getMerchantInfo(result.merchantSafe.infoDid);
+        merchantName = ` ${merchantInfo.name}`;
+      }
     } catch (e) {
       // What is to be done? Sentry? Does it matter?
     }

--- a/packages/hub/tasks/notify-merchant-claim.ts
+++ b/packages/hub/tasks/notify-merchant-claim.ts
@@ -70,7 +70,9 @@ export default class NotifyMerchantClaim {
     let notifiedAddress = result.merchantSafe.merchant.id;
     let amountInWei = result.amount;
 
-    let message = `You just claimed ${Web3.utils.fromWei(amountInWei)} ${token} from your${merchantName} business account`;
+    let message = `You just claimed ${Web3.utils.fromWei(
+      amountInWei
+    )} ${token} from your${merchantName} business account`;
 
     await this.workerClient.addJob('send-notifications', {
       notifiedAddress,

--- a/packages/hub/tasks/notify-merchant-claim.ts
+++ b/packages/hub/tasks/notify-merchant-claim.ts
@@ -62,7 +62,10 @@ export default class NotifyMerchantClaim {
     try {
       if (result.merchantSafe.infoDid) {
         let merchantInfo = await this.merchantInfo.getMerchantInfo(result.merchantSafe.infoDid);
-        merchantName = ` ${merchantInfo.name}`;
+
+        if (merchantInfo) {
+          merchantName = ` ${merchantInfo.name}`;
+        }
       }
     } catch (e) {
       // Silently ignore and just show notification without merchant name

--- a/packages/hub/tasks/notify-merchant-claim.ts
+++ b/packages/hub/tasks/notify-merchant-claim.ts
@@ -65,7 +65,7 @@ export default class NotifyMerchantClaim {
         merchantName = ` ${merchantInfo.name}`;
       }
     } catch (e) {
-      // What is to be done? Sentry? Does it matter?
+      // Silently ignore and just show notification without merchant name
     }
 
     let token = result.token.symbol;

--- a/packages/hub/tasks/notify-merchant-claim.ts
+++ b/packages/hub/tasks/notify-merchant-claim.ts
@@ -4,6 +4,7 @@ import Web3 from 'web3';
 import CardpaySDKService from '../services/cardpay-sdk';
 import MerchantInfoService from '../services/merchant-info';
 import WorkerClient from '../services/worker-client';
+import * as Sentry from '@sentry/node';
 
 export interface MerchantClaimsQueryResult {
   data: {
@@ -68,7 +69,11 @@ export default class NotifyMerchantClaim {
         }
       }
     } catch (e) {
-      // Silently ignore and just show notification without merchant name
+      Sentry.captureException(e, {
+        tags: {
+          action: 'notify-merchant-claim',
+        },
+      });
     }
 
     let token = result.token.symbol;

--- a/packages/hub/tasks/notify-merchant-claim.ts
+++ b/packages/hub/tasks/notify-merchant-claim.ts
@@ -57,13 +57,20 @@ export default class NotifyMerchantClaim {
       throw new Error(`Subgraph did not return information for merchant claim with transaction hash: "${payload}"`);
     }
 
-    let merchantInfo = await this.merchantInfo.getMerchantInfo(result.merchantSafe.infoDid);
+    let merchantName = '';
+
+    try {
+      let merchantInfo = await this.merchantInfo.getMerchantInfo(result.merchantSafe.infoDid);
+      merchantName = ` ${merchantInfo.name}`;
+    } catch (e) {
+      // What is to be done? Sentry? Does it matter?
+    }
 
     let token = result.token.symbol;
     let notifiedAddress = result.merchantSafe.merchant.id;
     let amountInWei = result.amount;
 
-    let message = `You just claimed ${Web3.utils.fromWei(amountInWei)} ${token} from your ${merchantInfo.name} business account`;
+    let message = `You just claimed ${Web3.utils.fromWei(amountInWei)} ${token} from your${merchantName} business account`;
 
     await this.workerClient.addJob('send-notifications', {
       notifiedAddress,

--- a/packages/hub/tasks/notify-merchant-claim.ts
+++ b/packages/hub/tasks/notify-merchant-claim.ts
@@ -64,7 +64,7 @@ export default class NotifyMerchantClaim {
       if (result.merchantSafe.infoDid) {
         let merchantInfo = await this.merchantInfo.getMerchantInfo(result.merchantSafe.infoDid);
 
-        if (merchantInfo) {
+        if (merchantInfo?.name) {
           merchantName = ` ${merchantInfo.name}`;
         }
       }

--- a/packages/hub/utils/jsonapi-document.ts
+++ b/packages/hub/utils/jsonapi-document.ts
@@ -1,0 +1,4 @@
+export interface JSONAPIDocument {
+  data: any;
+  included?: any[];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12062,11 +12062,6 @@ did-resolver@^3.1.0:
   resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-3.1.0.tgz#84f0e3d16abe9711dc04c34a5a0e2f63868c9611"
   integrity sha512-uf3/4LfHoDn3Ek8bFegO72OemHMytBhAkud6CA1HlB5I0iVwrCpG4oh+DA6DXUuBdhrA0cY4cGz1D0VNDTlgnw==
 
-did-resolver@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-3.1.3.tgz#ed530c9daa2c9925f85e9eabf258e51960db7e70"
-  integrity sha512-ab8y90tSiDkTdfddXRC9Qcb1QSd568aC6+OgFTrcE4rs1vQAZOil+VqXHDu+Ff/UvhxlckPO8oJtp86iICZG0w==
-
 diff-sequences@^27.0.6:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.0.6.tgz#3305cb2e55a033924054695cc66019fd7f8e5723"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12062,6 +12062,11 @@ did-resolver@^3.1.0:
   resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-3.1.0.tgz#84f0e3d16abe9711dc04c34a5a0e2f63868c9611"
   integrity sha512-uf3/4LfHoDn3Ek8bFegO72OemHMytBhAkud6CA1HlB5I0iVwrCpG4oh+DA6DXUuBdhrA0cY4cGz1D0VNDTlgnw==
 
+did-resolver@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-3.1.3.tgz#ed530c9daa2c9925f85e9eabf258e51960db7e70"
+  integrity sha512-ab8y90tSiDkTdfddXRC9Qcb1QSd568aC6+OgFTrcE4rs1vQAZOil+VqXHDu+Ff/UvhxlckPO8oJtp86iICZG0w==
+
 diff-sequences@^27.0.6:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.0.6.tgz#3305cb2e55a033924054695cc66019fd7f8e5723"


### PR DESCRIPTION
This follows #2434 to parse/fetch DIDs and insert the merchant name in the notification:

![image](https://user-images.githubusercontent.com/43280/144669915-d1cf7026-dc40-4335-90ce-92ec16245a1f.png)

It ignores failures that might arise when parsing the DID and parsing and fetching its associated JSON and just produces a generic “your business” notification.

I extracted the `JSONAPIDocument` type that was scattered through various files.