### PR TITLE
support for ?allFields query param to get all of a card's fields

### DIFF
--- a/packages/hub/lib/card-model-for-hub.ts
+++ b/packages/hub/lib/card-model-for-hub.ts
@@ -47,6 +47,7 @@ interface LoadedState {
   componentMeta: CardComponentMetaModule;
   deserialized: boolean; // TODO: Is this really needed?
   original: CardModel | undefined;
+  allFields: boolean;
 }
 
 export default class CardModelForHub implements CardModel {
@@ -185,7 +186,12 @@ export default class CardModelForHub implements CardModel {
       return serializeCardAsResource(undefined, this.data, this.serializerMap);
     }
 
-    let resource = serializeCardAsResource(this.url, this.data, this.serializerMap, this.usedFields);
+    let resource = serializeCardAsResource(
+      this.url,
+      this.data,
+      this.serializerMap,
+      !this.state.allFields ? this.usedFields : undefined
+    );
     let { componentModule, schemaModule } = this.state;
     resource.meta = merge({ componentModule, schemaModule }, resource.meta);
 
@@ -234,6 +240,7 @@ export default class CardModelForHub implements CardModel {
       componentMeta: this.state.componentMeta,
       original: undefined,
       deserialized: false,
+      allFields: false,
     };
   }
 }

--- a/packages/hub/routes/card-routes.ts
+++ b/packages/hub/routes/card-routes.ts
@@ -25,9 +25,9 @@ export default class CardRoutes {
     let {
       params: { encodedCardURL: url },
     } = ctx;
-
+    let allFields = ctx.query.allFields !== undefined;
     let format = getCardFormatFromRequest(ctx.query.format);
-    let card = await (await this.cardService.as(INSECURE_CONTEXT)).loadData(url, format);
+    let card = await (await this.cardService.as(INSECURE_CONTEXT)).loadData(url, format, allFields);
     ctx.body = { data: card.serialize() };
     ctx.status = 200;
   }

--- a/packages/hub/services/card-service.ts
+++ b/packages/hub/services/card-service.ts
@@ -56,11 +56,11 @@ export class CardService {
     };
   }
 
-  async loadData(cardURL: string, format: Format): Promise<CardModel> {
+  async loadData(cardURL: string, format: Format, allFields = false): Promise<CardModel> {
     log.trace('load', cardURL);
 
     let result = await this.loadCardFromDB(['url', 'data', 'schemaModule', 'componentInfos'], cardURL);
-    return await this.makeCardModelFromDatabase(format, result);
+    return await this.makeCardModelFromDatabase(format, result, allFields);
   }
 
   private async loadCardFromDB(columns: string[], cardURL: string): Promise<Record<string, any>> {
@@ -126,7 +126,11 @@ export class CardService {
     }
   }
 
-  private async makeCardModelFromDatabase(format: Format, result: Record<string, any>): Promise<CardModel> {
+  private async makeCardModelFromDatabase(
+    format: Format,
+    result: Record<string, any>,
+    allFields = false
+  ): Promise<CardModel> {
     let cardId = this.realmManager.parseCardURL(result.url);
 
     let componentMetaModule = result.componentInfos[format].metaModule.global;
@@ -141,6 +145,7 @@ export class CardService {
       schemaModule: result.schemaModule,
       componentModule: result.componentInfos[format].componentModule.global,
       componentMeta,
+      allFields,
     });
   }
 

--- a/packages/hub/services/search-index.ts
+++ b/packages/hub/services/search-index.ts
@@ -268,6 +268,7 @@ class IndexerRun implements IndexerHandle {
       schemaModule: definedCard.schemaModule.global,
       componentModule: definedCard.componentInfos[format].componentModule.global,
       componentMeta,
+      allFields: false,
     });
     return await this.writeToIndex(rawCard, definedCard, compiler, cardModel);
   }


### PR DESCRIPTION
This adds support for the browser to ask for all of a card's fields, such that in a future PR the browser's card model has the ability to ask for more fields than were originally provided from the requested format.