### PR TITLE
Add degradation notification

### DIFF
--- a/packages/web-client/app/services/degradation-detector.ts
+++ b/packages/web-client/app/services/degradation-detector.ts
@@ -1,0 +1,71 @@
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { task, TaskGenerator, timeout } from 'ember-concurrency';
+import * as Sentry from '@sentry/browser';
+import { taskFor } from 'ember-concurrency-ts';
+
+interface DegradationFileData {
+  status?: string;
+  notificationTitle?: string;
+  notificationBody?: string;
+}
+
+export default class DegradationDetector extends Service {
+  @tracked notificationShown: boolean = false;
+  @tracked status: 'degraded' | 'operational' = 'operational';
+  @tracked notificationTitle: string | null = null;
+  @tracked notificationBody: string | null = null;
+
+  constructor() {
+    super(...arguments);
+
+    taskFor(this.pollForStatusTask).perform();
+  }
+
+  @task *pollForStatusTask(): TaskGenerator<void> {
+    while (true) {
+      let statusData = yield this.getDegradationStatusData();
+
+      if (statusData.status === 'degraded') {
+        this.status = 'degraded';
+        this.notificationTitle = statusData.notificationTitle;
+        this.notificationBody = statusData.notificationBody;
+
+        console.log(`${this.notificationTitle}\n\n${this.notificationBody}`);
+      } else {
+        // TODO: show potential warnings from https://github.com/cardstack/cardstack/pull/2484
+
+        this.status = 'operational';
+        this.notificationTitle = null;
+        this.notificationBody = null;
+      }
+
+      yield timeout(1000 * 60);
+    }
+  }
+
+  async getDegradationStatusData(): Promise<DegradationFileData> {
+    let fileUrl =
+      'https://cardstack-status.s3.amazonaws.com/cardstack-status.json';
+
+    try {
+      let response = await fetch(fileUrl);
+      let data = await response.json();
+
+      return {
+        status: data.status,
+        notificationTitle: data.title,
+        notificationBody: data.body,
+      };
+    } catch (_) {
+      Sentry.captureException(`Unable to fetch status file from ${fileUrl}`);
+      return {};
+    }
+  }
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    'degradation-detector': DegradationDetector;
+  }
+}


### PR DESCRIPTION
Ticket: [CS-2752](https://linear.app/cardstack/issue/CS-2752/service-degradation-notice-in-dapp)

This implementation depends on a `cardstack-status.json` file that should be changed manually when we want to display the service degradation information. I created a new bucket in our production account named `cardstack-status`. Link to the file: https://cardstack-status.s3.amazonaws.com/cardstack-status.json. Fetching an independently hosted file is more robust than getting the info from the hub (in cases when the hub goes down). 

The detector continuously polls for this file and sets the tracked fields (`status`, `notificationTitle`, `notificationBody`) which can be used to display info in the banner (waiting for the design). 

A couple of points to discuss:

1. Ease of putting up / removing a degradation notice manually

Opening the production AWS account, editing the file, and reuploading it can be a bit cumbersome and error prone. Should we look into making a command for this? Maybe adding a command to Cardie bot?

2. Design / UX

Perhaps we should consider making a floating banner so that it stays on top even when a modal is opened (e.g. the workflow modal). 

1. Should the banner be dismissible? 
2. If yes, during the degradation, should we keep opening it after a while even when the user closes it? Or not allow dismissing it at all? 
3. And when the degradation is over, should we just close the banner, or replace it with a success message, e.g. "All systems restored"?

TODO: 
- [ ] Design + implement UI
- [ ] Separate staging/prod bucket
- [ ] Make sure the file doesn't get cached (for too long)
