### PR TITLE
Use more focused loggers

### DIFF
--- a/packages/hub/cli/event-listener.ts
+++ b/packages/hub/cli/event-listener.ts
@@ -1,8 +1,10 @@
 /* eslint-disable no-process-exit */
 
 import { createContainer, runInitializers } from '../main';
-import { eventListenerLog } from '../utils/logger';
 import * as Sentry from '@sentry/node';
+
+import logger from '@cardstack/logger';
+const log = logger('hub/event-listener');
 
 export const command = 'event-listener';
 export const describe = 'Boot the contract events listener (used for push notifications)';
@@ -16,7 +18,7 @@ export async function handler() {
     let eventListener = await container.lookup('contract-subscription-event-handler');
     eventListener.setupContractEventSubscriptions();
   } catch (e: any) {
-    eventListenerLog.error(`Unexpected error while running contracts event listener: ${e.message}`, e);
+    log.error(`Unexpected error while running contracts event listener: ${e.message}`, e);
     Sentry.withScope(function () {
       Sentry.captureException(e);
     });

--- a/packages/hub/cli/server.ts
+++ b/packages/hub/cli/server.ts
@@ -4,7 +4,8 @@ import logger from '@cardstack/logger';
 import nodeCleanup from 'node-cleanup';
 import { Argv, Options } from 'yargs';
 import { createContainer, HubServer } from '../main';
-import { serverLog } from '../utils/logger';
+
+const log = logger('hub/server');
 
 export let command = 'serve';
 export let aliases = 'server';
@@ -41,7 +42,7 @@ export async function handler(argv: any) {
   try {
     server = await container.lookup('hubServer');
   } catch (err: any) {
-    serverLog.error('Server failed to start cleanly: %s', err.stack || err);
+    log.error('Server failed to start cleanly: %s', err.stack || err);
     process.exit(-1);
   }
 
@@ -57,12 +58,12 @@ export async function handler(argv: any) {
     //
     // (If we weren't started under IPC, `process.connected` is
     // undefined, so this never happens.)
-    serverLog.info(`Shutting down because connected parent process has already exited.`);
+    log.info(`Shutting down because connected parent process has already exited.`);
     process.exit(0);
   }
 
   process.on('disconnect', () => {
-    serverLog.info(`Hub shutting down because connected parent process exited.`);
+    log.info(`Hub shutting down because connected parent process exited.`);
     process.exit(0);
   });
 

--- a/packages/hub/process-controllers/hub-bot-controller.ts
+++ b/packages/hub/process-controllers/hub-bot-controller.ts
@@ -2,14 +2,13 @@ import { runInitializers, createRegistry } from '../main';
 import HubBot from '../services/discord-bots/hub-bot';
 import * as Sentry from '@sentry/node';
 import { Registry, Container } from '@cardstack/di';
-import { botLog } from '../utils/logger';
+
+import logger from '@cardstack/logger';
+export const log = logger('hub/bot');
 
 export class HubBotController {
-  logger = botLog;
-  static logger = botLog;
-
   static async create(serverConfig?: { registryCallback?: (r: Registry) => void }): Promise<HubBotController> {
-    this.logger.info(`booting pid:${process.pid}`);
+    log.info(`booting pid:${process.pid}`);
     runInitializers();
 
     let registry = createRegistry();
@@ -23,7 +22,7 @@ export class HubBotController {
       bot = await container.instantiate(HubBot);
       await bot.start();
     } catch (e: any) {
-      this.logger.error(`Unexpected error ${e.message}`, e);
+      log.error(`Unexpected error ${e.message}`, e);
       Sentry.withScope(function () {
         Sentry.captureException(e);
       });
@@ -32,7 +31,7 @@ export class HubBotController {
     if (!bot) {
       throw new Error('Bot could not be created');
     }
-    this.logger.info(`started (${bot.type}:${bot.botInstanceId})`);
+    log.info(`started (${bot.type}:${bot.botInstanceId})`);
 
     return new this(bot, container);
   }
@@ -40,7 +39,7 @@ export class HubBotController {
   private constructor(public bot: HubBot, public container: Container) {}
 
   async teardown() {
-    this.logger.info('shutting down');
+    log.info('shutting down');
     await this.bot.destroy();
     await this.container.teardown();
   }

--- a/packages/hub/services/card-builder.ts
+++ b/packages/hub/services/card-builder.ts
@@ -9,7 +9,6 @@ import {
 import { Compiler, makeGloballyAddressable } from '@cardstack/core/src/compiler';
 
 import { inject } from '@cardstack/di';
-import { serverLog as logger } from '../utils/logger';
 import { JS_TYPE } from '@cardstack/core/src/utils/content';
 import { BROWSER, NODE } from '../interfaces';
 import { transformSync } from '@babel/core';
@@ -18,18 +17,21 @@ import TransformModulesCommonJS from '@babel/plugin-transform-modules-commonjs';
 // @ts-ignore
 import ClassPropertiesPlugin from '@babel/plugin-proposal-class-properties';
 
+import logger from '@cardstack/logger';
+const log = logger('hub/card-builder');
+
 export default class CardBuilder implements BuilderInterface {
   realmManager = inject('realm-manager', { as: 'realmManager' });
   cache = inject('card-cache', { as: 'cache' });
   cards = inject('card-service', { as: 'cards' });
 
-  logger = logger;
-
   async getRawCard(url: string): Promise<RawCard> {
+    log.trace('getRawCard: %s', url);
     return await this.realmManager.read(this.realmManager.parseCardURL(url.replace(/\/$/, '')));
   }
 
   async getCompiledCard(url: string): Promise<CompiledCard> {
+    log.trace('getCompiledCard: %s', url);
     let cached = this.cache.getCard(url);
     if (cached) {
       return cached;
@@ -56,6 +58,7 @@ export default class CardBuilder implements BuilderInterface {
   }
 
   private define(cardURL: string, localPath: string, type: string, source: string): string {
+    log.trace('define: %s %s', cardURL, { localPath, type });
     switch (type) {
       case JS_TYPE:
         this.cache.setModule(BROWSER, cardURL, localPath, source);

--- a/packages/hub/services/card-cache.ts
+++ b/packages/hub/services/card-cache.ts
@@ -15,7 +15,6 @@ import {
 import { join, dirname } from 'path';
 import { inject, injectionReady } from '@cardstack/di';
 import isEqual from 'lodash/isEqual';
-import { serverLog } from '../utils/logger';
 import { Client } from 'pg';
 import { CompiledCard } from '@cardstack/core/src/interfaces';
 
@@ -62,6 +61,10 @@ function setupCacheDir(cardCacheDir: string): void {
     throw new Error('package.json of cardCacheDir does not have properly configured exports');
   }
 }
+
+import logger from '@cardstack/logger';
+const log = logger('hub/card-cache');
+
 export default class CardCache {
   config = inject('card-cache-config', { as: 'config' });
   databaseManager = inject('database-manager', { as: 'databaseManager' });
@@ -91,7 +94,7 @@ export default class CardCache {
   }
 
   private writeFile(fsLocation: string, source: string): void {
-    serverLog.debug(`card-cache writing`, fsLocation);
+    log.trace('writing file: %s', fsLocation);
     mkdirpSync(dirname(fsLocation));
     writeFileSync(fsLocation, source);
   }
@@ -159,13 +162,13 @@ export default class CardCache {
       if (!existsSync(loc)) {
         continue;
       }
-      serverLog.debug(`card-cache deleting`, loc);
+      log.trace(`deleting`, loc);
       removeSync(loc);
     }
   }
 
   teardown(): void {
-    serverLog.info('Cleaning cardCache dir: ' + this.dir);
+    log.debug('Cleaning Cache dir: ' + this.dir);
     for (let subDir of ENVIRONMENTS) {
       removeSync(join(this.dir, subDir));
     }

--- a/packages/hub/services/contract-subscription-event-handler.ts
+++ b/packages/hub/services/contract-subscription-event-handler.ts
@@ -1,11 +1,13 @@
 import WorkerClient from './worker-client';
 import * as Sentry from '@sentry/node';
 import Web3SocketService from './web3-socket';
-import { contractSubscriptionEventHandlerLog } from '../utils/logger';
 import Contracts from './contracts';
 import { AddressKeys } from '@cardstack/cardpay-sdk';
 import LatestEventBlockQueries from './queries/latest-event-block';
 import { inject } from '@cardstack/di';
+
+import logger from '@cardstack/logger';
+const log = logger('hub/contract-subscription-event-handler');
 
 const CONTRACT_EVENTS = [
   {
@@ -30,8 +32,6 @@ export class ContractSubscriptionEventHandler {
     as: 'latestEventBlockQueries',
   });
 
-  #logger = contractSubscriptionEventHandlerLog;
-
   async setupContractEventSubscriptions() {
     let web3Instance = this.web3.getInstance();
 
@@ -52,9 +52,9 @@ export class ContractSubscriptionEventHandler {
               action: 'contract-subscription-event-handler',
             },
           });
-          this.#logger.error(`Error in ${contractEvent.contractName} subscription`, error);
+          log.error(`Error in ${contractEvent.contractName} subscription`, error);
         } else {
-          this.#logger.info(
+          log.info(
             `Received ${contractEvent.contractName} event (block number ${event.blockNumber})`,
             event.transactionHash
           );
@@ -65,7 +65,7 @@ export class ContractSubscriptionEventHandler {
       });
     }
 
-    this.#logger.info('Subscribed to events');
+    log.info('Subscribed to events');
   }
 }
 

--- a/packages/hub/utils/logger.ts
+++ b/packages/hub/utils/logger.ts
@@ -1,7 +1,0 @@
-import logger from '@cardstack/logger';
-
-export const contractSubscriptionEventHandlerLog = logger('hub/contract-subscription-event-handler');
-export const serverLog = logger('hub/server');
-export const workerLog = logger('hub/worker');
-export const botLog = logger('hub/bot');
-export const eventListenerLog = logger('hub/event-listener');


### PR DESCRIPTION
Reusing the `hub/server` logger is an anti-pattern. Using more focused loggers allows us to get access to the specific logging we care about: 
```
LOG_LEVELS='*=none,hub/fs-realm*=trace' yarn start:server
```