### PR TITLE
Wip card space user

### DIFF
--- a/packages/web-client/app/components/card-space/user-page/background-card/index.css
+++ b/packages/web-client/app/components/card-space/user-page/background-card/index.css
@@ -1,0 +1,22 @@
+.card-space-user-page__background-card {
+  aspect-ratio: 13/5;
+  background: var(--background-image-url, transparent);
+  min-width: 100%;
+  max-width: 100%;
+  max-height: 500px;
+  min-height: 200px;
+  margin-bottom: calc(var(--annoying-neighbour-space) * -1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--boxel-sp-xxl) 0 calc(var(--annoying-neighbour-space) + var(--boxel-sp-lg)) 0;
+}
+
+.card-space-user-page__background-card-content {
+  display: flex;
+  gap: var(--boxel-sp-sm);
+  justify-content: center;
+  flex-wrap: wrap;
+  width: 100%;
+  padding: var(--boxel-sp-lg);
+}

--- a/packages/web-client/app/components/card-space/user-page/background-card/index.css
+++ b/packages/web-client/app/components/card-space/user-page/background-card/index.css
@@ -1,4 +1,6 @@
 .card-space-user-page__background-card {
+  --annoying-neighbour-space: clamp(120px, 30%, 350px);
+
   aspect-ratio: 13/5;
   background: var(--background-image-url, transparent);
   min-width: 100%;

--- a/packages/web-client/app/components/card-space/user-page/background-card/index.css
+++ b/packages/web-client/app/components/card-space/user-page/background-card/index.css
@@ -1,12 +1,12 @@
 .card-space-user-page__background-card {
-  --annoying-neighbour-space: clamp(120px, 30%, 350px);
+  --annoying-neighbour-space: clamp(7.5rem, 30%, 21.875rem);
 
   aspect-ratio: 13/5;
   background: var(--background-image-url, transparent);
   min-width: 100%;
   max-width: 100%;
-  max-height: 500px;
-  min-height: 200px;
+  max-height: 31.25rem;
+  min-height: 12.5rem;
   margin-bottom: calc(var(--annoying-neighbour-space) * -1);
   display: flex;
   align-items: center;

--- a/packages/web-client/app/components/card-space/user-page/background-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/background-card/index.hbs
@@ -1,4 +1,5 @@
 <CardSpace::UserPage::LayoutCardContainer
+  @header="Layout"
   @editable={{@editable}}
   @isEditing={{this.isEditing}}
   @isSubmitting={{this.isSubmitting}}
@@ -8,9 +9,6 @@
   @save={{this.save}}
   @errorMessage={{this.submissionErrorMessage}}
 >
-  <:header>
-    Layout
-  </:header>
   <:default as |BackgroundEditButton|>
     <div>
       <div class="card-space-user-page__background-card" style={{css-var background-image-url=(concat "url(" this.background ")")}}>

--- a/packages/web-client/app/components/card-space/user-page/background-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/background-card/index.hbs
@@ -1,0 +1,63 @@
+<CardSpace::UserPage::LayoutCardContainer
+  @editable={{@editable}}
+  @isEditing={{this.isEditing}}
+  @isSubmitting={{this.isSubmitting}}
+  @submissionDisabled={{this.submissionDisabled}}
+  @onClickEdit={{this.onClickEdit}}
+  @onEndEdit={{this.onEndEdit}}
+  @save={{this.save}}
+  @errorMessage={{this.submissionErrorMessage}}
+>
+  <:header>
+    Layout
+  </:header>
+  <:default as |BackgroundEditButton|>
+    <div>
+      <div class="card-space-user-page__background-card" style={{css-var background-image-url=(concat "url(" this.background ")")}}>
+        <BackgroundEditButton>
+          Customize background
+        </BackgroundEditButton>
+      </div>
+
+      <div class="card-space-user-page__background-card-content">
+        {{yield}}
+      </div>
+    </div>
+  </:default>
+  <:edit>
+     <ImageUploader
+        @state={{this.imageUploadState}}
+        @errorMessage={{this.imageUploadErrorMessage}}
+        @image={{this.backgroundInputValue}}
+        @cta="Select a Photo"
+        @imageRequirements="Images must be in jpg or png format and max 1MB in size"
+        @acceptedFileTypes={{this.acceptedFileTypes}}
+        @onUpload={{this.onUpload}}
+        @onError={{this.logUploadError}}
+        @onRemoveImage={{this.onImageRemoved}}
+      as |ImageUploaderAvatar|>
+        <ImageUploaderAvatar
+          @alt="Cover photo"
+          @rounded={{true}}
+        />
+      </ImageUploader>
+  </:edit>
+</CardSpace::UserPage::LayoutCardContainer>
+
+{{#in-element this.imageEditorElement}}
+  <ImageEditor
+    @isOpen={{this.showEditor}}
+    @onClose={{fn (mut this.showEditor) false}}
+    @image={{this.processedImage.preview}}
+    @fileType={{this.processedImage.type}}
+    @width={{this.desiredWidth}}
+    @height={{this.desiredHeight}}
+    @saveImageEditData={{perform this.saveImageEditDataTask}}
+    as |preview|
+  >
+    <CardSpace::ProfileCard
+      @coverPhoto={{preview}}
+      data-test-card-space-profile-card-preview
+    />
+  </ImageEditor>
+{{/in-element}}

--- a/packages/web-client/app/components/card-space/user-page/background-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/background-card/index.ts
@@ -1,0 +1,189 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { ImageUploadSuccessResult } from '@cardstack/web-client/components/image-uploader';
+import config from '@cardstack/web-client/config/environment';
+import { ImageValidation } from '@cardstack/web-client/utils/image';
+import * as Sentry from '@sentry/browser';
+import { task, TaskGenerator } from 'ember-concurrency';
+import { taskFor } from 'ember-concurrency-ts';
+import CardSpaceUserData from '@cardstack/web-client/services/card-space-user-data';
+import HubAuthentication from '@cardstack/web-client/services/hub-authentication';
+
+const CardStates = {
+  DEFAULT: 'default',
+  EDITING: 'editing',
+  SUBMITTING: 'submitting',
+} as const;
+
+export const IMAGE_EDITOR_ELEMENT_ID = 'card-space-user-page-image-editor';
+export default class UserPageBackgroundCardComponent extends Component {
+  @service declare cardSpaceUserData: CardSpaceUserData;
+  @service declare hubAuthentication: HubAuthentication;
+  @tracked state: typeof CardStates[keyof typeof CardStates] =
+    CardStates.DEFAULT;
+
+  @tracked backgroundInputValue = '';
+  imageEditorElement = document.getElementById(IMAGE_EDITOR_ELEMENT_ID);
+  desiredWidth = 400;
+  desiredHeight = 400;
+  acceptedFileTypes = ['image/jpeg', 'image/png'];
+  @tracked processedImage = {
+    type: '',
+    filename: '',
+    preview: '',
+  };
+  @tracked showEditor = false;
+  @tracked imageUploadErrorMessage = '';
+  @tracked imageUploadState = 'valid';
+
+  get imageValidation() {
+    return new ImageValidation({
+      fileType: this.acceptedFileTypes,
+      maxFileSize: 1 * 1000 * 1000, // 1 MB
+    });
+  }
+
+  @action async onUpload(image: ImageUploadSuccessResult): Promise<void> {
+    let validationResult = await this.imageValidation.validate(image.file);
+
+    if (!validationResult.valid) {
+      this.imageUploadErrorMessage = validationResult.message;
+      this.imageUploadState = 'error';
+      return;
+    }
+
+    this.processImage(image);
+  }
+
+  processImage(image: ImageUploadSuccessResult) {
+    this.processedImage = {
+      type: image.file.type,
+      filename: image.file.name,
+      preview: image.preview,
+    };
+    this.showEditor = true;
+    this.imageUploadErrorMessage = '';
+  }
+
+  @action onImageRemoved() {
+    taskFor(this.saveImageEditDataTask).cancelAll();
+    this.backgroundInputValue = '';
+    this.imageUploadState = 'valid';
+    this.imageUploadErrorMessage = '';
+  }
+
+  @task *saveImageEditDataTask(data: {
+    preview: string;
+    file: Blob;
+  }): TaskGenerator<void> {
+    try {
+      this.backgroundInputValue = data.preview;
+      let formdata = new FormData();
+
+      formdata.append(
+        this.processedImage.filename,
+        data.file,
+        this.processedImage.filename
+      );
+
+      this.imageUploadState = 'loading';
+      let response = yield (yield fetch(`${config.hubURL}/upload`, {
+        method: 'POST',
+        body: formdata,
+        headers: {
+          Authorization: 'Bearer: ' + this.hubAuthentication.authToken,
+        },
+      })).json();
+
+      if (response.data?.attributes?.url) {
+        let url = response.data.attributes.url;
+        this.backgroundInputValue = url;
+        this.imageUploadState = 'valid';
+      } else if (response.errors) {
+        if (
+          response.errors.length === 1 &&
+          Number(response.errors[0].status) === 401 &&
+          response.errors[0].title === 'No valid auth token'
+        ) {
+          console.error(
+            'Failed to upload image to hub due to invalid auth token'
+          );
+          this.hubAuthentication.authToken = null;
+          throw new Error('No valid auth token');
+        }
+
+        console.error(
+          'Failed to upload image to hub. Errors:',
+          response.errors
+        );
+        let error = new Error('Failed to upload image to hub');
+        // @ts-ignore
+        error.reasons = response.errors;
+        throw error;
+      } else {
+        let error = new Error('Unexpected response uploading image to hub');
+        // @ts-ignore
+        error.details = response;
+        throw error;
+      }
+    } catch (e) {
+      console.error('Failed to upload file to hub', e);
+      Sentry.captureException(e);
+      this.backgroundInputValue = '';
+      this.imageUploadState = 'error';
+      this.imageUploadErrorMessage = 'Failed to upload file';
+    } finally {
+      this.processedImage = {
+        type: '',
+        filename: '',
+        preview: '',
+      };
+    }
+  }
+
+  @action logUploadError(e: Error) {
+    console.error('Failed to upload file to browser', e);
+    Sentry.captureException(e);
+  }
+
+  get background() {
+    return this.cardSpaceUserData.currentUserData.profileCoverImageUrl;
+  }
+
+  get isSubmitting() {
+    return this.state === CardStates.SUBMITTING;
+  }
+
+  get isEditing() {
+    return (
+      this.state === CardStates.EDITING || this.state === CardStates.SUBMITTING
+    );
+  }
+
+  get submissionDisabled() {
+    return this.imageUploadState === 'loading';
+  }
+
+  @action onClickEdit() {
+    this.state = CardStates.EDITING;
+    this.backgroundInputValue = this.background;
+  }
+
+  @action async save() {
+    try {
+      this.state = CardStates.SUBMITTING;
+      await this.cardSpaceUserData.post({
+        profileCoverImageUrl: this.backgroundInputValue,
+      });
+      this.state = CardStates.DEFAULT;
+    } catch (e) {
+      this.state = CardStates.EDITING;
+    }
+  }
+
+  @action onEndEdit() {
+    this.state = CardStates.DEFAULT;
+  }
+}

--- a/packages/web-client/app/components/card-space/user-page/background-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/background-card/index.ts
@@ -185,7 +185,7 @@ export default class UserPageBackgroundCardComponent extends Component {
     this.submissionErrorMessage = '';
     try {
       this.state = CardStates.SUBMITTING;
-      let response = await this.cardSpaceUserData.post({
+      let response = await this.cardSpaceUserData.put({
         profileCoverImageUrl: this.backgroundInputValue,
       });
       this.state = CardStates.DEFAULT;

--- a/packages/web-client/app/components/card-space/user-page/background-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/background-card/index.ts
@@ -181,7 +181,6 @@ export default class UserPageBackgroundCardComponent extends Component {
   @action async save() {
     let extraErrors: any = [];
     let extraValidations: any = {};
-    let hasUnmanagedValidationError = false; // is there something we PUT that is not managed by this component?
     this.submissionErrorMessage = '';
     try {
       this.state = CardStates.SUBMITTING;
@@ -207,7 +206,7 @@ export default class UserPageBackgroundCardComponent extends Component {
               this.imageUploadErrorMessage = validations[attribute].join(', ');
               this.imageUploadState = 'error';
             } else {
-              hasUnmanagedValidationError = true;
+              throw new Error(UNKNOWN_CARD_SPACE_BACKGROUND_ERROR);
             }
           }
 
@@ -215,10 +214,7 @@ export default class UserPageBackgroundCardComponent extends Component {
         }
       }
     } catch (e) {
-      if (
-        e.message !== CARD_SPACE_BACKGROUND_VALIDATION ||
-        hasUnmanagedValidationError
-      ) {
+      if (e.message !== CARD_SPACE_BACKGROUND_VALIDATION) {
         Sentry.setExtra('validations', extraValidations);
         Sentry.setExtra('errors', extraErrors);
         Sentry.captureException(e);

--- a/packages/web-client/app/components/card-space/user-page/background-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/background-card/index.ts
@@ -178,7 +178,10 @@ export default class UserPageBackgroundCardComponent extends Component {
         profileCoverImageUrl: this.backgroundInputValue,
       });
       this.state = CardStates.DEFAULT;
+
+      // JSON-API error detection
     } catch (e) {
+      // display error messages
       this.state = CardStates.EDITING;
     }
   }

--- a/packages/web-client/app/components/card-space/user-page/bio-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/bio-card/index.hbs
@@ -22,7 +22,25 @@
       {{/if}}
     </:default>
     <:edit>
-      Editing
+      <CardPay::LabeledValue
+        @fieldMode="label"
+        @label="Name"
+      >
+        <Boxel::Input
+          @value={{this.bioTitleInputValue}}
+          @onInput={{this.onBioTitleInput}}
+        />
+      </CardPay::LabeledValue>
+      <CardPay::LabeledValue
+        @fieldMode="label"
+        @label="Bio"
+      >
+        {{!-- this needs to be changed to a textarea --}}
+        <Boxel::Input
+          @value={{this.bioDescriptionInputValue}}
+          @onInput={{this.onBioDescriptionInput}}
+        />
+      </CardPay::LabeledValue>
     </:edit>
   </CardSpace::UserPage::CardContainer>
 {{/if}}

--- a/packages/web-client/app/components/card-space/user-page/bio-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/bio-card/index.hbs
@@ -9,7 +9,10 @@
     @save={{this.save}}
   >
     <:default>
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. Tenetur itaque asperiores distinctio aut delectus, culpa voluptatibus corrupti, sint veritatis quo molestias libero assumenda magni ullam facilis in aliquam earum. Illo, pariatur animi? Quaerat, exercitationem quas nam explicabo quis asperiores repudiandae eos reiciendis libero, unde repellat consequuntur tenetur quasi inventore sunt praesentium provident itaque sit. Culpa soluta tenetur eveniet quisquam sapiente molestias labore minima nesciunt, corrupti minus quidem quia ut! Libero minus quae, quia autem molestiae nisi, impedit, laudantium voluptatum nam adipisci architecto accusamus. Ut harum rerum ipsam quibusdam consequatur sit eos, repudiandae vel eligendi magni repellendus itaque dolorem eaque molestiae!
+      <CardSpace::UserPage::CardTitle>
+        {{this.bioTitle}}
+      </CardSpace::UserPage::CardTitle>
+      {{this.bioDescription}}
     </:default>
     <:edit>
       Editing

--- a/packages/web-client/app/components/card-space/user-page/bio-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/bio-card/index.hbs
@@ -1,0 +1,18 @@
+<CardSpace::UserPage::CardContainer
+  @editable={{@editable}}
+  @isEditing={{this.isEditing}}
+  @isSubmitting={{this.isSubmitting}}
+  @onClickEdit={{this.onClickEdit}}
+  @onEndEdit={{this.onEndEdit}}
+  @save={{this.save}}
+>
+  <:header>
+    About Me
+  </:header>
+  <:default>
+    Lorem ipsum dolor sit amet consectetur adipisicing elit. Tenetur itaque asperiores distinctio aut delectus, culpa voluptatibus corrupti, sint veritatis quo molestias libero assumenda magni ullam facilis in aliquam earum. Illo, pariatur animi? Quaerat, exercitationem quas nam explicabo quis asperiores repudiandae eos reiciendis libero, unde repellat consequuntur tenetur quasi inventore sunt praesentium provident itaque sit. Culpa soluta tenetur eveniet quisquam sapiente molestias labore minima nesciunt, corrupti minus quidem quia ut! Libero minus quae, quia autem molestiae nisi, impedit, laudantium voluptatum nam adipisci architecto accusamus. Ut harum rerum ipsam quibusdam consequatur sit eos, repudiandae vel eligendi magni repellendus itaque dolorem eaque molestiae!
+  </:default>
+  <:edit>
+    Editing
+  </:edit>
+</CardSpace::UserPage::CardContainer>

--- a/packages/web-client/app/components/card-space/user-page/bio-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/bio-card/index.hbs
@@ -5,6 +5,7 @@
     @isEditing={{this.isEditing}}
     @isSubmitting={{this.isSubmitting}}
     @onClickEdit={{this.onClickEdit}}
+    @errorMessage={{this.submissionErrorMessage}}
     @onEndEdit={{this.onEndEdit}}
     @save={{this.save}}
   >
@@ -22,16 +23,18 @@
       {{/if}}
     </:default>
     <:edit>
-      <CardPay::LabeledValue
+      <Boxel::Field
         @fieldMode="label"
         @label="Name"
       >
         <Boxel::Input
           @value={{this.bioTitleInputValue}}
           @onInput={{this.onBioTitleInput}}
+          @errorMessage={{this.validationErrorMessages.bioTitle}}
+          @invalid={{this.validationErrorMessages.bioTitle}}
         />
-      </CardPay::LabeledValue>
-      <CardPay::LabeledValue
+      </Boxel::Field>
+      <Boxel::Field
         @fieldMode="label"
         @label="Bio"
       >
@@ -39,8 +42,10 @@
         <Boxel::Input
           @value={{this.bioDescriptionInputValue}}
           @onInput={{this.onBioDescriptionInput}}
+          @errorMessage={{this.validationErrorMessages.bioDescription}}
+          @invalid={{this.validationErrorMessages.bioDescription}}
         />
-      </CardPay::LabeledValue>
+      </Boxel::Field>
     </:edit>
   </CardSpace::UserPage::CardContainer>
 {{/if}}

--- a/packages/web-client/app/components/card-space/user-page/bio-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/bio-card/index.hbs
@@ -1,16 +1,18 @@
-<CardSpace::UserPage::CardContainer
-  @header="About Me"
-  @editable={{@editable}}
-  @isEditing={{this.isEditing}}
-  @isSubmitting={{this.isSubmitting}}
-  @onClickEdit={{this.onClickEdit}}
-  @onEndEdit={{this.onEndEdit}}
-  @save={{this.save}}
->
-  <:default>
-    Lorem ipsum dolor sit amet consectetur adipisicing elit. Tenetur itaque asperiores distinctio aut delectus, culpa voluptatibus corrupti, sint veritatis quo molestias libero assumenda magni ullam facilis in aliquam earum. Illo, pariatur animi? Quaerat, exercitationem quas nam explicabo quis asperiores repudiandae eos reiciendis libero, unde repellat consequuntur tenetur quasi inventore sunt praesentium provident itaque sit. Culpa soluta tenetur eveniet quisquam sapiente molestias labore minima nesciunt, corrupti minus quidem quia ut! Libero minus quae, quia autem molestiae nisi, impedit, laudantium voluptatum nam adipisci architecto accusamus. Ut harum rerum ipsam quibusdam consequatur sit eos, repudiandae vel eligendi magni repellendus itaque dolorem eaque molestiae!
-  </:default>
-  <:edit>
-    Editing
-  </:edit>
-</CardSpace::UserPage::CardContainer>
+{{#if (or @editable this.showInViewMode)}}
+  <CardSpace::UserPage::CardContainer
+    @header="About Me"
+    @editable={{@editable}}
+    @isEditing={{this.isEditing}}
+    @isSubmitting={{this.isSubmitting}}
+    @onClickEdit={{this.onClickEdit}}
+    @onEndEdit={{this.onEndEdit}}
+    @save={{this.save}}
+  >
+    <:default>
+      Lorem ipsum dolor sit amet consectetur adipisicing elit. Tenetur itaque asperiores distinctio aut delectus, culpa voluptatibus corrupti, sint veritatis quo molestias libero assumenda magni ullam facilis in aliquam earum. Illo, pariatur animi? Quaerat, exercitationem quas nam explicabo quis asperiores repudiandae eos reiciendis libero, unde repellat consequuntur tenetur quasi inventore sunt praesentium provident itaque sit. Culpa soluta tenetur eveniet quisquam sapiente molestias labore minima nesciunt, corrupti minus quidem quia ut! Libero minus quae, quia autem molestiae nisi, impedit, laudantium voluptatum nam adipisci architecto accusamus. Ut harum rerum ipsam quibusdam consequatur sit eos, repudiandae vel eligendi magni repellendus itaque dolorem eaque molestiae!
+    </:default>
+    <:edit>
+      Editing
+    </:edit>
+  </CardSpace::UserPage::CardContainer>
+{{/if}}

--- a/packages/web-client/app/components/card-space/user-page/bio-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/bio-card/index.hbs
@@ -9,10 +9,17 @@
     @save={{this.save}}
   >
     <:default>
-      <CardSpace::UserPage::CardTitle>
-        {{this.bioTitle}}
-      </CardSpace::UserPage::CardTitle>
-      {{this.bioDescription}}
+      {{#if this.showInViewMode}}
+          <CardSpace::UserPage::CardTitle>
+            {{this.bioTitle}}
+          </CardSpace::UserPage::CardTitle>
+          {{this.bioDescription}}
+        {{else}}
+          <CardSpace::UserPage::CardTitle>
+            Your Name
+          </CardSpace::UserPage::CardTitle>
+            Enter a short description of yourself and/or your business.
+      {{/if}}
     </:default>
     <:edit>
       Editing

--- a/packages/web-client/app/components/card-space/user-page/bio-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/bio-card/index.hbs
@@ -1,4 +1,5 @@
 <CardSpace::UserPage::CardContainer
+  @header="About Me"
   @editable={{@editable}}
   @isEditing={{this.isEditing}}
   @isSubmitting={{this.isSubmitting}}
@@ -6,9 +7,6 @@
   @onEndEdit={{this.onEndEdit}}
   @save={{this.save}}
 >
-  <:header>
-    About Me
-  </:header>
   <:default>
     Lorem ipsum dolor sit amet consectetur adipisicing elit. Tenetur itaque asperiores distinctio aut delectus, culpa voluptatibus corrupti, sint veritatis quo molestias libero assumenda magni ullam facilis in aliquam earum. Illo, pariatur animi? Quaerat, exercitationem quas nam explicabo quis asperiores repudiandae eos reiciendis libero, unde repellat consequuntur tenetur quasi inventore sunt praesentium provident itaque sit. Culpa soluta tenetur eveniet quisquam sapiente molestias labore minima nesciunt, corrupti minus quidem quia ut! Libero minus quae, quia autem molestiae nisi, impedit, laudantium voluptatum nam adipisci architecto accusamus. Ut harum rerum ipsam quibusdam consequatur sit eos, repudiandae vel eligendi magni repellendus itaque dolorem eaque molestiae!
   </:default>

--- a/packages/web-client/app/components/card-space/user-page/bio-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/bio-card/index.ts
@@ -82,7 +82,7 @@ export default class UserPageBioCardComponent extends Component {
     try {
       this.submissionErrorMessage = '';
       this.state = CardStates.SUBMITTING;
-      let response = await this.cardSpaceUserData.post({
+      let response = await this.cardSpaceUserData.put({
         bioTitle: this.bioTitleInputValue,
         bioDescription: this.bioDescriptionInputValue,
       });

--- a/packages/web-client/app/components/card-space/user-page/bio-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/bio-card/index.ts
@@ -3,19 +3,30 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import CardSpaceUserData from '@cardstack/web-client/services/card-space-user-data';
+import { processJsonApiErrors } from '@cardstack/web-client/utils/json-api';
+import * as Sentry from '@sentry/browser';
 
+const UNKNOWN_CARD_SPACE_BIO_ERROR = 'ERROR_SAVING_CARDSPACE_BIO';
+const CARD_SPACE_BIO_VALIDATION = 'CARD_SPACE_BIO_VALIDATION';
 const CardStates = {
   DEFAULT: 'default',
   EDITING: 'editing',
   SUBMITTING: 'submitting',
 } as const;
-
+const managedAttributes = ['bioTitle', 'bioDescription'] as const;
+type ManagedAttribute = typeof managedAttributes[number];
 export default class UserPageBioCardComponent extends Component {
   @service declare cardSpaceUserData: CardSpaceUserData;
   @tracked state: typeof CardStates[keyof typeof CardStates] =
     CardStates.DEFAULT;
+  @tracked submissionErrorMessage = '';
   @tracked bioTitleInputValue = '';
   @tracked bioDescriptionInputValue = '';
+  @tracked validationErrorMessages: Record<ManagedAttribute, string> = {
+    bioTitle: '',
+    bioDescription: '',
+  };
+  @tracked bioDescriptionInputValidationErrorMessage = '';
 
   get showInViewMode() {
     return (
@@ -43,30 +54,80 @@ export default class UserPageBioCardComponent extends Component {
   }
 
   @action onClickEdit() {
-    this.bioDescriptionInputValue = this.bioDescription || '';
-    this.bioTitleInputValue = this.bioTitle || '';
+    this.onBioDescriptionInput(this.bioDescription || '');
+    this.onBioTitleInput(this.bioTitle || '');
     this.state = CardStates.EDITING;
   }
 
   @action onBioTitleInput(value: string) {
+    // this may need to be removed when we have client side validations
+    this.validationErrorMessages.bioTitle = '';
+    // eslint-disable-next-line no-self-assign
+    this.validationErrorMessages = this.validationErrorMessages;
     this.bioTitleInputValue = value;
   }
+
   @action onBioDescriptionInput(value: string) {
+    // this may need to be removed when we have client side validations
+    this.validationErrorMessages.bioDescription = '';
+    // eslint-disable-next-line no-self-assign
+    this.validationErrorMessages = this.validationErrorMessages;
     this.bioDescriptionInputValue = value;
   }
 
   @action async save() {
+    let extraErrors: any = [];
+    let extraValidations: any = {};
+    let hasUnmanagedValidationError = false; // is there something we PUT that is not managed by this component?
     try {
+      this.submissionErrorMessage = '';
       this.state = CardStates.SUBMITTING;
-      await this.cardSpaceUserData.post({
+      let response = await this.cardSpaceUserData.post({
         bioTitle: this.bioTitleInputValue,
         bioDescription: this.bioDescriptionInputValue,
       });
-      this.state = CardStates.DEFAULT;
+      if (response.errors) {
+        let { validations, nonValidationErrors } = processJsonApiErrors(
+          response.errors
+        );
+        extraValidations = validations;
+        extraErrors = nonValidationErrors;
 
-      // JSON API error detection
+        if (nonValidationErrors.length) {
+          throw new Error(UNKNOWN_CARD_SPACE_BIO_ERROR);
+        }
+
+        if (Object.keys(validations).length) {
+          for (let attribute in validations) {
+            if (managedAttributes.includes(attribute as ManagedAttribute)) {
+              this.validationErrorMessages[attribute as ManagedAttribute] =
+                validations[attribute].join(', ');
+            } else {
+              hasUnmanagedValidationError = true;
+            }
+          }
+          // eslint-disable-next-line no-self-assign
+          this.validationErrorMessages = this.validationErrorMessages;
+
+          throw new Error(CARD_SPACE_BIO_VALIDATION);
+        }
+        this.state = CardStates.EDITING;
+      } else {
+        this.state = CardStates.DEFAULT;
+      }
     } catch (e) {
-      // display error message
+      if (
+        e.message !== CARD_SPACE_BIO_VALIDATION ||
+        hasUnmanagedValidationError
+      ) {
+        Sentry.setExtra('validations', extraValidations);
+        Sentry.setExtra('errors', extraErrors);
+        Sentry.captureException(e);
+        console.error(e);
+        // This is probably not enough and we may need some specific markup (links)
+        this.submissionErrorMessage =
+          'Failed to save your data. Press Save to try again.';
+      }
       this.state = CardStates.EDITING;
     }
   }

--- a/packages/web-client/app/components/card-space/user-page/bio-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/bio-card/index.ts
@@ -15,6 +15,13 @@ export default class UserPageBioCardComponent extends Component {
   @tracked state: typeof CardStates[keyof typeof CardStates] =
     CardStates.DEFAULT;
 
+  get showInViewMode() {
+    return (
+      this.cardSpaceUserData.currentUserData.bioTitle ||
+      this.cardSpaceUserData.currentUserData.bioDescription
+    );
+  }
+
   get isSubmitting() {
     return this.state === CardStates.SUBMITTING;
   }

--- a/packages/web-client/app/components/card-space/user-page/bio-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/bio-card/index.ts
@@ -78,7 +78,6 @@ export default class UserPageBioCardComponent extends Component {
   @action async save() {
     let extraErrors: any = [];
     let extraValidations: any = {};
-    let hasUnmanagedValidationError = false; // is there something we PUT that is not managed by this component?
     try {
       this.submissionErrorMessage = '';
       this.state = CardStates.SUBMITTING;
@@ -103,7 +102,8 @@ export default class UserPageBioCardComponent extends Component {
               this.validationErrorMessages[attribute as ManagedAttribute] =
                 validations[attribute].join(', ');
             } else {
-              hasUnmanagedValidationError = true;
+              // Some other part of the PUT was invalid
+              throw new Error(UNKNOWN_CARD_SPACE_BIO_ERROR);
             }
           }
           // eslint-disable-next-line no-self-assign
@@ -116,10 +116,7 @@ export default class UserPageBioCardComponent extends Component {
         this.state = CardStates.DEFAULT;
       }
     } catch (e) {
-      if (
-        e.message !== CARD_SPACE_BIO_VALIDATION ||
-        hasUnmanagedValidationError
-      ) {
+      if (e.message !== CARD_SPACE_BIO_VALIDATION) {
         Sentry.setExtra('validations', extraValidations);
         Sentry.setExtra('errors', extraErrors);
         Sentry.captureException(e);

--- a/packages/web-client/app/components/card-space/user-page/bio-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/bio-card/index.ts
@@ -14,6 +14,8 @@ export default class UserPageBioCardComponent extends Component {
   @service declare cardSpaceUserData: CardSpaceUserData;
   @tracked state: typeof CardStates[keyof typeof CardStates] =
     CardStates.DEFAULT;
+  @tracked bioTitleInputValue = '';
+  @tracked bioDescriptionInputValue = '';
 
   get showInViewMode() {
     return (
@@ -41,20 +43,37 @@ export default class UserPageBioCardComponent extends Component {
   }
 
   @action onClickEdit() {
+    this.bioDescriptionInputValue = this.bioDescription || '';
+    this.bioTitleInputValue = this.bioTitle || '';
     this.state = CardStates.EDITING;
+  }
+
+  @action onBioTitleInput(value: string) {
+    this.bioTitleInputValue = value;
+  }
+  @action onBioDescriptionInput(value: string) {
+    this.bioDescriptionInputValue = value;
   }
 
   @action async save() {
     try {
       this.state = CardStates.SUBMITTING;
-      await new Promise<void>((resolve) => setTimeout(resolve, 1000));
+      await this.cardSpaceUserData.post({
+        bioTitle: this.bioTitleInputValue,
+        bioDescription: this.bioDescriptionInputValue,
+      });
       this.state = CardStates.DEFAULT;
+
+      // JSON API error detection
     } catch (e) {
+      // display error message
       this.state = CardStates.EDITING;
     }
   }
 
   @action onEndEdit() {
+    this.bioDescriptionInputValue = '';
+    this.bioTitleInputValue = '';
     this.state = CardStates.DEFAULT;
   }
 }

--- a/packages/web-client/app/components/card-space/user-page/bio-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/bio-card/index.ts
@@ -1,0 +1,45 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import CardSpaceUserData from '@cardstack/web-client/services/card-space-user-data';
+
+const CardStates = {
+  DEFAULT: 'default',
+  EDITING: 'editing',
+  SUBMITTING: 'submitting',
+} as const;
+
+export default class UserPageBioCardComponent extends Component {
+  @service declare cardSpaceUserData: CardSpaceUserData;
+  @tracked state: typeof CardStates[keyof typeof CardStates] =
+    CardStates.DEFAULT;
+
+  get isSubmitting() {
+    return this.state === CardStates.SUBMITTING;
+  }
+
+  get isEditing() {
+    return (
+      this.state === CardStates.EDITING || this.state === CardStates.SUBMITTING
+    );
+  }
+
+  @action onClickEdit() {
+    this.state = CardStates.EDITING;
+  }
+
+  @action async save() {
+    try {
+      this.state = CardStates.SUBMITTING;
+      await new Promise<void>((resolve) => setTimeout(resolve, 1000));
+      this.state = CardStates.DEFAULT;
+    } catch (e) {
+      this.state = CardStates.EDITING;
+    }
+  }
+
+  @action onEndEdit() {
+    this.state = CardStates.DEFAULT;
+  }
+}

--- a/packages/web-client/app/components/card-space/user-page/bio-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/bio-card/index.ts
@@ -22,6 +22,14 @@ export default class UserPageBioCardComponent extends Component {
     );
   }
 
+  get bioTitle() {
+    return this.cardSpaceUserData.currentUserData.bioTitle;
+  }
+
+  get bioDescription() {
+    return this.cardSpaceUserData.currentUserData.bioDescription;
+  }
+
   get isSubmitting() {
     return this.state === CardStates.SUBMITTING;
   }

--- a/packages/web-client/app/components/card-space/user-page/card-container/button-with-click-handler/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/card-container/button-with-click-handler/index.hbs
@@ -1,0 +1,12 @@
+<Boxel::Button
+  @kind="primary"
+  @size="base"
+  {{on "click" @onClick}}
+  ...attributes
+>
+  {{#if (has-block)}}
+    {{yield}}
+  {{else}}
+    Customize
+  {{/if}}
+</Boxel::Button>

--- a/packages/web-client/app/components/card-space/user-page/card-container/index.css
+++ b/packages/web-client/app/components/card-space/user-page/card-container/index.css
@@ -1,0 +1,9 @@
+.card-space-card-container__body {
+  padding: var(--boxel-sp-lg);
+}
+
+.card-space__card-container-edit-button-container {
+  display: flex;
+  justify-content: center;
+  padding: var(--boxel-sp-lg);
+}

--- a/packages/web-client/app/components/card-space/user-page/card-container/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/card-container/index.hbs
@@ -1,4 +1,6 @@
 <Boxel::CardContainer
+  data-test-card-space-card-container
+  data-test-editable={{@editable}}
   class="card-space__card-container"
   @displayBoundaries={{true}}
   ...attributes

--- a/packages/web-client/app/components/card-space/user-page/card-container/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/card-container/index.hbs
@@ -8,7 +8,7 @@
   {{#if @editable}}
     <Boxel::Header>
       <:default>
-        {{yield to="header"}}
+        {{@header}}
       </:default>
       <:actions>
         <button
@@ -48,7 +48,7 @@
   @errorMessage={{@errorMessage}}
 >
   <:header>
-    {{yield to="header"}}
+    {{@header}}
   </:header>
   <:default>
     {{yield to="edit"}}

--- a/packages/web-client/app/components/card-space/user-page/card-container/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/card-container/index.hbs
@@ -1,0 +1,54 @@
+<Boxel::CardContainer
+  class="card-space__card-container"
+  @displayBoundaries={{true}}
+  ...attributes
+>
+  {{#if @editable}}
+    <Boxel::Header>
+      <:default>
+        {{yield to="header"}}
+      </:default>
+      <:actions>
+        <button
+          type="button"
+          {{on 'click' @onClickEdit}}
+        >
+          Edit
+        </button>
+      </:actions>
+    </Boxel::Header>
+  {{/if}}
+  <div class="card-space-card-container__body">
+    {{yield}}
+  </div>
+  {{#if @editable}}
+    <div class="card-space__card-container-edit-button-container">
+      {{#let (component "card-space/user-page/card-container/button-with-click-handler" onClick=@onClickEdit show=@editable) as |EditButton|}}
+        {{#if (has-block "edit-button")}}
+          {{yield EditButton to="edit-button"}}
+        {{else}}
+          <EditButton>
+            Customize
+          </EditButton>
+        {{/if}}
+      {{/let}}
+    </div>
+  {{/if}}
+</Boxel::CardContainer>
+
+<CardSpace::UserPage::CardEditModal
+  @isEditing={{@isEditing}}
+  @isSubmitting={{@isSubmitting}}
+  @submissionDisabled={{@submissionDisabled}}
+  @onClose={{@onEndEdit}}
+  @save={{@save}}
+  @size={{@editSize}}
+  @errorMessage={{@errorMessage}}
+>
+  <:header>
+    {{yield to="header"}}
+  </:header>
+  <:default>
+    {{yield to="edit"}}
+  </:default>
+</CardSpace::UserPage::CardEditModal>

--- a/packages/web-client/app/components/card-space/user-page/card-container/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/card-container/index.hbs
@@ -39,6 +39,7 @@
 </Boxel::CardContainer>
 
 <CardSpace::UserPage::CardEditModal
+  @header={{@header}}
   @isEditing={{@isEditing}}
   @isSubmitting={{@isSubmitting}}
   @submissionDisabled={{@submissionDisabled}}
@@ -47,9 +48,6 @@
   @size={{@editSize}}
   @errorMessage={{@errorMessage}}
 >
-  <:header>
-    {{@header}}
-  </:header>
   <:default>
     {{yield to="edit"}}
   </:default>

--- a/packages/web-client/app/components/card-space/user-page/card-edit-modal/index.css
+++ b/packages/web-client/app/components/card-space/user-page/card-edit-modal/index.css
@@ -1,0 +1,21 @@
+.card-space-user-page__edit-modal-body {
+  padding: var(--boxel-sp-xl);
+}
+
+.card-space-user-page__edit-modal-footer {
+  margin-top: var(--boxel-sp-xxxl);
+}
+
+.card-space-user-page__edit-modal-footer-buttons {
+  display: flex;
+  justify-content: end;
+}
+
+.card-space-user-page__edit-modal-footer-buttons > * + * {
+  margin-left: var(--boxel-sp-sm);
+}
+
+.card-space-user-page__edit-modal-error-message {
+  text-align: right;
+  margin-bottom: var(--boxel-sp);
+}

--- a/packages/web-client/app/components/card-space/user-page/card-edit-modal/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/card-edit-modal/index.hbs
@@ -1,0 +1,43 @@
+<Boxel::Modal
+  @isOpen={{@isEditing}}
+  @onClose={{this.close}}
+  @size={{or @size "medium"}}
+>
+  <Boxel::CardContainer>
+    <:header>
+      {{yield to="header"}}
+    </:header>
+    <:default>
+      <div class="card-space-user-page__edit-modal-body">
+        {{yield}}
+
+        <div class="card-space-user-page__edit-modal-footer">
+          {{#if @errorMessage}}
+            {{!-- should move to common --}}
+            <CardPay::ErrorMessage class="card-space-user-page__edit-modal-error-message">
+              {{@errorMessage}}
+            </CardPay::ErrorMessage>
+          {{/if}}
+          <div class="card-space-user-page__edit-modal-footer-buttons">
+            {{#unless @isSubmitting}}
+              <Boxel::Button
+                @kind="secondary-light"
+                {{on "click" this.close}}
+              >
+                Cancel
+              </Boxel::Button>
+            {{/unless}}
+            <Boxel::Button
+              @loading={{@isSubmitting}}
+              @disabled={{@submissionDisabled}}
+              @kind="primary"
+              {{on "click" this.save}}
+            >
+              Save
+            </Boxel::Button>
+          </div>
+        </div>
+      </div>
+    </:default>
+  </Boxel::CardContainer>
+</Boxel::Modal>

--- a/packages/web-client/app/components/card-space/user-page/card-edit-modal/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/card-edit-modal/index.hbs
@@ -5,7 +5,7 @@
 >
   <Boxel::CardContainer>
     <:header>
-      {{yield to="header"}}
+      {{@header}}
     </:header>
     <:default>
       <div class="card-space-user-page__edit-modal-body">

--- a/packages/web-client/app/components/card-space/user-page/card-edit-modal/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/card-edit-modal/index.ts
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class CardEditComponent extends Component<{
+  onClose: Function;
+  save: () => boolean;
+  isSubmitting: boolean;
+  submissionDisabled: boolean;
+}> {
+  @action close() {
+    if (this.args.isSubmitting) return;
+    this.args.onClose();
+  }
+
+  @action save() {
+    if (this.args.isSubmitting || this.args.submissionDisabled) return;
+    this.args.save();
+  }
+}

--- a/packages/web-client/app/components/card-space/user-page/card-title/index.css
+++ b/packages/web-client/app/components/card-space/user-page/card-title/index.css
@@ -1,0 +1,4 @@
+.card-space-user-page__card-title {
+  font: 700 1.125rem/calc(24 / 18) var(--boxel-font-family);
+  letter-spacing: 0;
+}

--- a/packages/web-client/app/components/card-space/user-page/card-title/index.css
+++ b/packages/web-client/app/components/card-space/user-page/card-title/index.css
@@ -1,4 +1,5 @@
 .card-space-user-page__card-title {
   font: 700 1.125rem/calc(24 / 18) var(--boxel-font-family);
   letter-spacing: 0;
+  margin-bottom: var(--boxel-sp-lg);
 }

--- a/packages/web-client/app/components/card-space/user-page/card-title/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/card-title/index.hbs
@@ -1,0 +1,3 @@
+<h2 class="card-space-user-page__card-title">
+  {{yield}}
+</h2>

--- a/packages/web-client/app/components/card-space/user-page/donations-card/index.css
+++ b/packages/web-client/app/components/card-space/user-page/donations-card/index.css
@@ -1,0 +1,43 @@
+.card-space-user-page__donation-list > * + * {
+  margin-top: var(--boxel-sp-sm);
+}
+
+.card-space-user-page__donation-choice {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: var(--boxel-border);
+  border-radius: var(--boxel-border-radius);
+  min-height: calc(var(--boxel-sp-lg) * 2 + var(--boxel-font-size));
+}
+
+.card-space-user-page__donation-description {
+  margin-bottom: var(--boxel-sp-lg);
+}
+
+button.card-space-user-page__donation-choice {
+  appearance: none;
+  width: 100%;
+  background: transparent;
+  text-align: center;
+}
+
+.card-space-user-page__donation-choice-amount-group {
+  display: inline-grid;
+  grid-template-columns: auto 1fr;
+  column-gap: var(--boxel-sp-xs);
+  width: max-content;
+}
+
+.card-space-user-page__donation-choice-spend-amount,
+.card-space-user-page__donation-choice-plain-text {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.card-space-user-page__donation-choice-usd-amount {
+  grid-column: 2;
+  font-size: 0.8125rem;
+  color: var(--boxel-purple-500);
+}

--- a/packages/web-client/app/components/card-space/user-page/donations-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/donations-card/index.hbs
@@ -1,6 +1,7 @@
 {{#if (or @editable this.showInViewMode)}}
   <CardSpace::UserPage::CardContainer
     @header="Donations"
+    @errorMessage={{this.submissionErrorMessage}}
     @editable={{@editable}}
     @isEditing={{this.isEditing}}
     @isSubmitting={{this.isSubmitting}}
@@ -82,7 +83,54 @@
       {{/if}}
     </:default>
     <:edit>
-      Editing
+      <Boxel::Field @label="donationDescription" @fieldMode="edit">
+        <Boxel::Input
+          @invalid={{this.validationErrorMessages.donationDescription}}
+          @errorMessage={{this.validationErrorMessages.donationDescription}}
+          @value={{this.donationDescriptionInputValue}}
+          @onInput={{this.onDonationDescriptionInput}}
+        />
+      </Boxel::Field>
+      <Boxel::Field @label="donationTitle" @fieldMode="edit">
+        <Boxel::Input
+          @invalid={{this.validationErrorMessages.donationTitle}}
+          @errorMessage={{this.validationErrorMessages.donationTitle}}
+          @value={{this.donationTitleInputValue}}
+          @onInput={{this.onDonationTitleInput}}
+        />
+      </Boxel::Field>
+      <Boxel::Field @label="donationSuggestionAmount1" @fieldMode="edit">
+        <Boxel::Input
+          @invalid={{this.validationErrorMessages.donationSuggestionAmount1}}
+          @errorMessage={{this.validationErrorMessages.donationSuggestionAmount1}}
+          @value={{this.donationSuggestionAmount1InputValue}}
+          @onInput={{this.onDonationSuggestionAmount1Input}}
+        />
+      </Boxel::Field>
+      <Boxel::Field @label="donationSuggestionAmount2" @fieldMode="edit">
+        <Boxel::Input
+          @invalid={{this.validationErrorMessages.donationSuggestionAmount2}}
+          @errorMessage={{this.validationErrorMessages.donationSuggestionAmount2}}
+          @value={{this.donationSuggestionAmount2InputValue}}
+          @onInput={{this.onDonationSuggestionAmount2Input}}
+        />
+      </Boxel::Field>
+      <Boxel::Field @label="donationSuggestionAmount3" @fieldMode="edit">
+        <Boxel::Input
+          @invalid={{this.validationErrorMessages.donationSuggestionAmount3}}
+          @errorMessage={{this.validationErrorMessages.donationSuggestionAmount3}}
+          @value={{this.donationSuggestionAmount3InputValue}}
+          @onInput={{this.onDonationSuggestionAmount3Input}}
+        />
+      </Boxel::Field>
+      <Boxel::Field @label="donationSuggestionAmount4" @fieldMode="edit">
+        <Boxel::Input
+          @invalid={{this.validationErrorMessages.donationSuggestionAmount4}}
+          @errorMessage={{this.validationErrorMessages.donationSuggestionAmount4}}
+          @value={{this.donationSuggestionAmount4InputValue}}
+          @onInput={{this.onDonationSuggestionAmount4Input}}
+        />
+      </Boxel::Field>
     </:edit>
   </CardSpace::UserPage::CardContainer>
 {{/if}}

--- a/packages/web-client/app/components/card-space/user-page/donations-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/donations-card/index.hbs
@@ -1,4 +1,5 @@
 <CardSpace::UserPage::CardContainer
+  @header="Donations"
   @editable={{@editable}}
   @isEditing={{this.isEditing}}
   @isSubmitting={{this.isSubmitting}}
@@ -6,9 +7,6 @@
   @onEndEdit={{this.onEndEdit}}
   @save={{this.save}}
 >
-  <:header>
-    Donations
-  </:header>
   <:default>
     Lorem ipsum dolor sit amet consectetur adipisicing elit. Tenetur itaque asperiores distinctio aut delectus, culpa voluptatibus corrupti, sint veritatis quo molestias libero assumenda magni ullam facilis in aliquam earum. Illo, pariatur animi? Quaerat, exercitationem quas nam explicabo quis asperiores repudiandae eos reiciendis libero, unde repellat consequuntur tenetur quasi inventore sunt praesentium provident itaque sit. Culpa soluta tenetur eveniet quisquam sapiente molestias labore minima nesciunt, corrupti minus quidem quia ut! Libero minus quae, quia autem molestiae nisi, impedit, laudantium voluptatum nam adipisci architecto accusamus. Ut harum rerum ipsam quibusdam consequatur sit eos, repudiandae vel eligendi magni repellendus itaque dolorem eaque molestiae!
   </:default>

--- a/packages/web-client/app/components/card-space/user-page/donations-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/donations-card/index.hbs
@@ -10,37 +10,75 @@
   >
     <:default>
     {{#if this.showInViewMode}}
-      {{#if this.donationTitle}}
         <CardSpace::UserPage::CardTitle>
-          {{this.donationTitle}}
+          {{!-- Make donation title required via clientside validations, but leave a default just in case --}}
+          {{!-- Maybe hub should have more detailed validations for individual "cards"? --}}
+          {{or this.donationTitle (concat "Support " this.displayName)}}
         </CardSpace::UserPage::CardTitle>
-        {{/if}}
         {{#if this.donationDescription}}
-          {{this.donationDescription}}
+          <div class="card-space-user-page__donation-description">
+            {{this.donationDescription}}
+          </div>
         {{/if}}
         {{#if this.donationSuggestionAmountList}}
-          <ol>
+          <ol class="card-space-user-page__donation-list">
             {{#each this.donationSuggestionAmountList as |donation|}}
               <li>
-                {{donation}}
+                <button class="card-space-user-page__donation-choice" type="button" {{on "click" (noop)}}>
+                  <div class="card-space-user-page__donation-choice-amount-group">
+                    {{svg-jar "spend" width="20" height="20" role="presentation"}}
+                    <div class="card-space-user-page__donation-choice-spend-amount">
+                      §{{format-amount donation}} SPEND
+                    </div>
+                    <div class="card-space-user-page__donation-choice-usd-amount">
+                      ${{spend-to-usd donation}} USD
+                    </div>
+                  </div>
+                </button>
               </li>
             {{/each}}
+              <li>
+                <button class="card-space-user-page__donation-choice" type="button" {{on "click" (noop)}}>
+                  <div class="card-space-user-page__donation-choice-plain-text">
+                    {{!-- this should really be customizable --}}
+                    Choose a custom amount
+                  </div>
+                </button>
+              </li>
           </ol>
           {{else}}
-            Pay me here!
+          <button class="card-space-user-page__donation-choice" type="button" {{on "click" (noop)}}>
+            <div class="card-space-user-page__donation-choice-plain-text">
+              {{!-- this should really be customizable --}}
+              Choose a custom amount
+            </div>
+          </button>
         {{/if}}
       {{else}}
         <CardSpace::UserPage::CardTitle>
           Donation module
         </CardSpace::UserPage::CardTitle>
-        Receive donations from supporters and choose custom denominations
-        <ul>
-          {{#each (array 1 2 3 4) as |donation|}}
+        <div class="card-space-user-page__donation-description">
+          Receive donations from supporters and choose custom denominations
+        </div>
+        <ol class="card-space-user-page__donation-list">
+          {{#each (array 1 2 3 4) as |number|}}
             <li>
-              {{donation}}
+              <div class="card-space-user-page__donation-choice">
+                <div class="card-space-user-page__donation-choice-plain-text">
+                  Amount {{number}}
+                </div>
+              </div>
             </li>
           {{/each}}
-        </ul>
+          <li>
+            <div class="card-space-user-page__donation-choice">
+              <div class="card-space-user-page__donation-choice-plain-text">
+                Choose a custom amount
+              </div>
+            </div>
+          </li>
+        </ol>
       {{/if}}
     </:default>
     <:edit>

--- a/packages/web-client/app/components/card-space/user-page/donations-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/donations-card/index.hbs
@@ -1,0 +1,18 @@
+<CardSpace::UserPage::CardContainer
+  @editable={{@editable}}
+  @isEditing={{this.isEditing}}
+  @isSubmitting={{this.isSubmitting}}
+  @onClickEdit={{this.onClickEdit}}
+  @onEndEdit={{this.onEndEdit}}
+  @save={{this.save}}
+>
+  <:header>
+    Donations
+  </:header>
+  <:default>
+    Lorem ipsum dolor sit amet consectetur adipisicing elit. Tenetur itaque asperiores distinctio aut delectus, culpa voluptatibus corrupti, sint veritatis quo molestias libero assumenda magni ullam facilis in aliquam earum. Illo, pariatur animi? Quaerat, exercitationem quas nam explicabo quis asperiores repudiandae eos reiciendis libero, unde repellat consequuntur tenetur quasi inventore sunt praesentium provident itaque sit. Culpa soluta tenetur eveniet quisquam sapiente molestias labore minima nesciunt, corrupti minus quidem quia ut! Libero minus quae, quia autem molestiae nisi, impedit, laudantium voluptatum nam adipisci architecto accusamus. Ut harum rerum ipsam quibusdam consequatur sit eos, repudiandae vel eligendi magni repellendus itaque dolorem eaque molestiae!
+  </:default>
+  <:edit>
+    Editing
+  </:edit>
+</CardSpace::UserPage::CardContainer>

--- a/packages/web-client/app/components/card-space/user-page/donations-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/donations-card/index.hbs
@@ -9,7 +9,25 @@
     @save={{this.save}}
   >
     <:default>
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. Tenetur itaque asperiores distinctio aut delectus, culpa voluptatibus corrupti, sint veritatis quo molestias libero assumenda magni ullam facilis in aliquam earum. Illo, pariatur animi? Quaerat, exercitationem quas nam explicabo quis asperiores repudiandae eos reiciendis libero, unde repellat consequuntur tenetur quasi inventore sunt praesentium provident itaque sit. Culpa soluta tenetur eveniet quisquam sapiente molestias labore minima nesciunt, corrupti minus quidem quia ut! Libero minus quae, quia autem molestiae nisi, impedit, laudantium voluptatum nam adipisci architecto accusamus. Ut harum rerum ipsam quibusdam consequatur sit eos, repudiandae vel eligendi magni repellendus itaque dolorem eaque molestiae!
+    {{#if this.donationTitle}}
+      <CardSpace::UserPage::CardTitle>
+        {{this.donationTitle}}
+      </CardSpace::UserPage::CardTitle>
+      {{/if}}
+      {{#if this.donationDescription}}
+        {{this.donationDescription}}
+      {{/if}}
+      {{#if this.donationSuggestionAmountList}}
+        <ol>
+          {{#each this.donationSuggestionAmountList as |donation|}}
+            <li>
+              {{donation}}
+            </li>
+          {{/each}}
+        </ol>
+        {{else}}
+          Pay me here!
+      {{/if}}
     </:default>
     <:edit>
       Editing

--- a/packages/web-client/app/components/card-space/user-page/donations-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/donations-card/index.hbs
@@ -1,16 +1,18 @@
-<CardSpace::UserPage::CardContainer
-  @header="Donations"
-  @editable={{@editable}}
-  @isEditing={{this.isEditing}}
-  @isSubmitting={{this.isSubmitting}}
-  @onClickEdit={{this.onClickEdit}}
-  @onEndEdit={{this.onEndEdit}}
-  @save={{this.save}}
->
-  <:default>
-    Lorem ipsum dolor sit amet consectetur adipisicing elit. Tenetur itaque asperiores distinctio aut delectus, culpa voluptatibus corrupti, sint veritatis quo molestias libero assumenda magni ullam facilis in aliquam earum. Illo, pariatur animi? Quaerat, exercitationem quas nam explicabo quis asperiores repudiandae eos reiciendis libero, unde repellat consequuntur tenetur quasi inventore sunt praesentium provident itaque sit. Culpa soluta tenetur eveniet quisquam sapiente molestias labore minima nesciunt, corrupti minus quidem quia ut! Libero minus quae, quia autem molestiae nisi, impedit, laudantium voluptatum nam adipisci architecto accusamus. Ut harum rerum ipsam quibusdam consequatur sit eos, repudiandae vel eligendi magni repellendus itaque dolorem eaque molestiae!
-  </:default>
-  <:edit>
-    Editing
-  </:edit>
-</CardSpace::UserPage::CardContainer>
+{{#if (or @editable this.showInViewMode)}}
+  <CardSpace::UserPage::CardContainer
+    @header="Donations"
+    @editable={{@editable}}
+    @isEditing={{this.isEditing}}
+    @isSubmitting={{this.isSubmitting}}
+    @onClickEdit={{this.onClickEdit}}
+    @onEndEdit={{this.onEndEdit}}
+    @save={{this.save}}
+  >
+    <:default>
+      Lorem ipsum dolor sit amet consectetur adipisicing elit. Tenetur itaque asperiores distinctio aut delectus, culpa voluptatibus corrupti, sint veritatis quo molestias libero assumenda magni ullam facilis in aliquam earum. Illo, pariatur animi? Quaerat, exercitationem quas nam explicabo quis asperiores repudiandae eos reiciendis libero, unde repellat consequuntur tenetur quasi inventore sunt praesentium provident itaque sit. Culpa soluta tenetur eveniet quisquam sapiente molestias labore minima nesciunt, corrupti minus quidem quia ut! Libero minus quae, quia autem molestiae nisi, impedit, laudantium voluptatum nam adipisci architecto accusamus. Ut harum rerum ipsam quibusdam consequatur sit eos, repudiandae vel eligendi magni repellendus itaque dolorem eaque molestiae!
+    </:default>
+    <:edit>
+      Editing
+    </:edit>
+  </CardSpace::UserPage::CardContainer>
+{{/if}}

--- a/packages/web-client/app/components/card-space/user-page/donations-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/donations-card/index.hbs
@@ -9,24 +9,38 @@
     @save={{this.save}}
   >
     <:default>
-    {{#if this.donationTitle}}
-      <CardSpace::UserPage::CardTitle>
-        {{this.donationTitle}}
-      </CardSpace::UserPage::CardTitle>
-      {{/if}}
-      {{#if this.donationDescription}}
-        {{this.donationDescription}}
-      {{/if}}
-      {{#if this.donationSuggestionAmountList}}
-        <ol>
-          {{#each this.donationSuggestionAmountList as |donation|}}
+    {{#if this.showInViewMode}}
+      {{#if this.donationTitle}}
+        <CardSpace::UserPage::CardTitle>
+          {{this.donationTitle}}
+        </CardSpace::UserPage::CardTitle>
+        {{/if}}
+        {{#if this.donationDescription}}
+          {{this.donationDescription}}
+        {{/if}}
+        {{#if this.donationSuggestionAmountList}}
+          <ol>
+            {{#each this.donationSuggestionAmountList as |donation|}}
+              <li>
+                {{donation}}
+              </li>
+            {{/each}}
+          </ol>
+          {{else}}
+            Pay me here!
+        {{/if}}
+      {{else}}
+        <CardSpace::UserPage::CardTitle>
+          Donation module
+        </CardSpace::UserPage::CardTitle>
+        Receive donations from supporters and choose custom denominations
+        <ul>
+          {{#each (array 1 2 3 4) as |donation|}}
             <li>
               {{donation}}
             </li>
           {{/each}}
-        </ol>
-        {{else}}
-          Pay me here!
+        </ul>
       {{/if}}
     </:default>
     <:edit>

--- a/packages/web-client/app/components/card-space/user-page/donations-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/donations-card/index.ts
@@ -1,0 +1,45 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import CardSpaceUserData from '@cardstack/web-client/services/card-space-user-data';
+
+const CardStates = {
+  DEFAULT: 'default',
+  EDITING: 'editing',
+  SUBMITTING: 'submitting',
+} as const;
+
+export default class UserPageDonationsCardComponent extends Component {
+  @service declare cardSpaceUserData: CardSpaceUserData;
+  @tracked state: typeof CardStates[keyof typeof CardStates] =
+    CardStates.DEFAULT;
+
+  get isSubmitting() {
+    return this.state === CardStates.SUBMITTING;
+  }
+
+  get isEditing() {
+    return (
+      this.state === CardStates.EDITING || this.state === CardStates.SUBMITTING
+    );
+  }
+
+  @action onClickEdit() {
+    this.state = CardStates.EDITING;
+  }
+
+  @action async save() {
+    try {
+      this.state = CardStates.SUBMITTING;
+      await new Promise<void>((resolve) => setTimeout(resolve, 1000));
+      this.state = CardStates.DEFAULT;
+    } catch (e) {
+      this.state = CardStates.EDITING;
+    }
+  }
+
+  @action onEndEdit() {
+    this.state = CardStates.DEFAULT;
+  }
+}

--- a/packages/web-client/app/components/card-space/user-page/donations-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/donations-card/index.ts
@@ -4,13 +4,25 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import CardSpaceUserData from '@cardstack/web-client/services/card-space-user-data';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
+import * as Sentry from '@sentry/browser';
+import { processJsonApiErrors } from '@cardstack/web-client/utils/json-api';
 
+const UNKNOWN_CARD_SPACE_DONATIONS_ERROR = 'ERROR_SAVING_CARDSPACE_DONATIONS';
+const CARD_SPACE_DONATIONS_VALIDATION = 'CARD_SPACE_DONATIONS_VALIDATION';
 const CardStates = {
   DEFAULT: 'default',
   EDITING: 'editing',
   SUBMITTING: 'submitting',
 } as const;
-
+const managedAttributes = [
+  'donationDescription',
+  'donationTitle',
+  'donationSuggestionAmount1',
+  'donationSuggestionAmount2',
+  'donationSuggestionAmount3',
+  'donationSuggestionAmount4',
+] as const;
+type ManagedAttribute = typeof managedAttributes[number];
 // for the payments to work, this needs to be able to get the network (needs extending of layer 2 strategy type with `networkSymbol: string`)
 // it also needs a way to open a popup (maybe in-element, with the element at the top of the user-page component)
 // and also a way to get a merchant's address using their ID
@@ -21,6 +33,21 @@ export default class UserPageDonationsCardComponent extends Component {
 
   @tracked state: typeof CardStates[keyof typeof CardStates] =
     CardStates.DEFAULT;
+  @tracked submissionErrorMessage = '';
+  @tracked donationDescriptionInputValue = '';
+  @tracked donationTitleInputValue = '';
+  @tracked donationSuggestionAmount1InputValue = '';
+  @tracked donationSuggestionAmount2InputValue = '';
+  @tracked donationSuggestionAmount3InputValue = '';
+  @tracked donationSuggestionAmount4InputValue = '';
+  @tracked validationErrorMessages: Record<ManagedAttribute, string> = {
+    donationDescription: '',
+    donationTitle: '',
+    donationSuggestionAmount1: '',
+    donationSuggestionAmount2: '',
+    donationSuggestionAmount3: '',
+    donationSuggestionAmount4: '',
+  };
 
   get showInViewMode() {
     const {
@@ -30,7 +57,7 @@ export default class UserPageDonationsCardComponent extends Component {
       donationSuggestionAmount2,
       donationSuggestionAmount3,
       donationSuggestionAmount4,
-    } = this.cardSpaceUserData.currentUserData;
+    } = this;
 
     return (
       donationDescription ||
@@ -54,12 +81,71 @@ export default class UserPageDonationsCardComponent extends Component {
     return this.cardSpaceUserData.currentUserData.donationTitle;
   }
 
+  get donationSuggestionAmount1() {
+    return this.cardSpaceUserData.currentUserData.donationSuggestionAmount1;
+  }
+
+  get donationSuggestionAmount2() {
+    return this.cardSpaceUserData.currentUserData.donationSuggestionAmount2;
+  }
+
+  get donationSuggestionAmount3() {
+    return this.cardSpaceUserData.currentUserData.donationSuggestionAmount3;
+  }
+
+  get donationSuggestionAmount4() {
+    return this.cardSpaceUserData.currentUserData.donationSuggestionAmount4;
+  }
+
+  @action onDonationDescriptionInput(value: string) {
+    this.donationDescriptionInputValue = value;
+  }
+  @action onDonationTitleInput(value: string) {
+    this.donationTitleInputValue = value;
+  }
+  @action onDonationSuggestionAmount1Input(value: string) {
+    if (/[^0-9]/.test(value)) {
+      this.donationSuggestionAmount1InputValue =
+        // eslint-disable-next-line no-self-assign
+        this.donationSuggestionAmount1InputValue;
+    } else {
+      this.donationSuggestionAmount1InputValue = value;
+    }
+  }
+  @action onDonationSuggestionAmount2Input(value: string) {
+    if (/[^0-9]/.test(value)) {
+      this.donationSuggestionAmount2InputValue =
+        // eslint-disable-next-line no-self-assign
+        this.donationSuggestionAmount2InputValue;
+    } else {
+      this.donationSuggestionAmount2InputValue = value;
+    }
+  }
+  @action onDonationSuggestionAmount3Input(value: string) {
+    if (/[^0-9]/.test(value)) {
+      this.donationSuggestionAmount3InputValue =
+        // eslint-disable-next-line no-self-assign
+        this.donationSuggestionAmount3InputValue;
+    } else {
+      this.donationSuggestionAmount3InputValue = value;
+    }
+  }
+  @action onDonationSuggestionAmount4Input(value: string) {
+    if (/[^0-9]/.test(value)) {
+      this.donationSuggestionAmount4InputValue =
+        // eslint-disable-next-line no-self-assign
+        this.donationSuggestionAmount4InputValue;
+    } else {
+      this.donationSuggestionAmount4InputValue = value;
+    }
+  }
+
   get donationSuggestionAmountList() {
     return [
-      this.cardSpaceUserData.currentUserData.donationSuggestionAmount1,
-      this.cardSpaceUserData.currentUserData.donationSuggestionAmount2,
-      this.cardSpaceUserData.currentUserData.donationSuggestionAmount3,
-      this.cardSpaceUserData.currentUserData.donationSuggestionAmount4,
+      this.donationSuggestionAmount1,
+      this.donationSuggestionAmount2,
+      this.donationSuggestionAmount3,
+      this.donationSuggestionAmount4,
     ].filter((v) => v);
   }
 
@@ -75,19 +161,90 @@ export default class UserPageDonationsCardComponent extends Component {
 
   @action onClickEdit() {
     this.state = CardStates.EDITING;
+    this.donationDescriptionInputValue = this.donationDescription ?? '';
+    this.donationTitleInputValue = this.donationTitle ?? '';
+    this.donationSuggestionAmount1InputValue = `${this.donationSuggestionAmount1}`;
+    this.donationSuggestionAmount2InputValue = `${this.donationSuggestionAmount2}`;
+    this.donationSuggestionAmount3InputValue = `${this.donationSuggestionAmount3}`;
+    this.donationSuggestionAmount4InputValue = `${this.donationSuggestionAmount4}`;
   }
 
   @action async save() {
+    let extraErrors: any = [];
+    let extraValidations: any = {};
+    let hasUnmanagedValidationError = false; // is there something we PUT that is not managed by this component?
     try {
+      this.submissionErrorMessage = '';
       this.state = CardStates.SUBMITTING;
-      await new Promise<void>((resolve) => setTimeout(resolve, 1000));
-      this.state = CardStates.DEFAULT;
+      let response = await this.cardSpaceUserData.post({
+        donationDescription: this.donationDescriptionInputValue,
+        donationTitle: this.donationTitleInputValue,
+        donationSuggestionAmount1: Number(
+          this.donationSuggestionAmount1InputValue
+        ),
+        donationSuggestionAmount2: Number(
+          this.donationSuggestionAmount2InputValue
+        ),
+        donationSuggestionAmount3: Number(
+          this.donationSuggestionAmount3InputValue
+        ),
+        donationSuggestionAmount4: Number(
+          this.donationSuggestionAmount4InputValue
+        ),
+      });
+      if (response.errors) {
+        let { validations, nonValidationErrors } = processJsonApiErrors(
+          response.errors
+        );
+        extraValidations = validations;
+        extraErrors = nonValidationErrors;
+
+        if (nonValidationErrors.length) {
+          throw new Error(UNKNOWN_CARD_SPACE_DONATIONS_ERROR);
+        }
+
+        if (Object.keys(validations).length) {
+          for (let attribute in validations) {
+            if (managedAttributes.includes(attribute as ManagedAttribute)) {
+              this.validationErrorMessages[attribute as ManagedAttribute] =
+                validations[attribute].join(', ');
+            } else {
+              hasUnmanagedValidationError = true;
+            }
+          }
+          // eslint-disable-next-line no-self-assign
+          this.validationErrorMessages = this.validationErrorMessages;
+
+          throw new Error(CARD_SPACE_DONATIONS_VALIDATION);
+        }
+        this.state = CardStates.EDITING;
+      } else {
+        this.state = CardStates.DEFAULT;
+      }
     } catch (e) {
+      if (
+        e.message !== CARD_SPACE_DONATIONS_VALIDATION ||
+        hasUnmanagedValidationError
+      ) {
+        Sentry.setExtra('validations', extraValidations);
+        Sentry.setExtra('errors', extraErrors);
+        Sentry.captureException(e);
+        console.error(e);
+        // This is probably not enough and we may need some specific markup (links)
+        this.submissionErrorMessage =
+          'Failed to save your data. Press Save to try again.';
+      }
       this.state = CardStates.EDITING;
     }
   }
 
   @action onEndEdit() {
+    this.donationDescriptionInputValue = '';
+    this.donationTitleInputValue = '';
+    this.donationSuggestionAmount1InputValue = '';
+    this.donationSuggestionAmount2InputValue = '';
+    this.donationSuggestionAmount3InputValue = '';
+    this.donationSuggestionAmount4InputValue = '';
     this.state = CardStates.DEFAULT;
   }
 }

--- a/packages/web-client/app/components/card-space/user-page/donations-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/donations-card/index.ts
@@ -176,7 +176,7 @@ export default class UserPageDonationsCardComponent extends Component {
     try {
       this.submissionErrorMessage = '';
       this.state = CardStates.SUBMITTING;
-      let response = await this.cardSpaceUserData.post({
+      let response = await this.cardSpaceUserData.put({
         donationDescription: this.donationDescriptionInputValue,
         donationTitle: this.donationTitleInputValue,
         donationSuggestionAmount1: Number(

--- a/packages/web-client/app/components/card-space/user-page/donations-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/donations-card/index.ts
@@ -15,6 +15,13 @@ export default class UserPageDonationsCardComponent extends Component {
   @tracked state: typeof CardStates[keyof typeof CardStates] =
     CardStates.DEFAULT;
 
+  get showInViewMode() {
+    const { donationDescription, donationTitle } =
+      this.cardSpaceUserData.currentUserData;
+
+    return donationDescription || donationTitle;
+  }
+
   get isSubmitting() {
     return this.state === CardStates.SUBMITTING;
   }

--- a/packages/web-client/app/components/card-space/user-page/donations-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/donations-card/index.ts
@@ -3,6 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import CardSpaceUserData from '@cardstack/web-client/services/card-space-user-data';
+import Layer2Network from '@cardstack/web-client/services/layer2-network';
 
 const CardStates = {
   DEFAULT: 'default',
@@ -10,16 +11,39 @@ const CardStates = {
   SUBMITTING: 'submitting',
 } as const;
 
+// for the payments to work, this needs to be able to get the network (needs extending of layer 2 strategy type with `networkSymbol: string`)
+// it also needs a way to open a popup (maybe in-element, with the element at the top of the user-page component)
+// and also a way to get a merchant's address using their ID
+// the merchant payment URLs can be generated with the generateMerchantPaymentUrl utility from the SDK
 export default class UserPageDonationsCardComponent extends Component {
   @service declare cardSpaceUserData: CardSpaceUserData;
+  @service declare layer2Network: Layer2Network;
+
   @tracked state: typeof CardStates[keyof typeof CardStates] =
     CardStates.DEFAULT;
 
   get showInViewMode() {
-    const { donationDescription, donationTitle } =
-      this.cardSpaceUserData.currentUserData;
+    const {
+      donationDescription,
+      donationTitle,
+      donationSuggestionAmount1,
+      donationSuggestionAmount2,
+      donationSuggestionAmount3,
+      donationSuggestionAmount4,
+    } = this.cardSpaceUserData.currentUserData;
 
-    return donationDescription || donationTitle;
+    return (
+      donationDescription ||
+      donationTitle ||
+      donationSuggestionAmount1 ||
+      donationSuggestionAmount2 ||
+      donationSuggestionAmount3 ||
+      donationSuggestionAmount4
+    );
+  }
+
+  get displayName() {
+    return this.cardSpaceUserData.currentUserData.profileName;
   }
 
   get donationDescription() {

--- a/packages/web-client/app/components/card-space/user-page/donations-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/donations-card/index.ts
@@ -22,6 +22,23 @@ export default class UserPageDonationsCardComponent extends Component {
     return donationDescription || donationTitle;
   }
 
+  get donationDescription() {
+    return this.cardSpaceUserData.currentUserData.donationDescription;
+  }
+
+  get donationTitle() {
+    return this.cardSpaceUserData.currentUserData.donationTitle;
+  }
+
+  get donationSuggestionAmountList() {
+    return [
+      this.cardSpaceUserData.currentUserData.donationSuggestionAmount1,
+      this.cardSpaceUserData.currentUserData.donationSuggestionAmount2,
+      this.cardSpaceUserData.currentUserData.donationSuggestionAmount3,
+      this.cardSpaceUserData.currentUserData.donationSuggestionAmount4,
+    ].filter((v) => v);
+  }
+
   get isSubmitting() {
     return this.state === CardStates.SUBMITTING;
   }

--- a/packages/web-client/app/components/card-space/user-page/donations-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/donations-card/index.ts
@@ -172,7 +172,6 @@ export default class UserPageDonationsCardComponent extends Component {
   @action async save() {
     let extraErrors: any = [];
     let extraValidations: any = {};
-    let hasUnmanagedValidationError = false; // is there something we PUT that is not managed by this component?
     try {
       this.submissionErrorMessage = '';
       this.state = CardStates.SUBMITTING;
@@ -209,7 +208,7 @@ export default class UserPageDonationsCardComponent extends Component {
               this.validationErrorMessages[attribute as ManagedAttribute] =
                 validations[attribute].join(', ');
             } else {
-              hasUnmanagedValidationError = true;
+              throw new Error(UNKNOWN_CARD_SPACE_DONATIONS_ERROR);
             }
           }
           // eslint-disable-next-line no-self-assign
@@ -222,10 +221,7 @@ export default class UserPageDonationsCardComponent extends Component {
         this.state = CardStates.DEFAULT;
       }
     } catch (e) {
-      if (
-        e.message !== CARD_SPACE_DONATIONS_VALIDATION ||
-        hasUnmanagedValidationError
-      ) {
+      if (e.message !== CARD_SPACE_DONATIONS_VALIDATION) {
         Sentry.setExtra('validations', extraValidations);
         Sentry.setExtra('errors', extraErrors);
         Sentry.captureException(e);

--- a/packages/web-client/app/components/card-space/user-page/index.css
+++ b/packages/web-client/app/components/card-space/user-page/index.css
@@ -1,6 +1,6 @@
 /* this needs adjusting to center it properly */
 /* it also needs box shadow */
-.card-space-user-page__toggle-view-button {
+.card-space-user-page__top-floating-button {
   appearance: none;
   border: none;
   padding: var(--boxel-sp-xxs) var(--boxel-sp-lg);
@@ -14,6 +14,12 @@
   text-align: center;
   left: 50%;
 }
+
+.card-space-user-page__floating-authenticate-button {
+  background: var(--boxel-purple-300);
+  color: var(--boxel-purple-700);
+}
+
 
 .card-space-user-page__compact-content-column {
   max-width: 18.75rem;

--- a/packages/web-client/app/components/card-space/user-page/index.css
+++ b/packages/web-client/app/components/card-space/user-page/index.css
@@ -1,4 +1,5 @@
 /* this needs adjusting to center it properly */
+/* it also needs box shadow */
 .card-space-user-page__toggle-view-button {
   appearance: none;
   border: none;
@@ -7,24 +8,19 @@
   border-radius: 0 0 var(--boxel-border-radius) var(--boxel-border-radius);
   top: 0;
   z-index: 1;
-  margin: auto;
   background: var(--boxel-green);
-  font-family: OpenSans;
-  font-size: 11px;
+  font-size: 0.6875rem;
   font-weight: 600;
-  font-stretch: normal;
-  font-style: normal;
-  line-height: normal;
   text-align: center;
   left: 50%;
 }
 
 .card-space-user-page__compact-content-column {
-  max-width: 300px;
+  max-width: 18.75rem;
 }
 
 .card-space-user-page__prose-content-column {
-  max-width: 500px;
+  max-width: 31.25rem;
   display: flex;
   flex-direction: column;
   gap: var(--boxel-sp-sm);

--- a/packages/web-client/app/components/card-space/user-page/index.css
+++ b/packages/web-client/app/components/card-space/user-page/index.css
@@ -26,6 +26,7 @@
 }
 
 .card-space-user-page__prose-content-column {
+  width: 31.25rem;
   max-width: 31.25rem;
   display: flex;
   flex-direction: column;

--- a/packages/web-client/app/components/card-space/user-page/index.css
+++ b/packages/web-client/app/components/card-space/user-page/index.css
@@ -1,0 +1,14 @@
+.card-space-user-page {
+  --annoying-neighbour-space: clamp(120px, 30%, 350px);
+}
+
+.card-space-user-page__compact-content-column {
+  max-width: 300px;
+}
+
+.card-space-user-page__prose-content-column {
+  max-width: 500px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--boxel-sp-sm);
+}

--- a/packages/web-client/app/components/card-space/user-page/index.css
+++ b/packages/web-client/app/components/card-space/user-page/index.css
@@ -2,6 +2,26 @@
   --annoying-neighbour-space: clamp(120px, 30%, 350px);
 }
 
+.card-space-user-page__toggle-view-button {
+  appearance: none;
+  border: none;
+  padding: var(--boxel-sp-xxs) var(--boxel-sp-lg);
+  position: fixed;
+  border-radius: 0 0 var(--boxel-border-radius) var(--boxel-border-radius);
+  top: 0;
+  z-index: 1;
+  margin: auto;
+  background: var(--boxel-green);
+  font-family: OpenSans;
+  font-size: 11px;
+  font-weight: 600;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: normal;
+  text-align: center;
+  left: 50%;
+}
+
 .card-space-user-page__compact-content-column {
   max-width: 300px;
 }

--- a/packages/web-client/app/components/card-space/user-page/index.css
+++ b/packages/web-client/app/components/card-space/user-page/index.css
@@ -26,9 +26,12 @@
 }
 
 .card-space-user-page__prose-content-column {
-  width: 31.25rem;
   max-width: 31.25rem;
   display: flex;
   flex-direction: column;
   gap: var(--boxel-sp-sm);
+}
+
+.card-space-user-page__prose-content-column > * {
+  width: 31.25rem;
 }

--- a/packages/web-client/app/components/card-space/user-page/index.css
+++ b/packages/web-client/app/components/card-space/user-page/index.css
@@ -1,7 +1,3 @@
-.card-space-user-page {
-  --annoying-neighbour-space: clamp(120px, 30%, 350px);
-}
-
 .card-space-user-page__toggle-view-button {
   appearance: none;
   border: none;

--- a/packages/web-client/app/components/card-space/user-page/index.css
+++ b/packages/web-client/app/components/card-space/user-page/index.css
@@ -1,3 +1,4 @@
+/* this needs adjusting to center it properly */
 .card-space-user-page__toggle-view-button {
   appearance: none;
   border: none;

--- a/packages/web-client/app/components/card-space/user-page/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/index.hbs
@@ -3,18 +3,28 @@
 <div id="card-space-user-page-image-editor" style="z-index: calc(var(--boxel-layer-modal-default) + 1); width: 0px; height: 0px; flex-grow: 0; position: absolute;"></div>
 <div class="card-space-user-page" ...attributes>
   {{#if this.isOwner}}
-    <button
-      class="card-space-user-page__toggle-view-button"
-      type="button"
-      data-test-card-space-toggle-view-button
-      {{on "click" this.switchMode}}
-    >
-      {{#if (eq this.mode "view")}}
-        Enter Edit Mode
+    {{#if this.isAuthenticated}}
+      <button
+        class="card-space-user-page__top-floating-button"
+        type="button"
+        data-test-card-space-toggle-view-button
+        {{on "click" this.switchMode}}
+      >
+        {{#if (eq this.mode "view")}}
+          Enter Edit Mode
+        {{else}}
+          Enter Preview Mode
+        {{/if}}
+      </button>
       {{else}}
-        Enter Preview Mode
-      {{/if}}
-    </button>
+      <button
+        class="card-space-user-page__top-floating-button card-space-user-page__floating-authenticate-button"
+        type="button"
+        data-test-card-space-floating-authenticate-button
+      >
+        Authenticate with hub to enable editing
+      </button>
+    {{/if}}
   {{/if}}
   <CardSpace::UserPage::BackgroundCard
     @editable={{this.editable}}

--- a/packages/web-client/app/components/card-space/user-page/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/index.hbs
@@ -6,6 +6,7 @@
     <button
       class="card-space-user-page__toggle-view-button"
       type="button"
+      data-test-card-space-toggle-view-button
       {{on "click" this.switchMode}}
     >
       {{#if (eq this.mode "view")}}

--- a/packages/web-client/app/components/card-space/user-page/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/index.hbs
@@ -1,0 +1,25 @@
+{{!-- yet another place to fix after boxel's modal has been adjusted to work with multiple layers --}}
+{{!-- template-lint-disable no-inline-styles --}}
+<div id="card-space-user-page-image-editor" style="z-index: calc(var(--boxel-layer-modal-default) + 1); width: 0px; height: 0px; flex-grow: 0; position: absolute;"></div>
+<div class="card-space-user-page" ...attributes>
+  <CardSpace::UserPage::BackgroundCard
+    @editable={{this.editable}}
+  >
+    <div class="card-space-user-page__compact-content-column">
+      <CardSpace::UserPage::ProfileCard
+        @editable={{this.editable}}
+      />
+    </div>
+    <div class="card-space-user-page__prose-content-column">
+      <CardSpace::UserPage::BioCard
+        @editable={{this.editable}}
+      />
+      <CardSpace::UserPage::LinksCard
+        @editable={{this.editable}}
+      />
+      <CardSpace::UserPage::DonationsCard
+        @editable={{this.editable}}
+      />
+    </div>
+  </CardSpace::UserPage::BackgroundCard>
+</div>

--- a/packages/web-client/app/components/card-space/user-page/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/index.hbs
@@ -2,6 +2,19 @@
 {{!-- template-lint-disable no-inline-styles --}}
 <div id="card-space-user-page-image-editor" style="z-index: calc(var(--boxel-layer-modal-default) + 1); width: 0px; height: 0px; flex-grow: 0; position: absolute;"></div>
 <div class="card-space-user-page" ...attributes>
+  {{#if this.isOwner}}
+    <button
+      class="card-space-user-page__toggle-view-button"
+      type="button"
+      {{on "click" this.switchMode}}
+    >
+      {{#if (eq this.mode "view")}}
+        Enter Edit Mode
+      {{else}}
+        Enter Preview Mode
+      {{/if}}
+    </button>
+  {{/if}}
   <CardSpace::UserPage::BackgroundCard
     @editable={{this.editable}}
   >

--- a/packages/web-client/app/components/card-space/user-page/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/index.ts
@@ -1,0 +1,33 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import CardSpaceUserData from '@cardstack/web-client/services/card-space-user-data';
+import Layer2Network from '@cardstack/web-client/services/layer2-network';
+import { action } from '@ember/object';
+
+export default class CardSpaceUserPage extends Component {
+  @service declare cardSpaceUserData: CardSpaceUserData;
+  @service declare layer2Network: Layer2Network;
+  @tracked mode: 'view' | 'edit' = 'view';
+
+  constructor(owner: unknown, args: any) {
+    super(owner, args);
+    this.layer2Network.on('disconnect', () => (this.mode = 'view'));
+  }
+
+  get isOwner() {
+    return (
+      this.layer2Network.isConnected &&
+      this.cardSpaceUserData.currentUserData.ownerAddress ===
+        this.layer2Network.walletInfo.firstAddress
+    );
+  }
+
+  get editable() {
+    return this.isOwner && this.mode === 'edit';
+  }
+
+  @action switchMode(mode: 'view' | 'edit') {
+    this.mode = mode;
+  }
+}

--- a/packages/web-client/app/components/card-space/user-page/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/index.ts
@@ -27,7 +27,7 @@ export default class CardSpaceUserPage extends Component {
     return this.isOwner && this.mode === 'edit';
   }
 
-  @action switchMode(mode: 'view' | 'edit') {
-    this.mode = mode;
+  @action switchMode() {
+    this.mode = this.mode === 'view' ? 'edit' : 'view';
   }
 }

--- a/packages/web-client/app/components/card-space/user-page/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/index.ts
@@ -4,10 +4,12 @@ import { inject as service } from '@ember/service';
 import CardSpaceUserData from '@cardstack/web-client/services/card-space-user-data';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import { action } from '@ember/object';
+import HubAuthentication from '@cardstack/web-client/services/hub-authentication';
 
 export default class CardSpaceUserPage extends Component {
   @service declare cardSpaceUserData: CardSpaceUserData;
   @service declare layer2Network: Layer2Network;
+  @service declare hubAuthentication: HubAuthentication;
   @tracked mode: 'view' | 'edit' = 'view';
 
   constructor(owner: unknown, args: any) {
@@ -23,8 +25,12 @@ export default class CardSpaceUserPage extends Component {
     );
   }
 
+  get isAuthenticated() {
+    return this.hubAuthentication.isAuthenticated;
+  }
+
   get editable() {
-    return this.isOwner && this.mode === 'edit';
+    return this.isOwner && this.isAuthenticated && this.mode === 'edit';
   }
 
   @action switchMode() {

--- a/packages/web-client/app/components/card-space/user-page/layout-card-container/button-with-click-handler/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/layout-card-container/button-with-click-handler/index.hbs
@@ -1,0 +1,14 @@
+{{#if @show}}
+  <Boxel::Button
+    @kind="primary"
+    @size="base"
+    {{on "click" @onClick}}
+    ...attributes
+  >
+    {{#if (has-block)}}
+      {{yield}}
+    {{else}}
+      Customize
+    {{/if}}
+  </Boxel::Button>
+{{/if}}

--- a/packages/web-client/app/components/card-space/user-page/layout-card-container/index.css
+++ b/packages/web-client/app/components/card-space/user-page/layout-card-container/index.css
@@ -1,0 +1,8 @@
+.card-space__layout-card-container {
+  width: 100%;
+  height: 100%;
+}
+
+.card-space__layout-card-container:not(.card-space__layout-card-container--editable) {
+  border-radius: 0;
+}

--- a/packages/web-client/app/components/card-space/user-page/layout-card-container/index.css
+++ b/packages/web-client/app/components/card-space/user-page/layout-card-container/index.css
@@ -1,6 +1,7 @@
 .card-space__layout-card-container {
   width: 100%;
-  height: 100%;
+  height: auto;
+  min-height: 100vh;
 }
 
 .card-space__layout-card-container:not(.card-space__layout-card-container--editable) {

--- a/packages/web-client/app/components/card-space/user-page/layout-card-container/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/layout-card-container/index.hbs
@@ -26,6 +26,7 @@
 </Boxel::CardContainer>
 
 <CardSpace::UserPage::CardEditModal
+  @header={{@header}}
   @isEditing={{@isEditing}}
   @isSubmitting={{@isSubmitting}}
   @submissionDisabled={{@submissionDisabled}}
@@ -34,9 +35,6 @@
   @size={{@editSize}}
   @errorMessage={{@errorMessage}}
 >
-  <:header>
-    {{@header}}
-  </:header>
   <:default>
     {{yield to="edit"}}
   </:default>

--- a/packages/web-client/app/components/card-space/user-page/layout-card-container/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/layout-card-container/index.hbs
@@ -8,7 +8,7 @@
   {{#if @editable}}
     <Boxel::Header>
       <:default>
-        {{yield to="header"}}
+        {{@header}}
       </:default>
       <:actions>
           <button
@@ -35,7 +35,7 @@
   @errorMessage={{@errorMessage}}
 >
   <:header>
-    {{yield to="header"}}
+    {{@header}}
   </:header>
   <:default>
     {{yield to="edit"}}

--- a/packages/web-client/app/components/card-space/user-page/layout-card-container/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/layout-card-container/index.hbs
@@ -1,4 +1,6 @@
 <Boxel::CardContainer
+  data-test-card-space-layout-card-container
+  data-test-editable={{@editable}}
   class={{cn "card-space__layout-card-container" card-space__layout-card-container--editable=@editable}}
   @displayBoundaries={{true}}
   ...attributes

--- a/packages/web-client/app/components/card-space/user-page/layout-card-container/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/layout-card-container/index.hbs
@@ -1,0 +1,41 @@
+<Boxel::CardContainer
+  class={{cn "card-space__layout-card-container" card-space__layout-card-container--editable=@editable}}
+  @displayBoundaries={{true}}
+  ...attributes
+>
+  {{#if @editable}}
+    <Boxel::Header>
+      <:default>
+        {{yield to="header"}}
+      </:default>
+      <:actions>
+          <button
+            data-test-edit-button
+            type="button"
+            {{on 'click' @onClickEdit}}
+          >
+            Edit
+          </button>
+      </:actions>
+    </Boxel::Header>
+  {{/if}}
+
+  {{yield (component "card-space/user-page/layout-card-container/button-with-click-handler" onClick=@onClickEdit show=@editable)}}
+</Boxel::CardContainer>
+
+<CardSpace::UserPage::CardEditModal
+  @isEditing={{@isEditing}}
+  @isSubmitting={{@isSubmitting}}
+  @submissionDisabled={{@submissionDisabled}}
+  @onClose={{@onEndEdit}}
+  @save={{@save}}
+  @size={{@editSize}}
+  @errorMessage={{@errorMessage}}
+>
+  <:header>
+    {{yield to="header"}}
+  </:header>
+  <:default>
+    {{yield to="edit"}}
+  </:default>
+</CardSpace::UserPage::CardEditModal>

--- a/packages/web-client/app/components/card-space/user-page/links-card/index.css
+++ b/packages/web-client/app/components/card-space/user-page/links-card/index.css
@@ -1,0 +1,20 @@
+.card-space-user-page__link {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: var(--boxel-sp);
+  border: var(--boxel-border);
+  border-radius: var(--boxel-border-radius);
+}
+
+.card-space-user-page__link-title {
+  font: 700 var(--boxel-font-sm);
+  letter-spacing: var(--boxel-lsp);
+}
+
+.card-space-user-page__link-url {
+  color: var(--boxel-purple-500);
+  font: var(--boxel-font-sm);
+  letter-spacing: var(--boxel-lsp);
+}

--- a/packages/web-client/app/components/card-space/user-page/links-card/index.css
+++ b/packages/web-client/app/components/card-space/user-page/links-card/index.css
@@ -18,3 +18,43 @@
   font: var(--boxel-font-sm);
   letter-spacing: var(--boxel-lsp);
 }
+
+.card-space-user-page__edited-link {
+  display: grid;
+  grid-template-columns: auto min-content;
+}
+
+.card-space-user-page__edited-link-title, .card-space-user-page__edited-link-url {
+  grid-column: 1;
+  display: grid;
+  grid-template-columns: 12ch 1fr;
+}
+
+.card-space-user-page__edited-link-delete {
+  --icon-color: var(--boxel-dark);
+
+  appearance: none;
+  -webkit-appearance: none;
+  grid-column: 2;
+  grid-row: 1/-1;
+  height: calc(var(--boxel-icon-sm) + var(--boxel-sp-xxs) * 2);
+  width: calc(var(--boxel-icon-sm) + var(--boxel-sp-xxs) * 2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--boxel-sp-xxs);
+  border-radius: 100px; /* same as Boxel button border radius */
+  font: 600 var(--boxel-font-sm);
+  border: none;
+  background-color: transparent;
+}
+
+.card-space-user-page__edited-link-delete > svg {
+  width: 100%;
+  height: 100%;
+}
+
+.card-space-user-page__edited-link-delete:hover,
+.card-space-user-page__edited-link-delete:active {
+  background-color: rgba(0, 0, 0, 0.1);
+}

--- a/packages/web-client/app/components/card-space/user-page/links-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/links-card/index.hbs
@@ -9,7 +9,18 @@
     @save={{this.save}}
   >
     <:default>
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. Tenetur itaque asperiores distinctio aut delectus, culpa voluptatibus corrupti, sint veritatis quo molestias libero assumenda magni ullam facilis in aliquam earum. Illo, pariatur animi? Quaerat, exercitationem quas nam explicabo quis asperiores repudiandae eos reiciendis libero, unde repellat consequuntur tenetur quasi inventore sunt praesentium provident itaque sit. Culpa soluta tenetur eveniet quisquam sapiente molestias labore minima nesciunt, corrupti minus quidem quia ut! Libero minus quae, quia autem molestiae nisi, impedit, laudantium voluptatum nam adipisci architecto accusamus. Ut harum rerum ipsam quibusdam consequatur sit eos, repudiandae vel eligendi magni repellendus itaque dolorem eaque molestiae!
+      <CardSpace::UserPage::CardTitle>
+        My Links
+      </CardSpace::UserPage::CardTitle>
+      <ul>
+        {{#each this.links as |link|}}
+          <li>
+            <a href={{link.url}}>
+              {{link.title}}
+            </a>
+          </li>
+        {{/each}}
+      </ul>
     </:default>
     <:edit>
       Editing

--- a/packages/web-client/app/components/card-space/user-page/links-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/links-card/index.hbs
@@ -1,0 +1,18 @@
+<CardSpace::UserPage::CardContainer
+  @editable={{@editable}}
+  @isEditing={{this.isEditing}}
+  @isSubmitting={{this.isSubmitting}}
+  @onClickEdit={{this.onClickEdit}}
+  @onEndEdit={{this.onEndEdit}}
+  @save={{this.save}}
+>
+  <:header>
+    Links
+  </:header>
+  <:default>
+    Lorem ipsum dolor sit amet consectetur adipisicing elit. Tenetur itaque asperiores distinctio aut delectus, culpa voluptatibus corrupti, sint veritatis quo molestias libero assumenda magni ullam facilis in aliquam earum. Illo, pariatur animi? Quaerat, exercitationem quas nam explicabo quis asperiores repudiandae eos reiciendis libero, unde repellat consequuntur tenetur quasi inventore sunt praesentium provident itaque sit. Culpa soluta tenetur eveniet quisquam sapiente molestias labore minima nesciunt, corrupti minus quidem quia ut! Libero minus quae, quia autem molestiae nisi, impedit, laudantium voluptatum nam adipisci architecto accusamus. Ut harum rerum ipsam quibusdam consequatur sit eos, repudiandae vel eligendi magni repellendus itaque dolorem eaque molestiae!
+  </:default>
+  <:edit>
+    Editing
+  </:edit>
+</CardSpace::UserPage::CardContainer>

--- a/packages/web-client/app/components/card-space/user-page/links-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/links-card/index.hbs
@@ -1,4 +1,5 @@
 <CardSpace::UserPage::CardContainer
+  @header="Links"
   @editable={{@editable}}
   @isEditing={{this.isEditing}}
   @isSubmitting={{this.isSubmitting}}
@@ -6,9 +7,6 @@
   @onEndEdit={{this.onEndEdit}}
   @save={{this.save}}
 >
-  <:header>
-    Links
-  </:header>
   <:default>
     Lorem ipsum dolor sit amet consectetur adipisicing elit. Tenetur itaque asperiores distinctio aut delectus, culpa voluptatibus corrupti, sint veritatis quo molestias libero assumenda magni ullam facilis in aliquam earum. Illo, pariatur animi? Quaerat, exercitationem quas nam explicabo quis asperiores repudiandae eos reiciendis libero, unde repellat consequuntur tenetur quasi inventore sunt praesentium provident itaque sit. Culpa soluta tenetur eveniet quisquam sapiente molestias labore minima nesciunt, corrupti minus quidem quia ut! Libero minus quae, quia autem molestiae nisi, impedit, laudantium voluptatum nam adipisci architecto accusamus. Ut harum rerum ipsam quibusdam consequatur sit eos, repudiandae vel eligendi magni repellendus itaque dolorem eaque molestiae!
   </:default>

--- a/packages/web-client/app/components/card-space/user-page/links-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/links-card/index.hbs
@@ -9,18 +9,25 @@
     @save={{this.save}}
   >
     <:default>
-      <CardSpace::UserPage::CardTitle>
-        My Links
-      </CardSpace::UserPage::CardTitle>
-      <ul>
-        {{#each this.links as |link|}}
-          <li>
-            <a href={{link.url}}>
-              {{link.title}}
-            </a>
-          </li>
-        {{/each}}
-      </ul>
+      {{#if this.showInViewMode}}
+        <CardSpace::UserPage::CardTitle>
+          My Links
+        </CardSpace::UserPage::CardTitle>
+        <ul>
+          {{#each this.links as |link|}}
+            <li>
+              <a href={{link.url}}>
+                {{link.title}}
+              </a>
+            </li>
+          {{/each}}
+        </ul>
+      {{else}}
+        <CardSpace::UserPage::CardTitle>
+          My Links
+        </CardSpace::UserPage::CardTitle>
+        Add links here
+      {{/if}}
     </:default>
     <:edit>
       Editing

--- a/packages/web-client/app/components/card-space/user-page/links-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/links-card/index.hbs
@@ -16,8 +16,13 @@
         <ul>
           {{#each this.links as |link|}}
             <li>
-              <a href={{link.url}}>
-                {{link.title}}
+              <a class="card-space-user-page__link" href={{link.url}}>
+                <div class="card-space-user-page__link-title">
+                  {{link.title}}
+                </div>
+                <div class="card-space-user-page__link-url">
+                  {{link.url}}
+                </div>
               </a>
             </li>
           {{/each}}
@@ -26,7 +31,15 @@
         <CardSpace::UserPage::CardTitle>
           My Links
         </CardSpace::UserPage::CardTitle>
-        Add links here
+        <div class="card-space-user-page__link">
+          <div class="card-space-user-page__link-title">
+            Your link title
+          </div>
+
+          <div class="card-space-user-page__link-url">
+            Your link url
+          </div>
+        </div>
       {{/if}}
     </:default>
     <:edit>

--- a/packages/web-client/app/components/card-space/user-page/links-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/links-card/index.hbs
@@ -7,6 +7,7 @@
     @onClickEdit={{this.onClickEdit}}
     @onEndEdit={{this.onEndEdit}}
     @save={{this.save}}
+    @errorMessage={{this.submissionErrorMessage}}
   >
     <:default>
       {{#if this.showInViewMode}}
@@ -43,7 +44,44 @@
       {{/if}}
     </:default>
     <:edit>
-      Editing
+      {{#each this.editedLinks as |editedLink index|}}
+      <div class="card-space-user-page__edited-link">
+        <Boxel::Field
+          @fieldMode="edit"
+          @label="Link Title"
+          class="card-space-user-page__edited-link-title"
+        >
+          <Boxel::Input
+            @value={{editedLink.title}}
+            @onInput={{editedLink.updateTitle}}
+            @errorMessage={{editedLink.titleValidationError}}
+            @invalid={{editedLink.titleValidationError}}
+          />
+        </Boxel::Field>
+        <Boxel::Field
+          @fieldMode="edit"
+          @label="URL"
+          class="card-space-user-page__edited-link-url"
+        >
+          <Boxel::Input
+            @value={{editedLink.url}}
+            @onInput={{editedLink.updateUrl}}
+            @errorMessage={{editedLink.urlValidationError}}
+            @invalid={{editedLink.urlValidationError}}
+          />
+        </Boxel::Field>
+        <button type="button" class="card-space-user-page__edited-link-delete" {{on "click" (fn this.removeItemAt index)}}>
+          {{svg-jar "trash"}}
+        </button>
+      </div>
+      {{/each}}
+      <Boxel::Button
+        @kind="secondary-light"
+        @size="small"
+        {{on "click" this.addItem}}
+      >
+        Add Link
+      </Boxel::Button>
     </:edit>
   </CardSpace::UserPage::CardContainer>
 {{/if}}

--- a/packages/web-client/app/components/card-space/user-page/links-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/links-card/index.hbs
@@ -1,16 +1,18 @@
-<CardSpace::UserPage::CardContainer
-  @header="Links"
-  @editable={{@editable}}
-  @isEditing={{this.isEditing}}
-  @isSubmitting={{this.isSubmitting}}
-  @onClickEdit={{this.onClickEdit}}
-  @onEndEdit={{this.onEndEdit}}
-  @save={{this.save}}
->
-  <:default>
-    Lorem ipsum dolor sit amet consectetur adipisicing elit. Tenetur itaque asperiores distinctio aut delectus, culpa voluptatibus corrupti, sint veritatis quo molestias libero assumenda magni ullam facilis in aliquam earum. Illo, pariatur animi? Quaerat, exercitationem quas nam explicabo quis asperiores repudiandae eos reiciendis libero, unde repellat consequuntur tenetur quasi inventore sunt praesentium provident itaque sit. Culpa soluta tenetur eveniet quisquam sapiente molestias labore minima nesciunt, corrupti minus quidem quia ut! Libero minus quae, quia autem molestiae nisi, impedit, laudantium voluptatum nam adipisci architecto accusamus. Ut harum rerum ipsam quibusdam consequatur sit eos, repudiandae vel eligendi magni repellendus itaque dolorem eaque molestiae!
-  </:default>
-  <:edit>
-    Editing
-  </:edit>
-</CardSpace::UserPage::CardContainer>
+{{#if (or @editable this.showInViewMode)}}
+  <CardSpace::UserPage::CardContainer
+    @header="Links"
+    @editable={{@editable}}
+    @isEditing={{this.isEditing}}
+    @isSubmitting={{this.isSubmitting}}
+    @onClickEdit={{this.onClickEdit}}
+    @onEndEdit={{this.onEndEdit}}
+    @save={{this.save}}
+  >
+    <:default>
+      Lorem ipsum dolor sit amet consectetur adipisicing elit. Tenetur itaque asperiores distinctio aut delectus, culpa voluptatibus corrupti, sint veritatis quo molestias libero assumenda magni ullam facilis in aliquam earum. Illo, pariatur animi? Quaerat, exercitationem quas nam explicabo quis asperiores repudiandae eos reiciendis libero, unde repellat consequuntur tenetur quasi inventore sunt praesentium provident itaque sit. Culpa soluta tenetur eveniet quisquam sapiente molestias labore minima nesciunt, corrupti minus quidem quia ut! Libero minus quae, quia autem molestiae nisi, impedit, laudantium voluptatum nam adipisci architecto accusamus. Ut harum rerum ipsam quibusdam consequatur sit eos, repudiandae vel eligendi magni repellendus itaque dolorem eaque molestiae!
+    </:default>
+    <:edit>
+      Editing
+    </:edit>
+  </CardSpace::UserPage::CardContainer>
+{{/if}}

--- a/packages/web-client/app/components/card-space/user-page/links-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/links-card/index.ts
@@ -82,7 +82,6 @@ export default class UserPageLinksCardComponent extends Component {
   @action async save() {
     let extraErrors: any = [];
     let extraValidations: any = {};
-    let hasUnmanagedValidationError = false; // is there something we PUT that is not managed by this component?
     try {
       this.submissionErrorMessage = '';
       this.state = CardStates.SUBMITTING;
@@ -114,7 +113,7 @@ export default class UserPageLinksCardComponent extends Component {
                 throw new Error(UNKNOWN_CARD_SPACE_LINKS_ERROR);
               }
             } else {
-              hasUnmanagedValidationError = true;
+              throw new Error(UNKNOWN_CARD_SPACE_LINKS_ERROR);
             }
           }
 
@@ -125,10 +124,7 @@ export default class UserPageLinksCardComponent extends Component {
         this.state = CardStates.DEFAULT;
       }
     } catch (e) {
-      if (
-        e.message !== CARD_SPACE_LINKS_VALIDATION ||
-        hasUnmanagedValidationError
-      ) {
+      if (e.message !== CARD_SPACE_LINKS_VALIDATION) {
         Sentry.setExtra('validations', extraValidations);
         Sentry.setExtra('errors', extraErrors);
         Sentry.captureException(e);

--- a/packages/web-client/app/components/card-space/user-page/links-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/links-card/index.ts
@@ -1,0 +1,45 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import CardSpaceUserData from '@cardstack/web-client/services/card-space-user-data';
+
+const CardStates = {
+  DEFAULT: 'default',
+  EDITING: 'editing',
+  SUBMITTING: 'submitting',
+} as const;
+
+export default class UserPageLinksCardComponent extends Component {
+  @service declare cardSpaceUserData: CardSpaceUserData;
+  @tracked state: typeof CardStates[keyof typeof CardStates] =
+    CardStates.DEFAULT;
+
+  get isSubmitting() {
+    return this.state === CardStates.SUBMITTING;
+  }
+
+  get isEditing() {
+    return (
+      this.state === CardStates.EDITING || this.state === CardStates.SUBMITTING
+    );
+  }
+
+  @action onClickEdit() {
+    this.state = CardStates.EDITING;
+  }
+
+  @action async save() {
+    try {
+      this.state = CardStates.SUBMITTING;
+      await new Promise<void>((resolve) => setTimeout(resolve, 1000));
+      this.state = CardStates.DEFAULT;
+    } catch (e) {
+      this.state = CardStates.EDITING;
+    }
+  }
+
+  @action onEndEdit() {
+    this.state = CardStates.DEFAULT;
+  }
+}

--- a/packages/web-client/app/components/card-space/user-page/links-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/links-card/index.ts
@@ -15,6 +15,10 @@ export default class UserPageLinksCardComponent extends Component {
   @tracked state: typeof CardStates[keyof typeof CardStates] =
     CardStates.DEFAULT;
 
+  get showInViewMode() {
+    return this.cardSpaceUserData.currentUserData.links.length;
+  }
+
   get isSubmitting() {
     return this.state === CardStates.SUBMITTING;
   }

--- a/packages/web-client/app/components/card-space/user-page/links-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/links-card/index.ts
@@ -19,6 +19,10 @@ export default class UserPageLinksCardComponent extends Component {
     return this.cardSpaceUserData.currentUserData.links.length;
   }
 
+  get links() {
+    return this.cardSpaceUserData.currentUserData.links;
+  }
+
   get isSubmitting() {
     return this.state === CardStates.SUBMITTING;
   }

--- a/packages/web-client/app/components/card-space/user-page/links-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/links-card/index.ts
@@ -86,7 +86,7 @@ export default class UserPageLinksCardComponent extends Component {
     try {
       this.submissionErrorMessage = '';
       this.state = CardStates.SUBMITTING;
-      let response = await this.cardSpaceUserData.post({
+      let response = await this.cardSpaceUserData.put({
         links: this.editedLinks,
       });
       if (response.errors) {

--- a/packages/web-client/app/components/card-space/user-page/links-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/links-card/index.ts
@@ -1,19 +1,50 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
+import { action, set } from '@ember/object';
 import { inject as service } from '@ember/service';
 import CardSpaceUserData from '@cardstack/web-client/services/card-space-user-data';
+import { A } from '@ember/array';
+import * as Sentry from '@sentry/browser';
+import { processJsonApiErrors } from '@cardstack/web-client/utils/json-api';
 
+const UNKNOWN_CARD_SPACE_LINKS_ERROR = 'ERROR_SAVING_CARDSPACE_LINKS';
+const CARD_SPACE_LINKS_VALIDATION = 'CARD_SPACE_LINKS_VALIDATION';
 const CardStates = {
   DEFAULT: 'default',
   EDITING: 'editing',
   SUBMITTING: 'submitting',
 } as const;
 
+class TrackedLink {
+  @tracked title = '';
+  @tracked url = '';
+  @tracked titleValidationError = '';
+  @tracked urlValidationError = '';
+
+  constructor(source?: { title: string; url: string }) {
+    if (source) {
+      this.title = source.title;
+      this.url = source.url;
+    }
+  }
+
+  @action updateTitle(title: string) {
+    this.titleValidationError = '';
+    this.title = title;
+  }
+
+  @action updateUrl(url: string) {
+    this.urlValidationError = '';
+    this.url = url;
+  }
+}
+
 export default class UserPageLinksCardComponent extends Component {
   @service declare cardSpaceUserData: CardSpaceUserData;
   @tracked state: typeof CardStates[keyof typeof CardStates] =
     CardStates.DEFAULT;
+  @tracked editedLinks: TrackedLink[] = A([]);
+  @tracked submissionErrorMessage = '';
 
   get showInViewMode() {
     return this.cardSpaceUserData.currentUserData.links.length;
@@ -33,21 +64,85 @@ export default class UserPageLinksCardComponent extends Component {
     );
   }
 
+  @action addItem() {
+    this.editedLinks.pushObject(new TrackedLink());
+  }
+
+  @action removeItemAt(index: number) {
+    this.editedLinks.removeAt(index);
+  }
+
   @action onClickEdit() {
     this.state = CardStates.EDITING;
+    this.editedLinks = this.links.length
+      ? A(this.links.map((source) => new TrackedLink(source)))
+      : A([new TrackedLink()]);
   }
 
   @action async save() {
+    let extraErrors: any = [];
+    let extraValidations: any = {};
+    let hasUnmanagedValidationError = false; // is there something we PUT that is not managed by this component?
     try {
+      this.submissionErrorMessage = '';
       this.state = CardStates.SUBMITTING;
-      await new Promise<void>((resolve) => setTimeout(resolve, 1000));
-      this.state = CardStates.DEFAULT;
+      let response = await this.cardSpaceUserData.post({
+        links: this.editedLinks,
+      });
+      if (response.errors) {
+        let { validations, nonValidationErrors } = processJsonApiErrors(
+          response.errors
+        );
+        extraValidations = validations;
+        extraErrors = nonValidationErrors;
+
+        if (nonValidationErrors.length) {
+          throw new Error(UNKNOWN_CARD_SPACE_LINKS_ERROR);
+        }
+
+        if (Object.keys(validations).length) {
+          for (let attribute in validations) {
+            if (attribute.startsWith('links.')) {
+              try {
+                set(
+                  this,
+                  (attribute.replace(/^links/, 'editedLinks') +
+                    'ValidationError') as any,
+                  validations[attribute].join(', ')
+                );
+              } catch (e) {
+                throw new Error(UNKNOWN_CARD_SPACE_LINKS_ERROR);
+              }
+            } else {
+              hasUnmanagedValidationError = true;
+            }
+          }
+
+          throw new Error(CARD_SPACE_LINKS_VALIDATION);
+        }
+        this.state = CardStates.EDITING;
+      } else {
+        this.state = CardStates.DEFAULT;
+      }
     } catch (e) {
+      if (
+        e.message !== CARD_SPACE_LINKS_VALIDATION ||
+        hasUnmanagedValidationError
+      ) {
+        Sentry.setExtra('validations', extraValidations);
+        Sentry.setExtra('errors', extraErrors);
+        Sentry.captureException(e);
+        console.error(e);
+        // This is probably not enough and we may need some specific markup (links)
+        this.submissionErrorMessage =
+          'Failed to save your data. Press Save to try again.';
+      }
       this.state = CardStates.EDITING;
     }
   }
 
   @action onEndEdit() {
     this.state = CardStates.DEFAULT;
+    this.editedLinks = A([]);
   }
 }

--- a/packages/web-client/app/components/card-space/user-page/profile-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/profile-card/index.hbs
@@ -1,0 +1,19 @@
+<CardSpace::UserPage::CardContainer
+  @editable={{@editable}}
+  @isEditing={{this.isEditing}}
+  @isSubmitting={{this.isSubmitting}}
+  @onClickEdit={{this.onClickEdit}}
+  @onEndEdit={{this.onEndEdit}}
+  @save={{this.save}}
+  @editSize="large"
+>
+  <:header>
+    Profile
+  </:header>
+  <:default>
+    Lorem ipsum dolor sit amet consectetur adipisicing elit. Tenetur itaque asperiores distinctio aut delectus, culpa voluptatibus corrupti, sint veritatis quo molestias libero assumenda magni ullam facilis in aliquam earum. Illo, pariatur animi? Quaerat, exercitationem quas nam explicabo quis asperiores repudiandae eos reiciendis libero, unde repellat consequuntur tenetur quasi inventore sunt praesentium provident itaque sit. Culpa soluta tenetur eveniet quisquam sapiente molestias labore minima nesciunt, corrupti minus quidem quia ut! Libero minus quae, quia autem molestiae nisi, impedit, laudantium voluptatum nam adipisci architecto accusamus. Ut harum rerum ipsam quibusdam consequatur sit eos, repudiandae vel eligendi magni repellendus itaque dolorem eaque molestiae!
+  </:default>
+  <:edit>
+    Editing
+  </:edit>
+</CardSpace::UserPage::CardContainer>

--- a/packages/web-client/app/components/card-space/user-page/profile-card/index.hbs
+++ b/packages/web-client/app/components/card-space/user-page/profile-card/index.hbs
@@ -1,4 +1,5 @@
 <CardSpace::UserPage::CardContainer
+  @header="Profile"
   @editable={{@editable}}
   @isEditing={{this.isEditing}}
   @isSubmitting={{this.isSubmitting}}
@@ -7,9 +8,6 @@
   @save={{this.save}}
   @editSize="large"
 >
-  <:header>
-    Profile
-  </:header>
   <:default>
     Lorem ipsum dolor sit amet consectetur adipisicing elit. Tenetur itaque asperiores distinctio aut delectus, culpa voluptatibus corrupti, sint veritatis quo molestias libero assumenda magni ullam facilis in aliquam earum. Illo, pariatur animi? Quaerat, exercitationem quas nam explicabo quis asperiores repudiandae eos reiciendis libero, unde repellat consequuntur tenetur quasi inventore sunt praesentium provident itaque sit. Culpa soluta tenetur eveniet quisquam sapiente molestias labore minima nesciunt, corrupti minus quidem quia ut! Libero minus quae, quia autem molestiae nisi, impedit, laudantium voluptatum nam adipisci architecto accusamus. Ut harum rerum ipsam quibusdam consequatur sit eos, repudiandae vel eligendi magni repellendus itaque dolorem eaque molestiae!
   </:default>

--- a/packages/web-client/app/components/card-space/user-page/profile-card/index.ts
+++ b/packages/web-client/app/components/card-space/user-page/profile-card/index.ts
@@ -1,0 +1,45 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import CardSpaceUserData from '@cardstack/web-client/services/card-space-user-data';
+
+const CardStates = {
+  DEFAULT: 'default',
+  EDITING: 'editing',
+  SUBMITTING: 'submitting',
+} as const;
+
+export default class UserPageProfileCardComponent extends Component {
+  @service declare cardSpaceUserData: CardSpaceUserData;
+  @tracked state: typeof CardStates[keyof typeof CardStates] =
+    CardStates.DEFAULT;
+
+  get isSubmitting() {
+    return this.state === CardStates.SUBMITTING;
+  }
+
+  get isEditing() {
+    return (
+      this.state === CardStates.EDITING || this.state === CardStates.SUBMITTING
+    );
+  }
+
+  @action onClickEdit() {
+    this.state = CardStates.EDITING;
+  }
+
+  @action async save() {
+    try {
+      this.state = CardStates.SUBMITTING;
+      await new Promise<void>((resolve) => setTimeout(resolve, 1000));
+      this.state = CardStates.DEFAULT;
+    } catch (e) {
+      this.state = CardStates.EDITING;
+    }
+  }
+
+  @action onEndEdit() {
+    this.state = CardStates.DEFAULT;
+  }
+}

--- a/packages/web-client/app/controllers/card-space/index.ts
+++ b/packages/web-client/app/controllers/card-space/index.ts
@@ -1,9 +1,8 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import '../css/card-space.css';
 
-export default class CardSpaceController extends Controller {
+export default class CardSpaceIndexController extends Controller {
   queryParams = ['flow', { workflowPersistenceId: 'flow-id' }];
 
   @tracked flow: string | null = null;

--- a/packages/web-client/app/css/card-space.css
+++ b/packages/web-client/app/css/card-space.css
@@ -30,3 +30,7 @@
 .card-space-create-panel {
   padding: var(--boxel-sp) var(--boxel-sp-xs) var(--boxel-sp-xs);
 }
+
+.card-space-main-content {
+  grid-column: 2/-1;
+}

--- a/packages/web-client/app/css/card-space.css
+++ b/packages/web-client/app/css/card-space.css
@@ -33,4 +33,6 @@
 
 .card-space-main-content {
   grid-column: 2/-1;
+  max-height: 100vh;
+  overflow-y: auto;
 }

--- a/packages/web-client/app/router.ts
+++ b/packages/web-client/app/router.ts
@@ -16,7 +16,6 @@ Router.map(function () {
   this.route('card-space', function () {
     this.route('profile-card-temp');
   });
-  this.route('view-card-space');
   this.route('image-uploader-temp');
   this.route('pay', {
     path: '/pay/:network/:merchant_safe_id',

--- a/packages/web-client/app/routes/application.ts
+++ b/packages/web-client/app/routes/application.ts
@@ -1,5 +1,26 @@
 import Route from '@ember/routing/route';
+import RouterService from '@ember/routing/router-service';
+import { LocationService } from '../services/location';
+import { inject as service } from '@ember/service';
+import config from '@cardstack/web-client/config/environment';
+import '@cardstack/web-client/css/variables.css';
+import '@cardstack/web-client/css/card-space.css';
 
-import '../css/variables.css';
+export default class ApplicationRoute extends Route {
+  @service declare router: RouterService;
+  @service declare location: LocationService;
 
-export default class ApplicationRoute extends Route {}
+  beforeModel() {
+    // if we are on the card space domain, we should not allow
+    // users to visit other routes besides index
+    // some important functionality will be messed up
+    // eg. layer 1 infura calls via WalletConnect
+
+    // NOTE: there is a caveat to this. If the user uses a LinkTo from this page
+    // that leads to, say, card-pay.wallet, this interception will not run
+    // it may be better to create a base class for all routes that has this functionality
+    if (this.location.hostname.endsWith(config.cardSpaceHostnameSuffix)) {
+      this.router.replaceWith('index');
+    }
+  }
+}

--- a/packages/web-client/app/routes/card-space/index.ts
+++ b/packages/web-client/app/routes/card-space/index.ts
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import * as short from 'short-uuid';
 
-export default class CardSpaceRoute extends Route {
+export default class CardSpaceIndexRoute extends Route {
   queryParams = {
     flow: {
       refreshModel: true,

--- a/packages/web-client/app/routes/index.ts
+++ b/packages/web-client/app/routes/index.ts
@@ -20,7 +20,7 @@ import CardPayHor from '@cardstack/web-client/images/illustrations/card-pay-illu
 import CardCatalogHor from '@cardstack/web-client/images/illustrations/card-catalog-illustration-horizontal.svg';
 import CardMembershipHor from '@cardstack/web-client/images/illustrations/card-membership-illustration-horizontal.svg';
 
-import '../css/cardstack-landing-page.css';
+import '@cardstack/web-client/css/cardstack-landing-page.css';
 
 import ENV from '../config/environment';
 const { enableCardSpace, enableCardPay } = ENV.features;
@@ -132,7 +132,13 @@ export default class CardstackRoute extends Route {
         ''
       );
 
-      this.render('view-card-space', { model: { displayName } });
+      this.render('card-space', {
+        into: 'application',
+      });
+      this.render('view-card-space', {
+        into: 'card-space',
+        model: { displayName },
+      });
     } else {
       super.renderTemplate(controller, null);
     }

--- a/packages/web-client/app/services/card-space-user-data.ts
+++ b/packages/web-client/app/services/card-space-user-data.ts
@@ -47,7 +47,7 @@ export default class CardSpaceUserData extends Service {
     merchantId: '2acmichael',
   };
 
-  async post(data: any) {
+  async put(data: any) {
     console.log('sending data', data);
     await new Promise<void>((resolve) => setTimeout(resolve, 1000));
     for (let key in data) {

--- a/packages/web-client/app/services/card-space-user-data.ts
+++ b/packages/web-client/app/services/card-space-user-data.ts
@@ -1,6 +1,29 @@
 import Service from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
+export interface ICardSpaceUserData {
+  currentUserData: {
+    id: string;
+    url?: string;
+    profileName?: string;
+    profileDescription?: string;
+    profileCategory?: string;
+    profileButtonText?: string;
+    profileImageUrl?: string;
+    profileCoverImageUrl?: string;
+    bioTitle?: string;
+    bioDescription?: string;
+    links?: any[];
+    donationTitle?: string;
+    donationDescription?: string;
+    donationSuggestionAmount1?: number;
+    donationSuggestionAmount2?: number;
+    donationSuggestionAmount3?: number;
+    donationSuggestionAmount4?: number;
+    ownerAddress?: string;
+    merchantId?: string;
+  };
+}
 export default class CardSpaceUserData extends Service {
   @tracked currentUserData = {
     id: 'id',

--- a/packages/web-client/app/services/card-space-user-data.ts
+++ b/packages/web-client/app/services/card-space-user-data.ts
@@ -1,0 +1,44 @@
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class CardSpaceUserData extends Service {
+  @tracked currentUserData = {
+    id: 'id',
+    url: '2acmichael.card.space',
+    profileName: 'profileName',
+    profileDescription: 'profileDescription',
+    profileCategory: 'profileCategory',
+    profileButtonText: 'profileButtonText',
+    profileImageUrl: '',
+    profileCoverImageUrl: '',
+    bioTitle: 'bioTitle',
+    bioDescription: 'bioDescription',
+    links: [],
+    donationTitle: 'donationTitle',
+    donationDescription: 'donationDescription',
+    donationSuggestionAmount1: 100,
+    donationSuggestionAmount2: 200,
+    donationSuggestionAmount3: 300,
+    donationSuggestionAmount4: 400,
+    ownerAddress: 'ownerAddress',
+    merchantId: '2acmichael',
+  };
+
+  async post(data: any) {
+    console.log('sending data', data);
+    await new Promise<void>((resolve) => setTimeout(resolve, 1000));
+    for (let key in data) {
+      // @ts-ignore
+      this.currentUserData[key] = data[key];
+      // eslint-disable-next-line no-self-assign
+      this.currentUserData = this.currentUserData;
+    }
+  }
+}
+
+// DO NOT DELETE: this is how TypeScript knows how to look up your services.
+declare module '@ember/service' {
+  interface Registry {
+    'card-space-user-data': CardSpaceUserData;
+  }
+}

--- a/packages/web-client/app/services/location.ts
+++ b/packages/web-client/app/services/location.ts
@@ -9,7 +9,7 @@ export interface LocationService {
  */
 export default class Location extends Service implements LocationService {
   get hostname() {
-    return window.location.hostname;
+    return 'no.pouty.pizza';
   }
 }
 

--- a/packages/web-client/app/templates/card-space.hbs
+++ b/packages/web-client/app/templates/card-space.hbs
@@ -5,30 +5,5 @@
     class="card-space-left-edge"
     @home={{hash icon="cardstack-logo" action=this.transitionHome width="33px" height="35px"}}
   />
-  <div class="card-space-category-nav">
-    <h1 class="card-space-category-nav__title">Card Space</h1>
-  </div>
-  <section class="card-space-gallery">
-    <div class="card-space-create-panel">
-      <Boxel::Button
-        {{on "click" (fn this.transitionToWorkflow "create-space")}}
-        @kind="primary"
-        data-test-workflow-button="create-space"
-      >
-        Create Space
-      </Boxel::Button>
-
-      {{outlet}}
-    </div>
-  </section>
-
-  <Boxel::Modal
-    @size="large"
-    @isOpen={{eq this.flow "create-space"}}
-    @onClose={{this.resetQueryParams}}
-  >
-    {{#if (is-network-initialized)}}
-      <CardSpace::CreateSpaceWorkflow @onClose={{this.resetQueryParams}} />
-    {{/if}}
-  </Boxel::Modal>
+    {{outlet}}
 </main>

--- a/packages/web-client/app/templates/card-space/index.hbs
+++ b/packages/web-client/app/templates/card-space/index.hbs
@@ -1,0 +1,25 @@
+<div class="card-space-category-nav">
+    <h1 class="card-space-category-nav__title">Card Space</h1>
+  </div>
+  <section class="card-space-gallery">
+    <div class="card-space-create-panel">
+      <Boxel::Button
+        {{on "click" (fn this.transitionToWorkflow "create-space")}}
+        @kind="primary"
+        data-test-workflow-button="create-space"
+      >
+        Create Space
+      </Boxel::Button>
+
+    </div>
+  </section>
+
+  <Boxel::Modal
+    @size="large"
+    @isOpen={{eq this.flow "create-space"}}
+    @onClose={{this.resetQueryParams}}
+  >
+    {{#if (is-network-initialized)}}
+      <CardSpace::CreateSpaceWorkflow @onClose={{this.resetQueryParams}} />
+    {{/if}}
+  </Boxel::Modal>

--- a/packages/web-client/app/templates/view-card-space.hbs
+++ b/packages/web-client/app/templates/view-card-space.hbs
@@ -1,4 +1,3 @@
-TODO: Card Space user space for
-<span data-test-card-space-display-name>
-  {{@model.displayName}}
-</span>
+<CardSpace::UserPage
+  class="card-space-main-content"
+/>

--- a/packages/web-client/app/utils/json-api.ts
+++ b/packages/web-client/app/utils/json-api.ts
@@ -1,0 +1,57 @@
+import { camelize } from '@ember/string';
+
+export function processJsonApiErrors(errors: any[]) {
+  let nonValidationErrors = getNonAttributeValidationErrors(errors);
+  let validations = getAttributeValidationErrorsByProperty(errors);
+  return {
+    validations,
+    nonValidationErrors,
+  };
+}
+
+function getNonAttributeValidationErrors(errors: any[]) {
+  return errors.filter((e) => !isAttributeValidationError(e));
+}
+
+function getAttributeValidationErrorsByProperty(errors: any[]) {
+  let attributeValidationErrors = errors.filter((e) =>
+    isAttributeValidationError(e)
+  );
+  let result: Record<string, [string]> = {};
+  for (let attributeValidationError of attributeValidationErrors) {
+    let path = pathForAttributeValidationError(
+      attributeValidationError
+    ) as string;
+    let message = messageForError(attributeValidationError);
+    result[path] = result[path] ?? [];
+    result[path].push(message);
+  }
+  return result;
+}
+
+function isAttributeValidationError(error: {
+  status: string;
+  source?: { pointer?: string };
+}): error is { status: string; source: { pointer: string } } {
+  return error.status === '422' && typeof error.source?.pointer === 'string';
+}
+
+function messageForError(error: { title: string; detail?: string }) {
+  return error.detail ?? error.title;
+}
+
+function pathForAttributeValidationError(error: {
+  source?: {
+    pointer?: string;
+  };
+}) {
+  if (!error.source?.pointer) {
+    return null;
+  }
+
+  return error.source.pointer
+    .split('/')
+    .slice(3)
+    .map((str) => camelize(str))
+    .join('.');
+}

--- a/packages/web-client/tests/acceptance/visit-card-space-test.ts
+++ b/packages/web-client/tests/acceptance/visit-card-space-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { visit } from '@ember/test-helpers';
+import { currentURL, visit } from '@ember/test-helpers';
 import config from '@cardstack/web-client/config/environment';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { LocationService } from '@cardstack/web-client/services/location';
@@ -27,5 +27,14 @@ module('Acceptance | visit card space', function (hooks) {
       .hasText('displayNametodo');
 
     await percySnapshot(assert);
+  });
+
+  test('redirects from other links', async function (assert) {
+    await visit('/card-pay/wallet');
+
+    assert.equal(currentURL(), '/');
+    assert
+      .dom('[data-test-card-space-display-name]')
+      .hasText('displayNametodo');
   });
 });

--- a/packages/web-client/tests/integration/components/card-space/user-page/index-test.ts
+++ b/packages/web-client/tests/integration/components/card-space/user-page/index-test.ts
@@ -1,0 +1,120 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { setupHubAuthenticationToken } from '@cardstack/web-client/tests/helpers/setup';
+import { ICardSpaceUserData } from '@cardstack/web-client/services/card-space-user-data';
+import Service from '@ember/service';
+import {
+  createDepotSafe,
+  createSafeToken,
+} from '@cardstack/web-client/utils/test-factories';
+import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
+
+const layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
+class MockCardSpaceUserData extends Service implements ICardSpaceUserData {
+  currentUserData = {
+    id: 'id',
+    url: '2acmichael.card.space',
+    profileName: 'profileName',
+    profileDescription: 'profileDescription',
+    profileCategory: 'profileCategory',
+    profileButtonText: 'profileButtonText',
+    profileImageUrl: '',
+    profileCoverImageUrl: '',
+    bioTitle: 'bioTitle',
+    bioDescription: 'bioDescription',
+    links: [],
+    donationTitle: 'donationTitle',
+    donationDescription: 'donationDescription',
+    donationSuggestionAmount1: 100,
+    donationSuggestionAmount2: 200,
+    donationSuggestionAmount3: 300,
+    donationSuggestionAmount4: 400,
+    ownerAddress: layer2AccountAddress,
+    merchantId: '2acmichael',
+  };
+}
+
+module.only('Integration | Component | user-page', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.register('service:card-space-user-data', MockCardSpaceUserData);
+  });
+
+  test('it renders a Card Space user page for a non-owner', async function (assert) {
+    await render(hbs`
+      <CardSpace::UserPage/>
+    `);
+
+    assert.dom('[data-test-card-space-toggle-view-button]').doesNotExist();
+    assert.dom('[data-test-card-space-card-container]').exists({ count: 4 });
+    assert.dom('[data-test-card-space-layout-card-container]').exists();
+    assert
+      .dom('[data-test-card-space-card-container][data-test-editable]')
+      .doesNotExist();
+    assert
+      .dom('[data-test-card-space-layout-card-container][data-test-editable]')
+      .doesNotExist();
+  });
+
+  test('it contains an element with id card-space-image-editor', async function (assert) {
+    await render(hbs`
+      <CardSpace::UserPage/>
+    `);
+    assert.dom('#card-space-user-page-image-editor').exists({ count: 1 });
+  });
+
+  module('viewing as theowner', function (hooks) {
+    setupHubAuthenticationToken(hooks);
+
+    test('it allows toggling a Card Space user page to edit mode when viewed as the owner', async function (assert) {
+      let layer2Service = this.owner.lookup('service:layer2-network')
+        .strategy as Layer2TestWeb3Strategy;
+      layer2Service.test__simulateRemoteAccountSafes(layer2AccountAddress, [
+        createDepotSafe({
+          owners: [layer2AccountAddress],
+          tokens: [createSafeToken('DAI.CPXD', '0')],
+        }),
+      ]);
+      await layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
+
+      await render(hbs`
+        <CardSpace::UserPage/>
+      `);
+
+      assert.dom('[data-test-card-space-card-container]').exists({ count: 4 });
+      assert.dom('[data-test-card-space-layout-card-container]').exists();
+      assert
+        .dom('[data-test-card-space-card-container][data-test-editable]')
+        .doesNotExist();
+      assert
+        .dom('[data-test-card-space-layout-card-container][data-test-editable]')
+        .doesNotExist();
+      assert
+        .dom('[data-test-card-space-toggle-view-button]')
+        .containsText('Enter Edit Mode');
+
+      await click('[data-test-card-space-toggle-view-button]');
+
+      assert
+        .dom('[data-test-card-space-toggle-view-button]')
+        .containsText('Enter Preview Mode');
+      assert
+        .dom('[data-test-card-space-card-container][data-test-editable]')
+        .exists({ count: 4 });
+      assert
+        .dom('[data-test-card-space-layout-card-container][data-test-editable]')
+        .exists();
+      assert
+        .dom('[data-test-card-space-card-container]:not([data-test-editable])')
+        .doesNotExist();
+      assert
+        .dom(
+          '[data-test-card-space-layout-card-container]:not([data-test-editable])'
+        )
+        .doesNotExist();
+    });
+  });
+});


### PR DESCRIPTION
This PR will be split up + tests added before being ready for review. 
- layout for user page with 
- adds cards for background, bio, links, and donations
- adds a placeholder card for profile

TODO (after splitting this PR up):
- clientside validations for some cards
- tweak styles
- replace the mock card space user data service with a real one
- add a loading state for the card spacee user data service (should it be a resource?)