### PR TITLE
hub: Fix subscriptions to not exceed block history

### DIFF
--- a/packages/hub/node-tests/services/contract-subscription-event-handler-test.ts
+++ b/packages/hub/node-tests/services/contract-subscription-event-handler-test.ts
@@ -6,6 +6,7 @@ import waitFor from '../utils/wait-for';
 import Web3 from 'web3';
 
 import { setupHub, registry } from '../helpers/server';
+import { HISTORIC_BLOCKS_AVAILABLE } from '../../services/contract-subscription-event-handler';
 
 const { testkit, sentryTransport } = sentryTestkit();
 
@@ -38,9 +39,19 @@ class StubContracts {
   }
 }
 
+let web3BlockNumber = 1234;
+
 class StubWeb3 {
   getInstance() {
     return this;
+  }
+
+  get eth() {
+    return this;
+  }
+
+  async getBlockNumber() {
+    return Promise.resolve(web3BlockNumber);
   }
 }
 
@@ -79,6 +90,8 @@ describe('ContractSubscriptionEventHandler', function () {
     this.workerClient = (await getContainer().lookup('worker-client')) as unknown as StubWorkerClient;
     this.latestEventBlockQueries = await getContainer().lookup('latest-event-block-queries');
 
+    web3BlockNumber = 1234;
+
     await this.subject.setupContractEventSubscriptions();
   });
 
@@ -94,6 +107,20 @@ describe('ContractSubscriptionEventHandler', function () {
 
     expect(this.contracts.options.CustomerPayment).to.deep.equal({ fromBlock: 1234 });
     expect(this.contracts.options.MerchantClaim).to.deep.equal({ fromBlock: 1234 });
+  });
+
+  it('starts the event listener with the most-recently-available block when the latest block is more than 10000 ahead of the persisted block', async function () {
+    await this.latestEventBlockQueries.update(web3BlockNumber);
+    web3BlockNumber = web3BlockNumber + HISTORIC_BLOCKS_AVAILABLE * 2;
+
+    await this.subject.setupContractEventSubscriptions();
+
+    expect(this.contracts.options.CustomerPayment).to.deep.equal({
+      fromBlock: web3BlockNumber - HISTORIC_BLOCKS_AVAILABLE + 1,
+    });
+    expect(this.contracts.options.MerchantClaim).to.deep.equal({
+      fromBlock: web3BlockNumber - HISTORIC_BLOCKS_AVAILABLE + 1,
+    });
   });
 
   it('handles a CustomerPayment event and persists the latest block', async function () {

--- a/packages/hub/services/contract-subscription-event-handler.ts
+++ b/packages/hub/services/contract-subscription-event-handler.ts
@@ -5,6 +5,8 @@ import { inject } from '@cardstack/di';
 import logger from '@cardstack/logger';
 const log = logger('hub/contract-subscription-event-handler');
 
+export const HISTORIC_BLOCKS_AVAILABLE = 10000;
+
 export const CONTRACT_EVENTS = [
   {
     abiName: 'pay-merchant-handler',
@@ -32,10 +34,13 @@ export class ContractSubscriptionEventHandler {
     let web3Instance = this.web3.getInstance();
 
     let subscriptionOptions = {};
-    let latestBlock = await this.latestEventBlockQueries.read();
+    let subscriptionEventLatestBlock = await this.latestEventBlockQueries.read();
 
-    if (latestBlock) {
-      subscriptionOptions = { fromBlock: latestBlock };
+    if (subscriptionEventLatestBlock) {
+      let latestBlock = await web3Instance.eth.getBlockNumber();
+      let fromBlock = Math.max(latestBlock - HISTORIC_BLOCKS_AVAILABLE + 1, subscriptionEventLatestBlock);
+
+      subscriptionOptions = { fromBlock };
     }
 
     for (let contractEvent of CONTRACT_EVENTS) {


### PR DESCRIPTION
If the value stored in `latest_event_block` is older than
what the node can provide, the contract subscriptions
cannot be instantiated. This updates the subscriptions
`fromBlock` to choose the maximum of either
`latest_event_block` or the current block - 10k + 1.

`HISTORIC_BLOCKS_AVAILABLE` is a hard-coded constant of 10000, but is there a way to determine that programatically, from `web3`, perhaps? @habdelra