### PR TITLE
report web3-socket events to sentry

### DIFF
--- a/packages/hub/node-tests/services/web3-socket-test.ts
+++ b/packages/hub/node-tests/services/web3-socket-test.ts
@@ -7,25 +7,40 @@ const { testkit, sentryTransport } = sentryTestkit();
 const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001';
 
 describe('Web3Socket', function () {
-  this.beforeEach(function () {
+  let subject: Web3SocketService;
+  this.beforeAll(function () {
     Sentry.init({
       dsn: DUMMY_DSN,
       release: 'test',
       tracesSampleRate: 1,
       transport: sentryTransport,
     });
-
+  });
+  this.beforeEach(function () {
+    subject = new Web3SocketService();
     testkit.reset();
+  });
+  this.afterEach(async function () {
+    let connection = (subject.web3?.currentProvider as unknown as any)?.connection;
+    if (connection) {
+      if (connection.readyState === connection.OPEN) connection.close(1000, 'Closing because test is done');
+      // hack to make sure cleanup is properly done after tests
+      // https://github.com/theturtle32/WebSocket-Node/issues/426
+      connection._client.on('httpResponse', (r: any) => {
+        r.destroy();
+      });
+      connection._client.on('connect', (c: any) => {
+        c.close();
+      });
+    }
   });
 
   it('reports to sentry when web3 initialization fails', async function () {
-    let web3Socket = new Web3SocketService();
-
-    web3Socket.initializeWeb3 = () => {
+    subject.initializeWeb3 = () => {
       throw new Error('mock web3 initialization failure');
     };
 
-    expect(() => web3Socket.getInstance()).to.throw('mock web3 initialization failure');
+    expect(() => subject.getInstance()).to.throw('mock web3 initialization failure');
 
     await waitFor(() => testkit.reports().length > 0);
 
@@ -35,8 +50,7 @@ describe('Web3Socket', function () {
   });
 
   it('reports error events', async function () {
-    let web3Socket = new Web3SocketService();
-    let web3 = web3Socket.getInstance();
+    let web3 = subject.getInstance();
 
     let provider: any = web3.currentProvider;
     provider.emit(provider.ERROR, new Error('A test error'));
@@ -50,8 +64,7 @@ describe('Web3Socket', function () {
   });
 
   it('reports close events', async function () {
-    let web3Socket = new Web3SocketService();
-    let web3 = web3Socket.getInstance();
+    let web3 = subject.getInstance();
 
     let provider: any = web3.currentProvider;
     provider.emit(provider.CLOSE, {

--- a/packages/hub/node-tests/services/web3-socket-test.ts
+++ b/packages/hub/node-tests/services/web3-socket-test.ts
@@ -109,7 +109,7 @@ describe('Web3Socket', function () {
       reason: 'Testing',
       wasClean: false,
     });
-    expect(testkit.reports()[0].tags).to.deep.equal({
+    expect(originalReport.tags).to.deep.equal({
       action: 'web3-socket-connection',
     });
   });

--- a/packages/hub/node-tests/services/web3-socket-test.ts
+++ b/packages/hub/node-tests/services/web3-socket-test.ts
@@ -101,15 +101,15 @@ describe('Web3Socket', function () {
       return !!testkit.reports().length;
     }, 15000);
 
-    let originalReport = testkit
+    let testCaseReport = testkit
       .reports()
       .find((v) => (v?.originalReport?.extra?.__serialized__ as any).reason === 'Testing')!;
-    expect(originalReport?.extra?.__serialized__).to.deep.equal({
+    expect(testCaseReport?.extra?.__serialized__).to.deep.equal({
       code: 1000,
       reason: 'Testing',
       wasClean: false,
     });
-    expect(originalReport.tags).to.deep.equal({
+    expect(testCaseReport.tags).to.deep.equal({
       action: 'web3-socket-connection',
     });
   });

--- a/packages/hub/node-tests/services/web3-socket-test.ts
+++ b/packages/hub/node-tests/services/web3-socket-test.ts
@@ -7,13 +7,18 @@ const { testkit, sentryTransport } = sentryTestkit();
 const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001';
 
 describe('Web3Socket', function () {
-  it('reports to sentry when web3 initialization fails', async function () {
+  this.beforeEach(function () {
     Sentry.init({
       dsn: DUMMY_DSN,
       release: 'test',
       tracesSampleRate: 1,
       transport: sentryTransport,
     });
+
+    testkit.reset();
+  });
+
+  it('reports to sentry when web3 initialization fails', async function () {
     let web3Socket = new Web3SocketService();
 
     web3Socket.initializeWeb3 = () => {
@@ -24,6 +29,44 @@ describe('Web3Socket', function () {
 
     await waitFor(() => testkit.reports().length > 0);
 
+    expect(testkit.reports()[0].tags).to.deep.equal({
+      action: 'web3-socket-connection',
+    });
+  });
+
+  it('reports error events', async function () {
+    let web3Socket = new Web3SocketService();
+    let web3 = web3Socket.getInstance();
+
+    let provider: any = web3.currentProvider;
+    provider.emit(provider.ERROR, new Error('A test error'));
+
+    await waitFor(() => testkit.reports().length > 0);
+
+    expect(testkit.reports()[0].error?.message).to.equal('A test error');
+    expect(testkit.reports()[0].tags).to.deep.equal({
+      action: 'web3-socket-connection',
+    });
+  });
+
+  it('reports close events', async function () {
+    let web3Socket = new Web3SocketService();
+    let web3 = web3Socket.getInstance();
+
+    let provider: any = web3.currentProvider;
+    provider.emit(provider.CLOSE, {
+      code: 1006,
+      reason: 'Testing',
+      wasClean: false,
+    });
+
+    await waitFor(() => testkit.reports().length > 0);
+
+    expect(testkit.reports()[0]?.originalReport?.extra?.__serialized__).to.deep.equal({
+      code: 1006,
+      reason: 'Testing',
+      wasClean: false,
+    });
     expect(testkit.reports()[0].tags).to.deep.equal({
       action: 'web3-socket-connection',
     });

--- a/packages/hub/node-tests/utils/wait-for.ts
+++ b/packages/hub/node-tests/utils/wait-for.ts
@@ -17,6 +17,7 @@ export default function waitFor(
     async function rerun() {
       if (tries > maxTries) {
         reject(new Error(`Could not meet expectation within ${timeout}ms`));
+        return;
       }
       // eslint-disable-next-line no-use-before-define
       setTimeout(runExpectation, interval);

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -115,6 +115,7 @@
     "@types/pg-format": "^1.0.1",
     "@types/sane": "^2.0.1",
     "@types/supertest": "^2.0.11",
+    "@types/websocket": "^1.0.4",
     "@types/yargs": "^17.0.2",
     "chai": "^4.3.4",
     "copy-webpack-plugin": "^10.0.0",
@@ -131,7 +132,8 @@
     "tslog": "^3.2.2",
     "web3-utils": "1.5.2",
     "webpack": "^5.64.4",
-    "webpack-cli": "^4.9.1"
+    "webpack-cli": "^4.9.1",
+    "websocket": "^1.0.34"
   },
   "engines": {
     "node": "^14.0",

--- a/packages/hub/services/web3-socket.ts
+++ b/packages/hub/services/web3-socket.ts
@@ -8,19 +8,19 @@ interface Web3Config {
   network: string;
 }
 
-const { network } = config.get('web3') as Web3Config;
-let rpcURL = getConstantByNetwork('rpcWssNode', network);
 let log = Logger('service:web3-socket');
+const { network } = config.get('web3') as Web3Config;
 
 export default class Web3SocketService {
   web3: Web3 | undefined;
+  rpcURL = getConstantByNetwork('rpcWssNode', network);
 
   getInstance() {
     if (!this.web3) {
       try {
         this.web3 = this.initializeWeb3();
       } catch (e) {
-        log.error(`Error encountered while trying to connect to rpc node with url ${rpcURL}`, e);
+        log.error(`Error encountered while trying to connect to rpc node with url ${this.rpcURL}`, e);
         Sentry.captureException(e, {
           tags: {
             action: 'web3-socket-connection',
@@ -44,7 +44,7 @@ export default class Web3SocketService {
       on(...args: any[]): void;
     };
 
-    let provider = new Web3.providers.WebsocketProvider(rpcURL, {
+    let provider = new Web3.providers.WebsocketProvider(this.rpcURL, {
       timeout: 30000,
       reconnect: {
         auto: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6820,6 +6820,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/websocket@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.4.tgz#1dc497280d8049a5450854dd698ee7e6ea9e60b8"
+  integrity sha512-qn1LkcFEKK8RPp459jkjzsfpbsx36BBt3oC3pITYtkoBw/aVX+EZFa5j3ThCRTNpLFvIMr5dSTD4RaMdilIOpA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "20.2.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.0.tgz#dd3e6699ba3237f0348cd085e4698780204842f9"
@@ -8384,7 +8391,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@4.1.4, axe-core@^4.1.4:
+axe-core@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.4.tgz#f19cd99a84ee32a318b9c5b5bb8ed373ad94f143"
   integrity sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==
@@ -12786,7 +12793,7 @@ elliptic@6.5.4, elliptic@^6.0.0, elliptic@^6.4.0, elliptic@^6.5.2:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-ember-a11y-testing@4.0.3, ember-a11y-testing@^4.0.3:
+ember-a11y-testing@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-4.0.3.tgz#1f5c91266d39ea5b20614b0d294a562079887ac7"
   integrity sha512-Q7nq2crC9+bT+sZi/BORAM4FUhI080edEhnpsvB6vdkD9Ro2Rg4DksQs5Be65/DM108VNDMtbHZtrPS060Mzcw==
@@ -29779,6 +29786,18 @@ websocket@^1.0.32:
   version "1.0.33"
   resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.33.tgz#407f763fc58e74a3fa41ca3ae5d78d3f5e3b82a5"
   integrity sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==
+  dependencies:
+    bufferutil "^4.0.1"
+    debug "^2.2.0"
+    es5-ext "^0.10.50"
+    typedarray-to-buffer "^3.1.5"
+    utf-8-validate "^5.0.2"
+    yaeti "^0.0.6"
+
+websocket@^1.0.34:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.34.tgz#2bdc2602c08bf2c82253b730655c0ef7dcab3111"
+  integrity sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==
   dependencies:
     bufferutil "^4.0.1"
     debug "^2.2.0"


### PR DESCRIPTION
CS-2683

This lets us know if our websocket fails/disconnects for some reason. The tested service failing currently means that the contract subscription handler will not work and no push notifications for merchant payments + claims will be sent until it is back up, which probably needs manual intervention right now.

Will also add an alert to Sentry.