### PR TITLE
Nonusd to spend

### DIFF
--- a/packages/cardpay-sdk/sdk/currency-utils/amount-conversion.ts
+++ b/packages/cardpay-sdk/sdk/currency-utils/amount-conversion.ts
@@ -7,6 +7,7 @@ import BigNumber from 'bignumber.js';
 import { isNil } from 'lodash';
 import { multiply } from './arithmetic';
 import { isZero } from './comparison';
+import { roundAmountToNativeCurrencyDecimals } from './rounding-and-approximation';
 import { BigNumberish } from './types';
 
 /**
@@ -61,7 +62,6 @@ const SPEND_TO_USD_RATE = 0.01;
  * Returns `0` if `amountInSpend` is an empty string,
  * and otherwise `undefined` if amountInSpend is not a number.
  *
- * @see {@link usdToSpend}
  */
 export const spendToUsd = (amountInSpend: number): number | undefined => {
   if ((amountInSpend as unknown) === '') {
@@ -74,20 +74,15 @@ export const spendToUsd = (amountInSpend: number): number | undefined => {
 };
 
 /**
- * Converts USD to SPEND by dividing `amountInUsd` by 0.01.
- * The amount is rounded up to the nearest integer.
- * Returns `0` if `amountInUsd` is an empty string,
- * and otherwise `undefined` if amountInUsd is not a number.
+ * Rounds a given amount up to the specified currency's decimals and then converts it to spend, rounding up to the nearest integer.
+ * Internally uses {@link roundAmountToNativeCurrencyDecimals} with rounding mode = up
  *
- * @see {@link spendToUsd}
+ * @param amount A number
+ * @param currency A Currency specified in the SDK's currency module
+ * @param usdRate Exchange rate for this currency vs usd (amount of this currency equivalent to 1 USD)
+ *
+ * @returns integer spend amount
  */
-export const usdToSpend = (amountInUsd: number): number | undefined => {
-  if ((amountInUsd as unknown) === '') {
-    return 0;
-  }
-  if (typeof (amountInUsd as unknown) !== 'number') {
-    return undefined;
-  }
-
-  return Math.ceil(amountInUsd / SPEND_TO_USD_RATE);
+export const convertToSpend = (amount: number, currency: string, usdRate: number) => {
+  return Math.ceil(Number(roundAmountToNativeCurrencyDecimals(amount, currency)) / usdRate / SPEND_TO_USD_RATE);
 };

--- a/packages/cardpay-sdk/sdk/currency-utils/index.ts
+++ b/packages/cardpay-sdk/sdk/currency-utils/index.ts
@@ -6,7 +6,7 @@ import {
   convertRawAmountToDecimalFormat,
   fromWei,
   spendToUsd,
-  usdToSpend,
+  convertToSpend,
 } from './amount-conversion';
 import { subtract, mod, floorDivide, add, multiply, divide, fraction } from './arithmetic';
 import { greaterThan, greaterThanOrEqualTo, isEqual, isZero, lessThan } from './comparison';
@@ -70,7 +70,7 @@ export {
   convertRawAmountToDecimalFormat,
   fromWei,
   spendToUsd,
-  usdToSpend,
+  convertToSpend,
   isSupportedCurrency,
   countDecimalPlaces,
   handleSignificantDecimalsWithThreshold,

--- a/packages/cardpay-sdk/sdk/currency-utils/rounding-and-approximation.ts
+++ b/packages/cardpay-sdk/sdk/currency-utils/rounding-and-approximation.ts
@@ -80,7 +80,7 @@ export const addBuffer = (numberOne: BigNumberish, buffer: BigNumberish = '1.2')
   new BigNumber(numberOne).times(buffer).toFixed(0);
 
 /**
- * Rounds `value` down to the number of decimals specified by the native currency (see `currencies.ts`)
+ * Rounds `value` to the number of decimals specified by the native currency (see `currencies.ts`)
  */
 export const roundAmountToNativeCurrencyDecimals = (
   value: BigNumberish,

--- a/packages/web-client/tests/acceptance/pay-test.ts
+++ b/packages/web-client/tests/acceptance/pay-test.ts
@@ -8,11 +8,11 @@ import sinon from 'sinon';
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
 import {
   convertAmountToNativeDisplay,
+  convertToSpend,
   formatCurrencyAmount,
   generateMerchantPaymentUrl,
   roundAmountToNativeCurrencyDecimals,
   spendToUsd,
-  usdToSpend,
   ViewSafeResult,
 } from '@cardstack/cardpay-sdk';
 import config from '@cardstack/web-client/config/environment';
@@ -294,7 +294,10 @@ module('Acceptance | pay', function (hooks) {
     assert
       .dom(SECONDARY_AMOUNT)
       .containsText(
-        `§${formatCurrencyAmount(usdToSpend(roundedJpyAmountInUsd)!, 0)}`
+        `§${formatCurrencyAmount(
+          convertToSpend(roundedJpyAmountInUsd, 'USD', 1)!,
+          0
+        )}`
       );
 
     let expectedUrl = generateMerchantPaymentUrl({
@@ -311,8 +314,10 @@ module('Acceptance | pay', function (hooks) {
   test('it rounds amount up to min spend amount if currency is non-USD and non-SPEND', async function (assert) {
     const minJpyAmount = minUsdAmount * mirageConversionRate;
     const jpyAmount = minJpyAmount - 0.1;
-    const convertedMinSpendAmount = usdToSpend(
-      minJpyAmount / mirageConversionRate
+    const convertedMinSpendAmount = convertToSpend(
+      minJpyAmount,
+      'JPY',
+      mirageConversionRate
     );
 
     await visit(


### PR DESCRIPTION
Add utility function `convertToSpend` that converts amounts in native currencies to SPEND. Aims to solve CS-2641.