### PR TITLE
Make install script work on both OSX and Linux

### DIFF
--- a/packages/cardpay-cli/bin/install-cardpay.sh
+++ b/packages/cardpay-cli/bin/install-cardpay.sh
@@ -12,7 +12,7 @@ CARDPAY_BIN=".cardpay/bin"
 get_tarball() {
   printf "$cyan> Downloading tarball...$reset\n"
   url=https://install.cardstack.com/cardpay.tgz
-  tarball_tmp=$(mktemp -t cardpay.tgz.temp)
+  tarball_tmp=$(mktemp)
   if curl --fail -L -o "$tarball_tmp" "$url"; then
     printf "$cyan> Extracting to ~/.cardpay...$reset\n"
     temp=$(mktemp -d cardpay.XXXXXXXXXX)


### PR DESCRIPTION
mktemp works differently on osx and linux.
The -t flag specifies that a template should be used, and needs
to contain XXXX characters for the random part.

On OSX it is a flag for specifying a prefix, and the template
comes later.

Using it with no arguments should work correctly on both platforms.

**I can only test this on linux, and it works there but don't have a mac to test on**