### PR TITLE
ci: Fix Hub bot tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:boxel": "cd packages/boxel && ember test",
     "test:boxel:percy": "cd packages/boxel && percy exec -- ember test",
     "test:boxel:try": "cd packages/boxel && ember try:one",
-    "test:hub": "NODE_ENV=test yarn --cwd packages/hub test",
+    "test:hub": "NODE_ENV=test cd packages/hub && yarn test",
     "test:did-resolver": "yarn --cwd packages/did-resolver test",
     "test:discord-bot": "yarn --cwd packages/discord-bot test",
     "test:web-client": "cd packages/web-client && ember test",


### PR DESCRIPTION
Bot tests are [failing](https://github.com/cardstack/cardstack/runs/5095392991?check_suite_focus=true#step:9:745) using `--cwd` instead of prefixing
with the equivalent `cd`. It looks like possibly a problem
loading environment variables from .env, as described [here](https://old.reddit.com/r/node/comments/fnws1p/what_is_yarn_cwd/).

It doesn’t seem worth trying to understand what the problem
is vs just switching back to using `cd`.