### PR TITLE
Remove id check during adoptInToRealm and add test to confirm

### DIFF
--- a/packages/hub/lib/card-model-for-hub.ts
+++ b/packages/hub/lib/card-model-for-hub.ts
@@ -18,7 +18,7 @@ import isPlainObject from 'lodash/isPlainObject';
 import { cardURL } from '@cardstack/core/src/utils';
 import RealmManager from '../services/realm-manager';
 import { SearchIndex } from '../services/search-index';
-import { BadRequest, Conflict, isCardstackError } from '@cardstack/core/src/utils/errors';
+import { BadRequest } from '@cardstack/core/src/utils/errors';
 // import { tracked } from '@glimmer/tracking';
 
 export interface NewCardParams {
@@ -80,19 +80,6 @@ export default class CardModelForHub implements CardModel {
     }
     if (this.format !== 'isolated') {
       throw new Error(`Can only adoptIntoRealm from an isolated card. This card is ${this.format}`);
-    }
-    // TODO remove this. it's up to the realm manager to make this
-    // decision--and it's the one that needs to raise the errors
-    if (id) {
-      try {
-        await this.env.loadData(cardURL({ realm, id }), 'isolated');
-        throw new Conflict(`Card ${id} already exists in realm ${realm}`);
-      } catch (e: any) {
-        if (!isCardstackError(e) || e.status !== 404) {
-          throw e;
-        }
-        // we expect a 404 here, so we can continue
-      }
     }
     return new (this.constructor as typeof CardModelForHub)(this.env, {
       type: 'created',

--- a/packages/hub/node-tests/@core/card-model-test.ts
+++ b/packages/hub/node-tests/@core/card-model-test.ts
@@ -139,6 +139,18 @@ if (process.env.COMPILER) {
       expect(isolated.data.name).to.equal('Robert Barker');
     });
 
+    it('.save() on adopted card using pre-existing id', async function () {
+      let id = 'bob-barker';
+      let parentCard = await cards.loadData(`${realmURL}person`, 'isolated');
+      let model = await parentCard.adoptIntoRealm(realmURL, id);
+      try {
+        await model.save();
+        throw new Error('did not throw expected error');
+      } catch (e: any) {
+        expect(e.message).to.equal(`card ${realmURL}${id} already exists`);
+      }
+    });
+
     // note that we have route tests that also assert that setting values on
     // non-existent fields should error
     it('setData of unused field', async function () {


### PR DESCRIPTION
If `id` is sent into `adoptIntoRealm` method, a model will be returned but it's not possible to save it into the db because the realm manager is already doing its job. I couldn't find anything to change, unless we want to call realm manager's `create` method earlier, such as inside the `adoptFromRealm` and not wait until a `save`. 