### PR TITLE
stopgap to prevent too many walletconnect polling requests

### DIFF
--- a/packages/hub/services/discord-bots/hub-bot/services/wallet-connect.ts
+++ b/packages/hub/services/discord-bots/hub-bot/services/wallet-connect.ts
@@ -15,6 +15,7 @@ const { network } = config.get('web3') as Web3Config;
 export default class WalletConnectService {
   async getWeb3(message: Message): Promise<Web3 | undefined> {
     let provider = new WalletConnectProvider({
+      pollingInterval: 30000,
       clientMeta: {
         description: '',
         url: clientURL,


### PR DESCRIPTION
This sets the polling interval to 30 seconds, as opposed to a default of 8 seconds, which should significantly reduce the number of requests. 