### PR TITLE
Fix/missing dropdown highlights

### DIFF
--- a/packages/web-client/app/components/card-pay/balance-chooser-dropdown/index.css
+++ b/packages/web-client/app/components/card-pay/balance-chooser-dropdown/index.css
@@ -54,7 +54,6 @@
 }
 
 .balance-chooser-dropdown__option:hover {
-  background-color: var(--boxel-light-300);
   cursor: pointer;
 }
 

--- a/packages/web-client/app/components/card-pay/card-picker/index.css
+++ b/packages/web-client/app/components/card-pay/card-picker/index.css
@@ -70,7 +70,7 @@
 }
 
 .card-picker-dropdown__option--selected {
-  background-image: url('/images/icons/success-bordered.svg');
+  background-image: url('/@cardstack/boxel/images/icons/success-bordered.svg');
 }
 
 .ember-power-select-selected-item .card-picker-dropdown__option--selected {

--- a/packages/web-client/app/components/card-pay/card-picker/index.css
+++ b/packages/web-client/app/components/card-pay/card-picker/index.css
@@ -43,7 +43,7 @@
 
 .card-picker-dropdown .ember-basic-dropdown-content {
   max-width: 100%;
-  height: 100%;
+  height: 500px;
   width: var(--default-field-width);
   max-height: var(--options-menu-height);
   background-color: var(--boxel-light);
@@ -82,7 +82,6 @@
 }
 
 .card-picker-dropdown__option:hover:not(.card-picker-dropdown__option--disabled) {
-  background-color: var(--boxel-purple-100);
   cursor: pointer;
 }
 

--- a/packages/web-client/app/components/card-pay/safe-chooser-dropdown/index.css
+++ b/packages/web-client/app/components/card-pay/safe-chooser-dropdown/index.css
@@ -54,7 +54,6 @@
 }
 
 .safe-chooser-dropdown__option:hover {
-  background-color: var(--boxel-light-300);
   cursor: pointer;
 }
 

--- a/packages/web-client/app/styles/app.css
+++ b/packages/web-client/app/styles/app.css
@@ -55,3 +55,18 @@ ol {
     transform: translateY(0);
   }
 }
+
+/**
+ * Necessary to make our dropdowns usable via keyboard
+ * They should scroll to the item that keyboard navigation has highlighted
+ * and have a visible background to show that pressing enter
+ * or space will select an item
+ */
+.ember-power-select-options {
+  height: 100%;
+  overflow-y: scroll;
+}
+
+.ember-power-select-option[aria-current="true"] {
+  background-color: #5897fb;
+}


### PR DESCRIPTION
CS-2991

https://www.loom.com/share/174a2d01f5d042a5b35da28f66e45295

After recording the video, I changed the highlight color to a lighter one to avoid contrast issues:

![dropdown with new highlight color, a light cyan](https://user-images.githubusercontent.com/39579264/150748588-850cf9b8-d731-4206-befa-6ef006512cb6.png)
