### PR TITLE
hub: Add documentation about required plugin

### DIFF
--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -159,6 +159,8 @@ Hub > await workerClient.addJob('persist-off-chain-merchant-info', { id: 1 });
 
 ### Setup AWS Session Manager ssh config
 
+Install the [AWS Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) if you don’t already have it.
+
 Add the following to your `~/.ssh/config` file:
 
 ```


### PR DESCRIPTION
I was getting a silent failure running the tunnel command until
I ran it with verbose logging, then I saw this:

```
SessionManagerPlugin is not found. Please refer to SessionManager Documentation here: http://docs.aws.amazon.com/console/systems-manager/session-manager-plugin-not-found
```

However, even with that I’m still unable to connect, so I’ll keep this a draft in case I find anything else.