### PR TITLE
Fixes #CS-3097 issue with babel CJS class private property not working with child classes

### DIFF
--- a/packages/core/src/utils/babel.ts
+++ b/packages/core/src/utils/babel.ts
@@ -47,6 +47,19 @@ export function addImports(neededImports: ImportDetails, path: NodePath<t.Progra
   }
 }
 
+export function unusedClassMember(path: NodePath<t.Class>, nameLike: string, t: typeof Babel.types): string {
+  let i = 0;
+  let classMemberNames = path
+    .get('body')
+    .get('body')
+    .filter((p) => (t.isClassMethod(p.node) || t.isClassProperty(p.node)) && t.isIdentifier(p.node.key))
+    .map((p) => ((p.node as t.ClassMethod | t.ClassProperty).key as t.Identifier).name);
+  while (classMemberNames.includes(nameLike)) {
+    nameLike = `${nameLike}${i++}`;
+  }
+  return nameLike;
+}
+
 class CompilerError extends Error {
   constructor(message: string) {
     super(message);

--- a/packages/hub/node-tests/@core/compiler-test.ts
+++ b/packages/hub/node-tests/@core/compiler-test.ts
@@ -407,6 +407,7 @@ if (process.env.COMPILER) {
             import date from "https://cardstack.com/base/date";
 
             export default class Bio {
+              getRawField = "don't collide!";
               @contains(date) birthdate;
             }
           `,
@@ -476,10 +477,10 @@ if (process.env.COMPILER) {
         // the browser source has a lot less babel shenanigans
         let source = getFileCache().getModule(compiled.schemaModule.global, 'browser');
         expect(source).to.containsSource(`
-          #getRawField;
+          getRawField0;
 
           constructor(get) {
-            this.#getRawField = get;
+            this.getRawField0 = get;
           }
         `);
       });
@@ -524,7 +525,7 @@ if (process.env.COMPILER) {
         `);
         expect(source).to.containsSource(`
           get birthdate() {
-            return new FieldGetter(this.#getRawField, "birthdate");
+            return new FieldGetter(this.getRawField0, "birthdate");
           }
         `);
       });
@@ -539,7 +540,7 @@ if (process.env.COMPILER) {
         `);
         expect(source).to.containsSource(`
           get aboutMe() {
-            return new BioClass(innerField => this.#getRawField("aboutMe." + innerField));
+            return new BioClass(innerField => this.getRawField("aboutMe." + innerField));
           }
         `);
       });
@@ -570,11 +571,11 @@ if (process.env.COMPILER) {
         let { compiled } = await cards.load(`${realm}really-fancy-person`);
         let source = getFileCache().getModule(compiled.schemaModule.global, 'browser');
         expect(source).to.containsSource(`
-          #getRawField;
+          getRawField;
 
           constructor(get) {
             super(get);
-            this.#getRawField = get;
+            this.getRawField = get;
           }
         `);
       });

--- a/packages/hub/node-tests/@core/computed-test.ts
+++ b/packages/hub/node-tests/@core/computed-test.ts
@@ -17,7 +17,6 @@ if (process.env.COMPILER) {
             import string from "https://cardstack.com/base/string";
 
             export default class Bio {
-              getRawField = "don't collide!";
               @contains(string) short;
               @contains(string) favoriteColor;
             }
@@ -35,6 +34,7 @@ if (process.env.COMPILER) {
             import string from "https://cardstack.com/base/string";
             import bio from "../bio";
             export default class Person {
+              getRawField = "don't collide!";
               @contains(string) firstName;
               @contains(string) lastName;
 
@@ -114,7 +114,7 @@ if (process.env.COMPILER) {
         data: {
           firstName: 'Ains Ooal',
           lastName: 'Gown',
-          seriesName: 'Overload',
+          seriesName: 'Overlord',
           aboutMe: {
             short: 'Supreme overload of darkness',
             favoriteColor: 'black',
@@ -123,6 +123,7 @@ if (process.env.COMPILER) {
       });
       let card = await cards.loadData(`${realm}ains`, 'isolated');
       expect(await card.getField('fullName')).to.equal('Ains Ooal Gown');
+      expect(await card.getField('seriesName')).to.equal('Overlord');
     });
 
     // we can use the field meta short cut here to just return raw data without

--- a/packages/hub/node-tests/@core/computed-test.ts
+++ b/packages/hub/node-tests/@core/computed-test.ts
@@ -17,6 +17,7 @@ if (process.env.COMPILER) {
             import string from "https://cardstack.com/base/string";
 
             export default class Bio {
+              getRawField = "don't collide!";
               @contains(string) short;
               @contains(string) favoriteColor;
             }
@@ -92,6 +93,36 @@ if (process.env.COMPILER) {
         // are not used by the Person template
         favoriteColor: 'blue',
       });
+    });
+
+    it('can access a computed field defined in parent card', async function () {
+      await cards.create({
+        realm,
+        id: 'ains',
+        adoptsFrom: '../person',
+        schema: 'schema.js',
+        files: {
+          'schema.js': `
+            import { adopts, contains } from "@cardstack/types";
+            import string from "https://cardstack.com/base/string";
+            import person from "../person";
+            export default @adopts(person) class Isekai {
+              @contains(string) seriesName;
+            }
+          `,
+        },
+        data: {
+          firstName: 'Ains Ooal',
+          lastName: 'Gown',
+          seriesName: 'Overload',
+          aboutMe: {
+            short: 'Supreme overload of darkness',
+            favoriteColor: 'black',
+          },
+        },
+      });
+      let card = await cards.loadData(`${realm}ains`, 'isolated');
+      expect(await card.getField('fullName')).to.equal('Ains Ooal Gown');
     });
 
     // we can use the field meta short cut here to just return raw data without


### PR DESCRIPTION
This was a really fascinating bug. The issue came down the to the code that babel transpiles into CJS for class private properties. Specifically, when a class extends another class, babel would omit the call to set the weak map that babel internally uses for the private properties, hence the error reported in this bug which occurs when there is no value for the weak map. The fix was to just jettison private properties and use just normal class properties. To respect the namespace of the schema class members (which is userland code), we'll pick an unused class property if there is a collision.