### PR TITLE
center landing page content

### DIFF
--- a/packages/web-client/app/css/cardstack-landing-page.css
+++ b/packages/web-client/app/css/cardstack-landing-page.css
@@ -4,15 +4,18 @@
   --horizontal-card-gap: var(--boxel-sp-lg);
 
   width: 100%;
-  max-width:
-    calc(
-      var(--card-width) * 2 + var(--horizontal-card-gap) + var(--boxel-sp-lg) * 2
-    );
+  max-width: 100vw;
+  min-height: 100vh;
   margin: auto;
   padding: var(--boxel-sp);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .cardstack-landing-page-org-grid {
+  width: 100%;
+  max-width: calc(var(--card-width) * 2 + var(--horizontal-card-gap) + var(--boxel-sp-lg) * 2);
   list-style-type: none;
   padding: 0;
   display: grid;


### PR DESCRIPTION
Center landing page content where possible. In images where the content does not fit the viewport, it is scrollable. Images below (in order) are on tablet, laptop, and large monitor viewports.

![tablet-landing-page](https://user-images.githubusercontent.com/39579264/144416114-5b50a871-1827-4a8f-b6c7-df9b90fb03e2.png)

![laptop-landing-page](https://user-images.githubusercontent.com/39579264/144416087-c31ebcb2-d204-426e-a72f-fcb38356e090.png)

![large-monitor-landing-page](https://user-images.githubusercontent.com/39579264/144416108-9065b5a7-be08-4cc8-a8f5-dff4fe7df9b8.png)
