### PR TITLE
🔔 Add Firebase push notifications service

### DIFF
--- a/packages/hub/cli/console.ts
+++ b/packages/hub/cli/console.ts
@@ -1,6 +1,7 @@
 import config from 'dotenv';
 import repl from 'repl';
 import { createContainer } from '../main';
+import { runInitializers } from '../main';
 
 export const command = 'console';
 export const describe = 'Load up a REPL! 📖 🤔 🖨 🔁';
@@ -9,6 +10,8 @@ export const builder = {};
 export function handler(/* argv: Argv */) {
   config.config();
   let container = createContainer();
+  runInitializers();
+
   let replServer = repl.start({
     prompt: 'Hub > ',
   });

--- a/packages/hub/config/custom-environment-variables.json
+++ b/packages/hub/config/custom-environment-variables.json
@@ -54,5 +54,11 @@
   "web3storage": {
     "token": "WEB3_STORAGE_TOKEN"
   },
+  "firebase": {
+    "projectId": "FIREBASE_PROJECT_ID",
+    "clientEmail": "FIREBASE_CLIENT_EMAIL",
+    "privateKey": "FIREBASE_PRIVATE_KEY",
+    "databaseURL": "FIREBASE_DATABASE_URL"
+  },
   "serverSecret": "SERVER_SECRET"
 }

--- a/packages/hub/config/default.cjs
+++ b/packages/hub/config/default.cjs
@@ -38,6 +38,12 @@ module.exports = {
     enabled: false,
     environment: null,
   },
+  firebase: {
+    projectId: null,
+    clientEmail: null,
+    privateKey: null,
+    databaseURL: null,
+  },
   wyre: {
     accountId: null,
     apiKey: null,

--- a/packages/hub/initializers/firebase.ts
+++ b/packages/hub/initializers/firebase.ts
@@ -3,12 +3,14 @@ import admin from 'firebase-admin';
 import config from 'config';
 
 export default function initFirebase() {
-  initializeApp({
-    credential: admin.credential.cert({
-      projectId: config.get('firebase.projectId'),
-      clientEmail: config.get('firebase.clientEmail'),
-      privateKey: config.get('firebase.privateKey'),
-    }),
-    databaseURL: config.get('firebase.databaseURL'),
-  });
+  if (config.get('firebase.projectId')) {
+    initializeApp({
+      credential: admin.credential.cert({
+        projectId: config.get('firebase.projectId'),
+        clientEmail: config.get('firebase.clientEmail'),
+        privateKey: config.get('firebase.privateKey'),
+      }),
+      databaseURL: config.get('firebase.databaseURL'),
+    });
+  }
 }

--- a/packages/hub/initializers/firebase.ts
+++ b/packages/hub/initializers/firebase.ts
@@ -1,0 +1,14 @@
+import { initializeApp } from 'firebase-admin/app';
+import admin from 'firebase-admin';
+import config from 'config';
+
+export default function initFirebase() {
+  initializeApp({
+    credential: admin.credential.cert({
+      projectId: config.get('firebase.projectId'),
+      clientEmail: config.get('firebase.clientEmail'),
+      privateKey: config.get('firebase.privateKey'),
+    }),
+    databaseURL: config.get('firebase.databaseURL'),
+  });
+}

--- a/packages/hub/initializers/sentry.ts
+++ b/packages/hub/initializers/sentry.ts
@@ -1,0 +1,14 @@
+import * as Sentry from '@sentry/node';
+import config from 'config';
+import packageJson from '../package.json';
+
+export default function initSentry() {
+  if (config.get('sentry.enabled')) {
+    Sentry.init({
+      dsn: config.get('sentry.dsn'),
+      enabled: config.get('sentry.enabled'),
+      environment: config.get('sentry.environment'),
+      release: 'hub@' + packageJson.version,
+    });
+  }
+}

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -61,6 +61,7 @@
     "dotenv": "^10.0.0",
     "eth-sig-util": "^3.0.1",
     "fast-json-stable-stringify": "^2.1.0",
+    "firebase-admin": "^10.0.0",
     "fs-extra": "^10.0.0",
     "glob": "^7.1.7",
     "graphile-worker": "^0.11.3",

--- a/packages/hub/services/push-notifications/firebase.ts
+++ b/packages/hub/services/push-notifications/firebase.ts
@@ -1,0 +1,24 @@
+import admin from 'firebase-admin';
+
+interface FCMPayload {
+  message: {
+    notification: {
+      body: string;
+      title: string;
+      data: any; // TODO: Define deep link
+    };
+  };
+  token: string;
+}
+
+export default class FirebasePushNotifications {
+  async send(payload: FCMPayload) {
+    await admin.messaging().send(payload);
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'firebase-push-notifications': FirebasePushNotifications;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16301,6 +16301,22 @@ findup-sync@^4.0.0:
     micromatch "^4.0.2"
     resolve-dir "^1.0.1"
 
+firebase-admin@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/firebase-admin/-/firebase-admin-10.0.0.tgz#0638cd50d2395fddc9d8af4e1699d0a10b1b22d8"
+  integrity sha512-EOAk5ZaqXhBBvx9ZyXd28kw8glMTt3xl0g3BepGRCy0RSSUPGOzfAqjGhc65guSKgFOpT5mAUycYcJbqullKUQ==
+  dependencies:
+    "@firebase/database-compat" "^0.1.1"
+    "@firebase/database-types" "^0.7.2"
+    "@types/node" ">=12.12.47"
+    dicer "^0.3.0"
+    jsonwebtoken "^8.5.1"
+    jwks-rsa "^2.0.2"
+    node-forge "^0.10.0"
+  optionalDependencies:
+    "@google-cloud/firestore" "^4.5.0"
+    "@google-cloud/storage" "^5.3.0"
+
 firebase-admin@^9.11.0, firebase-admin@^9.8.0:
   version "9.12.0"
   resolved "https://registry.yarnpkg.com/firebase-admin/-/firebase-admin-9.12.0.tgz#d7e889e97c9c31610efbcd131bb6d06a783af757"


### PR DESCRIPTION
Ticket: [CS-2701](https://linear.app/cardstack/issue/CS-2701/add-firebase-cloud-messaging-service)

This PR adds the Firebase client which the notification worker will use to send push notifications. 

We'll have to align with the mobile team to define the app link so that the user will get to the relevant screen when tapping the notification.

There are couple of new ENV vars: FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, FIREBASE_PRIVATE_KEY, FIREBASE_DATABASE_URL which should be added in .env for development. These can be obtained by going to [https://console.firebase.google.com](https://console.firebase.google.com), choosing Project Settings > Service accounts > Generate new private key. 