### PR TITLE
Extend yarn clean script to also remove cardpay-sdk's dist/ and generated/ directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typescript": "4.2.3"
   },
   "scripts": {
-    "clean": "git clean -x -f --exclude=packages/*/.env --exclude=cardstack.code-workspace",
+    "clean": "git clean -x -f --exclude=packages/*/.env --exclude=cardstack.code-workspace && lerna run clean",
     "codegen:subgraph-sokol": "cd ./packages/cardpay-subgraph && yarn codegen-sokol",
     "codegen:subgraph-xdai": "cd ./packages/cardpay-subgraph && yarn codegen-xdai",
     "build:subgraph": "cd ./packages/cardpay-subgraph && yarn build",

--- a/packages/cardpay-sdk/package.json
+++ b/packages/cardpay-sdk/package.json
@@ -45,6 +45,7 @@
     "dist"
   ],
   "scripts": {
+    "clean": "rm -rf dist generated",
     "postinstall": "if [ -f ./bin/codegen.js ]; then node bin/codegen.js; fi",
     "prepack": "rm -rf ./dist && tsup ./index.ts --format esm,cjs --dts --legacy-output"
   },


### PR DESCRIPTION
- presence of .d.ts files in dist caused problems running web-client