### PR TITLE
Added test for unconsumed field imports

### DIFF
--- a/packages/hub/node-tests/@core/compiler-test.ts
+++ b/packages/hub/node-tests/@core/compiler-test.ts
@@ -391,6 +391,47 @@ if (process.env.COMPILER) {
       });
     });
 
+    describe('schema transpile', function () {
+      it('can handle unconsumed field import', async function () {
+        await cards.create({
+          realm,
+          id: 'foo',
+          schema: 'schema.js',
+          files: {
+            'schema.js': `
+              import { contains } from "@cardstack/types";
+              import string from "https://cardstack.com/base/string";
+
+              export default class Foo {
+                @contains(string) bar;
+              }
+            `,
+          },
+        });
+
+        let card = await cards.create({
+          realm,
+          id: 'person',
+          schema: 'schema.js',
+          files: {
+            'schema.js': `
+              import { contains } from "@cardstack/types";
+              import string from "https://cardstack.com/base/string";
+              import date from "https://cardstack.com/base/date";
+              import Foo from "../foo";
+
+              export default class Person {
+                @contains(string) name;
+              }
+            `,
+          },
+        });
+
+        // success is really just not throwing an exception
+        expect(card.compiled.url).to.eq(`${realm}person`);
+      });
+    });
+
     describe('computed fields', function () {
       let fancyDateCard: RawCard = {
         realm,


### PR DESCRIPTION
We saw that previously an unconsumed field import in the schema module would result in a babel transpile error. It looks like our refactors of the schema transpiler have inadvertently fixed this problem. however adding the tests to make sure it stays fixed.