### PR TITLE
[CS-3087] Primitive cards can provide a custom serializer

### DIFF
--- a/packages/base-cards/date/card.json
+++ b/packages/base-cards/date/card.json
@@ -1,6 +1,6 @@
 {
-    "schema": "schema.js",
-    "embedded": "embedded.js",
-    "edit": "edit.js",
-    "deserializer": "date"
+  "schema": "schema.js",
+  "embedded": "embedded.js",
+  "edit": "edit.js",
+  "serializer": "serializer.js"
 }

--- a/packages/base-cards/date/serializer.js
+++ b/packages/base-cards/date/serializer.js
@@ -12,5 +12,3 @@ export function serialize(d) {
 export function deserialize(d) {
   return parse(d, 'yyyy-MM-dd', new Date());
 }
-
-export default { serialize, deserialize };

--- a/packages/base-cards/date/serializer.js
+++ b/packages/base-cards/date/serializer.js
@@ -1,0 +1,13 @@
+import { parse, format } from 'date-fns';
+
+export function serialize(d) {
+  // If the model hasn't been deserialized yet it will still be a string
+  if (typeof d === 'string') {
+    return d;
+  }
+  return format(d, 'yyyy-MM-dd');
+}
+
+export function deserialize(d) {
+  return parse(d, 'yyyy-MM-dd', new Date());
+}

--- a/packages/base-cards/date/serializer.js
+++ b/packages/base-cards/date/serializer.js
@@ -1,4 +1,5 @@
-import { parse, format } from 'date-fns';
+import parse from 'date-fns/parse';
+import format from 'date-fns/format';
 
 export function serialize(d) {
   // If the model hasn't been deserialized yet it will still be a string
@@ -11,3 +12,5 @@ export function serialize(d) {
 export function deserialize(d) {
   return parse(d, 'yyyy-MM-dd', new Date());
 }
+
+export default { serialize, deserialize };

--- a/packages/base-cards/datetime/card.json
+++ b/packages/base-cards/datetime/card.json
@@ -1,6 +1,6 @@
 {
-    "schema": "schema.js",
-    "embedded": "embedded.js",
-    "edit": "edit.js",
-    "deserializer": "datetime"
+  "schema": "schema.js",
+  "embedded": "embedded.js",
+  "edit": "edit.js",
+  "serializer": "serializer.js"
 }

--- a/packages/base-cards/datetime/serializer.js
+++ b/packages/base-cards/datetime/serializer.js
@@ -11,5 +11,3 @@ export function serialize(d) {
 export function deserialize(d) {
   return parseISO(d);
 }
-
-export default { serialize, deserialize };

--- a/packages/base-cards/datetime/serializer.js
+++ b/packages/base-cards/datetime/serializer.js
@@ -1,0 +1,13 @@
+import { parseISO } from 'date-fns';
+
+export function serialize(d) {
+  // If the model hasn't been deserialized yet it will still be a string
+  if (typeof d === 'string') {
+    return d;
+  }
+  return d.toISOString();
+}
+
+export function deserialize(d) {
+  return parseISO(d);
+}

--- a/packages/base-cards/datetime/serializer.js
+++ b/packages/base-cards/datetime/serializer.js
@@ -1,4 +1,4 @@
-import { parseISO } from 'date-fns';
+import parseISO from 'date-fns/parseISO';
 
 export function serialize(d) {
   // If the model hasn't been deserialized yet it will still be a string
@@ -11,3 +11,5 @@ export function serialize(d) {
 export function deserialize(d) {
   return parseISO(d);
 }
+
+export default { serialize, deserialize };

--- a/packages/cardhost/app/lib/builder.ts
+++ b/packages/cardhost/app/lib/builder.ts
@@ -89,7 +89,7 @@ export default class LocalRealm implements Builder {
     let { compiled, raw } = await this.load(url);
 
     let componentModule = await this.cards.loadModule<CardComponentModule>(
-      compiled.componentInfos[format].moduleName.global
+      compiled.componentInfos[format].componentModule.global
     );
 
     // TODO we can optimize this structure in our CardModelForBrowser now that
@@ -100,7 +100,7 @@ export default class LocalRealm implements Builder {
       attributes: raw.data,
       meta: {
         schemaModule: compiled.schemaModule.global,
-        componentModule: compiled.componentInfos[format].moduleName.global,
+        componentModule: compiled.componentInfos[format].componentModule.global,
       },
     };
     let model = new CardModelForBrowser(

--- a/packages/cardhost/app/lib/card-model-for-browser.ts
+++ b/packages/cardhost/app/lib/card-model-for-browser.ts
@@ -305,11 +305,11 @@ export default class CardModelForBrowser implements CardModel {
   }
 
   get serializerMap(): ComponentInfo['serializerMap'] {
-    return this.state.componentModule.ComponentMeta.serializerMap;
+    return this.state.componentModule.serializerMap;
   }
 
   get usedFields(): ComponentInfo['usedFields'] {
-    return this.state.componentModule.ComponentMeta.usedFields;
+    return this.state.componentModule.usedFields;
   }
 
   async save(): Promise<void> {

--- a/packages/cardhost/app/lib/card-model-for-browser.ts
+++ b/packages/cardhost/app/lib/card-model-for-browser.ts
@@ -8,25 +8,22 @@ import {
   CardModel,
   RawCardData,
   Format,
-  ComponentInfo,
   CardComponentModule,
   CardSchemaModule,
-  SerializerName,
 } from '@cardstack/core/src/interfaces';
 // import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 // @ts-ignore @ember/component doesn't declare setComponentTemplate...yet!
 import { setComponentTemplate } from '@ember/component';
 import { hbs } from 'ember-cli-htmlbars';
-import { cloneDeep } from 'lodash';
 import { tracked as _tracked } from '@glimmer/tracking';
 import {
-  inversedSerializerMap,
-  serializeResource,
-  SERIALIZERS,
+  serializeField,
+  serializeCardAsResource,
 } from '@cardstack/core/src/serializers';
 import set from 'lodash/set';
 import get from 'lodash/get';
+import cloneDeep from 'lodash/cloneDeep';
 import Cards from 'cardhost/services/cards';
 import { fetchJSON } from './jsonapi-fetch';
 import config from 'cardhost/config/environment';
@@ -70,8 +67,6 @@ export default class CardModelForBrowser implements CardModel {
   private _schemaInstance: any | undefined;
   private _schemaClass: CardSchemaModule['default'] | undefined;
 
-  private inversedSerializerMap: Record<string, SerializerName>;
-
   constructor(
     private cards: Cards,
     state: CreatedState | Omit<LoadedState, 'deserialized' | 'original'>,
@@ -86,9 +81,6 @@ export default class CardModelForBrowser implements CardModel {
         original: undefined,
       };
     }
-
-    // TEMP: needed until serializerMap restructure
-    this.inversedSerializerMap = inversedSerializerMap(this.serializerMap);
 
     this.setters = this.makeSetter();
     let prop = tracked(this, '_data', {
@@ -164,10 +156,7 @@ export default class CardModelForBrowser implements CardModel {
     return editable;
   }
 
-  // TODO: Consolidate this into getField work
-  // It cant happen until the syncData we generate
-  // in component is the same data we use elsewhere
-  get data(): any {
+  get data(): object {
     return this._data;
   }
 
@@ -225,12 +214,7 @@ export default class CardModelForBrowser implements CardModel {
 
   private getRawField(fieldPath: string): any {
     let value = get(this.rawData, fieldPath);
-    return serializeField(
-      this.inversedSerializerMap,
-      fieldPath,
-      value,
-      'deserialize'
-    );
+    return serializeField(this.serializerMap, fieldPath, value, 'deserialize');
   }
 
   async schemaClass() {
@@ -289,26 +273,14 @@ export default class CardModelForBrowser implements CardModel {
       url = cardURL({ realm: this.state.realm, id: this.state.id });
     }
 
-    let attributes = cloneDeep(this.data);
-    let map = this.inversedSerializerMap;
-    for (let field of Object.keys(map)) {
-      let value = serializeField(
-        this.inversedSerializerMap,
-        field,
-        get(attributes, field),
-        'serialize'
-      );
-      set(attributes, field, value);
-    }
-
-    return serializeResource('card', url, attributes);
+    return serializeCardAsResource(url, this.data, this.serializerMap);
   }
 
-  get serializerMap(): ComponentInfo['serializerMap'] {
+  get serializerMap(): CardComponentModule['serializerMap'] {
     return this.state.componentModule.serializerMap;
   }
 
-  get usedFields(): ComponentInfo['usedFields'] {
+  get usedFields(): CardComponentModule['usedFields'] {
     return this.state.componentModule.usedFields;
   }
 
@@ -409,22 +381,4 @@ function tracked(
 
 function assertNever(value: never) {
   throw new Error(`should never happen ${value}`);
-}
-
-function serializeField(
-  serializerMap: Record<string, SerializerName>,
-  fieldPath: string,
-  value: any,
-  action: 'serialize' | 'deserialize'
-) {
-  if (!value) {
-    return;
-  }
-  let serializerName = get(serializerMap, fieldPath);
-  if (serializerName) {
-    let serializer = SERIALIZERS[serializerName];
-    return serializer[action](value);
-  }
-
-  return value;
 }

--- a/packages/cardhost/app/lib/card-model-for-browser.ts
+++ b/packages/cardhost/app/lib/card-model-for-browser.ts
@@ -305,11 +305,11 @@ export default class CardModelForBrowser implements CardModel {
   }
 
   get serializerMap(): ComponentInfo['serializerMap'] {
-    return this.state.componentModule.getCardModelOptions().serializerMap;
+    return this.state.componentModule.ComponentMeta.serializerMap;
   }
 
   get usedFields(): ComponentInfo['usedFields'] {
-    return this.state.componentModule.getCardModelOptions().usedFields;
+    return this.state.componentModule.ComponentMeta.usedFields;
   }
 
   async save(): Promise<void> {

--- a/packages/cardhost/tests/@core/compiler-adoption-test.ts
+++ b/packages/cardhost/tests/@core/compiler-adoption-test.ts
@@ -61,8 +61,8 @@ module('@core | compiler-adoption', function (hooks) {
       assert.deepEqual(Object.keys(compiled.fields), ['name', 'birthdate']);
       assert.deepEqual(compiled.adoptsFrom, parentCard);
       assert.equal(
-        compiled.componentInfos.embedded.moduleName,
-        parentCard.componentInfos.embedded.moduleName,
+        compiled.componentInfos.embedded.componentModule,
+        parentCard.componentInfos.embedded.componentModule,
         'It reports the module name for the template that it adopts'
       );
     });
@@ -196,7 +196,7 @@ module('@core | compiler-adoption', function (hooks) {
 
       assert.ok(
         await cardService.loadModule(
-          compiledCard.componentInfos.embedded.moduleName.global
+          compiledCard.componentInfos.embedded.componentModule.global
         ),
         'Has a embedded component'
       );
@@ -237,7 +237,7 @@ module('@core | compiler-adoption', function (hooks) {
       let compiledCard = await builder.getCompiledCard(cardURL(card));
       assert.ok(
         await cardService.loadModule(
-          compiledCard.componentInfos.embedded.moduleName.global
+          compiledCard.componentInfos.embedded.componentModule.global
         ),
         'Has a embedded component'
       );

--- a/packages/cardhost/tests/@core/compiler-basics-test.ts
+++ b/packages/cardhost/tests/@core/compiler-basics-test.ts
@@ -60,13 +60,13 @@ module('@core | compiler-basics', function (hooks) {
     assert.deepEqual(compiled.fields, {}, 'No fields');
     assert.ok(
       await cardService.loadModule(
-        compiled.componentInfos.isolated.moduleName.global
+        compiled.componentInfos.isolated.componentModule.global
       ),
       'Isolated module exists'
     );
     assert.ok(
       await cardService.loadModule(
-        compiled.componentInfos.embedded.moduleName.global
+        compiled.componentInfos.embedded.componentModule.global
       ),
       'Embedded module exists'
     );
@@ -281,7 +281,7 @@ module('@core | compiler-basics', function (hooks) {
 
     test('it inlines a simple field template', async function (assert) {
       assert.ok(
-        compiled.componentInfos.isolated.moduleName.global.includes(
+        compiled.componentInfos.isolated.componentModule.global.includes(
           `/isolated`
         ),
         'templateModule for "isolated" is full url'
@@ -294,7 +294,7 @@ module('@core | compiler-basics', function (hooks) {
       let compiled = await builder.getCompiledCard(cardURL(PERSON_RAW_CARD));
 
       let code = await cardService.loadModule<any>(
-        compiled.componentInfos.embedded.moduleName.global
+        compiled.componentInfos.embedded.componentModule.global
       );
 
       assert.equal(code.default.moduleName, '@glimmer/component/template-only');

--- a/packages/compiled/package.json
+++ b/packages/compiled/package.json
@@ -25,7 +25,8 @@
     "@cardstack/boxel": "0.28.17",
     "@cardstack/core": "0.28.17",
     "@embroider/addon-shim": "*",
-    "@glimmer/component": "^1.0.3"
+    "@glimmer/component": "^1.0.3",
+    "date-fns": "^2.22.1"
   },
   "ember-addon": {
     "version": 2,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,6 @@
     "@types/inflection": "^1.5.28",
     "@types/lodash": "^4.14.168",
     "babel-import-util": "^1.1.0",
-    "date-fns": "^2.22.1",
     "ember-cli-htmlbars": "^5.7.1",
     "http-status-codes": "^2.1.4",
     "inflection": "^1.12.0",

--- a/packages/core/src/babel-plugin-card-component-meta.ts
+++ b/packages/core/src/babel-plugin-card-component-meta.ts
@@ -1,0 +1,94 @@
+// import ETC from 'ember-source/dist/ember-template-compiler';
+// const { preprocess, print } = ETC._GlimmerSyntax;
+
+import { transformSync } from '@babel/core';
+import { NodePath } from '@babel/traverse';
+import type * as Babel from '@babel/core';
+import type { types as t } from '@babel/core';
+
+import { CompiledCard, SerializerName, SerializerMap } from './interfaces';
+
+import { buildSerializerMapFromUsedFields } from './utils/fields';
+import { augmentBadRequest } from './utils/errors';
+
+export interface CardComponentMetaPluginOptions {
+  debugPath: string;
+  fields: CompiledCard['fields'];
+  // these are for gathering output
+  usedFields: string[];
+  serializerMap: SerializerMap;
+}
+
+interface State {
+  opts: CardComponentMetaPluginOptions;
+}
+
+export default function (options: CardComponentMetaPluginOptions): { source: string; ast: t.File } {
+  try {
+    let out = transformSync('', {
+      ast: true,
+      plugins: [[babelPluginComponentMeta, options]],
+      // HACK: The / resets the relative path setup, removing the cwd of the hub.
+      // This allows the error module to look a lot more like the card URL.
+      filename: '/' + options.debugPath.replace(/^\//, ''),
+    });
+    return { source: out!.code!, ast: out!.ast! };
+  } catch (e: any) {
+    throw augmentBadRequest(e);
+  }
+}
+
+export function babelPluginComponentMeta(babel: typeof Babel) {
+  return {
+    visitor: {
+      Program: {
+        exit(path: NodePath<t.Program>, state: State) {
+          addComponentMetaExport(path, state, babel);
+        },
+      },
+    },
+  };
+}
+
+function addComponentMetaExport(path: NodePath<t.Program>, state: State, babel: typeof Babel) {
+  let t = babel.types;
+  let serializerMap = buildSerializerMapFromUsedFields(state.opts.fields, state.opts.usedFields);
+  state.opts.serializerMap = serializerMap;
+
+  path.node.body.push(
+    babel.template(`
+      export const ComponentMeta = {
+          serializerMap: %%serializerMap%%,
+          computedFields: %%computedFields%%,
+          usedFields: %%usedFields%%
+        };
+      `)({
+      serializerMap: t.objectExpression(buildSerializerMapProp(serializerMap, t)),
+      computedFields: t.arrayExpression(
+        Object.values(state.opts.fields)
+          .filter((field) => field.computed)
+          .map((field) => t.stringLiteral(field.name))
+      ),
+      usedFields: t.arrayExpression(state.opts.usedFields.map((field) => t.stringLiteral(field))),
+    }) as t.Statement
+  );
+}
+
+function buildSerializerMapProp(serializerMap: SerializerMap, t: typeof Babel.types): t.ObjectExpression['properties'] {
+  let props: t.ObjectExpression['properties'] = [];
+
+  for (let serializer in serializerMap) {
+    let fieldList = serializerMap[serializer as SerializerName];
+    if (!fieldList) {
+      continue;
+    }
+
+    let fieldListElements: t.ArrayExpression['elements'] = [];
+    for (let field of fieldList) {
+      fieldListElements.push(t.stringLiteral(field));
+    }
+    props.push(t.objectProperty(t.identifier(serializer), t.arrayExpression(fieldListElements)));
+  }
+
+  return props;
+}

--- a/packages/core/src/babel-plugin-card-component-meta.ts
+++ b/packages/core/src/babel-plugin-card-component-meta.ts
@@ -141,7 +141,7 @@ function addFieldToSerializerMap(
     map[usedPath] = state.importUtil.import(
       path,
       field.card.serializerModule.global,
-      'default',
+      '*',
       `${capitalize(cardId)}Serializer`
     );
   }

--- a/packages/core/src/babel-plugin-card-serializer-analyze.ts
+++ b/packages/core/src/babel-plugin-card-serializer-analyze.ts
@@ -1,0 +1,54 @@
+import type * as Babel from '@babel/core';
+import type { types as t } from '@babel/core';
+import { BabelFileResult, transformSync } from '@babel/core';
+import { NodePath } from '@babel/traverse';
+import difference from 'lodash/difference';
+import { name, error } from './utils/babel';
+import { augmentBadRequest } from './utils/errors';
+
+const REQUIRED_EXPORTS = ['serialize', 'deserialize'];
+
+interface State {
+  seenExports: string[];
+}
+
+export default function (schemaSrc: string): { code: BabelFileResult['code']; ast: BabelFileResult['ast'] } {
+  let out: BabelFileResult;
+  try {
+    out = transformSync(schemaSrc, {
+      ast: true,
+      plugins: [[babelPluginCardSerializerAnalyze]],
+    })!;
+  } catch (error: any) {
+    throw augmentBadRequest(error);
+  }
+
+  return {
+    code: out!.code,
+    ast: out!.ast,
+  };
+}
+
+export function babelPluginCardSerializerAnalyze(babel: typeof Babel) {
+  let t = babel.types;
+  return {
+    visitor: {
+      ExportNamedDeclaration(path: NodePath<t.ExportNamedDeclaration>, state: State) {
+        if (t.isFunctionDeclaration(path.node.declaration) && path.node.declaration.id) {
+          if (!state.seenExports) {
+            state.seenExports = [];
+          }
+          state.seenExports.push(name(path.node.declaration.id, t));
+        }
+      },
+      Program: {
+        exit(path: NodePath<t.Program>, state: State) {
+          let diff = difference(REQUIRED_EXPORTS, state.seenExports);
+          if (diff.length) {
+            throw error(path, `Serializer is malformed. It is missing the following exports: ${diff.join(', ')}`);
+          }
+        },
+      },
+    },
+  };
+}

--- a/packages/core/src/babel-plugin-card-template.ts
+++ b/packages/core/src/babel-plugin-card-template.ts
@@ -58,7 +58,7 @@ export function babelPluginCardTemplate(babel: typeof Babel) {
         },
         exit(path: NodePath<t.Program>, state: State) {
           path.node.body.push(
-            babel.template(`export { ComponentMeta } from %%metaModulePath%%;`)({
+            babel.template(`export * from %%metaModulePath%%;`)({
               metaModulePath: state.opts.metaModulePath,
             }) as t.Statement
           );

--- a/packages/core/src/babel-plugin-card-template.ts
+++ b/packages/core/src/babel-plugin-card-template.ts
@@ -9,7 +9,7 @@ import type * as Babel from '@babel/core';
 import type { types as t } from '@babel/core';
 import { ImportUtil } from 'babel-import-util';
 
-import { CompiledCard, Format } from './interfaces';
+import { CompiledCard, ComponentInfo, Format } from './interfaces';
 
 import { getObjectKey, error } from './utils/babel';
 import glimmerCardTemplateTransform from './glimmer-plugin-card-template';
@@ -22,7 +22,7 @@ export interface CardComponentPluginOptions {
   defaultFieldFormat: Format;
   metaModulePath: string;
   // these are for gathering output
-  usedFields: string[];
+  usedFields: ComponentInfo['usedFields'];
   inlineHBS: string | undefined;
 }
 

--- a/packages/core/src/babel-plugin-card-template.ts
+++ b/packages/core/src/babel-plugin-card-template.ts
@@ -9,21 +9,21 @@ import type * as Babel from '@babel/core';
 import type { types as t } from '@babel/core';
 import { ImportUtil } from 'babel-import-util';
 
-import { CompiledCard, SerializerName, Format, SerializerMap } from './interfaces';
+import { CompiledCard, Format } from './interfaces';
 
 import { getObjectKey, error } from './utils/babel';
 import glimmerCardTemplateTransform from './glimmer-plugin-card-template';
-import { buildSerializerMapFromUsedFields, buildUsedFieldsListFromUsageMeta } from './utils/fields';
+import { buildUsedFieldsListFromUsageMeta } from './utils/fields';
 import { augmentBadRequest } from './utils/errors';
 import { CallExpression } from '@babel/types';
 export interface CardComponentPluginOptions {
   debugPath: string;
   fields: CompiledCard['fields'];
   defaultFieldFormat: Format;
+  metaModulePath: string;
   // these are for gathering output
   usedFields: string[];
   inlineHBS: string | undefined;
-  serializerMap: SerializerMap;
 }
 
 interface State {
@@ -57,7 +57,11 @@ export function babelPluginCardTemplate(babel: typeof Babel) {
           state.insideExportDefault = false;
         },
         exit(path: NodePath<t.Program>, state: State) {
-          addGetCardModelOptions(path, state, babel);
+          path.node.body.push(
+            babel.template(`export { ComponentMeta } from %%metaModulePath%%;`)({
+              metaModulePath: state.opts.metaModulePath,
+            }) as t.Statement
+          );
         },
       },
 
@@ -77,57 +81,6 @@ export function babelPluginCardTemplate(babel: typeof Babel) {
       },
     },
   };
-}
-
-function addGetCardModelOptions(path: NodePath<t.Program>, state: State, babel: typeof Babel) {
-  let t = babel.types;
-  let serializerMap = buildSerializerMapFromUsedFields(state.opts.fields, state.opts.usedFields);
-  state.opts.serializerMap = serializerMap;
-
-  path.node.body.push(
-    t.exportNamedDeclaration(
-      t.functionDeclaration(
-        t.identifier('getCardModelOptions'),
-        [],
-        t.blockStatement([
-          babel.template(`
-            return {
-              serializerMap: %%serializerMap%%,
-              computedFields: %%computedFields%%,
-              usedFields: %%usedFields%%
-            };
-          `)({
-            serializerMap: t.objectExpression(buildSerializerMapProp(serializerMap, t)),
-            computedFields: t.arrayExpression(
-              Object.values(state.opts.fields)
-                .filter((field) => field.computed)
-                .map((field) => t.stringLiteral(field.name))
-            ),
-            usedFields: t.arrayExpression(state.opts.usedFields.map((field) => t.stringLiteral(field))),
-          }) as t.Statement,
-        ])
-      )
-    )
-  );
-}
-
-function buildSerializerMapProp(serializerMap: SerializerMap, t: typeof Babel.types): t.ObjectExpression['properties'] {
-  let props: t.ObjectExpression['properties'] = [];
-
-  for (let serializer in serializerMap) {
-    let fieldList = serializerMap[serializer as SerializerName];
-    if (!fieldList) {
-      continue;
-    }
-
-    let fieldListElements: t.ArrayExpression['elements'] = [];
-    for (let field of fieldList) {
-      fieldListElements.push(t.stringLiteral(field));
-    }
-    props.push(t.objectProperty(t.identifier(serializer), t.arrayExpression(fieldListElements)));
-  }
-
-  return props;
 }
 
 function callExpressionEnter(path: NodePath<t.CallExpression>, state: State, t: typeof Babel.types) {

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -176,7 +176,7 @@ export class Compiler<Identity extends Saved | Unsaved = Saved> {
   private getFile(cardSource: RawCard<Unsaved>, path: string): string {
     let fileSrc = cardSource.files && cardSource.files[path];
     if (!fileSrc) {
-      throw new CardstackError(`card refers to ${path} in its card.json but that file does not exist`);
+      throw new CardstackError(`card refers to ${path} in its card.json but that file does not exist`, { status: 422 });
     }
     return fileSrc;
   }

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -376,14 +376,14 @@ export class Compiler<Identity extends Saved | Unsaved = Saved> {
     };
 
     let { source, ast } = transformCardComponent(templateSource, options);
-    let moduleName = hashFilenameFromFields(localFile, fields);
-    modules[moduleName] = {
+    let componentModule = hashFilenameFromFields(localFile, fields);
+    modules[componentModule] = {
       type: JS_TYPE,
       source,
       ast,
     };
     let componentInfo: ComponentInfo<LocalRef> = {
-      moduleName: { local: moduleName },
+      componentModule: { local: componentModule },
       usedFields: options.usedFields,
       inlineHBS: options.inlineHBS,
       serializerMap: options.serializerMap,
@@ -456,7 +456,7 @@ export function makeGloballyAddressable(
 
   function ensureGlobalComponentInfo(info: ComponentInfo<ModuleRef>): ComponentInfo<GlobalRef> {
     return {
-      moduleName: ensureGlobal(info.moduleName),
+      componentModule: ensureGlobal(info.componentModule),
       usedFields: info.usedFields,
       inlineHBS: info.inlineHBS,
       inheritedFrom: info.inheritedFrom,

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -27,6 +27,7 @@ import { ensureTrailingSlash, getBasenameAndExtension } from './utils';
 import { getFileType } from './utils/content';
 import { CardstackError, BadRequest, augmentBadRequest, isCardstackError } from './utils/errors';
 import { hashCardFields } from './utils/fields';
+import babelPluginCardSerializerAnalyze from './babel-plugin-card-serializer-analyze';
 
 export const baseCardURL = 'https://cardstack.com/base/base';
 
@@ -413,6 +414,8 @@ export class Compiler<Identity extends Saved | Unsaved = Saved> {
     } else if (serializer) {
       serializerRef = { local: serializer };
       let source = await this.getFile(this.cardSource, serializer);
+
+      babelPluginCardSerializerAnalyze(source);
       this.modules[serializer] = {
         type: JS_TYPE,
         source,

--- a/packages/core/src/glimmer-plugin-card-template.ts
+++ b/packages/core/src/glimmer-plugin-card-template.ts
@@ -419,7 +419,7 @@ function rewriteFieldToComponent(
 
   let componentName = importAndChooseName(
     classify(field.card.url),
-    field.card.componentInfos[format].moduleName.global,
+    field.card.componentInfos[format].componentModule.global,
     'default'
   );
 

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -11,7 +11,7 @@ const componentFormats = {
   edit: '',
 };
 export type Format = keyof typeof componentFormats;
-export const FORMATS = Object.keys(componentFormats) as Format[];
+export const FORMATS = keys(componentFormats);
 
 export function isFormat(s: any): s is Format {
   return s && s in componentFormats;
@@ -21,7 +21,7 @@ const featureNamesMap = {
   schema: '',
 };
 export type FeatureFile = keyof typeof featureNamesMap & Format;
-export const FEATURE_NAMES = Object.keys(featureNamesMap).concat(FORMATS) as FeatureFile[];
+export const FEATURE_NAMES = [...keys(featureNamesMap), ...FORMATS];
 
 const serializerTypes = {
   date: '',

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -155,7 +155,7 @@ export interface CompiledCard<Identity extends Unsaved = Saved, Ref extends Modu
 
 export interface ComponentInfo<Ref extends ModuleRef = GlobalRef> {
   componentModule: Ref;
-  metaModule?: Ref;
+  metaModule: Ref;
   usedFields: string[]; // ["title", "author.firstName"]
 
   serializerMap: SerializerMap;
@@ -214,13 +214,17 @@ export interface CardSchemaModule {
   };
 }
 
-export interface CardComponentModule {
-  default: unknown;
-  getCardModelOptions(): {
+export interface CardComponentMetaModule {
+  ComponentMeta: {
     serializerMap: SerializerMap;
     computedFields: string[];
     usedFields: string[];
   };
+}
+
+export interface CardComponentModule {
+  default: unknown;
+  ComponentMeta: CardComponentMetaModule['ComponentMeta'];
 }
 
 export interface RealmConfig {

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -215,17 +215,14 @@ export interface CardSchemaModule {
 }
 
 export interface CardComponentMetaModule {
-  ComponentMeta: {
-    serializerMap: SerializerMap;
-    computedFields: string[];
-    usedFields: string[];
-  };
+  serializerMap: SerializerMap;
+  computedFields: string[];
+  usedFields: string[];
 }
 
-export interface CardComponentModule {
+export type CardComponentModule = {
   default: unknown;
-  ComponentMeta: CardComponentMetaModule['ComponentMeta'];
-}
+} & CardComponentMetaModule;
 
 export interface RealmConfig {
   url: string;

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -1,7 +1,7 @@
 import * as JSON from 'json-typescript';
-import difference from 'lodash/difference';
 import { CardstackError } from './utils/errors';
 import type { types as t } from '@babel/core';
+import { keys } from './utils';
 
 export { Query } from './query';
 
@@ -19,24 +19,15 @@ export function isFormat(s: any): s is Format {
 
 const featureNamesMap = {
   schema: '',
+  serializer: '',
 };
 export type FeatureFile = keyof typeof featureNamesMap & Format;
 export const FEATURE_NAMES = [...keys(featureNamesMap), ...FORMATS];
 
-const serializerTypes = {
-  date: '',
-  datetime: '',
-};
-export type SerializerName = keyof typeof serializerTypes;
-export const SERIALIZER_NAMES = Object.keys(serializerTypes) as SerializerName[];
-export type SerializerMap = { [key in SerializerName]?: string[] };
-
-export function assertValidSerializerMap(map: any): asserts map is SerializerMap {
-  let keys = Object.keys(map);
-  let diff = difference(keys, SERIALIZER_NAMES);
-  if (diff.length > 0) {
-    throw new CardstackError(`Unexpected serializer: ${diff.join(',')}`);
-  }
+export type SerializerMap = Record<string, PrimitiveSerializer>;
+export interface PrimitiveSerializer {
+  serialize(val: any): any;
+  deserialize(val: any): any;
 }
 
 export type CardData = Record<string, any>;
@@ -49,7 +40,6 @@ export interface CardId {
 }
 
 export type RawCardData = Record<string, any>;
-
 // RawCard represents the card "as authored". Nothing is preprocessed or
 // compiled, no other dependent data is included, no derived state is present.
 export interface RawCard<Identity extends Unsaved = Saved> {
@@ -61,8 +51,7 @@ export interface RawCard<Identity extends Unsaved = Saved> {
   isolated?: string;
   embedded?: string;
   edit?: string;
-
-  deserializer?: SerializerName;
+  serializer?: string;
 
   // url to the card we adopted from
   adoptsFrom?: string;
@@ -137,7 +126,7 @@ export interface CompiledCard<Identity extends Unsaved = Saved, Ref extends Modu
     [key: string]: Field;
   };
   schemaModule: Ref;
-  serializer?: SerializerName;
+  serializerModule?: Ref;
 
   componentInfos: Record<Format, ComponentInfo<Ref>>;
 

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -154,7 +154,8 @@ export interface CompiledCard<Identity extends Unsaved = Saved, Ref extends Modu
 }
 
 export interface ComponentInfo<Ref extends ModuleRef = GlobalRef> {
-  moduleName: Ref;
+  componentModule: Ref;
+  metaModule?: Ref;
   usedFields: string[]; // ["title", "author.firstName"]
 
   serializerMap: SerializerMap;

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -147,8 +147,6 @@ export interface ComponentInfo<Ref extends ModuleRef = GlobalRef> {
   metaModule: Ref;
   usedFields: string[]; // ["title", "author.firstName"]
 
-  serializerMap: SerializerMap;
-
   // optional optimization when this card can be inlined into cards that use it
   inlineHBS?: string;
 

--- a/packages/core/src/serializers/index.ts
+++ b/packages/core/src/serializers/index.ts
@@ -17,41 +17,6 @@ import {
 export { RawCardDeserializer } from './raw-card-deserializer';
 export { RawCardSerializer } from './raw-card-serializer';
 
-export interface PrimitiveSerializer {
-  serialize(val: any): any;
-  deserialize(val: any): any;
-}
-
-const DateTimeSerializer: PrimitiveSerializer = {
-  serialize(d: Date): string {
-    // If the model hasn't been deserialized yet it will still be a string
-    if (typeof d === 'string') {
-      return d;
-    }
-    return d.toISOString();
-  },
-  deserialize(d: string): Date {
-    return parseISO(d);
-  },
-};
-
-const DateSerializer: PrimitiveSerializer = {
-  serialize(d: Date): string {
-    // If the model hasn't been deserialized yet it will still be a string
-    if (typeof d === 'string') {
-      return d;
-    }
-    return format(d, 'yyyy-MM-dd');
-  },
-  deserialize(d: string): Date {
-    return parse(d, 'yyyy-MM-dd', new Date());
-  },
-};
-
-export const SERIALIZERS = {
-  datetime: DateTimeSerializer,
-  date: DateSerializer,
-};
 
 export function deserializeAttributes(attrs: { [name: string]: any } | undefined, serializerMap: SerializerMap) {
   return _serializeAttributes(cloneDeep(attrs), 'deserialize', serializerMap);

--- a/packages/core/src/serializers/index.ts
+++ b/packages/core/src/serializers/index.ts
@@ -1,130 +1,72 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { parseISO, parse, format } from 'date-fns';
-import merge from 'lodash/merge';
+import * as JSON from 'json-typescript';
 import set from 'lodash/set';
 import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
-import {
-  ResourceObject,
-  Saved,
-  JSONAPIDocument,
-  SerializerMap,
-  SerializerName,
-  Unsaved,
-  CardContent,
-} from '../interfaces';
+import { ResourceObject, Saved, SerializerMap, Unsaved, ComponentInfo } from '../interfaces';
+import { keys } from '../utils';
+import { pick } from 'lodash';
 
 export { RawCardDeserializer } from './raw-card-deserializer';
 export { RawCardSerializer } from './raw-card-serializer';
 
-
-export function deserializeAttributes(attrs: { [name: string]: any } | undefined, serializerMap: SerializerMap) {
-  return _serializeAttributes(cloneDeep(attrs), 'deserialize', serializerMap);
-}
-
-export function serializeAttributes(attrs: { [name: string]: any } | undefined, serializerMap: SerializerMap) {
-  return _serializeAttributes(cloneDeep(attrs), 'serialize', serializerMap);
-}
-
-function _serializeAttributes(
-  attrs: { [name: string]: any } | undefined,
-  action: 'serialize' | 'deserialize',
-  serializerMap: SerializerMap
-): any {
-  if (!attrs) {
-    return;
-  }
-  let serializerName: SerializerName;
-  for (serializerName in serializerMap) {
-    let serializer = SERIALIZERS[serializerName];
-    let paths = serializerMap[serializerName];
-    if (!paths) {
-      continue;
-    }
-    for (const path of paths) {
-      serializeAttribute(attrs, path, serializer, action);
-    }
-  }
-
-  return attrs;
-}
-
-function serializeAttribute(
-  attrs: { [name: string]: any },
-  path: string,
-  serializer: PrimitiveSerializer,
+export function serializeField(
+  serializerMap: SerializerMap,
+  fieldPath: string,
+  value: any,
   action: 'serialize' | 'deserialize'
 ) {
-  let [key, ...tail] = path.split('.');
-  let value = attrs[key];
   if (!value) {
     return;
   }
-
-  if (tail.length) {
-    let tailPath = tail.join('.');
-    if (Array.isArray(value)) {
-      for (let row of value) {
-        serializeAttribute(row, tailPath, serializer, action);
-      }
-    } else {
-      serializeAttribute(attrs[key], tailPath, serializer, action);
-    }
-  } else {
-    attrs[path] = serializer[action](value);
+  let serializer = get(serializerMap, fieldPath);
+  if (serializer) {
+    return serializer[action](value);
   }
+
+  return value;
 }
 
-// TEMP: This is here to support the future layout of the serializerMaps that will eventually be
-// built into the component
-export function inversedSerializerMap(serializerMap: SerializerMap): Record<string, SerializerName> {
-  let inversedMap: Record<string, SerializerName> = {};
-  for (const type of Object.keys(serializerMap) as SerializerName[]) {
-    for (const key of serializerMap[type] || []) {
-      inversedMap[key] = type;
+export function deserializeAttributes(attrs: any, serializerMap: SerializerMap): JSON.Object {
+  return serializeAttributes(attrs, serializerMap, 'deserialize');
+}
+
+export function serializeAttributes(
+  attrs: any,
+  serializerMap: SerializerMap,
+  action: 'serialize' | 'deserialize' = 'serialize'
+): JSON.Object {
+  let attributes = cloneDeep(attrs);
+
+  for (let field of keys(serializerMap)) {
+    let rawValue = get(attributes, field);
+    if (typeof rawValue === 'undefined') {
+      continue;
     }
+    let value = serializeField(serializerMap, field, rawValue, action);
+    set(attributes, field, value);
   }
-  return inversedMap;
+
+  return attributes;
 }
 
-export function serializeCardPayloadForFormat(card: CardContent): JSONAPIDocument<Saved> {
-  let { usedFields, componentModule } = card;
-  let resource = serializeResource('card', card.url, card.data, usedFields);
-  resource.meta = merge(
-    {
-      componentModule,
-    },
-    resource.meta
-  );
-  return { data: resource };
-}
-
-export function serializeResource<Identity extends Saved | Unsaved>(
-  type: string,
-  id: Identity,
-  payload: any,
-  attributes?: (string | Record<string, string>)[]
+export function serializeCardAsResource<Identity extends Saved | Unsaved>(
+  url: Identity,
+  payload: object,
+  serializerMap: SerializerMap,
+  usedFields?: ComponentInfo['usedFields']
 ): ResourceObject<Identity> {
-  let resource: ResourceObject<Identity> = {
-    id,
-    type,
+  let data = usedFields ? pick(payload, usedFields) : payload;
+  let attributes = serializeAttributes(data, serializerMap);
+
+  return {
+    id: url,
+    type: 'card',
+    attributes,
   };
-  resource.attributes = {};
-
-  if (!attributes) {
-    attributes = Object.keys(payload);
-  }
-
-  for (const attr of attributes) {
-    if (typeof attr === 'object') {
-      let [aliasName, name] = Object.entries(attr)[0];
-      set(resource.attributes, aliasName, get(payload, name) ?? null);
-    } else {
-      set(resource.attributes, attr, get(payload, attr) ?? null);
-    }
-  }
-  return resource;
 }
+
+//
 
 export function findIncluded(doc: any, ref: { type: string; id: string }) {
   return doc.included?.find((r: any) => r.id === ref.id && r.type === ref.type);

--- a/packages/core/src/serializers/raw-card-deserializer.ts
+++ b/packages/core/src/serializers/raw-card-deserializer.ts
@@ -54,7 +54,7 @@ export class RawCardDeserializer {
       url: resource.id,
       realm: attrs?.realm,
       schemaModule: attrs?.schemaModule,
-      serializer: attrs?.serializer,
+      serializerModule: attrs?.serializerModule,
       componentInfos: attrs?.componentInfos,
       fields: {},
       modules: attrs?.modules,

--- a/packages/core/src/serializers/raw-card-deserializer.ts
+++ b/packages/core/src/serializers/raw-card-deserializer.ts
@@ -1,4 +1,4 @@
-import { assertValidRawCard, CompiledCard, Field, RawCard } from '../interfaces';
+import { assertValidRawCard, CompiledCard, FEATURE_NAMES, Field, RawCard } from '../interfaces';
 import { findIncluded } from './index';
 
 export class RawCardDeserializer {
@@ -23,17 +23,8 @@ export class RawCardDeserializer {
       id: resource.id.slice(attrs.realm.length),
     };
 
-    let fields: (keyof RawCard)[] = [
-      'schema',
-      'isolated',
-      'embedded',
-      'edit',
-      'deserializer',
-      'adoptsFrom',
-      'files',
-      'data',
-    ];
-    for (let field of fields) {
+    let rawCardKeys: (keyof RawCard)[] = ['adoptsFrom', 'data', 'files', ...FEATURE_NAMES];
+    for (let field of rawCardKeys) {
       if (attrs[field] != null) {
         raw[field] = attrs[field];
       }

--- a/packages/core/src/serializers/raw-card-serializer.ts
+++ b/packages/core/src/serializers/raw-card-serializer.ts
@@ -1,6 +1,8 @@
 import * as JSON from 'json-typescript';
-import { serializeResource, findIncluded } from './index';
+import get from 'lodash/get';
+import set from 'lodash/set';
 import { RawCard, CompiledCard, Field, ResourceObject, Unsaved, Saved, FEATURE_NAMES } from '../interfaces';
+import { findIncluded } from './index';
 
 export class RawCardSerializer {
   doc: any;
@@ -53,4 +55,31 @@ export class RawCardSerializer {
     }
     return { type: 'fields', id };
   }
+}
+
+function serializeResource<Identity extends Saved | Unsaved>(
+  type: string,
+  id: Identity,
+  payload: any,
+  attributes?: (string | Record<string, string>)[]
+): ResourceObject<Identity> {
+  let resource: ResourceObject<Identity> = {
+    id,
+    type,
+  };
+  resource.attributes = {};
+
+  if (!attributes) {
+    attributes = Object.keys(payload);
+  }
+
+  for (const attr of attributes) {
+    if (typeof attr === 'object') {
+      let [aliasName, name] = Object.entries(attr)[0];
+      set(resource.attributes, aliasName, get(payload, name) ?? null);
+    } else {
+      set(resource.attributes, attr, get(payload, attr) ?? null);
+    }
+  }
+  return resource;
 }

--- a/packages/core/src/serializers/raw-card-serializer.ts
+++ b/packages/core/src/serializers/raw-card-serializer.ts
@@ -1,22 +1,13 @@
 import * as JSON from 'json-typescript';
-import { RawCard, CompiledCard, Field } from '../interfaces';
 import { serializeResource, findIncluded } from './index';
+import { RawCard, CompiledCard, Field, ResourceObject, Unsaved, Saved, FEATURE_NAMES } from '../interfaces';
 
 export class RawCardSerializer {
   doc: any;
 
   serialize(card: RawCard, compiled?: CompiledCard): JSON.Object {
-    let resource = serializeResource('raw-cards', `${card.realm}${card.id}`, card, [
-      'schema',
-      'isolated',
-      'embedded',
-      'edit',
-      'deserializer',
-      'adoptsFrom',
-      'files',
-      'data',
-      'realm',
-    ]);
+    let rawCardKeys: (keyof RawCard)[] = ['id', 'realm', 'adoptsFrom', 'data', 'files', ...FEATURE_NAMES];
+    let resource = serializeResource('raw-cards', `${card.realm}${card.id}`, card, rawCardKeys);
 
     this.doc = { data: resource };
 
@@ -31,12 +22,8 @@ export class RawCardSerializer {
 
   private includeCompiledMeta(compiled: CompiledCard) {
     if (!findIncluded(this.doc, { type: 'compiled-metas', id: compiled.url })) {
-      let resource = serializeResource('compiled-metas', compiled.url, compiled, [
-        'schemaModule',
-        'serializer',
-        'deps',
-        'componentInfos',
-      ]);
+      let keysToSerialize: (keyof CompiledCard)[] = ['schemaModule', 'serializerModule', 'deps', 'componentInfos'];
+      let resource = serializeResource('compiled-metas', compiled.url, compiled, keysToSerialize);
 
       resource.relationships ||= {};
       if (compiled.adoptsFrom) {

--- a/packages/core/src/utils/fields.ts
+++ b/packages/core/src/utils/fields.ts
@@ -1,5 +1,7 @@
 import { TemplateUsageMeta } from '../glimmer-plugin-card-template';
 import { assertValidSerializerMap, CompiledCard, ComponentInfo, Field, Format, SerializerMap } from '../interfaces';
+import reduce from 'lodash/reduce';
+import md5 from 'md5';
 import { isNotReadyError } from './errors';
 
 export function getFieldForPath(fields: CompiledCard['fields'], path: string): Field | undefined {
@@ -13,6 +15,18 @@ export function getFieldForPath(fields: CompiledCard['fields'], path: string): F
   }
 
   return field;
+}
+
+export function hashCardFields(fields: CompiledCard['fields']): string {
+  return md5(
+    reduce(
+      fields,
+      (result, f, name) => {
+        return (result += name + f.card.url);
+      },
+      ''
+    )
+  );
 }
 
 export function buildUsedFieldsListFromUsageMeta(

--- a/packages/core/src/utils/fields.ts
+++ b/packages/core/src/utils/fields.ts
@@ -1,5 +1,5 @@
 import { TemplateUsageMeta } from '../glimmer-plugin-card-template';
-import { assertValidSerializerMap, CompiledCard, ComponentInfo, Field, Format, SerializerMap } from '../interfaces';
+import { CompiledCard, ComponentInfo, Field, Format } from '../interfaces';
 import reduce from 'lodash/reduce';
 import md5 from 'md5';
 import { isNotReadyError } from './errors';
@@ -68,44 +68,6 @@ function buildUsedFieldListFromComponents(
     }
   }
 }
-
-export function buildSerializerMapFromUsedFields(fields: CompiledCard['fields'], usedFields: string[]): SerializerMap {
-  let map: any = {};
-
-  for (const fieldPath of usedFields) {
-    let field = getFieldForPath(fields, fieldPath);
-
-    if (!field) {
-      continue;
-    }
-
-    buildDeserializerMapForField(map, field, fieldPath);
-  }
-
-  assertValidSerializerMap(map);
-
-  return map;
-}
-
-function buildDeserializerMapForField(map: any, field: Field, usedPath: string): void {
-  if (Object.keys(field.card.fields).length) {
-    let { fields } = field.card;
-    for (const name in fields) {
-      buildDeserializerMapForField(map, fields[name], `${usedPath}.${name}`);
-    }
-  } else {
-    if (!field.card.serializer) {
-      return;
-    }
-
-    if (!map[field.card.serializer]) {
-      map[field.card.serializer] = [];
-    }
-
-    map[field.card.serializer].push(usedPath);
-  }
-}
-
 export async function getFieldValue(schemaInstance: any, fieldName: string): Promise<any> {
   // If the path is deeply nested, we need to recurse the down
   // the schema instances until we get to a field getter

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -36,3 +36,7 @@ export function getBasenameAndExtension(filename: string): {
 export function cardURL(card: CardId): string {
   return `${card.realm}${card.id}`;
 }
+
+export function keys<Obj>(o: Obj): (keyof Obj)[] {
+  return Object.keys(o) as (keyof Obj)[];
+}

--- a/packages/hub/lib/card-model-for-hub.ts
+++ b/packages/hub/lib/card-model-for-hub.ts
@@ -44,7 +44,7 @@ interface LoadedState {
   serializerMap: SerializerMap;
   rawData: NonNullable<RawCard['data']>;
   schemaModule: CompiledCard['schemaModule']['global'];
-  componentModule: ComponentInfo['moduleName']['global'];
+  componentModule: ComponentInfo['componentModule']['global'];
   usedFields: ComponentInfo['usedFields'];
   deserialized: boolean;
   original: CardModel | undefined;
@@ -237,7 +237,7 @@ export default class CardModelForHub implements CardModel {
       serializerMap: compiled.componentInfos['isolated'].serializerMap,
       rawData: raw.data ?? {},
       schemaModule: compiled.schemaModule.global,
-      componentModule: compiled.componentInfos['isolated'].moduleName.global,
+      componentModule: compiled.componentInfos['isolated'].componentModule.global,
       usedFields: compiled.componentInfos['isolated'].usedFields,
       original: undefined,
       deserialized: false,

--- a/packages/hub/node-tests/@core/babel-plugin-card-serializer-analyze-test.ts
+++ b/packages/hub/node-tests/@core/babel-plugin-card-serializer-analyze-test.ts
@@ -1,0 +1,37 @@
+import cardSerializerAnalyze from '@cardstack/core/src/babel-plugin-card-serializer-analyze';
+
+if (process.env.COMPILER) {
+  describe('BabelPluginCardSerializerAnalyze', function () {
+    it('Errors when the serializer does not include any exports', async function () {
+      try {
+        cardSerializerAnalyze(`function serializer() {}`);
+        throw new Error('failed to throw expected exception');
+      } catch (err: any) {
+        expect(err.message).to.include(
+          `Serializer is malformed. It is missing the following exports: serialize, deserialize`
+        );
+        expect(err.status).to.eq(400);
+      }
+    });
+
+    it('Errors when the serializer does not include a deserialize method', async function () {
+      try {
+        cardSerializerAnalyze(`export function serialize() {}`);
+        throw new Error('failed to throw expected exception');
+      } catch (err: any) {
+        expect(err.message).to.include(`Serializer is malformed. It is missing the following exports: deserialize`);
+        expect(err.status).to.eq(400);
+      }
+    });
+
+    it('Errors when the serializer does not include a serialize method', async function () {
+      try {
+        cardSerializerAnalyze(`export function deserialize() {}`);
+        throw new Error('failed to throw expected exception');
+      } catch (err: any) {
+        expect(err.message).to.include(`Serializer is malformed. It is missing the following exports: serialize`);
+        expect(err.status).to.eq(400);
+      }
+    });
+  });
+}

--- a/packages/hub/node-tests/@core/babel-plugin-card-template-test.ts
+++ b/packages/hub/node-tests/@core/babel-plugin-card-template-test.ts
@@ -52,11 +52,11 @@ if (process.env.COMPILER) {
 
       options = {
         fields: personCard.fields,
+        metaModulePath: './embedded-meta.js',
         debugPath: personCard.url,
         inlineHBS: undefined,
         defaultFieldFormat: 'embedded',
         usedFields: [],
-        serializerMap: {},
       };
       let src = templateOnlyComponentTemplate(
         '<div><h1><@fields.name /><@fields.fullName /></h1><@fields.birthdate /> <@fields.address /></div>'
@@ -78,21 +78,9 @@ if (process.env.COMPILER) {
       ]);
     });
 
-    it('includes the serializerMap', async function () {
-      expect(options.serializerMap).to.deep.equal({ date: ['birthdate', 'address.settlementDate'] });
-    });
-
-    it('can make a function to get options used to create a card model', async function () {
+    it('exports ComponentMeta', async function () {
       expect(code).to.containsSource(`
-        export function getCardModelOptions() {
-          return {
-            serializerMap: {
-              date: ["birthdate", "address.settlementDate"]
-            },
-            computedFields: ["fullName"],
-            usedFields: ["name", "fullName", "birthdate", "address.street", "address.city", "address.state", "address.zip", "address.settlementDate"]
-          };
-        }
+        export { ComponentMeta } from "${options.metaModulePath}";
       `);
     });
   });

--- a/packages/hub/node-tests/@core/babel-plugin-card-template-test.ts
+++ b/packages/hub/node-tests/@core/babel-plugin-card-template-test.ts
@@ -80,7 +80,7 @@ if (process.env.COMPILER) {
 
     it('exports ComponentMeta', async function () {
       expect(code).to.containsSource(`
-        export { ComponentMeta } from "${options.metaModulePath}";
+        export * from "${options.metaModulePath}";
       `);
     });
   });

--- a/packages/hub/node-tests/@core/card-model-test.ts
+++ b/packages/hub/node-tests/@core/card-model-test.ts
@@ -7,7 +7,7 @@ import { configureHubWithCompiler } from '../helpers/cards';
 import merge from 'lodash/merge';
 import { templateOnlyComponentTemplate } from '@cardstack/core/tests/helpers';
 import cloneDeep from 'lodash/cloneDeep';
-import set from 'lodash/set';
+// import set from 'lodash/set';
 import { CardModel } from '@cardstack/core/src/interfaces';
 
 function p(dateString: string): Date {
@@ -182,7 +182,9 @@ if (process.env.COMPILER) {
       delete result.meta;
 
       let expectedAttributes = cloneDeep(attributes);
-      set(expectedAttributes, 'address.zip', null);
+      // TODO: We currently do not store enough info in the database
+      // to know this should be her
+      // set(expectedAttributes, 'address.zip', null);
 
       expect(result).to.deep.equal({
         id: `${realmURL}bob-barker`,
@@ -215,7 +217,9 @@ if (process.env.COMPILER) {
       let result = model.serialize();
 
       let expectedAttributes = cloneDeep(attributes);
-      set(expectedAttributes, 'address.zip', null);
+      // TODO: We currently do not store enough info in the database
+      // to know this should be her
+      // set(expectedAttributes, 'address.zip', null);
 
       expect(result).to.deep.equal({
         id: undefined,

--- a/packages/hub/node-tests/@core/compiler-test.ts
+++ b/packages/hub/node-tests/@core/compiler-test.ts
@@ -70,7 +70,7 @@ if (process.env.COMPILER) {
       await cards.create(PERSON_CARD);
       let { compiled } = await cards.load(cardURL(PERSON_CARD));
 
-      expect(getFileCache().getModule(compiled.componentInfos.embedded.moduleName.global)).to.containsSource(
+      expect(getFileCache().getModule(compiled.componentInfos.embedded.componentModule.global)).to.containsSource(
         '{{@model.name}} was born on <HttpsCardstackComBaseDateField @model={{@model.birthdate}} data-test-field-name=\\"birthdate\\" />'
       );
 
@@ -85,13 +85,13 @@ if (process.env.COMPILER) {
 
       expect(compiled.componentInfos.edit.usedFields).to.deep.equal(['name', 'birthdate']);
       expect(
-        getFileCache().getModule(compiled.componentInfos.edit.moduleName.global),
+        getFileCache().getModule(compiled.componentInfos.edit.componentModule.global),
         'Edit template is rendered for text'
       ).to.containsSource(
         '<HttpsCardstackComBaseStringField @model={{@model.name}} data-test-field-name=\\"name\\" @set={{@set.setters.name}} />'
       );
       expect(
-        getFileCache().getModule(compiled.componentInfos.edit.moduleName.global),
+        getFileCache().getModule(compiled.componentInfos.edit.componentModule.global),
         'Edit template is rendered for date'
       ).to.containsSource(
         '<HttpsCardstackComBaseDateField @model={{@model.birthdate}}  data-test-field-name=\\"birthdate\\" @set={{@set.setters.birthdate}} />'
@@ -130,7 +130,7 @@ if (process.env.COMPILER) {
 
       expect(compiled.componentInfos.embedded.usedFields).to.deep.equal(['title', 'author.name', 'author.birthdate']);
 
-      expect(getFileCache().getModule(compiled.componentInfos.embedded.moduleName.global)).to.containsSource(
+      expect(getFileCache().getModule(compiled.componentInfos.embedded.componentModule.global)).to.containsSource(
         `<article><h1>{{@model.title}}</h1><p>{{@model.author.name}}</p><p><HttpsCardstackComBaseDateField @model={{@model.author.birthdate}} data-test-field-name=\\"birthdate\\"  /></p></article>`
       );
 
@@ -204,7 +204,7 @@ if (process.env.COMPILER) {
       expect(compiled.componentInfos.isolated.usedFields).to.deep.equal(['posts.title', 'posts.createdAt']);
 
       expect(
-        getFileCache().getModule(compiled.componentInfos.isolated.moduleName.global),
+        getFileCache().getModule(compiled.componentInfos.isolated.componentModule.global),
         'Isolated template includes PostField component'
       ).to.containsSource(
         `{{#each @model.posts as |Post|}}<HttpsCardstackLocalPostField @model={{Post}} data-test-field-name=\\"posts\\" />{{/each}}`
@@ -213,7 +213,7 @@ if (process.env.COMPILER) {
       expect(compiled.componentInfos.embedded.usedFields).to.deep.equal(['posts.title']);
 
       expect(
-        getFileCache().getModule(compiled.componentInfos.embedded.moduleName.global),
+        getFileCache().getModule(compiled.componentInfos.embedded.componentModule.global),
         'Embedded template inlines post title'
       ).to.containsSource(`<ul>{{#each @model.posts as |Post|}}<li>{{Post.title}}</li>{{/each}}</ul>`);
     });
@@ -339,7 +339,7 @@ if (process.env.COMPILER) {
 
       it('iterators of fields and inlines templates', async function () {
         let { compiled } = await cards.load(`${realm}post`);
-        expect(getFileCache().getModule(compiled.componentInfos.embedded.moduleName.global)).to.containsSource(
+        expect(getFileCache().getModule(compiled.componentInfos.embedded.componentModule.global)).to.containsSource(
           '<article><label>{{\\"title\\"}}</label></article>'
         );
       });
@@ -382,12 +382,12 @@ if (process.env.COMPILER) {
         let { compiled: timelyCompiled } = await cards.load(cardURL(timelyPostCard));
         let { compiled: fancyCompiled } = await cards.load(cardURL(fancyPostCard));
 
-        expect(getFileCache().getModule(timelyCompiled.componentInfos.embedded.moduleName.global)).to.containsSource(
-          '<article><label>{{\\"title\\"}}</label><label>{{\\"createdAt\\"}}</label></article>'
-        );
-        expect(getFileCache().getModule(fancyCompiled.componentInfos.embedded.moduleName.global)).to.containsSource(
-          '<article><label>{{\\"title\\"}}</label><label>{{\\"body\\"}}</label></article>'
-        );
+        expect(
+          getFileCache().getModule(timelyCompiled.componentInfos.embedded.componentModule.global)
+        ).to.containsSource('<article><label>{{\\"title\\"}}</label><label>{{\\"createdAt\\"}}</label></article>');
+        expect(
+          getFileCache().getModule(fancyCompiled.componentInfos.embedded.componentModule.global)
+        ).to.containsSource('<article><label>{{\\"title\\"}}</label><label>{{\\"body\\"}}</label></article>');
       });
     });
 

--- a/packages/hub/node-tests/@core/compiler-test.ts
+++ b/packages/hub/node-tests/@core/compiler-test.ts
@@ -30,7 +30,7 @@ const PERSON_CARD: RawCard = {
 };
 
 if (process.env.COMPILER) {
-  describe.only('Compiler', function () {
+  describe('Compiler', function () {
     let { cards, getFileCache } = configureHubWithCompiler(this);
 
     it('string card', async function () {
@@ -53,6 +53,7 @@ if (process.env.COMPILER) {
 
     it('CompiledCard embedded view', async function () {
       await cards.create(PERSON_CARD);
+      let { compiled: dateCompiled } = await cards.load('https://cardstack.com/base/date');
       let { compiled } = await cards.load(cardURL(PERSON_CARD));
       let { embedded } = compiled.componentInfos;
 
@@ -71,13 +72,12 @@ if (process.env.COMPILER) {
 
       let metaModuleSource = getFileCache().getModule(embedded.metaModule.global, 'browser');
       expect(metaModuleSource).to.containsSource(`
-        import { DateSerializer } from "@cardstack/core/src/serializers";
+        import DateSerializer from "${dateCompiled.serializerModule?.global}";
       `);
       expect(metaModuleSource).to.containsSource(`
         export const serializerMap = {
-          "birthdate": DateSerializer,
-          "address.settlementDate": DateSerializer
-        }
+          "birthdate": DateSerializer
+        };
       `);
       expect(metaModuleSource).to.containsSource(`
         export const computedFields = [];
@@ -321,7 +321,7 @@ if (process.env.COMPILER) {
       }
     });
 
-    describe.only('Custom Serializers', function () {
+    describe('Custom Serializers', function () {
       it('date card', async function () {
         let { compiled } = await cards.load('https://cardstack.com/base/date');
         expect(compiled.serializerModule?.global, 'Date card has date serializer').to.be.ok;
@@ -357,7 +357,7 @@ if (process.env.COMPILER) {
           throw new Error('failed to throw expected exception');
         } catch (err: any) {
           expect(err.message).to.include(`card refers to serializer.js in its card.json but that file does not exist`);
-          expect(err.status).to.eq(400);
+          expect(err.status).to.eq(422);
         }
       });
 

--- a/packages/hub/node-tests/@core/compiler-test.ts
+++ b/packages/hub/node-tests/@core/compiler-test.ts
@@ -80,18 +80,21 @@ if (process.env.COMPILER) {
       );
 
       expect(embedded.usedFields).to.deep.equal(['name', 'birthdate']);
-
       expect(embedded.serializerMap).to.deep.equal({
         date: ['birthdate'],
       });
-      expect(getFileCache().getModule(embedded.metaModule.global, 'browser')).to.containsSource(`
-        export const ComponentMeta = {
-          serializerMap: {
-            date: ["birthdate"]
-          },
-          computedFields: [],
-          usedFields: ["name", "birthdate"]
-        };
+
+      let metaModuleSource = getFileCache().getModule(embedded.metaModule.global, 'browser');
+      expect(metaModuleSource).to.containsSource(`
+        export const serializerMap = {
+          date: ["birthdate"]
+        }
+      `);
+      expect(metaModuleSource).to.containsSource(`
+        export const computedFields = [];
+      `);
+      expect(metaModuleSource).to.containsSource(`
+        export const usedFields = ["name", "birthdate"];
       `);
     });
 

--- a/packages/hub/node-tests/@core/compiler-test.ts
+++ b/packages/hub/node-tests/@core/compiler-test.ts
@@ -69,14 +69,30 @@ if (process.env.COMPILER) {
     it('CompiledCard embedded view', async function () {
       await cards.create(PERSON_CARD);
       let { compiled } = await cards.load(cardURL(PERSON_CARD));
+      let { embedded } = compiled.componentInfos;
 
-      expect(getFileCache().getModule(compiled.componentInfos.embedded.componentModule.global)).to.containsSource(
+      expect(getFileCache().getModule(embedded.componentModule.global)).to.containsSource(
         '{{@model.name}} was born on <HttpsCardstackComBaseDateField @model={{@model.birthdate}} data-test-field-name=\\"birthdate\\" />'
       );
 
       expect(getFileCache().getAsset(`${realm}person`, 'embedded.css'), 'Styles are defined').to.containsSource(
         PERSON_CARD.files!['embedded.css']
       );
+
+      expect(embedded.usedFields).to.deep.equal(['name', 'birthdate']);
+
+      expect(embedded.serializerMap).to.deep.equal({
+        date: ['birthdate'],
+      });
+      expect(getFileCache().getModule(embedded.metaModule.global, 'browser')).to.containsSource(`
+        export const ComponentMeta = {
+          serializerMap: {
+            date: ["birthdate"]
+          },
+          computedFields: [],
+          usedFields: ["name", "birthdate"]
+        };
+      `);
     });
 
     it('CompiledCard edit view', async function () {

--- a/packages/hub/node-tests/@core/compiler-test.ts
+++ b/packages/hub/node-tests/@core/compiler-test.ts
@@ -72,7 +72,7 @@ if (process.env.COMPILER) {
 
       let metaModuleSource = getFileCache().getModule(embedded.metaModule.global, 'browser');
       expect(metaModuleSource).to.containsSource(`
-        import DateSerializer from "${dateCompiled.serializerModule?.global}";
+        import * as DateSerializer from "${dateCompiled.serializerModule?.global}";
       `);
       expect(metaModuleSource).to.containsSource(`
         export const serializerMap = {
@@ -361,7 +361,7 @@ if (process.env.COMPILER) {
         }
       });
 
-      it.skip('Errors when the serializer is malformed', async function () {
+      it('Errors when the serializer is malformed', async function () {
         try {
           await cards.create({
             realm,
@@ -375,7 +375,7 @@ if (process.env.COMPILER) {
           });
           throw new Error('failed to throw expected exception');
         } catch (err: any) {
-          expect(err.message).to.include(`card serializer is malformed. It must have export a deserialize method`);
+          expect(err.message).to.include(`Serializer is malformed. It is missing the following exports: deserialize`);
           expect(err.status).to.eq(400);
         }
       });

--- a/packages/hub/node-tests/helpers/cards.ts
+++ b/packages/hub/node-tests/helpers/cards.ts
@@ -11,8 +11,10 @@ import { BASE_REALM_CONFIG } from '../../services/realms-config';
 
 tmp.setGracefulCleanup();
 
+let fileCacheTmpDir = tmp.dirSync();
+
 export class TestFileCacheConfig extends FileCacheConfig {
-  tmp = tmp.dirSync();
+  tmp = fileCacheTmpDir;
 
   get root() {
     return this.tmp.name;

--- a/packages/hub/node-tests/helpers/cards.ts
+++ b/packages/hub/node-tests/helpers/cards.ts
@@ -21,10 +21,6 @@ export class TestFileCacheConfig extends FileCacheConfig {
   get cacheDirectory() {
     return join(this.root, 'node_modules', this.packageName);
   }
-
-  cleanup() {
-    this.tmp.removeCallback();
-  }
 }
 
 export function resolveCard(root: string, modulePath: string): string {

--- a/packages/hub/node-tests/helpers/cards.ts
+++ b/packages/hub/node-tests/helpers/cards.ts
@@ -1,6 +1,6 @@
 import Mocha from 'mocha';
 import tmp from 'tmp';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import FileCacheConfig from '../../services/file-cache-config';
 import { contextFor, registry, setupHub } from './server';
 import { CardService, INSECURE_CONTEXT } from '../../services/card-service';
@@ -8,16 +8,18 @@ import FileCache from '../../services/file-cache';
 import { TEST_REALM } from '@cardstack/core/tests/helpers';
 import { RealmConfig } from '@cardstack/core/src/interfaces';
 import { BASE_REALM_CONFIG } from '../../services/realms-config';
+import { Project } from 'fixturify-project';
 
 tmp.setGracefulCleanup();
-
 let fileCacheTmpDir = tmp.dirSync();
 
-export class TestFileCacheConfig extends FileCacheConfig {
-  tmp = fileCacheTmpDir;
+let project = Project.fromDir(dirname(require.resolve('@cardstack/compiled/package.json')), { linkDeps: true });
+project.baseDir = join(fileCacheTmpDir.name, 'node_modules', '@cardstack/compiled');
+project.writeSync();
 
+export class TestFileCacheConfig extends FileCacheConfig {
   get root() {
-    return this.tmp.name;
+    return fileCacheTmpDir.name;
   }
 
   get cacheDirectory() {

--- a/packages/hub/node-tests/helpers/cards.ts
+++ b/packages/hub/node-tests/helpers/cards.ts
@@ -7,7 +7,7 @@ import { CardService, INSECURE_CONTEXT } from '../../services/card-service';
 import FileCache from '../../services/file-cache';
 import { TEST_REALM } from '@cardstack/core/tests/helpers';
 import { RealmConfig } from '@cardstack/core/src/interfaces';
-import { BASE_REALM_CONFIG, DEMO_REALM_CONFIG } from '../../services/realms-config';
+import { BASE_REALM_CONFIG } from '../../services/realms-config';
 
 tmp.setGracefulCleanup();
 
@@ -62,7 +62,7 @@ export function configureCompiler(mochaContext: Mocha.Suite) {
       reg.register(
         'realmsConfig',
         class TestRealmsConfig {
-          realms: RealmConfig[] = [BASE_REALM_CONFIG, DEMO_REALM_CONFIG, { url: TEST_REALM, directory: testRealmDir }];
+          realms: RealmConfig[] = [BASE_REALM_CONFIG, { url: TEST_REALM, directory: testRealmDir }];
         },
         { type: 'service' }
       );

--- a/packages/hub/node-tests/routes/sources/get-test.ts
+++ b/packages/hub/node-tests/routes/sources/get-test.ts
@@ -114,7 +114,7 @@ if (process.env.COMPILER) {
       expect(compiledMeta?.attributes.componentInfos.isolated).to.have.all.keys([
         'usedFields',
         'serializerMap',
-        'moduleName',
+        'componentModule',
         'inlineHBS',
         'inheritedFrom',
       ]);

--- a/packages/hub/node-tests/routes/sources/get-test.ts
+++ b/packages/hub/node-tests/routes/sources/get-test.ts
@@ -115,6 +115,7 @@ if (process.env.COMPILER) {
         'usedFields',
         'serializerMap',
         'componentModule',
+        'metaModule',
         'inlineHBS',
         'inheritedFrom',
       ]);

--- a/packages/hub/node-tests/routes/sources/get-test.ts
+++ b/packages/hub/node-tests/routes/sources/get-test.ts
@@ -68,10 +68,11 @@ if (process.env.COMPILER) {
         schema: 'schema.js',
         embedded: null,
         edit: null,
-        deserializer: null,
+        serializer: null,
         adoptsFrom: null,
         data: null,
         realm: realmURL,
+        id: 'post',
       });
     });
 
@@ -86,10 +87,11 @@ if (process.env.COMPILER) {
         schema: null,
         embedded: null,
         edit: null,
-        deserializer: null,
+        serializer: null,
         adoptsFrom: '../post',
         data: { title: 'Hello World', body: 'First post.' },
         realm: realmURL,
+        id: 'post0',
       });
     });
 
@@ -109,11 +111,10 @@ if (process.env.COMPILER) {
         (ref: any) => ref.type === 'compiled-metas' && ref.id === `${realmURL}post0`
       );
 
-      expect(compiledMeta?.attributes).to.have.all.keys(['schemaModule', 'serializer', 'componentInfos', 'deps']);
+      expect(compiledMeta?.attributes).to.have.all.keys(['schemaModule', 'serializerModule', 'componentInfos', 'deps']);
       expect(compiledMeta?.attributes.componentInfos).to.have.all.keys(['isolated', 'embedded', 'edit']);
       expect(compiledMeta?.attributes.componentInfos.isolated).to.have.all.keys([
         'usedFields',
-        'serializerMap',
         'componentModule',
         'metaModule',
         'inlineHBS',

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -101,7 +101,8 @@
     "web3": "1.5.2",
     "web3-core": "1.5.2",
     "web3.storage": "^3.3.4",
-    "yargs": "^17.0.0"
+    "yargs": "^17.0.0",
+    "date-fns": "^2.22.1"
   },
   "devDependencies": {
     "@cardstack/eslint-config": "0.28.17",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -101,8 +101,7 @@
     "web3": "1.5.2",
     "web3-core": "1.5.2",
     "web3.storage": "^3.3.4",
-    "yargs": "^17.0.0",
-    "date-fns": "^2.22.1"
+    "yargs": "^17.0.0"
   },
   "devDependencies": {
     "@cardstack/eslint-config": "0.28.17",
@@ -122,6 +121,7 @@
     "@types/yargs": "^17.0.2",
     "chai": "^4.3.4",
     "copy-webpack-plugin": "^10.0.0",
+    "fixturify-project": "^4.0.2",
     "ignore-loader": "^0.1.2",
     "json-stable-stringify": "^1.0.1",
     "mocha": "^8.3.2",

--- a/packages/hub/services/card-service.ts
+++ b/packages/hub/services/card-service.ts
@@ -135,7 +135,7 @@ export class CardService {
       rawData: result.data ?? {},
       schemaModule: result.schemaModule,
       usedFields: result.componentInfos[format].usedFields,
-      componentModule: result.componentInfos[format].moduleName.global,
+      componentModule: result.componentInfos[format].componentModule.global,
       serializerMap: result.componentInfos[format].serializerMap,
     });
   }

--- a/packages/hub/services/card-service.ts
+++ b/packages/hub/services/card-service.ts
@@ -35,6 +35,7 @@ export default class CardServiceFactory {
 
 export class CardService {
   private realmManager = service('realm-manager', { as: 'realmManager' });
+  private fileCache = service('file-cache', { as: 'fileCache' });
   private builder = service('card-builder', { as: 'builder' });
   private searchIndex = service('searchIndex');
   private db = inject('database-manager', { as: 'db' });
@@ -127,6 +128,10 @@ export class CardService {
 
   private async makeCardModelFromDatabase(format: Format, result: Record<string, any>): Promise<CardModel> {
     let cardId = this.realmManager.parseCardURL(result.url);
+
+    let componentMetaModule = result.componentInfos[format].metaModule.global;
+    let componentMeta = await this.fileCache.loadModule(componentMetaModule);
+
     return await getOwner(this).instantiate(CardModelForHub, {
       type: 'loaded',
       id: cardId.id,
@@ -134,9 +139,8 @@ export class CardService {
       format,
       rawData: result.data ?? {},
       schemaModule: result.schemaModule,
-      usedFields: result.componentInfos[format].usedFields,
       componentModule: result.componentInfos[format].componentModule.global,
-      serializerMap: result.componentInfos[format].serializerMap,
+      componentMeta,
     });
   }
 

--- a/packages/hub/services/file-cache.ts
+++ b/packages/hub/services/file-cache.ts
@@ -198,11 +198,11 @@ export default class FileCache {
   }
 
   teardown(): void {
-    log.debug('Cleaning Cache dir: ' + this.dir);
-    for (let subDir of ENVIRONMENTS) {
-      removeSync(join(this.dir, subDir));
-    }
-    removeSync(join(this.dir, 'assets'));
+    // log.debug('Cleaning Cache dir: ' + this.dir);
+    // for (let subDir of ENVIRONMENTS) {
+    //   removeSync(join(this.dir, subDir));
+    // }
+    // removeSync(join(this.dir, 'assets'));
   }
 }
 

--- a/packages/hub/services/file-cache.ts
+++ b/packages/hub/services/file-cache.ts
@@ -22,6 +22,11 @@ declare global {
   const __non_webpack_require__: any;
 }
 
+// TEMP: Until I figure out dynamic module importing in VM context
+import parse from 'date-fns/parse';
+import format from 'date-fns/format';
+import parseISO from 'date-fns/parseISO';
+
 export const MINIMAL_PACKAGE = {
   name: '@cardstack/compiled',
   exports: {
@@ -160,7 +165,19 @@ export default class FileCache {
       }
       let context = {
         exports: {},
-        require: (specifier: string) => this.loadModule(specifier),
+        require: (specifier: string) => {
+          // TODO: We need to figure out a pattern for importing npm code
+          switch (specifier) {
+            case 'date-fns/parse':
+              return parse;
+            case 'date-fns/parseISO':
+              return parseISO;
+            case 'date-fns/format':
+              return format;
+            default:
+              return this.loadModule(specifier);
+          }
+        },
 
         // we have to white list globals that we want available to our cards
         setTimeout,

--- a/packages/hub/services/file-cache.ts
+++ b/packages/hub/services/file-cache.ts
@@ -138,7 +138,7 @@ export default class FileCache {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    return require(require.resolve(moduleIdentifier, { paths: [this.dir] }));
+    return __non_webpack_require__(__non_webpack_require__.resolve(moduleIdentifier, { paths: [this.dir] }));
   }
 
   deleteCardModules(cardURL: string): void {

--- a/packages/hub/services/file-cache.ts
+++ b/packages/hub/services/file-cache.ts
@@ -8,67 +8,15 @@ import {
   ensureSymlinkSync,
   removeSync,
   pathExistsSync,
-  ensureDirSync,
-  outputJSONSync,
 } from 'fs-extra';
 import { join, dirname } from 'path';
 import { inject, injectionReady } from '@cardstack/di';
-import isEqual from 'lodash/isEqual';
 import { Client } from 'pg';
 import vm from 'vm';
 import fetch from 'node-fetch';
 
 declare global {
   const __non_webpack_require__: any;
-}
-
-// TEMP: Until I figure out dynamic module importing in VM context
-import parse from 'date-fns/parse';
-import format from 'date-fns/format';
-import parseISO from 'date-fns/parseISO';
-
-export const MINIMAL_PACKAGE = {
-  name: '@cardstack/compiled',
-  exports: {
-    './package.json': {
-      default: './package.json',
-    },
-    '.': {
-      browser: './browser',
-      default: './node',
-    },
-    './*': {
-      browser: './browser/*',
-      default: './node/*',
-    },
-  },
-};
-
-export function createMinimalPackageJSON(cardCacheDir: string): void {
-  outputJSONSync(join(cardCacheDir, 'package.json'), MINIMAL_PACKAGE);
-}
-const EXPORTS_PATHS = ['.', './*'];
-const EXPORTS_ENVIRONMENTS = ['browser', 'default'];
-function hasValidExports(pkg: any): boolean {
-  return EXPORTS_PATHS.every((key) => {
-    return pkg[key] && isEqual(Object.keys(pkg[key]), EXPORTS_ENVIRONMENTS);
-  });
-}
-
-function setupCacheDir(cardCacheDir: string): void {
-  ensureDirSync(cardCacheDir);
-
-  let pkg;
-  try {
-    pkg = __non_webpack_require__(`${cardCacheDir}/package.json`);
-  } catch (error) {
-    createMinimalPackageJSON(cardCacheDir);
-    pkg = MINIMAL_PACKAGE;
-  }
-
-  if (!hasValidExports(pkg.exports)) {
-    throw new Error('package.json of cardCacheDir does not have properly configured exports');
-  }
 }
 
 import logger from '@cardstack/logger';
@@ -90,7 +38,6 @@ export default class FileCache {
 
   async ready() {
     await injectionReady(this, 'file-cache-config');
-    setupCacheDir(this.dir);
     await injectionReady(this, 'database-manager');
     this.client = await this.databaseManager.getClient();
   }
@@ -166,17 +113,7 @@ export default class FileCache {
       let context = {
         exports: {},
         require: (specifier: string) => {
-          // TODO: We need to figure out a pattern for importing npm code
-          switch (specifier) {
-            case 'date-fns/parse':
-              return parse;
-            case 'date-fns/parseISO':
-              return parseISO;
-            case 'date-fns/format':
-              return format;
-            default:
-              return this.loadModule(specifier);
-          }
+          return this.loadModule(specifier);
         },
 
         // we have to white list globals that we want available to our cards
@@ -193,13 +130,15 @@ export default class FileCache {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       return require(`@cardstack/core/src/utils/${moduleIdentifier}`);
     }
+
     if (moduleIdentifier.startsWith('@cardstack/core/')) {
       moduleIdentifier = moduleIdentifier.replace('@cardstack/core/src/', '');
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       return require(`@cardstack/core/src/${moduleIdentifier}`);
     }
 
-    throw new Error(`don't know how to loadModule ${moduleIdentifier}`);
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require(require.resolve(moduleIdentifier, { paths: [this.dir] }));
   }
 
   deleteCardModules(cardURL: string): void {
@@ -212,14 +151,6 @@ export default class FileCache {
       log.trace(`deleting`, loc);
       removeSync(loc);
     }
-  }
-
-  teardown(): void {
-    // log.debug('Cleaning Cache dir: ' + this.dir);
-    // for (let subDir of ENVIRONMENTS) {
-    //   removeSync(join(this.dir, subDir));
-    // }
-    // removeSync(join(this.dir, 'assets'));
   }
 }
 

--- a/packages/hub/services/search-index.ts
+++ b/packages/hub/services/search-index.ts
@@ -454,7 +454,7 @@ function wrapCompiledCard(compiled: CompiledCard, raw: RawCard, url: string): Co
     adoptsFrom: compiled,
     fields: compiled.fields,
     schemaModule: compiled.schemaModule,
-    serializer: compiled.serializer,
+    serializerModule: compiled.serializerModule,
     componentInfos: compiled.componentInfos,
     modules: compiled.modules,
     deps: [...compiled.deps, compiled.url],

--- a/packages/hub/services/search-index.ts
+++ b/packages/hub/services/search-index.ts
@@ -262,7 +262,7 @@ class IndexerRun implements IndexerHandle {
       rawData: rawCard.data ?? {},
       schemaModule: definedCard.schemaModule.global,
       usedFields: definedCard.componentInfos[format].usedFields,
-      componentModule: definedCard.componentInfos[format].moduleName.global,
+      componentModule: definedCard.componentInfos[format].componentModule.global,
       serializerMap: definedCard.componentInfos[format].serializerMap,
     });
     return await this.writeToIndex(rawCard, definedCard, compiler, cardModel);

--- a/yarn.lock
+++ b/yarn.lock
@@ -16837,6 +16837,17 @@ fixturify-project@^2.1.0, fixturify-project@^2.1.1:
     tmp "^0.0.33"
     type-fest "^0.11.0"
 
+fixturify-project@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/fixturify-project/-/fixturify-project-4.0.2.tgz#203b0ad0b9bffe99aff73f0220edaea480a3d7a3"
+  integrity sha512-PzLu0LyK9PZtNgUkYVDFA3fFYFunKHrbcVW35wZjmQPHaFoJ8l7+bWPnoJvj+qMh0s3pdiuJuNiFot/lsaG1+Q==
+  dependencies:
+    fixturify "^2.1.1"
+    resolve-package-path "^3.1.0"
+    tmp "^0.0.33"
+    type-fest "^2.3.2"
+    walk-sync "^3.0.0"
+
 fixturify-project@ef4/node-fixturify-project#dcad8d1a56c586a38f63772eb0dd70ab2751d4e6:
   version "2.1.1"
   resolved "https://codeload.github.com/ef4/node-fixturify-project/tar.gz/dcad8d1a56c586a38f63772eb0dd70ab2751d4e6"
@@ -16861,6 +16872,18 @@ fixturify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fixturify/-/fixturify-2.1.0.tgz#a0437faac9b6e4aeb35910a1214df866aeec5d75"
   integrity sha512-gHq6UCv8DE91EpiaRSzrmvLoRvFOBzI961IQ3gXE5wfmMM1TtApDcZAonG2hnp6GJrVFCxHwP01wSw9VQJiJ1w==
+  dependencies:
+    "@types/fs-extra" "^8.1.0"
+    "@types/minimatch" "^3.0.3"
+    "@types/rimraf" "^2.0.3"
+    fs-extra "^8.1.0"
+    matcher-collection "^2.0.1"
+    walk-sync "^2.0.2"
+
+fixturify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fixturify/-/fixturify-2.1.1.tgz#e962d72f062600cb81a9651086f60d822c72d998"
+  integrity sha512-SRgwIMXlxkb6AUgaVjIX+jCEqdhyXu9hah7mcK+lWynjKtX73Ux1TDv71B7XyaQ+LJxkYRHl5yCL8IycAvQRUw==
   dependencies:
     "@types/fs-extra" "^8.1.0"
     "@types/minimatch" "^3.0.3"
@@ -28843,6 +28866,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^2.3.2:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.12.0.tgz#ce342f58cab9114912f54b493d60ab39c3fc82b6"
+  integrity sha512-Qe5GRT+n/4GoqCNGGVp5Snapg1Omq3V7irBJB3EaKsp7HWDo5Gv2d/67gfNyV+d5EXD+x/RF5l1h4yJ7qNkcGA==
 
 type-is@^1.6.14, type-is@^1.6.16, type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
Ok, this is a substantial change. From a high level: 

- It includes the commits from https://github.com/cardstack/cardstack/pull/2690, which cause us to generate a dedicated module for meta information about components
- Set's up the APIs for card to provide their own serializers

There are two major loose ends that needed to require the dedicated Component Meta module has brought about:

1. Now that there are generated files that are needed at runtime, our previous optimizations need to be applied to the file-cache in some way. I've documented my current approach, which works for now. If we're fine with keeping the file-cache around longer, we would need to come up with scenarios where we would want the cache cleared and how that would be triggered
2. Our current file-cache.`loadModule` approach has no obvious way to support npm packages. The serializerMap, exported by the Component Meta module, includes direct references to the serializer module code itself. So when we require it, we necessarily need to require the serializers, which have package deps. Is there a smart way to do this?
