### PR TITLE
hub: Add tests for contract subscription handler

### DIFF
--- a/packages/hub/contract-subscription-event-handler.ts
+++ b/packages/hub/contract-subscription-event-handler.ts
@@ -1,14 +1,10 @@
-// import { getAddressByNetwork, getABI } from '@cardstack/cardpay-sdk';
 import autoBind from 'auto-bind';
-// import config from 'config';
 import WorkerClient from './services/worker-client';
 import * as Sentry from '@sentry/node';
 import Web3SocketService from './services/web3-socket';
 import { contractSubscriptionEventHandlerLog } from './utils/logger';
 import { Contracts } from './services/contracts';
 import { AddressKeys } from '@cardstack/cardpay-sdk';
-
-// const { network } = config.get('web3') as { network: 'xdai' | 'sokol' };
 
 const CONTRACT_EVENTS = [
   {

--- a/packages/hub/contract-subscription-event-handler.ts
+++ b/packages/hub/contract-subscription-event-handler.ts
@@ -6,8 +6,24 @@ import * as Sentry from '@sentry/node';
 import Web3SocketService from './services/web3-socket';
 import { contractSubscriptionEventHandlerLog } from './utils/logger';
 import { Contracts } from './services/contracts';
+import { AddressKeys } from '@cardstack/cardpay-sdk';
 
 // const { network } = config.get('web3') as { network: 'xdai' | 'sokol' };
+
+const CONTRACT_EVENTS = [
+  {
+    abiName: 'pay-merchant-handler',
+    contractName: 'payMerchantHandler' as AddressKeys,
+    eventName: 'CustomerPayment',
+    taskName: 'notify-customer-payment',
+  },
+  {
+    abiName: 'revenue-pool',
+    contractName: 'revenuePool' as AddressKeys,
+    eventName: 'MerchantClaim',
+    taskName: 'notify-merchant-claim',
+  },
+];
 
 // DO NOT USE only for use in bootWorker to prevent duplicate notifications
 export class ContractSubscriptionEventHandler {
@@ -26,51 +42,23 @@ export class ContractSubscriptionEventHandler {
   async setupContractEventSubscriptions() {
     let web3Instance = this.#web3.getInstance();
 
-    // let RevenuePoolABI = await getABI('revenue-pool', web3Instance);
-    // let revenuePoolContract = new web3Instance.eth.Contract(
-    //   RevenuePoolABI,
-    //   getAddressByNetwork('revenuePool', network)
-    // );
-    let revenuePoolContract = await this.#contracts.getContract(web3Instance, 'revenue-pool', 'revenuePool');
+    for (let contractEvent of CONTRACT_EVENTS) {
+      let contract = await this.#contracts.getContract(web3Instance, contractEvent.abiName, contractEvent.contractName);
 
-    // let PayMerchantHandlerABI = await getABI('pay-merchant-handler', web3Instance);
-    // let payMerchantContract = new web3Instance.eth.Contract(
-    //   PayMerchantHandlerABI,
-    //   getAddressByNetwork('payMerchantHandler', network)
-    // );
-    let payMerchantContract = await this.#contracts.getContract(
-      web3Instance,
-      'pay-merchant-handler',
-      'payMerchantHandler'
-    );
-
-    payMerchantContract.events.CustomerPayment({}, async (error: Error, event: any) => {
-      if (error) {
-        Sentry.captureException(error, {
-          tags: {
-            action: 'contract-subscription-event-handler',
-          },
-        });
-        this.#logger.error('Error in CustomerPayment subscription', error);
-      } else {
-        this.#logger.info('Received CustomerPayment event', event.transactionHash);
-        this.#workerClient.addJob('notify-customer-payment', event.transactionHash);
-      }
-    });
-
-    revenuePoolContract.events.MerchantClaim({}, async (error: Error, event: any) => {
-      if (error) {
-        Sentry.captureException(error, {
-          tags: {
-            action: 'contract-subscription-event-handler',
-          },
-        });
-        this.#logger.error('Error in MerchantClaim subscription', error);
-      } else {
-        this.#logger.info('Received MerchantClaim event', event.transactionHash);
-        this.#workerClient.addJob('notify-merchant-claim', event.transactionHash);
-      }
-    });
+      contract.events[contractEvent.eventName]({}, async (error: Error, event: any) => {
+        if (error) {
+          Sentry.captureException(error, {
+            tags: {
+              action: 'contract-subscription-event-handler',
+            },
+          });
+          this.#logger.error(`Error in ${contractEvent.contractName} subscription`, error);
+        } else {
+          this.#logger.info(`Received ${contractEvent.contractName} event`, event.transactionHash);
+          this.#workerClient.addJob(contractEvent.taskName, event.transactionHash);
+        }
+      });
+    }
 
     this.#logger.info('Subscribed to events');
   }

--- a/packages/hub/contract-subscription-event-handler.ts
+++ b/packages/hub/contract-subscription-event-handler.ts
@@ -3,7 +3,7 @@ import WorkerClient from './services/worker-client';
 import * as Sentry from '@sentry/node';
 import Web3SocketService from './services/web3-socket';
 import { contractSubscriptionEventHandlerLog } from './utils/logger';
-import { Contracts } from './services/contracts';
+import Contracts from './services/contracts';
 import { AddressKeys } from '@cardstack/cardpay-sdk';
 
 const CONTRACT_EVENTS = [

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -91,7 +91,7 @@ import PushNotificationRegistrationSerializer from './services/serializers/push-
 import PushNotificationRegistrationQueries from './services/queries/push-notification-registration';
 import PushNotificationRegistrationsRoute from './routes/push_notification_registrations';
 import FirebasePushNotifications from './services/push-notifications/firebase';
-import { Contracts } from './services/contracts';
+import Contracts from './services/contracts';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -88,6 +88,7 @@ import SendNotificationsTask from './tasks/send-notifications';
 import PushNotificationRegistrationSerializer from './services/serializers/push-notification-registration-serializer';
 import PushNotificationRegistrationQueries from './services/queries/push-notification-registration';
 import PushNotificationRegistrationsRoute from './routes/push_notification_registrations';
+import { Contracts } from './services/contracts';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -101,6 +102,7 @@ export function createRegistry(): Registry {
   registry.register('callbacks-router', CallbacksRouter);
   registry.register('cardpay', CardpaySDKService);
   registry.register('clock', Clock);
+  registry.register('contracts', Contracts);
   registry.register('custodial-wallet-route', CustodialWalletRoute);
   registry.register('database-manager', DatabaseManager);
   registry.register('development-config', DevelopmentConfig);
@@ -344,12 +346,13 @@ export async function bootWorker() {
       Sentry.captureException(error);
     });
   });
+  let contracts = await container.lookup('contracts');
   let web3 = await container.lookup('web3-socket');
   let workerClient = await container.lookup('worker-client');
 
   // listen for contract events
   // internally this talks to the worker client
-  await new ContractSubscriptionEventHandler(web3, workerClient).setupContractEventSubscriptions();
+  await new ContractSubscriptionEventHandler(web3, workerClient, contracts).setupContractEventSubscriptions();
 
   await runner.promise;
 }

--- a/packages/hub/node-tests/contract-subscription-event-handler-test.ts
+++ b/packages/hub/node-tests/contract-subscription-event-handler-test.ts
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/node';
 import waitFor from './utils/wait-for';
 import Web3SocketService from '../services/web3-socket';
 import WorkerClient from '../services/worker-client';
-import { Contracts } from '../services/contracts';
+import Contracts from '../services/contracts';
 import Web3 from 'web3';
 
 const { testkit, sentryTransport } = sentryTestkit();

--- a/packages/hub/node-tests/contract-subscription-event-handler-test.ts
+++ b/packages/hub/node-tests/contract-subscription-event-handler-test.ts
@@ -58,6 +58,8 @@ let workerClient: StubWorkerClient;
 
 describe('ContractSubscriptionEventHandler', function () {
   this.beforeEach(async function () {
+    testkit.reset();
+
     contracts = new StubContracts();
     workerClient = new StubWorkerClient();
 
@@ -84,13 +86,16 @@ describe('ContractSubscriptionEventHandler', function () {
       transport: sentryTransport,
     });
 
-    contracts.handlers.CustomerPayment(new Error('Mock CustomerPayment error'));
+    let error = new Error('Mock CustomerPayment error');
+    contracts.handlers.CustomerPayment(error);
 
     await waitFor(() => testkit.reports().length > 0);
 
     expect(testkit.reports()[0].tags).to.deep.equal({
       action: 'contract-subscription-event-handler',
     });
+
+    expect(testkit.reports()[0].error?.message).to.equal(error.message);
   });
 
   it('handles a MerchantClaim event', async function () {
@@ -107,12 +112,15 @@ describe('ContractSubscriptionEventHandler', function () {
       transport: sentryTransport,
     });
 
-    contracts.handlers.MerchantClaim(new Error('Mock MerchantClaim error'));
+    let error = new Error('Mock MerchantClaim error');
+    contracts.handlers.MerchantClaim(error);
 
     await waitFor(() => testkit.reports().length > 0);
 
     expect(testkit.reports()[0].tags).to.deep.equal({
       action: 'contract-subscription-event-handler',
     });
+
+    expect(testkit.reports()[0].error?.message).to.equal(error.message);
   });
 });

--- a/packages/hub/node-tests/contract-subscription-event-handler-test.ts
+++ b/packages/hub/node-tests/contract-subscription-event-handler-test.ts
@@ -71,8 +71,6 @@ describe('ContractSubscriptionEventHandler', function () {
   });
 
   it('handles a CustomerPayment event', async function () {
-    expect(1).to.equal(1);
-
     contracts.handlers.CustomerPayment(null, { transactionHash: '0x123' });
 
     expect(workerClient.jobs).to.deep.equal([['notify-merchant-claim', '0x123']]);

--- a/packages/hub/node-tests/contract-subscription-event-handler-test.ts
+++ b/packages/hub/node-tests/contract-subscription-event-handler-test.ts
@@ -1,0 +1,80 @@
+import { ContractSubscriptionEventHandler } from '../contract-subscription-event-handler';
+import { Job, TaskSpec } from 'graphile-worker';
+import { expect } from 'chai';
+// import sentryTestkit from 'sentry-testkit';
+// import * as Sentry from '@sentry/node';
+// import waitFor from './utils/wait-for';
+import Web3SocketService from '../services/web3-socket';
+import WorkerClient from '../services/worker-client';
+import { Contracts } from '../services/contracts';
+import Web3 from 'web3';
+
+// const { testkit, sentryTransport } = sentryTestkit();
+
+class StubContracts {
+  handlers: Record<any, any> = {};
+
+  getContract(_web3: Web3, _abiName: string, contractName: string) {
+    if (contractName == 'payMerchantHandler') {
+      return {
+        events: {
+          CustomerPayment: (_config: any, callback: Function) => {
+            this.handlers.CustomerPayment = callback;
+          },
+        },
+      };
+    }
+    return {
+      events: {
+        MerchantClaim: (_config: any, callback: Function) => {
+          this.handlers.CustomerPayment = callback;
+        },
+      },
+    };
+  }
+}
+
+class StubWeb3 {
+  getInstance() {
+    return this;
+  }
+}
+
+class StubWorkerClient {
+  jobs: [string, any][] = [];
+
+  constructor() {
+    this.jobs = [];
+  }
+
+  async addJob(identifier: string, payload?: any, _spec?: TaskSpec): Promise<Job> {
+    this.jobs.push([identifier, payload]);
+    return Promise.resolve({} as Job);
+  }
+}
+
+let contracts: StubContracts;
+let workerClient: StubWorkerClient;
+
+describe('ContractSubscriptionEventHandler', function () {
+  this.beforeEach(async function () {
+    contracts = new StubContracts();
+    workerClient = new StubWorkerClient();
+
+    this.subject = new ContractSubscriptionEventHandler(
+      new StubWeb3() as unknown as Web3SocketService,
+      workerClient as unknown as WorkerClient,
+      contracts as unknown as Contracts
+    );
+
+    await this.subject.setupContractEventSubscriptions();
+  });
+
+  it('handles a CustomerPayment event', async function () {
+    expect(1).to.equal(1);
+
+    contracts.handlers.CustomerPayment(null, { transactionHash: '0x123' });
+
+    expect(workerClient.jobs).to.deep.equal([['notify-merchant-claim', '0x123']]);
+  });
+});

--- a/packages/hub/node-tests/contract-subscription-event-handler-test.ts
+++ b/packages/hub/node-tests/contract-subscription-event-handler-test.ts
@@ -23,14 +23,17 @@ class StubContracts {
           },
         },
       };
-    }
-    return {
-      events: {
-        MerchantClaim: (_config: any, callback: Function) => {
-          this.handlers.MerchantClaim = callback;
+    } else if (contractName == 'revenuePool') {
+      return {
+        events: {
+          MerchantClaim: (_config: any, callback: Function) => {
+            this.handlers.MerchantClaim = callback;
+          },
         },
-      },
-    };
+      };
+    }
+
+    return null;
   }
 }
 

--- a/packages/hub/node-tests/contract-subscription-event-handler-test.ts
+++ b/packages/hub/node-tests/contract-subscription-event-handler-test.ts
@@ -27,7 +27,7 @@ class StubContracts {
     return {
       events: {
         MerchantClaim: (_config: any, callback: Function) => {
-          this.handlers.CustomerPayment = callback;
+          this.handlers.MerchantClaim = callback;
         },
       },
     };
@@ -73,7 +73,7 @@ describe('ContractSubscriptionEventHandler', function () {
   it('handles a CustomerPayment event', async function () {
     contracts.handlers.CustomerPayment(null, { transactionHash: '0x123' });
 
-    expect(workerClient.jobs).to.deep.equal([['notify-merchant-claim', '0x123']]);
+    expect(workerClient.jobs).to.deep.equal([['notify-customer-payment', '0x123']]);
   });
 
   it('logs an error when receiving a CustomerPayment error', async function () {
@@ -85,6 +85,29 @@ describe('ContractSubscriptionEventHandler', function () {
     });
 
     contracts.handlers.CustomerPayment(new Error('Mock CustomerPayment error'));
+
+    await waitFor(() => testkit.reports().length > 0);
+
+    expect(testkit.reports()[0].tags).to.deep.equal({
+      action: 'contract-subscription-event-handler',
+    });
+  });
+
+  it('handles a MerchantClaim event', async function () {
+    contracts.handlers.MerchantClaim(null, { transactionHash: '0x123' });
+
+    expect(workerClient.jobs).to.deep.equal([['notify-merchant-claim', '0x123']]);
+  });
+
+  it('logs an error when receiving a MerchantClaim error', async function () {
+    Sentry.init({
+      dsn: 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001',
+      release: 'test',
+      tracesSampleRate: 1,
+      transport: sentryTransport,
+    });
+
+    contracts.handlers.MerchantClaim(new Error('Mock MerchantClaim error'));
 
     await waitFor(() => testkit.reports().length > 0);
 

--- a/packages/hub/node-tests/contract-subscription-event-handler-test.ts
+++ b/packages/hub/node-tests/contract-subscription-event-handler-test.ts
@@ -1,15 +1,15 @@
 import { ContractSubscriptionEventHandler } from '../contract-subscription-event-handler';
 import { Job, TaskSpec } from 'graphile-worker';
 import { expect } from 'chai';
-// import sentryTestkit from 'sentry-testkit';
-// import * as Sentry from '@sentry/node';
-// import waitFor from './utils/wait-for';
+import sentryTestkit from 'sentry-testkit';
+import * as Sentry from '@sentry/node';
+import waitFor from './utils/wait-for';
 import Web3SocketService from '../services/web3-socket';
 import WorkerClient from '../services/worker-client';
 import { Contracts } from '../services/contracts';
 import Web3 from 'web3';
 
-// const { testkit, sentryTransport } = sentryTestkit();
+const { testkit, sentryTransport } = sentryTestkit();
 
 class StubContracts {
   handlers: Record<any, any> = {};
@@ -76,5 +76,22 @@ describe('ContractSubscriptionEventHandler', function () {
     contracts.handlers.CustomerPayment(null, { transactionHash: '0x123' });
 
     expect(workerClient.jobs).to.deep.equal([['notify-merchant-claim', '0x123']]);
+  });
+
+  it('logs an error when receiving a CustomerPayment error', async function () {
+    Sentry.init({
+      dsn: 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001',
+      release: 'test',
+      tracesSampleRate: 1,
+      transport: sentryTransport,
+    });
+
+    contracts.handlers.CustomerPayment(new Error('Mock CustomerPayment error'));
+
+    await waitFor(() => testkit.reports().length > 0);
+
+    expect(testkit.reports()[0].tags).to.deep.equal({
+      action: 'contract-subscription-event-handler',
+    });
   });
 });

--- a/packages/hub/node-tests/contract-subscription-event-handler-test.ts
+++ b/packages/hub/node-tests/contract-subscription-event-handler-test.ts
@@ -61,6 +61,13 @@ let workerClient: StubWorkerClient;
 
 describe('ContractSubscriptionEventHandler', function () {
   this.beforeEach(async function () {
+    Sentry.init({
+      dsn: 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001',
+      release: 'test',
+      tracesSampleRate: 1,
+      transport: sentryTransport,
+    });
+
     testkit.reset();
 
     contracts = new StubContracts();
@@ -82,13 +89,6 @@ describe('ContractSubscriptionEventHandler', function () {
   });
 
   it('logs an error when receiving a CustomerPayment error', async function () {
-    Sentry.init({
-      dsn: 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001',
-      release: 'test',
-      tracesSampleRate: 1,
-      transport: sentryTransport,
-    });
-
     let error = new Error('Mock CustomerPayment error');
     contracts.handlers.CustomerPayment(error);
 
@@ -108,13 +108,6 @@ describe('ContractSubscriptionEventHandler', function () {
   });
 
   it('logs an error when receiving a MerchantClaim error', async function () {
-    Sentry.init({
-      dsn: 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001',
-      release: 'test',
-      tracesSampleRate: 1,
-      transport: sentryTransport,
-    });
-
     let error = new Error('Mock MerchantClaim error');
     contracts.handlers.MerchantClaim(error);
 

--- a/packages/hub/services/contracts.ts
+++ b/packages/hub/services/contracts.ts
@@ -4,7 +4,7 @@ import Web3 from 'web3';
 
 const { network } = config.get('web3') as { network: 'xdai' | 'sokol' };
 
-export class Contracts {
+export default class Contracts {
   async getContract(web3Instance: Web3, abiName: string, contractName: AddressKeys) {
     let ABI = await getABI(abiName, web3Instance);
     let contract = new web3Instance.eth.Contract(ABI, getAddressByNetwork(contractName, network));

--- a/packages/hub/services/contracts.ts
+++ b/packages/hub/services/contracts.ts
@@ -1,0 +1,20 @@
+import { getAddressByNetwork, getABI, AddressKeys } from '@cardstack/cardpay-sdk';
+import config from 'config';
+import Web3 from 'web3';
+
+const { network } = config.get('web3') as { network: 'xdai' | 'sokol' };
+
+export class Contracts {
+  async getContract(web3Instance: Web3, abiName: string, contractName: AddressKeys) {
+    let ABI = await getABI(abiName, web3Instance);
+    let contract = new web3Instance.eth.Contract(ABI, getAddressByNetwork(contractName, network));
+
+    return contract;
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    contracts: Contracts;
+  }
+}


### PR DESCRIPTION
These are tests for the `ContractSubscriptionEventHandler`, which imports contracts and maps subscribed contract events to notification-generating tasks. This is a precursor to persisting the latest-seen block number and resuming from it if there’s a disruption.