### PR TITLE
Add a tooltip modifier

### DIFF
--- a/packages/boxel/addon/components/boxel/card-catalog-tray-item/index.css
+++ b/packages/boxel/addon/components/boxel/card-catalog-tray-item/index.css
@@ -68,7 +68,7 @@
   grid-area: description;
   height: 1.875rem;
   margin: 0;
-  display: box;
+  display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
   overflow: hidden;

--- a/packages/boxel/tests/dummy/app/css/components/queue-card.css
+++ b/packages/boxel/tests/dummy/app/css/components/queue-card.css
@@ -79,7 +79,7 @@
   font: var(--boxel-font-sm);
   font-weight: 700;
   letter-spacing: var(--boxel-lsp);
-  display: box;
+  display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;

--- a/packages/web-client/app/components/card-pay/header/workflow-tracker/item/index.hbs
+++ b/packages/web-client/app/components/card-pay/header/workflow-tracker/item/index.hbs
@@ -33,8 +33,9 @@
         type="button"
         {{on 'click' this.showDeleteConfirmation}}
         data-test-delete-workflow-button
+        {{tippy "Abandon workflow"}}
       >
-        {{svg-jar 'trash' width="16" title="Abandon workflow"}}
+        {{svg-jar 'trash' width="16"}}
       </button>
     {{else}}
       <Boxel::ProgressIcon

--- a/packages/web-client/app/components/card-pay/prepaid-card/index.hbs
+++ b/packages/web-client/app/components/card-pay/prepaid-card/index.hbs
@@ -19,11 +19,11 @@
     <div>
       <div>Issued by</div>
       {{#let (or @issuerName "Enter name") as |name|}}
-        <div class="prepaid-card__name" title={{name}} data-test-prepaid-card-issuer-name>
+        <div class="prepaid-card__name" data-test-prepaid-card-issuer-name {{tippy (if @error "Failed to load card customization details" name)}}>
           {{name}}
           {{#if @error}}
             <span data-test-prepaid-card-load-warning>
-              {{svg-jar "failure-bordered" height="10" width="10" title="Failed to load card customization details"}}
+              {{svg-jar "failure-bordered" height="10" width="10"}}
             </span>
           {{/if}}
         </div>
@@ -31,7 +31,7 @@
     </div>
     <div class="prepaid-card__meta">
       <div class="prepaid-card__type">PREPAID CARD</div>
-      <div class="prepaid-card__address">{{truncate-middle @address}}</div>
+      <div class="prepaid-card__address" {{tippy @address theme="light-border address"}}>{{truncate-middle @address}}</div>
       <div class="prepaid-card__network">on {{@network}}</div>
     </div>
   </header>

--- a/packages/web-client/app/components/card-pay/safe/index.css
+++ b/packages/web-client/app/components/card-pay/safe/index.css
@@ -77,9 +77,10 @@
   font-size: 1.625rem;
   font-weight: 600;
   letter-spacing: 0;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .card-pay-safe__logo {

--- a/packages/web-client/app/components/card-pay/safe/index.hbs
+++ b/packages/web-client/app/components/card-pay/safe/index.hbs
@@ -75,7 +75,7 @@
     <section class="card-pay-safe__footer">
       <div>
         <div>Business ID</div>
-        <div class="card-pay-safe__footer-value" title={{this.data.info.id}} data-test-safe-footer-business-id>{{this.data.info.id}}</div>
+        <div class="card-pay-safe__footer-value" {{tippy this.data.info.id}} data-test-safe-footer-business-id>{{this.data.info.id}}</div>
       </div>
       <div data-test-safe-footer-managers>
         <span class="card-pay-safe__footer-value">{{@safe.owners.length}}</span>

--- a/packages/web-client/app/components/card-pay/safe/index.hbs
+++ b/packages/web-client/app/components/card-pay/safe/index.hbs
@@ -31,7 +31,7 @@
         />
       {{/if}}
       <div class='card-pay-safe__title-and-link'>
-        <h3 class='card-pay-safe__title' title={{this.data.info.name}} {{tippy this.data.info.name}}>
+        <h3 class='card-pay-safe__title' {{tippy this.data.info.name}}>
           {{this.data.info.name}}
         </h3>
         {{#if this.data.info.id}}

--- a/packages/web-client/app/components/card-pay/safe/index.hbs
+++ b/packages/web-client/app/components/card-pay/safe/index.hbs
@@ -31,7 +31,7 @@
         />
       {{/if}}
       <div class='card-pay-safe__title-and-link'>
-        <h3 class='card-pay-safe__title' title={{this.data.info.name}}>
+        <h3 class='card-pay-safe__title' title={{this.data.info.name}} {{tippy this.data.info.name}}>
           {{this.data.info.name}}
         </h3>
         {{#if this.data.info.id}}

--- a/packages/web-client/app/css/tippy.css
+++ b/packages/web-client/app/css/tippy.css
@@ -4,7 +4,6 @@
   word-wrap: break-word;
   max-width: calc(22ch + 9px * 2);
   font-family: var(--boxel-monospace-font-family);
-  font-size: var(--address-font-size);
   line-height: var(--address-line-height);
   letter-spacing: var(--boxel-lsp-sm);
   word-break: break-all;

--- a/packages/web-client/app/css/tippy.css
+++ b/packages/web-client/app/css/tippy.css
@@ -1,0 +1,11 @@
+.tippy-box[data-theme~="address"] .tippy-content {
+  padding: 5px 9px;
+  z-index: 1;
+  word-wrap: break-word;
+  max-width: calc(22ch + 9px * 2);
+  font-family: var(--boxel-monospace-font-family);
+  font-size: var(--address-font-size);
+  line-height: var(--address-line-height);
+  letter-spacing: var(--boxel-lsp-sm);
+  word-break: break-all;
+}

--- a/packages/web-client/app/modifiers/tippy.ts
+++ b/packages/web-client/app/modifiers/tippy.ts
@@ -1,0 +1,82 @@
+/**
+ * Vendored from https://github.com/nag5000/ember-tippy/blob/master/addon/modifiers/tippy.js
+ * So that we can apply modifications globally, easily
+ */
+import Modifier from 'ember-modifier';
+import { isHTMLSafe } from '@ember/template';
+
+import tippy, { Instance as TippyInstance } from 'tippy.js';
+import type { Props as TippyOptions } from 'tippy.js';
+import 'tippy.js/dist/tippy.css';
+import 'tippy.js/themes/light-border.css';
+
+const baseTippyOptions = {
+  theme: 'light-border',
+  placement: 'bottom',
+  arrow: false,
+};
+
+type ModifierOptions = Partial<TippyOptions>;
+
+export default class TippyModifier extends Modifier<{
+  positional: [string] | [];
+  named: any;
+}> {
+  _instances: TippyInstance[] = [];
+
+  get defaultTarget() {
+    return this.element;
+  }
+
+  get options() {
+    const optionsHash: ModifierOptions =
+      this.args.named.options || this.args.named;
+    return {
+      content: this.args.positional?.[0],
+      ...baseTippyOptions,
+      ...optionsHash,
+    };
+  }
+
+  parseOptions(options: any) {
+    if (options.content instanceof HTMLElement && options.content.hidden) {
+      options.content.hidden = false;
+    }
+
+    if (options.allowHTML == null && isHTMLSafe(options.content)) {
+      options.allowHTML = true;
+    }
+
+    const {
+      // the rest are tippy options (tippy warns about unknown options)
+      ...tippyOptions
+    } = options;
+
+    return {
+      tippyTargets: this.defaultTarget,
+      tippyOptions,
+    };
+  }
+
+  didInstall() {
+    const options = this.parseOptions(this.options);
+    const { tippyTargets, tippyOptions } = options;
+
+    // NOTE: tippy() returns a single instance or an array of instances,
+    // depending on the type of targets argument.
+    // https://atomiks.github.io/tippyjs/v6/tippy-instance/#accessing-an-instance
+    const instances = tippy(tippyTargets, tippyOptions);
+    this._instances = ([] as TippyInstance[]).concat(instances);
+  }
+
+  didUpdateArguments() {
+    const options = this.parseOptions(this.options);
+
+    this._instances.forEach((x) => x.setProps(options.tippyOptions));
+  }
+
+  willDestroy() {
+    this._instances.forEach((x) => x.destroy());
+    this._instances = [];
+  }
+}

--- a/packages/web-client/app/modifiers/tippy.ts
+++ b/packages/web-client/app/modifiers/tippy.ts
@@ -14,6 +14,7 @@ const baseTippyOptions = {
   theme: 'light-border',
   placement: 'bottom',
   arrow: false,
+  maxWidth: 280,
 };
 
 type ModifierOptions = Partial<TippyOptions>;

--- a/packages/web-client/app/modifiers/tippy.ts
+++ b/packages/web-client/app/modifiers/tippy.ts
@@ -9,6 +9,7 @@ import tippy, { Instance as TippyInstance } from 'tippy.js';
 import type { Props as TippyOptions } from 'tippy.js';
 import 'tippy.js/dist/tippy.css';
 import 'tippy.js/themes/light-border.css';
+import '@cardstack/web-client/css/tippy.css';
 
 const baseTippyOptions = {
   theme: 'light-border',

--- a/packages/web-client/app/modifiers/tippy.ts
+++ b/packages/web-client/app/modifiers/tippy.ts
@@ -12,9 +12,10 @@ import 'tippy.js/themes/light-border.css';
 
 const baseTippyOptions = {
   theme: 'light-border',
-  placement: 'bottom',
+  placement: 'bottom-start',
   arrow: false,
   maxWidth: 280,
+  offset: [0, 0],
 };
 
 type ModifierOptions = Partial<TippyOptions>;

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -180,6 +180,7 @@
     "macro-decorators": "^0.1.2",
     "markdown-it": "^12.2.0",
     "short-uuid": "^4.2.0",
+    "tippy.js": "^6.3.7",
     "typescript": "^4.2.3",
     "ua-parser-js": "^0.7.28",
     "web3-core": "^1.3.6",

--- a/packages/web-client/tests/integration/modifiers/tippy-test.ts
+++ b/packages/web-client/tests/integration/modifiers/tippy-test.ts
@@ -1,0 +1,103 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, find, focus, triggerEvent, tap } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+import { htmlSafe } from '@ember/string';
+
+module('Integration | Modifier | tippy', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(async function () {
+    this.set('content', 'Tooltip');
+    // seems like appendTo=parent is necessary
+    // to make it possible to detect the tooltip in tests
+    await render(hbs`
+      <div id="trigger" tabindex="0"
+        {{tippy content=this.content appendTo="parent"}}
+      >Trigger</div>
+    `);
+  });
+
+  test('expected html attrs and structure', async function (assert) {
+    const trigger = find('#trigger')!;
+    await focus(trigger);
+
+    const tippyId = trigger.getAttribute('aria-describedby') as string;
+    assert.ok(tippyId, 'trigger has an attached tippy');
+
+    const tippy = find('#' + tippyId)!;
+    assert.ok(tippy, 'attached tippy found');
+
+    assert.equal(trigger.parentElement!.children.namedItem(tippyId), tippy);
+    assert.equal(trigger.innerHTML, 'Trigger');
+    assert.equal(tippy.textContent, 'Tooltip');
+
+    // @ts-ignore property patched onto HTML element
+    const tippyInstance = trigger._tippy;
+    assert.ok(tippyInstance, 'tippyInstance');
+    assert.equal(tippyInstance.popper, tippy, 'tippyInstance.popper');
+    assert.equal(tippyInstance.reference, trigger, 'tippyInstance.reference');
+
+    assert.dom('[data-tippy-root]').hasAttribute('id', tippyId);
+    let tippyBoxData = (find('[data-tippy-root] .tippy-box') as HTMLElement)
+      .dataset;
+    assert.equal(tippyBoxData.state, 'visible');
+    assert.equal(tippyBoxData.placement, 'bottom');
+    assert.equal(
+      (find('[data-tippy-root] .tippy-box .tippy-content') as HTMLElement)
+        .dataset.state,
+      'visible'
+    );
+    assert
+      .dom('[data-tippy-root] .tippy-box .tippy-content')
+      .containsText('Tooltip');
+    assert.dom('[data-tippy-root] .tippy-box .tippy-arrow').doesNotExist();
+  });
+
+  test('it shows on hover', async function (assert) {
+    const trigger = find('#trigger')!;
+    await triggerEvent(trigger, 'mouseenter');
+
+    assert.deepEqual(
+      (find('[data-tippy-root] .tippy-box') as HTMLElement).dataset.state,
+      'visible'
+    );
+  });
+
+  test('it shows on focus', async function (assert) {
+    const trigger = find('#trigger')!;
+    await focus(trigger);
+
+    assert.deepEqual(
+      (find('[data-tippy-root] .tippy-box') as HTMLElement).dataset.state,
+      'visible'
+    );
+  });
+
+  test('it shows on touch', async function (assert) {
+    const trigger = find('#trigger')!;
+    await tap(trigger);
+
+    assert.deepEqual(
+      (find('[data-tippy-root] .tippy-box') as HTMLElement).dataset.state,
+      'visible'
+    );
+  });
+
+  test('it can render htmlSafe content', async function (assert) {
+    this.set('content', htmlSafe('Tool<b id="b">tip</b>'));
+
+    const trigger = find('#trigger')!;
+    await focus(trigger);
+
+    const tippyId = trigger.getAttribute('aria-describedby');
+    assert.ok(tippyId, 'trigger has an attached tippy');
+
+    const tippy = find('#' + tippyId)!;
+    assert.ok(tippy, 'attached tippy found');
+
+    assert.equal(tippy.textContent, 'Tooltip');
+    assert.equal(find('#b')!.textContent, 'tip');
+  });
+});

--- a/packages/web-client/tests/integration/modifiers/tippy-test.ts
+++ b/packages/web-client/tests/integration/modifiers/tippy-test.ts
@@ -43,7 +43,7 @@ module('Integration | Modifier | tippy', function (hooks) {
     let tippyBoxData = (find('[data-tippy-root] .tippy-box') as HTMLElement)
       .dataset;
     assert.equal(tippyBoxData.state, 'visible');
-    assert.equal(tippyBoxData.placement, 'bottom');
+    assert.equal(tippyBoxData.placement, 'bottom-start');
     assert.equal(
       (find('[data-tippy-root] .tippy-box .tippy-content') as HTMLElement)
         .dataset.state,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5381,6 +5381,11 @@
   dependencies:
     "@percy/logger" "1.0.0-beta.70"
 
+"@popperjs/core@^2.9.0":
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.2.tgz#830beaec4b4091a9e9398ac50f865ddea52186b9"
+  integrity sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -8206,7 +8211,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@4.1.4, axe-core@^4.1.4:
+axe-core@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.4.tgz#f19cd99a84ee32a318b9c5b5bb8ed373ad94f143"
   integrity sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==
@@ -12437,7 +12442,7 @@ elliptic@6.5.4, elliptic@^6.0.0, elliptic@^6.4.0, elliptic@^6.5.2:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-ember-a11y-testing@4.0.3, ember-a11y-testing@^4.0.3:
+ember-a11y-testing@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-4.0.3.tgz#1f5c91266d39ea5b20614b0d294a562079887ac7"
   integrity sha512-Q7nq2crC9+bT+sZi/BORAM4FUhI080edEhnpsvB6vdkD9Ro2Rg4DksQs5Be65/DM108VNDMtbHZtrPS060Mzcw==
@@ -12663,7 +12668,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0, em
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.16.0, ember-cli-babel@^6.17.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.2:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.16.0, ember-cli-babel@^6.17.0, ember-cli-babel@^6.6.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -13241,7 +13246,7 @@ ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.2:
     resolve "^1.3.3"
     semver "^5.3.0"
 
-ember-cli-version-checker@^3.0.0, ember-cli-version-checker@^3.0.1, ember-cli-version-checker@^3.1.2, ember-cli-version-checker@^3.1.3:
+ember-cli-version-checker@^3.0.0, ember-cli-version-checker@^3.0.1, ember-cli-version-checker@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz#7c9b4f5ff30fdebcd480b1c06c4de43bb51c522c"
   integrity sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==
@@ -14152,27 +14157,10 @@ ember-template-recast@^5.0.3:
     tmp "^0.2.1"
     workerpool "^6.1.4"
 
-ember-test-selectors@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ember-test-selectors/-/ember-test-selectors-2.1.0.tgz#faebdf06702aaa0bc510d55eb721ce54d2e85793"
-  integrity sha512-c5HmvefmeABH8hg380TSNZiE9VAK1CBeXWrgyXy+IXHtsew4lZHHw7GnqCAqsakxwvmaMARbAKY9KfSAE91s1g==
-  dependencies:
-    ember-cli-babel "^6.8.2"
-    ember-cli-version-checker "^3.1.2"
-
-ember-test-selectors@^5.0.0:
+ember-test-selectors@^2.1.0, ember-test-selectors@^5.0.0, ember-test-selectors@^6.0.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/ember-test-selectors/-/ember-test-selectors-5.3.0.tgz#1dee515e43e7beb7b7083a2fee2cdf808bf9de26"
   integrity sha512-B9kkCTO39l+XXcp6eRnfZWHeeL3Ffxdux8chXHSwmAPYCc50KI8VW7mr1uy2ZcUMNP/o0sk7VrpA6x3lBkSvWQ==
-  dependencies:
-    calculate-cache-key-for-tree "^2.0.0"
-    ember-cli-babel "^7.26.4"
-    ember-cli-version-checker "^5.1.2"
-
-ember-test-selectors@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/ember-test-selectors/-/ember-test-selectors-6.0.0.tgz#ba9bb19550d9dec6e4037d86d2b13c2cfd329341"
-  integrity sha512-PgYcI9PeNvtKaF0QncxfbS68olMYM1idwuI8v/WxsjOGqUx5bmsu6V17vy/d9hX4mwmjgsBhEghrVasGSuaIgw==
   dependencies:
     calculate-cache-key-for-tree "^2.0.0"
     ember-cli-babel "^7.26.4"
@@ -26846,6 +26834,13 @@ tiny-lr@^2.0.0:
     livereload-js "^3.3.1"
     object-assign "^4.1.0"
     qs "^6.4.0"
+
+tippy.js@^6.3.7:
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-6.3.7.tgz#8ccfb651d642010ed9a32ff29b0e9e19c5b8c61c"
+  integrity sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==
+  dependencies:
+    "@popperjs/core" "^2.9.0"
 
 tmp@0.0.28:
   version "0.0.28"


### PR DESCRIPTION
## What
Use a `{{tippy}}` modifier to replace the `title` attribute. 

## Why
This means less of a delay for users to get the tooltip, more readable text with styling that better fits the DApp, and better touch support.  The original task (CS-2889) was only for business accounts, but replacing only one `title` while leaving the rest meant that we would have 2 different ways of showing tooltip-ish stuff, so all `title`s were replaced.

Using a modifier + limiting options for styling while using sensible library-provided defaults feels better than using a full component for this, since we should not have to support functionality/UI that is too complex within a tooltip.

## Usage
Plain text content: `{{tippy "Some string"}}`
HTML content: `{{tippy (html-safe "<div style=\"color:red;\">Some string</div>")}}`
Options:  `{{tippy "Some string" ...tippy options here}}`

#### Theme
Following tippy's API, use themes for custom, targeted styling of groups of tooltips. Add a theme by providing the CSS (see the new `tippy.css` file, we basically just match `data-theme`, which is set by tippy), and by specifying the theme in the tippy modifier. 

```
{{tippy "Content" theme="my-theme"}}
{{tippy "Content" theme="light-border address"}} // multiple themes separated by space
```

The default theme, if unspecified, is the tippy-provided `light-border`. I've added an `address` theme as well so that the font difference is not too jarring when hovering an address, and also for text wrapping styles.

## Shots
Note that all tooltips are shown here only for ease of viewing changes, these will only show one-by-one as their targets are interacted with.

<img width="423" alt="Prepaid card with tooltips showing its full address, which was truncated, and its issuer name, which potentially can get truncated" src="https://user-images.githubusercontent.com/39579264/155002918-8591d8a7-2343-48bb-a75a-e89a72d0ed14.png">

<img width="416" alt="A business account with its name truncated to two lines. A tooltip shows its full name. A separate tooltip shows its id, which is not truncated but potentially could be." src="https://user-images.githubusercontent.com/39579264/155003417-dc855cfd-dbb7-415c-9d58-af4e9272bdc0.png">

<img width="306" alt="The workflow tracker with a tooltip shown on a button with a trash can icon, the tooltip's text reads 'Abandon workflow'." src="https://user-images.githubusercontent.com/39579264/155003859-806d8167-a73c-4569-b832-77249b6abd3b.png">

## Drawbacks
We are largely adding this to non-interactive content which means we either: 
- add non-interactive items to the tab order to show tooltips for plain text, OR
- don't show tooltips for plain text for keyboard-exclusive users

Neither of these are very nice, though I am not very clear what the impact is of choosing either just yet. I've opted to not show tooltips for keyboard-exclusive users for now, as this involves less change than adding many random items to the tab order and potentially making someone have to sift through a lot of noninteractive plain text to get to important things. 

While this use of a tooltip is an improvement over `title`, I hope that we can provide design solutions that don't truncate static text in the future to replace this solution.

## Some changes I'm considering
- Don't allow HTML by default, make the user have to specify `allowHTML=true` in the modifier arguments
- Tooltips are currently left aligned (if space allows) to make the association between them and their target elements clearer. Design spec appeared to specify center. 
- Typography tweaks. 
- Turning off tooltips in specific situations (a prepaid card in selection)
<img width="421" alt="Prepaid cards in a prepaid card selector still can show their tooltips for address and name." src="https://user-images.githubusercontent.com/39579264/155004739-3c5f8286-39c9-40b1-beae-4d0a3d86cbdb.png">
