### PR TITLE
Hub health check improvements

### DIFF
--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -15,6 +15,7 @@ import { Memoize } from 'typescript-memoize';
 
 import logger from '@cardstack/logger';
 import { Registry, Container, inject, getOwner, KnownServices } from '@cardstack/di';
+import { service } from '@cardstack/hub/services';
 
 import initSentry from './initializers/sentry';
 import initFirebase from './initializers/firebase';
@@ -58,7 +59,6 @@ import CardSpaceValidator from './services/validators/card-space';
 import { AuthenticationUtils } from './utils/authentication';
 import ApiRouter from './services/api-router';
 import CallbacksRouter from './services/callbacks-router';
-import HealthCheck from './services/health-check';
 import Upload from './routes/upload';
 import UploadQueries from './services/queries/upload';
 import NonceTracker from './services/nonce-tracker';
@@ -131,7 +131,6 @@ export function createRegistry(): Registry {
   registry.register('development-proxy-middleware', DevelopmentProxyMiddleware);
   registry.register('exchange-rates', ExchangeRatesService);
   registry.register('exchange-rates-route', ExchangeRatesRoute);
-  registry.register('health-check', HealthCheck);
   registry.register('upload-router', UploadRouter);
   registry.register('upload', Upload);
   registry.register('upload-queries', UploadQueries);
@@ -224,7 +223,7 @@ export class HubServer {
   private apiRouter = inject('api-router', { as: 'apiRouter' });
   private callbacksRouter = inject('callbacks-router', { as: 'callbacksRouter' });
   private cardRoutes: KnownServices['card-routes'] | undefined;
-  private healthCheck = inject('health-check', { as: 'healthCheck' });
+  private healthCheck = service('health-check', { as: 'healthCheck' });
   private uploadRouter = inject('upload-router', { as: 'uploadRouter' });
 
   constructor() {

--- a/packages/hub/services/health-check.ts
+++ b/packages/hub/services/health-check.ts
@@ -18,8 +18,8 @@ export default class HealthCheck {
   }
 }
 
-declare module '@cardstack/di' {
-  interface KnownServices {
+declare module '@cardstack/hub/services' {
+  interface HubServices {
     'health-check': HealthCheck;
   }
 }

--- a/packages/hub/services/health-check.ts
+++ b/packages/hub/services/health-check.ts
@@ -11,7 +11,17 @@ export default class HealthCheck {
       let db = await this.databaseManager.getClient();
       await db.query('SELECT 1');
       ctx.status = 200;
-      ctx.body = `Cardstack Hub is up and running at ${new Date().toISOString()}`;
+      let body = `
+Cardstack Hub
+-------------
+Up and running at ${new Date().toISOString()}
+${
+  process.env.WAYPOINT_DEPLOYMENT_ID
+    ? `Deployment ID: ${process.env.WAYPOINT_DEPLOYMENT_ID}`
+    : 'Running outside of Waypoint'
+}
+`;
+      ctx.body = body;
     });
 
     return healthCheckRouter.routes();


### PR DESCRIPTION
This change refactors the HealthCheck service to use the new lazy DI approach, and improves the health check response to include WAYPOINT_DEPLOYMENT_ID environment variable if present. This will make it easier when troubleshooting deployments to see which deployment is live and then the cutover happens.