### PR TITLE
Add migration script to hub CLI

### DIFF
--- a/packages/hub/DEPLOYMENT.md
+++ b/packages/hub/DEPLOYMENT.md
@@ -71,12 +71,12 @@ Usage:
 
 Connect to the instance where the app is deployed:
 ```sh
-waypoint exec -app=hub bash
+waypoint exec -app=hub sh
 ```
 
 Then, add node to the PATH and run the migrations:
 ```sh
 heroku@ip-10-91-1-8:/ cd /workspace
 heroku@ip-10-91-1-8:/workspace$ PATH=$PATH:/layers/heroku_nodejs-engine/nodejs/bin/;
-heroku@ip-10-91-1-8:/workspace$ npm run db:migrate up
+heroku@ip-10-91-1-8:/workspace$ node dist/hub.js db migrate up
 ```

--- a/packages/hub/DEPLOYMENT.md
+++ b/packages/hub/DEPLOYMENT.md
@@ -70,13 +70,13 @@ Usage:
 ## Step 4: Run migrations (if any)
 
 Connect to the instance where the app is deployed:
+
 ```sh
 waypoint exec -app=hub sh
 ```
 
-Then, add node to the PATH and run the migrations:
+Then, execute the db migrate command:
+
 ```sh
-heroku@ip-10-91-1-8:/ cd /workspace
-heroku@ip-10-91-1-8:/workspace$ PATH=$PATH:/layers/heroku_nodejs-engine/nodejs/bin/;
-heroku@ip-10-91-1-8:/workspace$ node dist/hub.js db migrate up
+/workspace/packages/hub # node dist/hub.js db migrate up
 ```

--- a/packages/hub/cli/db/index.ts
+++ b/packages/hub/cli/db/index.ts
@@ -1,4 +1,5 @@
 import * as dump from './dump';
 import * as initTest from './init';
 import * as seed from './seed';
-export const commands: any = [dump, initTest, seed];
+import * as migrate from './migrate';
+export const commands: any = [dump, initTest, seed, migrate];

--- a/packages/hub/cli/db/migrate.ts
+++ b/packages/hub/cli/db/migrate.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-process-exit */
+
 import { Argv } from 'yargs';
 import migrate from 'node-pg-migrate';
 import { join } from 'path';

--- a/packages/hub/cli/db/migrate.ts
+++ b/packages/hub/cli/db/migrate.ts
@@ -1,0 +1,41 @@
+import { Argv } from 'yargs';
+import migrate from 'node-pg-migrate';
+import { join } from 'path';
+import config from 'dotenv';
+import { createContainer } from '../../main';
+
+export let command = 'migrate';
+export let describe = 'Perform database migrations';
+export let builder = {};
+
+export async function handler(_argv: Argv & { _: string[] }) {
+  let {
+    _: [, , direction, ...args],
+  } = _argv;
+  if (direction! !== 'up' && direction! !== 'down') {
+    console.error(`Invalid migration direction: '${direction}'. Must be 'up' or 'down'`);
+    process.exit(1);
+  }
+  config.config();
+  let container = createContainer();
+  let dbManager = await container.lookup('database-manager');
+  let dbClient = await dbManager.getClient();
+  let dir = join('.', 'dist', 'migrations');
+  let checkOrder = args?.includes('--no-check-order') ? false : true;
+
+  try {
+    let migrations = await migrate({
+      direction,
+      dir,
+      migrationsTable: 'pgmigrations',
+      count: Infinity,
+      dbClient,
+      checkOrder,
+    });
+    console.log(JSON.stringify(migrations, null, 2));
+    container.teardown();
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+}

--- a/packages/hub/cli/db/migrate.ts
+++ b/packages/hub/cli/db/migrate.ts
@@ -8,9 +8,10 @@ export let command = 'migrate';
 export let describe = 'Perform database migrations';
 export let builder = {};
 
-export async function handler(_argv: Argv & { _: string[] }) {
+export async function handler(_argv: Argv & { _: string[]; checkOrder?: boolean }) {
   let {
-    _: [, , direction, ...args],
+    _: [, , direction],
+    checkOrder = true,
   } = _argv;
   if (direction! !== 'up' && direction! !== 'down') {
     console.error(`Invalid migration direction: '${direction}'. Must be 'up' or 'down'`);
@@ -20,11 +21,10 @@ export async function handler(_argv: Argv & { _: string[] }) {
   let container = createContainer();
   let dbManager = await container.lookup('database-manager');
   let dbClient = await dbManager.getClient();
-  let dir = join('.', 'dist', 'migrations');
-  let checkOrder = args?.includes('--no-check-order') ? false : true;
+  let dir = join('.', 'dist', 'db', 'migrations');
 
   try {
-    let migrations = await migrate({
+    await migrate({
       direction,
       dir,
       migrationsTable: 'pgmigrations',
@@ -32,7 +32,6 @@ export async function handler(_argv: Argv & { _: string[] }) {
       dbClient,
       checkOrder,
     });
-    console.log(JSON.stringify(migrations, null, 2));
     container.teardown();
   } catch (e) {
     console.error(e);

--- a/packages/hub/cli/db/migrate.ts
+++ b/packages/hub/cli/db/migrate.ts
@@ -5,7 +5,7 @@ import config from 'dotenv';
 import { createContainer } from '../../main';
 
 export let command = 'migrate';
-export let describe = 'Perform database migrations';
+export let describe = `Perform database migrations, specify direction 'up' or 'down' and optionally --no-check-order`;
 export let builder = {};
 
 export async function handler(_argv: Argv & { _: string[]; checkOrder?: boolean }) {

--- a/packages/hub/webpack.config.ts
+++ b/packages/hub/webpack.config.ts
@@ -36,6 +36,8 @@ module.exports = {
     new CopyPlugin({
       patterns: [
         {
+          // we are @cardstack/hub, so there is no need to declare ourselves as a dep
+          // eslint-disable-next-line node/no-extraneous-require
           from: path.join(path.dirname(require.resolve('@cardstack/hub/package.json')), 'db', 'migrations', '*.js'),
         },
       ],

--- a/packages/hub/webpack.config.ts
+++ b/packages/hub/webpack.config.ts
@@ -37,7 +37,6 @@ module.exports = {
       patterns: [
         {
           from: path.join(path.dirname(require.resolve('@cardstack/hub/package.json')), 'db', 'migrations', '*.js'),
-          to: 'migrations',
         },
       ],
     }),
@@ -93,6 +92,11 @@ module.exports = {
     // corde wants to insert itself at runtime, as it drives the bot tests. We
     // don't want to compile it in.
     corde: 'commonjs corde',
+
+    // node-pg-migrate has very specific logic for how it determines the path of
+    // the migration files which rely on a relative path calculation from
+    // __dirname
+    'node-pg-migrate': 'commonjs node-pg-migrate',
   },
 
   module: {

--- a/packages/hub/webpack.config.ts
+++ b/packages/hub/webpack.config.ts
@@ -30,6 +30,17 @@ module.exports = {
         },
       ],
     }),
+
+    // place the db migrations into the dist folder so that node-pg-migrate can
+    // find them
+    new CopyPlugin({
+      patterns: [
+        {
+          from: path.join(path.dirname(require.resolve('@cardstack/hub/package.json')), 'db', 'migrations', '*.js'),
+          to: 'migrations',
+        },
+      ],
+    }),
   ],
 
   entry: {


### PR DESCRIPTION
To deal with the fact that everything is build via webpack now, I added node-pg-migrate as part of our hub CLI. I tested this locally and I was able to perform @jurgenwerk 's DB migration via the webpack build.