### PR TITLE
web: Add filter to not report unknown chain

### DIFF
--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -276,7 +276,9 @@ export default abstract class Layer1ChainWeb3Strategy
       this.daiBalance = new BN(daiBalance);
       this.cardBalance = new BN(cardBalance);
     } catch (e) {
-      if (!e.message.includes('what name the network id')) {
+      // Incorrect chain id triggers controller:card-pay#onLayer2Incorrect to show a modal
+      if (e.message.includes('what name the network id')) {
+        // Exception being ignored: Don't know what name the network id ID is
         Sentry.captureException(e);
       }
     }

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -264,15 +264,22 @@ export default abstract class Layer1ChainWeb3Strategy
 
   async refreshBalances() {
     if (!this.isConnected) return;
-    let balances = await Promise.all<string>([
-      this.getDefaultTokenBalance(),
-      this.getErc20Balance('DAI'),
-      this.getErc20Balance('CARD'),
-    ]);
-    let [defaultTokenBalance, daiBalance, cardBalance] = balances;
-    this.defaultTokenBalance = new BN(defaultTokenBalance);
-    this.daiBalance = new BN(daiBalance);
-    this.cardBalance = new BN(cardBalance);
+
+    try {
+      let balances = await Promise.all<string>([
+        this.getDefaultTokenBalance(),
+        this.getErc20Balance('DAI'),
+        this.getErc20Balance('CARD'),
+      ]);
+      let [defaultTokenBalance, daiBalance, cardBalance] = balances;
+      this.defaultTokenBalance = new BN(defaultTokenBalance);
+      this.daiBalance = new BN(daiBalance);
+      this.cardBalance = new BN(cardBalance);
+    } catch (e) {
+      if (!e.message.includes('what name the network id')) {
+        Sentry.captureException(e);
+      }
+    }
   }
 
   private async getErc20Balance(

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -280,6 +280,7 @@ export default abstract class Layer1ChainWeb3Strategy
       if (e.message.includes('what name the network id')) {
         // Exception being ignored: Don't know what name the network id ID is
         Sentry.captureException(e);
+        throw e;
       }
     }
   }


### PR DESCRIPTION
This should remove some [noise in Sentry](https://sentry.io/organizations/cardstack/issues/2778166326) where people have
Metamask connected to Binance Smart Chain (id 56). The UI
already shows a modal when the incorrect chain is active.