### PR TITLE
Create card spaces for merchants

### DIFF
--- a/packages/hub/db/migrations/20220301101637933_create-card-space-profiles-for-existing-merchants.ts
+++ b/packages/hub/db/migrations/20220301101637933_create-card-space-profiles-for-existing-merchants.ts
@@ -1,0 +1,35 @@
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+import shortUuid from 'short-uuid';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  let merchantInfoIdsWithoutCardSpaceQuery =
+    'SELECT merchant_infos.id FROM merchant_infos LEFT JOIN card_spaces ON merchant_infos.id = card_spaces.merchant_id WHERE card_spaces.merchant_id IS NULL';
+
+  let merchantInfoIdsWithoutCardSpace = (await pgm.db.query(merchantInfoIdsWithoutCardSpaceQuery)).rows.map(
+    (row: any) => row.id
+  );
+
+  console.log(`Inserting ${merchantInfoIdsWithoutCardSpace.length} card spaces...`);
+
+  let insertValues = merchantInfoIdsWithoutCardSpace
+    .map((merchantId: string) => {
+      return `('${shortUuid.uuid()}', '${merchantId}')`;
+    })
+    .join(', ');
+
+  if (insertValues.length === 0) {
+    console.log('No card spaces to insert');
+    return;
+  }
+
+  let insertQuery = `INSERT INTO card_spaces (id, merchant_id) VALUES ${insertValues} RETURNING *`;
+
+  let result = await pgm.db.query(insertQuery);
+  console.log(`Inserted ${result.rows.length} card spaces.`);
+}
+
+export async function down(): Promise<void> {
+  console.log("Cant't easily reverse this migration. Delete card spaces manually if needed.");
+}


### PR DESCRIPTION
This creates card spaces for merchants created before we added automatic card space creation.

This could probably be just one SQL statement if our DB had the `uuid-ossp` extension installed which would allow us to use  the `uuid_generate_v4()` function for creating the ids. But without it we need to use `shortUuid.uuid()`. 

Currently there's 260 merchants in production which don't have a card space so I think this migration shouldn't eat too much of resources. 

