### PR TITLE
make session keys match hub CardSpace type

### DIFF
--- a/packages/web-client/app/components/card-space/create-space-workflow/display-name/index.ts
+++ b/packages/web-client/app/components/card-space/create-space-workflow/display-name/index.ts
@@ -42,7 +42,7 @@ export default class DisplayNameComponent extends Component<WorkflowCardComponen
     super(owner, args);
     this.profileImage =
       this.args.workflowSession.getValue<string>('profileImageUrl') ?? '';
-    let displayName = this.args.workflowSession.getValue<string>('displayName');
+    let displayName = this.args.workflowSession.getValue<string>('profileName');
     this.displayName = displayName ?? '';
     if (!this.args.isComplete && displayName) {
       taskFor(this.updateDisplayNameTask).perform(displayName);
@@ -84,18 +84,18 @@ export default class DisplayNameComponent extends Component<WorkflowCardComponen
 
       if (errors.length === 0) {
         this.displayName = displayName;
-        this.args.workflowSession.setValue('displayName', displayName);
+        this.args.workflowSession.setValue('profileName', displayName);
         this.displayNameInputState = 'valid';
         this.displayNameInputErrorMessage = '';
       } else {
         this.displayNameInputState = 'invalid';
         this.displayNameInputErrorMessage = errors[0].detail;
-        this.args.workflowSession.delete('displayName');
+        this.args.workflowSession.delete('profileName');
       }
     } catch (e) {
       console.error('Error validating card space displayName', e);
       Sentry.captureException(e);
-      this.args.workflowSession.delete('displayName');
+      this.args.workflowSession.delete('profileName');
       this.displayNameInputState = 'invalid';
       this.displayNameInputErrorMessage =
         'There was an error validating your Card Space display name. Please try again or contact support';

--- a/packages/web-client/app/components/card-space/create-space-workflow/index.ts
+++ b/packages/web-client/app/components/card-space/create-space-workflow/index.ts
@@ -326,12 +326,12 @@ export default class CreateSpaceWorkflowComponent extends RestorableWorkflowComp
   get currentCardSpaceDetails() {
     return {
       profilePhoto: this.workflow.session.getValue('profileImageUrl'),
-      coverPhoto: this.workflow.session.getValue('coverPhotoUrl'),
-      name: this.workflow.session.getValue('displayName'),
+      coverPhoto: this.workflow.session.getValue('profileCoverImageUrl'),
+      name: this.workflow.session.getValue('profileName'),
       host: this.workflow.session.getValue('url'),
       category: this.workflow.session.getValue('profileCategory'),
       description: this.workflow.session.getValue('profileDescription'),
-      buttonText: this.workflow.session.getValue('buttonText'),
+      buttonText: this.workflow.session.getValue('profileButtonText'),
     };
   }
 

--- a/packages/web-client/app/components/card-space/create-space-workflow/next-steps/index.ts
+++ b/packages/web-client/app/components/card-space/create-space-workflow/next-steps/index.ts
@@ -4,7 +4,7 @@ import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow
 
 class CreateSpaceWorkflowNextStepsComponent extends Component<WorkflowCardComponentArgs> {
   get visitSpaceHref() {
-    let displayName = this.args.workflowSession.getValue('displayName');
+    let displayName = this.args.workflowSession.getValue('profileName');
     return `//${displayName}.${config.cardSpaceHostnameSuffix}`;
   }
 }

--- a/packages/web-client/app/components/card-space/edit-details/button-text/index.ts
+++ b/packages/web-client/app/components/card-space/edit-details/button-text/index.ts
@@ -13,11 +13,11 @@ class CardSpaceEditDetailsButtonTextComponent extends Component<WorkflowCardComp
   options = OPTIONS;
 
   get buttonTextValue() {
-    return this.args.workflowSession.getValue<string>('buttonText');
+    return this.args.workflowSession.getValue<string>('profileButtonText');
   }
 
   @action setButtonTextValue(val: string) {
-    this.args.workflowSession.setValue('buttonText', val);
+    this.args.workflowSession.setValue('profileButtonText', val);
   }
 }
 

--- a/packages/web-client/tests/integration/components/card-space/create-space-workflow/display-name-test.ts
+++ b/packages/web-client/tests/integration/components/card-space/create-space-workflow/display-name-test.ts
@@ -88,7 +88,7 @@ module(
 
     test('it renders the card in a filled in, memorialized state', async function (assert) {
       session.setValue({
-        displayName: 'monchi',
+        profileName: 'monchi',
         profileImageUrl: sampleImage,
       });
       this.set('isComplete', true);

--- a/packages/web-client/tests/integration/components/card-space/details/button-text-card-test.ts
+++ b/packages/web-client/tests/integration/components/card-space/details/button-text-card-test.ts
@@ -38,7 +38,10 @@ module(
 
       await click(`[data-test-button-text-option]:nth-child(2)`);
 
-      assert.equal(workflowSession.getValue<string>('buttonText'), OPTIONS[1]);
+      assert.equal(
+        workflowSession.getValue<string>('profileButtonText'),
+        OPTIONS[1]
+      );
       assert
         .dom('[data-test-button-text-option]:nth-child(2) input')
         .isChecked();
@@ -47,7 +50,7 @@ module(
     test('it restores input from session', async function (this: Context, assert) {
       let workflowSession = new WorkflowSession();
       this.set('workflowSession', workflowSession);
-      workflowSession.setValue('buttonText', OPTIONS[1]);
+      workflowSession.setValue('profileButtonText', OPTIONS[1]);
 
       await render(hbs`
         <CardSpace::EditDetails::ButtonText


### PR DESCRIPTION
Things like `displayName` don't match hub and so have a mismatch with `profileName`... but they match our UI. However the items stored in workflow session (that need to be retrieved to be posted to hub, eg. `profileName`) do match the way hub refers to this data.

Referred to https://github.com/cardstack/cardstack/blob/c7df8cabd565ace3637225a97daa1efc0797dcf5/packages/hub/routes/card-spaces.ts#L13-L33 for the keys.