### PR TITLE
🔔 📲 Consider notification preferences when handling a notification event

### DIFF
--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -97,6 +97,7 @@ import NotificationTypeQueries from './services/queries/notification-type';
 import NotificationPreferenceQueries from './services/queries/notification-preference';
 import NotificationPreferenceSerializer from './services/serializers/notification-preference-serializer';
 import NotificationPreferencesRoute from './routes/notification-preferences';
+import NotificationPreferenceService from './services/push-notifications/preferences';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -158,6 +159,7 @@ export function createRegistry(): Registry {
   registry.register('notification-preferences-route', NotificationPreferencesRoute);
   registry.register('notification-preference-queries', NotificationPreferenceQueries);
   registry.register('notification-preference-serializer', NotificationPreferenceSerializer);
+  registry.register('notification-preference-service', NotificationPreferenceService);
   registry.register('relay', RelayService);
   registry.register('reserved-words', ReservedWords);
   registry.register('reservations-route', ReservationsRoute);

--- a/packages/hub/node-tests/services/notification-preference-test.ts
+++ b/packages/hub/node-tests/services/notification-preference-test.ts
@@ -1,0 +1,104 @@
+import { setupHub } from '../helpers/server';
+
+describe('NotificationPreferenceService', function () {
+  let { getContainer } = setupHub(this);
+
+  this.beforeEach(async function () {
+    let dbManager = await getContainer().lookup('database-manager');
+    let db = await dbManager.getClient();
+    await db.query('INSERT INTO notification_types(id, notification_type, default_status) VALUES($1, $2, $3)', [
+      '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+      'merchant_claim',
+      'enabled',
+    ]);
+    await db.query('INSERT INTO notification_types(id, notification_type, default_status) VALUES($1, $2, $3)', [
+      '2cbe34e4-f41d-41d5-b7d2-ee875dc7c588',
+      'customer_payment',
+      'enabled',
+    ]);
+    let registrationQueries = await getContainer().lookup('push-notification-registration-queries');
+    let preferenceQueries = await getContainer().lookup('notification-preference-queries');
+
+    // 1st device
+    await registrationQueries.insert({
+      id: 'f6942dbf-1422-4c3f-baa3-24f0c5b5d475',
+      ownerAddress: '0x01',
+      pushClientId: '123',
+      disabledAt: null,
+    });
+
+    // 2nd device
+    await registrationQueries.insert({
+      id: '5ffa1144-6a8d-4a43-98bd-ce526f48b7e4',
+      ownerAddress: '0x01',
+      pushClientId: '124',
+      disabledAt: null,
+    });
+
+    // 3rd device, disabled
+    await registrationQueries.insert({
+      id: 'c7ef64dd-a608-4f0a-8a48-ce58c66e7f20',
+      ownerAddress: '0x01',
+      pushClientId: '125',
+      disabledAt: '2021-12-09T10:28:16.921',
+    });
+
+    // device from some other EOA
+    await registrationQueries.insert({
+      id: '6ab0df2c-880d-433d-8e37-fb916afaf6ec',
+      ownerAddress: '0x02',
+      pushClientId: '888',
+      disabledAt: null,
+    });
+
+    // Preference override for 1st device
+    await preferenceQueries.upsert({
+      ownerAddress: '0x01',
+      pushClientId: '123',
+      notificationType: 'customer_payment',
+      status: 'disabled',
+    });
+  });
+
+  it('returns preferences for an EOA', async function () {
+    let service = await getContainer().lookup('notification-preference-service');
+
+    let preferences = await service.getPreferences('0x01');
+
+    // 1st device (123) has a preference override for customer_payment
+    // 2nd device (124) has default preferences
+    expect(preferences).to.deep.equal([
+      {
+        notificationType: 'merchant_claim',
+        ownerAddress: '0x01',
+        pushClientId: '123',
+        status: 'enabled',
+      },
+      {
+        notificationType: 'customer_payment',
+        ownerAddress: '0x01',
+        pushClientId: '123',
+        status: 'disabled',
+      },
+      {
+        notificationType: 'merchant_claim',
+        ownerAddress: '0x01',
+        pushClientId: '124',
+        status: 'enabled',
+      },
+      {
+        notificationType: 'customer_payment',
+        ownerAddress: '0x01',
+        pushClientId: '124',
+        status: 'enabled',
+      },
+    ]);
+  });
+
+  it('returns which devices should receive a notification for an EOA and notification type', async function () {
+    let service = await getContainer().lookup('notification-preference-service');
+
+    expect(await service.getEligiblePushClientIds('0x01', 'customer_payment')).to.deep.equal(['124']);
+    expect(await service.getEligiblePushClientIds('0x01', 'merchant_claim')).to.deep.equal(['123', '124']);
+  });
+});

--- a/packages/hub/node-tests/tasks/notify-customer-payment-test.ts
+++ b/packages/hub/node-tests/tasks/notify-customer-payment-test.ts
@@ -34,13 +34,13 @@ class StubCardPay {
   }
 }
 
-let lastAddedJobIdentifier: string | undefined;
-let lastAddedJobPayload: any | undefined;
+let addedJobIdentifiers: string[] = [];
+let addedJobPayloads: string[] = [];
 
 class StubWorkerClient {
   async addJob(identifier: string, payload?: any, _spec?: TaskSpec): Promise<Job> {
-    lastAddedJobIdentifier = identifier;
-    lastAddedJobPayload = payload;
+    addedJobIdentifiers.push(identifier);
+    addedJobPayloads.push(payload);
     return Promise.resolve({} as Job);
   }
 }
@@ -58,6 +58,12 @@ class StubMerchantInfo {
   }
 }
 
+class StubNotificationPreferenceService {
+  async getEligiblePushClientIds(_ownerAddress: string, _notificationType: string) {
+    return ['123', '456'];
+  }
+}
+
 describe('NotifyCustomerPaymentTask', function () {
   this.beforeEach(function () {
     mockData.value = undefined;
@@ -65,12 +71,13 @@ describe('NotifyCustomerPaymentTask', function () {
     registry(this).register('cardpay', StubCardPay);
     registry(this).register('merchant-info', StubMerchantInfo);
     registry(this).register('worker-client', StubWorkerClient);
+    registry(this).register('notification-preference-service', StubNotificationPreferenceService);
   });
   let { getContainer } = setupHub(this);
 
   this.afterEach(async function () {
-    lastAddedJobIdentifier = undefined;
-    lastAddedJobPayload = undefined;
+    addedJobIdentifiers = [];
+    addedJobPayloads = [];
   });
 
   it('adds a send-notifications job for the merchant’s owner', async function () {
@@ -96,11 +103,19 @@ describe('NotifyCustomerPaymentTask', function () {
 
     await task.perform('a');
 
-    expect(lastAddedJobIdentifier).to.equal('send-notifications');
-    expect(lastAddedJobPayload).to.deep.equal({
-      notifiedAddress: 'eoa-address',
-      message: `Mandello received a payment of §2324`,
-    });
+    expect(addedJobIdentifiers).to.deep.equal(['send-notifications', 'send-notifications']);
+    expect(addedJobPayloads).to.deep.equal([
+      {
+        notifiedAddress: 'eoa-address',
+        pushClientId: '123',
+        message: `Mandello received a payment of §2324`,
+      },
+      {
+        notifiedAddress: 'eoa-address',
+        pushClientId: '456',
+        message: `Mandello received a payment of §2324`,
+      },
+    ]);
   });
 
   it('omits the merchant name and logs an error when fetching it fails', async function () {
@@ -134,11 +149,19 @@ describe('NotifyCustomerPaymentTask', function () {
 
     await task.perform('a');
 
-    expect(lastAddedJobIdentifier).to.equal('send-notifications');
-    expect(lastAddedJobPayload).to.deep.equal({
-      notifiedAddress: 'eoa-address',
-      message: `You received a payment of §2324`,
-    });
+    expect(addedJobIdentifiers).to.deep.equal(['send-notifications', 'send-notifications']);
+    expect(addedJobPayloads).to.deep.equal([
+      {
+        notifiedAddress: 'eoa-address',
+        pushClientId: '123',
+        message: `You received a payment of §2324`,
+      },
+      {
+        notifiedAddress: 'eoa-address',
+        pushClientId: '456',
+        message: `You received a payment of §2324`,
+      },
+    ]);
 
     await waitFor(() => testkit.reports().length > 0);
 
@@ -170,11 +193,19 @@ describe('NotifyCustomerPaymentTask', function () {
 
     await task.perform('a');
 
-    expect(lastAddedJobIdentifier).to.equal('send-notifications');
-    expect(lastAddedJobPayload).to.deep.equal({
-      notifiedAddress: 'eoa-address',
-      message: `You received a payment of §2324`,
-    });
+    expect(addedJobIdentifiers).to.deep.equal(['send-notifications', 'send-notifications']);
+    expect(addedJobPayloads).to.deep.equal([
+      {
+        notifiedAddress: 'eoa-address',
+        pushClientId: '123',
+        message: `You received a payment of §2324`,
+      },
+      {
+        notifiedAddress: 'eoa-address',
+        pushClientId: '456',
+        message: `You received a payment of §2324`,
+      },
+    ]);
   });
 
   it('throws when the transaction is not found on the subgraph', async function () {
@@ -183,8 +214,8 @@ describe('NotifyCustomerPaymentTask', function () {
     return expect(task.perform('a'))
       .to.be.rejectedWith(`Subgraph did not return information for prepaid card payment with transaction hash: "a"`)
       .then(() => {
-        expect(lastAddedJobIdentifier).to.be.undefined;
-        expect(lastAddedJobPayload).to.be.undefined;
+        expect(addedJobIdentifiers).to.deep.equal([]);
+        expect(addedJobPayloads).to.deep.equal([]);
       });
   });
 });

--- a/packages/hub/node-tests/utils/queries-test.ts
+++ b/packages/hub/node-tests/utils/queries-test.ts
@@ -1,0 +1,14 @@
+import { buildConditions } from '../../utils/queries';
+
+describe('Queries utils', function () {
+  describe('buildConditions', function () {
+    it('returns correct values', async function () {
+      expect(buildConditions({ a: 1, b: 2 })).to.deep.equal({ where: 'a=$1 AND b=$2', values: [1, 2] });
+
+      expect(buildConditions({ a: 1, b: null, c: 2 })).to.deep.equal({
+        where: 'a=$1 AND c=$2 AND b IS NULL',
+        values: [1, 2],
+      });
+    });
+  });
+});

--- a/packages/hub/services/push-notifications/preferences.ts
+++ b/packages/hub/services/push-notifications/preferences.ts
@@ -1,0 +1,68 @@
+import { inject } from '@cardstack/di';
+import { NotificationPreference } from '../../routes/notification-preferences';
+import NotificationPreferenceQueries from '../queries/notification-preference';
+import NotificationTypeQueries from '../queries/notification-type';
+import PushNotificationRegistrationQueries from '../queries/push-notification-registration';
+
+export default class NotificationPreferenceService {
+  notificationTypeQueries: NotificationTypeQueries = inject('notification-type-queries', {
+    as: 'notificationTypeQueries',
+  });
+  notificationPreferenceQueries: NotificationPreferenceQueries = inject('notification-preference-queries', {
+    as: 'notificationPreferenceQueries',
+  });
+  pushNotificationRegistrationQueries: PushNotificationRegistrationQueries = inject(
+    'push-notification-registration-queries',
+    {
+      as: 'pushNotificationRegistrationQueries',
+    }
+  );
+
+  async getPreferences(ownerAddress: string, pushClientId?: string): Promise<NotificationPreference[]> {
+    let notificationTypes = await this.notificationTypeQueries.query();
+    let preferences = await this.notificationPreferenceQueries.query({
+      ownerAddress,
+    });
+
+    let pushClientIds;
+
+    if (!pushClientId) {
+      let registrations = await this.pushNotificationRegistrationQueries.query({ ownerAddress, disabledAt: null });
+      pushClientIds = registrations.map((registration) => registration.pushClientId);
+    } else {
+      pushClientIds = [pushClientId];
+    }
+
+    return pushClientIds.flatMap((pushClientId) => {
+      return notificationTypes.map((nt) => {
+        let preference = preferences.find(
+          (preference) =>
+            preference.pushClientId === pushClientId && preference.notificationType === nt.notificationType
+        );
+        if (!preference) {
+          preference = {
+            status: nt.defaultStatus,
+            notificationType: nt.notificationType,
+            ownerAddress: ownerAddress,
+            pushClientId: pushClientId,
+          };
+        }
+        return preference;
+      });
+    });
+  }
+
+  async getEligiblePushClientIds(ownerAddress: string, notificationType: string): Promise<string[]> {
+    return (await this.getPreferences(ownerAddress))
+      .filter((preference) => {
+        return preference.notificationType === notificationType && preference.status === 'enabled';
+      })
+      .map((preference) => preference.pushClientId);
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'notification-preference-service': NotificationPreferenceService;
+  }
+}

--- a/packages/hub/services/queries/notification-preference.ts
+++ b/packages/hub/services/queries/notification-preference.ts
@@ -6,7 +6,7 @@ import pgFormat from 'pg-format';
 
 interface NotificationPreferenceQueriesFilter {
   ownerAddress: string;
-  pushClientId: string;
+  pushClientId?: string;
   notificationType?: string;
 }
 

--- a/packages/hub/services/queries/push-notification-registration.ts
+++ b/packages/hub/services/queries/push-notification-registration.ts
@@ -5,7 +5,8 @@ import { buildConditions } from '../../utils/queries';
 
 interface PushNotificationRegistrationQueriesFilter {
   ownerAddress: string;
-  pushClientId: string;
+  pushClientId?: string;
+  disabledAt?: string | null;
 }
 
 export default class PushNotificationRegistrationQueries {

--- a/packages/hub/tasks/notify-customer-payment.ts
+++ b/packages/hub/tasks/notify-customer-payment.ts
@@ -4,6 +4,7 @@ import CardpaySDKService from '../services/cardpay-sdk';
 import MerchantInfoService from '../services/merchant-info';
 import WorkerClient from '../services/worker-client';
 import * as Sentry from '@sentry/node';
+import NotificationPreferenceService from '../services/push-notifications/preferences';
 
 export interface PrepaidCardPaymentsQueryResult {
   data: {
@@ -54,6 +55,9 @@ export default class NotifyCustomerPayment {
   cardpay: CardpaySDKService = inject('cardpay');
   merchantInfo: MerchantInfoService = inject('merchant-info', { as: 'merchantInfo' });
   workerClient: WorkerClient = inject('worker-client', { as: 'workerClient' });
+  notificationPreferenceService: NotificationPreferenceService = inject('notification-preference-service', {
+    as: 'notificationPreferenceService',
+  });
 
   async perform(payload: string) {
     await this.cardpay.waitForSubgraphIndex(payload, network);
@@ -68,6 +72,17 @@ export default class NotifyCustomerPayment {
       throw new Error(
         `Subgraph did not return information for prepaid card payment with transaction hash: "${payload}"`
       );
+    }
+
+    let notifiedAddress = result.merchant.id;
+
+    let pushClientIdsForNotification = await this.notificationPreferenceService.getEligiblePushClientIds(
+      notifiedAddress,
+      'customer_payment'
+    );
+
+    if (pushClientIdsForNotification.length === 0) {
+      return;
     }
 
     let merchantName = 'You';
@@ -88,13 +103,15 @@ export default class NotifyCustomerPayment {
       });
     }
 
-    let notifiedAddress = result.merchant.id;
     let spendAmount = result.spendAmount;
     let message = `${merchantName} received a payment of §${spendAmount}`;
 
-    await this.workerClient.addJob('send-notifications', {
-      notifiedAddress,
-      message,
-    });
+    for (const pushClientId of pushClientIdsForNotification) {
+      await this.workerClient.addJob('send-notifications', {
+        notifiedAddress,
+        pushClientId,
+        message,
+      });
+    }
   }
 }

--- a/packages/hub/utils/queries.ts
+++ b/packages/hub/utils/queries.ts
@@ -1,3 +1,5 @@
+import { pickBy } from 'lodash';
+
 const camelToSnakeCase = (str: string) => str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
 
 // Takes an object with keys and values for querying and transforms them into parts
@@ -7,14 +9,23 @@ const camelToSnakeCase = (str: string) => str.replace(/[A-Z]/g, (letter) => `_${
 // => { where: 'name=$1 AND age=$2', values: [ 'Phil', 45 ] }
 
 export function buildConditions(params: any) {
-  let conditions = Object.keys(params).map((key, index) => {
+  let nonNullParams = pickBy(params, function (value) {
+    return value !== null;
+  });
+  let nullParams = pickBy(params, function (value) {
+    return value === null;
+  });
+
+  let nonNullconditions = Object.keys(nonNullParams).map((key, index) => {
     return `${camelToSnakeCase(key)}=$${index + 1}`;
   });
 
-  let values = Object.values(params);
+  let nullConditions = Object.keys(nullParams).map((key) => {
+    return `${camelToSnakeCase(key)} IS NULL`;
+  });
 
   return {
-    where: conditions.join(' AND '),
-    values: values,
+    where: nonNullconditions.concat(nullConditions).flat().join(' AND '),
+    values: Object.values(nonNullParams),
   };
 }


### PR DESCRIPTION
Ticket: [CS-2726](https://linear.app/cardstack/issue/CS-2726/only-send-notifications-for-registered-eoas-consider-notification)

This PR adds a feature where in the notification workers we figure out to which devices the notification should be sent to, and send them. 