### PR TITLE
hub: Fix autotest script

### DIFF
--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -22,7 +22,7 @@
     "test": "npm-run-all test:*",
     "test:node": "NODE_ENV=test mocha dist/tests.js --timeout 60000",
     "test:bot": "bin/corde",
-    "autotest": "NODE_ENV=test mocha -w --reporter=min mocha -r @cardstack/test-support/prepare-node-tests 'node-tests/**/*-test.js' --timeout 60000"
+    "autotest": "NODE_ENV=test mocha -w --reporter=min mocha -r @cardstack/test-support/prepare-node-tests 'dist/*tests.js' --timeout 60000"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.18.0",


### PR DESCRIPTION
Since the built artefacts are no longer alongside the TS files, this runs the built tests from `dist/` instead.