### PR TITLE
[CS-1806] working toward compile error handling in indexers

### DIFF
--- a/packages/cardhost/app/lib/builder.ts
+++ b/packages/cardhost/app/lib/builder.ts
@@ -11,7 +11,10 @@ import type {
 import { RawCardDeserializer } from '@cardstack/core/src/raw-card-deserializer';
 import { fetchJSON } from './jsonapi-fetch';
 import config from 'cardhost/config/environment';
-import { Compiler, defineModules } from '@cardstack/core/src/compiler';
+import {
+  Compiler,
+  makeGloballyAddressable,
+} from '@cardstack/core/src/compiler';
 import { CSS_TYPE, JS_TYPE } from '@cardstack/core/src/utils/content';
 import dynamicCardTransform from './dynamic-card-transform';
 import { cardURL, encodeCardURL } from '@cardstack/core/src/utils';
@@ -143,8 +146,10 @@ export default class LocalRealm implements Builder {
     if (cardId) {
       let rawCard = await this.getRawCard(url);
       let compiledCard = await this.compiler.compile(rawCard);
-      let definedCard = defineModules(compiledCard, (local, type, src) =>
-        this.define(url, local, type, src)
+      let definedCard = makeGloballyAddressable(
+        url,
+        compiledCard,
+        (local, type, src) => this.define(url, local, type, src)
       );
       this.compiledCardCache.set(url, definedCard);
       return definedCard;

--- a/packages/cardhost/app/lib/builder.ts
+++ b/packages/cardhost/app/lib/builder.ts
@@ -59,7 +59,6 @@ export default class LocalRealm implements Builder {
   private remoteRawCards = new Map<string, RawCard>();
 
   private compiledCardCache = new Map<string, CompiledCard>();
-  private compiler: Compiler;
   private localModules = new Map<string, LocalModule>();
   private deserializer = new RawCardDeserializer();
 
@@ -67,9 +66,6 @@ export default class LocalRealm implements Builder {
     if (!ownRealmURL.endsWith('/')) {
       throw new Error(`realm URLs must have trailing slash`);
     }
-    this.compiler = new Compiler({
-      builder: this,
-    });
   }
 
   async load(url: string, format: Format): Promise<CardJSONResponse> {
@@ -145,7 +141,11 @@ export default class LocalRealm implements Builder {
     let cardId = this.parseOwnRealmURL(url);
     if (cardId) {
       let rawCard = await this.getRawCard(url);
-      let compiledCard = await this.compiler.compile(rawCard);
+      let compiler = new Compiler({
+        builder: this,
+        cardSource: rawCard,
+      });
+      let compiledCard = await compiler.compile();
       let definedCard = makeGloballyAddressable(
         url,
         compiledCard,

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -54,7 +54,7 @@ export class Compiler {
   async compile(cardSource: NewRawCard): Promise<CompiledCard<Unsaved, ModuleRef>>;
   async compile(cardSource: NewRawCard | RawCard): Promise<CompiledCard<Saved | Unsaved, ModuleRef>> {
     let options = {};
-    let modules: CompiledCard['modules'] = {};
+    let modules: CompiledCard<Unsaved, LocalRef>['modules'] = {};
     let schemaModule: ModuleRef | undefined = await this.prepareSchema(cardSource, options, modules);
     let meta = getMeta(options);
 
@@ -181,7 +181,7 @@ export class Compiler {
   private async prepareSchema(
     cardSource: NewRawCard,
     options: any,
-    modules: CompiledCard['modules']
+    modules: CompiledCard<Unsaved, LocalRef>['modules']
   ): Promise<LocalRef | undefined> {
     let schemaLocalFilePath = cardSource.schema;
     if (!schemaLocalFilePath) {
@@ -253,7 +253,7 @@ export class Compiler {
     cardSource: NewRawCard,
     fields: CompiledCard['fields'],
     parentCard: CompiledCard | undefined,
-    modules: CompiledCard['modules']
+    modules: CompiledCard<Unsaved, LocalRef>['modules']
   ) {
     let components: Partial<Pick<CompiledCard<Unsaved, ModuleRef>, Format>> = {};
     for (const format of FORMATS) {
@@ -267,7 +267,7 @@ export class Compiler {
     fields: CompiledCard['fields'],
     parentCard: CompiledCard | undefined,
     which: Format,
-    modules: CompiledCard['modules']
+    modules: CompiledCard<Unsaved, LocalRef>['modules']
   ): Promise<ComponentInfo<ModuleRef>> {
     let localFilePath = cardSource[which];
 
@@ -335,7 +335,7 @@ export class Compiler {
     debugPath: string,
     localFile: string,
     format: Format,
-    modules: CompiledCard['modules']
+    modules: CompiledCard<Unsaved, LocalRef>['modules']
   ): Promise<ComponentInfo<LocalRef>> {
     let options: CardComponentPluginOptions = {
       debugPath,
@@ -400,10 +400,11 @@ export function resolveCard(url: string, realm: string): string {
   return resolved;
 }
 
-export function defineModules<Identity extends Saved | Unsaved>(
-  card: CompiledCard<Identity, ModuleRef>,
+export function makeGloballyAddressable(
+  url: string,
+  card: CompiledCard<Saved | Unsaved, ModuleRef>,
   define: (localPath: string, type: string, source: string) => string
-): CompiledCard<Identity, GlobalRef> {
+): CompiledCard<Saved, GlobalRef> {
   let localToGlobal = new Map<string, string>();
 
   for (let [localPath, { type, source }] of Object.entries(card.modules)) {
@@ -432,7 +433,7 @@ export function defineModules<Identity extends Saved | Unsaved>(
   }
 
   return {
-    url: card.url,
+    url: url,
     realm: card.realm,
     adoptsFrom: card.adoptsFrom,
     fields: card.fields,

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -41,17 +41,23 @@ function getNonAssetFilePaths(sourceCard: RawCard<Unsaved>): (string | undefined
   return paths.filter(Boolean);
 }
 
-export class Compiler {
-  builder: Builder;
-  compiledBaseCard?: CompiledCard;
+export class Compiler<Identity extends Saved | Unsaved = Saved> {
+  private builder: Builder;
+  private cardSource: RawCard<Identity>;
 
-  constructor(params: { builder: Builder }) {
+  constructor(params: { builder: Builder; cardSource: RawCard<Identity> }) {
     this.builder = params.builder;
+    this.cardSource = params.cardSource;
   }
 
-  async compile<Identity extends Unsaved>(cardSource: RawCard<Identity>): Promise<CompiledCard<Identity, ModuleRef>> {
+  get dependencies(): string[] {
+    return [];
+  }
+
+  async compile(): Promise<CompiledCard<Identity, ModuleRef>> {
     let options = {};
     let modules: CompiledCard<Unsaved, LocalRef>['modules'] = {};
+    let { cardSource } = this;
     let schemaModule: ModuleRef | undefined = await this.prepareSchema(cardSource, options, modules);
     let meta = getMeta(options);
 

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -45,9 +45,9 @@ export interface CardId {
   id: string;
 }
 
-export interface NewRawCard {
+export interface RawCard<Identity extends Unsaved = Saved> {
+  id: Identity;
   realm: string;
-  id?: string;
 
   // Feature Files. Value is path inside the files list
   schema?: string;
@@ -65,10 +65,6 @@ export interface NewRawCard {
 
   // if this card contains data (as opposed to just schema & code), it goes here
   data?: Record<string, any> | undefined;
-}
-
-export interface RawCard extends NewRawCard {
-  id: string;
 }
 
 export function assertValidRawCard(obj: any): asserts obj is RawCard {
@@ -119,9 +115,9 @@ export interface GlobalRef {
 }
 export type ModuleRef = LocalRef | GlobalRef;
 export type Saved = string;
-export type Unsaved = undefined;
+export type Unsaved = string | undefined;
 
-export interface CompiledCard<Identity extends Saved | Unsaved = Saved, Ref extends ModuleRef = GlobalRef> {
+export interface CompiledCard<Identity extends Unsaved = Saved, Ref extends ModuleRef = GlobalRef> {
   url: Identity;
   realm: string;
   adoptsFrom?: CompiledCard<string, GlobalRef>;

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2020",
     "module": "commonjs",
     "declaration": true,
     "typeRoots": ["../../node_modules/@types", "../../types"],

--- a/packages/hub/config/default.cjs
+++ b/packages/hub/config/default.cjs
@@ -20,7 +20,8 @@ module.exports = {
     url: 'postgres://postgres:postgres@localhost:5432/hub_development',
     'migrations-dir': 'db/migrations',
     'migration-filename-format': 'utc',
-    'ignore-pattern': 'README.md|.*\\.ts|.*\\.js\\.map',
+    'ignore-pattern': 'README.md',
+    'check-order': false,
   },
   discord: {
     botId: '896093538297708564',

--- a/packages/hub/config/default.cjs
+++ b/packages/hub/config/default.cjs
@@ -20,7 +20,7 @@ module.exports = {
     url: 'postgres://postgres:postgres@localhost:5432/hub_development',
     'migrations-dir': 'db/migrations',
     'migration-filename-format': 'utc',
-    'ignore-pattern': 'README.md',
+    'ignore-pattern': 'README.md|.*\\.d\\.ts',
     'check-order': false,
   },
   discord: {

--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -728,7 +728,8 @@ CREATE TABLE public.cards (
     "searchData" jsonb,
     realm text NOT NULL,
     generation integer,
-    "compileErrors" jsonb
+    "compileErrors" jsonb,
+    deps text[]
 );
 
 
@@ -1481,7 +1482,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 19	20211206195559187_card-index-generations	2021-12-15 16:26:59.71672
 20	20211207151150639_sent-push-notifications	2021-12-15 16:26:59.71672
 21	20211207190527999_create-latest-event-block	2021-12-15 16:26:59.71672
-22	20211214163123421_card-index-errors	2021-12-15 16:26:59.71672
+23	20211214163123421_card-index-errors	2021-12-16 17:33:59.571247
 \.
 
 
@@ -1489,7 +1490,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 -- Name: pgmigrations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.pgmigrations_id_seq', 22, true);
+SELECT pg_catalog.setval('public.pgmigrations_id_seq', 23, true);
 
 
 --

--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 13.5
--- Dumped by pg_dump version 13.5
+-- Dumped from database version 13.5 (Debian 13.5-1.pgdg110+1)
+-- Dumped by pg_dump version 14.1
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -727,7 +727,8 @@ CREATE TABLE public.cards (
     ancestors text[],
     "searchData" jsonb,
     realm text NOT NULL,
-    generation integer
+    generation integer,
+    "compileErrors" jsonb
 );
 
 
@@ -1424,8 +1425,8 @@ ALTER TABLE graphile_worker.known_crontabs ENABLE ROW LEVEL SECURITY;
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 13.5
--- Dumped by pg_dump version 13.5
+-- Dumped from database version 13.5 (Debian 13.5-1.pgdg110+1)
+-- Dumped by pg_dump version 14.1
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -1443,14 +1444,14 @@ SET row_security = off;
 --
 
 COPY graphile_worker.migrations (id, ts) FROM stdin;
-1	2021-12-13 23:58:57.177179+08
-2	2021-12-13 23:58:57.177179+08
-3	2021-12-13 23:58:57.177179+08
-4	2021-12-13 23:58:57.177179+08
-5	2021-12-13 23:58:57.177179+08
-6	2021-12-13 23:58:57.177179+08
-7	2021-12-13 23:58:57.177179+08
-8	2021-12-13 23:58:57.177179+08
+1	2021-12-15 16:26:59.71672+00
+2	2021-12-15 16:26:59.71672+00
+3	2021-12-15 16:26:59.71672+00
+4	2021-12-15 16:26:59.71672+00
+5	2021-12-15 16:26:59.71672+00
+6	2021-12-15 16:26:59.71672+00
+7	2021-12-15 16:26:59.71672+00
+8	2021-12-15 16:26:59.71672+00
 \.
 
 
@@ -1459,27 +1460,28 @@ COPY graphile_worker.migrations (id, ts) FROM stdin;
 --
 
 COPY public.pgmigrations (id, name, run_on) FROM stdin;
-1	20210527151505645_create-prepaid-card-tables	2021-12-13 23:58:57.177179
-2	20210614080132698_create-prepaid-card-customizations-table	2021-12-13 23:58:57.177179
-3	20210623052200757_create-graphile-worker-schema	2021-12-13 23:58:57.177179
-4	20210809113449561_merchant-infos	2021-12-13 23:58:57.177179
-5	20210817184105100_wallet-orders	2021-12-13 23:58:57.177179
-6	20210920142313915_prepaid-card-reservations	2021-12-13 23:58:57.177179
-7	20210924200122612_order-indicies	2021-12-13 23:58:57.177179
-8	20211006090701108_create-card-spaces	2021-12-13 23:58:57.177179
-9	20211013155536724_card-index	2021-12-13 23:58:57.177179
-10	20211013173917696_beta-testers	2021-12-13 23:58:57.177179
-11	20211014131843187_add-fields-to-card-spaces	2021-12-13 23:58:57.177179
-12	20211020231214235_discord-bots	2021-12-13 23:58:57.177179
-13	20211105180905492_wyre-price-service	2021-12-13 23:58:57.177179
-14	20211110210324178_card-index-part-duex	2021-12-13 23:58:57.177179
-15	20211118084217151_create-uploads	2021-12-13 23:58:57.177179
-16	20211129083801382_create-push-notification-registrations	2021-12-13 23:58:57.177179
-17	20211129123635817_create-notification-types	2021-12-13 23:58:57.177179
-18	20211129130425303_create-notification-preferences	2021-12-13 23:58:57.177179
-19	20211206195559187_card-index-generations	2021-12-13 23:58:57.177179
-20	20211207151150639_sent-push-notifications	2021-12-13 23:58:57.177179
-21	20211207190527999_create-latest-event-block	2021-12-13 23:58:57.177179
+1	20210527151505645_create-prepaid-card-tables	2021-12-15 16:26:59.71672
+2	20210614080132698_create-prepaid-card-customizations-table	2021-12-15 16:26:59.71672
+3	20210623052200757_create-graphile-worker-schema	2021-12-15 16:26:59.71672
+4	20210809113449561_merchant-infos	2021-12-15 16:26:59.71672
+5	20210817184105100_wallet-orders	2021-12-15 16:26:59.71672
+6	20210920142313915_prepaid-card-reservations	2021-12-15 16:26:59.71672
+7	20210924200122612_order-indicies	2021-12-15 16:26:59.71672
+8	20211006090701108_create-card-spaces	2021-12-15 16:26:59.71672
+9	20211013155536724_card-index	2021-12-15 16:26:59.71672
+10	20211013173917696_beta-testers	2021-12-15 16:26:59.71672
+11	20211014131843187_add-fields-to-card-spaces	2021-12-15 16:26:59.71672
+12	20211020231214235_discord-bots	2021-12-15 16:26:59.71672
+13	20211105180905492_wyre-price-service	2021-12-15 16:26:59.71672
+14	20211110210324178_card-index-part-duex	2021-12-15 16:26:59.71672
+15	20211118084217151_create-uploads	2021-12-15 16:26:59.71672
+16	20211129083801382_create-push-notification-registrations	2021-12-15 16:26:59.71672
+17	20211129123635817_create-notification-types	2021-12-15 16:26:59.71672
+18	20211129130425303_create-notification-preferences	2021-12-15 16:26:59.71672
+19	20211206195559187_card-index-generations	2021-12-15 16:26:59.71672
+20	20211207151150639_sent-push-notifications	2021-12-15 16:26:59.71672
+21	20211207190527999_create-latest-event-block	2021-12-15 16:26:59.71672
+22	20211214163123421_card-index-errors	2021-12-15 16:26:59.71672
 \.
 
 
@@ -1487,7 +1489,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 -- Name: pgmigrations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.pgmigrations_id_seq', 21, true);
+SELECT pg_catalog.setval('public.pgmigrations_id_seq', 22, true);
 
 
 --

--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -922,6 +922,18 @@ CREATE TABLE public.push_notification_registrations (
 ALTER TABLE public.push_notification_registrations OWNER TO postgres;
 
 --
+-- Name: realm_metas; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.realm_metas (
+    realm text NOT NULL,
+    meta jsonb
+);
+
+
+ALTER TABLE public.realm_metas OWNER TO postgres;
+
+--
 -- Name: reservations; Type: TABLE; Schema: public; Owner: postgres
 --
 
@@ -1166,6 +1178,14 @@ ALTER TABLE ONLY public.prepaid_card_patterns
 
 ALTER TABLE ONLY public.push_notification_registrations
     ADD CONSTRAINT push_notification_registrations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: realm_metas realm_metas_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.realm_metas
+    ADD CONSTRAINT realm_metas_pkey PRIMARY KEY (realm);
 
 
 --
@@ -1484,7 +1504,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 19	20211206195559187_card-index-generations	2021-12-15 16:26:59.71672
 20	20211207151150639_sent-push-notifications	2021-12-15 16:26:59.71672
 21	20211207190527999_create-latest-event-block	2021-12-15 16:26:59.71672
-24	20211214163123421_card-index-errors	2021-12-17 15:55:08.870044
+25	20211214163123421_card-index-errors	2021-12-17 16:40:35.43273
 \.
 
 
@@ -1492,7 +1512,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 -- Name: pgmigrations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.pgmigrations_id_seq', 24, true);
+SELECT pg_catalog.setval('public.pgmigrations_id_seq', 25, true);
 
 
 --

--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -729,7 +729,9 @@ CREATE TABLE public.cards (
     realm text NOT NULL,
     generation integer,
     "compileErrors" jsonb,
-    deps text[]
+    deps text[],
+    raw jsonb,
+    compiled jsonb
 );
 
 
@@ -1482,7 +1484,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 19	20211206195559187_card-index-generations	2021-12-15 16:26:59.71672
 20	20211207151150639_sent-push-notifications	2021-12-15 16:26:59.71672
 21	20211207190527999_create-latest-event-block	2021-12-15 16:26:59.71672
-23	20211214163123421_card-index-errors	2021-12-16 17:33:59.571247
+24	20211214163123421_card-index-errors	2021-12-17 15:55:08.870044
 \.
 
 
@@ -1490,7 +1492,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 -- Name: pgmigrations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.pgmigrations_id_seq', 23, true);
+SELECT pg_catalog.setval('public.pgmigrations_id_seq', 24, true);
 
 
 --

--- a/packages/hub/db/migrations/20211214163123421_card-index-errors.ts
+++ b/packages/hub/db/migrations/20211214163123421_card-index-errors.ts
@@ -12,6 +12,11 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     raw: { type: 'jsonb' },
     compiled: { type: 'jsonb' },
   });
+
+  pgm.createTable('realm_metas', {
+    realm: { type: 'text', primaryKey: true },
+    meta: { type: 'jsonb' },
+  });
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
@@ -19,4 +24,5 @@ export async function down(pgm: MigrationBuilder): Promise<void> {
   pgm.dropColumn('cards', 'deps');
   pgm.dropColumn('cards', 'raw');
   pgm.dropColumn('cards', 'compiled');
+  pgm.dropTable('realm_metas');
 }

--- a/packages/hub/db/migrations/20211214163123421_card-index-errors.ts
+++ b/packages/hub/db/migrations/20211214163123421_card-index-errors.ts
@@ -3,13 +3,20 @@ import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
 export const shorthands: ColumnDefinitions | undefined = undefined;
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
+  // this is because we're repurposing "data" column
+  pgm.sql('DELETE FROM cards');
+
   pgm.addColumn('cards', {
     compileErrors: { type: 'jsonb' },
     deps: { type: 'text[]' },
+    raw: { type: 'jsonb' },
+    compiled: { type: 'jsonb' },
   });
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
   pgm.dropColumn('cards', 'compileErrors');
   pgm.dropColumn('cards', 'deps');
+  pgm.dropColumn('cards', 'raw');
+  pgm.dropColumn('cards', 'compiled');
 }

--- a/packages/hub/db/migrations/20211214163123421_card-index-errors.ts
+++ b/packages/hub/db/migrations/20211214163123421_card-index-errors.ts
@@ -5,9 +5,11 @@ export const shorthands: ColumnDefinitions | undefined = undefined;
 export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.addColumn('cards', {
     compileErrors: { type: 'jsonb' },
+    deps: { type: 'text[]' },
   });
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
   pgm.dropColumn('cards', 'compileErrors');
+  pgm.dropColumn('cards', 'deps');
 }

--- a/packages/hub/db/migrations/20211214163123421_card-index-errors.ts
+++ b/packages/hub/db/migrations/20211214163123421_card-index-errors.ts
@@ -1,0 +1,13 @@
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn('cards', {
+    compileErrors: { type: 'jsonb' },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn('cards', 'compileErrors');
+}

--- a/packages/hub/interfaces.ts
+++ b/packages/hub/interfaces.ts
@@ -1,4 +1,4 @@
-import type { RawCard, Builder, NewRawCard, CardId } from '@cardstack/core/src/interfaces';
+import type { RawCard, Builder, Unsaved, CardId } from '@cardstack/core/src/interfaces';
 import type RealmManager from './services/realm-manager';
 import { IndexerHandle } from './services/search-index';
 
@@ -21,7 +21,7 @@ export interface CardstackContext {
 export interface RealmInterface<Meta = unknown> {
   url: string;
   read(cardId: CardId): Promise<RawCard>;
-  create(raw: NewRawCard): Promise<RawCard>;
+  create(raw: RawCard<Unsaved>): Promise<RawCard>;
   update(raw: RawCard): Promise<RawCard>;
   delete(cardId: CardId): Promise<void>;
   reindex(ops: IndexerHandle, meta: Meta | undefined): Promise<Meta>;

--- a/packages/hub/interfaces.ts
+++ b/packages/hub/interfaces.ts
@@ -1,6 +1,7 @@
 import type { RawCard, Builder, Unsaved, CardId } from '@cardstack/core/src/interfaces';
 import type RealmManager from './services/realm-manager';
 import { IndexerHandle } from './services/search-index';
+import { PgPrimitive } from './utils/expressions';
 
 const ENVIRONMENTS_OBJ = {
   browser: '',
@@ -18,13 +19,13 @@ export interface CardstackContext {
   requireCard: (path: string) => any;
 }
 
-export interface RealmInterface<Meta = unknown> {
+export interface RealmInterface<Meta = PgPrimitive> {
   url: string;
   read(cardId: CardId): Promise<RawCard>;
   create(raw: RawCard<Unsaved>): Promise<RawCard>;
   update(raw: RawCard): Promise<RawCard>;
   delete(cardId: CardId): Promise<void>;
-  reindex(ops: IndexerHandle, meta: Meta | undefined): Promise<Meta>;
+  reindex(ops: IndexerHandle, meta: Meta | null): Promise<Meta>;
   teardown(): Promise<void>;
 }
 

--- a/packages/hub/node-tests/@core/compiler-test.ts
+++ b/packages/hub/node-tests/@core/compiler-test.ts
@@ -230,7 +230,7 @@ if (process.env.COMPILER) {
     it(`gives a good error when a card can't compile because adoptsFrom does not exist`, async function () {
       let rawCard: RawCard = { realm, id: 'post', adoptsFrom: '../post' };
       try {
-        await builder.compileCardFromRaw(rawCard);
+        await builder.compileCardFromRaw(rawCard).compile();
         throw new Error('failed to throw expected exception');
       } catch (err: any) {
         expect(err.message).to.eq(`tried to adopt from card ${realm}post but it failed to load`);
@@ -256,7 +256,7 @@ if (process.env.COMPILER) {
         },
       };
       try {
-        await builder.compileCardFromRaw(rawCard);
+        await builder.compileCardFromRaw(rawCard).compile();
         throw new Error('failed to throw expected exception');
       } catch (err: any) {
         expect(err.message).to.eq(`tried to lookup field 'author' but it failed to load`);

--- a/packages/hub/node-tests/routes/cards/query-test.ts
+++ b/packages/hub/node-tests/routes/cards/query-test.ts
@@ -9,11 +9,6 @@ if (process.env.COMPILER) {
       return request().get(url);
     }
 
-    this.afterEach(async function () {
-      let si = await getContainer().lookup('searchIndex');
-      await si.reset();
-    });
-
     let { getContainer, realmURL, request, cards } = configureHubWithCompiler(this);
 
     this.beforeEach(async function () {

--- a/packages/hub/node-tests/services/card-service-test.ts
+++ b/packages/hub/node-tests/services/card-service-test.ts
@@ -147,6 +147,11 @@ if (process.env.COMPILER) {
         expect(card.compiled!.adoptsFrom!.url).to.eq(`${realmURL}post`);
       });
 
+      it('returns a card from the base realm', async function () {
+        let card = await cards.load('https://cardstack.com/base/string');
+        expect(card.compiled!.url).to.eq('https://cardstack.com/base/string');
+      });
+
       it('handles missing card', async function () {
         try {
           await cards.load(`${realmURL}nonexistent`);

--- a/packages/hub/node-tests/services/search-index-test.ts
+++ b/packages/hub/node-tests/services/search-index-test.ts
@@ -23,7 +23,7 @@ if (process.env.COMPILER) {
       }
     });
 
-    it.skip(`recovers automatically from a bad compile once the problem is addressed`, async function () {
+    it(`recovers automatically from a bad compile once the problem is addressed`, async function () {
       outputJSONSync(join(getRealmDir(), 'example', 'card.json'), {
         adoptsFrom: '../post',
         data: { title: 'Hello World' },

--- a/packages/hub/node-tests/services/search-index-test.ts
+++ b/packages/hub/node-tests/services/search-index-test.ts
@@ -20,8 +20,11 @@ if (process.env.COMPILER) {
         await cards.load(`${realmURL}example`);
         throw new Error('failed to throw expected exception');
       } catch (err: any) {
-        expect(err.message).to.eq(`Error: tried to adopt from card ${realmURL}post but it failed to load`);
+        expect(err.message).to.eq(`tried to adopt from card ${realmURL}post but it failed to load`);
         expect(err.status).to.eq(422);
+        let innerError = err.additionalErrors?.[0];
+        expect(innerError?.message).to.eq('card post not found');
+        expect(innerError?.status).to.eq(404);
       }
     });
   });

--- a/packages/hub/node-tests/services/search-index-test.ts
+++ b/packages/hub/node-tests/services/search-index-test.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { configureHubWithCompiler } from '../helpers/cards';
 
 if (process.env.COMPILER) {
-  describe.skip('SearchIndex', function () {
+  describe('SearchIndex', function () {
     let { getRealmDir, getContainer, realmURL, cards } = configureHubWithCompiler(this);
 
     this.beforeEach(async function () {

--- a/packages/hub/node-tests/services/search-index-test.ts
+++ b/packages/hub/node-tests/services/search-index-test.ts
@@ -7,12 +7,7 @@ if (process.env.COMPILER) {
   describe('SearchIndex', function () {
     let { getRealmDir, getContainer, realmURL, cards } = configureHubWithCompiler(this);
 
-    this.beforeEach(async function () {
-      let si = await getContainer().lookup('searchIndex');
-      await si.indexAllRealms();
-    });
-
-    it(`gives a good error when a card can't compile`, async function () {
+    it(`gives a good error at load time when a card can't compile`, async function () {
       outputJSONSync(join(getRealmDir(), 'example', 'card.json'), { adoptsFrom: '../post' });
       let si = await getContainer().lookup('searchIndex');
       await si.indexAllRealms();
@@ -26,6 +21,38 @@ if (process.env.COMPILER) {
         expect(innerError?.message).to.eq('card post not found');
         expect(innerError?.status).to.eq(404);
       }
+    });
+
+    it.skip(`recovers automatically from a bad compile once the problem is addressed`, async function () {
+      outputJSONSync(join(getRealmDir(), 'example', 'card.json'), {
+        adoptsFrom: '../post',
+        data: { title: 'Hello World' },
+      });
+      let si = await getContainer().lookup('searchIndex');
+      await si.indexAllRealms();
+
+      // at this point we expect loading of `example` is broken because it's
+      // missing its adoption parent. This precondition is proved by the
+      // previous test.
+
+      await cards.create({
+        realm: realmURL,
+        id: 'post',
+        schema: 'schema.js',
+        files: {
+          'schema.js': `
+            import { contains } from '@cardstack/types';
+            import string from 'https://cardstack.com/base/string';
+            export default class Post {
+              @contains(string)
+              title;
+            }
+          `,
+        },
+      });
+
+      let example = await cards.load(`${realmURL}example`);
+      expect(example.data?.title).to.eq('Hello World');
     });
   });
 }

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -80,6 +80,7 @@
     "node-fetch": "^2.6.1",
     "node-pg-migrate": "^5.9.0",
     "pg": "^8.6.0",
+    "pg-cursor": "^2.7.1",
     "pg-format": "^1.0.4",
     "qs": "^6.10.1",
     "query-string": "^7.0.0",

--- a/packages/hub/realms/fs-realm.ts
+++ b/packages/hub/realms/fs-realm.ts
@@ -9,20 +9,27 @@ import { cardURL, ensureTrailingSlash } from '@cardstack/core/src/utils';
 
 import { RealmInterface } from '../interfaces';
 import { nanoid } from '../utils/ids';
-import { serverLog as logger } from '../utils/logger';
+import logger from '@cardstack/logger';
+import Logger from '@cardstack/logger/src/logger';
 
 import { IndexerHandle } from '../services/search-index';
 import RealmManager from '../services/realm-manager';
 
-export default class FSRealm implements RealmInterface {
+interface Meta {
+  mtime: number;
+  pid: number;
+}
+
+export default class FSRealm implements RealmInterface<Meta> {
   url: string;
   private directory: string;
-  private logger = logger;
   private watcher?: sane.Watcher;
+  private log: Logger;
 
   constructor(url: string, directory: string, private notify: RealmManager['notify'] | undefined) {
     this.url = url;
     this.directory = ensureTrailingSlash(directory);
+    this.log = logger(`hub/fs-realm[${url}]`);
   }
 
   async ready() {
@@ -40,19 +47,33 @@ export default class FSRealm implements RealmInterface {
     this.watcher?.close();
   }
 
-  // async reindex(ops: IndexingOperations, meta: Meta | undefined): Promise<Meta> {
-  async reindex(ops: IndexerHandle): Promise<void> {
-    this.logger.info(`Indexing realm: ${this.url}`);
+  async reindex(ops: IndexerHandle, meta: Meta | null): Promise<Meta> {
+    let fullReindex = meta?.pid !== process.pid;
+    let newestMtime = 0;
 
-    await ops.beginReplaceAll();
-    let cards = walkSync(this.directory, { globs: ['**/card.json'] });
-    for (let cardPath of cards) {
-      let id = cardPath.replace('/card.json', '');
-      this.logger.info(`--> ${id}`);
-      let rawCard = await this.read({ id, realm: this.url });
-      await ops.save(rawCard);
+    if (fullReindex) {
+      await ops.beginReplaceAll();
     }
-    await ops.finishReplaceAll();
+    this.log.trace('fullReindex=%s', fullReindex);
+    let cards = walkSync.entries(this.directory, {
+      globs: ['**/card.json'],
+      fs: undefined as any,
+    });
+    for (let { relativePath: cardPath, mtime } of cards) {
+      newestMtime = Math.max(newestMtime, mtime);
+      let id = cardPath.replace('/card.json', '');
+      if (fullReindex || meta?.mtime == null || meta.mtime < mtime) {
+        this.log.trace(`indexing %s`, id);
+        let rawCard = await this.read({ id, realm: this.url });
+        await ops.save(rawCard);
+      } else {
+        this.log.trace(`skipping %s`, id);
+      }
+    }
+    if (fullReindex) {
+      await ops.finishReplaceAll();
+    }
+    return { mtime: newestMtime, pid: process.pid };
   }
 
   private onFileChanged(action: 'save' | 'delete', filepath: string) {

--- a/packages/hub/realms/fs-realm.ts
+++ b/packages/hub/realms/fs-realm.ts
@@ -3,7 +3,7 @@ import { sep, join } from 'path';
 import sane from 'sane';
 import walkSync from 'walk-sync';
 
-import { assertValidRawCard, CardId, NewRawCard, RawCard } from '@cardstack/core/src/interfaces';
+import { assertValidRawCard, CardId, Unsaved, RawCard } from '@cardstack/core/src/interfaces';
 import { CardstackError, Conflict, NotFound, augmentBadRequest } from '@cardstack/core/src/utils/errors';
 import { cardURL, ensureTrailingSlash } from '@cardstack/core/src/utils';
 
@@ -117,7 +117,7 @@ export default class FSRealm implements RealmInterface {
     return doc;
   }
 
-  private ensureCardId(raw: NewRawCard): CardId {
+  private ensureCardId(raw: RawCard<Unsaved>): CardId {
     if (raw.id) {
       return { id: raw.id, realm: this.url };
     } else {
@@ -125,7 +125,7 @@ export default class FSRealm implements RealmInterface {
     }
   }
 
-  async create(raw: NewRawCard): Promise<RawCard> {
+  async create(raw: RawCard<Unsaved>): Promise<RawCard> {
     let cardId = this.ensureCardId(raw);
     let cardDir = this.buildCardPath(cardId);
 
@@ -138,7 +138,7 @@ export default class FSRealm implements RealmInterface {
       throw new Conflict(`card ${cardURL(cardId)} already exists`);
     }
     let completeRawCard: RawCard;
-    if ('id' in raw) {
+    if (raw.id) {
       completeRawCard = raw as RawCard;
     } else {
       completeRawCard = Object.assign({}, raw, { ...cardId });

--- a/packages/hub/routes/card-routes.ts
+++ b/packages/hub/routes/card-routes.ts
@@ -10,7 +10,7 @@ import { NotFound, BadRequest } from '@cardstack/core/src/utils/errors';
 import { difference } from 'lodash';
 import { assertQuery } from '@cardstack/core/src/query';
 import qs from 'qs';
-import { NewRawCard } from '@cardstack/core/src/interfaces';
+import { RawCard, Unsaved } from '@cardstack/core/src/interfaces';
 
 declare global {
   const __non_webpack_require__: any;
@@ -74,7 +74,8 @@ export default class CardRoutes {
     let inputData = body.data;
     let format = getCardFormatFromRequest(ctx.query.format);
 
-    let card: NewRawCard = {
+    let card: RawCard<Unsaved> = {
+      id: undefined,
       realm: realmURL,
       adoptsFrom: parentCardURL,
       data: inputData.attributes,

--- a/packages/hub/services/card-builder.ts
+++ b/packages/hub/services/card-builder.ts
@@ -1,17 +1,23 @@
-import { Builder as BuilderInterface, RawCard, CompiledCard, Saved, ModuleRef } from '@cardstack/core/src/interfaces';
-import { Compiler, defineModules } from '@cardstack/core/src/compiler';
+import {
+  Builder as BuilderInterface,
+  RawCard,
+  CompiledCard,
+  Saved,
+  ModuleRef,
+  Unsaved,
+  NewRawCard,
+} from '@cardstack/core/src/interfaces';
+import { Compiler, makeGloballyAddressable } from '@cardstack/core/src/compiler';
 
-import { transformSync } from '@babel/core';
-import { NODE, BROWSER } from '../interfaces';
-import { JS_TYPE } from '@cardstack/core/src/utils/content';
 import { inject } from '@cardstack/di';
 import { serverLog as logger } from '../utils/logger';
-
+import { JS_TYPE } from '@cardstack/core/src/utils/content';
+import { BROWSER, NODE } from '../interfaces';
+import { transformSync } from '@babel/core';
 // @ts-ignore
 import TransformModulesCommonJS from '@babel/plugin-transform-modules-commonjs';
 // @ts-ignore
 import ClassPropertiesPlugin from '@babel/plugin-proposal-class-properties';
-import { cardURL } from '@cardstack/core/src/utils';
 
 export default class CardBuilder implements BuilderInterface {
   realmManager = inject('realm-manager', { as: 'realmManager' });
@@ -23,6 +29,35 @@ export default class CardBuilder implements BuilderInterface {
   private compiler = new Compiler({
     builder: this,
   });
+
+  async getRawCard(url: string): Promise<RawCard> {
+    return await this.realmManager.read(this.realmManager.parseCardURL(url.replace(/\/$/, '')));
+  }
+
+  async getCompiledCard(url: string): Promise<CompiledCard> {
+    let cached = this.cache.getCard(url);
+    if (cached) {
+      return cached;
+    }
+    let rawCard = await this.getRawCard(url);
+    let compiledCard: CompiledCard<Saved, ModuleRef> | undefined;
+    let err: unknown;
+    try {
+      compiledCard = await this.compiler.compile(rawCard);
+    } catch (e) {
+      err = e;
+    }
+    if (compiledCard) {
+      let definedCard = makeGloballyAddressable(url, compiledCard, (local, type, src) =>
+        this.define(url, local, type, src)
+      );
+      this.cache.setCard(url, definedCard);
+      return definedCard;
+    } else {
+      this.cache.deleteCard(url);
+      throw err;
+    }
+  }
 
   private define(cardURL: string, localPath: string, type: string, source: string): string {
     switch (type) {
@@ -44,37 +79,10 @@ export default class CardBuilder implements BuilderInterface {
     return out!.code!;
   }
 
-  async getRawCard(url: string): Promise<RawCard> {
-    return await this.realmManager.read(this.realmManager.parseCardURL(url.replace(/\/$/, '')));
-  }
-
-  async getCompiledCard(url: string): Promise<CompiledCard> {
-    let compiledCard = this.cache.getCard(url);
-    if (compiledCard) {
-      return compiledCard;
-    }
-    let rawCard = await this.getRawCard(url);
-    return await this.compileCardFromRaw(rawCard);
-  }
-
-  async compileCardFromRaw(rawCard: RawCard): Promise<CompiledCard> {
-    let compiledCard: CompiledCard<Saved, ModuleRef> | undefined;
-    let err: unknown;
-    try {
-      compiledCard = await this.compiler.compile(rawCard);
-    } catch (e) {
-      err = e;
-    }
-    if (compiledCard) {
-      let definedCard = defineModules(compiledCard, (local, type, src) =>
-        this.define(cardURL(rawCard), local, type, src)
-      );
-      this.cache.setCard(cardURL(rawCard), definedCard);
-      return definedCard;
-    } else {
-      this.cache.deleteCard(cardURL(rawCard));
-      throw err;
-    }
+  async compileCardFromRaw(rawCard: NewRawCard): Promise<CompiledCard<Unsaved, ModuleRef>>;
+  async compileCardFromRaw(rawCard: RawCard): Promise<CompiledCard<Saved, ModuleRef>>;
+  async compileCardFromRaw(rawCard: NewRawCard | RawCard): Promise<CompiledCard<Unsaved | Saved, ModuleRef>> {
+    return await this.compiler.compile(rawCard);
   }
 }
 

--- a/packages/hub/services/card-builder.ts
+++ b/packages/hub/services/card-builder.ts
@@ -5,7 +5,6 @@ import {
   Saved,
   ModuleRef,
   Unsaved,
-  NewRawCard,
 } from '@cardstack/core/src/interfaces';
 import { Compiler, makeGloballyAddressable } from '@cardstack/core/src/compiler';
 
@@ -79,9 +78,9 @@ export default class CardBuilder implements BuilderInterface {
     return out!.code!;
   }
 
-  async compileCardFromRaw(rawCard: NewRawCard): Promise<CompiledCard<Unsaved, ModuleRef>>;
-  async compileCardFromRaw(rawCard: RawCard): Promise<CompiledCard<Saved, ModuleRef>>;
-  async compileCardFromRaw(rawCard: NewRawCard | RawCard): Promise<CompiledCard<Unsaved | Saved, ModuleRef>> {
+  async compileCardFromRaw<Identity extends Unsaved>(
+    rawCard: RawCard<Identity>
+  ): Promise<CompiledCard<Identity, ModuleRef>> {
     return await this.compiler.compile(rawCard);
   }
 }

--- a/packages/hub/services/card-service.ts
+++ b/packages/hub/services/card-service.ts
@@ -77,14 +77,14 @@ export class CardService {
   async query(query: Query): Promise<Card[]> {
     let client = await this.db.getPool();
     try {
-      let expression: CardExpression = ['select data from cards'];
+      let expression: CardExpression = ['select compiled from cards'];
       if (query.filter) {
         expression = [...expression, 'where', ...filterToExpression(query.filter, 'https://cardstack.com/base/base')];
       }
-      let result = await client.query<{ data: any }>(expressionToSql(await this.prepareExpression(expression)));
+      let result = await client.query<{ compiled: any }>(expressionToSql(await this.prepareExpression(expression)));
       let deserializer = new RawCardDeserializer();
       return result.rows.map((row) => {
-        let { raw, compiled } = deserializer.deserialize(row.data.data, row.data);
+        let { raw, compiled } = deserializer.deserialize(row.compiled.data, row.compiled);
         if (!compiled) {
           throw new Error(`bug: database entry for ${cardURL(raw)} is missing the compiled card`);
         }

--- a/packages/hub/services/card-service.ts
+++ b/packages/hub/services/card-service.ts
@@ -1,4 +1,4 @@
-import { CompiledCard, NewRawCard, RawCard } from '@cardstack/core/src/interfaces';
+import { CompiledCard, Unsaved, RawCard } from '@cardstack/core/src/interfaces';
 import { RawCardDeserializer } from '@cardstack/core/src/raw-card-deserializer';
 import { Filter, Query } from '@cardstack/core/src/query';
 import { inject } from '@cardstack/di';
@@ -55,7 +55,7 @@ export class CardService {
     return { data: raw.data, compiled };
   }
 
-  async create(raw: NewRawCard): Promise<Card> {
+  async create(raw: RawCard<Unsaved>): Promise<Card> {
     let compiledCard = await this.builder.compileCardFromRaw(raw);
     let rawCard = await this.realmManager.create(raw);
     let compiled = await this.searchIndex.indexCard(rawCard, compiledCard);

--- a/packages/hub/services/card-service.ts
+++ b/packages/hub/services/card-service.ts
@@ -56,9 +56,10 @@ export class CardService {
   }
 
   async create(raw: RawCard<Unsaved>): Promise<Card> {
-    let compiledCard = await this.builder.compileCardFromRaw(raw);
+    let compiler = this.builder.compileCardFromRaw(raw);
+    let compiledCard = await compiler.compile();
     let rawCard = await this.realmManager.create(raw);
-    let compiled = await this.searchIndex.indexCard(rawCard, compiledCard);
+    let compiled = await this.searchIndex.indexCard(rawCard, compiledCard, compiler);
     return { data: rawCard.data, compiled };
   }
 

--- a/packages/hub/services/card-service.ts
+++ b/packages/hub/services/card-service.ts
@@ -56,10 +56,9 @@ export class CardService {
   }
 
   async create(raw: NewRawCard): Promise<Card> {
-    // NEW: Compile it to make sure everything is valid
-    // `${realm}${id ?? 'NEW_CARD'}/${localFile}`
+    let compiledCard = await this.builder.compileCardFromRaw(raw);
     let rawCard = await this.realmManager.create(raw);
-    let compiled = await this.searchIndex.indexCard(rawCard);
+    let compiled = await this.searchIndex.indexCard(rawCard, compiledCard);
     return { data: rawCard.data, compiled };
   }
 

--- a/packages/hub/services/realm-manager.ts
+++ b/packages/hub/services/realm-manager.ts
@@ -6,7 +6,7 @@ import { RealmInterface } from '../interfaces';
 import { getOwner, inject, injectionReady } from '@cardstack/di';
 
 export default class RealmManager {
-  realms: RealmInterface[] = [];
+  realms: RealmInterface<any>[] = [];
 
   private realmsConfig = inject('realmsConfig');
   private searchIndex = inject('searchIndex');

--- a/packages/hub/services/realm-manager.ts
+++ b/packages/hub/services/realm-manager.ts
@@ -1,6 +1,6 @@
 import FSRealm from '../realms/fs-realm';
 import { NotFound } from '@cardstack/core/src/utils/errors';
-import { CardId, NewRawCard, RawCard, RealmConfig } from '@cardstack/core/src/interfaces';
+import { CardId, RawCard, RealmConfig, Unsaved } from '@cardstack/core/src/interfaces';
 import { ensureTrailingSlash } from '@cardstack/core/src/utils';
 import { RealmInterface } from '../interfaces';
 import { getOwner, inject, injectionReady } from '@cardstack/di';
@@ -63,7 +63,7 @@ export default class RealmManager {
     throw new NotFound(`${targetRealm} is not a realm we know about`);
   }
 
-  async create(card: NewRawCard): Promise<RawCard> {
+  async create(card: RawCard<Unsaved>): Promise<RawCard> {
     return this.findRealm(card.realm).create(card);
   }
 

--- a/packages/hub/services/search-index.ts
+++ b/packages/hub/services/search-index.ts
@@ -43,7 +43,8 @@ export class SearchIndex {
         throw new NotFound(`Card ${cardURL} was not found`);
       }
       if (result.compileErrors) {
-        throw new Error(`found a broken card`);
+        const err = Object.assign(new Error(result.compileErrors.why), { status: result.compileErrors.status });
+        throw err;
       }
       return deserializer.deserialize(result.data.data, result.data);
     } finally {
@@ -163,7 +164,7 @@ class IndexerRun implements IndexerHandle {
       ancestors: param(null),
       data: param(null),
       searchData: param(null),
-      compileErrors: param({ why: String(err) }),
+      compileErrors: param({ why: String(err), status: err.status }),
     });
     await this.db.query(expressionToSql(expression));
   }

--- a/packages/hub/services/search-index.ts
+++ b/packages/hub/services/search-index.ts
@@ -1,17 +1,26 @@
-import { CompiledCard, RawCard } from '@cardstack/core/src/interfaces';
+import { makeGloballyAddressable } from '@cardstack/core/src/compiler';
+import { CompiledCard, ModuleRef, RawCard, Saved, Unsaved } from '@cardstack/core/src/interfaces';
 import { RawCardDeserializer } from '@cardstack/core/src/raw-card-deserializer';
 import { cardURL } from '@cardstack/core/src/utils';
+import { JS_TYPE } from '@cardstack/core/src/utils/content';
 import { NotFound } from '@cardstack/core/src/utils/errors';
 import { inject } from '@cardstack/di';
 import { PoolClient } from 'pg';
+import { BROWSER, NODE } from '../interfaces';
 import { expressionToSql, param, upsert } from '../utils/expressions';
 import { serializeRawCard } from '../utils/serialization';
 import CardBuilder from './card-builder';
+import { transformSync } from '@babel/core';
+// @ts-ignore
+import TransformModulesCommonJS from '@babel/plugin-transform-modules-commonjs';
+// @ts-ignore
+import ClassPropertiesPlugin from '@babel/plugin-proposal-class-properties';
 
 export class SearchIndex {
   private realmManager = inject('realm-manager', { as: 'realmManager' });
   private builder = inject('card-builder', { as: 'builder' });
   private database = inject('database-manager', { as: 'database' });
+  private fileCache = inject('card-cache', { as: 'fileCache' });
 
   async indexAllRealms(): Promise<void> {
     await Promise.all(
@@ -29,9 +38,12 @@ export class SearchIndex {
     try {
       let {
         rows: [result],
-      } = await db.query('SELECT data from cards where url = $1', [cardURL]);
+      } = await db.query('SELECT data, "compileErrors" from cards where url = $1', [cardURL]);
       if (!result) {
         throw new NotFound(`Card ${cardURL} was not found`);
+      }
+      if (result.compileErrors) {
+        throw new Error(`found a broken card`);
       }
       return deserializer.deserialize(result.data.data, result.data);
     } finally {
@@ -39,16 +51,16 @@ export class SearchIndex {
     }
   }
 
-  async indexCard(raw: RawCard): Promise<CompiledCard> {
+  async indexCard(raw: RawCard, compiled: CompiledCard<Saved | Unsaved, ModuleRef>): Promise<CompiledCard> {
     return await this.runIndexing(raw.realm, async (ops) => {
-      return await ops.saveAndReturn(raw);
+      return await ops.internalSave(raw, compiled);
     });
   }
 
   private async runIndexing<Out>(realmURL: string, fn: (ops: IndexerRun) => Promise<Out>): Promise<Out> {
     let db = await this.database.getPool();
     try {
-      let run = new IndexerRun(db, this.builder, realmURL);
+      let run = new IndexerRun(db, this.builder, realmURL, this.fileCache);
       let result = await fn(run);
       await run.finalize();
       return result;
@@ -82,16 +94,54 @@ export interface IndexerHandle {
 class IndexerRun implements IndexerHandle {
   private generation?: number;
 
-  constructor(private db: PoolClient, private builder: CardBuilder, private realmURL: string) {}
+  constructor(
+    private db: PoolClient,
+    private builder: CardBuilder,
+    private realmURL: string,
+    private fileCache: SearchIndex['fileCache']
+  ) {}
 
   async finalize() {}
 
+  // available to each realm's indexer
   async save(card: RawCard): Promise<void> {
-    await this.saveAndReturn(card);
+    try {
+      let compiledCard = await this.builder.compileCardFromRaw(card);
+      await this.internalSave(card, compiledCard);
+    } catch (err: any) {
+      await this.saveErrorState(card, err);
+    }
   }
 
-  async saveAndReturn(card: RawCard): Promise<CompiledCard> {
-    let compiledCard = await this.builder.compileCardFromRaw(card);
+  // used directly by the hub when mutating cards
+  async internalSave(rawCard: RawCard, compiledCard: CompiledCard<Saved | Unsaved, ModuleRef>): Promise<CompiledCard> {
+    let definedCard = makeGloballyAddressable(cardURL(rawCard), compiledCard, (local, type, src) =>
+      this.define(cardURL(rawCard), local, type, src)
+    );
+    return await this.writeToIndex(rawCard, definedCard);
+  }
+
+  private define(cardURL: string, localPath: string, type: string, source: string): string {
+    switch (type) {
+      case JS_TYPE:
+        this.fileCache.setModule(BROWSER, cardURL, localPath, source);
+        return this.fileCache.setModule(NODE, cardURL, localPath, this.transformToCommonJS(localPath, source));
+      default:
+        return this.fileCache.writeAsset(cardURL, localPath, source);
+    }
+  }
+
+  private transformToCommonJS(moduleURL: string, source: string): string {
+    let out = transformSync(source, {
+      configFile: false,
+      babelrc: false,
+      filenameRelative: moduleURL,
+      plugins: [ClassPropertiesPlugin, TransformModulesCommonJS],
+    });
+    return out!.code!;
+  }
+
+  private async writeToIndex(card: RawCard, compiledCard: CompiledCard): Promise<CompiledCard> {
     let expression = upsert('cards', 'cards_pkey', {
       url: param(cardURL(card)),
       realm: param(this.realmURL),
@@ -99,9 +149,23 @@ class IndexerRun implements IndexerHandle {
       ancestors: param(ancestorsOf(compiledCard)),
       data: param(serializeRawCard(card, compiledCard)),
       searchData: param(card.data ? searchOptimizedData(card.data, compiledCard) : null),
+      compileErrors: param(null),
     });
     await this.db.query(expressionToSql(expression));
     return compiledCard;
+  }
+
+  private async saveErrorState(card: RawCard, err: any): Promise<void> {
+    let expression = upsert('cards', 'cards_pkey', {
+      url: param(cardURL(card)),
+      realm: param(this.realmURL),
+      generation: param(this.generation || null),
+      ancestors: param(null),
+      data: param(null),
+      searchData: param(null),
+      compileErrors: param({ why: String(err) }),
+    });
+    await this.db.query(expressionToSql(expression));
   }
 
   async delete(cardURL: string): Promise<void> {

--- a/packages/hub/services/search-index.ts
+++ b/packages/hub/services/search-index.ts
@@ -1,5 +1,5 @@
 import { makeGloballyAddressable } from '@cardstack/core/src/compiler';
-import { CompiledCard, ModuleRef, RawCard, Saved, Unsaved } from '@cardstack/core/src/interfaces';
+import { CompiledCard, ModuleRef, RawCard, Unsaved } from '@cardstack/core/src/interfaces';
 import { RawCardDeserializer } from '@cardstack/core/src/raw-card-deserializer';
 import { cardURL } from '@cardstack/core/src/utils';
 import { JS_TYPE } from '@cardstack/core/src/utils/content';
@@ -51,7 +51,7 @@ export class SearchIndex {
     }
   }
 
-  async indexCard(raw: RawCard, compiled: CompiledCard<Saved | Unsaved, ModuleRef>): Promise<CompiledCard> {
+  async indexCard(raw: RawCard, compiled: CompiledCard<Unsaved, ModuleRef>): Promise<CompiledCard> {
     return await this.runIndexing(raw.realm, async (ops) => {
       return await ops.internalSave(raw, compiled);
     });
@@ -114,7 +114,7 @@ class IndexerRun implements IndexerHandle {
   }
 
   // used directly by the hub when mutating cards
-  async internalSave(rawCard: RawCard, compiledCard: CompiledCard<Saved | Unsaved, ModuleRef>): Promise<CompiledCard> {
+  async internalSave(rawCard: RawCard, compiledCard: CompiledCard<Unsaved, ModuleRef>): Promise<CompiledCard> {
     let definedCard = makeGloballyAddressable(cardURL(rawCard), compiledCard, (local, type, src) =>
       this.define(cardURL(rawCard), local, type, src)
     );

--- a/types/pg-cursor/index.d.ts
+++ b/types/pg-cursor/index.d.ts
@@ -1,0 +1,6 @@
+declare module 'pg-cursor' {
+  export default class Cursor {
+    constructor(sql: string, params: any[]);
+    read(length: number, cb: (err: any, rows: Record<string, any>[]) => void);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8160,7 +8160,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@4.1.4, axe-core@^4.1.4:
+axe-core@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.4.tgz#f19cd99a84ee32a318b9c5b5bb8ed373ad94f143"
   integrity sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==
@@ -12552,7 +12552,7 @@ elliptic@6.5.4, elliptic@^6.0.0, elliptic@^6.4.0, elliptic@^6.5.2:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-ember-a11y-testing@4.0.3, ember-a11y-testing@^4.0.3:
+ember-a11y-testing@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-4.0.3.tgz#1f5c91266d39ea5b20614b0d294a562079887ac7"
   integrity sha512-Q7nq2crC9+bT+sZi/BORAM4FUhI080edEhnpsvB6vdkD9Ro2Rg4DksQs5Be65/DM108VNDMtbHZtrPS060Mzcw==
@@ -23534,6 +23534,11 @@ pg-connection-string@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.5.0.tgz#538cadd0f7e603fc09a12590f3b8a452c2c0cf34"
   integrity sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==
+
+pg-cursor@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/pg-cursor/-/pg-cursor-2.7.1.tgz#0c545b70006589537232986fa06c03a799d8f22b"
+  integrity sha512-dtxtyvx4BcSammddki27KPBVA0sZ8AguLabgs7++gqaefX7dlQ5zaRlk1Gi5mvyO25aCmHFAZyNq9zYtPDwFTA==
 
 pg-format@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
- [x] Error serialization for cards that can't be compiled
- [x] Next test: Fix index error and see that invalidation system kicks in
  - Write dependencies to index column when error is saved
  - Call create to make the missing thing in the test
  - Keep track of all changed cards in an indexerRun, recompile dependents
  - See that recompile happens
- [ ] ~Remove old cache support~ https://linear.app/cardstack/issue/CS-2840/remove-storage-of-compiled-cards-from-card-cache