### PR TITLE
[CS-2849] add indexing to card service delete

### DIFF
--- a/packages/hub/node-tests/routes/cards/delete-test.ts
+++ b/packages/hub/node-tests/routes/cards/delete-test.ts
@@ -28,10 +28,8 @@ if (process.env.COMPILER) {
             import { contains } from "@cardstack/types";
             import string from "https://cardstack.com/base/string";
             export default class Post {
-              @contains(string)
-              title;
-              @contains(string)
-              body;
+              @contains(string) title;
+              @contains(string) body;
             }
           `,
           'isolated.js': templateOnlyComponentTemplate('<h1><@fields.title/></h1><article><@fields.body/></article>'),
@@ -53,7 +51,7 @@ if (process.env.COMPILER) {
       await deleteCard(`${realmURL}car0`).expect(404);
     });
 
-    it.skip('can delete an existing card that has no children', async function () {
+    it('can delete an existing card that has no children', async function () {
       await getCard(`${realmURL}post0`).expect(200);
 
       await deleteCard(`${realmURL}post0`).expect(204);

--- a/packages/hub/node-tests/routes/cards/delete-test.ts
+++ b/packages/hub/node-tests/routes/cards/delete-test.ts
@@ -64,5 +64,19 @@ if (process.env.COMPILER) {
 
       expect(existsSync(join(getRealmDir(), 'post0')), 'card is deleted from realm').to.be.false;
     });
+
+    it('can delete an existing card that has children', async function () {
+      await getCard(`${realmURL}post`).expect(200);
+      await deleteCard(`${realmURL}post`).expect(204);
+      await getCard(`${realmURL}post`).expect(404); // Deleted card is deleted!
+      await getCard(`${realmURL}post0`).expect(422); // card is in an error state
+
+      expect(
+        existsSync(join(getFileCache().dir, 'node', encodeCardURL(`${realmURL}post`))),
+        'Cache for card is deleted'
+      ).to.be.false;
+
+      expect(existsSync(join(getRealmDir(), 'post')), 'card is deleted from realm').to.be.false;
+    });
   });
 }

--- a/packages/hub/routes/card-routes.ts
+++ b/packages/hub/routes/card-routes.ts
@@ -107,8 +107,8 @@ export default class CardRoutes {
       params: { encodedCardURL: url },
     } = ctx;
 
-    await this.realmManager.delete(this.realmManager.parseCardURL(url));
-    this.cache.deleteCard(url);
+    let cardId = this.realmManager.parseCardURL(url);
+    await this.cards.as(INSECURE_CONTEXT).delete(cardId);
 
     ctx.status = 204;
     ctx.body = null;

--- a/packages/hub/services/card-service.ts
+++ b/packages/hub/services/card-service.ts
@@ -69,6 +69,11 @@ export class CardService {
     return { data: raw.data, compiled };
   }
 
+  async delete(raw: RawCard): Promise<void> {
+    await this.realmManager.delete(raw);
+    await this.searchIndex.deleteCard(raw);
+  }
+
   async query(query: Query): Promise<Card[]> {
     let client = await this.db.getPool();
     try {

--- a/packages/hub/services/file-cache.ts
+++ b/packages/hub/services/file-cache.ts
@@ -139,7 +139,7 @@ export default class FileCache {
     return this.readFile(join(this.dir, env, moduleURL.replace(this.pkgName + '', '')));
   }
 
-  deleteCard(cardURL: string): void {
+  deleteCardModules(cardURL: string): void {
     for (const env of ENVIRONMENTS) {
       let loc = this.getCardLocation(env, cardURL);
 

--- a/packages/hub/services/search-index.ts
+++ b/packages/hub/services/search-index.ts
@@ -57,6 +57,12 @@ export class SearchIndex {
     }
   }
 
+  async deleteCard(raw: RawCard) {
+    await this.runIndexing(raw.realm, async (ops) => {
+      return await ops.delete(cardURL(raw));
+    });
+  }
+
   async indexCard(
     raw: RawCard,
     compiled: CompiledCard<Unsaved, ModuleRef>,
@@ -264,8 +270,9 @@ class IndexerRun implements IndexerHandle {
     await this.db.query(expressionToSql(expression));
   }
 
-  async delete(cardURL: string): Promise<void> {
-    await this.db.query(`DELETE from cards where url=$1`, [cardURL]);
+  async delete(url: string): Promise<void> {
+    await this.db.query('DELETE FROM cards where url = $1', [url]);
+    this.fileCache.deleteCard(url);
   }
 
   async beginReplaceAll(): Promise<void> {

--- a/packages/hub/services/search-index.ts
+++ b/packages/hub/services/search-index.ts
@@ -39,6 +39,7 @@ export class SearchIndex {
   }
 
   async getCard(cardURL: string): Promise<{ raw: RawCard; compiled: CompiledCard | undefined }> {
+    log.trace('getCard', cardURL);
     let db = await this.database.getPool();
     let deserializer = new RawCardDeserializer();
     try {
@@ -58,8 +59,10 @@ export class SearchIndex {
   }
 
   async deleteCard(raw: RawCard) {
+    let url = cardURL(raw);
+    log.trace('deleteCard', url);
     await this.runIndexing(raw.realm, async (ops) => {
-      return await ops.delete(cardURL(raw));
+      return await ops.delete(url);
     });
   }
 
@@ -68,6 +71,7 @@ export class SearchIndex {
     compiled: CompiledCard<Unsaved, ModuleRef>,
     compiler: Compiler<Unsaved>
   ): Promise<CompiledCard> {
+    log.trace('indexCard', cardURL(raw));
     return await this.runIndexing(raw.realm, async (ops) => {
       return await ops.internalSave(raw, compiled, compiler);
     });
@@ -76,11 +80,11 @@ export class SearchIndex {
   private async runIndexing<Out>(realmURL: string, fn: (ops: IndexerRun) => Promise<Out>): Promise<Out> {
     let db = await this.database.getPool();
     try {
-      log.info(`starting to index realm`, realmURL);
+      log.trace(`starting to index realm`, realmURL);
       let run = new IndexerRun(db, this.builder, realmURL, this.fileCache);
       let result = await fn(run);
       await run.finalize();
-      log.info(`finished indexing realm`, realmURL);
+      log.trace(`finished indexing realm`, realmURL);
       return result;
     } finally {
       db.release();
@@ -271,6 +275,7 @@ class IndexerRun implements IndexerHandle {
   }
 
   async delete(url: string): Promise<void> {
+    this.touched.set(url, this.touchCounter++);
     await this.db.query('DELETE FROM cards where url = $1', [url]);
     this.fileCache.deleteCard(url);
   }

--- a/packages/hub/services/search-index.ts
+++ b/packages/hub/services/search-index.ts
@@ -277,7 +277,7 @@ class IndexerRun implements IndexerHandle {
   async delete(url: string): Promise<void> {
     this.touched.set(url, this.touchCounter++);
     await this.db.query('DELETE FROM cards where url = $1', [url]);
-    this.fileCache.deleteCard(url);
+    this.fileCache.deleteCardModules(url);
   }
 
   async beginReplaceAll(): Promise<void> {


### PR DESCRIPTION
Right now we just nuke the children when you delete a card. Maybe this is not what we want in the long run, but it's consistent with how we do things when creating/updating