### PR TITLE
web: Update Card Space next step to link to space

### DIFF
--- a/packages/web-client/app/components/card-space/create-space-workflow/next-steps/index.ts
+++ b/packages/web-client/app/components/card-space/create-space-workflow/next-steps/index.ts
@@ -2,13 +2,23 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import RouterService from '@ember/routing/router-service';
+import { next } from '@ember/runloop';
 import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 
 class CreateSpaceWorkflowNextStepsComponent extends Component<WorkflowCardComponentArgs> {
   @service declare router: RouterService;
 
   @action async visitSpace() {
-    // TODO
+    let username = this.args.workflowSession.getValue('username');
+
+    await this.router.transitionTo({
+      queryParams: { flow: null, 'flow-id': null },
+    });
+
+    next(this, () => {
+      this.router.transitionTo('card-space.userspace', { username });
+    });
+
     return;
   }
 }

--- a/packages/web-client/app/components/card-space/create-space-workflow/username/index.hbs
+++ b/packages/web-client/app/components/card-space/create-space-workflow/username/index.hbs
@@ -12,8 +12,8 @@
   >
     <:default as |d|>
       <d.ActionButton
-        {{on "click" @onComplete}}
         data-test-card-space-username-save-button
+        {{on 'click' this.save}}
       >
         Continue
       </d.ActionButton>

--- a/packages/web-client/app/components/card-space/create-space-workflow/username/index.ts
+++ b/packages/web-client/app/components/card-space/create-space-workflow/username/index.ts
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
+
+class CreateSpaceUsernameCard extends Component<WorkflowCardComponentArgs> {
+  @action save() {
+    this.args.workflowSession.setValue('username', 'usernametodo');
+    this.args.onComplete?.();
+  }
+}
+
+export default CreateSpaceUsernameCard;

--- a/packages/web-client/app/router.ts
+++ b/packages/web-client/app/router.ts
@@ -15,6 +15,9 @@ Router.map(function () {
   });
   this.route('card-space', function () {
     this.route('profile-card-temp');
+    this.route('userspace', {
+      path: '/:username',
+    });
   });
   this.route('image-uploader-temp');
   this.route('pay', {

--- a/packages/web-client/app/templates/card-space/userspace.hbs
+++ b/packages/web-client/app/templates/card-space/userspace.hbs
@@ -1,0 +1,1 @@
+TODO: Card Space user space for {{@model.username}}

--- a/packages/web-client/tests/acceptance/create-card-space-test.ts
+++ b/packages/web-client/tests/acceptance/create-card-space-test.ts
@@ -165,8 +165,9 @@ module('Acceptance | create card space', function (hooks) {
     await waitFor(epiloguePostableSel(2));
 
     await percySnapshot(assert);
-    // TODO
-    // await click('[data-test-card-space-next-step="visit-space"]');
+
+    await click('[data-test-card-space-next-step="visit-space"]');
+    assert.equal(currentURL(), '/card-space/usernametodo');
   });
 
   module('tests with layer 2 already connected', function (hooks) {


### PR DESCRIPTION
This is a narrowly-focused PR to wire up the Next Steps button
after the Create Card Space workflow to forward to the newly-
created space.

Some arbitrary decisions that are lightweight enough to change
easily if/when needed:
* the workflow property name is `username`
* the route is `/card-space/username`
* the template is a placeholder that shows the username