### PR TITLE
remove extra . in asset names

### DIFF
--- a/packages/web-client/ember-cli-build.js
+++ b/packages/web-client/ember-cli-build.js
@@ -73,7 +73,7 @@ module.exports = function (defaults) {
           },
         },
         output: {
-          assetModuleFilename: '[path][name]-[contenthash].[ext]',
+          assetModuleFilename: '[path][name]-[contenthash][ext]',
         },
         module: {
           rules: [


### PR DESCRIPTION
when moving from `file-loader` to asset modules, I didn't realise that `[ext]` now includes the .