### PR TITLE
Show degradation banner by reading from the statuspage

### DIFF
--- a/packages/web-client/app/components/common/degraded-service-banner/index.css
+++ b/packages/web-client/app/components/common/degraded-service-banner/index.css
@@ -15,6 +15,27 @@
   color: var(--degraded-service-banner-text-color);
 }
 
+.degraded-service-banner__container {
+  max-width: calc(var(--degraded-service-banner-icon-area-width) + 80ch);
+  display: flex;
+}
+
+.degraded-service-banner__icon-area {
+  --degraded-service-banner-icon-area-width: 1.7rem;
+
+  display: flex;
+  align-items: center;
+  width: var(--degraded-service-banner-icon-area-width);
+}
+
+.degraded-service-banner__container a {
+  text-decoration: underline;
+}
+
+.degraded-service-banner__container a:hover {
+  color: inherit;
+}
+
 .degraded-service-banner.degraded-service-banner--severe {
   --degraded-service-banner-text-color: var(--boxel-light);
   --degraded-service-banner-background-color: var(--boxel-red);

--- a/packages/web-client/app/components/common/degraded-service-banner/index.hbs
+++ b/packages/web-client/app/components/common/degraded-service-banner/index.hbs
@@ -1,7 +1,17 @@
-<div class={{cn
-  "degraded-service-banner"
-  degraded-service-banner--severe=@severe
-}}>
-    {{svg-jar "failure-bordered" class="degraded-service-banner__icon"}}
-    {{yield}}
-</div>
+{{#if this.notificationShown}}
+  <div
+    class={{cn "degraded-service-banner" degraded-service-banner--severe=this.isSevere}}
+    data-test-degraded-service-banner
+  >
+    <div class="degraded-service-banner__container">
+      <div class="degraded-service-banner__icon-area">
+        {{svg-jar "failure-bordered" class="degraded-service-banner__icon"}}
+      </div>
+
+      <div>
+        {{this.notificationBody}}
+        For more details, check our <a href={{this.statusPageUrl}} target="_blank" rel="noopener noreferrer">status page</a>.
+      </div>
+    </div>
+  </div>
+{{/if}}

--- a/packages/web-client/app/components/common/degraded-service-banner/index.ts
+++ b/packages/web-client/app/components/common/degraded-service-banner/index.ts
@@ -1,0 +1,17 @@
+import config from '@cardstack/web-client/config/environment';
+import { inject as service } from '@ember/service';
+import DegradedServiceDetector from '@cardstack/web-client/services/degraded-service-detector';
+import { reads } from 'macro-decorators';
+import Component from '@glimmer/component';
+
+export default class DegradedServiceBannerComponent extends Component {
+  statusPageUrl = config.urls.statusPageUrl;
+  @service declare degradedServiceDetector: DegradedServiceDetector;
+
+  @reads('degradedServiceDetector.notificationShown')
+  declare notificationShown: boolean;
+  @reads('degradedServiceDetector.notificationBody') declare notificationBody:
+    | string
+    | null;
+  @reads('degradedServiceDetector.isSevere') declare isSevere: boolean;
+}

--- a/packages/web-client/app/config/environment.d.ts
+++ b/packages/web-client/app/config/environment.d.ts
@@ -16,6 +16,7 @@ interface UrlsOptions {
   googlePlayLink: string | undefined;
   testFlightLink: string;
   discordSupportChannelUrl: string;
+  statusPageUrl: string;
 }
 
 /**

--- a/packages/web-client/app/services/degraded-service-detector.ts
+++ b/packages/web-client/app/services/degraded-service-detector.ts
@@ -1,0 +1,98 @@
+import Service from '@ember/service';
+import config from '../config/environment';
+import { taskFor } from 'ember-concurrency-ts';
+import { task, TaskGenerator, timeout } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
+import * as Sentry from '@sentry/browser';
+
+export default class DegradedServiceDetector extends Service {
+  @tracked notificationShown: boolean = false;
+  @tracked notificationBody: string | null = null;
+  @tracked impact: 'none' | 'minor' | 'major' | 'critical' | null = null;
+
+  statusPageUrl = config.urls.statusPageUrl;
+
+  constructor() {
+    super(...arguments);
+    taskFor(this.pollForStatusTask).perform();
+  }
+
+  get isSevere() {
+    return this.impact === 'major' || this.impact === 'critical';
+  }
+
+  @task *pollForStatusTask(): TaskGenerator<void> {
+    while (true) {
+      let statusData = yield this.getDegradationStatusData();
+
+      if (statusData) {
+        this.notificationShown = true;
+        this.impact = statusData.impact;
+        this.notificationBody = statusData.name;
+      } else {
+        this.notificationShown = false;
+        this.notificationBody = null;
+        this.impact = null;
+      }
+
+      if (config.environment === 'test') {
+        return;
+      }
+
+      yield timeout(1000 * 60);
+    }
+  }
+
+  async getDegradationStatusData(): Promise<any> {
+    let statusPageUrl = `${this.statusPageUrl}/api/v2/incidents/unresolved.json`;
+
+    let data = {} as any;
+
+    try {
+      let response = await fetch(statusPageUrl);
+      data = await response.json();
+    } catch (e) {
+      console.error('Failed to fetch exchange rates');
+      Sentry.captureException(e);
+
+      return null;
+    }
+
+    let order = ['none', 'minor', 'major', 'critical'];
+
+    if (data.incidents.length === 0) {
+      return null;
+    }
+
+    let highestImpact = data.incidents.sort((a: any, b: any) => {
+      if (order.indexOf(a.impact) > order.indexOf(b.impact)) {
+        return -1;
+      }
+      if (order.indexOf(a.impact) < order.indexOf(b.impact)) {
+        return 1;
+      }
+
+      return 0;
+    })[0].impact;
+
+    let incident = data.incidents
+      .filterBy('impact', highestImpact)
+      .sort((a: any, b: any) => {
+        return +new Date(b.started_at) - +new Date(a.started_at);
+      })[0];
+
+    return {
+      status: incident.status,
+      name: this.addPunctuation(incident.name),
+      impact: incident.impact,
+    };
+  }
+
+  addPunctuation(text: string) {
+    if (text.endsWith('.')) {
+      return text;
+    }
+
+    return `${text}.`;
+  }
+}

--- a/packages/web-client/app/templates/card-pay.hbs
+++ b/packages/web-client/app/templates/card-pay.hbs
@@ -1,5 +1,7 @@
 {{page-title "Card Pay" replace=true}}
 
+<Common::DegradedServiceBanner />
+
 <Boxel::Dashboard @darkTheme={{true}} class="card-pay" data-test-card-pay>
   <:header>
     <CardPay::Header

--- a/packages/web-client/config/environment.js
+++ b/packages/web-client/config/environment.js
@@ -82,6 +82,7 @@ module.exports = function (environment) {
       testFlightLink: 'https://testflight.apple.com/join/OgFq1EZ0',
       discordSupportChannelUrl:
         'https://discord.com/channels/584043165066199050/899645340746141806',
+      statusPageUrl: 'https://status.cardstack.com',
     },
     // basically our favicons for now
     walletConnectIcons: [

--- a/packages/web-client/tests/integration/components/degraded-service-banner-test.ts
+++ b/packages/web-client/tests/integration/components/degraded-service-banner-test.ts
@@ -1,0 +1,194 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, waitFor } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { Response as MirageResponse } from 'ember-cli-mirage';
+import { MirageTestContext } from 'ember-cli-mirage/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+interface Context extends MirageTestContext {}
+
+module('Integration | Component | degraded-service-banner', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('It doesn not display a banner when there are no incidents', async function (this: Context, assert) {
+    this.server.get(
+      'https://status.cardstack.com/api/v2/incidents/unresolved.json',
+      function () {
+        return new MirageResponse(
+          200,
+          {},
+          {
+            incidents: [],
+          }
+        );
+      }
+    );
+
+    await render(hbs`<Common::DegradedServiceBanner />`);
+
+    assert.dom('[data-test-degraded-service-banner]').doesNotExist();
+  });
+
+  test('It shows a critical impact incident as severe', async function (this: Context, assert) {
+    this.server.get(
+      'https://status.cardstack.com/api/v2/incidents/unresolved.json',
+      function () {
+        return new MirageResponse(
+          200,
+          {},
+          {
+            incidents: [
+              {
+                name: 'All systems down.',
+                impact: 'critical',
+              },
+            ],
+          }
+        );
+      }
+    );
+
+    await render(hbs`<Common::DegradedServiceBanner />`);
+    await waitFor('[data-test-degraded-service-banner]');
+    assert
+      .dom('[data-test-degraded-service-banner]')
+      .containsText(
+        'All systems down. For more details, check our status page'
+      );
+    assert
+      .dom('[data-test-degraded-service-banner]')
+      .hasClass('degraded-service-banner--severe');
+  });
+
+  test('It shows a major impact incident as severe', async function (this: Context, assert) {
+    this.server.get(
+      'https://status.cardstack.com/api/v2/incidents/unresolved.json',
+      function () {
+        return new MirageResponse(
+          200,
+          {},
+          {
+            incidents: [
+              {
+                name: 'All systems down.',
+                impact: 'major',
+              },
+            ],
+          }
+        );
+      }
+    );
+
+    await render(hbs`<Common::DegradedServiceBanner />`);
+    await waitFor('[data-test-degraded-service-banner]');
+    assert
+      .dom('[data-test-degraded-service-banner]')
+      .hasClass('degraded-service-banner--severe');
+  });
+
+  test('It shows a minor impact incident as default', async function (this: Context, assert) {
+    this.server.get(
+      'https://status.cardstack.com/api/v2/incidents/unresolved.json',
+      function () {
+        return new MirageResponse(
+          200,
+          {},
+          {
+            incidents: [
+              {
+                name: 'One small system down.',
+                impact: 'minor',
+              },
+            ],
+          }
+        );
+      }
+    );
+
+    await render(hbs`<Common::DegradedServiceBanner />`);
+    await waitFor('[data-test-degraded-service-banner]');
+    assert
+      .dom('[data-test-degraded-service-banner]')
+      .containsText(
+        'One small system down. For more details, check our status page'
+      );
+    assert
+      .dom('[data-test-degraded-service-banner]')
+      .doesNotHaveClass('degraded-service-banner--severe');
+  });
+
+  test('It shows only the most recent and most impactful incident', async function (this: Context, assert) {
+    this.server.get(
+      'https://status.cardstack.com/api/v2/incidents/unresolved.json',
+      function () {
+        return new MirageResponse(
+          200,
+          {},
+          {
+            incidents: [
+              {
+                name: 'All systems down.',
+                impact: 'major',
+                started_at: '2021-10-10T10:10:00.000Z',
+              },
+              {
+                name: 'One small system down.',
+                impact: 'minor',
+                started_at: '2021-10-10T10:10:00.003Z',
+              },
+              {
+                name: 'World down.',
+                impact: 'critical',
+                started_at: '2021-10-10T10:10:00.002Z',
+              },
+              {
+                name: 'Internet down.',
+                impact: 'critical',
+                started_at: '2021-10-10T10:10:00.001Z',
+              },
+            ],
+          }
+        );
+      }
+    );
+
+    await render(hbs`<Common::DegradedServiceBanner />`);
+    await waitFor('[data-test-degraded-service-banner]');
+    assert
+      .dom('[data-test-degraded-service-banner]')
+      .containsText('World down. For more details, check our status page');
+    assert
+      .dom('[data-test-degraded-service-banner]')
+      .hasClass('degraded-service-banner--severe');
+  });
+
+  test('It adds punctuation if missing', async function (this: Context, assert) {
+    this.server.get(
+      'https://status.cardstack.com/api/v2/incidents/unresolved.json',
+      function () {
+        return new MirageResponse(
+          200,
+          {},
+          {
+            incidents: [
+              {
+                name: 'We are experiencing issues',
+                impact: 'major',
+              },
+            ],
+          }
+        );
+      }
+    );
+
+    await render(hbs`<Common::DegradedServiceBanner />`);
+    await waitFor('[data-test-degraded-service-banner]');
+    assert
+      .dom('[data-test-degraded-service-banner]')
+      .containsText(
+        'We are experiencing issues. For more details, check our status page'
+      );
+  });
+});

--- a/packages/web-client/tests/integration/components/degraded-service-banner-test.ts
+++ b/packages/web-client/tests/integration/components/degraded-service-banner-test.ts
@@ -5,26 +5,26 @@ import hbs from 'htmlbars-inline-precompile';
 import { Response as MirageResponse } from 'ember-cli-mirage';
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import config from '@cardstack/web-client/config/environment';
 
 interface Context extends MirageTestContext {}
+
+let statusPageUrl = `${config.urls.statusPageUrl}/api/v2/incidents/unresolved.json`;
 
 module('Integration | Component | degraded-service-banner', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
   test('It doesn not display a banner when there are no incidents', async function (this: Context, assert) {
-    this.server.get(
-      'https://status.cardstack.com/api/v2/incidents/unresolved.json',
-      function () {
-        return new MirageResponse(
-          200,
-          {},
-          {
-            incidents: [],
-          }
-        );
-      }
-    );
+    this.server.get(statusPageUrl, function () {
+      return new MirageResponse(
+        200,
+        {},
+        {
+          incidents: [],
+        }
+      );
+    });
 
     await render(hbs`<Common::DegradedServiceBanner />`);
 
@@ -32,23 +32,20 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
   });
 
   test('It shows a critical impact incident as severe', async function (this: Context, assert) {
-    this.server.get(
-      'https://status.cardstack.com/api/v2/incidents/unresolved.json',
-      function () {
-        return new MirageResponse(
-          200,
-          {},
-          {
-            incidents: [
-              {
-                name: 'All systems down.',
-                impact: 'critical',
-              },
-            ],
-          }
-        );
-      }
-    );
+    this.server.get(statusPageUrl, function () {
+      return new MirageResponse(
+        200,
+        {},
+        {
+          incidents: [
+            {
+              name: 'All systems down.',
+              impact: 'critical',
+            },
+          ],
+        }
+      );
+    });
 
     await render(hbs`<Common::DegradedServiceBanner />`);
     await waitFor('[data-test-degraded-service-banner]');
@@ -63,23 +60,20 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
   });
 
   test('It shows a major impact incident as severe', async function (this: Context, assert) {
-    this.server.get(
-      'https://status.cardstack.com/api/v2/incidents/unresolved.json',
-      function () {
-        return new MirageResponse(
-          200,
-          {},
-          {
-            incidents: [
-              {
-                name: 'All systems down.',
-                impact: 'major',
-              },
-            ],
-          }
-        );
-      }
-    );
+    this.server.get(statusPageUrl, function () {
+      return new MirageResponse(
+        200,
+        {},
+        {
+          incidents: [
+            {
+              name: 'All systems down.',
+              impact: 'major',
+            },
+          ],
+        }
+      );
+    });
 
     await render(hbs`<Common::DegradedServiceBanner />`);
     await waitFor('[data-test-degraded-service-banner]');
@@ -89,23 +83,20 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
   });
 
   test('It shows a minor impact incident as default', async function (this: Context, assert) {
-    this.server.get(
-      'https://status.cardstack.com/api/v2/incidents/unresolved.json',
-      function () {
-        return new MirageResponse(
-          200,
-          {},
-          {
-            incidents: [
-              {
-                name: 'One small system down.',
-                impact: 'minor',
-              },
-            ],
-          }
-        );
-      }
-    );
+    this.server.get(statusPageUrl, function () {
+      return new MirageResponse(
+        200,
+        {},
+        {
+          incidents: [
+            {
+              name: 'One small system down.',
+              impact: 'minor',
+            },
+          ],
+        }
+      );
+    });
 
     await render(hbs`<Common::DegradedServiceBanner />`);
     await waitFor('[data-test-degraded-service-banner]');
@@ -120,39 +111,36 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
   });
 
   test('It shows only the most recent and most impactful incident', async function (this: Context, assert) {
-    this.server.get(
-      'https://status.cardstack.com/api/v2/incidents/unresolved.json',
-      function () {
-        return new MirageResponse(
-          200,
-          {},
-          {
-            incidents: [
-              {
-                name: 'All systems down.',
-                impact: 'major',
-                started_at: '2021-10-10T10:10:00.000Z',
-              },
-              {
-                name: 'One small system down.',
-                impact: 'minor',
-                started_at: '2021-10-10T10:10:00.003Z',
-              },
-              {
-                name: 'World down.',
-                impact: 'critical',
-                started_at: '2021-10-10T10:10:00.002Z',
-              },
-              {
-                name: 'Internet down.',
-                impact: 'critical',
-                started_at: '2021-10-10T10:10:00.001Z',
-              },
-            ],
-          }
-        );
-      }
-    );
+    this.server.get(statusPageUrl, function () {
+      return new MirageResponse(
+        200,
+        {},
+        {
+          incidents: [
+            {
+              name: 'All systems down.',
+              impact: 'major',
+              started_at: '2021-10-10T10:10:00.000Z',
+            },
+            {
+              name: 'One small system down.',
+              impact: 'minor',
+              started_at: '2021-10-10T10:10:00.003Z',
+            },
+            {
+              name: 'World down.',
+              impact: 'critical',
+              started_at: '2021-10-10T10:10:00.002Z',
+            },
+            {
+              name: 'Internet down.',
+              impact: 'critical',
+              started_at: '2021-10-10T10:10:00.001Z',
+            },
+          ],
+        }
+      );
+    });
 
     await render(hbs`<Common::DegradedServiceBanner />`);
     await waitFor('[data-test-degraded-service-banner]');
@@ -165,23 +153,20 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
   });
 
   test('It adds punctuation if missing', async function (this: Context, assert) {
-    this.server.get(
-      'https://status.cardstack.com/api/v2/incidents/unresolved.json',
-      function () {
-        return new MirageResponse(
-          200,
-          {},
-          {
-            incidents: [
-              {
-                name: 'We are experiencing issues',
-                impact: 'major',
-              },
-            ],
-          }
-        );
-      }
-    );
+    this.server.get(statusPageUrl, function () {
+      return new MirageResponse(
+        200,
+        {},
+        {
+          incidents: [
+            {
+              name: 'We are experiencing issues',
+              impact: 'major',
+            },
+          ],
+        }
+      );
+    });
 
     await render(hbs`<Common::DegradedServiceBanner />`);
     await waitFor('[data-test-degraded-service-banner]');


### PR DESCRIPTION
Ticket: [CS-2752](https://linear.app/cardstack/issue/CS-2752/service-degradation-notice-in-dapp)

![image](https://user-images.githubusercontent.com/273660/146778293-fa1db2c7-4c8a-4d5d-80c3-944b4dbb51c7.png)

This PR shows the degradation banner in Card Pay route in case there is an open incident in Statuspage. 

Incident severity can be categorized as "none", "minor", "major", "critical" in statuspage. For "major" and "critical" we show the red background, and yellow for the rest.  