### PR TITLE
Create Statuspage incidents when Checkly sends an alert

### DIFF
--- a/packages/hub/config/custom-environment-variables.json
+++ b/packages/hub/config/custom-environment-variables.json
@@ -54,6 +54,10 @@
   "web3storage": {
     "token": "WEB3_STORAGE_TOKEN"
   },
+  "statuspage": {
+    "pageId": "STATUSPAGE_PAGE_ID",
+    "apiKey": "STATUSPAGE_API_KEY"
+  },
   "firebase": {
     "projectId": "FIREBASE_PROJECT_ID",
     "clientEmail": "FIREBASE_CLIENT_EMAIL",

--- a/packages/hub/config/custom-environment-variables.json
+++ b/packages/hub/config/custom-environment-variables.json
@@ -58,6 +58,9 @@
     "pageId": "STATUSPAGE_PAGE_ID",
     "apiKey": "STATUSPAGE_API_KEY"
   },
+  "checkly": {
+    "webhookSecret": "CHECKLY_WEBHOOK_SECRET"
+  },
   "firebase": {
     "projectId": "FIREBASE_PROJECT_ID",
     "clientEmail": "FIREBASE_CLIENT_EMAIL",

--- a/packages/hub/config/default.cjs
+++ b/packages/hub/config/default.cjs
@@ -73,4 +73,8 @@ module.exports = {
   web3storage: {
     token: null,
   },
+  statuspage: {
+    apiKey: null,
+    pageId: null,
+  },
 };

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -103,6 +103,7 @@ import RemoveOldSentNotificationsTask from './tasks/remove-old-sent-notification
 import { ContractSubscriptionEventHandler } from './services/contract-subscription-event-handler';
 import { HubWorker } from './worker';
 import HubBot from './services/discord-bots/hub-bot';
+import StatuspageApi from './services/statuspage-api';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -187,6 +188,7 @@ export function createRegistry(): Registry {
   registry.register('wyre-callback-route', WyreCallbackRoute);
   registry.register('wyre-prices-route', WyrePricesRoute);
   registry.register('web3-storage', Web3Storage);
+  registry.register('statuspage-api', StatuspageApi);
 
   if (process.env.COMPILER) {
     registry.register('card-service', CardService);

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -104,6 +104,7 @@ import { ContractSubscriptionEventHandler } from './services/contract-subscripti
 import { HubWorker } from './worker';
 import HubBot from './services/discord-bots/hub-bot';
 import StatuspageApi from './services/statuspage-api';
+import ChecklyWebhookRoute from './routes/checkly-webhook';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -189,6 +190,7 @@ export function createRegistry(): Registry {
   registry.register('wyre-prices-route', WyrePricesRoute);
   registry.register('web3-storage', Web3Storage);
   registry.register('statuspage-api', StatuspageApi);
+  registry.register('checkly-webhook-route', ChecklyWebhookRoute);
 
   if (process.env.COMPILER) {
     registry.register('card-service', CardService);

--- a/packages/hub/node-tests/routes/checkly-webhook-test.ts
+++ b/packages/hub/node-tests/routes/checkly-webhook-test.ts
@@ -18,9 +18,9 @@ describe('POST /api/checkly-webhook', async function () {
 
   it('returns 200 when processing a check', async function () {
     await request()
-      .post('/api/checkly-webhook')
-      .set('Accept', 'application/vnd.api+json')
-      .set('Content-Type', 'application/vnd.api+json')
+      .post('/callbacks/checkly')
+      .set('Accept', 'application/json')
+      .set('Content-Type', 'application/json')
       .send({
         check_name: 'hub-prod subgraph / RPC node block number diff within threshold',
         alert_type: 'ALERT_FAILURE',
@@ -30,9 +30,9 @@ describe('POST /api/checkly-webhook', async function () {
 
   it('returns 422 when processing an unrecognized check', async function () {
     await request()
-      .post('/api/checkly-webhook')
-      .set('Accept', 'application/vnd.api+json')
-      .set('Content-Type', 'application/vnd.api+json')
+      .post('/callbacks/checkly')
+      .set('Accept', 'application/json')
+      .set('Content-Type', 'application/json')
       .send({
         check_name: 'abc123',
         alert_type: 'ALERT_FAILURE',

--- a/packages/hub/node-tests/routes/checkly-webhook-test.ts
+++ b/packages/hub/node-tests/routes/checkly-webhook-test.ts
@@ -1,0 +1,42 @@
+import { registry, setupHub } from '../helpers/server';
+
+class StubStatuspageApi {
+  async createIncident(_componentName: string, _name: string) {
+    return true;
+  }
+  async resolveIncident(_componentName: string) {
+    return true;
+  }
+}
+
+describe('POST /api/checkly-webhook', async function () {
+  this.beforeEach(function () {
+    registry(this).register('statuspage-api', StubStatuspageApi);
+  });
+
+  let { request } = setupHub(this);
+
+  it('returns 200 when processing a check', async function () {
+    await request()
+      .post('/api/checkly-webhook')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .send({
+        check_name: 'hub-prod subgraph / RPC node block number diff within threshold',
+        alert_type: 'ALERT_FAILURE',
+      })
+      .expect(200);
+  });
+
+  it('returns 422 when processing an unrecognized check', async function () {
+    await request()
+      .post('/api/checkly-webhook')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .send({
+        check_name: 'abc123',
+        alert_type: 'ALERT_FAILURE',
+      })
+      .expect(422);
+  });
+});

--- a/packages/hub/node-tests/routes/checkly-webhook-test.ts
+++ b/packages/hub/node-tests/routes/checkly-webhook-test.ts
@@ -1,22 +1,33 @@
 import { registry, setupHub } from '../helpers/server';
 
+let createdIncident: { componentName: string; message: string } | null,
+  resolvedIncident: { componentName: string } | null;
+
 class StubStatuspageApi {
-  async createIncident(_componentName: string, _name: string) {
-    return true;
+  async createIncident(componentName: string, message: string): Promise<void> {
+    createdIncident = {
+      componentName,
+      message,
+    };
   }
-  async resolveIncident(_componentName: string) {
-    return true;
+  async resolveIncident(componentName: string): Promise<void> {
+    resolvedIncident = {
+      componentName,
+    };
   }
 }
 
 describe('POST /api/checkly-webhook', async function () {
   this.beforeEach(function () {
+    createdIncident = null;
+    resolvedIncident = null;
+
     registry(this).register('statuspage-api', StubStatuspageApi);
   });
 
   let { request } = setupHub(this);
 
-  it('returns 200 when processing a check', async function () {
+  it('creates a new alert when the check failed', async function () {
     await request()
       .post('/callbacks/checkly')
       .set('Accept', 'application/json')
@@ -26,6 +37,29 @@ describe('POST /api/checkly-webhook', async function () {
         alert_type: 'ALERT_FAILURE',
       })
       .expect(200);
+
+    expect(createdIncident).to.deep.equal({
+      componentName: 'Subgraph',
+      message:
+        'We are experiencing blockchain indexing delays. The blockchain index is delayed by at least 10 blocks. This will result increased transaction processing times.',
+    });
+  });
+
+  it('creates a new alert when the check recovered', async function () {
+    await request()
+      .post('/callbacks/checkly')
+      .set('Accept', 'application/json')
+      .set('Content-Type', 'application/json')
+      .send({
+        check_name: 'hub-prod subgraph / RPC node block number diff within threshold',
+        alert_type: 'ALERT_RECOVERY',
+      })
+      .expect(200);
+
+    expect(createdIncident).to.be.null;
+    expect(resolvedIncident).to.deep.equal({
+      componentName: 'Subgraph',
+    });
   });
 
   it('returns 422 when processing an unrecognized check', async function () {

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -58,6 +58,7 @@
     "auto-bind": "^4.0.0",
     "config": "^3.3.6",
     "corde": "^4.4.1",
+    "crypto": "^1.0.1",
     "dag-map": "^2.0.2",
     "did-resolver": "^3.1.0",
     "dotenv": "^10.0.0",

--- a/packages/hub/routes/checkly-webhook.ts
+++ b/packages/hub/routes/checkly-webhook.ts
@@ -5,10 +5,11 @@ import StatuspageApi from '../services/statuspage-api';
 import crypto from 'crypto';
 import config from 'config';
 
+// Check names and component names should map to the names and components in Checkly
 type CheckName = 'hub-prod subgraph / RPC node block number diff within threshold';
 type Checks = {
   [key in CheckName]: {
-    componentName: string; // Component name in Checkly
+    componentName: 'Subgraph'; // Component name in Checkly
     incidentMessage: string; // Will be shown in Statuspage
   };
 };
@@ -48,10 +49,14 @@ export default class ChecklyWebhookRoute {
       } else if (alertType == 'ALERT_RECOVERY') {
         await this.statuspageApi.resolveIncident(check.componentName);
       }
+
+      ctx.status = 200;
+      ctx.body = {};
+    } else {
+      ctx.status = 422;
+      ctx.body = { error: `Unrecognized check name: ${checkName}` };
     }
 
-    ctx.status = 200;
-    ctx.body = {};
     ctx.type = 'application/vnd.api+json';
   }
 

--- a/packages/hub/routes/checkly-webhook.ts
+++ b/packages/hub/routes/checkly-webhook.ts
@@ -1,0 +1,52 @@
+import Koa from 'koa';
+import autoBind from 'auto-bind';
+import { inject } from '@cardstack/di';
+import StatuspageApi from '../services/statuspage-api';
+
+type CheckName = 'hub-prod subgraph / RPC node block number diff within threshold';
+type Checks = {
+  [key in CheckName]: {
+    componentName: string; // Component name in Checkly
+    incidentMessage: string; // Will be shown in Statuspage
+  };
+};
+
+export default class ChecklyWebhookRoute {
+  statuspageApi: StatuspageApi = inject('statuspage-api', { as: 'statuspageApi' });
+
+  checks: Checks = {
+    'hub-prod subgraph / RPC node block number diff within threshold': {
+      componentName: 'Subgraph',
+      incidentMessage: 'Subgraph block number is behind RPC block number by more than 10 blocks',
+    },
+  };
+
+  constructor() {
+    autoBind(this);
+  }
+
+  async post(ctx: Koa.Context) {
+    let checkName = ctx.request.body.check_name as keyof Checks;
+    let check = this.checks[checkName];
+
+    if (check) {
+      let alertType = ctx.request.body.alert_type;
+
+      if (alertType === 'ALERT_FAILURE') {
+        await this.statuspageApi.createIncident(check.componentName, check.incidentMessage);
+      } else if (alertType == 'ALERT_RECOVERY') {
+        await this.statuspageApi.resolveIncident(check.componentName);
+      }
+    }
+
+    ctx.status = 200;
+    ctx.body = {};
+    ctx.type = 'application/vnd.api+json';
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'checkly-webhook-route': ChecklyWebhookRoute;
+  }
+}

--- a/packages/hub/routes/checkly-webhook.ts
+++ b/packages/hub/routes/checkly-webhook.ts
@@ -4,6 +4,7 @@ import { inject } from '@cardstack/di';
 import StatuspageApi from '../services/statuspage-api';
 import crypto from 'crypto';
 import config from 'config';
+import { DEGRADED_THRESHOLD as degradedSubgraphThreshold } from '../routes/status';
 
 // Check names and component names should map to the names and components in Checkly
 type CheckName = 'hub-prod subgraph / RPC node block number diff within threshold';
@@ -20,7 +21,7 @@ export default class ChecklyWebhookRoute {
   checks: Checks = {
     'hub-prod subgraph / RPC node block number diff within threshold': {
       componentName: 'Subgraph',
-      incidentMessage: 'Subgraph block number is behind RPC block number by more than 10 blocks',
+      incidentMessage: `We are experiencing blockchain indexing delays. The blockchain index is delayed by at least ${degradedSubgraphThreshold} blocks. This will result increased transaction processing times.`,
     },
   };
 

--- a/packages/hub/routes/checkly-webhook.ts
+++ b/packages/hub/routes/checkly-webhook.ts
@@ -57,7 +57,7 @@ export default class ChecklyWebhookRoute {
       ctx.body = { error: `Unrecognized check name: ${checkName}` };
     }
 
-    ctx.type = 'application/vnd.api+json';
+    ctx.type = 'application/json';
   }
 
   private isVerifiedPayload(payload: string, signature: string) {

--- a/packages/hub/routes/status.ts
+++ b/packages/hub/routes/status.ts
@@ -4,7 +4,7 @@ import { inject } from '@cardstack/di';
 import * as Sentry from '@sentry/node';
 import { JSONAPIDocument } from '../utils/jsonapi-document';
 
-const DEGRADED_THRESHOLD = 10;
+export const DEGRADED_THRESHOLD = 10;
 
 export default class StatusRoute {
   subgraph = inject('subgraph');

--- a/packages/hub/services/api-router.ts
+++ b/packages/hub/services/api-router.ts
@@ -38,7 +38,7 @@ export default class APIRouter {
   reservationsRoute = inject('reservations-route', { as: 'reservationsRoute' });
   inventoryRoute = inject('inventory-route', { as: 'inventoryRoute' });
   wyrePricesRoute = inject('wyre-prices-route', { as: 'wyrePricesRoute' });
-  checklyWebhookRoute = inject('checkly-webhook-route', { as: 'checklyWebhookRoute' });
+
   routes() {
     let {
       boomRoute,

--- a/packages/hub/services/api-router.ts
+++ b/packages/hub/services/api-router.ts
@@ -57,7 +57,6 @@ export default class APIRouter {
       wyrePricesRoute,
       pushNotificationRegistrationsRoute,
       notificationPreferencesRoute,
-      checklyWebhookRoute,
     } = this;
     let apiSubrouter = new Router();
     apiSubrouter.get('/boom', boomRoute.get);
@@ -94,7 +93,6 @@ export default class APIRouter {
     apiSubrouter.get('/notification-preferences/:push_client_id', parseBody, notificationPreferencesRoute.get);
     apiSubrouter.put('/notification-preferences/:push_client_id', parseBody, notificationPreferencesRoute.put);
     apiSubrouter.get('/wyre-prices', parseBody, wyrePricesRoute.get);
-    apiSubrouter.post('/checkly-webhook', parseBody, checklyWebhookRoute.post);
     apiSubrouter.all('/(.*)', notFound);
 
     let apiRouter = new Router();

--- a/packages/hub/services/api-router.ts
+++ b/packages/hub/services/api-router.ts
@@ -38,6 +38,7 @@ export default class APIRouter {
   reservationsRoute = inject('reservations-route', { as: 'reservationsRoute' });
   inventoryRoute = inject('inventory-route', { as: 'inventoryRoute' });
   wyrePricesRoute = inject('wyre-prices-route', { as: 'wyrePricesRoute' });
+  checklyWebhookRoute = inject('checkly-webhook-route', { as: 'checklyWebhookRoute' });
   routes() {
     let {
       boomRoute,
@@ -56,6 +57,7 @@ export default class APIRouter {
       wyrePricesRoute,
       pushNotificationRegistrationsRoute,
       notificationPreferencesRoute,
+      checklyWebhookRoute,
     } = this;
     let apiSubrouter = new Router();
     apiSubrouter.get('/boom', boomRoute.get);
@@ -92,6 +94,7 @@ export default class APIRouter {
     apiSubrouter.get('/notification-preferences/:push_client_id', parseBody, notificationPreferencesRoute.get);
     apiSubrouter.put('/notification-preferences/:push_client_id', parseBody, notificationPreferencesRoute.put);
     apiSubrouter.get('/wyre-prices', parseBody, wyrePricesRoute.get);
+    apiSubrouter.post('/checkly-webhook', parseBody, checklyWebhookRoute.post);
     apiSubrouter.all('/(.*)', notFound);
 
     let apiRouter = new Router();

--- a/packages/hub/services/callbacks-router.ts
+++ b/packages/hub/services/callbacks-router.ts
@@ -10,10 +10,13 @@ import { parseBody } from '../middleware';
 
 export default class CallbacksRouter {
   wyreCallbackRoute: WyreCallbackRoute = inject('wyre-callback-route', { as: 'wyreCallbackRoute' });
+  checklyWebhookRoute = inject('checkly-webhook-route', { as: 'checklyWebhookRoute' });
+
   routes() {
-    let { wyreCallbackRoute } = this;
+    let { wyreCallbackRoute, checklyWebhookRoute } = this;
     let callbacksSubrouter = new Router();
     callbacksSubrouter.post('/wyre', parseBody, wyreCallbackRoute.post);
+    callbacksSubrouter.post('/checkly', parseBody, checklyWebhookRoute.post);
     callbacksSubrouter.all('/(.*)', notFound);
 
     let callbacksRouter = new Router();

--- a/packages/hub/services/statuspage-api.ts
+++ b/packages/hub/services/statuspage-api.ts
@@ -1,0 +1,124 @@
+import config from 'config';
+import fetch from 'node-fetch';
+
+interface StatuspageComponent {
+  id: string;
+  name: string;
+}
+
+interface StatuspageIncident {
+  id: string;
+  name: string;
+  component_ids: [];
+}
+
+let baseUrl = 'https://api.statuspage.io/v1';
+let pageId = config.get('statuspage.pageId');
+let apiKey = config.get('statuspage.apiKey');
+
+export default class StatuspageApi {
+  async createIncident(componentName: string, name: string) {
+    let componentId = await this.getComponentId(componentName);
+    let unresolvedIncidents = await this.getUnresolvedIncidents();
+    let relatedIncident = this.findIncidentByComponentId(unresolvedIncidents, componentId);
+
+    if (relatedIncident) {
+      return; // An incident for this component is already open
+    }
+
+    return await this.request(`/pages/${pageId}/incidents`, 'POST', {
+      incident: {
+        name,
+        impact: 'minor',
+        status: 'investigating',
+        components: { [componentId]: 'partial_outage' }, // Will update individual components' status
+        component_ids: [componentId], // Will associate incident with the component
+      },
+    });
+  }
+
+  async resolveIncident(componentName: string) {
+    let componentId = await this.getComponentId(componentName);
+    let unresolvedIncidents = await this.getUnresolvedIncidents();
+    let relatedIncident = this.findIncidentByComponentId(unresolvedIncidents, componentId);
+
+    if (relatedIncident) {
+      await this.request(`/pages/${pageId}/incidents/${relatedIncident.id}`, 'PATCH', {
+        incident: {
+          components: { [componentId]: 'operational' },
+          status: 'resolved',
+        },
+      });
+    }
+  }
+
+  private async getUnresolvedIncidents(): Promise<StatuspageIncident[]> {
+    let incidents = await this.request(`/pages/${pageId}/incidents/unresolved`);
+
+    return incidents.map((incident: any) => {
+      return {
+        id: incident.id,
+        component_ids: incident.components.map((component: any) => component.id),
+      };
+    });
+  }
+
+  private async getComponentId(componentName: string) {
+    let component = (await this.getComponents()).find((component) => {
+      return component.name === componentName;
+    });
+
+    if (!component) {
+      throw new Error(`Statuspage component ${componentName} not found`);
+    } else {
+      return component.id;
+    }
+  }
+
+  private async getComponents(): Promise<StatuspageComponent[]> {
+    let components = await this.request(`/pages/${pageId}/components`);
+
+    return components.map((component: StatuspageComponent) => {
+      return {
+        id: component.id,
+        name: component.name,
+      };
+    });
+  }
+
+  private findIncidentByComponentId(incidents: StatuspageIncident[], componentId: string) {
+    return incidents.find((incident) => {
+      // Checks for array equality
+      return JSON.stringify(incident.component_ids) === JSON.stringify([componentId]);
+    });
+  }
+
+  private async request(path: string, method: 'GET' | 'POST' | 'PATCH' = 'GET', payload: any = null) {
+    let params = {
+      method,
+      headers: {
+        Authorization: `OAuth: ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+    };
+
+    if (payload) {
+      (params as any).body = JSON.stringify(payload);
+    }
+
+    let result = await fetch(`${baseUrl}${path}`, params);
+    let jsonResponse = await result.json();
+
+    if (jsonResponse.error) {
+      throw new Error(`Statuspage client error: ${jsonResponse.error}`);
+    }
+
+    return jsonResponse;
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'statuspage-api': StatuspageApi;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11795,6 +11795,11 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
+crypto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
+  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
+
 css-element-queries@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/css-element-queries/-/css-element-queries-0.4.0.tgz#cb5bcde9d980ac3699e7471f798e70600088d3de"


### PR DESCRIPTION
Ticket: [CS-2885](https://linear.app/cardstack/issue/CS-2885/automatically-create-statuspage-incidents-when-subgraph-lag-is)

This PR aims to automatically create incidents on https://status.cardstack.com/ when Checkly reports a failed check. When there is an active incident on Statuspage, the web client will display it in the banner.

Currently, this is only configured for the ["hub-prod subgraph / RPC node block number diff within threshold"](https://app.checklyhq.com/checks/5add1b2a-89c8-4f4c-8921-638b4b1643fd/) check, but we can add more.

When the above check performed by Checkly fails, it will send a webhook (`ALERT_FAILURE` alert type) to the hub. There, the hub endpoint will create an incident on Statuspage using the Statuspage API. When Checkly detects the degradation is over, it will send another webhook (`ALERT_RECOVERY` alert type) to the hub endpoint, which will resolve the incident.

There is an issue though - this whole mechanism relies on the hub being up and running. Meaning the automated incident reporting will not work in case the hub is not reachable. The most basic case where this falls apart is the "hub health check", where if the hub is down, Checkly can't use it to create an incident on Statuspage.

I'm thinking it would be great if we could host this somewhere separately from the hub. Perhaps this can be a Lambda function exposed via AWS API Gateway which Checkly can send alerts to directly, effectively removing the hub's point of failure. What do you think?

TODO:
- [ ] Configure the webhook URL in Checkly 
- [x] Implement webhook validation (for security)