### PR TITLE
include node-pg-migrate as external pkg in webpack build

### DIFF
--- a/packages/hub/DEPLOYMENT.md
+++ b/packages/hub/DEPLOYMENT.md
@@ -78,5 +78,17 @@ waypoint exec -app=hub sh
 Then, execute the db migrate command:
 
 ```sh
-/workspace/packages/hub # node dist/hub.js db migrate up
+node dist/hub.js db migrate up
+```
+If you receive an error like:
+```sh
+Error: Not run migration 20211013155536724_card-index is preceding already run migration 20211013173917696_beta-testers
+    at checkOrder (/workspace/node_modules/node-pg-migrate/dist/runner.js:103:19)
+    at exports.default (/workspace/node_modules/node-pg-migrate/dist/runner.js:149:13)
+    at processTicksAndRejections (internal/process/task_queues.js:95:5)
+    at async Object.handler (/workspace/packages/hub/dist/hub.js:713760:9)
+  ```
+  Then include the `--no-check-order` flag:
+  ```sh
+node dist/hub.js db migrate up --no-check-order
 ```

--- a/packages/hub/Dockerfile
+++ b/packages/hub/Dockerfile
@@ -5,6 +5,35 @@ WORKDIR /workspace
 COPY dist packages/hub/dist
 COPY config packages/hub/config
 COPY dist/sql node_modules/graphile-worker/sql
+
+# Replicate enough of the node_modules structure to support node-pg-migrate
+COPY dist/node-pg-migrate node_modules/node-pg-migrate
+COPY dist/pg node_modules/pg
+COPY dist/pg-connection-string node_modules/pg-connection-string
+COPY dist/pg-format node_modules/pg-format
+COPY dist/pg-int8 node_modules/pg-int8
+COPY dist/pg-pool node_modules/pg-pool
+COPY dist/pg-protocol node_modules/pg-protocol
+COPY dist/pg-types node_modules/pg-types
+COPY dist/pgpass node_modules/pgpass
+COPY dist/postgres-array node_modules/postgres-array
+COPY dist/postgres-bytea node_modules/postgres-bytea
+COPY dist/postgres-date node_modules/postgres-date
+COPY dist/postgres-interval node_modules/postgres-interval
+COPY dist/buffer-writer node_modules/buffer-writer
+COPY dist/packet-reader node_modules/packet-reader
+COPY dist/xtend node_modules/xtend
+COPY dist/split2 node_modules/split2
+COPY dist/readable-stream node_modules/readable-stream
+COPY dist/inherits node_modules/inherits
+COPY dist/string_decoder node_modules/string_decoder
+COPY dist/util-deprecate node_modules/util-deprecate
+COPY dist/lodash node_modules/lodash
+COPY dist/fs-extra node_modules/fs-extra
+COPY dist/graceful-fs node_modules/graceful-fs
+COPY dist/jsonfile node_modules/jsonfile
+COPY dist/universalify node_modules/universalify
+
 RUN mkdir node_modules/graphile-worker/dist
 WORKDIR /workspace/packages/hub
 CMD node ./dist/hub.js $stored_hub_command

--- a/packages/hub/cli/db/migrate.ts
+++ b/packages/hub/cli/db/migrate.ts
@@ -4,15 +4,13 @@ import { Argv } from 'yargs';
 import { join } from 'path';
 import config from 'dotenv';
 import { createContainer } from '../../main';
+import migrate from 'node-pg-migrate';
 
 export let command = 'migrate';
 export let describe = `Perform database migrations, specify direction 'up' or 'down' and optionally --no-check-order`;
 export let builder = {};
 
 export async function handler(_argv: Argv & { _: string[]; checkOrder?: boolean }) {
-  const migrateModule = join(process.cwd(), 'dist', 'node-pg-migrate');
-  const { default: migrate } = __non_webpack_require__(migrateModule);
-
   let {
     _: [, , direction],
     checkOrder = true,

--- a/packages/hub/cli/db/migrate.ts
+++ b/packages/hub/cli/db/migrate.ts
@@ -1,14 +1,20 @@
 /* eslint-disable no-process-exit */
 
 import { Argv } from 'yargs';
-import migrate from 'node-pg-migrate';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import config from 'dotenv';
 import { createContainer } from '../../main';
 
 export let command = 'migrate';
 export let describe = `Perform database migrations, specify direction 'up' or 'down' and optionally --no-check-order`;
 export let builder = {};
+
+const migrateModule = join(
+  dirname(__non_webpack_require__.resolve('@cardstack/hub/package.json')),
+  'dist',
+  'node-pg-migrate'
+);
+const { default: migrate } = __non_webpack_require__(migrateModule);
 
 export async function handler(_argv: Argv & { _: string[]; checkOrder?: boolean }) {
   let {

--- a/packages/hub/cli/db/migrate.ts
+++ b/packages/hub/cli/db/migrate.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-process-exit */
 
 import { Argv } from 'yargs';
-import { join, dirname } from 'path';
+import { join } from 'path';
 import config from 'dotenv';
 import { createContainer } from '../../main';
 
@@ -9,14 +9,10 @@ export let command = 'migrate';
 export let describe = `Perform database migrations, specify direction 'up' or 'down' and optionally --no-check-order`;
 export let builder = {};
 
-const migrateModule = join(
-  dirname(__non_webpack_require__.resolve('@cardstack/hub/package.json')),
-  'dist',
-  'node-pg-migrate'
-);
-const { default: migrate } = __non_webpack_require__(migrateModule);
-
 export async function handler(_argv: Argv & { _: string[]; checkOrder?: boolean }) {
+  const migrateModule = join(process.cwd(), 'dist', 'node-pg-migrate');
+  const { default: migrate } = __non_webpack_require__(migrateModule);
+
   let {
     _: [, , direction],
     checkOrder = true,

--- a/packages/hub/db/migrations/README.md
+++ b/packages/hub/db/migrations/README.md
@@ -1,1 +1,3 @@
 Migrations currently must be authored in Javascript. `node-pg-migrate` has typescript support but I was unable to get it to work with our repository.
+
+Note that any `require()` that you add to the migration scripts must also be accompanied by adding the package to the list of pkg's that node-pg-migrate needs (and the graph of the pgk's deps) in the webpack.config.ts, as well as updating the Docker file to copy the pkg into the docker container's file system's node_modules folder.

--- a/packages/hub/services/card-cache-config.ts
+++ b/packages/hub/services/card-cache-config.ts
@@ -4,7 +4,7 @@ export class CardCacheConfig {
   packageName = '@cardstack/compiled';
 
   get root() {
-    return dirname(__non_webpack_require__.resolve('@cardstack/hub/package.json'));
+    return process.cwd();
   }
 
   get cacheDirectory() {

--- a/packages/hub/webpack.config.ts
+++ b/packages/hub/webpack.config.ts
@@ -42,6 +42,18 @@ module.exports = {
         },
       ],
     }),
+
+    // we exclude node-pg-migrate from the webpack build because of the logic it
+    // uses to locate migration modules needs to use __dirname to work. So we
+    // copy over the original npm pkg to dist
+    new CopyPlugin({
+      patterns: [
+        {
+          from: path.dirname(require.resolve('node-pg-migrate')),
+          to: 'node-pg-migrate',
+        },
+      ],
+    }),
   ],
 
   entry: {

--- a/packages/hub/webpack.config.ts
+++ b/packages/hub/webpack.config.ts
@@ -43,17 +43,46 @@ module.exports = {
       ],
     }),
 
-    // we exclude node-pg-migrate from the webpack build because of the logic it
-    // uses to locate migration modules needs to use __dirname to work. So we
-    // copy over the original npm pkg to dist
-    new CopyPlugin({
-      patterns: [
-        {
-          from: path.dirname(require.resolve('node-pg-migrate')),
-          to: 'node-pg-migrate',
-        },
-      ],
-    }),
+    // copy over pkgs necessary for node-pg-migrate to work. these will be added
+    // to the docker image's file system
+    ...[
+      'node-pg-migrate',
+      'pg',
+      'pg-connection-string',
+      'pg-format',
+      'pg-int8',
+      'pg-pool',
+      'pg-protocol',
+      'pg-types',
+      'pgpass',
+      'postgres-array',
+      'postgres-bytea',
+      'postgres-date',
+      'postgres-interval',
+      'buffer-writer',
+      'packet-reader',
+      'xtend',
+      'split2',
+      'readable-stream',
+      'inherits',
+      'string_decoder',
+      'util-deprecate',
+      'lodash',
+      'fs-extra',
+      'graceful-fs',
+      'jsonfile',
+      'universalify',
+    ].map(
+      (pkg) =>
+        new CopyPlugin({
+          patterns: [
+            {
+              from: path.dirname(require.resolve(`${pkg}/package.json`)),
+              to: pkg,
+            },
+          ],
+        })
+    ),
   ],
 
   entry: {


### PR DESCRIPTION
Fixes #CS-2770 This works locally for me, but I'll test it as well in waypoint too. at the very least this shields the rest of the hub from the migration script logic since we are dynamically requiring it now.