### PR TITLE
removing the timeout test for corde

### DIFF
--- a/packages/hub/bot-tests/services/discord-bots/hub-bot/commands-test.ts
+++ b/packages/hub/bot-tests/services/discord-bots/hub-bot/commands-test.ts
@@ -67,11 +67,6 @@ it(`can respond to a guild command`, async function () {
   expect('ping').toReturn('pong');
 });
 
-it(`does not respond in a non-allowed channel`, async function () {
-  await setupTest();
-  expect('ping', '898897116913623050').not.toReturn('pong');
-});
-
 it(`can start a conversation for a beta tester that has not received an airdrop`, async function () {
   await setupTest();
   expect('card-drop').toMessageContentContains(`Connect your Card Wallet app to receive your prepaid card`);

--- a/packages/hub/bot-tests/services/discord-bots/hub-bot/commands-test.ts
+++ b/packages/hub/bot-tests/services/discord-bots/hub-bot/commands-test.ts
@@ -66,13 +66,3 @@ it(`can respond to a guild command`, async function () {
   await setupTest();
   expect('ping').toReturn('pong');
 });
-
-it(`can start a conversation for a beta tester that has not received an airdrop`, async function () {
-  await setupTest();
-  expect('card-drop').toMessageContentContains(`Connect your Card Wallet app to receive your prepaid card`);
-  // arg, corde asserts need to start with a command, since we have entered a DM
-  // there there is no way to make any more assertions since the following
-  // responses are just text and not commands (since bots can't DM each other
-  // corde doesn't current provide any DM support--everything is command
-  // centric)
-});


### PR DESCRIPTION
we just need corde to be able to assert that the hub-bot can operate in a channel. the ping test is the only real test we need for that