### PR TITLE
prevent dynamic ts imports from breaking hub rebuilds

### DIFF
--- a/packages/cardpay-sdk/sdk/version-resolver.ts
+++ b/packages/cardpay-sdk/sdk/version-resolver.ts
@@ -102,12 +102,7 @@ export async function getABI(contractName: string, web3: Web3): Promise<AbiItem[
   for (let version of protocolVersions) {
     // we have to exclude .d.ts files because webpack tries to build
     // these for the dynamic import case.
-    versionMap[version.replace('v', '')] = (
-      await import(
-        /* webpackExclude: /\.d\.ts$/ */
-        `../contracts/abi/${version}/${contractName}.ts`
-      )
-    ).default;
+    versionMap[version.replace('v', '')] = (await import(`../contracts/abi/${version}/${contractName}.ts`)).default;
   }
   let abi = getAPIVersion(versionMap, protocolVersion);
   return abi;

--- a/packages/cardpay-sdk/sdk/version-resolver.ts
+++ b/packages/cardpay-sdk/sdk/version-resolver.ts
@@ -100,7 +100,14 @@ export async function getABI(contractName: string, web3: Web3): Promise<AbiItem[
   let protocolVersion = await versionManager.methods.version().call();
   let versionMap: { [version: string]: AbiItem[] } = {};
   for (let version of protocolVersions) {
-    versionMap[version.replace('v', '')] = (await import(`../contracts/abi/${version}/${contractName}.ts`)).default;
+    // we have to exclude .d.ts files because webpack tries to build
+    // these for the dynamic import case.
+    versionMap[version.replace('v', '')] = (
+      await import(
+        /* webpackExclude: /\.d\.ts$/ */
+        `../contracts/abi/${version}/${contractName}.ts`
+      )
+    ).default;
   }
   let abi = getAPIVersion(versionMap, protocolVersion);
   return abi;

--- a/packages/cardpay-sdk/sdk/version-resolver.ts
+++ b/packages/cardpay-sdk/sdk/version-resolver.ts
@@ -100,8 +100,6 @@ export async function getABI(contractName: string, web3: Web3): Promise<AbiItem[
   let protocolVersion = await versionManager.methods.version().call();
   let versionMap: { [version: string]: AbiItem[] } = {};
   for (let version of protocolVersions) {
-    // we have to exclude .d.ts files because webpack tries to build
-    // these for the dynamic import case.
     versionMap[version.replace('v', '')] = (await import(`../contracts/abi/${version}/${contractName}.ts`)).default;
   }
   let abi = getAPIVersion(versionMap, protocolVersion);

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -114,6 +114,7 @@
     "@types/yargs": "^17.0.2",
     "chai": "^4.3.4",
     "copy-webpack-plugin": "^10.0.0",
+    "ignore-loader": "^0.1.2",
     "json-stable-stringify": "^1.0.1",
     "mocha": "^8.3.2",
     "moment-timezone": "^0.5.33",

--- a/packages/hub/webpack.config.ts
+++ b/packages/hub/webpack.config.ts
@@ -169,9 +169,13 @@ module.exports = {
 
     rules: [
       {
-        test: /\.ts$/,
+        test: /(?<!\.d)\.ts?$/,
         use: 'ts-loader',
         exclude: /node_modules/,
+      },
+      {
+        test: /\.d\.ts$/,
+        loader: 'ignore-loader',
       },
       {
         test: /\.node$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8160,7 +8160,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@4.1.4, axe-core@^4.1.4:
+axe-core@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.4.tgz#f19cd99a84ee32a318b9c5b5bb8ed373ad94f143"
   integrity sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==
@@ -12552,7 +12552,7 @@ elliptic@6.5.4, elliptic@^6.0.0, elliptic@^6.4.0, elliptic@^6.5.2:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-ember-a11y-testing@4.0.3, ember-a11y-testing@^4.0.3:
+ember-a11y-testing@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-4.0.3.tgz#1f5c91266d39ea5b20614b0d294a562079887ac7"
   integrity sha512-Q7nq2crC9+bT+sZi/BORAM4FUhI080edEhnpsvB6vdkD9Ro2Rg4DksQs5Be65/DM108VNDMtbHZtrPS060Mzcw==
@@ -17909,6 +17909,11 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
+
+ignore-loader@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ignore-loader/-/ignore-loader-0.1.2.tgz#d81f240376d0ba4f0d778972c3ad25874117a463"
+  integrity sha1-2B8kA3bQuk8Nd4lyw60lh0EXpGM=
 
 ignore-walk@^3.0.1, ignore-walk@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
Webpack was trying to compile the `.d.ts` files - happens when `yarn rebuild` is run or sequential `yarn build`s are run without a `yarn clean` in between. This change excludes `.d.ts`. This works for consuming this package via hub's webpack config. 