### PR TITLE
CS-2625 Add block numbers to subgraph

### DIFF
--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -63,6 +63,7 @@ type BridgeToLayer1Event @entity {
   transaction: Transaction!
   safe: Safe
   timestamp: BigInt!
+  blockNumber: BigInt!
   account: Account!
   token: Token!
   amount: BigInt!
@@ -84,16 +85,18 @@ type SupplierInfoDIDUpdate @entity {
   transaction: Transaction!
   infoDID: String!
   timestamp: BigInt!
+  blockNumber: BigInt!
   supplier: Account!
 }
 
 type PrepaidCardPayment @entity {
   id: ID!
   timestamp: BigInt!
+  blockNumber: BigInt!
   transaction: Transaction!
   prepaidCard: PrepaidCard!
   prepaidCardOwner: Account!
-  merchantSafe: MerchantSafe   # for merchant registration this will not be set
+  merchantSafe: MerchantSafe # for merchant registration this will not be set
   merchant: Account
   issuingToken: Token!
   issuingTokenAmount: BigInt!
@@ -109,6 +112,7 @@ type PrepaidCardPayment @entity {
 type PrepaidCardSplit @entity {
   id: ID!
   timestamp: BigInt!
+  blockNumber: BigInt!
   transaction: Transaction!
   prepaidCard: PrepaidCard!
   issuer: Account!
@@ -136,6 +140,7 @@ type PrepaidCardAsk @entity {
 type PrepaidCardAskSetEvent @entity {
   id: ID!
   timestamp: BigInt!
+  blockNumber: BigInt!
   transaction: Transaction!
   sku: SKU!
   issuingToken: Token!
@@ -161,6 +166,7 @@ type SKUInventory @entity {
 type PrepaidCardInventoryEvent @entity {
   id: ID!                   # id is 'txHash-prepaidCard'
   timestamp: BigInt!
+  blockNumber: BigInt!
   transaction: Transaction!
   inventory: SKUInventory!
   prepaidCard: PrepaidCard!
@@ -172,6 +178,7 @@ type PrepaidCardInventoryEvent @entity {
 type PrepaidCardInventoryAddEvent @entity {
   id: ID!
   timestamp: BigInt!
+  blockNumber: BigInt!
   transaction: Transaction!
   prepaidCard: PrepaidCard!
   inventory: SKUInventory!
@@ -180,6 +187,7 @@ type PrepaidCardInventoryAddEvent @entity {
 type PrepaidCardInventoryRemoveEvent @entity {
   id: ID!
   timestamp: BigInt!
+  blockNumber: BigInt!
   transaction: Transaction!
   prepaidCard: PrepaidCard!
   inventory: SKUInventory!
@@ -188,6 +196,7 @@ type PrepaidCardInventoryRemoveEvent @entity {
 type PrepaidCardProvisionedEvent @entity {
   id: ID!
   timestamp: BigInt!
+  blockNumber: BigInt!
   txnHash: String!
   transaction: Transaction!
   prepaidCard: PrepaidCard!
@@ -199,6 +208,7 @@ type PrepaidCardProvisionedEvent @entity {
 type PrepaidCardTransfer @entity {
   id: ID!
   timestamp: BigInt!
+  blockNumber: BigInt!
   transaction: Transaction!
   prepaidCard: PrepaidCard!
   from: Account!
@@ -226,6 +236,7 @@ type RevenueEarningsByDay @entity {
 type MerchantClaim @entity {
   id: ID!
   timestamp: BigInt!
+  blockNumber: BigInt!
   transaction: Transaction!
   merchantSafe: MerchantSafe!
   token: Token!
@@ -235,6 +246,7 @@ type MerchantClaim @entity {
 type MerchantWithdraw @entity {
   id: ID!
   timestamp: BigInt!
+  blockNumber: BigInt!
   transaction: Transaction!
   merchantSafe: MerchantSafe!
   token: Token!
@@ -245,6 +257,7 @@ type MerchantWithdraw @entity {
 type MerchantDeposit @entity {
   id: ID!
   timestamp: BigInt!
+  blockNumber: BigInt!
   transaction: Transaction!
   merchantSafe: MerchantSafe!
   token: Token!
@@ -256,6 +269,7 @@ type MerchantRevenueEvent @entity {
   id: ID!
   transaction: Transaction!
   timestamp: BigInt!
+  blockNumber: BigInt!
   historicLifetimeAccumulation: BigInt!
   historicUnclaimedBalance: BigInt!
   merchantRevenue: MerchantRevenue!
@@ -268,6 +282,7 @@ type MerchantRevenueEvent @entity {
 type SpendAccumulation @entity {
   id: ID!
   timestamp: BigInt!
+  blockNumber: BigInt!
   transaction: Transaction!
   merchantSafe: MerchantSafe!
   amount: BigInt!
@@ -277,6 +292,7 @@ type SpendAccumulation @entity {
 type MerchantFeePayment @entity {
   id: ID!
   timestamp: BigInt!
+  blockNumber: BigInt!
   transaction: Transaction!
   prepaidCard: PrepaidCard!
   merchantSafe: MerchantSafe!
@@ -288,6 +304,7 @@ type PrepaidCardCreation @entity {
   id: ID!
   transaction: Transaction!
   createdAt: BigInt!
+  blockNumber: BigInt!
   prepaidCard: PrepaidCard!
   depot: Depot # prepaid card may not heave been created from depot.
   createdFromAddress: String!
@@ -302,6 +319,7 @@ type MerchantCreation @entity {
   id: ID!
   transaction: Transaction!
   createdAt: BigInt!
+  blockNumber: BigInt!
   merchantSafe: MerchantSafe!
   merchant: Account!
 }
@@ -310,6 +328,7 @@ type MerchantRegistrationPayment @entity {
   id: ID!
   transaction: Transaction!
   createdAt: BigInt!
+  blockNumber: BigInt!
   paidWith: PrepaidCard!
   prepaidCardPayment: PrepaidCardPayment!
   issuingToken: Token!
@@ -321,6 +340,7 @@ type TokenSwap @entity {
   id: ID!
   transaction: Transaction!
   timestamp: BigInt!
+  blockNumber: BigInt!
   tokenPair: TokenPair!
   to: Account!
   token0AmountIn: BigInt!
@@ -347,6 +367,7 @@ type SafeTransaction @entity {
   id: ID!
   transaction: Transaction!
   timestamp: BigInt!
+  blockNumber: BigInt!
   safe: Safe!
   to: String!
   value: BigInt!
@@ -364,6 +385,7 @@ type SafeTransaction @entity {
 type SafeOwnerChange @entity {
   id: ID!
   timestamp: BigInt!
+  blockNumber: BigInt!
   transaction: Transaction!
   safe: Safe!
    # these are not Account types because the owner may be a contract address
@@ -375,6 +397,7 @@ type PrepaidCardSendAction @entity {
   id: ID!
   transaction: Transaction!
   timestamp: BigInt!
+  blockNumber: BigInt!
   prepaidCard: PrepaidCard!
   spendAmount: BigInt!
   rateLock: BigInt!
@@ -440,6 +463,7 @@ type SafeOwner @entity {
 type TokenTransfer @entity {
   id: ID!              # Set to token address + txn-hash + log index
   timestamp: BigInt!
+  blockNumber: BigInt!
   transaction: Transaction!
   token: Token!
   amount: BigInt!
@@ -475,6 +499,7 @@ type TokenHistory @entity {
   sent: TokenTransfer
   received: TokenTransfer
   timestamp: BigInt!
+  blockNumber: BigInt!
   tokenHolder: TokenHolder!
 }
 
@@ -491,6 +516,7 @@ type RewardProgramRegistrationPayment @entity {
   admin: Account!
   transaction: Transaction!
   createdAt: BigInt!
+  blockNumber: BigInt!
   prepaidCardPayment: PrepaidCardPayment!
 }
 
@@ -500,6 +526,7 @@ type RewardeeRegistrationPayment @entity {
   rewardee: Account!
   transaction: Transaction!
   createdAt: BigInt!
+  blockNumber: BigInt!
   prepaidCardPayment: PrepaidCardPayment!
 }
 
@@ -528,6 +555,7 @@ type RewardeeClaim @entity {
   amount: BigInt!
   transaction: Transaction!
   timestamp: BigInt!
+  blockNumber: BigInt!
 }
 
 type RewardTokensAdd @entity {
@@ -538,4 +566,5 @@ type RewardTokensAdd @entity {
   amount: BigInt!
   transaction: Transaction!
   timestamp: BigInt!
+  blockNumber: BigInt!
 }

--- a/packages/cardpay-subgraph/src/mappings/depot.ts
+++ b/packages/cardpay-subgraph/src/mappings/depot.ts
@@ -47,6 +47,7 @@ export function handleSentBridgedTokens(event: TokensBridgingInitiated): void {
   let bridgeEventEntity = new BridgeToLayer1Event(txnHash);
   bridgeEventEntity.transaction = txnHash;
   bridgeEventEntity.timestamp = event.block.timestamp;
+  bridgeEventEntity.blockNumber = event.block.number;
   bridgeEventEntity.token = makeToken(event.params.token);
   bridgeEventEntity.amount = event.params.value;
 
@@ -78,6 +79,7 @@ export function handleSetInfoDID(event: SupplierInfoDIDUpdated): void {
 
   let updateEntity = new SupplierInfoDIDUpdate(event.transaction.hash.toHex());
   updateEntity.timestamp = event.block.timestamp;
+  updateEntity.blockNumber = event.block.number;
   updateEntity.transaction = event.transaction.hash.toHex();
   updateEntity.infoDID = infoDID;
   updateEntity.supplier = supplier;

--- a/packages/cardpay-subgraph/src/mappings/deprecated/merchant-manager-v0_6_7.ts
+++ b/packages/cardpay-subgraph/src/mappings/deprecated/merchant-manager-v0_6_7.ts
@@ -23,6 +23,7 @@ export function handleMerchantCreation(event: MerchantCreationEvent): void {
   let creationEntity = new MerchantCreation(merchantSafe);
   creationEntity.transaction = event.transaction.hash.toHex();
   creationEntity.createdAt = event.block.timestamp;
+  creationEntity.blockNumber = event.block.number;
   creationEntity.merchantSafe = merchantSafe;
   creationEntity.merchant = merchant;
   creationEntity.save();

--- a/packages/cardpay-subgraph/src/mappings/gnosis-safe.ts
+++ b/packages/cardpay-subgraph/src/mappings/gnosis-safe.ts
@@ -31,6 +31,7 @@ export function handleAddedOwner(event: AddedOwner): void {
   let ownerChangeEntity = new SafeOwnerChange(safeAddress + '-add-' + owner + '-' + txnHash);
   ownerChangeEntity.transaction = txnHash;
   ownerChangeEntity.timestamp = event.block.timestamp;
+  ownerChangeEntity.blockNumber = event.block.number;
   ownerChangeEntity.safe = safeAddress;
   ownerChangeEntity.ownerAdded = owner;
   ownerChangeEntity.save();
@@ -46,6 +47,7 @@ export function handleRemovedOwner(event: RemovedOwner): void {
   let ownerChangeEntity = new SafeOwnerChange(safeAddress + '-remove-' + owner + '-' + txnHash);
   ownerChangeEntity.transaction = txnHash;
   ownerChangeEntity.timestamp = event.block.timestamp;
+  ownerChangeEntity.blockNumber = event.block.number;
   ownerChangeEntity.safe = safeAddress;
   ownerChangeEntity.ownerRemoved = owner;
   ownerChangeEntity.save();
@@ -74,6 +76,7 @@ export function handleExecutionSuccess(event: ExecutionSuccess): void {
     safeTxEntity.safe = safeAddress;
     safeTxEntity.transaction = txnHash;
     safeTxEntity.timestamp = event.block.timestamp;
+    safeTxEntity.blockNumber = event.block.number;
 
     let decoded = decode(EXEC_TRANSACTION, bytes);
     safeTxEntity.to = toChecksumAddress(decoded[0].toAddress());
@@ -89,12 +92,13 @@ export function handleExecutionSuccess(event: ExecutionSuccess): void {
     safeTxEntity.signatures = decoded[9].toBytes();
 
     log.debug(
-      'SafeTransaction indexed in txn hash {}, id {}, safe: {}, timestamp {}, to: {}, value: {}, data: {}, operation: {}, safeTxGas {}, baseGas {}, gasPrice {}, gasToken: {}, refundReceiver: {}, signatures: {}',
+      'SafeTransaction indexed in txn hash {}, id {}, safe: {}, timestamp {}, blockNumber {}, to: {}, value: {}, data: {}, operation: {}, safeTxGas {}, baseGas {}, gasPrice {}, gasToken: {}, refundReceiver: {}, signatures: {}',
       [
         txnHash,
         safeTxEntity.id,
         safeTxEntity.safe,
         safeTxEntity.timestamp.toString(),
+        safeTxEntity.blockNumber.toString(),
         safeTxEntity.to,
         safeTxEntity.value.toString(),
         safeTxEntity.data.toHex(),

--- a/packages/cardpay-subgraph/src/mappings/merchant-manager.ts
+++ b/packages/cardpay-subgraph/src/mappings/merchant-manager.ts
@@ -22,6 +22,7 @@ export function handleMerchantCreation(event: MerchantCreationEvent): void {
   let creationEntity = new MerchantCreation(merchantSafe);
   creationEntity.transaction = event.transaction.hash.toHex();
   creationEntity.createdAt = event.block.timestamp;
+  creationEntity.blockNumber = event.block.number;
   creationEntity.merchantSafe = merchantSafe;
   creationEntity.merchant = merchant;
   creationEntity.save();

--- a/packages/cardpay-subgraph/src/mappings/merchant-registration.ts
+++ b/packages/cardpay-subgraph/src/mappings/merchant-registration.ts
@@ -21,6 +21,7 @@ export function handleMerchantRegistrationFee(event: MerchantRegistrationFee): v
   let registrationFeeEntity = new MerchantRegistrationPayment(txnHash);
   registrationFeeEntity.transaction = txnHash;
   registrationFeeEntity.createdAt = event.block.timestamp;
+  registrationFeeEntity.blockNumber = event.block.number;
   registrationFeeEntity.paidWith = prepaidCard;
   registrationFeeEntity.prepaidCardPayment = txnHash;
   registrationFeeEntity.issuingToken = issuingToken;

--- a/packages/cardpay-subgraph/src/mappings/pay-merchant-handler.ts
+++ b/packages/cardpay-subgraph/src/mappings/pay-merchant-handler.ts
@@ -36,6 +36,7 @@ export function handleMerchantPayment(event: MerchantPaymentEvent): void {
   let revenueEventEntity = new MerchantRevenueEvent(txnHash);
   revenueEventEntity.transaction = txnHash;
   revenueEventEntity.timestamp = event.block.timestamp;
+  revenueEventEntity.blockNumber = event.block.number;
   revenueEventEntity.merchantRevenue = revenueEntity.id;
   revenueEventEntity.historicLifetimeAccumulation = revenueEntity.lifetimeAccumulation;
   revenueEventEntity.historicUnclaimedBalance = revenueEntity.unclaimedBalance;
@@ -49,6 +50,7 @@ export function handleMerchantFee(event: MerchantFeeEvent): void {
   let entity = new MerchantFeePayment(event.transaction.hash.toHex()); // There will only ever be one merchant fee collection event per txn
   entity.transaction = event.transaction.hash.toHex();
   entity.timestamp = event.block.timestamp;
+  entity.blockNumber = event.block.number;
   entity.prepaidCard = toChecksumAddress(event.params.card);
   entity.merchantSafe = toChecksumAddress(event.params.merchantSafe);
   entity.issuingToken = makeToken(event.params.issuingToken);

--- a/packages/cardpay-subgraph/src/mappings/prepaid-card-market.ts
+++ b/packages/cardpay-subgraph/src/mappings/prepaid-card-market.ts
@@ -23,6 +23,7 @@ import { log } from '@graphprotocol/graph-ts';
 export function handleProvisionedPrepaidCard(event: ProvisionedPrepaidCard): void {
   let txnHash = event.transaction.hash.toHex();
   let timestamp = event.block.timestamp;
+  let blockNumber = event.block.number;
   let prepaidCard = toChecksumAddress(event.params.prepaidCard);
   let customer = toChecksumAddress(event.params.customer);
   let sku = event.params.sku.toHex();
@@ -43,6 +44,7 @@ export function handleProvisionedPrepaidCard(event: ProvisionedPrepaidCard): voi
 
   let provisionedEventEntity = new PrepaidCardProvisionedEvent(txnHash + '-' + prepaidCard);
   provisionedEventEntity.timestamp = timestamp;
+  provisionedEventEntity.blockNumber = blockNumber;
   provisionedEventEntity.txnHash = txnHash;
   provisionedEventEntity.transaction = txnHash;
   provisionedEventEntity.prepaidCard = prepaidCard;
@@ -59,6 +61,7 @@ export function handleProvisionedPrepaidCard(event: ProvisionedPrepaidCard): voi
 export function handleItemSet(event: ItemSet): void {
   let txnHash = event.transaction.hash.toHex();
   let timestamp = event.block.timestamp;
+  let blockNumber = event.block.number;
   let prepaidCard = toChecksumAddress(event.params.prepaidCard);
   let issuer = toChecksumAddress(event.params.issuer);
   let sku = event.params.sku.toHex();
@@ -74,6 +77,7 @@ export function handleItemSet(event: ItemSet): void {
 
   let addEventEntity = new PrepaidCardInventoryAddEvent(txnHash + '-' + prepaidCard);
   addEventEntity.timestamp = timestamp;
+  addEventEntity.blockNumber = blockNumber;
   addEventEntity.transaction = txnHash;
   addEventEntity.prepaidCard = prepaidCard;
   addEventEntity.inventory = sku;
@@ -87,6 +91,7 @@ export function handleItemSet(event: ItemSet): void {
 export function handleAskSet(event: AskSet): void {
   let txnHash = event.transaction.hash.toHex();
   let timestamp = event.block.timestamp;
+  let blockNumber = event.block.number;
   let askPrice = event.params.askPrice;
   let sku = event.params.sku.toHex();
   let issuer = toChecksumAddress(event.params.issuer);
@@ -113,6 +118,7 @@ export function handleAskSet(event: AskSet): void {
 
   let askEventEntity = new PrepaidCardAskSetEvent(txnHash);
   askEventEntity.timestamp = timestamp;
+  askEventEntity.blockNumber = blockNumber;
   askEventEntity.transaction = txnHash;
   askEventEntity.sku = sku;
   askEventEntity.issuingToken = issuingToken;
@@ -123,6 +129,7 @@ export function handleAskSet(event: AskSet): void {
 export function handleItemRemoved(event: ItemRemoved): void {
   let txnHash = event.transaction.hash.toHex();
   let timestamp = event.block.timestamp;
+  let blockNumber = event.block.number;
   let prepaidCard = toChecksumAddress(event.params.prepaidCard);
   let issuer = toChecksumAddress(event.params.issuer);
   let sku = event.params.sku.toHex();
@@ -142,6 +149,7 @@ export function handleItemRemoved(event: ItemRemoved): void {
 
   let removeEventEntity = new PrepaidCardInventoryRemoveEvent(txnHash + '-' + prepaidCard);
   removeEventEntity.timestamp = timestamp;
+  removeEventEntity.blockNumber = blockNumber;
   removeEventEntity.transaction = txnHash;
   removeEventEntity.prepaidCard = prepaidCard;
   removeEventEntity.inventory = sku;
@@ -190,9 +198,11 @@ function makeInventoryItem(sku: string, prepaidCard: string): PrepaidCardInvento
 function makeInventoryEvent(sku: string, prepaidCard: string, event: ethereum.Event): PrepaidCardInventoryEvent {
   let txnHash = event.transaction.hash.toHex();
   let timestamp = event.block.timestamp;
+  let blockNumber = event.block.number;
   let id = txnHash + '-' + prepaidCard;
   let entity = new PrepaidCardInventoryEvent(id);
   entity.timestamp = timestamp;
+  entity.blockNumber = blockNumber;
   entity.transaction = txnHash;
   entity.inventory = sku;
   entity.prepaidCard = prepaidCard;

--- a/packages/cardpay-subgraph/src/mappings/prepaid-card.ts
+++ b/packages/cardpay-subgraph/src/mappings/prepaid-card.ts
@@ -55,6 +55,7 @@ export function handleCreatePrepaidCard(event: CreatePrepaidCard): void {
   let creationEntity = new PrepaidCardCreation(prepaidCard);
   creationEntity.transaction = event.transaction.hash.toHex();
   creationEntity.createdAt = event.block.timestamp;
+  creationEntity.blockNumber = event.block.number;
   creationEntity.prepaidCard = prepaidCard;
   creationEntity.issuer = issuer;
   creationEntity.issuingToken = issuingToken;
@@ -94,6 +95,7 @@ export function handleTransferPrepaidCard(event: TransferredPrepaidCard): void {
 
   let transferEntity = new PrepaidCardTransfer(txnHash);
   transferEntity.timestamp = event.block.timestamp;
+  transferEntity.blockNumber = event.block.number;
   transferEntity.transaction = txnHash;
   transferEntity.prepaidCard = prepaidCard;
   transferEntity.from = from;
@@ -106,6 +108,7 @@ export function handleSendAction(event: PrepaidCardSend): void {
   let txnHash = event.transaction.hash.toHex();
   let entity = new PrepaidCardSendAction(txnHash);
   entity.timestamp = event.block.timestamp;
+  entity.blockNumber = event.block.number;
   entity.transaction = txnHash;
   entity.prepaidCard = toChecksumAddress(event.params.prepaidCard);
   entity.spendAmount = event.params.spendAmount;

--- a/packages/cardpay-subgraph/src/mappings/register-reward-program-handler.ts
+++ b/packages/cardpay-subgraph/src/mappings/register-reward-program-handler.ts
@@ -29,6 +29,7 @@ export function handleRewardProgramRegistrationFee(event: RewardProgramRegistrat
   entity.admin = admin;
   entity.transaction = txnHash;
   entity.createdAt = event.block.timestamp;
+  entity.blockNumber = event.block.number;
   entity.prepaidCardPayment = txnHash;
   entity.save();
 }

--- a/packages/cardpay-subgraph/src/mappings/revenue-pool.ts
+++ b/packages/cardpay-subgraph/src/mappings/revenue-pool.ts
@@ -26,6 +26,7 @@ export function handleMerchantClaim(event: MerchantClaimEvent): void {
   let claimEntity = new MerchantClaim(txnHash);
   claimEntity.transaction = txnHash;
   claimEntity.timestamp = event.block.timestamp;
+  claimEntity.blockNumber = event.block.number;
   claimEntity.merchantSafe = merchantSafe;
   claimEntity.token = token;
   claimEntity.amount = event.params.amount;
@@ -34,6 +35,7 @@ export function handleMerchantClaim(event: MerchantClaimEvent): void {
   let revenueEventEntity = new MerchantRevenueEvent(txnHash);
   revenueEventEntity.transaction = txnHash;
   revenueEventEntity.timestamp = event.block.timestamp;
+  revenueEventEntity.blockNumber = event.block.number;
   revenueEventEntity.merchantRevenue = revenueEntity.id;
   revenueEventEntity.historicLifetimeAccumulation = revenueEntity.lifetimeAccumulation;
   revenueEventEntity.historicUnclaimedBalance = revenueEntity.unclaimedBalance;

--- a/packages/cardpay-subgraph/src/mappings/reward-pool.ts
+++ b/packages/cardpay-subgraph/src/mappings/reward-pool.ts
@@ -39,6 +39,7 @@ export function handleRewardeeClaim(event: RewardeeClaimEvent): void {
   entity.rewardSafe = rewardSafe;
   entity.transaction = txnHash;
   entity.timestamp = event.block.timestamp;
+  entity.blockNumber = event.block.number;
   entity.save();
 }
 
@@ -66,5 +67,6 @@ export function handleRewardTokensAdded(event: RewardTokensAdded): void {
   entity.amount = amount;
   entity.transaction = txnHash;
   entity.timestamp = event.block.timestamp;
+  entity.blockNumber = event.block.number;
   entity.save();
 }

--- a/packages/cardpay-subgraph/src/mappings/spend.ts
+++ b/packages/cardpay-subgraph/src/mappings/spend.ts
@@ -25,6 +25,7 @@ export function handleMint(event: MintEvent): void {
   let entity = new SpendAccumulation(event.transaction.hash.toHex()); // There will only ever be one spend minting event per txn
   entity.transaction = txnHash;
   entity.timestamp = event.block.timestamp;
+  entity.blockNumber = event.block.number;
   entity.merchantSafe = merchantSafe;
   entity.amount = event.params.amount;
   entity.historicSpendBalance = spendBalance;

--- a/packages/cardpay-subgraph/src/mappings/split-prepaid-card-handler.ts
+++ b/packages/cardpay-subgraph/src/mappings/split-prepaid-card-handler.ts
@@ -29,6 +29,7 @@ export function handlePrepaidCardSplit(event: SplitPrepaidCardEvent): void {
 
   let splitEntity = new PrepaidCardSplit(txnHash);
   splitEntity.timestamp = event.block.timestamp;
+  splitEntity.blockNumber = event.block.number;
   splitEntity.transaction = txnHash;
   splitEntity.prepaidCard = prepaidCard;
   splitEntity.issuer = issuer;

--- a/packages/cardpay-subgraph/src/mappings/token-pair.ts
+++ b/packages/cardpay-subgraph/src/mappings/token-pair.ts
@@ -16,6 +16,7 @@ export function handleSwap(event: SwapEvent): void {
   let swapEntity = new TokenSwap(txnHash);
   swapEntity.transaction = txnHash;
   swapEntity.timestamp = event.block.timestamp;
+  swapEntity.blockNumber = event.block.number;
   swapEntity.tokenPair = pair;
   swapEntity.to = to;
   swapEntity.token0AmountIn = event.params.amount0In;

--- a/packages/cardpay-subgraph/src/mappings/token.ts
+++ b/packages/cardpay-subgraph/src/mappings/token.ts
@@ -43,6 +43,7 @@ export function handleTransfer(event: TransferEvent): void {
       if (MerchantSafe.load(to) != null && from != revenuePoolAddress) {
         let merchantDepositEntity = new MerchantDeposit(txnHash);
         merchantDepositEntity.timestamp = event.block.timestamp;
+        merchantDepositEntity.blockNumber = event.block.number;
         merchantDepositEntity.transaction = txnHash;
         merchantDepositEntity.merchantSafe = to;
         merchantDepositEntity.token = tokenAddress;
@@ -68,6 +69,7 @@ export function handleTransfer(event: TransferEvent): void {
       if (MerchantSafe.load(from) != null && to != relayFunder) {
         let merchantWithdrawEntity = new MerchantWithdraw(txnHash);
         merchantWithdrawEntity.timestamp = event.block.timestamp;
+        merchantWithdrawEntity.blockNumber = event.block.number;
         merchantWithdrawEntity.transaction = txnHash;
         merchantWithdrawEntity.merchantSafe = from;
         merchantWithdrawEntity.token = tokenAddress;
@@ -87,6 +89,7 @@ export function handleTransfer(event: TransferEvent): void {
   let transferEntity = new TokenTransfer(tokenAddress + '-' + txnHash + '-' + event.transactionLogIndex.toString());
   transferEntity.transaction = txnHash;
   transferEntity.timestamp = event.block.timestamp;
+  transferEntity.blockNumber = event.block.number;
   transferEntity.token = tokenAddress;
   transferEntity.amount = event.params.value;
   transferEntity.from = from != ZERO_ADDRESS ? from : null;
@@ -100,6 +103,7 @@ export function handleTransfer(event: TransferEvent): void {
     let historyEntity = new TokenHistory(transferEntity.id + '-' + sender.id);
     historyEntity.transaction = txnHash;
     historyEntity.timestamp = event.block.timestamp;
+    historyEntity.blockNumber = event.block.number;
     historyEntity.sent = transferEntity.id;
     historyEntity.tokenHolder = sender.id;
     historyEntity.save();
@@ -109,6 +113,7 @@ export function handleTransfer(event: TransferEvent): void {
     let historyEntity = new TokenHistory(transferEntity.id + '-' + receiver.id);
     historyEntity.transaction = txnHash;
     historyEntity.timestamp = event.block.timestamp;
+    historyEntity.blockNumber = event.block.number;
     historyEntity.received = transferEntity.id;
     historyEntity.tokenHolder = receiver.id;
     historyEntity.save();
@@ -164,6 +169,7 @@ function makeMerchantRevenueEvent(event: ethereum.Event, merchantSafe: string, t
   let revenueEventEntity = new MerchantRevenueEvent(txnHash);
   revenueEventEntity.transaction = txnHash;
   revenueEventEntity.timestamp = event.block.timestamp;
+  revenueEventEntity.blockNumber = event.block.number;
   revenueEventEntity.merchantRevenue = revenueEntity.id;
   revenueEventEntity.historicLifetimeAccumulation = revenueEntity.lifetimeAccumulation;
   revenueEventEntity.historicUnclaimedBalance = revenueEntity.unclaimedBalance;

--- a/packages/cardpay-subgraph/src/utils.ts
+++ b/packages/cardpay-subgraph/src/utils.ts
@@ -127,6 +127,7 @@ export function makePrepaidCardPayment(
   let paymentEntity = new PrepaidCardPayment(txnHash); // There will only ever be one merchant payment event per txn
   paymentEntity.transaction = txnHash;
   paymentEntity.timestamp = timestamp;
+  paymentEntity.blockNumber = event.block.number;
   paymentEntity.prepaidCard = prepaidCard;
   paymentEntity.prepaidCardOwner = prepaidCardEntity.owner;
   if (merchantSafe != null) {


### PR DESCRIPTION
There are a lot of entities with a timestamp & a linked transaction, this adds block numbers alongside them consistently. This could (as with the timestamp) be determined by joining to the transaction table but for extracting & filtering it helps to have this in the tables themselves.

This could be limited to a smaller set of tables for the current use case but I thought it was better to be consistent across the board.