### PR TITLE
remove spend amount from customer payment notifs

### DIFF
--- a/packages/hub/node-tests/tasks/notify-customer-payment-test.ts
+++ b/packages/hub/node-tests/tasks/notify-customer-payment-test.ts
@@ -157,14 +157,14 @@ describe('NotifyCustomerPaymentTask', function () {
     expect(addedJobIdentifiers).to.deep.equal(['send-notifications', 'send-notifications']);
     expect(addedJobPayloads).to.deep.equal([
       {
-        notificationBody: 'Mandello received a payment of §2324',
+        notificationBody: 'Mandello has a new payment',
         notificationId: 'sokol::a::123::eoa-address',
         notificationType: 'customer_payment',
         pushClientId: '123',
         notificationData: mockNotificationData,
       },
       {
-        notificationBody: 'Mandello received a payment of §2324',
+        notificationBody: 'Mandello has a new payment',
         notificationId: 'sokol::a::456::eoa-address',
         notificationType: 'customer_payment',
         pushClientId: '456',
@@ -258,14 +258,14 @@ describe('NotifyCustomerPaymentTask', function () {
     expect(addedJobIdentifiers).to.deep.equal(['send-notifications', 'send-notifications']);
     expect(addedJobPayloads).to.deep.equal([
       {
-        notificationBody: 'You received a payment of §2324',
+        notificationBody: 'You have a new payment',
         notificationId: 'sokol::a::123::eoa-address',
         notificationType: 'customer_payment',
         pushClientId: '123',
         notificationData: mockNotificationData,
       },
       {
-        notificationBody: 'You received a payment of §2324',
+        notificationBody: 'You have a new payment',
         notificationId: 'sokol::a::456::eoa-address',
         notificationType: 'customer_payment',
         pushClientId: '456',
@@ -355,14 +355,14 @@ describe('NotifyCustomerPaymentTask', function () {
     expect(addedJobIdentifiers).to.deep.equal(['send-notifications', 'send-notifications']);
     expect(addedJobPayloads).to.deep.equal([
       {
-        notificationBody: 'You received a payment of §2324',
+        notificationBody: 'You have a new payment',
         notificationId: 'sokol::a::123::eoa-address',
         notificationType: 'customer_payment',
         pushClientId: '123',
         notificationData: mockNotificationData,
       },
       {
-        notificationBody: 'You received a payment of §2324',
+        notificationBody: 'You have a new payment',
         notificationId: 'sokol::a::456::eoa-address',
         notificationType: 'customer_payment',
         pushClientId: '456',

--- a/packages/hub/tasks/notify-customer-payment.ts
+++ b/packages/hub/tasks/notify-customer-payment.ts
@@ -116,14 +116,14 @@ export default class NotifyCustomerPayment {
       return;
     }
 
-    let merchantName = 'You';
+    let notificationBody = 'You have a new payment';
 
     try {
       if (result.merchantSafe?.infoDid) {
         let merchantInfo = await this.merchantInfo.getMerchantInfo(result.merchantSafe.infoDid);
 
         if (merchantInfo?.name) {
-          merchantName = merchantInfo.name;
+          notificationBody = `${merchantInfo.name} has a new payment`;
         }
       }
     } catch (e) {
@@ -134,8 +134,6 @@ export default class NotifyCustomerPayment {
       });
     }
 
-    let spendAmount = result.spendAmount;
-    let notificationBody = `${merchantName} received a payment of §${spendAmount}`;
     let notificationData = {
       notificationType: 'customer_payment',
       transactionInformation: JSON.stringify(omit(result, 'merchant')),


### PR DESCRIPTION
Just the string message. We keep the `spendAmount` property to send to the wallet in notification data.