### PR TITLE
ssr: Add meta tags for link previews

### DIFF
--- a/packages/ssr-web/app/components/card-pay/merchant-payment-request-header/index.hbs
+++ b/packages/ssr-web/app/components/card-pay/merchant-payment-request-header/index.hbs
@@ -1,6 +1,7 @@
 <InHead>
   {{!-- template-lint-disable no-forbidden-elements --}}
   <meta property='og:image' content={{this.cardPayLogoPng}} />
+  <meta name='twitter:image' content={{this.cardPayLogoPng}} />
 </InHead>
 <Boxel::OrgHeader
   class="merchant-payment-request-header"

--- a/packages/ssr-web/app/templates/pay.hbs
+++ b/packages/ssr-web/app/templates/pay.hbs
@@ -1,6 +1,6 @@
 {{#let
-  (concat 'Pay Business: ' (or this.merchantInfo.name @model.merchantSafe.address))
-  (concat 'Pay ' this.cleanedAmounts.displayed.amount ' with Card Wallet')
+  (concat (or this.merchantInfo.name @model.merchantSafe.address) ' requests payment')
+  (concat 'Pay ' this.cleanedAmounts.displayed.amount)
   as |title description|
 }}
   {{page-title title replace=true}}

--- a/packages/ssr-web/app/templates/pay.hbs
+++ b/packages/ssr-web/app/templates/pay.hbs
@@ -1,4 +1,8 @@
-{{#let (concat "Pay Business: " (or this.merchantInfo.name @model.merchantSafe.address)) as |title|}}
+{{#let
+  (concat 'Pay Business: ' (or this.merchantInfo.name @model.merchantSafe.address))
+  (concat 'Pay ' this.cleanedAmounts.displayed.amount ' with Card Wallet')
+  as |title description|
+}}
   {{page-title title replace=true}}
 
   <InHead>
@@ -6,6 +10,13 @@
     <meta property='og:title' content={{title}} />
     <meta property='og:type' content='website' />
     <meta property='og:url' content={{this.paymentURL}} />
+    <meta property='og:description' content={{description}} />
+    <meta name='twitter:title' content={{title}} />
+    <meta name='twitter:card' content='summary' />
+    <meta name='twitter:description' content={{description}} />
+    <meta name='twitter:url' content={{this.paymentURL}} />
+    {{!-- template-lint-disable no-potential-path-strings --}}
+    <meta name='twitter:site' content='@cardstack' />
   </InHead>
 {{/let}}
 

--- a/packages/ssr-web/config/environment.js
+++ b/packages/ssr-web/config/environment.js
@@ -2,9 +2,9 @@
 
 // Note that the SDK (which holds these constants) is a TS lib, so we can't
 // require it in this CJS file.
-const MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME = 'wallet.cardstack.com';
+const MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME = 'ssr-wallet.cardstack.com';
 const MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME =
-  'wallet-staging.stack.cards';
+  'ssr-wallet-staging.stack.cards';
 
 const universalLinkHostnamesByTarget = {
   staging: MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,

--- a/packages/ssr-web/ember-cli-build.js
+++ b/packages/ssr-web/ember-cli-build.js
@@ -71,7 +71,7 @@ module.exports = function (defaults) {
           },
         },
         output: {
-          assetModuleFilename: '[path][name]-[contenthash].[ext]',
+          assetModuleFilename: '[path][name]-[contenthash][ext]',
         },
         module: {
           rules: [

--- a/packages/ssr-web/tests/acceptance/pay-test.ts
+++ b/packages/ssr-web/tests/acceptance/pay-test.ts
@@ -190,7 +190,41 @@ module('Acceptance | pay', function (hooks) {
 
     assert
       .dom(
+        `meta[name='twitter:title'][content='Pay Business: ${merchantName}']`,
+        document.documentElement
+      )
+      .exists();
+
+    assert
+      .dom(
         `meta[property='og:url'][content$='${expectedPath}']`,
+        document.documentElement
+      )
+      .exists();
+
+    assert
+      .dom(
+        `meta[name='twitter:url'][content$='${expectedPath}']`,
+        document.documentElement
+      )
+      .exists();
+
+    let amountInUSD = convertAmountToNativeDisplay(
+      spendToUsd(roundedSpendAmount)!,
+      'USD'
+    );
+    let description = `Pay ${amountInUSD} with Card Wallet`;
+
+    assert
+      .dom(
+        `meta[property='og:description'][content$='${description}']`,
+        document.documentElement
+      )
+      .exists();
+
+    assert
+      .dom(
+        `meta[name='twitter:description'][content$='${description}']`,
         document.documentElement
       )
       .exists();

--- a/packages/ssr-web/tests/acceptance/pay-test.ts
+++ b/packages/ssr-web/tests/acceptance/pay-test.ts
@@ -183,14 +183,14 @@ module('Acceptance | pay', function (hooks) {
 
     assert
       .dom(
-        `meta[property='og:title'][content='Pay Business: ${merchantName}']`,
+        `meta[property='og:title'][content='${merchantName} requests payment']`,
         document.documentElement
       )
       .exists();
 
     assert
       .dom(
-        `meta[name='twitter:title'][content='Pay Business: ${merchantName}']`,
+        `meta[name='twitter:title'][content='${merchantName} requests payment']`,
         document.documentElement
       )
       .exists();
@@ -213,7 +213,7 @@ module('Acceptance | pay', function (hooks) {
       spendToUsd(roundedSpendAmount)!,
       'USD'
     );
-    let description = `Pay ${amountInUSD} with Card Wallet`;
+    let description = `Pay ${amountInUSD}`;
 
     assert
       .dom(


### PR DESCRIPTION
This is extracted from #2698, where it has been exercised (in concert with the in-progress work). For [this payment request](https://ssr-wallet-staging.stack.cards/pay/sokol/0xA458a7C13B33188b4F71aA47A1067f651284361E?amount=1&currency=CAD), here are previews as rendered by Twitter and Facebook developer tools:

![image](https://user-images.githubusercontent.com/43280/155222407-ab541aa5-3117-45fa-9f8c-f984cf4423fa.png)

![image](https://user-images.githubusercontent.com/43280/155222450-70b4c277-cc78-4c6a-97a8-305ef0ae76d7.png)

The wording has since been changed since I inserted those screenshots. This is easily tweaked in the future, as is the image. The goal here is to make the necessary changes so that tags show at all.