### PR TITLE
Fix firebase private key parsing

### DIFF
--- a/packages/hub/initializers/firebase.ts
+++ b/packages/hub/initializers/firebase.ts
@@ -9,7 +9,7 @@ export default function initFirebase() {
       credential: admin.credential.cert({
         projectId: config.get('firebase.projectId'),
         clientEmail: config.get('firebase.clientEmail'),
-        privateKey: config.get('firebase.privateKey'),
+        privateKey: (config.get('firebase.privateKey') as string).replace(/\\n/g, '\n'),
       }),
       databaseURL: config.get('firebase.databaseURL'),
     });


### PR DESCRIPTION
Attempting to fix the "Server failed to start cleanly: Error: Failed to parse private key: Error: Invalid
PEM formatted message" error on hub boot. 

From https://pipedream.com/apps/firebase-admin-sdk.