### PR TITLE
web: Fix filtering of unknown network error

### DIFF
--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -290,7 +290,7 @@ export default abstract class Layer1ChainWeb3Strategy
       this.cardBalance = new BN(cardBalance);
     } catch (e) {
       // Incorrect chain id triggers controller:card-pay#onLayer2Incorrect to show a modal
-      if (e.message.includes('what name the network id')) {
+      if (!e.message.includes('what name the network id')) {
         // Exception being ignored: Don't know what name the network id ID is
         Sentry.captureException(e);
         throw e;


### PR DESCRIPTION
I made an error when updating #2526 to incorporate feedback and
dropped the not, so unknown network errors are the only ones
being logged to Sentry instead of not being logged 😳