### PR TITLE
remove spend from the pay page

### DIFF
--- a/packages/web-client/app/controllers/pay.ts
+++ b/packages/web-client/app/controllers/pay.ts
@@ -13,7 +13,6 @@ import IsIOS from '../services/is-ios';
 import { useResource } from 'ember-resources';
 import { MerchantInfo } from '../resources/merchant-info';
 import config from '@cardstack/web-client/config/environment';
-import { formatAmount } from '../helpers/format-amount';
 import { MIN_PAYMENT_AMOUNT_IN_SPEND__PREFER_ON_CHAIN_WHEN_POSSIBLE as MIN_PAYMENT_AMOUNT_IN_SPEND } from '@cardstack/cardpay-sdk';
 
 const minSpendAmount = MIN_PAYMENT_AMOUNT_IN_SPEND;
@@ -57,11 +56,7 @@ export default class PayController extends Controller {
       return {
         amount,
         displayed: {
-          amount: `§${formatAmount(amount)}`,
-          secondaryAmount: convertAmountToNativeDisplay(
-            spendToUsd(amount)!,
-            'USD'
-          ),
+          amount: convertAmountToNativeDisplay(spendToUsd(amount)!, 'USD'),
         },
       };
     } else if (this.currency === 'USD') {
@@ -73,15 +68,12 @@ export default class PayController extends Controller {
         amount,
         displayed: {
           amount: convertAmountToNativeDisplay(amount, 'USD'),
-          secondaryAmount: `§${formatAmount(
-            convertToSpend(Number(amount), 'USD', 1)!
-          )}`,
         },
       };
     } else {
       let rate = this.model.exchangeRates?.[this.currency];
       let amount: number;
-      let formattedSpendAmount: string | undefined;
+      let usdAmount: string | undefined;
       if (rate) {
         amount = Number(
           roundAmountToNativeCurrencyDecimals(this.amount, this.currency)
@@ -93,19 +85,22 @@ export default class PayController extends Controller {
           spendAmount = convertToSpend(amount, this.currency, rate);
         }
 
-        formattedSpendAmount = `§${formatAmount(spendAmount)}`;
+        usdAmount = convertAmountToNativeDisplay(
+          spendToUsd(spendAmount)!,
+          'USD'
+        );
       } else {
         amount = Number(
           roundAmountToNativeCurrencyDecimals(this.amount, this.currency)
         );
-        formattedSpendAmount = undefined;
+        usdAmount = undefined;
       }
 
       return {
         amount,
         displayed: {
           amount: convertAmountToNativeDisplay(amount, this.currency),
-          secondaryAmount: formattedSpendAmount,
+          secondaryAmount: usdAmount,
         },
       };
     }

--- a/packages/web-client/tests/acceptance/pay-test.ts
+++ b/packages/web-client/tests/acceptance/pay-test.ts
@@ -9,7 +9,6 @@ import { MirageTestContext } from 'ember-cli-mirage/test-support';
 import {
   convertAmountToNativeDisplay,
   convertToSpend,
-  formatCurrencyAmount,
   generateMerchantPaymentUrl,
   roundAmountToNativeCurrencyDecimals,
   spendToUsd,
@@ -144,12 +143,12 @@ module('Acceptance | pay', function (hooks) {
       `/pay/${network}/${merchantSafe.address}?amount=${spendAmount}&currency=${spendSymbol}`
     );
 
-    assert.dom(AMOUNT).containsText(`§${spendAmount}`);
     assert
-      .dom(SECONDARY_AMOUNT)
+      .dom(AMOUNT)
       .containsText(
-        `${convertAmountToNativeDisplay(spendToUsd(spendAmount)!, 'USD')}`
+        convertAmountToNativeDisplay(spendToUsd(spendAmount)!, 'USD')
       );
+    assert.dom(SECONDARY_AMOUNT).doesNotExist();
 
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,
@@ -204,15 +203,12 @@ module('Acceptance | pay', function (hooks) {
       `/pay/${network}/${merchantSafe.address}?amount=${floatingSpendAmount}&currency=${spendSymbol}`
     );
 
-    assert.dom(AMOUNT).containsText(`§${roundedSpendAmount}`);
     assert
-      .dom(SECONDARY_AMOUNT)
+      .dom(AMOUNT)
       .containsText(
-        `${convertAmountToNativeDisplay(
-          spendToUsd(roundedSpendAmount)!,
-          'USD'
-        )}`
+        convertAmountToNativeDisplay(spendToUsd(roundedSpendAmount)!, 'USD')
       );
+    assert.dom(SECONDARY_AMOUNT).doesNotExist();
 
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,
@@ -230,10 +226,11 @@ module('Acceptance | pay', function (hooks) {
       `/pay/${network}/${merchantSafe.address}?amount=${lessThanMinSpendAmount}&currency=${spendSymbol}`
     );
 
-    assert.dom(AMOUNT).containsText(`§${minSpendAmount}`);
     assert
-      .dom(SECONDARY_AMOUNT)
+      .dom(AMOUNT)
       .containsText(convertAmountToNativeDisplay(minUsdAmount, 'USD'));
+    assert.dom(SECONDARY_AMOUNT).doesNotExist();
+
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,
       network,
@@ -251,12 +248,13 @@ module('Acceptance | pay', function (hooks) {
       `/pay/${network}/${merchantSafe.address}?amount=${spendAmount}`
     );
 
-    assert.dom(AMOUNT).containsText(`§${spendAmount}`);
     assert
-      .dom(SECONDARY_AMOUNT)
+      .dom(AMOUNT)
       .containsText(
-        `${convertAmountToNativeDisplay(spendToUsd(spendAmount)!, 'USD')}`
+        convertAmountToNativeDisplay(spendToUsd(spendAmount)!, 'USD')
       );
+    assert.dom(SECONDARY_AMOUNT).doesNotExist();
+
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,
       network,
@@ -276,9 +274,10 @@ module('Acceptance | pay', function (hooks) {
     assert
       .dom(AMOUNT)
       .containsText(
-        `${convertAmountToNativeDisplay(spendToUsd(spendAmount)!, 'USD')}`
+        convertAmountToNativeDisplay(spendToUsd(spendAmount)!, 'USD')
       );
-    assert.dom(SECONDARY_AMOUNT).containsText(`§${spendAmount}`);
+    assert.dom(SECONDARY_AMOUNT).doesNotExist();
+
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,
       network,
@@ -298,7 +297,8 @@ module('Acceptance | pay', function (hooks) {
     assert
       .dom(AMOUNT)
       .containsText(convertAmountToNativeDisplay(minUsdAmount, 'USD'));
-    assert.dom(SECONDARY_AMOUNT).containsText(`§${minSpendAmount}`);
+    assert.dom(SECONDARY_AMOUNT).doesNotExist();
+
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,
       network,
@@ -329,10 +329,10 @@ module('Acceptance | pay', function (hooks) {
     assert
       .dom(SECONDARY_AMOUNT)
       .containsText(
-        `§${formatCurrencyAmount(
-          convertToSpend(roundedJpyAmountInUsd, 'USD', 1)!,
-          0
-        )}`
+        convertAmountToNativeDisplay(
+          spendToUsd(convertToSpend(roundedJpyAmountInUsd, 'USD', 1)!)!,
+          'USD'
+        )
       );
 
     let expectedUrl = generateMerchantPaymentUrl({
@@ -362,7 +362,14 @@ module('Acceptance | pay', function (hooks) {
     assert
       .dom(AMOUNT)
       .containsText(convertAmountToNativeDisplay(minJpyAmount, jpySymbol));
-    assert.dom(SECONDARY_AMOUNT).containsText(`§${convertedMinSpendAmount}`);
+    assert
+      .dom(SECONDARY_AMOUNT)
+      .containsText(
+        convertAmountToNativeDisplay(
+          spendToUsd(convertedMinSpendAmount)!,
+          'USD'
+        )
+      );
 
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,
@@ -451,12 +458,12 @@ module('Acceptance | pay', function (hooks) {
       `/pay/${network}/${merchantSafe.address}?amount=${spendAmount}&currrency=${spendSymbol}`
     );
 
-    assert.dom(AMOUNT).containsText(`§${spendAmount}`);
     assert
-      .dom(SECONDARY_AMOUNT)
+      .dom(AMOUNT)
       .containsText(
-        `${convertAmountToNativeDisplay(spendToUsd(spendAmount)!, 'USD')}`
+        convertAmountToNativeDisplay(spendToUsd(spendAmount)!, 'USD')
       );
+    assert.dom(SECONDARY_AMOUNT).doesNotExist();
 
     // assert that the deep link view is rendered
     assert.dom(QR_CODE).doesNotExist();
@@ -498,12 +505,12 @@ module('Acceptance | pay', function (hooks) {
       .containsText(
         'Unable to find business details for this address. Use caution when paying.'
       );
-    assert.dom(AMOUNT).containsText(`§${spendAmount}`);
     assert
-      .dom(SECONDARY_AMOUNT)
+      .dom(AMOUNT)
       .containsText(
-        `${convertAmountToNativeDisplay(spendToUsd(spendAmount)!, 'USD')}`
+        convertAmountToNativeDisplay(spendToUsd(spendAmount)!, 'USD')
       );
+    assert.dom(SECONDARY_AMOUNT).doesNotExist();
 
     let expectedUrl = generateMerchantPaymentUrl({
       domain: universalLinkDomain,


### PR DESCRIPTION
### Pay page with USD specified as currency and 475 as amount, shows payment request for 475 USD
![Pay page with USD specified as currency and 475 as amount, shows payment request for 475 USD](https://user-images.githubusercontent.com/39579264/154023272-00c9602e-f8f7-4fc5-8085-f140368e427d.png)

### Pay page with no specified currency and 475 as amount, shows payment request for 4.75 USD
![Pay page with no specified currency and 475 as amount, shows payment request for 4.75 USD](https://user-images.githubusercontent.com/39579264/154022657-1635de36-e685-46e3-8ae1-630e216f8299.png)

### Pay page with GBP specified as currency and 475 as amount, shows payment request for 475 GBP with USD secondary amount
![Pay page with GBP specified as currency and 475 as amount, shows payment request for 475 GBP with USD secondary amount](https://user-images.githubusercontent.com/39579264/154022640-8a2a912a-59a7-4d69-a5d3-51695a125eac.png)

### !!**no exchange rates fetched**!! Pay page with GBP specified as currency and 475 as amount, shows payment request for 475 GBP with no USD secondary amount
![Pay page with GBP specified as currency and 475 as amount, shows payment request for 475 GBP with no USD secondary amount](https://user-images.githubusercontent.com/39579264/154023721-d9ae6558-3301-4e51-b80c-730abbdf04a4.png)

