### PR TITLE
Add business account selector to card space workflow

### DIFF
--- a/packages/hub/node-tests/routes/merchant-infos-test.ts
+++ b/packages/hub/node-tests/routes/merchant-infos-test.ts
@@ -418,3 +418,108 @@ describe('GET /api/merchant-infos/validate-slug/:slug', function () {
       .expect('Content-Type', 'application/vnd.api+json');
   });
 });
+
+describe('GET /api/merchant-infos', function () {
+  this.beforeEach(function () {
+    registry(this).register('authentication-utils', StubAuthenticationUtils);
+    registry(this).register('worker-client', StubWorkerClient);
+  });
+
+  let { request, getContainer } = setupHub(this);
+
+  it('fetches merchant infos available for association to a new card space', async function () {
+    let cardSpaceQueries = await getContainer().lookup('card-space-queries');
+    let merchantInfoQueries = await getContainer().lookup('merchant-info-queries');
+
+    // 3 merchants (jerry, kramer, george) belonging to first user
+    let merchantInfoId = 'c5cd6479-ec74-4ecd-9aa6-96bdb02d255e';
+    await merchantInfoQueries.insert({
+      id: merchantInfoId,
+      name: '/',
+      slug: 'jerry',
+      color: '/',
+      textColor: '/',
+      ownerAddress: stubUserAddress,
+    });
+
+    await merchantInfoQueries.insert({
+      id: '303c5efa-9cd5-404a-a3fb-9a99969ffcf4',
+      name: '/',
+      slug: 'kramer',
+      color: '/',
+      textColor: '/',
+      ownerAddress: stubUserAddress,
+    });
+
+    await merchantInfoQueries.insert({
+      id: '0b9f7594-0f83-4e09-a1ae-d3272decf8fb',
+      name: '/',
+      slug: 'george',
+      color: '/',
+      textColor: '/',
+      ownerAddress: stubUserAddress,
+    });
+
+    // 1 merchant belonging to the second user
+    await merchantInfoQueries.insert({
+      id: '6484e35a-a581-4246-ac36-c52f69b1cb52',
+      name: '/',
+      slug: 'elaine',
+      color: '/',
+      textColor: '/',
+      ownerAddress: '0x1',
+    });
+
+    // First user registers a card space with jerry merchant
+    await cardSpaceQueries.insert({
+      id: '255aaa5c-92d0-468b-8939-3dd2d72684c3',
+      url: 'jerry.card.space', // To be removed
+      profileName: 'Test',
+      profileImageUrl: 'https://test.com/test1.png',
+      profileCoverImageUrl: 'https://test.com/test2.png',
+      profileDescription: 'Test',
+      profileButtonText: 'Test',
+      profileCategory: 'Test',
+      ownerAddress: stubUserAddress,
+      merchantId: merchantInfoId,
+    });
+
+    // The first user should be able to register 2 more card spaces (1 merchant used, 2 merchants left)
+    await request()
+      .get('/api/merchant-infos?availableForCardSpace=true')
+      .send({})
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(200)
+      .expect({
+        // kramer and george should be available for card space. jerry is already taken, and elaine belongs to another user
+        data: [
+          {
+            attributes: {
+              color: '/',
+              did: 'did:cardstack:1m6Xtdkc8n7Q7XGwV3Eo2k5qb2777873aaab7bfe',
+              name: '/',
+              'owner-address': '0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13',
+              slug: 'kramer',
+              'text-color': '/',
+            },
+            id: '303c5efa-9cd5-404a-a3fb-9a99969ffcf4',
+            type: 'merchant-infos',
+          },
+          {
+            attributes: {
+              color: '/',
+              did: 'did:cardstack:1m2rfah5ytCe84ae7dGBnGwp44f435150427e4cc',
+              name: '/',
+              'owner-address': '0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13',
+              slug: 'george',
+              'text-color': '/',
+            },
+            id: '0b9f7594-0f83-4e09-a1ae-d3272decf8fb',
+            type: 'merchant-infos',
+          },
+        ],
+      });
+  });
+});

--- a/packages/hub/node-tests/utils/queries-test.ts
+++ b/packages/hub/node-tests/utils/queries-test.ts
@@ -9,6 +9,11 @@ describe('Queries utils', function () {
         where: 'a=$1 AND c=$2 AND b IS NULL',
         values: [1, 2],
       });
+
+      expect(buildConditions({ a: 'test', non_literals: { should_be: 'ignored' } })).to.deep.equal({
+        where: 'a=$1',
+        values: ['test'],
+      });
     });
   });
 });

--- a/packages/hub/services/api-router.ts
+++ b/packages/hub/services/api-router.ts
@@ -70,6 +70,7 @@ export default class APIRouter {
     apiSubrouter.post('/prepaid-card-customizations', parseBody, prepaidCardCustomizationsRoute.post);
     apiSubrouter.post('/merchant-infos', parseBody, merchantInfosRoute.post);
     apiSubrouter.get('/merchant-infos/validate-slug/:slug', merchantInfosRoute.getValidation);
+    apiSubrouter.get('/merchant-infos', parseBody, merchantInfosRoute.get);
     apiSubrouter.get('/custodial-wallet', custodialWalletRoute.get);
     apiSubrouter.get('/inventories', inventoryRoute.get);
     apiSubrouter.post('/orders', parseBody, ordersRoute.post);

--- a/packages/hub/services/queries/card-space.ts
+++ b/packages/hub/services/queries/card-space.ts
@@ -6,6 +6,7 @@ import { buildConditions } from '../../utils/queries';
 interface CardSpaceQueriesFilter {
   id?: string;
   url?: string;
+  ownerAddress?: string;
 }
 
 export default class CardSpaceQueries {
@@ -15,7 +16,7 @@ export default class CardSpaceQueries {
     let db = await this.databaseManager.getClient();
 
     await db.query(
-      'INSERT INTO card_spaces (id, url, profile_name, profile_image_url, profile_cover_image_url, profile_description, profile_button_text, profile_category, owner_address) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9)',
+      'INSERT INTO card_spaces (id, url, profile_name, profile_image_url, profile_cover_image_url, profile_description, profile_button_text, profile_category, owner_address, merchant_id) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)',
       [
         model.id,
         model.url,
@@ -26,6 +27,7 @@ export default class CardSpaceQueries {
         model.profileButtonText,
         model.profileCategory,
         model.ownerAddress,
+        model.merchantId,
       ]
     );
   }

--- a/packages/hub/services/serializers/merchant-info-serializer.ts
+++ b/packages/hub/services/serializers/merchant-info-serializer.ts
@@ -8,7 +8,7 @@ import { JSONAPIDocument } from '../../utils/jsonapi-document';
 export default class MerchantInfoSerializer {
   databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
 
-  async serialize(model: MerchantInfo): Promise<JSONAPIDocument> {
+  serialize(model: MerchantInfo): JSONAPIDocument {
     let did = encodeDID({ type: 'MerchantInfo', uniqueId: model.id });
 
     const result = {
@@ -27,6 +27,16 @@ export default class MerchantInfoSerializer {
           'owner-address': model.ownerAddress,
         },
       },
+    };
+
+    return result as JSONAPIDocument;
+  }
+
+  serializeCollection(models: MerchantInfo[]): JSONAPIDocument {
+    let result = {
+      data: models.map((model) => {
+        return this.serialize(model).data;
+      }),
     };
 
     return result as JSONAPIDocument;

--- a/packages/hub/utils/queries.ts
+++ b/packages/hub/utils/queries.ts
@@ -9,10 +9,17 @@ const camelToSnakeCase = (str: string) => str.replace(/[A-Z]/g, (letter) => `_${
 // => { where: 'name=$1 AND age=$2', values: [ 'Phil', 45 ] }
 
 export function buildConditions(params: any) {
-  let nonNullParams = pickBy(params, function (value) {
+  // Only allow nulls, strings and numbers in the params
+  let filteredParams = Object.fromEntries(
+    Object.entries(params).filter(
+      ([_key, value]) => value == null || typeof value === 'number' || typeof value === 'string'
+    )
+  );
+
+  let nonNullParams = pickBy(filteredParams, function (value) {
     return value !== null;
   });
-  let nullParams = pickBy(params, function (value) {
+  let nullParams = pickBy(filteredParams, function (value) {
     return value === null;
   });
 

--- a/packages/web-client/app/components/card-pay/hub-authentication/index.hbs
+++ b/packages/web-client/app/components/card-pay/hub-authentication/index.hbs
@@ -54,7 +54,7 @@
       </i.ActionStatusArea>
     </:in-progress>
     <:memorialized as |m|>
-      <m.ActionStatusArea data-test-memorialized>
+      <m.ActionStatusArea data-test-authentication-memorialized>
         Authenticated with Hub
       </m.ActionStatusArea>
     </:memorialized>

--- a/packages/web-client/app/components/card-pay/hub-authentication/index.hbs
+++ b/packages/web-client/app/components/card-pay/hub-authentication/index.hbs
@@ -1,5 +1,6 @@
 <ActionCardContainer
   @isComplete={{@isComplete}}
+  {{did-insert this.checkIfAuthenticated}}
 >
   <Boxel::ActionChin
     @state={{this.authState}}
@@ -53,7 +54,7 @@
       </i.ActionStatusArea>
     </:in-progress>
     <:memorialized as |m|>
-      <m.ActionStatusArea>
+      <m.ActionStatusArea data-test-memorialized>
         Authenticated with Hub
       </m.ActionStatusArea>
     </:memorialized>

--- a/packages/web-client/app/components/card-pay/hub-authentication/index.ts
+++ b/packages/web-client/app/components/card-pay/hub-authentication/index.ts
@@ -5,6 +5,7 @@ import { race, rawTimeout, task, TaskGenerator } from 'ember-concurrency';
 import HubAuthentication from '@cardstack/web-client/services/hub-authentication';
 import { tracked } from '@glimmer/tracking';
 import config from '@cardstack/web-client/config/environment';
+import { action } from '@ember/object';
 
 interface CardPayWorkflowHubAuthComponentArgs {
   onComplete: () => void;
@@ -19,6 +20,12 @@ export default class CardPayWorkflowHubAuthComponent extends Component<CardPayWo
   @tracked error?: Error;
   @tracked authTaskRunningForAWhile = false;
   supportURL = config.urls.discordSupportChannelUrl;
+
+  @action checkIfAuthenticated() {
+    if (this.hubAuthentication.isAuthenticated) {
+      this.args.onComplete();
+    }
+  }
 
   @task *authenticationTask(): TaskGenerator<void> {
     try {
@@ -47,7 +54,7 @@ export default class CardPayWorkflowHubAuthComponent extends Component<CardPayWo
   get authState() {
     if (taskFor(this.authenticationTask).isRunning) {
       return 'in-progress';
-    } else if (this.args.isComplete) {
+    } else if (this.args.isComplete || this.hubAuthentication.isAuthenticated) {
       return 'memorialized';
     } else {
       return 'default';

--- a/packages/web-client/app/components/card-pay/safe-chooser-dropdown/index.hbs
+++ b/packages/web-client/app/components/card-pay/safe-chooser-dropdown/index.hbs
@@ -16,6 +16,7 @@
         safe-chooser-dropdown__option--selected=(eq safe.address selectedSafe.address)
       }}
       @safe={{safe}}
+      @showSafeId={{@showSafeId}}
     />
   </PowerSelect>
 {{/let}}

--- a/packages/web-client/app/components/card-pay/safe-chooser-dropdown/safe-option/index.css
+++ b/packages/web-client/app/components/card-pay/safe-chooser-dropdown/safe-option/index.css
@@ -35,3 +35,7 @@
   font-family: var(--boxel-monospace-font-family);
   color: var(--boxel-purple-500);
 }
+
+.safe-option__id {
+  color: var(--boxel-purple-500);
+}

--- a/packages/web-client/app/components/card-pay/safe-chooser-dropdown/safe-option/index.hbs
+++ b/packages/web-client/app/components/card-pay/safe-chooser-dropdown/safe-option/index.hbs
@@ -9,11 +9,18 @@
       @logoTextColor={{this.data.info.textColor}}
     />
   {{/if}}
-  <div class='safe-option__name-and-type'>
-    <span class='safe-option__name'>{{this.data.info.name}}</span>
-    {{#if this.data.type}}
-      <span class='safe-option__type'>{{this.data.type}}</span>
-    {{/if}}
-  </div>
-  <div class='safe-option__address'>{{@safe.address}}</div>
+  {{#if @showSafeId}}
+    <div class='safe-option__name-and-type'>
+      <span class='safe-option__name'>{{this.data.info.name}}</span>
+    </div>
+    <div class='safe-option__id'>{{this.data.info.id}}</div>
+  {{else}}
+    <div class='safe-option__name-and-type'>
+      <span class='safe-option__name'>{{this.data.info.name}}</span>
+      {{#if this.data.type}}
+        <span class='safe-option__type'>{{this.data.type}}</span>
+      {{/if}}
+    </div>
+    <div class='safe-option__address'>{{@safe.address}}</div>
+  {{/if}}
 </div>

--- a/packages/web-client/app/components/card-space/create-space-workflow/create-business-account-cta/index.hbs
+++ b/packages/web-client/app/components/card-space/create-space-workflow/create-business-account-cta/index.hbs
@@ -1,0 +1,5 @@
+<Boxel::NextStepsBox @title="Workflow canceled" data-test-create-card-space-workflow-create-business-account-cta>
+  <Boxel::Button @kind="primary" {{on "click" this.openCreateBusinessAccountWorkflow}} >
+    Create Business Account
+  </Boxel::Button>
+</Boxel::NextStepsBox>

--- a/packages/web-client/app/components/card-space/create-space-workflow/create-business-account-cta/index.ts
+++ b/packages/web-client/app/components/card-space/create-space-workflow/create-business-account-cta/index.ts
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import RouterService from '@ember/routing/router-service';
+
+class CardPayIssuePrepaidCardWorkflowInsufficientFundsComponent extends Component {
+  @service declare router: RouterService;
+
+  @action async openCreateBusinessAccountWorkflow() {
+    this.router.transitionTo('card-pay.payments', {
+      queryParams: { flow: 'create-business' },
+    });
+  }
+}
+
+export default CardPayIssuePrepaidCardWorkflowInsufficientFundsComponent;

--- a/packages/web-client/app/components/card-space/create-space-workflow/index.ts
+++ b/packages/web-client/app/components/card-space/create-space-workflow/index.ts
@@ -29,10 +29,7 @@ const FAILURE_REASONS = {
   RESTORATION_L2_ACCOUNT_CHANGED: 'RESTORATION_L2_ACCOUNT_CHANGED',
   RESTORATION_UNAUTHENTICATED: 'RESTORATION_UNAUTHENTICATED',
   NO_BUSINESS_ACCOUNT: 'NO_BUSINESS_ACCOUNT',
-  RESTORATION_NO_BUSINESS_ACCOUNT: 'RESTORATION_NO_BUSINESS_ACCOUNT',
   ALL_BUSINESS_ACCOUNTS_TAKEN: 'ALL_BUSINESS_ACCOUNTS_TAKEN',
-  RESTORATION_ALL_BUSINESS_ACCOUNTS_TAKEN:
-    'RESTORATION_ALL_BUSINESS_ACCOUNTS_TAKEN',
 } as const;
 
 export const MILESTONE_TITLES = [
@@ -250,9 +247,7 @@ class CreateSpaceWorkflow extends Workflow {
       includeIf() {
         return (
           this.workflow?.cancelationReason ===
-            FAILURE_REASONS.NO_BUSINESS_ACCOUNT ||
-          this.workflow?.cancelationReason ===
-            FAILURE_REASONS.RESTORATION_NO_BUSINESS_ACCOUNT
+          FAILURE_REASONS.NO_BUSINESS_ACCOUNT
         );
       },
     }),
@@ -261,9 +256,7 @@ class CreateSpaceWorkflow extends Workflow {
       includeIf() {
         return (
           this.workflow?.cancelationReason ===
-            FAILURE_REASONS.ALL_BUSINESS_ACCOUNTS_TAKEN ||
-          this.workflow?.cancelationReason ===
-            FAILURE_REASONS.RESTORATION_ALL_BUSINESS_ACCOUNTS_TAKEN
+          FAILURE_REASONS.ALL_BUSINESS_ACCOUNTS_TAKEN
         );
       },
     }),
@@ -272,13 +265,11 @@ class CreateSpaceWorkflow extends Workflow {
         'card-space/create-space-workflow/create-business-account-cta',
       includeIf() {
         return (
-          [
-            FAILURE_REASONS.NO_BUSINESS_ACCOUNT,
-            FAILURE_REASONS.RESTORATION_NO_BUSINESS_ACCOUNT,
-            FAILURE_REASONS.ALL_BUSINESS_ACCOUNTS_TAKEN,
-            FAILURE_REASONS.RESTORATION_ALL_BUSINESS_ACCOUNTS_TAKEN,
-          ] as any[]
-        ).includes(this.workflow?.cancelationReason);
+          this.workflow?.cancelationReason ===
+            FAILURE_REASONS.NO_BUSINESS_ACCOUNT ||
+          this.workflow?.cancelationReason ===
+            FAILURE_REASONS.ALL_BUSINESS_ACCOUNTS_TAKEN
+        );
       },
     }),
     ...standardCancelationPostables(),
@@ -312,6 +303,8 @@ class CreateSpaceWorkflow extends Workflow {
     if (!hubAuthentication.isAuthenticated) {
       errors.push(FAILURE_REASONS.RESTORATION_UNAUTHENTICATED);
     }
+
+    // TODO: check if there are any business accounts available for Card Space which haven't been used yet
 
     return errors;
   }

--- a/packages/web-client/app/components/card-space/create-space-workflow/select-business-account/index.hbs
+++ b/packages/web-client/app/components/card-space/create-space-workflow/select-business-account/index.hbs
@@ -39,7 +39,8 @@
           />
           <div></div>
           <div class="form-input-info">
-            The business ID will be used for your Card Space URL
+            The business ID will be used for your Card Space URL. Only business accounts that
+            you haven't yet been used for Card Space are shown.
           </div>
         </CardPay::LabeledValue>
 

--- a/packages/web-client/app/components/card-space/create-space-workflow/select-business-account/index.hbs
+++ b/packages/web-client/app/components/card-space/create-space-workflow/select-business-account/index.hbs
@@ -1,0 +1,73 @@
+<ActionCardContainer
+  @header="Business account"
+  @isComplete={{@isComplete}}
+  {{did-insert this.setupBusinessAccountSelection}}
+  data-test-card-space-select-business-account-is-complete={{@isComplete}}
+>
+  <ActionCardContainer::Section @title="Select a business account" class="merchant-customization">
+    {{#if @isComplete}}
+      <CardPay::LabeledValue
+        class="merchant-customization__name"
+        @label="Business Name"
+      >
+        <CardPay::Merchant
+          @name={{this.merchantData.name}}
+          @logoBackground={{this.merchantData.backgroundColor}}
+          @logoTextColor={{this.merchantData.logoTextColor}}
+          @size="large"
+          @vertical={{true}}
+        />
+      </CardPay::LabeledValue>
+
+      <CardPay::LabeledValue @label="Business ID">
+        {{this.merchantData.id}}
+      </CardPay::LabeledValue>
+
+      <CardPay::LabeledValue @label="Card Space URL">
+        {{this.merchantData.id}}.card.space
+      </CardPay::LabeledValue>
+    {{else}}
+      <CardPay::FieldStack>
+        <CardPay::LabeledValue
+          @label="Business Account"
+        >
+          <CardPay::SafeChooserDropdown
+            @safes={{this.merchantSafes}}
+            @selectedSafe={{this.selectedSafe}}
+            @onChooseSafe={{this.chooseSafe}}
+            @showSafeId={{true}}
+          />
+          <div></div>
+          <div class="form-input-info">
+            The business ID will be used for your Card Space URL
+          </div>
+        </CardPay::LabeledValue>
+
+        <CardPay::LabeledValue @label="Card Space URL">
+          {{this.merchantData.id}}.card.space
+        </CardPay::LabeledValue>
+      </CardPay::FieldStack>
+    {{/if}}
+  </ActionCardContainer::Section>
+
+  <Boxel::ActionChin
+    @state={{if @isComplete "memorialized" "default"}}
+    @disabled={{@frozen}}
+  >
+    <:default as |d|>
+      <d.ActionButton
+        data-test-card-space-select-business-account-save-button
+        {{on 'click' @onComplete}}
+      >
+        Continue
+      </d.ActionButton>
+    </:default>
+    <:memorialized as |m|>
+      <m.ActionButton
+        {{on "click" @onIncomplete}}
+      >
+        Edit
+      </m.ActionButton>
+    </:memorialized>
+  </Boxel::ActionChin>
+</ActionCardContainer>

--- a/packages/web-client/app/components/card-space/create-space-workflow/select-business-account/index.ts
+++ b/packages/web-client/app/components/card-space/create-space-workflow/select-business-account/index.ts
@@ -1,0 +1,63 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
+import Layer2Network from '@cardstack/web-client/services/layer2-network';
+import { tracked } from '@glimmer/tracking';
+import { MerchantSafe } from '@cardstack/cardpay-sdk';
+import { action } from '@ember/object';
+import { MerchantInfo } from '@cardstack/web-client/resources/merchant-info';
+import { useResource } from 'ember-resources';
+
+class CreateSpaceWorkflowSelectBusiness extends Component<WorkflowCardComponentArgs> {
+  @service declare layer2Network: Layer2Network;
+  @tracked merchantSafes: MerchantSafe[] | null = null;
+  @tracked selectedSafe: MerchantSafe | null = null;
+
+  get merchantData() {
+    if (this.selectedSafe) {
+      return useResource(this, MerchantInfo, () => ({
+        infoDID: this.selectedSafe!.infoDID,
+      }));
+    } else {
+      return null;
+    }
+  }
+
+  @action async setupBusinessAccountSelection() {
+    await this.layer2Network.waitForAccount;
+
+    let merchantSafes = this.layer2Network.safes.value.filterBy(
+      'type',
+      'merchant'
+    ) as MerchantSafe[];
+
+    this.merchantSafes = merchantSafes;
+
+    if (merchantSafes.length > 0) {
+      let merchantAddress = this.args.workflowSession.getValue(
+        'merchantSafeAddress'
+      );
+
+      if (merchantAddress) {
+        let safe = merchantSafes.findBy('address', merchantAddress);
+        if (safe) {
+          this.selectedSafe = safe;
+        } else {
+          this.selectedSafe = merchantSafes[0];
+        }
+      } else {
+        this.selectedSafe = merchantSafes[0];
+      }
+    }
+  }
+
+  @action chooseSafe(safe: MerchantSafe) {
+    this.selectedSafe = safe;
+    this.args.workflowSession.setValue(
+      'merchantSafeAddress',
+      this.selectedSafe!.address
+    );
+  }
+}
+
+export default CreateSpaceWorkflowSelectBusiness;

--- a/packages/web-client/app/components/common/forms/index.css
+++ b/packages/web-client/app/components/common/forms/index.css
@@ -1,5 +1,5 @@
 .form-input-info {
   margin-left: var(--boxel-sp-xxs);
-  color: var(--boxel-purple-600);
+  color: var(--boxel-purple-400);
   font-size: var(--boxel-font-size-sm);
 }

--- a/packages/web-client/app/components/common/forms/index.css
+++ b/packages/web-client/app/components/common/forms/index.css
@@ -1,0 +1,5 @@
+.form-input-info {
+  margin-left: var(--boxel-sp-xxs);
+  color: var(--boxel-purple-600);
+  font-size: var(--boxel-font-size-sm);
+}

--- a/packages/web-client/app/services/merchant-info.ts
+++ b/packages/web-client/app/services/merchant-info.ts
@@ -22,6 +22,25 @@ interface CheckMerchantSlugUniquenessTaskParams {
 export default class MerchantInfoService extends Service {
   @service declare hubAuthentication: HubAuthentication;
 
+  @task
+  *fetchMerchantInfosAvailableForCardSpace(): TaskGenerator<MerchantInfo[]> {
+    let response = yield fetch(
+      `${config.hubURL}/api/merchant-infos?availableForCardSpace=true`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer ' + this.hubAuthentication.authToken,
+          Accept: 'application/vnd.api+json',
+          'Content-Type': 'application/vnd.api+json',
+        },
+      }
+    );
+
+    let merchantInfosData = yield response.json();
+
+    return merchantInfosData.data.map((m: any) => ({ did: m.attributes.did }));
+  }
+
   @task *persistMerchantInfoTask(
     params: PersistMerchantInfoTaskParams
   ): TaskGenerator<MerchantInfo> {

--- a/packages/web-client/mirage/config.js
+++ b/packages/web-client/mirage/config.js
@@ -23,6 +23,9 @@ export default function () {
   });
 
   this.post('/merchant-infos');
+  this.get('/merchant-infos', function (schema) {
+    return schema.merchantInfos.all();
+  });
 
   this.get(
     '/merchant-infos/validate-slug/:slug',

--- a/packages/web-client/tests/acceptance/create-card-space-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/create-card-space-persistence-test.ts
@@ -10,6 +10,10 @@ import {
   MILESTONE_TITLES,
   WORKFLOW_VERSION,
 } from '@cardstack/web-client/components/card-space/create-space-workflow';
+import {
+  createMerchantSafe,
+  createSafeToken,
+} from '@cardstack/web-client/utils/test-factories';
 
 interface Context extends MirageTestContext {}
 
@@ -37,6 +41,18 @@ module('Acceptance | create card space persistence', function (hooks) {
       'service:workflow-persistence'
     );
 
+    layer2Service.test__simulateRemoteAccountSafes(layer2AccountAddress, [
+      createMerchantSafe({
+        address: '0xmerchantbAB0644ffCD32518eBF4924ba8666666',
+        merchant: '0xprepaidDbAB0644ffCD32518eBF4924ba8666666',
+        accumulatedSpendValue: 100,
+        tokens: [
+          createSafeToken('DAI.CPXD', '125000000000000000000'),
+          createSafeToken('CARD.CPXD', '450000000000000000000'),
+        ],
+      }),
+    ]);
+
     workflowPersistenceService.clear();
   });
 
@@ -60,7 +76,11 @@ module('Acceptance | create card space persistence', function (hooks) {
       let state = buildState({
         meta: {
           version: WORKFLOW_VERSION,
-          completedCardNames: ['LAYER2_CONNECT', 'CARD_SPACE_DISPLAY_NAME'],
+          completedCardNames: [
+            'LAYER2_CONNECT',
+            'SELECT_BUSINESS_ACCOUNT',
+            'CARD_SPACE_DISPLAY_NAME',
+          ],
         },
       });
 
@@ -72,9 +92,10 @@ module('Acceptance | create card space persistence', function (hooks) {
       await visit('/card-space?flow=create-space&flow-id=abc123');
 
       assert.dom(milestoneCompletedSel(0)).exists(); // L2 connect
-      assert.dom(milestoneCompletedSel(1)).exists(); // Display name
-      assert.dom(milestoneCompletedSel(2)).doesNotExist();
-      assert.dom('[data-test-milestone="2"][data-test-postable="2"]').exists();
+      assert.dom(milestoneCompletedSel(1)).exists(); // Business account
+      assert.dom(milestoneCompletedSel(2)).exists(); // Display name
+      assert.dom(milestoneCompletedSel(3)).doesNotExist();
+      assert.dom('[data-test-milestone="3"][data-test-postable="2"]').exists();
       assert.dom('[data-test-card-space-details-start-button]').isNotDisabled();
     });
 
@@ -84,6 +105,7 @@ module('Acceptance | create card space persistence', function (hooks) {
           version: WORKFLOW_VERSION,
           completedCardNames: [
             'LAYER2_CONNECT',
+            'SELECT_BUSINESS_ACCOUNT',
             'CARD_SPACE_DISPLAY_NAME',
             'CARD_SPACE_DETAILS',
             'CARD_SPACE_CONFIRM',
@@ -99,9 +121,11 @@ module('Acceptance | create card space persistence', function (hooks) {
       await visit('/card-space?flow=create-space&flow-id=abc123');
 
       assert.dom(milestoneCompletedSel(0)).exists(); // L2 connect
-      assert.dom(milestoneCompletedSel(1)).exists(); // Display name
-      assert.dom(milestoneCompletedSel(2)).exists(); // Details
-      assert.dom(milestoneCompletedSel(3)).exists(); // Confirm
+      assert.dom(milestoneCompletedSel(1)).exists(); // Business account
+      assert.dom(milestoneCompletedSel(2)).exists(); // Display name
+      assert.dom(milestoneCompletedSel(3)).exists(); // Details
+      assert.dom(milestoneCompletedSel(4)).exists(); // Confirm
+
       assert
         .dom('[data-test-epilogue][data-test-postable="0"]')
         .includesText(`Congrats, you have created your Card Space!`);
@@ -111,7 +135,11 @@ module('Acceptance | create card space persistence', function (hooks) {
       const state = buildState({
         meta: {
           version: WORKFLOW_VERSION,
-          completedCardNames: ['LAYER2_CONNECT', 'CARD_SPACE_DISPLAY_NAME'],
+          completedCardNames: [
+            'LAYER2_CONNECT',
+            'SELECT_BUSINESS_ACCOUNT',
+            'CARD_SPACE_DISPLAY_NAME',
+          ],
           isCanceled: true,
           cancelationReason: 'L2_DISCONNECTED',
         },
@@ -125,8 +153,9 @@ module('Acceptance | create card space persistence', function (hooks) {
       await visit('/card-space?flow=create-space&flow-id=abc123');
 
       assert.dom(milestoneCompletedSel(0)).exists(); // L2 connect
-      assert.dom(milestoneCompletedSel(1)).exists(); // Display name
-      assert.dom(milestoneCompletedSel(2)).doesNotExist();
+      assert.dom(milestoneCompletedSel(1)).exists(); // Select Business Account
+      assert.dom(milestoneCompletedSel(2)).exists(); // Display name
+      assert.dom(milestoneCompletedSel(3)).doesNotExist();
       assert
         .dom('[data-test-cancelation]')
         .includesText(
@@ -145,7 +174,11 @@ module('Acceptance | create card space persistence', function (hooks) {
       const state = buildState({
         meta: {
           version: WORKFLOW_VERSION,
-          completedCardNames: ['LAYER2_CONNECT', 'CARD_SPACE_DISPLAY_NAME'],
+          completedCardNames: [
+            'LAYER2_CONNECT',
+            'SELECT_BUSINESS_ACCOUNT',
+            'CARD_SPACE_DISPLAY_NAME',
+          ],
         },
       });
 
@@ -159,7 +192,7 @@ module('Acceptance | create card space persistence', function (hooks) {
       await visit('/card-space?flow=create-space&flow-id=abc123');
 
       assert.dom(milestoneCompletedSel(0)).doesNotExist(); // L2 connect
-      assert.dom(milestoneCompletedSel(1)).doesNotExist(); // Display name
+      assert.dom(milestoneCompletedSel(1)).doesNotExist(); // Business account
       assert
         .dom('[data-test-cancelation]')
         .includesText(
@@ -169,7 +202,7 @@ module('Acceptance | create card space persistence', function (hooks) {
       await click('[data-test-workflow-default-cancelation-restart]');
 
       assert.dom(milestoneCompletedSel(0)).exists(); // L2 connect
-      assert.dom(milestoneCompletedSel(1)).doesNotExist(); // Display name
+      assert.dom(milestoneCompletedSel(1)).doesNotExist(); // Business account
       assert.dom(`[data-test-authentication-button]`).exists();
 
       const workflowPersistenceId = new URL(
@@ -236,7 +269,6 @@ module('Acceptance | create card space persistence', function (hooks) {
           version: WORKFLOW_VERSION,
           completedCardNames: ['LAYER2_CONNECT'],
         },
-        displayName: 'Display name',
       });
 
       workflowPersistenceService.persistData('abc123', {
@@ -250,9 +282,11 @@ module('Acceptance | create card space persistence', function (hooks) {
       assert.dom(milestoneCompletedSel(1)).doesNotExist();
 
       await waitFor('[data-test-postable="1"][data-test-milestone="1"]');
-      assert.dom('[data-test-card-space-display-name-save-button]').isEnabled();
+      assert
+        .dom('[data-test-card-space-select-business-account-save-button]')
+        .isEnabled();
 
-      await click('[data-test-card-space-display-name-save-button]');
+      await click('[data-test-card-space-select-business-account-save-button]');
       assert.dom(milestoneCompletedSel(1)).exists();
     });
 

--- a/packages/web-client/tests/acceptance/create-card-space-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/create-card-space-persistence-test.ts
@@ -267,7 +267,7 @@ module('Acceptance | create card space persistence', function (hooks) {
       const state = buildState({
         meta: {
           version: WORKFLOW_VERSION,
-          completedCardNames: ['LAYER2_CONNECT'],
+          completedCardNames: ['LAYER2_CONNECT', 'HUB_AUTH'],
         },
       });
 

--- a/packages/web-client/tests/acceptance/create-card-space-test.ts
+++ b/packages/web-client/tests/acceptance/create-card-space-test.ts
@@ -18,7 +18,7 @@ import {
   createMerchantSafe,
   createSafeToken,
 } from '@cardstack/web-client/utils/test-factories';
-import { setupMirage } from 'ember-cli-mirage/test-support';
+import { MirageTestContext, setupMirage } from 'ember-cli-mirage/test-support';
 
 function postableSel(milestoneIndex: number, postableIndex: number): string {
   return `[data-test-milestone="${milestoneIndex}"][data-test-postable="${postableIndex}"]`;
@@ -37,420 +37,474 @@ module('Acceptance | create card space', function (hooks) {
   let layer2Service: Layer2TestWeb3Strategy;
   let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
 
-  test('initiating workflow without wallet connections', async function (assert) {
-    let subdomain = ''; // TODO: replace this when other parts of the form are filled out
+  module('tests without layer 2 connection', function (hooks) {
+    hooks.beforeEach(async function (this: MirageTestContext) {
+      this.server.create('merchant-info', {
+        did: 'MerchantSafeDID',
+      });
+    });
+    test('initiating the workflow', async function (assert) {
+      let subdomain = ''; // TODO: replace this when other parts of the form are filled out
 
-    await visit('/card-space');
-    await click('[data-test-workflow-button="create-space"]');
+      await visit('/card-space');
+      await click('[data-test-workflow-button="create-space"]');
 
-    assert
-      .dom('[data-test-boxel-thread-header]')
-      .containsText('Card Space Creation');
+      assert
+        .dom('[data-test-boxel-thread-header]')
+        .containsText('Card Space Creation');
 
-    assert
-      .dom(
-        '[data-test-sidebar-preview-body] [data-test-profile-card-placeholder-cover-photo]'
-      )
-      .exists();
-    assert
-      .dom(
-        '[data-test-sidebar-preview-body] [data-test-profile-card-placeholder-profile-photo]'
-      )
-      .exists();
+      assert
+        .dom(
+          '[data-test-sidebar-preview-body] [data-test-profile-card-placeholder-cover-photo]'
+        )
+        .exists();
+      assert
+        .dom(
+          '[data-test-sidebar-preview-body] [data-test-profile-card-placeholder-profile-photo]'
+        )
+        .exists();
 
-    // test that the preview shows a blank state
-    assert
-      .dom('[data-test-sidebar-preview-body] [data-test-profile-card-name]')
-      .containsText('Name');
-    assert
-      .dom('[data-test-sidebar-preview-body] [data-test-profile-card-host]')
-      .containsText('blank.card.space');
-    assert
-      .dom('[data-test-sidebar-preview-body] [data-test-profile-card-category]')
-      .containsText('Category');
-    assert
-      .dom(
-        '[data-test-sidebar-preview-body] [data-test-profile-card-description]'
-      )
-      .containsText('Description');
-    assert
-      .dom(
-        '[data-test-sidebar-preview-body] [data-test-profile-card-button-text]'
-      )
-      .containsText('Button Text');
+      // test that the preview shows a blank state
+      assert
+        .dom('[data-test-sidebar-preview-body] [data-test-profile-card-name]')
+        .containsText('Name');
+      assert
+        .dom('[data-test-sidebar-preview-body] [data-test-profile-card-host]')
+        .containsText('blank.card.space');
+      assert
+        .dom(
+          '[data-test-sidebar-preview-body] [data-test-profile-card-category]'
+        )
+        .containsText('Category');
+      assert
+        .dom(
+          '[data-test-sidebar-preview-body] [data-test-profile-card-description]'
+        )
+        .containsText('Description');
+      assert
+        .dom(
+          '[data-test-sidebar-preview-body] [data-test-profile-card-button-text]'
+        )
+        .containsText('Button Text');
 
-    // Milestone 1
-    assert.dom(`${postableSel(0, 0)} img`).exists();
-    assert.dom(postableSel(0, 0)).containsText(`Hello, welcome to Card Space`);
+      // Milestone 1
+      assert.dom(`${postableSel(0, 0)} img`).exists();
+      assert
+        .dom(postableSel(0, 0))
+        .containsText(`Hello, welcome to Card Space`);
 
-    // L2 wallet connection
-    assert
-      .dom(postableSel(0, 1))
-      .containsText(`connect your ${c.layer2.fullName} wallet`);
-    assert
-      .dom(postableSel(0, 2))
-      .containsText(`Once you have installed the app`);
+      // L2 wallet connection
+      assert
+        .dom(postableSel(0, 1))
+        .containsText(`connect your ${c.layer2.fullName} wallet`);
+      assert
+        .dom(postableSel(0, 2))
+        .containsText(`Once you have installed the app`);
 
-    layer2Service = this.owner.lookup('service:layer2-network')
-      .strategy as Layer2TestWeb3Strategy;
-
-    let merchantAddress = '0xmerchantbAB0644ffCD32518eBF4924ba8666666';
-
-    layer2Service.test__simulateRemoteAccountSafes(layer2AccountAddress, [
-      createMerchantSafe({
-        address: merchantAddress,
-        merchant: '0xprepaidDbAB0644ffCD32518eBF4924ba8666666',
-        accumulatedSpendValue: 100,
-        tokens: [
-          createSafeToken('DAI.CPXD', '125000000000000000000'),
-          createSafeToken('CARD.CPXD', '450000000000000000000'),
-        ],
-      }),
-    ]);
-
-    layer2Service.test__simulateWalletConnectUri();
-
-    await waitFor('[data-test-wallet-connect-qr-code]');
-
-    layer2Service.test__simulateRemoteAccountSafes(layer2AccountAddress, [
-      createDepotSafe({
-        owners: [layer2AccountAddress],
-        tokens: [createSafeToken('DAI.CPXD', '0')],
-      }),
-    ]);
-
-    await layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
-
-    await settled();
-    assert
-      .dom('[data-test-layer-2-wallet-summary] [data-test-address-field]')
-      .containsText(layer2AccountAddress);
-
-    await waitFor(milestoneCompletedSel(0));
-    assert
-      .dom(milestoneCompletedSel(0))
-      .containsText(`${c.layer2.fullName} wallet connected`);
-
-    // Hub auth
-    assert.dom(postableSel(1, 0)).containsText(`you need to authenticate`);
-
-    await click(`[data-test-authentication-button]`);
-    layer2Service.test__simulateHubAuthentication('abc123--def456--ghi789');
-
-    // Select a business account
-    await waitFor(postableSel(1, 3)); // First merchant will be automatically selected
-    await click('[data-test-card-space-select-business-account-save-button]');
-    assert
-      .dom('[data-test-card-space-select-business-account-is-complete]')
-      .exists();
-
-    // Display name
-    await waitFor(postableSel(2, 1));
-    assert.dom(postableSel(2, 1)).containsText(`Pick a display name`);
-
-    await fillIn(
-      '[data-test-card-space-display-name-input] input',
-      'Hello there'
-    );
-
-    await waitFor(
-      '[data-test-card-space-display-name-save-button]:not(:disabled)'
-    );
-
-    await click('[data-test-card-space-display-name-save-button]');
-    assert.dom('[data-test-card-space-display-name-is-complete]').exists();
-
-    await waitFor(milestoneCompletedSel(2));
-    assert.dom(milestoneCompletedSel(2)).containsText(`Display name picked`);
-
-    // Details
-
-    await waitFor(postableSel(3, 2));
-    assert
-      .dom(postableSel(3, 1))
-      .containsText(`Now it’s time to set up your space.`);
-    assert
-      .dom(postableSel(3, 2))
-      .containsText(`Fill out the Card Space details`);
-
-    await click('[data-test-card-space-details-start-button]');
-    await click('[data-test-card-space-edit-details-save-button]');
-
-    assert.dom('[data-test-card-space-details-is-complete]').exists();
-
-    await waitFor(milestoneCompletedSel(3));
-    assert
-      .dom(milestoneCompletedSel(3))
-      .containsText(`Card Space details saved`);
-
-    // Reservation badge
-    await waitFor(postableSel(4, 1));
-    assert
-      .dom(postableSel(4, 0))
-      .containsText(`We have sent your URL reservation badge`);
-    assert.dom(postableSel(4, 1)).containsText(`URL reservation`);
-    assert
-      .dom(`${postableSel(4, 1)} [data-test-full-card-space-domain]`)
-      .containsText(`${subdomain}.card.space`);
-
-    // Confirm
-    await waitFor(postableSel(4, 3));
-
-    await click('[data-test-card-space-creation-button]');
-    assert.dom('[data-test-card-space-creation-is-complete]').exists();
-
-    await waitFor(milestoneCompletedSel(4));
-    assert.dom(milestoneCompletedSel(4)).containsText(`Card Space created`);
-
-    assert
-      .dom(
-        '[data-test-milestone] [data-test-boxel-action-chin] button[data-test-boxel-button]:not([disabled])'
-      )
-      .doesNotExist();
-
-    // Epilogue
-    await waitFor(epiloguePostableSel(0));
-
-    assert
-      .dom(epiloguePostableSel(0))
-      .containsText(`Congrats, you have created your Card Space!`);
-
-    // test that the preview is filled in
-    assert
-      .dom('[data-test-sidebar-preview-body] [data-test-profile-card-name]')
-      .containsText('Hello there');
-    // TODO: fill these in as we update the workflow (these are the required fields.
-    // I haven't added assertions on images. they are not required fields.)
-    // These should fail as the workflow is filled out and starts modifying the correct values in the
-    // workflow session
-    assert
-      .dom('[data-test-sidebar-preview-body] [data-test-profile-card-host]')
-      .containsText('blank.card.space');
-    assert
-      .dom('[data-test-sidebar-preview-body] [data-test-profile-card-category]')
-      .containsText('Category');
-    assert
-      .dom(
-        '[data-test-sidebar-preview-body] [data-test-profile-card-description]'
-      )
-      .containsText('Description');
-    assert
-      .dom(
-        '[data-test-sidebar-preview-body] [data-test-profile-card-button-text]'
-      )
-      .containsText('Button Text');
-
-    await waitFor(epiloguePostableSel(1));
-
-    await percySnapshot(assert);
-
-    // TODO: fix this assertion after we have fixed the subdomain/business ID
-    // things
-    // let spaceHostname = `displayNametodo.${config.cardSpaceHostnameSuffix}`;
-    // assert
-    //   .dom('[data-test-card-space-next-step="visit-space"]')
-    //   .hasAttribute('href', new RegExp(spaceHostname.replace(/\./g, '\\.')));
-  });
-
-  module('tests with layer 2 already connected', function (hooks) {
-    setupHubAuthenticationToken(hooks);
-
-    hooks.beforeEach(async function () {
       layer2Service = this.owner.lookup('service:layer2-network')
         .strategy as Layer2TestWeb3Strategy;
-      layer2Service.test__simulateRemoteAccountSafes(layer2AccountAddress, [
-        createDepotSafe({
-          owners: [layer2AccountAddress],
-          tokens: [createSafeToken('DAI.CPXD', '0')],
-        }),
-      ]);
+
+      let merchantAddress = '0xmerchantbAB0644ffCD32518eBF4924ba8666666';
+
       layer2Service.test__simulateRemoteAccountSafes(layer2AccountAddress, [
         createMerchantSafe({
-          address: '0xmerchantbAB0644ffCD32518eBF4924ba8666666',
+          address: merchantAddress,
           merchant: '0xprepaidDbAB0644ffCD32518eBF4924ba8666666',
           accumulatedSpendValue: 100,
           tokens: [
             createSafeToken('DAI.CPXD', '125000000000000000000'),
             createSafeToken('CARD.CPXD', '450000000000000000000'),
           ],
+          infoDID: 'MerchantSafeDID',
+        }),
+      ]);
+
+      layer2Service.test__simulateWalletConnectUri();
+
+      await waitFor('[data-test-wallet-connect-qr-code]');
+
+      layer2Service.test__simulateRemoteAccountSafes(layer2AccountAddress, [
+        createDepotSafe({
+          owners: [layer2AccountAddress],
+          tokens: [createSafeToken('DAI.CPXD', '0')],
         }),
       ]);
 
       await layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
-    });
 
-    test('initiating workflow with L2 wallet already connected', async function (assert) {
-      await visit('/card-space?flow=create-space');
-
-      const flowId = new URL(
-        'http://domain.test/' + currentURL()
-      ).searchParams.get('flow-id');
-      assert.equal(
-        currentURL(),
-        `/card-space?flow=create-space&flow-id=${flowId}`
-      );
-
-      assert
-        .dom(postableSel(0, 1))
-        .containsText(
-          `Looks like you’ve already connected your ${c.layer2.fullName} wallet`
-        );
-      assert
-        .dom(
-          '[data-test-layer-2-wallet-card] [data-test-layer-2-wallet-connected-status]'
-        )
-        .containsText('Connected');
-      assert
-        .dom(
-          '[data-test-layer-2-wallet-card] [data-test-wallet-connect-qr-code]'
-        )
-        .doesNotExist();
-
-      assert
-        .dom(milestoneCompletedSel(0))
-        .containsText(`${c.layer2.fullName} wallet connected`);
-
-      await waitFor(postableSel(1, 1));
-      assert
-        .dom(postableSel(1, 0))
-        .containsText(`Please select a business account`);
-
-      let workflowPersistenceService = this.owner.lookup(
-        'service:workflow-persistence'
-      ) as WorkflowPersistence;
-
-      let workflowPersistenceId = new URL(
-        'http://domain.test/' + currentURL()
-      ).searchParams.get('flow-id')!;
-
-      let persistedData = workflowPersistenceService.getPersistedData(
-        workflowPersistenceId
-      );
-
-      assert.ok(
-        persistedData.state.layer2WalletAddress.includes(layer2AccountAddress),
-        'expected the layer 2 address to have been persisted when the wallet was already connected'
-      );
-    });
-
-    test('disconnecting L2 should cancel the workflow', async function (assert) {
-      await visit('/card-space');
-      await click('[data-test-workflow-button="create-space"]');
-
-      assert
-        .dom('[data-test-layer-2-wallet-card] [data-test-address-field]')
-        .containsText(layer2AccountAddress)
-        .isVisible();
-      assert
-        .dom(milestoneCompletedSel(0))
-        .containsText(`${c.layer2.fullName} wallet connected`);
-
-      layer2Service.test__simulateDisconnectFromWallet();
       await settled();
-
       assert
-        .dom('[data-test-postable="0"][data-test-cancelation]')
-        .containsText(
-          `It looks like your ${c.layer2.fullName} wallet got disconnected. If you still want to create a Card Space, please start again by connecting your wallet.`
-        );
+        .dom('[data-test-layer-2-wallet-summary] [data-test-address-field]')
+        .containsText(layer2AccountAddress);
+
+      await waitFor(milestoneCompletedSel(0));
       assert
-        .dom('[data-test-workflow-default-cancelation-cta="create-space"]')
-        .containsText('Workflow canceled');
-      assert.dom('[data-test-sidebar-preview-body]').doesNotExist();
+        .dom(milestoneCompletedSel(0))
+        .containsText(`${c.layer2.fullName} wallet connected`);
 
-      // restart workflow
-      await click(
-        '[data-test-workflow-default-cancelation-restart="create-space"]'
-      );
+      // Hub auth
+      assert.dom(postableSel(1, 0)).containsText(`you need to authenticate`);
 
-      assert.dom('[data-test-sidebar-preview-body]').exists();
-      layer2Service.test__simulateWalletConnectUri();
-      await waitFor('[data-test-wallet-connect-qr-code]');
+      await click(`[data-test-authentication-button]`);
+      layer2Service.test__simulateHubAuthentication('abc123--def456--ghi789');
 
+      // Select a business account
+      await waitFor(postableSel(1, 3)); // First merchant will be automatically selected
+      await click('[data-test-card-space-select-business-account-save-button]');
       assert
-        .dom(
-          '[data-test-layer-2-wallet-card] [data-test-wallet-connect-qr-code]'
-        )
+        .dom('[data-test-card-space-select-business-account-is-complete]')
         .exists();
-      assert
-        .dom('[data-test-workflow-default-cancelation-cta="create-space"]')
-        .doesNotExist();
-    });
 
-    test('changing L2 account should cancel the workflow', async function (assert) {
-      let differentL2Address = '0x5416C61193C3393B46C2774ac4717C252031c0bE';
+      // Display name
+      await waitFor(postableSel(2, 1));
+      assert.dom(postableSel(2, 1)).containsText(`Pick a display name`);
 
-      await visit('/card-space');
-      await click('[data-test-workflow-button="create-space"]');
-
-      assert
-        .dom('[data-test-layer-2-wallet-card] [data-test-address-field]')
-        .containsText(layer2AccountAddress)
-        .isVisible();
-
-      assert
-        .dom(milestoneCompletedSel(0))
-        .containsText(`${c.layer2.fullName} wallet connected`);
-
-      await layer2Service.test__simulateAccountsChanged([differentL2Address]);
-      await settled();
-
-      assert
-        .dom('[data-test-postable="0"][data-test-cancelation]')
-        .containsText(
-          'It looks like you changed accounts in the middle of this workflow. If you still want to create a Card Space, please restart the workflow.'
-        );
-      assert
-        .dom('[data-test-workflow-default-cancelation-cta="create-space"]')
-        .containsText('Workflow canceled');
-      assert.dom('[data-test-sidebar-preview-body]').doesNotExist();
-
-      // restart workflow
-      await click(
-        '[data-test-workflow-default-cancelation-restart="create-space"]'
+      await fillIn(
+        '[data-test-card-space-display-name-input] input',
+        'Hello there'
       );
 
-      assert.dom('[data-test-sidebar-preview-body]').exists();
+      await waitFor(
+        '[data-test-card-space-display-name-save-button]:not(:disabled)'
+      );
+
+      await click('[data-test-card-space-display-name-save-button]');
+      assert.dom('[data-test-card-space-display-name-is-complete]').exists();
+
+      await waitFor(milestoneCompletedSel(2));
+      assert.dom(milestoneCompletedSel(2)).containsText(`Display name picked`);
+
+      // Details
+
+      await waitFor(postableSel(3, 2));
       assert
-        .dom(postableSel(0, 1))
-        .containsText(
-          `Looks like you’ve already connected your ${c.layer2.fullName} wallet`
-        );
+        .dom(postableSel(3, 1))
+        .containsText(`Now it’s time to set up your space.`);
       assert
-        .dom('[data-test-layer-2-wallet-card] [data-test-address-field]')
-        .containsText(differentL2Address)
-        .isVisible();
+        .dom(postableSel(3, 2))
+        .containsText(`Fill out the Card Space details`);
+
+      await click('[data-test-card-space-details-start-button]');
+      await click('[data-test-card-space-edit-details-save-button]');
+
+      assert.dom('[data-test-card-space-details-is-complete]').exists();
+
+      await waitFor(milestoneCompletedSel(3));
       assert
-        .dom('[data-test-workflow-default-cancelation-cta="create-space"]')
+        .dom(milestoneCompletedSel(3))
+        .containsText(`Card Space details saved`);
+
+      // Reservation badge
+      await waitFor(postableSel(4, 1));
+      assert
+        .dom(postableSel(4, 0))
+        .containsText(`We have sent your URL reservation badge`);
+      assert.dom(postableSel(4, 1)).containsText(`URL reservation`);
+      assert
+        .dom(`${postableSel(4, 1)} [data-test-full-card-space-domain]`)
+        .containsText(`${subdomain}.card.space`);
+
+      // Confirm
+      await waitFor(postableSel(4, 3));
+
+      await click('[data-test-card-space-creation-button]');
+      assert.dom('[data-test-card-space-creation-is-complete]').exists();
+
+      await waitFor(milestoneCompletedSel(4));
+      assert.dom(milestoneCompletedSel(4)).containsText(`Card Space created`);
+
+      assert
+        .dom(
+          '[data-test-milestone] [data-test-boxel-action-chin] button[data-test-boxel-button]:not([disabled])'
+        )
         .doesNotExist();
+
+      // Epilogue
+      await waitFor(epiloguePostableSel(0));
+
+      assert
+        .dom(epiloguePostableSel(0))
+        .containsText(`Congrats, you have created your Card Space!`);
+
+      // test that the preview is filled in
+      assert
+        .dom('[data-test-sidebar-preview-body] [data-test-profile-card-name]')
+        .containsText('Hello there');
+      // TODO: fill these in as we update the workflow (these are the required fields.
+      // I haven't added assertions on images. they are not required fields.)
+      // These should fail as the workflow is filled out and starts modifying the correct values in the
+      // workflow session
+      assert
+        .dom('[data-test-sidebar-preview-body] [data-test-profile-card-host]')
+        .containsText('blank.card.space');
+      assert
+        .dom(
+          '[data-test-sidebar-preview-body] [data-test-profile-card-category]'
+        )
+        .containsText('Category');
+      assert
+        .dom(
+          '[data-test-sidebar-preview-body] [data-test-profile-card-description]'
+        )
+        .containsText('Description');
+      assert
+        .dom(
+          '[data-test-sidebar-preview-body] [data-test-profile-card-button-text]'
+        )
+        .containsText('Button Text');
+
+      await percySnapshot(assert);
+
+      // TODO: fix this assertion after we have fixed the subdomain/business ID
+      // things
+      // let spaceHostname = `displayNametodo.${config.cardSpaceHostnameSuffix}`;
+      // assert
+      //   .dom('[data-test-card-space-next-step="visit-space"]')
+      //   .hasAttribute('href', new RegExp(spaceHostname.replace(/\./g, '\\.')));
     });
-  });
 
-  test('cancels the workflow when there are no merchant safes (business accounts)', async function (assert) {
-    layer2Service = this.owner.lookup('service:layer2-network')
-      .strategy as Layer2TestWeb3Strategy;
-    layer2Service.test__simulateRemoteAccountSafes(layer2AccountAddress, [
-      createDepotSafe({
-        owners: [layer2AccountAddress],
-        tokens: [createSafeToken('DAI.CPXD', '0')],
-      }),
-    ]);
+    module('tests with layer 2 already connected', function (hooks) {
+      setupHubAuthenticationToken(hooks);
 
-    await layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
+      hooks.beforeEach(async function () {
+        layer2Service = this.owner.lookup('service:layer2-network')
+          .strategy as Layer2TestWeb3Strategy;
+        layer2Service.test__simulateRemoteAccountSafes(layer2AccountAddress, [
+          createDepotSafe({
+            owners: [layer2AccountAddress],
+            tokens: [createSafeToken('DAI.CPXD', '0')],
+          }),
+        ]);
+        layer2Service.test__simulateRemoteAccountSafes(layer2AccountAddress, [
+          createMerchantSafe({
+            address: '0xmerchantbAB0644ffCD32518eBF4924ba8666666',
+            merchant: '0xprepaidDbAB0644ffCD32518eBF4924ba8666666',
+            accumulatedSpendValue: 100,
+            tokens: [
+              createSafeToken('DAI.CPXD', '125000000000000000000'),
+              createSafeToken('CARD.CPXD', '450000000000000000000'),
+            ],
+            infoDID: 'MerchantSafeDID',
+          }),
+        ]);
+        await layer2Service.test__simulateAccountsChanged([
+          layer2AccountAddress,
+        ]);
+      });
 
-    await visit('/card-space');
-    await click('[data-test-workflow-button="create-space"]');
+      test('initiating workflow with L2 wallet already connected', async function (assert) {
+        await visit('/card-space?flow=create-space');
 
-    assert
-      .dom('[data-test-cancelation]')
-      .containsText('It looks like you haven’t created a business account yet');
+        const flowId = new URL(
+          'http://domain.test/' + currentURL()
+        ).searchParams.get('flow-id');
+        assert.equal(
+          currentURL(),
+          `/card-space?flow=create-space&flow-id=${flowId}`
+        );
 
-    await click(
-      '[data-test-create-card-space-workflow-create-business-account-cta] button'
-    );
+        assert
+          .dom(postableSel(0, 1))
+          .containsText(
+            `Looks like you’ve already connected your ${c.layer2.fullName} wallet`
+          );
+        assert
+          .dom(
+            '[data-test-layer-2-wallet-card] [data-test-layer-2-wallet-connected-status]'
+          )
+          .containsText('Connected');
+        assert
+          .dom(
+            '[data-test-layer-2-wallet-card] [data-test-wallet-connect-qr-code]'
+          )
+          .doesNotExist();
 
-    assert
-      .dom('[data-test-boxel-thread-header]')
-      .containsText('Business Account Creation');
+        assert
+          .dom(milestoneCompletedSel(0))
+          .containsText(`${c.layer2.fullName} wallet connected`);
+
+        await waitFor(postableSel(1, 2));
+        assert
+          .dom(postableSel(1, 2))
+          .containsText(`Please select a business account`);
+
+        let workflowPersistenceService = this.owner.lookup(
+          'service:workflow-persistence'
+        ) as WorkflowPersistence;
+
+        let workflowPersistenceId = new URL(
+          'http://domain.test/' + currentURL()
+        ).searchParams.get('flow-id')!;
+
+        let persistedData = workflowPersistenceService.getPersistedData(
+          workflowPersistenceId
+        );
+
+        assert.ok(
+          persistedData.state.layer2WalletAddress.includes(
+            layer2AccountAddress
+          ),
+          'expected the layer 2 address to have been persisted when the wallet was already connected'
+        );
+      });
+
+      test('disconnecting L2 should cancel the workflow', async function (assert) {
+        await visit('/card-space');
+        await click('[data-test-workflow-button="create-space"]');
+
+        assert
+          .dom('[data-test-layer-2-wallet-card] [data-test-address-field]')
+          .containsText(layer2AccountAddress)
+          .isVisible();
+        assert
+          .dom(milestoneCompletedSel(0))
+          .containsText(`${c.layer2.fullName} wallet connected`);
+
+        layer2Service.test__simulateDisconnectFromWallet();
+        await settled();
+
+        assert
+          .dom('[data-test-postable="0"][data-test-cancelation]')
+          .containsText(
+            `It looks like your ${c.layer2.fullName} wallet got disconnected. If you still want to create a Card Space, please start again by connecting your wallet.`
+          );
+        assert
+          .dom('[data-test-workflow-default-cancelation-cta="create-space"]')
+          .containsText('Workflow canceled');
+        assert.dom('[data-test-sidebar-preview-body]').doesNotExist();
+
+        // restart workflow
+        await click(
+          '[data-test-workflow-default-cancelation-restart="create-space"]'
+        );
+
+        assert.dom('[data-test-sidebar-preview-body]').exists();
+        layer2Service.test__simulateWalletConnectUri();
+        await waitFor('[data-test-wallet-connect-qr-code]');
+
+        assert
+          .dom(
+            '[data-test-layer-2-wallet-card] [data-test-wallet-connect-qr-code]'
+          )
+          .exists();
+        assert
+          .dom('[data-test-workflow-default-cancelation-cta="create-space"]')
+          .doesNotExist();
+      });
+
+      test('changing L2 account should cancel the workflow', async function (assert) {
+        let differentL2Address = '0x5416C61193C3393B46C2774ac4717C252031c0bE';
+
+        await visit('/card-space');
+        await click('[data-test-workflow-button="create-space"]');
+
+        assert
+          .dom('[data-test-layer-2-wallet-card] [data-test-address-field]')
+          .containsText(layer2AccountAddress)
+          .isVisible();
+
+        assert
+          .dom(milestoneCompletedSel(0))
+          .containsText(`${c.layer2.fullName} wallet connected`);
+
+        await layer2Service.test__simulateAccountsChanged([differentL2Address]);
+        await settled();
+
+        assert
+          .dom('[data-test-postable="0"][data-test-cancelation]')
+          .containsText(
+            'It looks like you changed accounts in the middle of this workflow. If you still want to create a Card Space, please restart the workflow.'
+          );
+        assert
+          .dom('[data-test-workflow-default-cancelation-cta="create-space"]')
+          .containsText('Workflow canceled');
+        assert.dom('[data-test-sidebar-preview-body]').doesNotExist();
+
+        // restart workflow
+        await click(
+          '[data-test-workflow-default-cancelation-restart="create-space"]'
+        );
+
+        assert
+          .dom(postableSel(0, 1))
+          .containsText(
+            `Looks like you’ve already connected your ${c.layer2.fullName} wallet`
+          );
+        assert
+          .dom('[data-test-layer-2-wallet-card] [data-test-address-field]')
+          .containsText(differentL2Address)
+          .isVisible();
+        assert
+          .dom('[data-test-workflow-default-cancelation-cta="create-space"]')
+          .doesNotExist();
+      });
+
+      module('tests without any available business accounts', function (hooks) {
+        hooks.beforeEach(async function (this: MirageTestContext) {
+          // @ts-ignore
+          this.server.db.merchantInfos.remove(this.server.db.merchantInfos[0]);
+        });
+
+        test('cancels the workflow when all business acounts have already been used for card space', async function (assert) {
+          layer2Service = this.owner.lookup('service:layer2-network')
+            .strategy as Layer2TestWeb3Strategy;
+
+          await visit('/card-space');
+          await click('[data-test-workflow-button="create-space"]');
+
+          await waitFor('[data-test-cancelation]');
+          assert
+            .dom('[data-test-cancelation]')
+            .containsText(
+              'It looks like you all your business accounts have already been used to create a Card Space'
+            );
+          await waitFor(
+            '[data-test-create-card-space-workflow-create-business-account-cta]'
+          );
+          await click(
+            '[data-test-create-card-space-workflow-create-business-account-cta] button'
+          );
+
+          assert
+            .dom('[data-test-boxel-thread-header]')
+            .containsText('Business Account Creation');
+        });
+      });
+    });
+
+    module('tests with no merchant safes', function (hooks) {
+      setupHubAuthenticationToken(hooks);
+
+      test('cancels the workflow when there are no merchant safes (business accounts)', async function (assert) {
+        layer2Service = this.owner.lookup('service:layer2-network')
+          .strategy as Layer2TestWeb3Strategy;
+        layer2Service.test__simulateRemoteAccountSafes(layer2AccountAddress, [
+          createDepotSafe({
+            owners: [layer2AccountAddress],
+            tokens: [createSafeToken('DAI.CPXD', '0')],
+          }),
+        ]);
+        await layer2Service.test__simulateAccountsChanged([
+          layer2AccountAddress,
+        ]);
+
+        await visit('/card-space');
+        await click('[data-test-workflow-button="create-space"]');
+
+        assert
+          .dom('[data-test-cancelation]')
+          .containsText(
+            'It looks like you haven’t created a business account yet'
+          );
+
+        await click(
+          '[data-test-create-card-space-workflow-create-business-account-cta] button'
+        );
+
+        assert
+          .dom('[data-test-boxel-thread-header]')
+          .containsText('Business Account Creation');
+      });
+    });
   });
 });

--- a/packages/web-client/tests/integration/components/card-pay/hub-authentication-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/hub-authentication-test.ts
@@ -8,11 +8,16 @@ import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { MirageTestContext } from 'ember-cli-mirage/test-support';
 import RSVP from 'rsvp';
+import Service from '@ember/service';
 
 const FAILURE_MESSAGE = 'Authentication failed or was canceled.';
 
 interface Context extends MirageTestContext {
   isComplete: boolean;
+}
+
+class AuthServiceStub extends Service {
+  isAuthenticated = true;
 }
 
 module(
@@ -24,20 +29,21 @@ module(
     setupRenderingTest(hooks);
     setupMirage(hooks);
 
-    hooks.beforeEach(async function (this: Context) {
-      hubAuthentication = this.owner.lookup('service:hub-authentication');
-      layer2Service = this.owner.lookup('service:layer2-network').strategy;
+    module('Initialized unauthenticated', function (hooks) {
+      hooks.beforeEach(async function (this: Context) {
+        hubAuthentication = this.owner.lookup('service:hub-authentication');
+        layer2Service = this.owner.lookup('service:layer2-network').strategy;
 
-      this.setProperties({
-        onComplete: () => {
-          this.set('isComplete', true);
-        },
-        onIncomplete: () => {},
-        isComplete: false,
-        frozen: false,
-      });
+        this.setProperties({
+          onComplete: () => {
+            this.set('isComplete', true);
+          },
+          onIncomplete: () => {},
+          isComplete: false,
+          frozen: false,
+        });
 
-      await render(hbs`
+        await render(hbs`
       <CardPay::HubAuthentication
         @onComplete={{this.onComplete}}
         @isComplete={{this.isComplete}}
@@ -45,102 +51,129 @@ module(
         @frozen={{this.frozen}}
       />
     `);
-    });
+      });
 
-    test('it disables the chin button when card is frozen', async function (assert) {
-      assert.dom('[data-test-authentication-button]').isNotDisabled();
-      this.set('frozen', true);
-      assert.dom('[data-test-authentication-button]').isDisabled();
-    });
+      test('it disables the chin button when card is frozen', async function (assert) {
+        assert.dom('[data-test-authentication-button]').isNotDisabled();
+        this.set('frozen', true);
+        assert.dom('[data-test-authentication-button]').isDisabled();
+      });
 
-    module('Test the sdk hub authentication calls', function () {
-      test('It shows the failure message if the signing request fails or is rejected', async function (assert) {
+      module('Test the sdk hub authentication calls', function () {
+        test('It shows the failure message if the signing request fails or is rejected', async function (assert) {
+          let deferred = RSVP.defer<void>();
+          sinon
+            .stub(hubAuthentication, 'ensureAuthenticated')
+            .returns(deferred.promise);
+
+          await click('[data-test-authentication-button]');
+          assert
+            .dom('[data-test-boxel-action-chin]')
+            .containsText(
+              'You will receive a confirmation request from the Card Wallet app in a few moments'
+            );
+
+          deferred.reject(new Error('User rejected request'));
+
+          await waitFor('[data-test-failed]');
+
+          assert.dom('[data-test-failed]').containsText(FAILURE_MESSAGE);
+        });
+
+        test('It attempts to re-authenticate when Try Again button is pressed', async function (assert) {
+          let deferred = RSVP.defer<void>();
+          let stub = sinon
+            .stub(hubAuthentication, 'ensureAuthenticated')
+            .returns(deferred.promise);
+
+          await click('[data-test-authentication-button]');
+
+          deferred.reject(new Error('User rejected request'));
+
+          await waitFor('[data-test-failed]');
+
+          stub.restore();
+
+          await click('[data-test-authentication-retry-button]');
+
+          assert
+            .dom('[data-test-boxel-action-chin]')
+            .containsText(
+              'You will receive a confirmation request from the Card Wallet app in a few moments'
+            );
+
+          layer2Service.test__simulateHubAuthentication('some-auth-token');
+          await settled();
+
+          assert
+            .dom('[data-test-boxel-action-chin]')
+            .containsText('Authenticated with Hub');
+        });
+
+        test('It shows the successful state if authentication succeeds', async function (assert) {
+          let deferred = RSVP.defer<void>();
+          sinon
+            .stub(hubAuthentication, 'ensureAuthenticated')
+            .returns(deferred.promise);
+
+          await click('[data-test-authentication-button]');
+          assert
+            .dom('[data-test-boxel-action-chin]')
+            .containsText(
+              'You will receive a confirmation request from the Card Wallet app in a few moments'
+            );
+          hubAuthentication.authToken = 'some-auth-token';
+          hubAuthentication.isAuthenticated = true;
+          deferred.resolve();
+          await settled();
+          assert
+            .dom('[data-test-boxel-action-chin]')
+            .containsText('Authenticated with Hub');
+        });
+      });
+
+      test('It shows a message on timeout', async function (assert) {
         let deferred = RSVP.defer<void>();
         sinon
           .stub(hubAuthentication, 'ensureAuthenticated')
           .returns(deferred.promise);
 
         await click('[data-test-authentication-button]');
-        assert
-          .dom('[data-test-boxel-action-chin]')
-          .containsText(
-            'You will receive a confirmation request from the Card Wallet app in a few moments'
-          );
-
-        deferred.reject(new Error('User rejected request'));
 
         await waitFor('[data-test-failed]');
 
-        assert.dom('[data-test-failed]').containsText(FAILURE_MESSAGE);
-      });
-
-      test('It attempts to re-authenticate when Try Again button is pressed', async function (assert) {
-        let deferred = RSVP.defer<void>();
-        let stub = sinon
-          .stub(hubAuthentication, 'ensureAuthenticated')
-          .returns(deferred.promise);
-
-        await click('[data-test-authentication-button]');
-
-        deferred.reject(new Error('User rejected request'));
-
-        await waitFor('[data-test-failed]');
-
-        stub.restore();
-
-        await click('[data-test-authentication-retry-button]');
-
         assert
-          .dom('[data-test-boxel-action-chin]')
+          .dom('[data-test-failed]')
           .containsText(
-            'You will receive a confirmation request from the Card Wallet app in a few moments'
+            "Authentication with Card Wallet timed out. If you didn't receive a confirmation request on your device, try again, or contact Cardstack support"
           );
-
-        layer2Service.test__simulateHubAuthentication('some-auth-token');
-        await settled();
-
-        assert
-          .dom('[data-test-boxel-action-chin]')
-          .containsText('Authenticated with Hub');
-      });
-
-      test('It shows the successful state if authentication succeeds', async function (assert) {
-        let deferred = RSVP.defer<void>();
-        sinon
-          .stub(hubAuthentication, 'ensureAuthenticated')
-          .returns(deferred.promise);
-
-        await click('[data-test-authentication-button]');
-        assert
-          .dom('[data-test-boxel-action-chin]')
-          .containsText(
-            'You will receive a confirmation request from the Card Wallet app in a few moments'
-          );
-        hubAuthentication.authToken = 'some-auth-token';
-        hubAuthentication.isAuthenticated = true;
-        deferred.resolve();
-        await settled();
-        assert
-          .dom('[data-test-boxel-action-chin]')
-          .containsText('Authenticated with Hub');
       });
     });
 
-    test('It shows a message on timeout', async function (assert) {
-      let deferred = RSVP.defer<void>();
-      sinon
-        .stub(hubAuthentication, 'ensureAuthenticated')
-        .returns(deferred.promise);
+    module('Initialized authenticated', function () {
+      test('It shows authenticated state', async function (assert) {
+        this.owner.register('service:hub-authentication', AuthServiceStub);
+        this.setProperties({
+          onComplete: () => {
+            this.set('isComplete', true);
+          },
+          onIncomplete: () => {},
+          isComplete: false,
+          frozen: false,
+        });
 
-      await click('[data-test-authentication-button]');
-
-      await waitFor('[data-test-failed]');
-
-      assert
-        .dom('[data-test-failed]')
-        .containsText(
-          "Authentication with Card Wallet timed out. If you didn't receive a confirmation request on your device, try again, or contact Cardstack support"
-        );
+        await render(hbs`
+          <CardPay::HubAuthentication
+            @onComplete={{this.onComplete}}
+            @isComplete={{this.isComplete}}
+            @onIncomplete={{this.onIncomplete}}
+            @frozen={{this.frozen}}
+          />
+        `);
+        assert
+          .dom('[data-test-memorialized]')
+          .containsText('Authenticated with Hub');
+      });
     });
   }
 );

--- a/packages/web-client/tests/integration/components/card-pay/hub-authentication-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/hub-authentication-test.ts
@@ -171,7 +171,7 @@ module(
           />
         `);
         assert
-          .dom('[data-test-memorialized]')
+          .dom('[data-test-authentication-memorialized]')
           .containsText('Authenticated with Hub');
       });
     });


### PR DESCRIPTION
Ticket: [CS-1981](https://linear.app/cardstack/issue/CS-1981/updates-to-card-space-setup-workflow-if-user-already-has-a-merchant)

Adds a business account selection step in the create card space workflow.

Edit:
![image](https://user-images.githubusercontent.com/273660/150522154-ac0aa2b2-a26d-4857-bf62-956180811dc3.png)

Materialized:
![image](https://user-images.githubusercontent.com/273660/150522189-27569934-eda1-47df-94f0-73934628b903.png)

User didn't create a merchant:
![image](https://user-images.githubusercontent.com/273660/150522353-ca123784-cc8b-436e-876c-5fc98170be88.png)
