### PR TITLE
Fix/clear transaction hash on error

### DIFF
--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/prepaid-card-choice/index.ts
@@ -210,6 +210,7 @@ export default class CardPayCreateMerchantWorkflowPrepaidCardChoiceComponent ext
 
       this.args.onComplete();
     } catch (e) {
+      workflowSession.delete('txnHash');
       let insufficientFunds = e.message.startsWith(
         'Prepaid card does not have enough balance to register a merchant.'
       );

--- a/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/transaction-amount/index.ts
@@ -209,6 +209,7 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<Workflo
       }
       session.setValue('unlockTxnReceipt', transactionReceipt);
     } catch (e) {
+      session.delete('unlockTxnHash');
       console.error(e);
       this.errorMessage =
         'There was a problem unlocking your tokens for deposit. This may be due to a network issue, or perhaps you canceled the request in your wallet.';
@@ -220,8 +221,8 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<Workflo
   }
 
   @task *newDeposit(): TaskGenerator<void> {
+    let session = this.args.workflowSession;
     try {
-      let session = this.args.workflowSession;
       let layer2BlockHeightBeforeBridging =
         yield this.layer2Network.getBlockHeight();
       let layer2Address = this.layer2Network.walletInfo.firstAddress!;
@@ -249,6 +250,7 @@ class CardPayDepositWorkflowTransactionAmountComponent extends Component<Workflo
       session.setValue('relayTokensTxnReceipt', transactionReceipt);
       this.args.onComplete?.();
     } catch (e) {
+      session.delete('relayTokensTxnHash');
       if (didCancel(e)) {
         return;
       }

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/preview/index.ts
@@ -179,6 +179,7 @@ export default class CardPayPrepaidCardWorkflowPreviewComponent extends Componen
 
       this.args.onComplete();
     } catch (e) {
+      this.args.workflowSession.delete('txnHash');
       let insufficientFunds = e.message.startsWith(
         'Safe does not have enough balance to make prepaid card(s).'
       );

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.ts
@@ -106,6 +106,7 @@ class CardPayWithdrawalWorkflowTokenClaimComponent extends Component<WorkflowCar
       this.args.workflowSession.setValue('didClaimTokens', true);
       this.args.onComplete?.();
     } catch (e: any) {
+      this.args.workflowSession.delete('claimTokensTxnHash');
       console.error(e);
       this.errorMessage = `There was a problem with claiming your tokens. This may be due
       to a network issue, or perhaps you canceled the request in your wallet.`;

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-amount/index.ts
@@ -206,6 +206,7 @@ class CardPayWithdrawalWorkflowTransactionAmountComponent extends Component<Work
       );
       this.args.onComplete?.();
     } catch (e) {
+      this.args.workflowSession.delete('relayTokensTxnHash');
       this.isConfirmed = false;
 
       if (

--- a/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/token-claim-test.ts
+++ b/packages/web-client/tests/integration/components/card-pay/withdrawal-workflow/token-claim-test.ts
@@ -1,0 +1,88 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render, settled } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import Layer2TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer2';
+import Layer1TestWeb3Strategy from '@cardstack/web-client/utils/web3-strategies/test-layer1';
+import BN from 'bn.js';
+import sinon from 'sinon';
+
+import { WorkflowSession } from '@cardstack/web-client/models/workflow';
+import {
+  createDepotSafe,
+  createSafeToken,
+} from '@cardstack/web-client/utils/test-factories';
+import { defer } from 'rsvp';
+import { BridgeValidationResult } from '@cardstack/cardpay-sdk';
+import { TransactionReceipt } from 'web3-core';
+import { ClaimBridgedTokensOptions } from '@cardstack/web-client/utils/web3-strategies/types';
+
+module(
+  'Integration | Component | card-pay/withdrawal-workflow/token-claim',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('It clears the token if claim transaction is reverted', async function (assert) {
+      let session = new WorkflowSession();
+      this.set('session', session);
+
+      let layer1AccountAddress = '0xaCD5f5534B756b856ae3B2CAcF54B3321dd6654Fb6';
+      let layer1Service = this.owner.lookup('service:layer1-network')
+        .strategy as Layer1TestWeb3Strategy;
+      layer1Service.test__simulateAccountsChanged(
+        [layer1AccountAddress],
+        'metamask'
+      );
+      layer1Service.test__simulateBalances({
+        dai: new BN('150500000000000000000'),
+      });
+
+      let layer2Service = this.owner.lookup('service:layer2-network')
+        .strategy as Layer2TestWeb3Strategy;
+      let layer2AccountAddress = '0x182619c6Ea074C053eF3f1e1eF81Ec8De6Eb6E44';
+      let depotAddress = '0xB236ca8DbAB0644ffCD32518eBF4924ba8666666';
+      let testDepot = createDepotSafe({
+        address: depotAddress,
+        tokens: [createSafeToken('DAI.CPXD', '250000000000000000000')],
+      });
+      await layer2Service.test__simulateRemoteAccountSafes(
+        layer2AccountAddress,
+        [testDepot]
+      );
+      await layer2Service.test__simulateAccountsChanged([layer2AccountAddress]);
+      session.setValue('bridgeValidationResult', {} as BridgeValidationResult);
+      session.setValue('withdrawalSafe', depotAddress);
+      session.setValue('withdrawalToken', 'DAI.CPXD');
+      session.setValue('withdrawnAmount', new BN('123456000000000000000'));
+
+      await render(hbs`
+        <CardPay::WithdrawalWorkflow::TokenClaim
+          @workflowSession={{this.session}}
+          @onComplete={{this.onComplete}}
+          @onIncomplete={{this.onIncomplete}}
+          @isComplete={{this.isComplete}}
+        />
+      `);
+
+      let receipt = defer<TransactionReceipt>();
+      sinon
+        .stub(layer1Service, 'claimBridgedTokens')
+        .callsFake(function (
+          _bridgeValidationResult: BridgeValidationResult,
+          { onTxnHash }: ClaimBridgedTokensOptions
+        ) {
+          onTxnHash?.('test hash');
+          return receipt.promise;
+        });
+
+      await click('[data-test-claim-button]');
+
+      assert.equal(session.getValue('claimTokensTxnHash'), 'test hash');
+
+      receipt.reject(new Error('Test reverted transaction'));
+      await settled();
+
+      assert.notOk(session.getValue('claimTokensTxnHash'));
+    });
+  }
+);


### PR DESCRIPTION
Clear transaction hashes when a transaction errors so we don't end up retrying a transaction that should fail. Handling of resumed transactions should come with https://github.com/cardstack/cardstack/pull/2695