### PR TITLE
hub: Change incidents to have shorter names

### DIFF
--- a/packages/hub/node-tests/routes/checkly-webhook-test.ts
+++ b/packages/hub/node-tests/routes/checkly-webhook-test.ts
@@ -1,12 +1,13 @@
 import { registry, setupHub } from '../helpers/server';
 
-let createdIncident: { componentName: string; message: string } | null,
+let createdIncident: { componentName: string; name: string, message: string } | null,
   resolvedIncident: { componentName: string } | null;
 
 class StubStatuspageApi {
-  async createIncident(componentName: string, message: string): Promise<void> {
+  async createIncident(componentName: string, name: string, message: string): Promise<void> {
     createdIncident = {
       componentName,
+      name,
       message,
     };
   }

--- a/packages/hub/node-tests/routes/checkly-webhook-test.ts
+++ b/packages/hub/node-tests/routes/checkly-webhook-test.ts
@@ -41,7 +41,7 @@ describe('POST /api/checkly-webhook', async function () {
 
     expect(createdIncident).to.deep.equal({
       componentName: 'Subgraph',
-      name: 'Experiencing degraded service',
+      name: 'Transactions delayed',
       message:
         'We are experiencing blockchain indexing delays. The blockchain index is delayed by at least 10 blocks. This will result increased transaction processing times.',
     });

--- a/packages/hub/node-tests/routes/checkly-webhook-test.ts
+++ b/packages/hub/node-tests/routes/checkly-webhook-test.ts
@@ -40,12 +40,13 @@ describe('POST /api/checkly-webhook', async function () {
 
     expect(createdIncident).to.deep.equal({
       componentName: 'Subgraph',
+      name: 'Experiencing degraded service',
       message:
         'We are experiencing blockchain indexing delays. The blockchain index is delayed by at least 10 blocks. This will result increased transaction processing times.',
     });
   });
 
-  it('creates a new alert when the check recovered', async function () {
+  it('resolves an incident when the check recovered', async function () {
     await request()
       .post('/callbacks/checkly')
       .set('Accept', 'application/json')

--- a/packages/hub/node-tests/routes/checkly-webhook-test.ts
+++ b/packages/hub/node-tests/routes/checkly-webhook-test.ts
@@ -1,6 +1,6 @@
 import { registry, setupHub } from '../helpers/server';
 
-let createdIncident: { componentName: string; name: string, message: string } | null,
+let createdIncident: { componentName: string; name: string; message: string } | null,
   resolvedIncident: { componentName: string } | null;
 
 class StubStatuspageApi {

--- a/packages/hub/routes/checkly-webhook.ts
+++ b/packages/hub/routes/checkly-webhook.ts
@@ -11,6 +11,7 @@ type CheckName = 'hub-prod subgraph / RPC node block number diff within threshol
 type Checks = {
   [key in CheckName]: {
     componentName: 'Subgraph'; // Component name in Checkly
+    incidentName: string; // Incident name in Checkly
     incidentMessage: string; // Will be shown in Statuspage
   };
 };
@@ -21,6 +22,7 @@ export default class ChecklyWebhookRoute {
   checks: Checks = {
     'hub-prod subgraph / RPC node block number diff within threshold': {
       componentName: 'Subgraph',
+      incidentName: 'Experiencing degraded service',
       incidentMessage: `We are experiencing blockchain indexing delays. The blockchain index is delayed by at least ${degradedSubgraphThreshold} blocks. This will result increased transaction processing times.`,
     },
   };
@@ -46,7 +48,7 @@ export default class ChecklyWebhookRoute {
       let alertType = ctx.request.body.alert_type;
 
       if (alertType === 'ALERT_FAILURE') {
-        await this.statuspageApi.createIncident(check.componentName, check.incidentMessage);
+        await this.statuspageApi.createIncident(check.componentName, check.incidentName, check.incidentMessage);
       } else if (alertType == 'ALERT_RECOVERY') {
         await this.statuspageApi.resolveIncident(check.componentName);
       }

--- a/packages/hub/routes/checkly-webhook.ts
+++ b/packages/hub/routes/checkly-webhook.ts
@@ -22,7 +22,7 @@ export default class ChecklyWebhookRoute {
   checks: Checks = {
     'hub-prod subgraph / RPC node block number diff within threshold': {
       componentName: 'Subgraph',
-      incidentName: 'Experiencing degraded service',
+      incidentName: 'Transactions delayed',
       incidentMessage: `We are experiencing blockchain indexing delays. The blockchain index is delayed by at least ${degradedSubgraphThreshold} blocks. This will result increased transaction processing times.`,
     },
   };

--- a/packages/hub/services/statuspage-api.ts
+++ b/packages/hub/services/statuspage-api.ts
@@ -17,7 +17,7 @@ let pageId = config.get('statuspage.pageId');
 let apiKey = config.get('statuspage.apiKey');
 
 export default class StatuspageApi {
-  async createIncident(componentName: string, name: string) {
+  async createIncident(componentName: string, name: string, body: string) {
     let componentId = await this.getComponentId(componentName);
     let unresolvedIncidents = await this.getUnresolvedIncidents();
     let relatedIncident = this.findIncidentByComponentId(unresolvedIncidents, componentId);
@@ -29,6 +29,7 @@ export default class StatuspageApi {
     return await this.request(`/pages/${pageId}/incidents`, 'POST', {
       incident: {
         name,
+        body,
         impact: 'minor',
         status: 'investigating',
         components: { [componentId]: 'partial_outage' }, // Will update individual components' status

--- a/packages/web-client/app/services/degraded-service-detector.ts
+++ b/packages/web-client/app/services/degraded-service-detector.ts
@@ -86,7 +86,7 @@ export default class DegradedServiceDetector extends Service {
 
     return {
       status: incident.status,
-      name: this.addPunctuation(lastUpdate.body),
+      name: `${incident.name}: ${this.addPunctuation(lastUpdate.body)}`,
       impact: incident.impact,
     };
   }

--- a/packages/web-client/app/services/degraded-service-detector.ts
+++ b/packages/web-client/app/services/degraded-service-detector.ts
@@ -43,10 +43,10 @@ export default class DegradedServiceDetector extends Service {
     }
   }
 
-  async getDegradationStatusData(): Promise<any> {
+  async getDegradationStatusData(): Promise<Incident | null> {
     let statusPageUrl = `${this.statusPageUrl}/api/v2/incidents/unresolved.json`;
 
-    let data = {} as any;
+    let data = {} as StatuspageStatusAPIUnresolvedResponse;
 
     try {
       let response = await fetch(statusPageUrl);
@@ -81,9 +81,12 @@ export default class DegradedServiceDetector extends Service {
         return +new Date(b.started_at) - +new Date(a.started_at);
       })[0];
 
+    let lastUpdate =
+      incident.incident_updates[incident.incident_updates.length - 1];
+
     return {
       status: incident.status,
-      name: this.addPunctuation(incident.name),
+      name: this.addPunctuation(lastUpdate.body),
       impact: incident.impact,
     };
   }
@@ -96,3 +99,25 @@ export default class DegradedServiceDetector extends Service {
     return `${text}.`;
   }
 }
+
+// https://metastatuspage.com/api#incidents-unresolved
+type StatuspageStatusAPIUnresolvedResponse = {
+  incidents: Array<StatuspageIncident>;
+};
+
+type StatuspageIncident = {
+  impact: string;
+  incident_updates: [
+    {
+      body: string;
+    }
+  ];
+  name: string;
+  status: string;
+};
+
+type Incident = {
+  name: string;
+  impact: string;
+  status: string;
+};

--- a/packages/web-client/tests/integration/components/degraded-service-banner-test.ts
+++ b/packages/web-client/tests/integration/components/degraded-service-banner-test.ts
@@ -39,7 +39,7 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
         {
           incidents: [
             {
-              name: 'Ignored',
+              name: 'Name',
               impact: 'critical',
               incident_updates: [
                 { body: 'An old error' },
@@ -56,7 +56,7 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
     assert
       .dom('[data-test-degraded-service-banner]')
       .containsText(
-        'All systems down. For more details, check our status page'
+        'Name: All systems down. For more details, check our status page'
       );
     assert
       .dom('[data-test-degraded-service-banner]')
@@ -71,7 +71,7 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
         {
           incidents: [
             {
-              name: 'All systems down.',
+              name: 'Name',
               impact: 'major',
               incident_updates: [{ body: 'All systems down.' }],
             },
@@ -95,7 +95,7 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
         {
           incidents: [
             {
-              name: 'Ignored',
+              name: 'Name',
               impact: 'minor',
               incident_updates: [{ body: 'One small system down.' }],
             },
@@ -109,7 +109,7 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
     assert
       .dom('[data-test-degraded-service-banner]')
       .containsText(
-        'One small system down. For more details, check our status page'
+        'Name: One small system down. For more details, check our status page'
       );
     assert
       .dom('[data-test-degraded-service-banner]')
@@ -136,7 +136,7 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
               started_at: '2021-10-10T10:10:00.003Z',
             },
             {
-              name: 'Ignored',
+              name: 'Shown',
               impact: 'critical',
               incident_updates: [{ body: 'World down.' }],
               started_at: '2021-10-10T10:10:00.002Z',
@@ -156,7 +156,9 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
     await waitFor('[data-test-degraded-service-banner]');
     assert
       .dom('[data-test-degraded-service-banner]')
-      .containsText('World down. For more details, check our status page');
+      .containsText(
+        'Shown: World down. For more details, check our status page'
+      );
     assert
       .dom('[data-test-degraded-service-banner]')
       .hasClass('degraded-service-banner--severe');
@@ -170,7 +172,7 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
         {
           incidents: [
             {
-              name: 'Ignored',
+              name: 'Name',
               impact: 'major',
               incident_updates: [{ body: 'We are experiencing issues' }],
             },
@@ -184,7 +186,7 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
     assert
       .dom('[data-test-degraded-service-banner]')
       .containsText(
-        'We are experiencing issues. For more details, check our status page'
+        'Name: We are experiencing issues. For more details, check our status page'
       );
   });
 });

--- a/packages/web-client/tests/integration/components/degraded-service-banner-test.ts
+++ b/packages/web-client/tests/integration/components/degraded-service-banner-test.ts
@@ -39,8 +39,12 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
         {
           incidents: [
             {
-              name: 'All systems down.',
+              name: 'Ignored',
               impact: 'critical',
+              incident_updates: [
+                { body: 'An old error' },
+                { body: 'All systems down.' },
+              ],
             },
           ],
         }
@@ -69,6 +73,7 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
             {
               name: 'All systems down.',
               impact: 'major',
+              incident_updates: [{ body: 'All systems down.' }],
             },
           ],
         }
@@ -90,8 +95,9 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
         {
           incidents: [
             {
-              name: 'One small system down.',
+              name: 'Ignored',
               impact: 'minor',
+              incident_updates: [{ body: 'One small system down.' }],
             },
           ],
         }
@@ -118,23 +124,27 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
         {
           incidents: [
             {
-              name: 'All systems down.',
+              name: 'Ignored',
               impact: 'major',
+              incident_updates: [{ body: 'All systems down.' }],
               started_at: '2021-10-10T10:10:00.000Z',
             },
             {
-              name: 'One small system down.',
+              name: 'Ignored',
               impact: 'minor',
+              incident_updates: [{ body: 'One small system down.' }],
               started_at: '2021-10-10T10:10:00.003Z',
             },
             {
-              name: 'World down.',
+              name: 'Ignored',
               impact: 'critical',
+              incident_updates: [{ body: 'World down.' }],
               started_at: '2021-10-10T10:10:00.002Z',
             },
             {
-              name: 'Internet down.',
+              name: 'Ignored',
               impact: 'critical',
+              incident_updates: [{ body: 'Internet down.' }],
               started_at: '2021-10-10T10:10:00.001Z',
             },
           ],
@@ -160,8 +170,9 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
         {
           incidents: [
             {
-              name: 'We are experiencing issues',
+              name: 'Ignored',
               impact: 'major',
+              incident_updates: [{ body: 'We are experiencing issues' }],
             },
           ],
         }

--- a/packages/web-client/tests/integration/components/workflow-thread-test.ts
+++ b/packages/web-client/tests/integration/components/workflow-thread-test.ts
@@ -28,8 +28,11 @@ module('Integration | Component | workflow-thread', function (hooks) {
         {
           incidents: [
             {
-              name: 'This should be visible in a workflow.',
+              name: 'Ignored',
               impact: 'critical',
+              incident_updates: [
+                { body: 'This should be visible in a workflow.' },
+              ],
             },
           ],
         }

--- a/packages/web-client/tests/integration/components/workflow-thread-test.ts
+++ b/packages/web-client/tests/integration/components/workflow-thread-test.ts
@@ -28,7 +28,7 @@ module('Integration | Component | workflow-thread', function (hooks) {
         {
           incidents: [
             {
-              name: 'Ignored',
+              name: 'Name',
               impact: 'critical',
               incident_updates: [
                 { body: 'This should be visible in a workflow.' },
@@ -49,7 +49,7 @@ module('Integration | Component | workflow-thread', function (hooks) {
     assert
       .dom('[data-test-degraded-service-banner]')
       .isVisible()
-      .containsText('This should be visible in a workflow.');
+      .containsText('Name: This should be visible in a workflow.');
   });
 
   test('it renders before-content named block', async function (assert) {


### PR DESCRIPTION
This shifts what was the `name` to the `body` when creating a Statuspage incident to allow the `name` to be a shorter string (`Experiencing degraded service` only, for now). When you [create a new incident](https://developer.statuspage.io/#operation/postPagesPageIdIncidents), `body` is the “initial message, created as the first incident update.”

The desire is to have a more concise message to show in Card Wallet:

![image](https://user-images.githubusercontent.com/43280/150414829-d275dce1-5f8b-4782-a835-5999a7e70afe.png)

Since web client’s design is more able to facilitate longer messages, it ignores the `name` and chooses the `body` of the last `incident_updates` entry.