### PR TITLE
Worker job options

### DIFF
--- a/packages/hub/node-tests/tasks/notify-merchant-claim-test.ts
+++ b/packages/hub/node-tests/tasks/notify-merchant-claim-test.ts
@@ -18,6 +18,7 @@ const mockData: {
   get queryReturnValue() {
     return {
       data: {
+        timestamp: '0',
         merchantClaims: this.value ? [this.value] : [],
       },
     };
@@ -82,6 +83,7 @@ describe('NotifyMerchantClaimTask', function () {
 
   it('adds a send-notifications job for the merchant’s owner', async function () {
     mockData.value = {
+      timestamp: '0',
       merchantSafe: {
         id: 'merchant-safe-address',
         infoDid: 'did:cardstack:1m1C1LK4xoVSyybjNRcLB4APbc07954765987f62',
@@ -125,6 +127,7 @@ describe('NotifyMerchantClaimTask', function () {
 
     merchantInfoShouldError = true;
     mockData.value = {
+      timestamp: '0',
       merchantSafe: {
         id: 'merchant-safe-address',
         infoDid: 'did:cardstack:1m1C1LK4xoVSyybjNRcLB4APbc07954765987f62',
@@ -168,6 +171,7 @@ describe('NotifyMerchantClaimTask', function () {
 
   it('omits the merchant name when there is no DID', async function () {
     mockData.value = {
+      timestamp: '0',
       merchantSafe: {
         id: 'merchant-safe-address',
         infoDid: undefined,

--- a/packages/hub/node-tests/tasks/notify-merchant-claim-test.ts
+++ b/packages/hub/node-tests/tasks/notify-merchant-claim-test.ts
@@ -1,6 +1,9 @@
 import { Job, TaskSpec } from 'graphile-worker';
 import { registry, setupHub } from '../helpers/server';
-import NotifyMerchantClaim, { MerchantClaimsQueryResult } from '../../tasks/notify-merchant-claim';
+import NotifyMerchantClaim, {
+  MerchantClaimsQueryResult,
+  MERCHANT_CLAIM_EXPIRY_TIME,
+} from '../../tasks/notify-merchant-claim';
 import { expect } from 'chai';
 import sentryTestkit from 'sentry-testkit';
 import * as Sentry from '@sentry/node';
@@ -18,7 +21,7 @@ const mockData: {
   get queryReturnValue() {
     return {
       data: {
-        timestamp: '0',
+        timestamp: '0', // because timestamp is 0, the sendBy will be the expiry time
         merchantClaims: this.value ? [this.value] : [],
       },
     };
@@ -107,12 +110,14 @@ describe('NotifyMerchantClaimTask', function () {
         notificationId: 'sokol::a::123::eoa-address',
         notificationType: 'merchant_claim',
         pushClientId: '123',
+        sendBy: MERCHANT_CLAIM_EXPIRY_TIME,
       },
       {
         notificationBody: 'You just claimed 1155 DAI.CPXD from your Mandello business account',
         notificationId: 'sokol::a::456::eoa-address',
         notificationType: 'merchant_claim',
         pushClientId: '456',
+        sendBy: MERCHANT_CLAIM_EXPIRY_TIME,
       },
     ]);
   });
@@ -153,12 +158,14 @@ describe('NotifyMerchantClaimTask', function () {
         notificationId: 'sokol::a::123::eoa-address',
         notificationType: 'merchant_claim',
         pushClientId: '123',
+        sendBy: MERCHANT_CLAIM_EXPIRY_TIME,
       },
       {
         notificationBody: 'You just claimed 1155 DAI.CPXD from your business account',
         notificationId: 'sokol::a::456::eoa-address',
         notificationType: 'merchant_claim',
         pushClientId: '456',
+        sendBy: MERCHANT_CLAIM_EXPIRY_TIME,
       },
     ]);
 
@@ -197,12 +204,14 @@ describe('NotifyMerchantClaimTask', function () {
         notificationId: 'sokol::a::123::eoa-address',
         notificationType: 'merchant_claim',
         pushClientId: '123',
+        sendBy: MERCHANT_CLAIM_EXPIRY_TIME,
       },
       {
         notificationBody: 'You just claimed 1155 DAI.CPXD from your business account',
         notificationId: 'sokol::a::456::eoa-address',
         notificationType: 'merchant_claim',
         pushClientId: '456',
+        sendBy: MERCHANT_CLAIM_EXPIRY_TIME,
       },
     ]);
   });

--- a/packages/hub/node-tests/tasks/send-notifications-test.ts
+++ b/packages/hub/node-tests/tasks/send-notifications-test.ts
@@ -9,7 +9,7 @@ import * as Sentry from '@sentry/node';
 import sentryTestkit from 'sentry-testkit';
 
 // https://github.com/graphile/worker/blob/e3176eab42ada8f4f3718192bada776c22946583/__tests__/helpers.ts#L135
-export function makeMockJob(taskIdentifier: string): Job {
+function makeMockJob(taskIdentifier: string): Job {
   const createdAt = new Date(Date.now() - 12345678);
   return {
     id: String(Math.floor(Math.random() * 4294967296)),
@@ -39,10 +39,10 @@ let helpers = makeJobHelpers({}, makeMockJob('send-notifications'), {
 
 const messageID = 'firebase-message-id';
 let createPushNotification: (prefix: string) => PushNotificationData = (prefix = '') => ({
-  notificationId: `${prefix}-mock-notification-id`,
+  notificationId: `${prefix}mock-notification-id`,
   notificationTitle: `${prefix}notification-title`,
   notificationBody: `${prefix}notification-body`,
-  notificationData: [],
+  notificationData: {},
   notificationType: `${prefix}mock`,
   pushClientId: 'push-client-id',
 });
@@ -50,6 +50,8 @@ let existingNotification = createPushNotification('existing-');
 let newlyAddedNotification = createPushNotification('newly-added-');
 let expiredNotification = createPushNotification('expired-');
 expiredNotification.sendBy = Date.now() - 1;
+let evergreenNotification = createPushNotification('evergreen-');
+evergreenNotification.sendBy = undefined;
 
 let lastSentData: any;
 let notificationSent = false;
@@ -244,5 +246,19 @@ describe('SendNotificationsTask expired notifications', function () {
       notificationId: expiredNotification.notificationId,
       notificationType: expiredNotification.notificationType,
     });
+  });
+
+  it('should not expire a notification without a sendBy', async function () {
+    await subject.perform(evergreenNotification, helpers);
+
+    expect(lastSentData).to.deep.equal({
+      notification: {
+        body: evergreenNotification.notificationBody,
+        title: evergreenNotification.notificationTitle,
+      },
+      data: evergreenNotification.notificationData,
+      token: evergreenNotification.pushClientId,
+    });
+    expect(notificationSent).to.equal(true);
   });
 });

--- a/packages/hub/tasks/notify-customer-payment.ts
+++ b/packages/hub/tasks/notify-customer-payment.ts
@@ -120,7 +120,11 @@ export default class NotifyCustomerPayment {
         notificationBody,
         notificationType: 'customer_payment',
       };
-      await this.workerClient.addJob('send-notifications', notification);
+      await this.workerClient.addJob('send-notifications', notification, {
+        jobKey: notification.notificationId,
+        jobKeyMode: 'preserve_run_at',
+        maxAttempts: 8, // 8th attempt is estimated to run at 28 mins. https://github.com/graphile/worker#exponential-backoff
+      });
     }
   }
 }

--- a/packages/hub/tasks/notify-merchant-claim.ts
+++ b/packages/hub/tasks/notify-merchant-claim.ts
@@ -9,6 +9,8 @@ import NotificationPreferenceService from '../services/push-notifications/prefer
 import { PushNotificationData } from './send-notifications';
 import { generateContractEventNotificationId } from '../utils/notifications';
 
+export const MERCHANT_CLAIM_EXPIRY_TIME = 30 * 60 * 1000;
+
 export interface MerchantClaimsQueryResult {
   data: {
     merchantClaims: {
@@ -103,7 +105,7 @@ export default class NotifyMerchantClaim {
 
     for (const pushClientId of pushClientIdsForNotification) {
       let notification: PushNotificationData = {
-        sendBy: parseInt(result.timestamp) * 1000 + 30 * 60 * 1000,
+        sendBy: parseInt(result.timestamp) * 1000 + MERCHANT_CLAIM_EXPIRY_TIME,
         notificationId: generateContractEventNotificationId({
           network,
           ownerAddress,

--- a/packages/hub/tasks/notify-merchant-claim.ts
+++ b/packages/hub/tasks/notify-merchant-claim.ts
@@ -12,6 +12,7 @@ import { generateContractEventNotificationId } from '../utils/notifications';
 export interface MerchantClaimsQueryResult {
   data: {
     merchantClaims: {
+      timestamp: string;
       merchantSafe: {
         id: string;
         infoDid: string | undefined;
@@ -28,6 +29,7 @@ export interface MerchantClaimsQueryResult {
 const merchantClaimsQuery = `
 query($txn: String!) {
   merchantClaims(where: { transaction: $txn }) {
+    timestamp
     merchantSafe {
       id
       infoDid
@@ -101,6 +103,7 @@ export default class NotifyMerchantClaim {
 
     for (const pushClientId of pushClientIdsForNotification) {
       let notification: PushNotificationData = {
+        sendBy: parseInt(result.timestamp) * 1000 + 30 * 60 * 1000,
         notificationId: generateContractEventNotificationId({
           network,
           ownerAddress,

--- a/packages/hub/tasks/notify-merchant-claim.ts
+++ b/packages/hub/tasks/notify-merchant-claim.ts
@@ -112,7 +112,11 @@ export default class NotifyMerchantClaim {
         notificationType: 'merchant_claim',
       };
 
-      await this.workerClient.addJob('send-notifications', notification);
+      await this.workerClient.addJob('send-notifications', notification, {
+        jobKey: notification.notificationId,
+        jobKeyMode: 'preserve_run_at',
+        maxAttempts: 8, // 8th attempt is estimated to run at 28 mins. https://github.com/graphile/worker#exponential-backoff
+      });
     }
   }
 }


### PR DESCRIPTION
- Adds graphile worker options to retry up to 8 times / half an hour
- Adds deduplication via job key (job key mode is `preserve_run_at` to be forgiving for convenience of things like manual retries
- Adds `sendBy` property to `send-notifications` task payload so that notifications' expiry times can be set
- Uses `sendBy` to expire `merchant_claim` notifications