### PR TITLE
Throw on reverted receipt

### DIFF
--- a/packages/cardpay-sdk/.eslintrc.cjs
+++ b/packages/cardpay-sdk/.eslintrc.cjs
@@ -9,6 +9,15 @@ module.exports = {
       files: ['*.ts'],
       rules: {
         '@typescript-eslint/consistent-type-exports': 'error',
+        '@typescript-eslint/ban-types': [
+          'error',
+          {
+            types: {
+              TransactionReceipt:
+                'Use SuccessfulTransactionReceipt for SDK return types. Unsuccessful transaction receipts should throw.',
+            },
+          },
+        ],
       },
     },
   ],

--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -19,7 +19,7 @@ This is a package that provides an SDK to use the Cardpay protocol.
   - [`TokenBridgeForeignSide.claimBridgedTokens`](#tokenbridgeforeignsideclaimbridgedtokens)
   - [`TokenBridgeForeignSide.getSupportedTokens` (TBD)](#tokenbridgeforeignsidegetsupportedtokens-tbd)
 - [`TokenBridgeHomeSide`](#tokenbridgehomeside)
-  - [`TokenBridgeHomeSide.withdrawlLimits`](#tokenbridgehomesidewithdrawllimits)
+  - [`TokenBridgeHomeSide.withdrawalLimits`](#tokenbridgehomesidewithdrawallimits)
   - [`TokenBridgeHomeSide.relayTokens`](#tokenbridgehomesiderelaytokens)
   - [`TokenBridgeHomeSide.waitForBridgingValidation`](#tokenbridgehomesidewaitforbridgingvalidation)
   - [`TokenBridgeHomeSide.waitForBridgingToLayer2Completed`](#tokenbridgehomesidewaitforbridgingtolayer2completed)
@@ -217,7 +217,7 @@ let web3 = new Web3(myProvider); // Layer 2 web3 instance
 let tokenBridge = await getSDK('TokenBridgeHomeSide', web3);
 ```
 
-### `TokenBridgeHomeSide.withdrawlLimits`
+### `TokenBridgeHomeSide.withdrawalLimits`
 This call will return the minimum and maximum withdrawal limits as a string in units of `wei` for bridging a token to layer 1. This method is invoked with the layer 2 CPXD token address of the CPXD token being withdrawn.
 
 ```js

--- a/packages/cardpay-sdk/sdk/prepaid-card-market/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card-market/base.ts
@@ -4,7 +4,7 @@ import { AbiItem } from 'web3-utils';
 import PrepaidCardMarketABI from '../../contracts/abi/v0.8.7/prepaid-card-market';
 import PrepaidCardManagerABI from '../../contracts/abi/v0.8.7/prepaid-card-manager';
 import GnosisSafeABI from '../../contracts/abi/gnosis-safe';
-import { TransactionReceipt } from 'web3-core';
+import type { SuccessfulTransactionReceipt } from '../utils/successful-transaction-receipt';
 import { ContractOptions } from 'web3-eth-contract';
 import { isTransactionHash, TransactionOptions, waitForSubgraphIndexWithTxnReceipt } from '../utils/general-utils';
 import {
@@ -75,21 +75,21 @@ export default class PrepaidCardMarket {
     };
   }
 
-  async addToInventory(txnHash: string): Promise<TransactionReceipt>;
+  async addToInventory(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async addToInventory(
     fundingPrepaidCard: string,
     prepaidCardToAdd: string,
     marketAddress?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async addToInventory(
     fundingPrepaidCardOrTxnHash: string,
     prepaidCardToAdd?: string,
     marketAddress?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (isTransactionHash(fundingPrepaidCardOrTxnHash)) {
       let txnHash = fundingPrepaidCardOrTxnHash;
       return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
@@ -167,21 +167,21 @@ export default class PrepaidCardMarket {
     return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
 
-  async removeFromInventory(txnHash: string): Promise<TransactionReceipt>;
+  async removeFromInventory(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async removeFromInventory(
     fundingPrepaidCard: string,
     prepaidCardAddresses: string[],
     marketAddress?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async removeFromInventory(
     fundingPrepaidCardOrTxnHash: string,
     prepaidCardAddresses?: string[],
     marketAddress?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (isTransactionHash(fundingPrepaidCardOrTxnHash)) {
       let txnHash = fundingPrepaidCardOrTxnHash;
       return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
@@ -234,7 +234,7 @@ export default class PrepaidCardMarket {
     return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
 
-  async setAsk(txnHash: string): Promise<TransactionReceipt>;
+  async setAsk(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async setAsk(
     prepaidCard: string,
     sku: string,
@@ -242,7 +242,7 @@ export default class PrepaidCardMarket {
     marketAddress?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async setAsk(
     prepaidCardOrTxnHash: string,
     sku?: string,
@@ -250,7 +250,7 @@ export default class PrepaidCardMarket {
     marketAddress?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (isTransactionHash(prepaidCardOrTxnHash)) {
       let txnHash = prepaidCardOrTxnHash;
       return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);

--- a/packages/cardpay-sdk/sdk/prepaid-card/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card/base.ts
@@ -27,8 +27,9 @@ import {
 import { isTransactionHash, TransactionOptions, waitForSubgraphIndexWithTxnReceipt } from '../utils/general-utils';
 import { Signature, signSafeTxAsBytes, signPrepaidCardSendTx, signSafeTx } from '../utils/signing-utils';
 import { PrepaidCardSafe } from '../safes';
-import { TransactionReceipt } from 'web3-core';
+import type { SuccessfulTransactionReceipt } from '../utils/successful-transaction-receipt';
 import { itemSetEventABI } from '../prepaid-card-market/base';
+import { TransactionReceipt } from 'web3-core';
 
 const { fromWei } = Web3.utils;
 const POLL_INTERVAL = 500;
@@ -88,21 +89,21 @@ export default class PrepaidCard {
     return { min: parseInt(min.toString()), max: MAXIMUM_PAYMENT_AMOUNT };
   }
 
-  async payMerchant(txnHash: string): Promise<TransactionReceipt>;
+  async payMerchant(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async payMerchant(
     merchantSafe: string,
     prepaidCardAddress: string,
     spendAmount: number,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async payMerchant(
     merchantSafeOrTxnHash: string,
     prepaidCardAddress?: string,
     spendAmount?: number,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (isTransactionHash(merchantSafeOrTxnHash)) {
       let txnHash = merchantSafeOrTxnHash;
       return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
@@ -165,19 +166,19 @@ export default class PrepaidCard {
     return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
 
-  async transfer(txnHash: string): Promise<TransactionReceipt>;
+  async transfer(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async transfer(
     prepaidCardAddress: string,
     newOwner: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async transfer(
     prepaidCardAddressOrTxnHash: string,
     newOwner?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (isTransactionHash(prepaidCardAddressOrTxnHash)) {
       let txnHash = prepaidCardAddressOrTxnHash;
       return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
@@ -259,7 +260,7 @@ export default class PrepaidCard {
 
   async split(
     txnHash: string
-  ): Promise<{ prepaidCards: PrepaidCardSafe[]; sku: string; txReceipt: TransactionReceipt }>;
+  ): Promise<{ prepaidCards: PrepaidCardSafe[]; sku: string; txReceipt: SuccessfulTransactionReceipt }>;
   async split(
     prepaidCardAddress: string,
     faceValues: number[],
@@ -267,7 +268,7 @@ export default class PrepaidCard {
     customizationDID: string | undefined,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<{ prepaidCards: PrepaidCardSafe[]; sku: string; txReceipt: TransactionReceipt }>;
+  ): Promise<{ prepaidCards: PrepaidCardSafe[]; sku: string; txReceipt: SuccessfulTransactionReceipt }>;
   async split(
     prepaidCardAddressOrTxnHash: string,
     faceValues?: number[],
@@ -275,7 +276,7 @@ export default class PrepaidCard {
     customizationDID?: string | undefined,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<{ prepaidCards: PrepaidCardSafe[]; sku: string; txReceipt: TransactionReceipt }> {
+  ): Promise<{ prepaidCards: PrepaidCardSafe[]; sku: string; txReceipt: SuccessfulTransactionReceipt }> {
     if (isTransactionHash(prepaidCardAddressOrTxnHash)) {
       let txnHash = prepaidCardAddressOrTxnHash;
       let txReceipt = await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
@@ -378,7 +379,7 @@ export default class PrepaidCard {
     };
   }
 
-  async create(txnHash: string): Promise<{ prepaidCards: PrepaidCardSafe[]; txnReceipt: TransactionReceipt }>;
+  async create(txnHash: string): Promise<{ prepaidCards: PrepaidCardSafe[]; txnReceipt: SuccessfulTransactionReceipt }>;
   async create(
     safeAddress: string,
     tokenAddress: string,
@@ -388,7 +389,7 @@ export default class PrepaidCard {
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions,
     force?: boolean // force a prepaid card to be created when DAI Oracle is not snapped to USD rate
-  ): Promise<{ prepaidCards: PrepaidCardSafe[]; txnReceipt: TransactionReceipt }>;
+  ): Promise<{ prepaidCards: PrepaidCardSafe[]; txnReceipt: SuccessfulTransactionReceipt }>;
   async create(
     safeAddressOrTxnHash: string,
     tokenAddress?: string,
@@ -398,7 +399,7 @@ export default class PrepaidCard {
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions,
     force?: boolean // force a prepaid card to be created when DAI Oracle is not snapped to USD rate
-  ): Promise<{ prepaidCards: PrepaidCardSafe[]; txnReceipt: TransactionReceipt }> {
+  ): Promise<{ prepaidCards: PrepaidCardSafe[]; txnReceipt: SuccessfulTransactionReceipt }> {
     if (isTransactionHash(safeAddressOrTxnHash)) {
       let txnHash = safeAddressOrTxnHash;
       return {

--- a/packages/cardpay-sdk/sdk/prepaid-card/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card/base.ts
@@ -605,6 +605,8 @@ export default class PrepaidCard {
     );
   }
 
+  // allow TransactionReceipt as argument
+  // eslint-disable-next-line @typescript-eslint/ban-types
   private async getSkuFromTxnReceipt(txnReceipt: TransactionReceipt): Promise<string> {
     // this assumes the default prepaid card market address, once we have
     // multiple prepaid card markets we should refactor this

--- a/packages/cardpay-sdk/sdk/revenue-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/revenue-pool/base.ts
@@ -22,7 +22,7 @@ import { TransactionOptions, waitForSubgraphIndexWithTxnReceipt, isTransactionHa
 import { Signature, signPrepaidCardSendTx, signSafeTx } from '../utils/signing-utils';
 import { getSDK } from '../version-resolver';
 import BN from 'bn.js';
-import { TransactionReceipt } from 'web3-core';
+import type { SuccessfulTransactionReceipt } from '../utils/successful-transaction-receipt';
 import { MerchantSafe, Safe } from '../safes';
 
 const { fromWei } = Web3.utils;
@@ -95,21 +95,21 @@ export default class RevenuePool {
     return gasInToken(estimate).toString();
   }
 
-  async claim(txnHash: string): Promise<TransactionReceipt>;
+  async claim(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async claim(
     merchantSafeAddress: string,
     tokenAddress: string,
     amount: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async claim(
     merchantSafeAddressOrTxnHash: string,
     tokenAddress?: string,
     amount?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (isTransactionHash(merchantSafeAddressOrTxnHash)) {
       let txnHash = merchantSafeAddressOrTxnHash;
       return waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
@@ -175,19 +175,21 @@ export default class RevenuePool {
     return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
 
-  async registerMerchant(txnHash: string): Promise<{ merchantSafe: MerchantSafe; txReceipt: TransactionReceipt }>;
+  async registerMerchant(
+    txnHash: string
+  ): Promise<{ merchantSafe: MerchantSafe; txReceipt: SuccessfulTransactionReceipt }>;
   async registerMerchant(
     prepaidCardAddress: string,
     infoDID: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<{ merchantSafe: MerchantSafe; txReceipt: TransactionReceipt }>;
+  ): Promise<{ merchantSafe: MerchantSafe; txReceipt: SuccessfulTransactionReceipt }>;
   async registerMerchant(
     prepaidCardAddressOrTxnHash: string,
     infoDID?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<{ merchantSafe: MerchantSafe; txReceipt: TransactionReceipt }> {
+  ): Promise<{ merchantSafe: MerchantSafe; txReceipt: SuccessfulTransactionReceipt }> {
     if (isTransactionHash(prepaidCardAddressOrTxnHash)) {
       let txnHash = prepaidCardAddressOrTxnHash;
       let merchantSafeAddress = await this.getMerchantSafeFromTxn(txnHash);

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -6,7 +6,7 @@ import { getAddress } from '../../contracts/addresses';
 import { AbiItem, randomHex, toChecksumAddress, fromWei, toWei } from 'web3-utils';
 import { isTransactionHash, TransactionOptions, waitForSubgraphIndexWithTxnReceipt } from '../utils/general-utils';
 import { getSDK } from '../version-resolver';
-import { TransactionReceipt } from 'web3-core';
+import type { SuccessfulTransactionReceipt } from '../utils/successful-transaction-receipt';
 import {
   EventABI,
   getParamsFromEvent,
@@ -54,19 +54,21 @@ export default class RewardManager {
 
   constructor(private layer2Web3: Web3) {}
 
-  async registerRewardProgram(txnHash: string): Promise<{ rewardProgramId: string; txReceipt: TransactionReceipt }>;
+  async registerRewardProgram(
+    txnHash: string
+  ): Promise<{ rewardProgramId: string; txReceipt: SuccessfulTransactionReceipt }>;
   async registerRewardProgram(
     prepaidCardAddress: string,
     admin: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<{ rewardProgramId: string; txReceipt: TransactionReceipt }>;
+  ): Promise<{ rewardProgramId: string; txReceipt: SuccessfulTransactionReceipt }>;
   async registerRewardProgram(
     prepaidCardAddressOrTxnHash: string,
     admin?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<{ rewardProgramId: string; txReceipt: TransactionReceipt }> {
+  ): Promise<{ rewardProgramId: string; txReceipt: SuccessfulTransactionReceipt }> {
     let rewardManager = await getSDK('RewardManager', this.layer2Web3);
     let rewardProgramId = await rewardManager.newRewardProgramId();
     if (isTransactionHash(prepaidCardAddressOrTxnHash)) {
@@ -142,19 +144,19 @@ export default class RewardManager {
     };
   }
 
-  async registerRewardee(txnHash: string): Promise<{ rewardSafe: string; txReceipt: TransactionReceipt }>;
+  async registerRewardee(txnHash: string): Promise<{ rewardSafe: string; txReceipt: SuccessfulTransactionReceipt }>;
   async registerRewardee(
     prepaidCardAddress: string,
     rewardProgramId: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<{ rewardSafe: string; txReceipt: TransactionReceipt }>;
+  ): Promise<{ rewardSafe: string; txReceipt: SuccessfulTransactionReceipt }>;
   async registerRewardee(
     prepaidCardAddressOrTxnHash: string,
     rewardProgramId?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<{ rewardSafe: string; txReceipt: TransactionReceipt }> {
+  ): Promise<{ rewardSafe: string; txReceipt: SuccessfulTransactionReceipt }> {
     if (isTransactionHash(prepaidCardAddressOrTxnHash)) {
       let txnHash = prepaidCardAddressOrTxnHash;
       return {
@@ -208,19 +210,19 @@ export default class RewardManager {
     };
   }
 
-  async lockRewardProgram(txnHash: string): Promise<TransactionReceipt>;
+  async lockRewardProgram(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async lockRewardProgram(
     prepaidCardAddress: string,
     rewardProgramId: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async lockRewardProgram(
     prepaidCardAddressOrTxnHash: string,
     rewardProgramId?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (isTransactionHash(prepaidCardAddressOrTxnHash)) {
       let txnHash = prepaidCardAddressOrTxnHash;
       return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
@@ -269,21 +271,21 @@ export default class RewardManager {
     return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
 
-  async updateRewardProgramAdmin(txnHash: string): Promise<TransactionReceipt>;
+  async updateRewardProgramAdmin(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async updateRewardProgramAdmin(
     prepaidCardAddress: string,
     rewardProgramId: string,
     newAdmin: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async updateRewardProgramAdmin(
     prepaidCardAddressOrTxnHash: string,
     rewardProgramId?: string,
     newAdmin?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (isTransactionHash(prepaidCardAddressOrTxnHash)) {
       let txnHash = prepaidCardAddressOrTxnHash;
       return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
@@ -341,21 +343,21 @@ export default class RewardManager {
     return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
 
-  async addRewardRule(txnHash: string): Promise<TransactionReceipt>;
+  async addRewardRule(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async addRewardRule(
     prepaidCardAddress: string,
     rewardProgramId: string,
     blob: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async addRewardRule(
     prepaidCardAddressOrTxnHash: string,
     rewardProgramId?: string,
     blob?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (isTransactionHash(prepaidCardAddressOrTxnHash)) {
       let txnHash = prepaidCardAddressOrTxnHash;
       return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
@@ -407,7 +409,7 @@ export default class RewardManager {
     }
     return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
   }
-  async withdraw(txnHash: string): Promise<TransactionReceipt>;
+  async withdraw(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async withdraw(
     safeAddress: string,
     to: string,
@@ -415,7 +417,7 @@ export default class RewardManager {
     amount: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async withdraw(
     safeAddressOrTxnHash: string,
     to?: string,
@@ -423,7 +425,7 @@ export default class RewardManager {
     amount?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (isTransactionHash(safeAddressOrTxnHash)) {
       let txnHash = safeAddressOrTxnHash;
       return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
@@ -542,19 +544,19 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
     return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, gnosisTxn.ethereumTx.txHash);
   }
 
-  async transfer(txnHash: string): Promise<TransactionReceipt>;
+  async transfer(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async transfer(
     safeAddress: string,
     newOwner: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async transfer(
     safeAddressOrTxnHash: string,
     newOwner?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (isTransactionHash(safeAddressOrTxnHash)) {
       let txnHash = safeAddressOrTxnHash;
       return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);

--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -13,7 +13,7 @@ import ERC20ABI from '../../contracts/abi/erc-20';
 import ERC677ABI from '../../contracts/abi/erc-677';
 import { gasEstimate, executeTransaction, getNextNonceFromEstimate, Operation } from '../utils/safe-utils';
 import { isTransactionHash, TransactionOptions, waitForSubgraphIndexWithTxnReceipt } from '../utils/general-utils';
-import { TransactionReceipt } from 'web3-core';
+import type { SuccessfulTransactionReceipt } from '../utils/successful-transaction-receipt';
 import GnosisSafeABI from '../../contracts/abi/gnosis-safe';
 
 export interface Proof {
@@ -179,7 +179,7 @@ export default class RewardPool {
     return this.addTokenSymbol(aggregateBalance(tokenBalances));
   }
 
-  async addRewardTokens(txnHash: string): Promise<TransactionReceipt>;
+  async addRewardTokens(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async addRewardTokens(
     safeAddress: string,
     rewardProgramId: string,
@@ -187,7 +187,7 @@ export default class RewardPool {
     amount: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async addRewardTokens(
     safeAddressOrTxnHash: string,
     rewardProgramId?: string,
@@ -195,7 +195,7 @@ export default class RewardPool {
     amount?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (isTransactionHash(safeAddressOrTxnHash)) {
       let txnHash = safeAddressOrTxnHash;
       return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
@@ -263,7 +263,7 @@ export default class RewardPool {
     return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, gnosisTxn.ethereumTx.txHash);
   }
 
-  async claim(txnHash: string): Promise<TransactionReceipt>;
+  async claim(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async claim(
     safeAddress: string,
     leaf: string,
@@ -271,7 +271,7 @@ export default class RewardPool {
     acceptPartialClaim?: boolean,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async claim(
     safeAddressOrTxnHash: string,
     leaf?: string,
@@ -279,7 +279,7 @@ export default class RewardPool {
     acceptPartialClaim?: boolean,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (isTransactionHash(safeAddressOrTxnHash)) {
       let txnHash = safeAddressOrTxnHash;
       return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);
@@ -423,7 +423,7 @@ The reward program ${rewardProgramId} has balance equals ${fromWei(
     return await waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, gnosisTxn.ethereumTx.txHash);
   }
 
-  async recoverTokens(txnHash: string): Promise<TransactionReceipt>;
+  async recoverTokens(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async recoverTokens(
     safeAddress: string,
     rewardProgramId: string,
@@ -431,7 +431,7 @@ The reward program ${rewardProgramId} has balance equals ${fromWei(
     amount?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async recoverTokens(
     safeAddressOrTxnHash: string,
     rewardProgramId?: string,
@@ -439,7 +439,7 @@ The reward program ${rewardProgramId} has balance equals ${fromWei(
     amount?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (isTransactionHash(safeAddressOrTxnHash)) {
       let txnHash = safeAddressOrTxnHash;
       return waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);

--- a/packages/cardpay-sdk/sdk/safes.ts
+++ b/packages/cardpay-sdk/sdk/safes.ts
@@ -6,7 +6,7 @@ import { gasEstimate, executeTransaction, getNextNonceFromEstimate, Operation, g
 import { signSafeTx } from './utils/signing-utils';
 import BN from 'bn.js';
 import { query } from './utils/graphql';
-import { TransactionReceipt } from 'web3-core';
+import type { SuccessfulTransactionReceipt } from './utils/successful-transaction-receipt';
 import { TransactionOptions, waitForSubgraphIndexWithTxnReceipt, isTransactionHash } from './utils/general-utils';
 const { fromWei } = Web3.utils;
 
@@ -16,7 +16,7 @@ export interface ISafes {
   view(owner?: string): Promise<ViewSafesResult>;
   view(owner?: string, options?: Partial<Options>): Promise<ViewSafesResult>;
   sendTokensGasEstimate(safeAddress: string, tokenAddress: string, recipient: string, amount: string): Promise<string>;
-  sendTokens(txnHash: string): Promise<TransactionReceipt>;
+  sendTokens(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   sendTokens(
     safeAddress: string,
     tokenAddress: string,
@@ -24,7 +24,7 @@ export interface ISafes {
     amount: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
 }
 
 export type Safe = DepotSafe | PrepaidCardSafe | MerchantSafe | RewardSafe | ExternalSafe;
@@ -299,7 +299,7 @@ export default class Safes implements ISafes {
     return gasInToken(estimate).toString();
   }
 
-  async sendTokens(txnHash: string): Promise<TransactionReceipt>;
+  async sendTokens(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async sendTokens(
     safeAddress: string,
     tokenAddress: string,
@@ -307,7 +307,7 @@ export default class Safes implements ISafes {
     amount: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async sendTokens(
     safeAddressOrTxnHash: string,
     tokenAddress?: string,
@@ -315,7 +315,7 @@ export default class Safes implements ISafes {
     amount?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (isTransactionHash(safeAddressOrTxnHash)) {
       let txnHash = safeAddressOrTxnHash;
       return waitForSubgraphIndexWithTxnReceipt(this.layer2Web3, txnHash);

--- a/packages/cardpay-sdk/sdk/token-bridge-foreign-side.ts
+++ b/packages/cardpay-sdk/sdk/token-bridge-foreign-side.ts
@@ -1,6 +1,7 @@
 import BN from 'bn.js';
 import Web3 from 'web3';
-import { TransactionReceipt, TransactionConfig } from 'web3-core';
+import { TransactionConfig } from 'web3-core';
+import type { SuccessfulTransactionReceipt } from './utils/successful-transaction-receipt';
 import { ContractOptions } from 'web3-eth-contract';
 import { AbiItem } from 'web3-utils';
 import ERC20ABI from '../contracts/abi/erc-20';
@@ -19,29 +20,29 @@ import {
 // The Foreign network can be any chain, but generally refers to the Ethereum mainnet.
 
 export interface ITokenBridgeForeignSide {
-  unlockTokens(txnHash: string): Promise<TransactionReceipt>;
+  unlockTokens(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   unlockTokens(
     tokenAddress: string,
     amount: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
-  relayTokens(txnHash: string): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
+  relayTokens(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   relayTokens(
     tokenAddress: string,
     recipientAddress: string,
     amount: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
-  claimBridgedTokens(txnHash: string): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
+  claimBridgedTokens(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   claimBridgedTokens(
     messageId: string,
     encodedData: string,
     signatures: string[],
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
 }
 
 // Note that as we support new CPXD tokens, we'll need to measure the gas limit
@@ -55,19 +56,19 @@ const CLAIM_BRIDGED_TOKENS_GAS_LIMIT = 350000;
 export default class TokenBridgeForeignSide implements ITokenBridgeForeignSide {
   constructor(private layer1Web3: Web3) {}
 
-  async unlockTokens(txnHash: string): Promise<TransactionReceipt>;
+  async unlockTokens(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async unlockTokens(
     tokenAddress: string,
     amount: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async unlockTokens(
     tokenAddressOrTxnHash: string,
     amount?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (isTransactionHash(tokenAddressOrTxnHash)) {
       let txnHash = tokenAddressOrTxnHash;
       return await waitUntilOneBlockAfterTxnMined(this.layer1Web3, txnHash);
@@ -117,21 +118,21 @@ export default class TokenBridgeForeignSide implements ITokenBridgeForeignSide {
     });
   }
 
-  async relayTokens(txnHash: string): Promise<TransactionReceipt>;
+  async relayTokens(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async relayTokens(
     tokenAddress: string,
     recipientAddress: string,
     amount: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async relayTokens(
     tokenAddressOrTxnHash: string,
     recipientAddress?: string,
     amount?: string,
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (isTransactionHash(tokenAddressOrTxnHash)) {
       let txnHash = tokenAddressOrTxnHash;
       return await waitUntilOneBlockAfterTxnMined(this.layer1Web3, txnHash);
@@ -192,21 +193,21 @@ export default class TokenBridgeForeignSide implements ITokenBridgeForeignSide {
     return estimatedGasInWei.divRound(rounder).mul(rounder);
   }
 
-  async claimBridgedTokens(txnHash: string): Promise<TransactionReceipt>;
+  async claimBridgedTokens(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async claimBridgedTokens(
     messageId: string,
     encodedData: string,
     signatures: string[],
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt>;
+  ): Promise<SuccessfulTransactionReceipt>;
   async claimBridgedTokens(
     messageIdOrTxnHash: string,
     encodedData?: string,
     signatures?: string[],
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
-  ): Promise<TransactionReceipt> {
+  ): Promise<SuccessfulTransactionReceipt> {
     if (!encodedData) {
       let txnHash = messageIdOrTxnHash;
       return await waitUntilOneBlockAfterTxnMined(this.layer1Web3, txnHash);

--- a/packages/cardpay-sdk/sdk/token-bridge-home-side.ts
+++ b/packages/cardpay-sdk/sdk/token-bridge-home-side.ts
@@ -232,7 +232,7 @@ export default class TokenBridgeHomeSide implements ITokenBridgeHomeSide {
         `Timed out waiting for tokens to be bridged to layer 2 for safe owned by ${recipientAddress} after block ${fromBlock}`
       );
     }
-    // TODO: can this use waitForSubgraphIndex?
+
     let {
       transaction: { id: txnHash },
     } = receivedBridgedTokens[0];

--- a/packages/cardpay-sdk/sdk/utils/safe-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/safe-utils.ts
@@ -247,7 +247,7 @@ export async function executeSend(
   return response.json();
 }
 
-// allow transaction receipts as arguments
+// allow TransactionReceipt as argument
 // eslint-disable-next-line @typescript-eslint/ban-types
 export function getParamsFromEvent(web3: Web3, txnReceipt: TransactionReceipt, eventAbi: EventABI, address: string) {
   let eventParams = txnReceipt.logs

--- a/packages/cardpay-sdk/sdk/utils/safe-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/safe-utils.ts
@@ -247,6 +247,8 @@ export async function executeSend(
   return response.json();
 }
 
+// allow transaction receipts as arguments
+// eslint-disable-next-line @typescript-eslint/ban-types
 export function getParamsFromEvent(web3: Web3, txnReceipt: TransactionReceipt, eventAbi: EventABI, address: string) {
   let eventParams = txnReceipt.logs
     .filter((log) => isEventMatch(log, eventAbi.topic, address))

--- a/packages/cardpay-sdk/sdk/utils/successful-transaction-receipt.ts
+++ b/packages/cardpay-sdk/sdk/utils/successful-transaction-receipt.ts
@@ -1,0 +1,5 @@
+import type { TransactionReceipt as MaybeSuccessfulTransactionReceipt } from 'web3-core';
+
+export interface SuccessfulTransactionReceipt extends MaybeSuccessfulTransactionReceipt {
+  status: true;
+}


### PR DESCRIPTION
Make the SDK throw when a transaction receipt is for a reverted transaction, prevent returning reverted transaction receipts by banning the `TransactionReceipt` type in favour of `SuccessfulTransactionReceipt`.

Part of CS-2502