### PR TITLE
enable hub staging sentry

### DIFF
--- a/packages/hub/config/staging.json
+++ b/packages/hub/config/staging.json
@@ -7,5 +7,8 @@
   },
   "wyre": {
     "callbackUrl": "https://hub-staging.stack.cards/callbacks/wyre"
+  },
+  "sentry": {
+    "enabled": true
   }
 }


### PR DESCRIPTION
DSN + environment are read from `custom-environment-variables`, so we should just need to set `sentry.enabled` in the staging config file.