### PR TITLE
use firebase's own types for notification payload, return a string from a send call

### DIFF
--- a/packages/hub/services/push-notifications/firebase.ts
+++ b/packages/hub/services/push-notifications/firebase.ts
@@ -1,19 +1,9 @@
 import admin from 'firebase-admin';
-
-interface FCMPayload {
-  message: {
-    notification: {
-      body: string;
-      title: string;
-      data: any; // TODO: Define deep link
-    };
-  };
-  token: string;
-}
+import { TokenMessage } from 'firebase-admin/lib/messaging/messaging-api';
 
 export default class FirebasePushNotifications {
-  async send(payload: FCMPayload) {
-    await admin.messaging().send(payload);
+  async send(payload: TokenMessage) {
+    return await admin.messaging().send(payload);
   }
 }
 


### PR DESCRIPTION
Extracted from https://github.com/cardstack/cardstack/pull/2474

I think the previous type would have failed silently because `message` is not part of the interface of `Message`? But since `notification` is not a required property, this wasn't caught by typescript.