### PR TITLE
Fix/intercept statuspage calls

### DIFF
--- a/packages/web-client/app/services/degraded-service-detector.ts
+++ b/packages/web-client/app/services/degraded-service-detector.ts
@@ -52,7 +52,7 @@ export default class DegradedServiceDetector extends Service {
       let response = await fetch(statusPageUrl);
       data = await response.json();
     } catch (e) {
-      console.error('Failed to fetch exchange rates');
+      console.error('Failed to fetch unresolved status page incidents');
       Sentry.captureException(e);
 
       return null;

--- a/packages/web-client/mirage/config.js
+++ b/packages/web-client/mirage/config.js
@@ -3,6 +3,7 @@ import {
   defaultCreatedPrepaidCardDID,
 } from '@cardstack/web-client/utils/test-factories';
 import { nativeCurrencies } from '@cardstack/cardpay-sdk';
+import config from '@cardstack/web-client/config/environment';
 
 export default function () {
   this.namespace = 'api';
@@ -82,6 +83,16 @@ export default function () {
     function (schema, { params: { idWithExtension } }) {
       let [id] = idWithExtension.split('.');
       return schema.merchantInfos.find(id);
+    }
+  );
+
+  // prevent sporadic test failure because of degradation banner
+  this.get(
+    `${config.urls.statusPageUrl}/api/v2/incidents/unresolved.json`,
+    function () {
+      return {
+        incidents: [],
+      };
     }
   );
 

--- a/packages/web-client/tests/acceptance/accessibility-test.ts
+++ b/packages/web-client/tests/acceptance/accessibility-test.ts
@@ -2,9 +2,11 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | accessibility', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('accessibility check', async function (assert) {
     await visit('/');

--- a/packages/web-client/tests/acceptance/connect-wallet-test.ts
+++ b/packages/web-client/tests/acceptance/connect-wallet-test.ts
@@ -11,9 +11,11 @@ import percySnapshot from '@percy/ember';
 import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
 import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | Connect Wallet', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('Connecting a layer 1 wallet via Metamask', async function (assert) {
     await visit('/');

--- a/packages/web-client/tests/acceptance/create-card-space-test.ts
+++ b/packages/web-client/tests/acceptance/create-card-space-test.ts
@@ -16,6 +16,7 @@ import {
   createDepotSafe,
   createSafeToken,
 } from '@cardstack/web-client/utils/test-factories';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 function postableSel(milestoneIndex: number, postableIndex: number): string {
   return `[data-test-milestone="${milestoneIndex}"][data-test-postable="${postableIndex}"]`;
@@ -29,6 +30,7 @@ function epiloguePostableSel(postableIndex: number): string {
 
 module('Acceptance | create card space', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   let layer2Service: Layer2TestWeb3Strategy;
   let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -21,6 +21,7 @@ import {
   createDepotSafe,
   createSafeToken,
 } from '@cardstack/web-client/utils/test-factories';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 function postableSel(milestoneIndex: number, postableIndex: number): string {
   return `[data-test-milestone="${milestoneIndex}"][data-test-postable="${postableIndex}"]`;
@@ -40,6 +41,7 @@ function cancelationPostableSel(postableIndex: number) {
 
 module('Acceptance | deposit', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('Initiating workflow without wallet connections', async function (assert) {
     await visit('/card-pay/deposit-withdrawal');

--- a/packages/web-client/tests/acceptance/network-problems-test.ts
+++ b/packages/web-client/tests/acceptance/network-problems-test.ts
@@ -5,6 +5,7 @@ import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/
 import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
 
 import { createDepotSafe } from '@cardstack/web-client/utils/test-factories';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 const MODAL = '[data-test-network-problem-modal]';
 const MODAL_TITLE = '[data-test-network-problem-modal-title]';
@@ -16,6 +17,8 @@ const MODAL_IS_DISMISSABLE_ATTRIBUTE =
 
 module('Acceptance | network-problems', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
+
   let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
   let layer2Service: Layer2TestWeb3Strategy;
   let layer1Service: Layer1TestWeb3Strategy;

--- a/packages/web-client/tests/acceptance/withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-test.ts
@@ -23,6 +23,7 @@ import {
   createMerchantSafe,
   createSafeToken,
 } from '@cardstack/web-client/utils/test-factories';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 function postableSel(milestoneIndex: number, postableIndex: number): string {
   return `[data-test-milestone="${milestoneIndex}"][data-test-postable="${postableIndex}"]`;
@@ -42,7 +43,7 @@ function cancelationPostableSel(postableIndex: number) {
 
 module('Acceptance | withdrawal', function (hooks) {
   setupApplicationTest(hooks);
-
+  setupMirage(hooks);
   test('Initiating workflow without wallet connections', async function (assert) {
     await visit('/card-pay/deposit-withdrawal');
     assert.equal(currentURL(), '/card-pay/deposit-withdrawal');


### PR DESCRIPTION
Intercept degraded-service-detector's calls to the statuspage API to make sure the degraded service banner doesn't show and cause test failures randomly.

Am not sure if modifying the behaviour/url used for testing in the degraded-service-detector is better. Would prefer not to do that... but using mirage does mean that we should add mirage to almost all acceptance tests to prevent these sporadic failures.