### PR TITLE
Async Computed Fields

### DIFF
--- a/packages/cardhost/app/lib/card-model-for-browser.ts
+++ b/packages/cardhost/app/lib/card-model-for-browser.ts
@@ -32,6 +32,7 @@ import { fetchJSON } from './jsonapi-fetch';
 import config from 'cardhost/config/environment';
 import LocalRealm, { LOCAL_REALM } from './builder';
 import { cardURL } from '@cardstack/core/src/utils';
+import { getFieldValue } from '@cardstack/core/src/utils/fields';
 
 const { cardServer } = config as any; // Environment types arent working
 
@@ -210,19 +211,7 @@ export default class CardModelForBrowser implements CardModel {
       this._schemaInstance = new klass(this.getRawField.bind(this)) as any;
     }
 
-    // If the path is deeply nested, we need to recurse the down
-    // the schema instances until we get to a field getter
-    function getGetter(schema: any, path: string): any {
-      let [key, ...tail] = path.split('.');
-      let getter = schema[key];
-      if (tail && tail.length) {
-        return getGetter(getter, tail.join('.'));
-      }
-      return getter;
-    }
-
-    let getter = getGetter(this._schemaInstance, fieldPath);
-    return await getter;
+    return await getFieldValue(this._schemaInstance, fieldPath);
   }
 
   get rawData(): any {

--- a/packages/cardhost/tests/@core/compiler-adoption-test.ts
+++ b/packages/cardhost/tests/@core/compiler-adoption-test.ts
@@ -296,8 +296,7 @@ module('@core | compiler-adoption', function (hooks) {
         await builder.getCompiledCard(cardURL(card));
       } catch (err) {
         assert.ok(
-          /@adopts decorator accepts exactly one argument/.test(err.message),
-          err.message
+          /@adopts decorator can only have 1 argument/.test(err.message)
         );
       }
     });

--- a/packages/cardhost/tests/@core/compiler-basics-test.ts
+++ b/packages/cardhost/tests/@core/compiler-basics-test.ts
@@ -465,7 +465,7 @@ module('@core | compiler-basics', function (hooks) {
             import string from "https://cardstack.com/base/string";
 
             class X {
-              @contains(string, 1)
+              @contains(string, {}, 1)
               title;
             }
           `,
@@ -478,7 +478,9 @@ module('@core | compiler-basics', function (hooks) {
         await builder.getCompiledCard(cardURL(card));
       } catch (err) {
         assert.ok(
-          /contains decorator accepts exactly one argument/.test(err.message),
+          /contains decorator can only have between 1 and 2 arguments/.test(
+            err.message
+          ),
           err.message
         );
       }

--- a/packages/cardhost/tests/integration/rendering-test.ts
+++ b/packages/cardhost/tests/integration/rendering-test.ts
@@ -1,4 +1,4 @@
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupCardTest } from '../helpers/setup';
 import { templateOnlyComponentTemplate } from '@cardstack/core/tests/helpers/templates';
 
@@ -82,5 +82,45 @@ module('Integration | Card Rendering', function (hooks) {
     assert.dom('p').containsText('Bob likes pizza');
   });
 
-  skip('Can render an async computed field');
+  test('Can render an async computed field', async function (assert) {
+    createCard({
+      id: 'bob',
+      realm: localRealmURL,
+      schema: 'schema.js',
+      isolated: 'isolated.js',
+      data: {
+        firstName: 'Bob',
+      },
+      files: {
+        'schema.js': `
+          import { contains } from "@cardstack/types";
+          import string from "https://cardstack.com/base/string";
+
+          export default class Hello {
+            @contains(string)
+            firstName;
+
+            @contains(string, { computeVia: "computeFoodPref" }) foodPref;
+            async computeFoodPref() {
+              await new Promise(resolve => setTimeout(resolve, 10));
+              return this.firstName + " likes pizza";
+            }
+
+            @contains(string)
+            get loudFoodPref() {
+              return this.foodPref + "!";
+            }
+          }
+        `,
+        'isolated.js': templateOnlyComponentTemplate(
+          `<h1><@fields.firstName /></h1><p><@fields.loudFoodPref /></p>`
+        ),
+      },
+    });
+
+    await renderCard({ id: 'bob' });
+
+    assert.dom('h1').containsText('Bob');
+    assert.dom('p').containsText('Bob likes pizza!');
+  });
 });

--- a/packages/core/src/babel-plugin-card-schema-analyze.ts
+++ b/packages/core/src/babel-plugin-card-schema-analyze.ts
@@ -218,7 +218,12 @@ function extractDecoratorArguments(
   }
   let { min, max } = argumentLengths;
   if (callExpression.node.arguments.length > max || callExpression.node.arguments.length < min) {
-    throw error(callExpression, `@${decorator} decorator can only have between ${min} and ${max} arguments`);
+    throw error(
+      callExpression,
+      `@${decorator} decorator can only have ${
+        min === max ? min + ' argument' : 'between ' + min + ' and ' + max + ' arguments'
+      }`
+    );
   }
 
   let decoratorArguments = callExpression.get('arguments');

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -103,3 +103,28 @@ export function serializableError(err: any): any {
   result.additionalErrors = result.additionalErrors?.map((inner) => serializableError(inner)) ?? null;
   return result;
 }
+
+// This is a very special type of error that is used as a signal for us that
+// there is unfinished async work when loading card field values.
+export class NotReady extends Error {
+  isNotReadyError: true = true;
+  constructor(
+    readonly fieldName: string,
+    readonly computeVia: string,
+    readonly cacheFieldName: string,
+    readonly cardName: string
+  ) {
+    super(`The field ${cardName}.${fieldName} is not ready`);
+  }
+}
+
+export function isNotReadyError(err: any): err is NotReady {
+  return (
+    err != null &&
+    typeof err === 'object' &&
+    err.isNotReadyError &&
+    'fieldName' in err &&
+    'computeVia' in err &&
+    'cacheFieldName' in err
+  );
+}

--- a/packages/hub/node-tests/@core/babel-plugin-card-schema-analyze-test.ts
+++ b/packages/hub/node-tests/@core/babel-plugin-card-schema-analyze-test.ts
@@ -57,7 +57,7 @@ if (process.env.COMPILER) {
       });
     });
 
-    it('adds computed info to fieldMeta', async function () {
+    it('adds synchronous computed info to fieldMeta', async function () {
       let options = {};
       let source = `
   	    import { contains } from "@cardstack/types";
@@ -68,8 +68,8 @@ if (process.env.COMPILER) {
   	      @contains(string) street;
 
   	      @contains(string)
-					async home() {
-						return (await this.street()) + " is home";
+					get home() {
+						return this.street + " is home";
 					};
   	    }
   	  `;
@@ -88,6 +88,41 @@ if (process.env.COMPILER) {
         type: 'contains',
         typeDecoratorLocalName: 'string',
         computed: true,
+      });
+    });
+
+    it('adds async computed info to fieldMeta', async function () {
+      let options = {};
+      let source = `
+  	    import { contains } from "@cardstack/types";
+  	    import string from "https://cardstack.com/base/string";
+  	    import date from "https://cardstack.com/base/date";
+
+  	    export default class Address {
+  	      @contains(string) street;
+
+  	      @contains(string, { computeVia: "computeHome" }) home
+					async computeHome() {
+						return (await this.street) + " is home";
+					};
+  	    }
+  	  `;
+      cardSchemaAnalyze(source, options);
+      let meta = getMeta(options);
+
+      expect(meta.fields).to.deep.property('street', {
+        cardURL: 'https://cardstack.com/base/string',
+        type: 'contains',
+        typeDecoratorLocalName: 'string',
+        computed: false,
+      });
+
+      expect(meta.fields).to.deep.property('home', {
+        cardURL: 'https://cardstack.com/base/string',
+        type: 'contains',
+        typeDecoratorLocalName: 'string',
+        computed: true,
+        computeVia: 'computeHome',
       });
     });
   });

--- a/packages/hub/node-tests/@core/babel-plugin-card-template-test.ts
+++ b/packages/hub/node-tests/@core/babel-plugin-card-template-test.ts
@@ -36,8 +36,8 @@ if (process.env.COMPILER) {
                 @contains(address) address;
 
                 @contains(string)
-                async fullName() {
-                  return await 'Mr. ' + await this.name;
+                get fullName() {
+                  return 'Mr. ' + this.name;
                 }
               }
             `,

--- a/packages/hub/node-tests/@core/compiler-test.ts
+++ b/packages/hub/node-tests/@core/compiler-test.ts
@@ -586,7 +586,7 @@ if (process.env.COMPILER) {
             if (this._cachedSlowName0 !== undefined) {
               return this._cachedSlowName0;
             } else {
-              throw new NotReady("slowName", "computeSlowName", "_cachedSlowName0");
+              throw new NotReady("slowName", "computeSlowName", "_cachedSlowName0", "Person");
             }
           }
         `);

--- a/packages/hub/node-tests/@core/compiler-test.ts
+++ b/packages/hub/node-tests/@core/compiler-test.ts
@@ -471,6 +471,14 @@ if (process.env.COMPILER) {
               get fullName() {
                 return "Mr or Mrs " + this.lastName;
               }
+
+              @contains(string, { computeVia: "computeSlowName" }) slowName;
+              async slowName() {
+                await new Promise(resolve => setTimeout(resolve, 10));
+                return this.fullName;
+              }
+
+              _cachedSlowName = "don't collide!";
             }
           `,
         },
@@ -564,7 +572,25 @@ if (process.env.COMPILER) {
         `);
       });
 
-      it('can compile async computed field in schema.js module');
+      it('can compile async computed field in schema.js module', async function () {
+        let { compiled } = await cards.load(`${realm}person`);
+        let source = getFileCache().getModule(compiled.schemaModule.global, 'browser');
+        expect(source).to.not.containsSource(`@contains`);
+        expect(source).to.containsSource(`
+          import { NotReady } from "@cardstack/core/src/utils/errors";
+        `);
+        expect(source).to.containsSource(`
+          _cachedSlowName0;
+
+          get slowName() {
+            if (this._cachedSlowName0 !== undefined) {
+              return this._cachedSlowName0;
+            } else {
+              throw new NotReady("slowName", "computeSlowName", "_cachedSlowName0");
+            }
+          }
+        `);
+      });
 
       it('can compile a schema.js that adopts from a composite card has no additional fields', async function () {
         let { compiled } = await cards.load(`${realm}fancy-person`);

--- a/packages/hub/node-tests/@core/computed-test.ts
+++ b/packages/hub/node-tests/@core/computed-test.ts
@@ -124,6 +124,7 @@ if (process.env.COMPILER) {
     });
 
     it('can access an asynchronous field via a contained card');
+
     it('can access an asynchronous computed field');
     it('can access an asynchronous computed field defined in parent card');
 

--- a/packages/hub/node-tests/@core/computed-test.ts
+++ b/packages/hub/node-tests/@core/computed-test.ts
@@ -52,6 +52,17 @@ if (process.env.COMPILER) {
               get summary() {
                 return this.fullName + " is a person. Their story is: " + this.aboutMe.short;
               }
+
+              @contains(string, { computeVia: "computeSlowSummary" }) slowSummary;
+              async computeSlowSummary() {
+                await new Promise(resolve => setTimeout(resolve, 10));
+                return this.summary;
+              }
+
+              @contains(string)
+              get loudSummary() {
+                return this.slowSummary + "!";
+              }
             }
           `,
           // firstName, lastName, summary, and bio.short should be considered as used
@@ -75,21 +86,31 @@ if (process.env.COMPILER) {
       });
     });
 
-    it(`can access a one-level-deep computed field`, async function () {
+    it(`can access a synchronous computed field`, async function () {
       let card = await cards.loadData(`${realm}arthur`, 'isolated');
       expect(await card.getField('fullName')).to.equal('Arthur Faulkner');
     });
 
-    it(`can access a two-level-deep computed field`, async function () {
+    it(`can access a two-level-deep synchronous computed field`, async function () {
       let card = await cards.loadData(`${realm}arthur`, 'isolated');
       expect(await card.getField('summary')).to.equal('Arthur Faulkner is a person. Their story is: son of Ed');
     });
 
-    it('can access a synchronous composite field', async function () {
+    it('can access a composite field', async function () {
       let card = await cards.loadData(`${realm}arthur`, 'isolated');
       let aboutMe = await card.getField('aboutMe');
       expect(aboutMe.short).to.equal('son of Ed');
       expect(aboutMe.favoriteColor).to.equal('blue');
+    });
+
+    it('can access an asynchronous computed field', async function () {
+      let card = await cards.loadData(`${realm}arthur`, 'isolated');
+      expect(await card.getField('slowSummary')).to.equal('Arthur Faulkner is a person. Their story is: son of Ed');
+    });
+
+    it('can indirectly access an asynchronous computed field', async function () {
+      let card = await cards.loadData(`${realm}arthur`, 'isolated');
+      expect(await card.getField('loudSummary')).to.equal('Arthur Faulkner is a person. Their story is: son of Ed!');
     });
 
     it('can access a synchronous computed field defined in parent card', async function () {
@@ -123,10 +144,38 @@ if (process.env.COMPILER) {
       expect(await card.getField('seriesName')).to.equal('Overlord');
     });
 
-    it('can access an asynchronous field via a contained card');
-
-    it('can access an asynchronous computed field');
-    it('can access an asynchronous computed field defined in parent card');
+    it('can access an asynchronous computed field defined in parent card', async function () {
+      await cards.create({
+        realm,
+        id: 'ains',
+        adoptsFrom: '../person',
+        schema: 'schema.js',
+        files: {
+          'schema.js': `
+            import { adopts, contains } from "@cardstack/types";
+            import string from "https://cardstack.com/base/string";
+            import person from "../person";
+            export default @adopts(person) class Isekai {
+              @contains(string) seriesName;
+            }
+          `,
+        },
+        data: {
+          firstName: 'Ains Ooal',
+          lastName: 'Gown',
+          seriesName: 'Overlord',
+          aboutMe: {
+            short: 'Supreme overlord of darkness',
+            favoriteColor: 'black',
+          },
+        },
+      });
+      let card = await cards.loadData(`${realm}ains`, 'isolated');
+      expect(await card.getField('fullName')).to.equal('Ains Ooal Gown');
+      expect(await card.getField('loudSummary')).to.equal(
+        'Ains Ooal Gown is a person. Their story is: Supreme overlord of darkness!'
+      );
+    });
 
     it('can access a field that requires deserialization');
     it('can have a field that is the same card as itself');

--- a/packages/hub/services/file-cache.ts
+++ b/packages/hub/services/file-cache.ts
@@ -16,6 +16,7 @@ import { inject, injectionReady } from '@cardstack/di';
 import isEqual from 'lodash/isEqual';
 import { Client } from 'pg';
 import vm from 'vm';
+import fetch from 'node-fetch';
 
 declare global {
   const __non_webpack_require__: any;
@@ -160,6 +161,10 @@ export default class FileCache {
       let context = {
         exports: {},
         require: (specifier: string) => this.loadModule(specifier),
+
+        // we have to white list globals that we want available to our cards
+        setTimeout,
+        fetch,
       };
       vm.createContext(context);
       vm.runInContext(code, context, { filename: this.resolveModule(moduleIdentifier) });


### PR DESCRIPTION
~~This is basically the prep work for the computed async. I thought i'd break this down so the final PR isn't super huge. This includes some new FieldMeta for the async computeds (`computeVia`), as well as the transpiled schema source and new `NotReady` error. the next step will be to harness the updated Schema and `NotReady` errors for the async computeds. This source code follows the sketch in https://linear.app/cardstack/issue/CS-3106/refactor-computeds~~

UPDATE: it turns out the extra work for handling the `NotReady` errors and loading the async is actually not that much more. I'll just include into this PR too. This PR includes the remaining async computed support for both hub and browser.