### PR TITLE
hub: Add preliminary status endpoint

### DIFF
--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -30,6 +30,7 @@ import WyreService from './services/wyre';
 import BoomRoute from './routes/boom';
 import ExchangeRatesRoute from './routes/exchange-rates';
 import SessionRoute from './routes/session';
+import StatusRoute from './routes/status';
 import PrepaidCardColorSchemesRoute from './routes/prepaid-card-color-schemes';
 import PrepaidCardColorSchemeSerializer from './services/serializers/prepaid-card-color-scheme-serializer';
 import PrepaidCardPatternSerializer from './services/serializers/prepaid-card-pattern-serializer';
@@ -173,6 +174,7 @@ export function createRegistry(): Registry {
   registry.register('reservations-route', ReservationsRoute);
   registry.register('session-route', SessionRoute);
   registry.register('sent-push-notifications-queries', SentPushNotificationsQueries);
+  registry.register('status-route', StatusRoute);
   registry.register('subgraph', SubgraphService);
   registry.register('wallet-connect', WalletConnectService);
   registry.register('worker-client', WorkerClient);

--- a/packages/hub/node-tests/routes/status-test.ts
+++ b/packages/hub/node-tests/routes/status-test.ts
@@ -84,7 +84,7 @@ describe.only('GET /api/status', function () {
           type: 'status',
           attributes: {
             rpcBlockNumber: 19492430,
-            status: 'healthy',
+            status: 'operational',
             subgraphBlockNumber: 19492428,
           },
         },

--- a/packages/hub/node-tests/routes/status-test.ts
+++ b/packages/hub/node-tests/routes/status-test.ts
@@ -106,21 +106,13 @@ describe('GET /api/status', function () {
           type: 'status',
           attributes: {
             subgraph: {
+              details: 'Experiencing slow service',
               rpcBlockNumber: 19492430,
               status: 'degraded',
               subgraphBlockNumber: 19492419,
             },
           },
         },
-        errors: [
-          {
-            id: 'subgraph',
-            title: 'Experiencing slow service',
-            source: {
-              pointer: '/data/attributes/subgraph/subgraphBlockNumber',
-            },
-          },
-        ],
       })
       .expect('Content-Type', 'application/vnd.api+json');
   });
@@ -138,21 +130,13 @@ describe('GET /api/status', function () {
           type: 'status',
           attributes: {
             subgraph: {
+              details: 'Error checking status',
               rpcBlockNumber: 19492430,
-              status: 'degraded',
+              status: 'unknown',
               subgraphBlockNumber: null,
             },
           },
         },
-        errors: [
-          {
-            id: 'subgraph',
-            title: 'Error checking status',
-            source: {
-              service: 'subgraph',
-            },
-          },
-        ],
       })
       .expect('Content-Type', 'application/vnd.api+json');
 
@@ -178,21 +162,13 @@ describe('GET /api/status', function () {
           type: 'status',
           attributes: {
             subgraph: {
+              details: 'Error checking status',
               rpcBlockNumber: null,
-              status: 'degraded',
+              status: 'unknown',
               subgraphBlockNumber: 19492428,
             },
           },
         },
-        errors: [
-          {
-            id: 'subgraph',
-            title: 'Error checking status',
-            source: {
-              service: 'web3-http',
-            },
-          },
-        ],
       })
       .expect('Content-Type', 'application/vnd.api+json');
 

--- a/packages/hub/node-tests/routes/status-test.ts
+++ b/packages/hub/node-tests/routes/status-test.ts
@@ -115,6 +115,7 @@ describe('GET /api/status', function () {
         errors: [
           {
             id: 'subgraph',
+            title: 'Experiencing slow service',
             source: {
               pointer: '/data/attributes/subgraph/subgraphBlockNumber',
             },
@@ -146,6 +147,7 @@ describe('GET /api/status', function () {
         errors: [
           {
             id: 'subgraph',
+            title: 'Error checking status',
             source: {
               service: 'subgraph',
             },
@@ -185,6 +187,7 @@ describe('GET /api/status', function () {
         errors: [
           {
             id: 'subgraph',
+            title: 'Error checking status',
             source: {
               service: 'web3-http',
             },

--- a/packages/hub/node-tests/routes/status-test.ts
+++ b/packages/hub/node-tests/routes/status-test.ts
@@ -112,6 +112,14 @@ describe('GET /api/status', function () {
             },
           },
         },
+        errors: [
+          {
+            id: 'subgraph',
+            source: {
+              pointer: '/data/attributes/subgraph/subgraphBlockNumber',
+            },
+          },
+        ],
       })
       .expect('Content-Type', 'application/vnd.api+json');
   });
@@ -135,6 +143,14 @@ describe('GET /api/status', function () {
             },
           },
         },
+        errors: [
+          {
+            id: 'subgraph',
+            source: {
+              service: 'subgraph',
+            },
+          },
+        ],
       })
       .expect('Content-Type', 'application/vnd.api+json');
 
@@ -166,6 +182,14 @@ describe('GET /api/status', function () {
             },
           },
         },
+        errors: [
+          {
+            id: 'subgraph',
+            source: {
+              service: 'web3-http',
+            },
+          },
+        ],
       })
       .expect('Content-Type', 'application/vnd.api+json');
 

--- a/packages/hub/node-tests/routes/status-test.ts
+++ b/packages/hub/node-tests/routes/status-test.ts
@@ -47,8 +47,7 @@ class StubWeb3 {
   }
 }
 
-// eslint-disable-next-line mocha/no-exclusive-tests
-describe.only('GET /api/status', function () {
+describe('GET /api/status', function () {
   this.beforeEach(function () {
     Sentry.init({
       dsn: 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001',

--- a/packages/hub/node-tests/routes/status-test.ts
+++ b/packages/hub/node-tests/routes/status-test.ts
@@ -1,0 +1,88 @@
+import { registry, setupHub } from '../helpers/server';
+
+let stubWeb3Available = true;
+
+let subgraphBlockNumber = 19492428;
+
+class StubSubgraph {
+  async getMeta() {
+    return {
+      data: {
+        _meta: {
+          block: {
+            number: subgraphBlockNumber,
+          },
+          hasIndexingErrors: false,
+        },
+      },
+    };
+  }
+}
+
+class StubWeb3 {
+  isAvailable() {
+    return Promise.resolve(stubWeb3Available);
+  }
+  getInstance() {
+    return {
+      eth: {
+        getBlockNumber: async () => 19492430,
+      },
+    };
+  }
+}
+
+// eslint-disable-next-line mocha/no-exclusive-tests
+describe.only('GET /api/status', function () {
+  this.beforeEach(function () {
+    registry(this).register('subgraph', StubSubgraph);
+    registry(this).register('web3-http', StubWeb3);
+  });
+
+  let { request } = setupHub(this);
+
+  this.beforeEach(async function () {
+    subgraphBlockNumber = 19492428;
+    stubWeb3Available = true;
+  });
+
+  it('reports status information', async function () {
+    await request()
+      .get('/api/status')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(200)
+      .expect({
+        data: {
+          type: 'status',
+          attributes: {
+            rpcBlockNumber: 19492430,
+            status: 'healthy',
+            subgraphBlockNumber: 19492428,
+          },
+        },
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('reports degraded status when the subgraph is behind', async function () {
+    subgraphBlockNumber = 19492419;
+
+    await request()
+      .get('/api/status')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(200)
+      .expect({
+        data: {
+          type: 'status',
+          attributes: {
+            rpcBlockNumber: 19492430,
+            status: 'degraded',
+            subgraphBlockNumber: 19492419,
+          },
+        },
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+});

--- a/packages/hub/node-tests/routes/status-test.ts
+++ b/packages/hub/node-tests/routes/status-test.ts
@@ -82,9 +82,11 @@ describe('GET /api/status', function () {
         data: {
           type: 'status',
           attributes: {
-            rpcBlockNumber: 19492430,
-            status: 'operational',
-            subgraphBlockNumber: 19492428,
+            subgraph: {
+              rpcBlockNumber: 19492430,
+              status: 'operational',
+              subgraphBlockNumber: 19492428,
+            },
           },
         },
       })
@@ -103,9 +105,11 @@ describe('GET /api/status', function () {
         data: {
           type: 'status',
           attributes: {
-            rpcBlockNumber: 19492430,
-            status: 'degraded',
-            subgraphBlockNumber: 19492419,
+            subgraph: {
+              rpcBlockNumber: 19492430,
+              status: 'degraded',
+              subgraphBlockNumber: 19492419,
+            },
           },
         },
       })
@@ -124,9 +128,11 @@ describe('GET /api/status', function () {
         data: {
           type: 'status',
           attributes: {
-            rpcBlockNumber: 19492430,
-            status: 'degraded',
-            subgraphBlockNumber: null,
+            subgraph: {
+              rpcBlockNumber: 19492430,
+              status: 'degraded',
+              subgraphBlockNumber: null,
+            },
           },
         },
       })
@@ -153,9 +159,11 @@ describe('GET /api/status', function () {
         data: {
           type: 'status',
           attributes: {
-            rpcBlockNumber: null,
-            status: 'degraded',
-            subgraphBlockNumber: 19492428,
+            subgraph: {
+              rpcBlockNumber: null,
+              status: 'degraded',
+              subgraphBlockNumber: 19492428,
+            },
           },
         },
       })

--- a/packages/hub/routes/status.ts
+++ b/packages/hub/routes/status.ts
@@ -50,9 +50,11 @@ export default class StatusRoute {
       data: {
         type: 'status',
         attributes: {
-          status,
-          subgraphBlockNumber,
-          rpcBlockNumber,
+          subgraph: {
+            status,
+            subgraphBlockNumber,
+            rpcBlockNumber,
+          },
         },
       },
     };

--- a/packages/hub/routes/status.ts
+++ b/packages/hub/routes/status.ts
@@ -1,0 +1,42 @@
+import Koa from 'koa';
+import autoBind from 'auto-bind';
+import { inject } from '@cardstack/di';
+
+const DEGRADED_THRESHOLD = 10;
+
+export default class StatusRoute {
+  subgraph = inject('subgraph');
+  web3 = inject('web3-http', { as: 'web3' });
+
+  constructor() {
+    autoBind(this);
+  }
+
+  async get(ctx: Koa.Context) {
+    let subgraphMeta = await this.subgraph.getMeta();
+
+    let subgraphBlockNumber = subgraphMeta.data._meta.block.number;
+    let rpcBlockNumber = await this.web3.getInstance().eth.getBlockNumber();
+
+    let status = rpcBlockNumber - subgraphBlockNumber >= DEGRADED_THRESHOLD ? 'degraded' : 'healthy';
+
+    ctx.status = 200;
+    ctx.body = {
+      data: {
+        type: 'status',
+        attributes: {
+          status,
+          subgraphBlockNumber,
+          rpcBlockNumber,
+        },
+      },
+    };
+    ctx.type = 'application/vnd.api+json';
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'status-route': StatusRoute;
+  }
+}

--- a/packages/hub/routes/status.ts
+++ b/packages/hub/routes/status.ts
@@ -42,7 +42,7 @@ export default class StatusRoute {
     let status = 'degraded';
 
     if (rpcBlockNumber && subgraphBlockNumber && rpcBlockNumber - subgraphBlockNumber < DEGRADED_THRESHOLD) {
-      status = 'healthy';
+      status = 'operational';
     }
 
     ctx.status = 200;

--- a/packages/hub/routes/status.ts
+++ b/packages/hub/routes/status.ts
@@ -48,6 +48,7 @@ export default class StatusRoute {
     } else if (!rpcBlockNumber) {
       errors.push({
         id: 'subgraph',
+        title: 'Error checking status',
         source: {
           service: 'web3-http',
         },
@@ -55,6 +56,7 @@ export default class StatusRoute {
     } else if (!subgraphBlockNumber) {
       errors.push({
         id: 'subgraph',
+        title: 'Error checking status',
         source: {
           service: 'subgraph',
         },
@@ -62,6 +64,7 @@ export default class StatusRoute {
     } else {
       errors.push({
         id: 'subgraph',
+        title: 'Experiencing slow service',
         source: {
           pointer: '/data/attributes/subgraph/subgraphBlockNumber',
         },

--- a/packages/hub/routes/status.ts
+++ b/packages/hub/routes/status.ts
@@ -40,35 +40,17 @@ export default class StatusRoute {
       });
     }
 
-    let status = 'degraded';
-    let errors = [];
+    let status;
+    let details;
 
     if (rpcBlockNumber && subgraphBlockNumber && rpcBlockNumber - subgraphBlockNumber < DEGRADED_THRESHOLD) {
       status = 'operational';
-    } else if (!rpcBlockNumber) {
-      errors.push({
-        id: 'subgraph',
-        title: 'Error checking status',
-        source: {
-          service: 'web3-http',
-        },
-      });
-    } else if (!subgraphBlockNumber) {
-      errors.push({
-        id: 'subgraph',
-        title: 'Error checking status',
-        source: {
-          service: 'subgraph',
-        },
-      });
+    } else if (!rpcBlockNumber || !subgraphBlockNumber) {
+      details = 'Error checking status';
+      status = 'unknown';
     } else {
-      errors.push({
-        id: 'subgraph',
-        title: 'Experiencing slow service',
-        source: {
-          pointer: '/data/attributes/subgraph/subgraphBlockNumber',
-        },
-      });
+      details = 'Experiencing slow service';
+      status = 'degraded';
     }
 
     let body: JSONAPIDocument = {
@@ -84,8 +66,8 @@ export default class StatusRoute {
       },
     };
 
-    if (errors.length > 0) {
-      body.errors = errors;
+    if (details) {
+      body.data.attributes.subgraph.details = details;
     }
 
     ctx.status = 200;

--- a/packages/hub/services/api-router.ts
+++ b/packages/hub/services/api-router.ts
@@ -11,6 +11,7 @@ export default class APIRouter {
   boomRoute = inject('boom-route', { as: 'boomRoute' });
   exchangeRatesRoute = inject('exchange-rates-route', { as: 'exchangeRatesRoute' });
   sessionRoute = inject('session-route', { as: 'sessionRoute' });
+  statusRoute = inject('status-route', { as: 'statusRoute' });
   prepaidCardColorSchemesRoute = inject('prepaid-card-color-schemes-route', {
     as: 'prepaidCardColorSchemesRoute',
   });
@@ -47,6 +48,7 @@ export default class APIRouter {
       merchantInfosRoute,
       custodialWalletRoute,
       sessionRoute,
+      statusRoute,
       ordersRoute,
       reservationsRoute,
       inventoryRoute,
@@ -60,6 +62,7 @@ export default class APIRouter {
     apiSubrouter.get('/exchange-rates', exchangeRatesRoute.get);
     apiSubrouter.get('/session', sessionRoute.get);
     apiSubrouter.post('/session', parseBody, sessionRoute.post);
+    apiSubrouter.get('/status', statusRoute.get);
     apiSubrouter.get('/prepaid-card-color-schemes', prepaidCardColorSchemesRoute.get);
     apiSubrouter.get('/prepaid-card-patterns', prepaidCardPatternsRoute.get);
     apiSubrouter.post('/prepaid-card-customizations', parseBody, prepaidCardCustomizationsRoute.post);

--- a/packages/hub/services/subgraph.ts
+++ b/packages/hub/services/subgraph.ts
@@ -51,6 +51,28 @@ const provisionedPrepaidCardQuery = `
   }
 `;
 
+export interface MetaSubgraph {
+  data: {
+    _meta: {
+      hasIndexingErrors: boolean;
+      block: {
+        number: number;
+      };
+    };
+  };
+}
+
+const metaQuery = `
+  query {
+    _meta {
+      hasIndexingErrors
+      block {
+        number
+      }
+    }
+  }
+`;
+
 export default class Subgraph {
   // we use the subgraph to wait for the prepaid card provisioning to be mined
   // so that the SDK safe API results are consistent with the new prepaid card
@@ -112,6 +134,10 @@ export default class Subgraph {
       }
     `
     )) as InventorySubgraph;
+  }
+
+  async getMeta() {
+    return (await gqlQuery(network, metaQuery)) as MetaSubgraph;
   }
 }
 

--- a/packages/hub/utils/jsonapi-document.ts
+++ b/packages/hub/utils/jsonapi-document.ts
@@ -1,4 +1,5 @@
 export interface JSONAPIDocument {
   data: any;
   included?: any[];
+  errors?: any[];
 }


### PR DESCRIPTION
This is a simple `GET /api/status` endpoint that reports degraded status if the subgraph is ≥10 blocks behind the RPC node. It has opportunities for improvement like adding status messages from a table, checking on the subgraph’s `hasIndexingErrors` value, and caching.