### PR TITLE
[CS-3218] Update convertToSpend to fix a bug with decimal conversion

### DIFF
--- a/packages/cardpay-sdk/sdk/currency-utils/amount-conversion.ts
+++ b/packages/cardpay-sdk/sdk/currency-utils/amount-conversion.ts
@@ -5,10 +5,11 @@
 
 import BigNumber from 'bignumber.js';
 import { isNil } from 'lodash';
-import { multiply } from './arithmetic';
+import { multiply, divide } from './arithmetic';
 import { isZero } from './comparison';
 import { roundAmountToNativeCurrencyDecimals } from './rounding-and-approximation';
 import { BigNumberish } from './types';
+import { convertStringToNumber } from './type-conversion';
 
 /**
  * Converts a human-readable amount to an amount friendly for specifying on-chain transactions.
@@ -84,5 +85,9 @@ export const spendToUsd = (amountInSpend: number): number | undefined => {
  * @returns integer spend amount
  */
 export const convertToSpend = (amount: number, currency: string, usdRate: number) => {
-  return Math.ceil(Number(roundAmountToNativeCurrencyDecimals(amount, currency)) / usdRate / SPEND_TO_USD_RATE);
+  return Math.ceil(
+    convertStringToNumber(
+      divide(divide(roundAmountToNativeCurrencyDecimals(amount, currency), usdRate), SPEND_TO_USD_RATE)
+    )
+  );
 };


### PR DESCRIPTION
`convertToSpend(0.56, 'USD', 1)`($0.56USD to spend) returns 57 but should be 56. Investigated and looks it's cause of divide by decimal number and then use Math.ceil. Tests are passed on CardWallet side.

Ref: [CS-3218](https://linear.app/cardstack/issue/CS-3218/bug-as-a-customer-if-i-enter-56-usd-or-56-spend-into-a-payment-request)