### PR TITLE
Fixes #CS-3085 add support for creating a local card with presupplied ID

### DIFF
--- a/packages/cardhost/app/components/card-container/index.hbs
+++ b/packages/cardhost/app/components/card-container/index.hbs
@@ -6,8 +6,8 @@
     <:actions>
       {{#if @editable}}
         <button data-test-edit-button {{on 'click' (perform this.modal.editCardTask @card)}}>Edit</button>
-        <button data-test-new-button-server {{on 'click' (perform this.modal.newCardTask @card this.REALM)}}>New (Server)</button>
-        <button data-test-new-button-local {{on 'click' (perform this.modal.newCardTask @card this.LOCAL_REALM)}}>New (Local)</button>
+        <button data-test-new-button-server {{on 'click' (perform this.modal.newCardTask @card this.REALM false)}}>New (Server)</button>
+        <button data-test-new-button-local {{on 'click' (perform this.modal.newCardTask @card this.LOCAL_REALM false)}}>New (Local)</button>
         <button data-test-new-button-with-id {{on 'click' (perform this.modal.newCardTask @card this.LOCAL_REALM true)}}>New (with ID)</button>
       {{/if}}
       {{yield to="actions"}}

--- a/packages/cardhost/app/components/card-container/index.hbs
+++ b/packages/cardhost/app/components/card-container/index.hbs
@@ -8,6 +8,7 @@
         <button data-test-edit-button {{on 'click' (perform this.modal.editCardTask @card)}}>Edit</button>
         <button data-test-new-button-server {{on 'click' (perform this.modal.newCardTask @card this.REALM)}}>New (Server)</button>
         <button data-test-new-button-local {{on 'click' (perform this.modal.newCardTask @card this.LOCAL_REALM)}}>New (Local)</button>
+        <button data-test-new-button-with-id {{on 'click' (perform this.modal.newCardTask @card this.LOCAL_REALM true)}}>New (with ID)</button>
       {{/if}}
       {{yield to="actions"}}
     </:actions>

--- a/packages/cardhost/app/lib/builder.ts
+++ b/packages/cardhost/app/lib/builder.ts
@@ -18,7 +18,6 @@ import { RawCardDeserializer } from '@cardstack/core/src/serializers';
 import { fetchJSON } from './jsonapi-fetch';
 import config from 'cardhost/config/environment';
 import {
-  baseCardURL,
   Compiler,
   makeGloballyAddressable,
 } from '@cardstack/core/src/compiler';

--- a/packages/cardhost/app/lib/builder.ts
+++ b/packages/cardhost/app/lib/builder.ts
@@ -18,6 +18,7 @@ import { RawCardDeserializer } from '@cardstack/core/src/serializers';
 import { fetchJSON } from './jsonapi-fetch';
 import config from 'cardhost/config/environment';
 import {
+  baseCardURL,
   Compiler,
   makeGloballyAddressable,
 } from '@cardstack/core/src/compiler';
@@ -88,7 +89,7 @@ export default class LocalRealm implements Builder {
   async loadData(url: string, format: Format): Promise<CardModel> {
     let { compiled, raw } = await this.load(url);
 
-    let componentModule = await this.loadModule<CardComponentModule>(
+    let componentModule = await this.cards.loadModule<CardComponentModule>(
       compiled.componentInfos[format].moduleName.global
     );
 
@@ -326,10 +327,7 @@ export default class LocalRealm implements Builder {
   async loadModule<T extends object>(moduleIdentifier: string): Promise<T> {
     let module = this.localModules.get(moduleIdentifier);
     if (!module) {
-      // in the scenario where you are adopting a remote card into the local
-      // realm, the local modules won't exist yet. in that case fallback to
-      // loading the modules remotely
-      return await this.cards.loadModule(moduleIdentifier);
+      throw new Error(`missing local module ${moduleIdentifier}`);
     }
     switch (module.state) {
       case 'preparing':

--- a/packages/cardhost/app/lib/builder.ts
+++ b/packages/cardhost/app/lib/builder.ts
@@ -214,7 +214,9 @@ export default class LocalRealm implements Builder {
   ): Promise<JSONAPIDocument> {
     assertDocumentDataIsResource(resource);
     let data = resource.attributes;
-    let id = this.generateId();
+    let id = resource.id
+      ? this.parseOwnRealmURL(resource.id)!.id
+      : this.generateId();
     this.createRawCard({
       realm: this.realmURL,
       id,

--- a/packages/cardhost/app/lib/builder.ts
+++ b/packages/cardhost/app/lib/builder.ts
@@ -326,7 +326,10 @@ export default class LocalRealm implements Builder {
   async loadModule<T extends object>(moduleIdentifier: string): Promise<T> {
     let module = this.localModules.get(moduleIdentifier);
     if (!module) {
-      throw new Error(`missing local module ${moduleIdentifier}`);
+      // in the scenario where you are adopting a remote card into the local
+      // realm, the local modules won't exist yet. in that case fallback to
+      // loading the modules remotely
+      return await this.cards.loadModule(moduleIdentifier);
     }
     switch (module.state) {
       case 'preparing':

--- a/packages/cardhost/app/lib/card-model-for-browser.ts
+++ b/packages/cardhost/app/lib/card-model-for-browser.ts
@@ -95,6 +95,11 @@ export default class CardModelForBrowser implements CardModel {
     if (this.state.type !== 'loaded') {
       throw new Error(`tried to adopt from an unsaved card`);
     }
+    let builder = await this.cards.builder();
+    let localRealm;
+    if (realm === builder.realmURL) {
+      localRealm = builder;
+    }
     return new (this.constructor as typeof CardModelForBrowser)(
       this.cards,
       {
@@ -105,7 +110,7 @@ export default class CardModelForBrowser implements CardModel {
         schemaModuleId: this.state.schemaModuleId,
         format: this.state.format,
       },
-      this.localRealm
+      localRealm ?? this.localRealm
     );
   }
 

--- a/packages/cardhost/app/lib/card-model-for-browser.ts
+++ b/packages/cardhost/app/lib/card-model-for-browser.ts
@@ -213,18 +213,10 @@ export default class CardModelForBrowser implements CardModel {
       return this._schemaInstance;
     }
     let SchemaClass = (
-      await this.loadModule<CardSchemaModule>(this.state.schemaModuleId)
+      await this.cards.loadModule<CardSchemaModule>(this.state.schemaModuleId)
     ).default;
     this._schemaInstance = new SchemaClass(this.getRawField.bind(this));
     return this._schemaInstance;
-  }
-
-  private async loadModule<T extends Object>(moduleId: string): Promise<T> {
-    if (this.localRealm) {
-      return await this.localRealm.loadModule<T>(moduleId);
-    } else {
-      return await this.cards.loadModule<T>(moduleId);
-    }
   }
 
   private makeSetter(segments: string[] = []): Setter {

--- a/packages/cardhost/app/lib/card-model-for-browser.ts
+++ b/packages/cardhost/app/lib/card-model-for-browser.ts
@@ -96,12 +96,12 @@ export default class CardModelForBrowser implements CardModel {
     if (this.state.type !== 'loaded') {
       throw new Error(`tried to adopt from an unsaved card`);
     }
-    let localRealm;
-    if (this.localRealm) {
-      localRealm = this.localRealm;
-    } else if (LOCAL_REALM && !this.localRealm) {
-      localRealm = await this.cards.builder();
+
+    let localRealm: LocalRealm | undefined;
+    if (realm === LOCAL_REALM) {
+      localRealm = this.localRealm ?? (await this.cards.builder());
     }
+
     return new (this.constructor as typeof CardModelForBrowser)(
       this.cards,
       {
@@ -113,7 +113,7 @@ export default class CardModelForBrowser implements CardModel {
         schemaModuleId: this.state.schemaModuleId,
         format: this.state.format,
       },
-      localRealm ?? this.localRealm
+      localRealm
     );
   }
 

--- a/packages/cardhost/app/services/modal.ts
+++ b/packages/cardhost/app/services/modal.ts
@@ -66,7 +66,7 @@ export default class Modal extends Service {
   @task async newCardTask(
     parentCard: CardModel,
     realm: string,
-    withId = false
+    withId: boolean
   ) {
     // this is a contrived example for our tests meant to demonstrate that an ID
     // can be supplied to a new card

--- a/packages/cardhost/app/services/modal.ts
+++ b/packages/cardhost/app/services/modal.ts
@@ -63,10 +63,20 @@ export default class Modal extends Service {
     };
   }
 
-  @task async newCardTask(parentCard: CardModel, realm: string) {
+  @task async newCardTask(
+    parentCard: CardModel,
+    realm: string,
+    withId = false
+  ) {
+    // this is a contrived example for our tests meant to demonstrate that an ID
+    // can be supplied to a new card
+    let id = withId
+      ? `CUSTOM_ID_${Math.floor(Math.random() * 1000000)}`
+      : undefined;
+
     this.state = { name: 'loading' };
     let editableParent = await parentCard.editable();
-    let loadedCard = await editableParent.adoptIntoRealm(realm);
+    let loadedCard = await editableParent.adoptIntoRealm(realm, id);
     this.state = {
       name: 'loaded',
       loadedCard,

--- a/packages/cardhost/tests/acceptance/card-create-test.ts
+++ b/packages/cardhost/tests/acceptance/card-create-test.ts
@@ -62,6 +62,8 @@ module('Acceptance | Card Creation', function (hooks) {
       );
   });
 
+  // TODO we need a mechanism to create cards on the server. I think probably
+  // that means that the /sources/new API endpoint needs to be implemented
   skip('Creating a local card from a remote card');
 
   test('Creating a card with an ID', async function (assert) {

--- a/packages/cardhost/tests/acceptance/card-create-test.ts
+++ b/packages/cardhost/tests/acceptance/card-create-test.ts
@@ -70,13 +70,11 @@ module('Acceptance | Card Creation', function (hooks) {
     await visit(`/?url=${personURL}`);
     assert.equal(currentURL(), `/?url=${personURL}`);
     await waitFor(PERSON);
-    assert.dom(PERSON).hasText('Hi! I am Arthur');
 
     await click(NEW_WITH_ID);
     assert.dom(MODAL).exists('The modal is opened');
     await waitFor('[data-test-field-name="name"]');
     await fillIn('[data-test-field-name="name"]', 'Bob Barker');
-    await fillIn('[data-test-field-name="city"]', 'San Francisco');
     await click(SAVE);
     await waitFor(PERSON);
     assert.includes(

--- a/packages/cardhost/tests/acceptance/card-create-test.ts
+++ b/packages/cardhost/tests/acceptance/card-create-test.ts
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, skip, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupCardTest } from '../helpers/setup';
 
@@ -15,6 +15,7 @@ import { cardURL } from '@cardstack/core/src/utils';
 const PERSON = '[data-test-person]';
 const MODAL = '[data-test-modal]';
 const NEW = '[data-test-new-button-local]';
+const NEW_WITH_ID = '[data-test-new-button-with-id]';
 const SAVE = '[data-test-modal-save]';
 
 module('Acceptance | Card Creation', function (hooks) {
@@ -39,7 +40,7 @@ module('Acceptance | Card Creation', function (hooks) {
     );
   });
 
-  test('Creating a card', async function (assert) {
+  test('Creating a local card from a local card', async function (assert) {
     await visit(`/?url=${personURL}`);
     assert.equal(currentURL(), `/?url=${personURL}`);
     await waitFor(PERSON);
@@ -59,5 +60,27 @@ module('Acceptance | Card Creation', function (hooks) {
         'Hi! I am Bob Barker',
         'The original instance of the card is updated'
       );
+  });
+
+  skip('Creating a local card from a remote card');
+
+  test('Creating a card with an ID', async function (assert) {
+    await visit(`/?url=${personURL}`);
+    assert.equal(currentURL(), `/?url=${personURL}`);
+    await waitFor(PERSON);
+    assert.dom(PERSON).hasText('Hi! I am Arthur');
+
+    await click(NEW_WITH_ID);
+    assert.dom(MODAL).exists('The modal is opened');
+    await waitFor('[data-test-field-name="name"]');
+    await fillIn('[data-test-field-name="name"]', 'Bob Barker');
+    await fillIn('[data-test-field-name="city"]', 'San Francisco');
+    await click(SAVE);
+    await waitFor(PERSON);
+    assert.includes(
+      currentURL(),
+      'CUSTOM_ID',
+      'The card is created with a pre-supplied ID'
+    );
   });
 });

--- a/packages/hub/lib/card-model-for-hub.ts
+++ b/packages/hub/lib/card-model-for-hub.ts
@@ -184,11 +184,12 @@ export default class CardModelForHub implements CardModel {
     if (this.state.type === 'created') {
       return serializeResource('card', undefined, serializeAttributes(this.data, this.serializerMap), this.usedFields);
     }
-    let { usedFields, componentModule } = this.state;
+    let { usedFields, componentModule, schemaModule } = this.state;
     let resource = serializeResource('card', this.url, serializeAttributes(this.data, this.serializerMap), usedFields);
     resource.meta = merge(
       {
         componentModule,
+        schemaModule,
       },
       resource.meta
     );


### PR DESCRIPTION
Also fixed the issue where we are not able to load modules when you create a card in the local realm from a card in the remote realm: all module leading needs to go thru the card service which knows how to load modules from the right place. Sadly this is not testable, because we cant create cards on the server from our cardhost tests--but you can see this when playing with the demo app.