### PR TITLE
Render user into card space template

### DIFF
--- a/packages/web-client/README.md
+++ b/packages/web-client/README.md
@@ -26,6 +26,10 @@ You will need the following things properly installed on your computer.
 
 Note that you will have to run the hub for some functionality of this app, see [the hub README](../hub/README.md#running).
 
+To develop the Card Space user page locally, you should:
+1. Add `app.card.space.test` to your `/etc/hosts` as an alias of localhost
+2. Visit `app.card.space.test:4200?card-space-id=${cardSpaceId}` to simulate visiting a card space with that id
+
 ### Required environment variables
 Connecting to the Kovan Testnet with WalletConnect requires an Infura project id. This should be specified in a `.env` file in this package's root as:
 ```

--- a/packages/web-client/app/controllers/card-space/index.ts
+++ b/packages/web-client/app/controllers/card-space/index.ts
@@ -1,7 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import '@cardstack/web-client/css/card-space.css';
 
 export default class CardSpaceIndexController extends Controller {
   queryParams = ['flow', { workflowPersistenceId: 'flow-id' }];

--- a/packages/web-client/app/controllers/card-space/index.ts
+++ b/packages/web-client/app/controllers/card-space/index.ts
@@ -1,9 +1,9 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import '../css/card-space.css';
+import '@cardstack/web-client/css/card-space.css';
 
-export default class CardSpaceController extends Controller {
+export default class CardSpaceIndexController extends Controller {
   queryParams = ['flow', { workflowPersistenceId: 'flow-id' }];
 
   @tracked flow: string | null = null;

--- a/packages/web-client/app/controllers/index.ts
+++ b/packages/web-client/app/controllers/index.ts
@@ -6,6 +6,11 @@ import Layer2Network from '@cardstack/web-client/services/layer2-network';
 
 class IndexController extends Controller {
   @service declare layer2Network: Layer2Network;
+  queryParams = [
+    {
+      cardSpaceId: 'card-space-id',
+    },
+  ];
 
   @action connectToWallet() {
     console.log('Connect to wallet here');

--- a/packages/web-client/app/router.ts
+++ b/packages/web-client/app/router.ts
@@ -16,7 +16,6 @@ Router.map(function () {
   this.route('card-space', function () {
     this.route('profile-card-temp');
   });
-  this.route('view-card-space');
   this.route('image-uploader-temp');
   this.route('pay', {
     path: '/pay/:network/:merchant_safe_id',

--- a/packages/web-client/app/routes/application.ts
+++ b/packages/web-client/app/routes/application.ts
@@ -2,8 +2,9 @@ import Route from '@ember/routing/route';
 import RouterService from '@ember/routing/router-service';
 import { LocationService } from '../services/location';
 import { inject as service } from '@ember/service';
-import '@cardstack/web-client/css/variables.css';
 import config from '@cardstack/web-client/config/environment';
+import '@cardstack/web-client/css/variables.css';
+import '@cardstack/web-client/css/card-space.css';
 
 export default class ApplicationRoute extends Route {
   @service declare router: RouterService;

--- a/packages/web-client/app/routes/application.ts
+++ b/packages/web-client/app/routes/application.ts
@@ -1,5 +1,25 @@
 import Route from '@ember/routing/route';
+import RouterService from '@ember/routing/router-service';
+import { LocationService } from '../services/location';
+import { inject as service } from '@ember/service';
+import '@cardstack/web-client/css/variables.css';
+import config from '@cardstack/web-client/config/environment';
 
-import '../css/variables.css';
+export default class ApplicationRoute extends Route {
+  @service declare router: RouterService;
+  @service declare location: LocationService;
 
-export default class ApplicationRoute extends Route {}
+  beforeModel() {
+    // if we are on the card space domain, we should not allow
+    // users to visit other routes besides index
+    // some important functionality will be messed up
+    // eg. layer 1 infura calls via WalletConnect
+
+    // NOTE: there is a caveat to this. If the user uses a LinkTo from this page
+    // that leads to, say, card-pay.wallet, this interception will not run
+    // it may be better to create a base class for all routes that has this functionality
+    if (this.location.hostname.endsWith(config.cardSpaceHostnameSuffix)) {
+      this.router.replaceWith('index');
+    }
+  }
+}

--- a/packages/web-client/app/routes/card-space/index.ts
+++ b/packages/web-client/app/routes/card-space/index.ts
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import * as short from 'short-uuid';
 
-export default class CardSpaceRoute extends Route {
+export default class CardSpaceIndexRoute extends Route {
   queryParams = {
     flow: {
       refreshModel: true,

--- a/packages/web-client/app/routes/index.ts
+++ b/packages/web-client/app/routes/index.ts
@@ -20,7 +20,7 @@ import CardPayHor from '@cardstack/web-client/images/illustrations/card-pay-illu
 import CardCatalogHor from '@cardstack/web-client/images/illustrations/card-catalog-illustration-horizontal.svg';
 import CardMembershipHor from '@cardstack/web-client/images/illustrations/card-membership-illustration-horizontal.svg';
 
-import '../css/cardstack-landing-page.css';
+import '@cardstack/web-client/css/cardstack-landing-page.css';
 
 import ENV from '../config/environment';
 const { enableCardSpace, enableCardPay } = ENV.features;

--- a/packages/web-client/app/routes/index.ts
+++ b/packages/web-client/app/routes/index.ts
@@ -118,8 +118,10 @@ const ORGS = [
 
 export default class CardstackRoute extends Route {
   @service declare location: LocationService;
+  cardSpaceId = '';
 
-  async model() {
+  model(params: any) {
+    this.cardSpaceId = params['cardSpaceId'];
     return {
       orgs: ORGS,
     };
@@ -127,10 +129,20 @@ export default class CardstackRoute extends Route {
 
   renderTemplate(controller: Controller) {
     if (this.location.hostname.endsWith(config.cardSpaceHostnameSuffix)) {
-      let displayName = this.location.hostname.replace(
-        `.${config.cardSpaceHostnameSuffix}`,
-        ''
-      );
+      let displayName: string;
+      if (config.environment === 'development') {
+        displayName = this.cardSpaceId;
+        if (!displayName) {
+          throw new Error(
+            'card-space-id query parameter is required for card space user page in development'
+          );
+        }
+      } else {
+        displayName = this.location.hostname.replace(
+          `.${config.cardSpaceHostnameSuffix}`,
+          ''
+        );
+      }
 
       this.render('card-space', {
         into: 'application',

--- a/packages/web-client/app/routes/index.ts
+++ b/packages/web-client/app/routes/index.ts
@@ -132,7 +132,13 @@ export default class CardstackRoute extends Route {
         ''
       );
 
-      this.render('view-card-space', { model: { displayName } });
+      this.render('card-space', {
+        into: 'application',
+      });
+      this.render('view-card-space', {
+        into: 'card-space',
+        model: { displayName },
+      });
     } else {
       super.renderTemplate(controller, null);
     }

--- a/packages/web-client/app/templates/card-space.hbs
+++ b/packages/web-client/app/templates/card-space.hbs
@@ -5,30 +5,5 @@
     class="card-space-left-edge"
     @home={{hash icon="cardstack-logo" action=this.transitionHome width="33px" height="35px"}}
   />
-  <div class="card-space-category-nav">
-    <h1 class="card-space-category-nav__title">Card Space</h1>
-  </div>
-  <section class="card-space-gallery">
-    <div class="card-space-create-panel">
-      <Boxel::Button
-        {{on "click" (fn this.transitionToWorkflow "create-space")}}
-        @kind="primary"
-        data-test-workflow-button="create-space"
-      >
-        Create Space
-      </Boxel::Button>
-
-      {{outlet}}
-    </div>
-  </section>
-
-  <Boxel::Modal
-    @size="large"
-    @isOpen={{eq this.flow "create-space"}}
-    @onClose={{this.resetQueryParams}}
-  >
-    {{#if (is-network-initialized)}}
-      <CardSpace::CreateSpaceWorkflow @onClose={{this.resetQueryParams}} />
-    {{/if}}
-  </Boxel::Modal>
+    {{outlet}}
 </main>

--- a/packages/web-client/app/templates/card-space/index.hbs
+++ b/packages/web-client/app/templates/card-space/index.hbs
@@ -1,0 +1,25 @@
+<div class="card-space-category-nav">
+    <h1 class="card-space-category-nav__title">Card Space</h1>
+  </div>
+  <section class="card-space-gallery">
+    <div class="card-space-create-panel">
+      <Boxel::Button
+        {{on "click" (fn this.transitionToWorkflow "create-space")}}
+        @kind="primary"
+        data-test-workflow-button="create-space"
+      >
+        Create Space
+      </Boxel::Button>
+
+    </div>
+  </section>
+
+  <Boxel::Modal
+    @size="large"
+    @isOpen={{eq this.flow "create-space"}}
+    @onClose={{this.resetQueryParams}}
+  >
+    {{#if (is-network-initialized)}}
+      <CardSpace::CreateSpaceWorkflow @onClose={{this.resetQueryParams}} />
+    {{/if}}
+  </Boxel::Modal>

--- a/packages/web-client/config/environment.js
+++ b/packages/web-client/config/environment.js
@@ -16,6 +16,7 @@ const universalLinkHostnamesByTarget = {
   production: MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME,
 };
 
+const CARD_SPACE_HOSTNAME_LOCAL_DEV_SUFFIX = 'card.space.test';
 const CARD_SPACE_HOSTNAME_SUFFIX = 'card.space';
 const CARD_SPACE_HOSTNAME_STAGING_SUFFIX = 'pouty.pizza';
 const CARD_SPACE_HOSTNAME_TEST_SUFFIX = 'space.example.com';
@@ -41,7 +42,7 @@ module.exports = function (environment) {
       MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,
     cardSpaceHostnameSuffix:
       cardSpaceHostnameSuffixesByTarget[process.env.DEPLOY_TARGET] ??
-      CARD_SPACE_HOSTNAME_STAGING_SUFFIX,
+      CARD_SPACE_HOSTNAME_LOCAL_DEV_SUFFIX,
     version: pkg.version,
     sentryDsn: process.env.SENTRY_DSN,
     '@sentry/ember': {

--- a/packages/web-client/tests/acceptance/visit-card-space-test.ts
+++ b/packages/web-client/tests/acceptance/visit-card-space-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { visit } from '@ember/test-helpers';
+import { currentURL, visit } from '@ember/test-helpers';
 import config from '@cardstack/web-client/config/environment';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { LocationService } from '@cardstack/web-client/services/location';
@@ -27,5 +27,14 @@ module('Acceptance | visit card space', function (hooks) {
       .hasText('displayNametodo');
 
     await percySnapshot(assert);
+  });
+
+  test('redirects from other links', async function (assert) {
+    await visit('/card-pay/wallet');
+
+    assert.equal(currentURL(), '/');
+    assert
+      .dom('[data-test-card-space-display-name]')
+      .hasText('displayNametodo');
   });
 });


### PR DESCRIPTION
1. Separates UI for card space index route (where you can create a card space) from  the user page so that users cannot open the creation workflow from a user's page via the query params of the url
3. Renders the user page with some UI shared with the card space index route, such as the left edge.
4. Prevents a user from visiting `someone.card.space/card-pay/wallet` or other non-index routes on `someone.card.space`, with a caveat of not preventing transitions initiated within the app (clicking on a `<LinkTo>` in Card Space).