### PR TITLE
Use >= 0.1 subgraph extractor, add rewards data

### DIFF
--- a/packages/cardpay-subgraph-extraction/config/prepaid_card_payments.yaml
+++ b/packages/cardpay-subgraph-extraction/config/prepaid_card_payments.yaml
@@ -21,12 +21,11 @@ base: &base
             max_value: 18446744073709551615
             type: uint64
             validity_column: timestamp_uint64_valid
-      partition_column: block_number
       partition_sizes:
         - 524288
         - 32768
         - 1024
-  version: 0.0.1
+  version: 0.0.2
 
 staging:
   <<: *base

--- a/packages/cardpay-subgraph-extraction/config/rewards.yaml
+++ b/packages/cardpay-subgraph-extraction/config/rewards.yaml
@@ -1,0 +1,118 @@
+base: &base
+  name: rewards
+  tables:
+    merkle_root_submission:
+      column_mappings:
+        block_number:
+          block_number_uint64:
+            default: 0
+            max_value: 18446744073709551615
+            type: uint64
+            validity_column: block_number_uint64_valid
+        payment_cycle:
+          payment_cycle_uint64:
+            default: 0
+            max_value: 18446744073709551615
+            type: uint64
+            validity_column: payment_cycle_uint64_valid
+        timestamp:
+          timestamp_uint64:
+            default: 0
+            max_value: 18446744073709551615
+            type: uint64
+            validity_column: timestamp_uint64_valid
+      partition_sizes:
+        - 524288
+        - 131072
+        - 16384
+        - 1024
+    reward_program:
+      partition_sizes:
+        - 524288
+        - 131072
+        - 16384
+        - 1024
+    reward_safe:
+      partition_sizes:
+        - 524288
+        - 131072
+        - 16384
+        - 1024
+    reward_tokens_add:
+      column_mappings:
+        amount:
+          amount_uint64:
+            default: 0
+            max_value: 18446744073709551615
+            type: uint64
+            validity_column: amount_uint64_valid
+        block_number:
+          block_number_uint64:
+            default: 0
+            max_value: 18446744073709551615
+            type: uint64
+            validity_column: block_number_uint64_valid
+        timestamp:
+          timestamp_uint64:
+            default: 0
+            max_value: 18446744073709551615
+            type: uint64
+            validity_column: timestamp_uint64_valid
+      partition_sizes:
+        - 524288
+        - 131072
+        - 16384
+        - 1024
+    rewardee_claim:
+      column_mappings:
+        amount:
+          amount_uint64:
+            default: 0
+            max_value: 18446744073709551615
+            type: uint64
+            validity_column: amount_uint64_valid
+        block_number:
+          block_number_uint64:
+            default: 0
+            max_value: 18446744073709551615
+            type: uint64
+            validity_column: block_number_uint64_valid
+        timestamp:
+          timestamp_uint64:
+            default: 0
+            max_value: 18446744073709551615
+            type: uint64
+            validity_column: timestamp_uint64_valid
+      partition_sizes:
+        - 524288
+        - 131072
+        - 16384
+        - 1024
+    rewardee_registration_payment:
+      column_mappings:
+        block_number:
+          block_number_uint64:
+            default: 0
+            max_value: 18446744073709551615
+            type: uint64
+            validity_column: block_number_uint64_valid
+        created_at:
+          created_at_uint64:
+            default: 0
+            max_value: 18446744073709551615
+            type: uint64
+            validity_column: created_at_uint64_valid
+      partition_sizes:
+        - 524288
+        - 131072
+        - 16384
+        - 1024
+  version: 0.0.1
+
+staging:
+  <<: *base
+  subgraph: habdelra/cardpay-sokol
+
+production:
+  <<: *base
+  subgraph: habdelra/cardpay-xdai

--- a/packages/cardpay-subgraph-extraction/export.py
+++ b/packages/cardpay-subgraph-extraction/export.py
@@ -27,9 +27,8 @@ def setup_regular_extraction(config, database_string, output_location):
     # If we find nothing else, assume at least hourly
     min_duration = 3600
     for _table, table_config in config["tables"].items():
-        if table_config["partition_column"] == "block_number":
-            min_partition = min(table_config["partition_sizes"])
-            min_duration = min(min_duration, (min_partition * BLOCK_DURATION) // 2)
+        min_partition = min(table_config["partition_sizes"])
+        min_duration = min(min_duration, (min_partition * BLOCK_DURATION) // 2)
 
     # Don't run more than every 10 seconds
     if min_duration < 10:

--- a/packages/cardpay-subgraph-extraction/requirements.txt
+++ b/packages/cardpay-subgraph-extraction/requirements.txt
@@ -1,4 +1,4 @@
-subgraph_extractor>=0.0.7
+subgraph_extractor>=0.1
 click
 cloudpathlib[s3]
 schedule


### PR DESCRIPTION
This removes the need for partition column specifications (all
are block based now), and supports better information around
what has been extracted so far.

Deployed to staging, working correctly.