### PR TITLE
FastBoot environment uses SSR_WEB_ENVIRONMENT variable to distinguish between staging/prod links

### DIFF
--- a/.github/actions/deploy-ssr-web/action.yml
+++ b/.github/actions/deploy-ssr-web/action.yml
@@ -26,7 +26,7 @@ runs:
       shell: bash
 
     - name: Build
-      run: SENTRY_ENVIRONMENT=${{ inputs.environment }} yarn build:ssr-web:${{ inputs.environment }}
+      run: SSR_WEB_ENVIRONMENT=${{ inputs.environment }} yarn build:ssr-web:${{ inputs.environment }}
       shell: bash
 
     - name: Deploy dist

--- a/packages/ssr-web/config/environment.js
+++ b/packages/ssr-web/config/environment.js
@@ -22,9 +22,8 @@ module.exports = function (environment) {
     locationType: 'auto',
     hubURL: process.env.HUB_URL,
     universalLinkDomain:
-      universalLinkHostnamesByTarget[
-        process.env.DEPLOY_TARGET || process.env.SSR_WEB_ENVIRONMENT // front-end uses DEPLOY_TARGET, fastboot uses SSR_WEB_ENVIRONMENT
-      ] ?? MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,
+      universalLinkHostnamesByTarget[process.env.SSR_WEB_ENVIRONMENT] ??
+      MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,
     version: pkg.version,
     sentryDsn: process.env.SENTRY_DSN,
     '@sentry/ember': {

--- a/packages/ssr-web/config/environment.js
+++ b/packages/ssr-web/config/environment.js
@@ -22,8 +22,9 @@ module.exports = function (environment) {
     locationType: 'auto',
     hubURL: process.env.HUB_URL,
     universalLinkDomain:
-      universalLinkHostnamesByTarget[process.env.DEPLOY_TARGET] ??
-      MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,
+      universalLinkHostnamesByTarget[
+        process.env.DEPLOY_TARGET || process.env.SSR_WEB_ENVIRONMENT // front-end uses DEPLOY_TARGET, fastboot uses SSR_WEB_ENVIRONMENT
+      ] ?? MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,
     version: pkg.version,
     sentryDsn: process.env.SENTRY_DSN,
     '@sentry/ember': {


### PR DESCRIPTION
In the production ssr-web deploy I noticed the links lead to staging:

<img width="1100" alt="image" src="https://user-images.githubusercontent.com/273660/155528457-2c3474b6-1af0-410f-8f84-7283657bcc07.png">

This PR fixes the logic so that FastBoot is able to see which environment it is in. 
