### PR TITLE
ssr: Add mobile Percy snapshots

### DIFF
--- a/packages/ssr-web/.percy.js
+++ b/packages/ssr-web/.percy.js
@@ -1,7 +1,7 @@
 module.exports = {
   version: 2,
   snapshot: {
-    widths: [1280],
+    widths: [375, 1280],
     percyCSS: `
       /* Hide frequently-changing element */
       .styled-qr-code {


### PR DESCRIPTION
This is actually [the default](https://docs.percy.io/docs/cli-configuration#snapshot) so it could be removed entirely but I’m ambivalent about that. Thoughts?