### PR TITLE
Prevent multiple firebase client initialization

### DIFF
--- a/packages/hub/initializers/firebase.ts
+++ b/packages/hub/initializers/firebase.ts
@@ -3,7 +3,8 @@ import admin from 'firebase-admin';
 import config from 'config';
 
 export default function initFirebase() {
-  if (config.get('firebase.projectId')) {
+  // apps.length check is to prevent "multiple initialization error" when running tests
+  if (config.get('firebase.projectId') && admin.apps.length === 0) {
     initializeApp({
       credential: admin.credential.cert({
         projectId: config.get('firebase.projectId'),


### PR DESCRIPTION
Been getting this error when running tests (while having `FIREBASE_PROJECT_ID` configured in the .env file). 

```
Error: The default Firebase app already exists. This means you called initializeApp() more
than once without providing an app name as the second argument. In most cases you 
only need to call initializeApp() once. But if you do want to initialize multiple apps, 
pass a second argument to initializeApp() to give each app a unique name.
```

