### PR TITLE
hub: Add tracking to prevent missed contract events

### DIFF
--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 13.4
+-- Dumped from database version 13.5
 -- Dumped by pg_dump version 13.4
 
 SET statement_timeout = 0;
@@ -33,7 +33,7 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
 
 
 --
--- Name: EXTENSION pgcrypto; Type: COMMENT; Schema: -; Owner:
+-- Name: EXTENSION pgcrypto; Type: COMMENT; Schema: -; Owner: 
 --
 
 COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
@@ -764,6 +764,20 @@ CREATE TABLE public.dm_channels (
 ALTER TABLE public.dm_channels OWNER TO postgres;
 
 --
+-- Name: latest_event_block; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.latest_event_block (
+    id integer DEFAULT 1 NOT NULL,
+    block_number integer NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT latest_event_block_singleton CHECK ((id = 1))
+);
+
+
+ALTER TABLE public.latest_event_block OWNER TO postgres;
+
+--
 -- Name: merchant_infos; Type: TABLE; Schema: public; Owner: postgres
 --
 
@@ -1069,6 +1083,14 @@ ALTER TABLE ONLY public.dm_channels
 
 
 --
+-- Name: latest_event_block latest_event_block_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.latest_event_block
+    ADD CONSTRAINT latest_event_block_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: merchant_infos merchant_infos_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
@@ -1369,7 +1391,7 @@ ALTER TABLE graphile_worker.known_crontabs ENABLE ROW LEVEL SECURITY;
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 13.4
+-- Dumped from database version 13.5
 -- Dumped by pg_dump version 13.4
 
 SET statement_timeout = 0;
@@ -1388,14 +1410,14 @@ SET row_security = off;
 --
 
 COPY graphile_worker.migrations (id, ts) FROM stdin;
-1	2021-11-29 17:02:42.091944-05
-2	2021-11-29 17:02:42.091944-05
-3	2021-11-29 17:02:42.091944-05
-4	2021-11-29 17:02:42.091944-05
-5	2021-11-29 17:02:42.091944-05
-6	2021-11-29 17:02:42.091944-05
-7	2021-11-29 17:02:42.091944-05
-8	2021-11-29 17:02:42.091944-05
+1	2021-12-08 14:30:02.864241-06
+2	2021-12-08 14:30:02.864241-06
+3	2021-12-08 14:30:02.864241-06
+4	2021-12-08 14:30:02.864241-06
+5	2021-12-08 14:30:02.864241-06
+6	2021-12-08 14:30:02.864241-06
+7	2021-12-08 14:30:02.864241-06
+8	2021-12-08 14:30:02.864241-06
 \.
 
 
@@ -1404,25 +1426,26 @@ COPY graphile_worker.migrations (id, ts) FROM stdin;
 --
 
 COPY public.pgmigrations (id, name, run_on) FROM stdin;
-1	20210527151505645_create-prepaid-card-tables	2021-08-02 16:26:07.752752
-2	20210614080132698_create-prepaid-card-customizations-table	2021-08-02 16:26:07.752752
-3	20210623052200757_create-graphile-worker-schema	2021-08-02 16:26:07.752752
-5	20210809113449561_merchant-infos	2021-08-12 09:52:27.790806
-6	20210817184105100_wallet-orders	2021-08-25 08:15:41.07505
-7	20210920142313915_prepaid-card-reservations	2021-10-06 14:32:47.039161
-8	20210924200122612_order-indicies	2021-10-06 14:32:47.039161
-13	20211006090701108_create-card-spaces	2021-10-14 10:38:51.140793
-21	20211020231214235_discord-bots	2021-11-18 11:18:35.492811
-14	20211013155536724_card-index	2021-10-18 09:59:34.440379
-19	20211013173917696_beta-testers	2021-11-18 11:18:35.492811
-20	20211014131843187_add-fields-to-card-spaces	2021-11-18 11:18:35.492811
-42	20211105180905492_wyre-price-service	2021-11-30 14:56:46.211409
-43	20211110210324178_card-index-part-duex	2021-11-30 14:56:46.211409
-44	20211118084217151_create-uploads	2021-11-30 14:56:46.211409
-45	20211129083801382_create-push-notification-registrations	2021-11-30 14:56:46.211409
-46	20211129123635817_create-notification-types	2021-11-30 14:56:46.211409
-51	20211129130425303_create-notification-preferences	2021-12-03 10:12:08.511999
-52	20211206195559187_card-index-generations	2021-12-08 10:33:57.847407
+1	20210527151505645_create-prepaid-card-tables	2021-12-08 14:30:02.864241
+2	20210614080132698_create-prepaid-card-customizations-table	2021-12-08 14:30:02.864241
+3	20210623052200757_create-graphile-worker-schema	2021-12-08 14:30:02.864241
+4	20210809113449561_merchant-infos	2021-12-08 14:30:02.864241
+5	20210817184105100_wallet-orders	2021-12-08 14:30:02.864241
+6	20210920142313915_prepaid-card-reservations	2021-12-08 14:30:02.864241
+7	20210924200122612_order-indicies	2021-12-08 14:30:02.864241
+8	20211006090701108_create-card-spaces	2021-12-08 14:30:02.864241
+9	20211013155536724_card-index	2021-12-08 14:30:02.864241
+10	20211013173917696_beta-testers	2021-12-08 14:30:02.864241
+11	20211014131843187_add-fields-to-card-spaces	2021-12-08 14:30:02.864241
+12	20211020231214235_discord-bots	2021-12-08 14:30:02.864241
+13	20211105180905492_wyre-price-service	2021-12-08 14:30:02.864241
+14	20211110210324178_card-index-part-duex	2021-12-08 14:30:02.864241
+15	20211118084217151_create-uploads	2021-12-08 14:30:02.864241
+16	20211129083801382_create-push-notification-registrations	2021-12-08 14:30:02.864241
+17	20211129123635817_create-notification-types	2021-12-08 14:30:02.864241
+18	20211129130425303_create-notification-preferences	2021-12-08 14:30:02.864241
+19	20211206195559187_card-index-generations	2021-12-08 14:30:02.864241
+20	20211207190527999_create-latest-event-block	2021-12-08 14:30:02.864241
 \.
 
 
@@ -1430,7 +1453,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 -- Name: pgmigrations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.pgmigrations_id_seq', 26, true);
+SELECT pg_catalog.setval('public.pgmigrations_id_seq', 20, true);
 
 
 --

--- a/packages/hub/contract-subscription-event-handler.ts
+++ b/packages/hub/contract-subscription-event-handler.ts
@@ -5,6 +5,7 @@ import Web3SocketService from './services/web3-socket';
 import { contractSubscriptionEventHandlerLog } from './utils/logger';
 import Contracts from './services/contracts';
 import { AddressKeys } from '@cardstack/cardpay-sdk';
+import LatestEventBlockQueries from './services/queries/latest-event-block';
 
 const CONTRACT_EVENTS = [
   {
@@ -26,22 +27,36 @@ export class ContractSubscriptionEventHandler {
   #contracts: Contracts;
   #web3: Web3SocketService;
   #workerClient: WorkerClient;
+  #latestEventBlockQueries: LatestEventBlockQueries;
   #logger = contractSubscriptionEventHandlerLog;
 
-  constructor(web3: Web3SocketService, workerClient: WorkerClient, contracts: Contracts) {
+  constructor(
+    web3: Web3SocketService,
+    workerClient: WorkerClient,
+    contracts: Contracts,
+    latestEventBlockQueries: LatestEventBlockQueries
+  ) {
     autoBind(this);
     this.#contracts = contracts;
     this.#web3 = web3;
     this.#workerClient = workerClient;
+    this.#latestEventBlockQueries = latestEventBlockQueries;
   }
 
   async setupContractEventSubscriptions() {
     let web3Instance = this.#web3.getInstance();
 
+    let subscriptionOptions = {};
+    let latestBlock = await this.#latestEventBlockQueries.read();
+
+    if (latestBlock) {
+      subscriptionOptions = { fromBlock: latestBlock };
+    }
+
     for (let contractEvent of CONTRACT_EVENTS) {
       let contract = await this.#contracts.getContract(web3Instance, contractEvent.abiName, contractEvent.contractName);
 
-      contract.events[contractEvent.eventName]({}, async (error: Error, event: any) => {
+      contract.events[contractEvent.eventName](subscriptionOptions, async (error: Error, event: any) => {
         if (error) {
           Sentry.captureException(error, {
             tags: {
@@ -50,7 +65,12 @@ export class ContractSubscriptionEventHandler {
           });
           this.#logger.error(`Error in ${contractEvent.contractName} subscription`, error);
         } else {
-          this.#logger.info(`Received ${contractEvent.contractName} event`, event.transactionHash);
+          this.#logger.info(
+            `Received ${contractEvent.contractName} event (block number ${event.blockNumber})`,
+            event.transactionHash
+          );
+
+          await this.#latestEventBlockQueries.update(event.blockNumber);
           this.#workerClient.addJob(contractEvent.taskName, event.transactionHash);
         }
       });

--- a/packages/hub/db/migrations/20211207190527999_create-latest-event-block.js
+++ b/packages/hub/db/migrations/20211207190527999_create-latest-event-block.js
@@ -1,0 +1,20 @@
+const LATEST_EVENT_BLOCK_TABLE = 'latest_event_block';
+const LATEST_EVENT_SINGLETON_CONSTRAINT = 'latest_event_block_singleton';
+
+exports.TABLE = LATEST_EVENT_BLOCK_TABLE;
+
+exports.up = async function up(pgm) {
+  pgm.createTable(LATEST_EVENT_BLOCK_TABLE, {
+    id: { type: 'integer', primaryKey: true, default: 1 },
+    block_number: { type: 'integer', notNull: true },
+    updated_at: { type: 'timestamp', notNull: true, default: pgm.func('current_timestamp') },
+  });
+
+  // To restrict table to a single row: https://stackoverflow.com/a/29429083
+  pgm.addConstraint(LATEST_EVENT_BLOCK_TABLE, LATEST_EVENT_SINGLETON_CONSTRAINT, { check: 'id = 1' });
+};
+
+exports.down = async function down(pgm) {
+  pgm.dropConstraint(LATEST_EVENT_BLOCK_TABLE, LATEST_EVENT_SINGLETON_CONSTRAINT);
+  pgm.dropTable(LATEST_EVENT_BLOCK_TABLE);
+};

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -92,6 +92,7 @@ import PushNotificationRegistrationQueries from './services/queries/push-notific
 import PushNotificationRegistrationsRoute from './routes/push_notification_registrations';
 import FirebasePushNotifications from './services/push-notifications/firebase';
 import Contracts from './services/contracts';
+import LatestEventBlockQueries from './services/queries/latest-event-block';
 import NotificationTypeQueries from './services/queries/notification-type';
 import NotificationPreferenceQueries from './services/queries/notification-preference';
 import NotificationPreferenceSerializer from './services/serializers/notification-preference-serializer';
@@ -125,6 +126,7 @@ export function createRegistry(): Registry {
   registry.register('hub-dm-channels-db-gateway', HubDmChannelsDbGateway);
   registry.register('inventory', InventoryService);
   registry.register('inventory-route', InventoryRoute);
+  registry.register('latest-event-block-queries', LatestEventBlockQueries);
   registry.register('merchant-infos-route', MerchantInfosRoute);
   registry.register('merchant-info-serializer', MerchantInfoSerializer);
   registry.register('merchant-info', MerchantInfoService);
@@ -356,9 +358,16 @@ export async function bootWorker() {
   let web3 = await container.lookup('web3-socket');
   let workerClient = await container.lookup('worker-client');
 
+  let latestEventBlockQueries = await container.lookup('latest-event-block-queries');
+
   // listen for contract events
   // internally this talks to the worker client
-  await new ContractSubscriptionEventHandler(web3, workerClient, contracts).setupContractEventSubscriptions();
+  await new ContractSubscriptionEventHandler(
+    web3,
+    workerClient,
+    contracts,
+    latestEventBlockQueries
+  ).setupContractEventSubscriptions();
 
   await runner.promise;
 }

--- a/packages/hub/services/queries/latest-event-block.ts
+++ b/packages/hub/services/queries/latest-event-block.ts
@@ -1,0 +1,48 @@
+import DatabaseManager from '@cardstack/db';
+import { inject } from '@cardstack/di';
+
+const LATEST_EVENT_BLOCK_TABLE = 'latest_event_block';
+
+export default class LatestEventBlockQueries {
+  databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
+
+  async read(): Promise<number | undefined> {
+    let db = await this.databaseManager.getClient();
+
+    let queryResult = await db.query(`SELECT block_number from ${LATEST_EVENT_BLOCK_TABLE} WHERE id = 1`);
+
+    if (queryResult.rowCount) {
+      let row = queryResult.rows[0];
+      return row['block_number'];
+    } else {
+      return undefined;
+    }
+  }
+
+  async update(blockNumber: number) {
+    let db = await this.databaseManager.getClient();
+
+    // Insert if empty, update but only if the block number is higher
+    await db.query(
+      `
+      INSERT INTO ${LATEST_EVENT_BLOCK_TABLE} (id, block_number)
+      VALUES ($1, $2)
+
+      ON CONFLICT (id)
+      DO UPDATE SET
+        block_number = GREATEST(
+          $2,
+          (SELECT block_number FROM ${LATEST_EVENT_BLOCK_TABLE} WHERE id = 1)
+        ),
+        updated_at = NOW()
+      `,
+      [1, blockNumber]
+    );
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'latest-event-block-queries': LatestEventBlockQueries;
+  }
+}


### PR DESCRIPTION
This adds a `latest_event_block` table that stores a `block_number` for the latest contract subscription event that has been received. When subscribing to contract events, it passes that as the `lastBlock` configuration option so events that occur during downtime for the subscription process are not missed.

In this GIF I’ve just completed a transaction while the subscription process isn’t running; I show the latest block in the subgraph being lower than the persisted `block_number` and then that the transaction still produces a notification after starting the subscription process:

![screencast 2021-12-07 17-14-43](https://user-images.githubusercontent.com/43280/145121113-7e454623-abfc-4f36-9f7c-1315b665f436.gif)