### PR TITLE
web: Fix missed supportURL conversion

### DIFF
--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.hbs
@@ -72,7 +72,7 @@
         {{else if (eq this.error.message "USER_REJECTION")}}
           It looks like you have canceled the request in your wallet. Please try again if you want to continue with this workflow.
         {{else}}
-          There was a problem creating your business account. This may be due to a network issue, or perhaps you canceled the request in your wallet. Please try again if you want to continue with this workflow, or contact <a href={{supportURL}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
+          There was a problem creating your business account. This may be due to a network issue, or perhaps you canceled the request in your wallet. Please try again if you want to continue with this workflow, or contact <a href={{mailToSupportUrl}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
         {{/if}}
       </CardPay::ErrorMessage>
     {{/if}}


### PR DESCRIPTION
This should have been in #2658, but also this CI error should
have failed the build! I’ll examine that separately:
https://github.com/cardstack/cardstack/runs/5059503542?check_suite_focus=true#step:6:44