### PR TITLE
missing blockNumber in MerchantRevenueEvent entity

### DIFF
--- a/packages/cardpay-subgraph/src/utils.ts
+++ b/packages/cardpay-subgraph/src/utils.ts
@@ -118,6 +118,7 @@ export function makeMerchantRevenueEvent(
   let revenueEventEntity = new MerchantRevenueEvent(txnHash);
   revenueEventEntity.transaction = txnHash;
   revenueEventEntity.timestamp = event.block.timestamp;
+  revenueEventEntity.blockNumber = event.block.number;
   revenueEventEntity.merchantRevenue = revenueEntity.id;
   revenueEventEntity.historicLifetimeAccumulation = revenueEntity.lifetimeAccumulation;
   revenueEventEntity.historicUnclaimedBalance = revenueEntity.unclaimedBalance;


### PR DESCRIPTION
The subgraph indexing broke because this field is not being set and it's non-nullable.

@IanCal in sokol the following error appears, and all subgrpah indexing halts after this error:
```
Dec 02 23:16:47.709 ERRO Subgraph instance failed to run: failed to process trigger: block #22129093 (0xd84a…6525), transaction cee3d6e15e405afde9b05b0c0862d8eebb341eb1a1cbde1a6d36cbb845ec3321: Entity MerchantRevenueEvent[0xcee3d6e15e405afde9b05b0c0862d8eebb341eb1a1cbde1a6d36cbb845ec3321]: missing value for non-nullable field `blockNumber`	wasm backtrace:	    0: 0x27d8 - <unknown>!generated/schema/MerchantRevenueEvent#save    1: 0x29a8 - <unknown>!src/mappings/token/handleTransfer	, code: SubgraphSyncingFailure, sgd: 5, subgraph_id: QmTjF4Y85R7abUodDpEFvgigjs7QGe4vuLYDHHvnwTHww3, component: SubgraphInstanceManager
```