### PR TITLE
Card services unification

### DIFF
--- a/packages/cardhost/.eslintrc.js
+++ b/packages/cardhost/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-this-alias': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'off',
   },
   overrides: [
     // node files

--- a/packages/cardhost/app/lib/builder.ts
+++ b/packages/cardhost/app/lib/builder.ts
@@ -108,12 +108,14 @@ export default class LocalRealm implements Builder {
       {
         type: 'loaded',
         url,
-        rawData: rawServerResponse,
-        componentModule,
-        schemaModuleId: compiled.schemaModule.global,
-        format,
       },
-      this
+      {
+        format,
+        realm: this.realmURL,
+        rawData: rawServerResponse,
+        schemaModule: compiled.schemaModule.global,
+        componentModule,
+      }
     );
     await model.computeData();
     return model;
@@ -131,7 +133,7 @@ export default class LocalRealm implements Builder {
     if (!routableCardURL) {
       throw new Error(`Could not find routable card: ${routableCardURL}`);
     }
-    return await this.cards.load(routableCardURL, 'isolated');
+    return await this.cards.loadData(routableCardURL, 'isolated');
   }
 
   async createRawCard(rawCard: RawCard): Promise<void> {
@@ -209,6 +211,7 @@ export default class LocalRealm implements Builder {
     }
   }
 
+  // TODO this should take a CardModel as a param
   async create(
     parentCardURL: string,
     resource: ResourceObject<Unsaved>
@@ -235,6 +238,7 @@ export default class LocalRealm implements Builder {
     };
   }
 
+  // TODO this should take a CardModel as a param
   async update(
     url: string,
     resource: ResourceObject<Saved>

--- a/packages/cardhost/app/lib/card-model-for-browser.ts
+++ b/packages/cardhost/app/lib/card-model-for-browser.ts
@@ -3,149 +3,70 @@ import {
   Saved,
   Unsaved,
   ResourceObject,
-  assertDocumentDataIsResource,
   CardModel,
   RawCardData,
-  Format,
-  CardComponentModule,
-  CardSchemaModule,
   CardService,
-  CompiledCard,
   CardModelArgs,
-  ComponentInfo,
+  SerializerMap,
+  CardComponentModule,
 } from '@cardstack/core/src/interfaces';
+import BaseCardModel, {
+  CreatedState,
+  LoadedState,
+} from '@cardstack/core/src/card-model';
 import Component from '@glimmer/component';
 // @ts-ignore @ember/component doesn't declare setComponentTemplate...yet!
 import { setComponentTemplate } from '@ember/component';
 import { hbs } from 'ember-cli-htmlbars';
-import cloneDeep from 'lodash/cloneDeep';
 import merge from 'lodash/merge';
-import set from 'lodash/set';
-import get from 'lodash/get';
-import { tracked } from '@glimmer/tracking';
-import {
-  serializeField,
-  serializeCardAsResource,
-} from '@cardstack/core/src/serializers';
-import { cardURL } from '@cardstack/core/src/utils';
-import { getFieldValue } from '@cardstack/core/src/utils/fields';
 import { restartableTask } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import { registerDestructor } from '@ember/destroyable';
+import { tracked as _tracked } from '@glimmer/tracking';
 
-export interface NewCardParams {
-  realm: string;
-  parentCardURL: string;
-}
-
-export interface CreatedState {
-  type: 'created';
-  id?: string;
-  parentCardURL: string;
-}
-
-export interface LoadedState {
-  type: 'loaded';
-  url: string;
-  allFields: boolean;
-}
-
-export default class CardModelForBrowser implements CardModel {
-  @tracked private _schemaInstance: any | undefined;
-  private _realm: string;
-  private schemaModule: CompiledCard['schemaModule']['global'];
-  private _format: Format;
-  private componentModuleRef: ComponentInfo['componentModule']['global'];
-  private rawData: RawCardData;
-  private saveModel: CardModelArgs['saveModel'];
-  private state: CreatedState | LoadedState;
-  private _schemaClass: CardSchemaModule['default'] | undefined;
-
+export default class CardModelForBrowser
+  extends BaseCardModel
+  implements CardModel
+{
   setters: Setter;
   private wrapperComponent: unknown | undefined;
-  private _componentModule: CardComponentModule | undefined;
 
   constructor(
-    private cards: CardService,
+    cards: CardService,
     state: CreatedState | LoadedState,
     args: CardModelArgs
   ) {
-    let {
-      realm,
-      schemaModule,
-      format,
-      componentModuleRef,
-      rawData,
-      saveModel,
-    } = args;
-    this._realm = realm;
-    this.schemaModule = schemaModule;
-    this._format = format;
-    this.componentModuleRef = componentModuleRef;
-    this.rawData = rawData;
-    this.saveModel = saveModel;
-    this.state = state;
+    super(cards, state, args);
 
     this.setters = this.makeSetter();
     registerDestructor(this, this.rerenderFinished.bind(this));
+
+    let prop = tracked(this, '_schemaInstance', {
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+    if (prop) {
+      Object.defineProperty(this, '_schemaInstance', prop);
+    }
   }
 
-  async adoptIntoRealm(realm: string, id?: string): Promise<CardModel> {
-    if (this.state.type !== 'loaded') {
-      throw new Error(`tried to adopt from an unsaved card`);
-    }
+  async computeData(schemaInstance?: any): Promise<Record<string, any>> {
+    // need to load component module since usedFields originates from there
+    await this.componentModule();
+    return super.computeData(schemaInstance);
+  }
 
-    return new (this.constructor as typeof CardModelForBrowser)(
-      this.cards,
-      {
-        type: 'created',
-        id,
-        parentCardURL: this.state.url,
-      },
-      {
-        realm,
-        format: this.format,
-        componentModuleRef: this.componentModuleRef,
-        schemaModule: this.schemaModule,
-        rawData: { id: undefined, type: 'card', attributes: {} },
-        saveModel: this.saveModel,
-      }
-    );
+  serialize(): ResourceObject<Saved | Unsaved> {
+    let response = super.serialize();
+
+    // no need to serialize the meta on the browser
+    delete response.meta;
+    return response;
   }
 
   setData(_data: RawCardData) {
     throw new Error('unimplemented');
-  }
-
-  get id(): string {
-    return this.url;
-  }
-
-  get realm(): string {
-    return this._realm;
-  }
-
-  get url(): string {
-    if (this.state.type === 'created') {
-      throw new Error(
-        `bug: card in state ${this.state.type} does not have a url`
-      );
-    }
-    return this.state.url;
-  }
-
-  get format(): Format {
-    return this._format;
-  }
-
-  get parentCardURL(): string {
-    if (this.state.type === 'created') {
-      return this.state.parentCardURL;
-    } else {
-      throw new Error(
-        `card ${this.url} in state ${this.state.type} does not support parentCardURL`
-      );
-    }
   }
 
   async editable(): Promise<CardModel> {
@@ -160,47 +81,6 @@ export default class CardModelForBrowser implements CardModel {
     await editable.computeData();
 
     return editable;
-  }
-
-  get data(): object {
-    return this._schemaInstance;
-  }
-
-  async computeData(schemaInstance?: any): Promise<Record<string, any>> {
-    // need to prime the component module since usedFields originates from there
-    await this.componentModule();
-    let syncData: Record<string, any> = {};
-    for (let field of this.usedFields) {
-      set(syncData, field, await this.getField(field, schemaInstance));
-    }
-    return syncData;
-  }
-
-  private async componentModule() {
-    if (!this._componentModule) {
-      this._componentModule = await this.cards.loadModule<CardComponentModule>(
-        this.componentModuleRef
-      );
-    }
-    return this._componentModule;
-  }
-
-  get serializerMap(): CardComponentModule['serializerMap'] {
-    if (!this._componentModule) {
-      throw new Error(
-        `ComponentModule has not yet been loaded for card model ${this.url}`
-      );
-    }
-    return this._componentModule.serializerMap;
-  }
-
-  get usedFields(): CardComponentModule['usedFields'] {
-    if (!this._componentModule) {
-      throw new Error(
-        `ComponentModule has not yet been loaded for card model ${this.url}`
-      );
-    }
-    return this._componentModule.usedFields;
   }
 
   async component(): Promise<unknown> {
@@ -224,43 +104,58 @@ export default class CardModelForBrowser implements CardModel {
     return this.wrapperComponent;
   }
 
-  async getField(name: string, schemaInstance?: any): Promise<any> {
-    // TODO: add isComputed somewhere in the metadata coming out of the compiler so we can do this optimization
-    // if (this.isComputedField(name)) {
-    //   return get(this.data, name);
-    // }
+  @restartableTask async rerenderData(
+    data: Record<string, any>
+  ): Promise<void> {
+    this.rawData = merge({}, this.rawData, data);
+    let newSchemaInstance = await this.createSchemaInstance();
+    await this.computeData(newSchemaInstance);
+    this._schemaInstance = newSchemaInstance;
+  }
 
-    schemaInstance = schemaInstance ?? this._schemaInstance;
+  async rerenderFinished() {
+    await taskFor(this.rerenderData).last;
+  }
 
-    if (!schemaInstance) {
-      schemaInstance = this._schemaInstance = await this.createSchemaInstance();
+  protected get serializerMap(): SerializerMap {
+    if (!this._componentModule) {
+      throw new Error(
+        `ComponentModule has not yet been loaded for card model ${this.url}`
+      );
     }
-
-    return await getFieldValue(schemaInstance, name);
+    return this._componentModule.serializerMap;
   }
 
-  private async createSchemaInstance() {
-    let klass = await this.schemaClass();
-    // We can't await the instance creation in a separate, as it's thenable and confuses async methods
-    return new klass(this.getRawField.bind(this)) as any;
-  }
-
-  private getRawField(fieldPath: string): any {
-    let value = get(this.rawData, fieldPath);
-    return serializeField(this.serializerMap, fieldPath, value, 'deserialize');
-  }
-
-  async schemaClass() {
-    if (this._schemaClass) {
-      return this._schemaClass;
+  protected get usedFields(): string[] {
+    if (!this._componentModule) {
+      throw new Error(
+        `ComponentModule has not yet been loaded for card model ${this.url}`
+      );
     }
-    this._schemaClass = (
-      await this.cards.loadModule<CardSchemaModule>(this.schemaModule)
-    ).default;
-
-    return this._schemaClass;
+    return this._componentModule.usedFields;
   }
 
+  protected get allFields(): string[] {
+    if (!this._componentModule) {
+      throw new Error(
+        `ComponentModule has not yet been loaded for card model ${this.url}`
+      );
+    }
+    // as far as the browser can tell all the fields that the server told it
+    // about are all that exist
+    return this._componentModule.usedFields;
+  }
+
+  protected async componentModule() {
+    if (!this._componentModule) {
+      this._componentModule = await this.cards.loadModule<CardComponentModule>(
+        this.componentModuleRef
+      );
+    }
+    return this._componentModule;
+  }
+
+  // TODO move this into the base class so that the hub can share it
   private makeSetter(segments: string[] = []): Setter {
     let s = (value: any) => {
       let innerSegments = segments.slice();
@@ -269,7 +164,7 @@ export default class CardModelForBrowser implements CardModel {
         return;
       }
 
-      let data = this.dataAsUsedFieldsShape();
+      let data = this.shapeData('all-fields');
       let cursor: any = data;
       for (let segment of innerSegments) {
         let nextCursor = cursor[segment];
@@ -297,70 +192,13 @@ export default class CardModelForBrowser implements CardModel {
 
     return s;
   }
-
-  @restartableTask async rerenderData(
-    data: Record<string, any>
-  ): Promise<void> {
-    this.rawData = merge({}, this.rawData, data);
-    let newSchemaInstance = await this.createSchemaInstance();
-    await this.computeData(newSchemaInstance);
-    this._schemaInstance = newSchemaInstance;
-  }
-
-  async rerenderFinished() {
-    await taskFor(this.rerenderData).last;
-  }
-
-  // we have a few places that are very sensitive to the shape of the data, and
-  // won't be able to deal with a schema instance that has additional properties
-  // and methods beyond just the data itself, so this method is for those places
-  private dataAsUsedFieldsShape() {
-    let syncData: Record<string, any> = {};
-    for (let field of this.usedFields) {
-      set(syncData, field, get(this._schemaInstance, field));
-    }
-    return syncData;
-  }
-
-  serialize(): ResourceObject<Saved | Unsaved> {
-    let url: string | undefined;
-    if (this.state.type === 'loaded') {
-      url = this.state.url;
-    } else if (this.state.id != null) {
-      url = cardURL({ realm: this.realm, id: this.state.id });
-    }
-
-    return serializeCardAsResource(
-      url,
-      this.dataAsUsedFieldsShape(),
-      this.serializerMap
-    );
-  }
-
-  async save(): Promise<void> {
-    let data: ResourceObject<Saved>;
-    switch (this.state.type) {
-      case 'created':
-        data = await this.saveModel(this, 'create');
-        break;
-      case 'loaded':
-        data = await this.saveModel(this, 'update');
-        break;
-      default:
-        throw assertNever(this.state);
-    }
-
-    assertDocumentDataIsResource(data);
-
-    this.rawData = cloneDeep(data.attributes ?? {});
-    this.state = {
-      type: 'loaded',
-      url: data.id,
-      allFields: false,
-    };
-  }
 }
 
-function assertNever(value: never) {
-  throw new Error(`should never happen ${value}`);
+function tracked(
+  target: CardModel,
+  prop: string,
+  desc: PropertyDescriptor
+): PropertyDescriptor | void {
+  //@ts-ignore the types for glimmer tracked don't seem to be lining
+  return _tracked(target, prop, desc);
 }

--- a/packages/cardhost/app/services/cards.ts
+++ b/packages/cardhost/app/services/cards.ts
@@ -80,7 +80,9 @@ export default class Cards extends Service implements CardService {
 
     return await Promise.all(
       data.map(async (cardResponse) => {
-        return this.makeCardModelFromResponse(cardResponse, format);
+        let model = await this.makeCardModelFromResponse(cardResponse, format);
+        await model.computeData();
+        return model;
       })
     );
   }
@@ -132,7 +134,7 @@ export default class Cards extends Service implements CardService {
     cardResponse: ResourceObject,
     format: Format,
     allFields = false
-  ): Promise<CardModel> {
+  ): Promise<CardModelForBrowser> {
     let schemaModule = cardResponse.meta?.schemaModule;
     if (!schemaModule) {
       throw new Error(

--- a/packages/cardhost/app/services/modal.ts
+++ b/packages/cardhost/app/services/modal.ts
@@ -62,7 +62,7 @@ export default class Modal extends Service {
     this.destroyCurrentCard();
     this.state = { name: 'loading' };
 
-    let loadedCard = await this.cards.load(url, format);
+    let loadedCard = await this.cards.loadData(url, format);
     associateDestroyableChild(this, loadedCard);
 
     this.state = {

--- a/packages/cardhost/app/services/modal.ts
+++ b/packages/cardhost/app/services/modal.ts
@@ -62,7 +62,7 @@ export default class Modal extends Service {
     this.destroyCurrentCard();
     this.state = { name: 'loading' };
 
-    let loadedCard = await this.cards.loadData(url, format);
+    let loadedCard = await this.cards.loadModel(url, format);
     associateDestroyableChild(this, loadedCard);
 
     this.state = {

--- a/packages/cardhost/tests/@core/card-model-test.ts
+++ b/packages/cardhost/tests/@core/card-model-test.ts
@@ -80,7 +80,7 @@ module('@core | card-model-for-browser', function (hooks) {
   });
 
   test('.data', async function (assert) {
-    let model = await lookup(this, 'cards').loadData(
+    let model = await lookup(this, 'cards').loadModel(
       `${localRealmURL}bob`,
       'isolated'
     );
@@ -106,7 +106,7 @@ module('@core | card-model-for-browser', function (hooks) {
   });
 
   skip('unused fields are not present', async function (assert) {
-    let model = await lookup(this, 'cards').loadData(
+    let model = await lookup(this, 'cards').loadModel(
       `${localRealmURL}bob`,
       'embedded'
     );
@@ -123,7 +123,7 @@ module('@core | card-model-for-browser', function (hooks) {
   });
 
   test('.serialize', async function (assert) {
-    let model = await lookup(this, 'cards').loadData(
+    let model = await lookup(this, 'cards').loadModel(
       `${localRealmURL}bob`,
       'isolated'
     );

--- a/packages/cardhost/tests/@core/card-model-test.ts
+++ b/packages/cardhost/tests/@core/card-model-test.ts
@@ -80,7 +80,7 @@ module('@core | card-model-for-browser', function (hooks) {
   });
 
   test('.data', async function (assert) {
-    let model = await lookup(this, 'cards').load(
+    let model = await lookup(this, 'cards').loadData(
       `${localRealmURL}bob`,
       'isolated'
     );
@@ -106,7 +106,7 @@ module('@core | card-model-for-browser', function (hooks) {
   });
 
   skip('unused fields are not present', async function (assert) {
-    let model = await lookup(this, 'cards').load(
+    let model = await lookup(this, 'cards').loadData(
       `${localRealmURL}bob`,
       'embedded'
     );
@@ -123,7 +123,7 @@ module('@core | card-model-for-browser', function (hooks) {
   });
 
   test('.serialize', async function (assert) {
-    let model = await lookup(this, 'cards').load(
+    let model = await lookup(this, 'cards').loadData(
       `${localRealmURL}bob`,
       'isolated'
     );

--- a/packages/cardhost/tests/helpers/setup.ts
+++ b/packages/cardhost/tests/helpers/setup.ts
@@ -55,7 +55,7 @@ export function setupCardTest(
     cardId: Partial<CardId> & { id: string },
     format: Format = 'isolated'
   ) {
-    let card = await cardService.loadData(testCardURL(cardId), format);
+    let card = await cardService.loadModel(testCardURL(cardId), format);
     (getContext() as TestContext).set('component', await card.component());
     await render(hbs`<this.component />`);
   }

--- a/packages/cardhost/tests/helpers/setup.ts
+++ b/packages/cardhost/tests/helpers/setup.ts
@@ -55,7 +55,7 @@ export function setupCardTest(
     cardId: Partial<CardId> & { id: string },
     format: Format = 'isolated'
   ) {
-    let card = await cardService.load(testCardURL(cardId), format);
+    let card = await cardService.loadData(testCardURL(cardId), format);
     (getContext() as TestContext).set('component', await card.component());
     await render(hbs`<this.component />`);
   }

--- a/packages/cardhost/tests/integration/card-service-test.ts
+++ b/packages/cardhost/tests/integration/card-service-test.ts
@@ -60,7 +60,7 @@ module('Integration | card-service', function (hooks) {
     });
 
     test(`load a card's isolated view and model`, async function (assert) {
-      let model = await cards.loadData(cardID, 'isolated');
+      let model = await cards.loadModel(cardID, 'isolated');
       assert.equal(model.url, cardID, '@model id is correct');
       assert.equal(
         model.data.title,
@@ -120,7 +120,10 @@ module('Integration | card-service', function (hooks) {
       assert.dom('h1').containsText('A blog post title');
       assert.dom('h2').containsText('May 17, 2021');
 
-      let model = await cards.loadData(`${localRealmURL}post-list`, 'isolated');
+      let model = await cards.loadModel(
+        `${localRealmURL}post-list`,
+        'isolated'
+      );
       assert.ok(
         model.data.posts[0].createdAt instanceof Date,
         'CreatedAt is an instance of Date'

--- a/packages/cardhost/tests/integration/card-service-test.ts
+++ b/packages/cardhost/tests/integration/card-service-test.ts
@@ -60,7 +60,7 @@ module('Integration | card-service', function (hooks) {
     });
 
     test(`load a card's isolated view and model`, async function (assert) {
-      let model = await cards.load(cardID, 'isolated');
+      let model = await cards.loadData(cardID, 'isolated');
       assert.equal(model.url, cardID, '@model id is correct');
       assert.equal(
         model.data.title,
@@ -120,7 +120,7 @@ module('Integration | card-service', function (hooks) {
       assert.dom('h1').containsText('A blog post title');
       assert.dom('h2').containsText('May 17, 2021');
 
-      let model = await cards.load(`${localRealmURL}post-list`, 'isolated');
+      let model = await cards.loadData(`${localRealmURL}post-list`, 'isolated');
       assert.ok(
         model.data.posts[0].createdAt instanceof Date,
         'CreatedAt is an instance of Date'

--- a/packages/core/src/card-model.ts
+++ b/packages/core/src/card-model.ts
@@ -1,0 +1,236 @@
+import {
+  CompiledCard,
+  Format,
+  ResourceObject,
+  Saved,
+  Unsaved,
+  RawCardData,
+  ComponentInfo,
+  assertDocumentDataIsResource,
+  CardService,
+  CardModelArgs,
+  CardSchemaModule,
+  CardComponentModule,
+  CardModel as CardModelInterface,
+  Setter,
+  SerializerMap,
+  CardComponentMetaModule,
+} from '@cardstack/core/src/interfaces';
+import { serializeCardAsResource, serializeField } from '@cardstack/core/src/serializers';
+import merge from 'lodash/merge';
+import { cardURL } from '@cardstack/core/src/utils';
+import get from 'lodash/get';
+import set from 'lodash/set';
+import cloneDeep from 'lodash/cloneDeep';
+import { getFieldValue } from '@cardstack/core/src/utils/fields';
+
+export interface CreatedState {
+  type: 'created';
+  id?: string;
+  parentCardURL: string;
+}
+
+export interface LoadedState {
+  type: 'loaded';
+  url: string;
+  allFields: boolean;
+}
+
+export default abstract class CardModel implements CardModelInterface {
+  protected _schemaInstance: any | undefined;
+  protected componentModuleRef: ComponentInfo['componentModule']['global'];
+  protected rawData: RawCardData;
+  protected state: CreatedState | LoadedState;
+  protected _componentModule: CardComponentModule | undefined;
+  protected componentMeta: CardComponentMetaModule | undefined;
+
+  private _realm: string;
+  private schemaModule: CompiledCard['schemaModule']['global'];
+  private _format: Format;
+  private saveModel: CardModelArgs['saveModel'];
+  private _schemaClass: CardSchemaModule['default'] | undefined;
+
+  constructor(protected cards: CardService, state: CreatedState | LoadedState, args: CardModelArgs) {
+    let { realm, schemaModule, format, componentModuleRef, rawData, componentMeta, saveModel } = args;
+    this._realm = realm;
+    this.schemaModule = schemaModule;
+    this._format = format;
+    this.componentModuleRef = componentModuleRef;
+    this.rawData = rawData;
+    this.componentMeta = componentMeta;
+    this.saveModel = saveModel;
+    this.state = state;
+  }
+
+  abstract setters: Setter | undefined;
+  abstract editable(): Promise<CardModelInterface>;
+  abstract setData(data: RawCardData): void;
+  abstract component(): Promise<unknown>;
+  protected abstract get serializerMap(): SerializerMap;
+  protected abstract get usedFields(): string[];
+  protected abstract get allFields(): string[];
+  protected abstract componentModule(): Promise<CardComponentModule | void>;
+
+  adoptIntoRealm(realm: string, id?: string): CardModelInterface {
+    if (this.state.type !== 'loaded') {
+      throw new Error(`tried to adopt from an unsaved card`);
+    }
+
+    return new (this.constructor as any)(
+      this.cards,
+      {
+        type: 'created',
+        id,
+        parentCardURL: this.state.url,
+      },
+      {
+        realm,
+        format: this.format,
+        rawData: { id: undefined, type: 'card', attributes: {} },
+        saveModel: this.saveModel,
+        schemaModule: this.schemaModule,
+        componentMeta: this.componentMeta,
+        componentModuleRef: this.componentModuleRef,
+      }
+    );
+  }
+
+  async computeData(schemaInstance?: any): Promise<Record<string, any>> {
+    let syncData: Record<string, any> = {};
+    for (let field of this.usedFields) {
+      set(syncData, field, await this.getField(field, schemaInstance));
+    }
+    return syncData;
+  }
+
+  async getField(name: string, schemaInstance?: any): Promise<any> {
+    schemaInstance = schemaInstance ?? this._schemaInstance;
+
+    if (!schemaInstance) {
+      schemaInstance = this._schemaInstance = await this.createSchemaInstance();
+    }
+
+    return await getFieldValue(schemaInstance, name);
+  }
+
+  get data(): object {
+    return this._schemaInstance;
+  }
+
+  get id(): string | undefined {
+    if (this.state.type === 'created') {
+      return this.state.id;
+    }
+    return this.url.slice(this.realm.length);
+  }
+
+  get realm(): string {
+    return this._realm;
+  }
+
+  get url(): string {
+    if (this.state.type === 'created') {
+      throw new Error(`bug: card in state ${this.state.type} does not have a url`);
+    }
+    return this.state.url;
+  }
+
+  get format(): Format {
+    return this._format;
+  }
+
+  get parentCardURL(): string {
+    if (this.state.type === 'created') {
+      return this.state.parentCardURL;
+    } else {
+      throw new Error(`card ${this.url} in state ${this.state.type} does not support parentCardURL`);
+    }
+  }
+
+  serialize(): ResourceObject<Saved | Unsaved> {
+    let url: string | undefined;
+    if (this.state.type === 'loaded') {
+      url = this.state.url;
+    } else if (this.state.id != null) {
+      url = cardURL({ realm: this.realm, id: this.state.id });
+    }
+
+    if (this.state.type === 'created') {
+      return serializeCardAsResource(url, this.shapeData('used-fields'), this.serializerMap);
+    }
+
+    let resource = serializeCardAsResource(
+      url,
+      this.shapeData(this.state.allFields ? 'all-fields' : 'used-fields'),
+      this.serializerMap
+    );
+    resource.meta = merge({ componentModule: this.componentModuleRef, schemaModule: this.schemaModule }, resource.meta);
+    return resource;
+  }
+
+  async save(): Promise<void> {
+    let data: ResourceObject<Saved>;
+    switch (this.state.type) {
+      case 'created':
+        data = await this.saveModel(this, 'create');
+        break;
+      case 'loaded':
+        data = await this.saveModel(this, 'update');
+        break;
+      default:
+        throw assertNever(this.state);
+    }
+
+    assertDocumentDataIsResource(data);
+    this.rawData = cloneDeep(data.attributes ?? {});
+    // on the browser the id will be the full URL, but on the hub, the id is
+    // actually just the realm specific identifier
+    let url = data.id.startsWith(this.realm) ? data.id : cardURL({ realm: this.realm, id: data.id });
+    this.state = {
+      type: 'loaded',
+      url,
+      allFields: false,
+    };
+  }
+
+  // we have a few places that are very sensitive to the shape of the data, and
+  // won't be able to deal with a schema instance that has additional properties
+  // and methods beyond just the data itself, so this method is for those places
+  protected shapeData(shape: 'used-fields' | 'all-fields') {
+    let syncData: Record<string, any> = {};
+
+    let fields = shape === 'used-fields' ? this.usedFields : this.allFields;
+    for (let field of fields) {
+      let value = get(this._schemaInstance, field);
+      // undefined is a signal that the field should not exist
+      if (value !== undefined) {
+        set(syncData, field, value);
+      }
+    }
+    return syncData;
+  }
+
+  protected async createSchemaInstance() {
+    let klass = await this.schemaClass();
+    // We can't await the instance creation in a separate, as it's thenable and confuses async methods
+    return new klass(this.getRawField.bind(this)) as any;
+  }
+
+  private getRawField(fieldPath: string): any {
+    let value = get(this.rawData, fieldPath);
+    return serializeField(this.serializerMap, fieldPath, value, 'deserialize');
+  }
+
+  private async schemaClass() {
+    if (this._schemaClass) {
+      return this._schemaClass;
+    }
+    this._schemaClass = (await this.cards.loadModule<CardSchemaModule>(this.schemaModule)).default;
+
+    return this._schemaClass;
+  }
+}
+
+function assertNever(value: never) {
+  throw new Error(`should never happen ${value}`);
+}

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -182,7 +182,7 @@ export interface Builder {
 
 export interface CardModel {
   setters: Setter | undefined;
-  adoptIntoRealm(realm: string, id?: string): Promise<CardModel>;
+  adoptIntoRealm(realm: string, id?: string): CardModel;
   editable(): Promise<CardModel>;
   url: string;
   id: string | undefined;
@@ -203,6 +203,7 @@ export interface CardModelArgs {
   format: Format;
   rawData: NonNullable<RawCard['data']>;
   componentModuleRef: ComponentInfo['componentModule']['global'];
+  componentMeta?: CardComponentMetaModule;
   saveModel: (model: CardModel, operation: 'create' | 'update') => Promise<ResourceObject<Saved>>;
 }
 
@@ -226,6 +227,7 @@ export interface CardComponentMetaModule {
   serializerMap: SerializerMap;
   computedFields: string[];
   usedFields: string[];
+  allFields: string[];
 }
 
 export type CardComponentModule = {

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -2,6 +2,7 @@ import * as JSON from 'json-typescript';
 import { CardstackError } from './utils/errors';
 import type { types as t } from '@babel/core';
 import { keys } from './utils';
+import { Query } from './query';
 
 export { Query } from './query';
 
@@ -185,6 +186,7 @@ export interface CardModel {
   editable(): Promise<CardModel>;
   url: string;
   id: string | undefined;
+  realm: string;
   data: Record<string, any>;
   getField(name: string): Promise<any>;
   format: Format;
@@ -193,6 +195,29 @@ export interface CardModel {
   component(): Promise<unknown>;
   usedFields: ComponentInfo['usedFields'];
   save(): Promise<void>;
+  parentCardURL: string;
+}
+
+export interface CardModelArgs {
+  realm: string;
+  schemaModule: string;
+  format: Format;
+  rawData: NonNullable<RawCard['data']>;
+}
+
+export interface CardService {
+  load(cardURL: string): Promise<Card>;
+  loadData(cardURL: string, format: Format, allFields?: boolean): Promise<CardModel>;
+  create(raw: RawCard<Unsaved>): Promise<Card>;
+  update(partialRaw: RawCard): Promise<Card>;
+  delete(raw: RawCard): Promise<void>;
+  query(format: Format, query: Query): Promise<CardModel[]>;
+  loadModule<T extends Object>(moduleIdentifier: string): Promise<T>;
+
+  // it would be great if we could merge these with create and update--but we
+  // have a need to pass the CardModel thru this...
+  createModel(card: CardModel): Promise<JSONAPIDocument>; // TODO refactor to not use JSONAPIDocument
+  updateModel(card: CardModel): Promise<JSONAPIDocument>; // TODO refactor to not use JSONAPIDocument
 }
 
 export interface CardSchemaModule {

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -193,7 +193,6 @@ export interface CardModel {
   setData(data: RawCardData): void;
   serialize(): ResourceObject<Saved | Unsaved>;
   component(): Promise<unknown>;
-  usedFields: ComponentInfo['usedFields'];
   save(): Promise<void>;
   parentCardURL: string;
 }
@@ -203,21 +202,18 @@ export interface CardModelArgs {
   schemaModule: string;
   format: Format;
   rawData: NonNullable<RawCard['data']>;
+  componentModuleRef: ComponentInfo['componentModule']['global'];
+  saveModel: (model: CardModel, operation: 'create' | 'update') => Promise<ResourceObject<Saved>>;
 }
 
 export interface CardService {
   load(cardURL: string): Promise<Card>;
-  loadData(cardURL: string, format: Format, allFields?: boolean): Promise<CardModel>;
+  loadModel(cardURL: string, format: Format, allFields?: boolean): Promise<CardModel>;
   create(raw: RawCard<Unsaved>): Promise<Card>;
   update(partialRaw: RawCard): Promise<Card>;
   delete(raw: RawCard): Promise<void>;
   query(format: Format, query: Query): Promise<CardModel[]>;
   loadModule<T extends Object>(moduleIdentifier: string): Promise<T>;
-
-  // it would be great if we could merge these with create and update--but we
-  // have a need to pass the CardModel thru this...
-  createModel(card: CardModel): Promise<ResourceObject<Saved>>;
-  updateModel(card: CardModel): Promise<ResourceObject<Saved>>;
 }
 
 export interface CardSchemaModule {

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -216,8 +216,8 @@ export interface CardService {
 
   // it would be great if we could merge these with create and update--but we
   // have a need to pass the CardModel thru this...
-  createModel(card: CardModel): Promise<JSONAPIDocument>; // TODO refactor to not use JSONAPIDocument
-  updateModel(card: CardModel): Promise<JSONAPIDocument>; // TODO refactor to not use JSONAPIDocument
+  createModel(card: CardModel): Promise<ResourceObject<Saved>>;
+  updateModel(card: CardModel): Promise<ResourceObject<Saved>>;
 }
 
 export interface CardSchemaModule {

--- a/packages/hub/lib/card-model-for-hub.ts
+++ b/packages/hub/lib/card-model-for-hub.ts
@@ -1,179 +1,20 @@
-import {
-  CardModel,
-  SerializerMap,
-  CompiledCard,
-  Format,
-  ResourceObject,
-  Saved,
-  Unsaved,
-  RawCardData,
-  CardComponentMetaModule,
-  ComponentInfo,
-  CardService,
-  CardModelArgs,
-  CardSchemaModule,
-} from '@cardstack/core/src/interfaces';
-import { serializeAttributes, serializeCardAsResource, serializeField } from '@cardstack/core/src/serializers';
-import { getOwner } from '@cardstack/di';
+import { CardModel, SerializerMap, RawCardData, CardComponentMetaModule } from '@cardstack/core/src/interfaces';
+import BaseCardModel from '@cardstack/core/src/card-model';
+import { serializeAttributes } from '@cardstack/core/src/serializers';
 import merge from 'lodash/merge';
 import isPlainObject from 'lodash/isPlainObject';
-import { cardURL } from '@cardstack/core/src/utils';
 import { BadRequest } from '@cardstack/core/src/utils/errors';
-import get from 'lodash/get';
-import set from 'lodash/set';
-import { getFieldValue } from '@cardstack/core/src/utils/fields';
 
-export interface NewCardParams {
-  realm: string;
-  parentCardURL: string;
-}
-
-export interface CreatedState {
-  type: 'created';
-  id?: string;
-  parentCardURL: string;
-}
-
-interface LoadedState {
-  type: 'loaded';
-  id: string;
-  allFields: boolean;
-}
-
-export default class CardModelForHub implements CardModel {
-  private _schemaInstance: any | undefined;
-  private _realm: string;
-  private schemaModule: CompiledCard['schemaModule']['global'];
-  private _format: Format;
-  private componentModuleRef: ComponentInfo['componentModule']['global'];
-  private rawData: RawCardData;
-  private saveModel: CardModelArgs['saveModel'];
-  private state: CreatedState | LoadedState;
-  private _schemaClass: CardSchemaModule['default'] | undefined;
-
-  private componentMeta: CardComponentMetaModule;
+export default class CardModelForHub extends BaseCardModel implements CardModel {
   setters: undefined;
-
-  constructor(
-    private cards: CardService,
-    state: CreatedState | Omit<LoadedState, 'deserialized'>,
-    // TODO let's work on unifying these args with the CardModelForBrowser
-    args: CardModelArgs & { componentMeta: CardComponentMetaModule }
-  ) {
-    let { rawData, realm, format, schemaModule, componentMeta, saveModel, componentModuleRef } = args;
-    this._realm = realm;
-    this._format = format;
-    this.schemaModule = schemaModule;
-    this.componentModuleRef = componentModuleRef;
-    this.componentMeta = componentMeta;
-    this.rawData = rawData;
-    this.saveModel = saveModel;
-    this.state = state;
-  }
-
-  async getField(name: string, schemaInstance?: any): Promise<any> {
-    // TODO: add isComputed somewhere in the metadata coming out of the compiler so we can do this optimization
-    // if (this.isComputedField(name)) {
-    //   TODO need to deserialize value
-    //   return get(this.data, name);
-    // }
-
-    schemaInstance = schemaInstance ?? this._schemaInstance;
-
-    if (!schemaInstance) {
-      schemaInstance = this._schemaInstance = await this.createSchemaInstance();
-    }
-
-    return await getFieldValue(schemaInstance, name);
-  }
-
-  private async createSchemaInstance() {
-    let klass = await this.schemaClass();
-    // We can't await the instance creation in a separate, as it's thenable and confuses async methods
-    return new klass(this.getRawField.bind(this)) as any;
-  }
-
-  private getRawField(fieldPath: string): any {
-    let value = get(this.rawData, fieldPath);
-    return serializeField(this.serializerMap, fieldPath, value, 'deserialize');
-  }
-
-  async schemaClass() {
-    if (this._schemaClass) {
-      return this._schemaClass;
-    }
-    this._schemaClass = (await this.cards.loadModule<CardSchemaModule>(this.schemaModule)).default;
-
-    return this._schemaClass;
-  }
-
-  async adoptIntoRealm(realm: string, id?: string): Promise<CardModel> {
-    if (this.state.type !== 'loaded') {
-      throw new Error(`tried to adopt from an unsaved card`);
-    }
-    if (this.format !== 'isolated') {
-      throw new Error(`Can only adoptIntoRealm from an isolated card. This card is ${this.format}`);
-    }
-    return await getOwner(this).instantiate(
-      this.constructor as typeof CardModelForHub,
-      this.cards,
-      {
-        type: 'created',
-        id,
-        parentCardURL: this.url,
-      },
-      {
-        realm,
-        format: this.format,
-        rawData: {},
-        saveModel: this.saveModel,
-        schemaModule: this.schemaModule,
-        componentModuleRef: this.componentModuleRef,
-        componentMeta: this.componentMeta,
-      }
-    );
-  }
-
-  get innerComponent(): unknown {
-    throw new Error('Hub does not have use of innerComponent');
-  }
-
-  get serializerMap(): SerializerMap {
-    return this.componentMeta.serializerMap;
-  }
-
-  get id(): string | undefined {
-    return this.state.id;
-  }
-  get realm(): string {
-    return this._realm;
-  }
-
-  get url(): string {
-    if (this.state.type === 'created') {
-      throw new Error(`bug: card in state ${this.state.type} does not have a url yet`);
-    }
-    return cardURL({ realm: this.realm, id: this.state.id });
-  }
-
-  get format() {
-    return this._format;
-  }
-
-  get parentCardURL(): string {
-    if (this.state.type === 'created') {
-      return this.state.parentCardURL;
-    } else {
-      throw new Error(`card ${this.url} in state ${this.state.type} does not support parentCardURL`);
-    }
-  }
-
-  get usedFields(): CardComponentMetaModule['usedFields'] {
-    return this.componentMeta.usedFields;
-  }
 
   async editable(): Promise<CardModel> {
     throw new Error('Hub does not have use of editable');
+  }
+
+  // TODO in the future when we do SSR, we'll have a need for this
+  async component(): Promise<unknown> {
+    throw new Error('Hub does not have use of component');
   }
 
   // TODO refactor to use CardModelForBrowser's setter
@@ -187,11 +28,35 @@ export default class CardModelForHub implements CardModel {
       );
     }
 
-    // TODO need to write a test that proves data consistency
     this.rawData = serializeAttributes(merge({}, this.rawData, data), this.serializerMap);
     let newSchemaInstance = await this.createSchemaInstance();
     await this.computeData(newSchemaInstance);
     this._schemaInstance = newSchemaInstance;
+  }
+
+  protected get serializerMap(): SerializerMap {
+    if (!this.componentMeta) {
+      throw new Error(`bug: CardModelForHub has no componentMeta`);
+    }
+    return this.componentMeta.serializerMap;
+  }
+
+  protected get usedFields(): CardComponentMetaModule['usedFields'] {
+    if (!this.componentMeta) {
+      throw new Error(`bug: CardModelForHub has no componentMeta`);
+    }
+    return this.componentMeta.usedFields;
+  }
+
+  protected get allFields(): CardComponentMetaModule['allFields'] {
+    if (!this.componentMeta) {
+      throw new Error(`bug: CardModelForHub has no componentMeta`);
+    }
+    return this.componentMeta.allFields;
+  }
+
+  protected componentModule() {
+    return Promise.resolve();
   }
 
   // TODO: we need to really use a validation mechanism which will use code from
@@ -208,71 +73,4 @@ export default class CardModelForHub implements CardModel {
     }
     return nonExistentFields;
   }
-
-  get data(): object {
-    return this._schemaInstance;
-  }
-
-  async computeData(schemaInstance?: any): Promise<Record<string, any>> {
-    let syncData: Record<string, any> = {};
-    for (let field of this.usedFields) {
-      set(syncData, field, await this.getField(field, schemaInstance));
-    }
-    return syncData;
-  }
-
-  async component(): Promise<unknown> {
-    throw new Error('Hub does not have use of component');
-  }
-
-  // we have a few places that are very sensitive to the shape of the data, and
-  // won't be able to deal with a schema instance that has additional properties
-  // and methods beyond just the data itself, so this method is for those places
-  private dataAsUsedFieldsShape() {
-    let syncData: Record<string, any> = {};
-    for (let field of this.usedFields) {
-      set(syncData, field, get(this._schemaInstance, field));
-    }
-    return syncData;
-  }
-
-  serialize(): ResourceObject<Saved | Unsaved> {
-    if (this.state.type === 'created') {
-      return serializeCardAsResource(undefined, this.dataAsUsedFieldsShape(), this.serializerMap);
-    }
-
-    let resource = serializeCardAsResource(
-      this.url,
-      this.rawData,
-      this.serializerMap,
-      !this.state.allFields ? this.usedFields : undefined
-    );
-    resource.meta = merge({ componentModule: this.componentModuleRef, schemaModule: this.schemaModule }, resource.meta);
-
-    return resource;
-  }
-
-  async save(): Promise<void> {
-    let data: ResourceObject<Saved>;
-    switch (this.state.type) {
-      case 'created':
-        data = await this.saveModel(this, 'create');
-        break;
-      case 'loaded':
-        data = await this.saveModel(this, 'update');
-        break;
-      default:
-        throw assertNever(this.state);
-    }
-    this.rawData = data.attributes ?? {};
-    this.state = {
-      type: 'loaded',
-      id: data.id,
-      allFields: false,
-    };
-  }
-}
-
-function assertNever(value: never) {
-  throw new Error(`should never happen ${value}`);
 }

--- a/packages/hub/lib/card-model-for-hub.ts
+++ b/packages/hub/lib/card-model-for-hub.ts
@@ -226,18 +226,22 @@ export default class CardModelForHub implements CardModel {
     let { realm } = this;
     switch (this.state.type) {
       case 'created':
-        data = await this.cards.createModel(this);
-        let { id } = data;
-        compiled = await this.searchIndex.indexData(
-          { id, realm, adoptsFrom: this.parentCardURL, data: data.attributes },
-          this
-        );
+        {
+          data = await this.cards.createModel(this);
+          let { id } = data;
+          compiled = await this.searchIndex.indexData(
+            { id, realm, adoptsFrom: this.parentCardURL, data: data.attributes },
+            this
+          );
+        }
         break;
       case 'loaded':
         {
-          data = await this.cards.updateModel(this);
-          let { id } = data;
-          compiled = await this.searchIndex.indexData({ id, realm, data: data.attributes }, this);
+          {
+            data = await this.cards.updateModel(this);
+            let { id } = data;
+            compiled = await this.searchIndex.indexData({ id, realm, data: data.attributes }, this);
+          }
         }
         break;
       default:

--- a/packages/hub/node-tests/@core/card-model-test.ts
+++ b/packages/hub/node-tests/@core/card-model-test.ts
@@ -7,7 +7,7 @@ import { configureHubWithCompiler } from '../helpers/cards';
 import merge from 'lodash/merge';
 import { templateOnlyComponentTemplate } from '@cardstack/core/tests/helpers';
 import cloneDeep from 'lodash/cloneDeep';
-// import set from 'lodash/set';
+import set from 'lodash/set';
 import { CardModel } from '@cardstack/core/src/interfaces';
 
 function p(dateString: string): Date {
@@ -27,13 +27,9 @@ let attributes: Record<string, any> = {
 
 if (process.env.COMPILER) {
   describe('CardModelForHub', function () {
-    let { getContainer, realmURL, cards } = configureHubWithCompiler(this);
-    let cardDBResult: Record<string, any>;
+    let { realmURL, cards } = configureHubWithCompiler(this);
 
     this.beforeEach(async function () {
-      let dbManager = await getContainer().lookup('database-manager');
-      let db = await dbManager.getClient();
-
       await cards.create(ADDRESS_RAW_CARD);
       await cards.create(
         merge({}, PERSON_RAW_CARD, {
@@ -56,22 +52,10 @@ if (process.env.COMPILER) {
         adoptsFrom: '../person',
         data: attributes,
       });
-
-      let {
-        rows: [result],
-      } = await db.query(
-        'SELECT url, data, "schemaModule", "componentInfos", "compileErrors", deps from cards where url = $1',
-        [`${realmURL}bob-barker`]
-      );
-      cardDBResult = result;
     });
 
     it('.data', async function () {
-      // TODO: I made makeCardModelFromDatabase private because it shouldn't be
-      // exposed. This test should be refactored to use public API, and the
-      // public API around data may be changing anyway to account for including
-      // computed fields
-      let model: CardModel = await (cards as any).makeCardModelFromDatabase('isolated', cardDBResult);
+      let model: CardModel = await cards.loadModel(`${realmURL}bob-barker`, 'isolated');
       expect(model.data.name).to.equal(attributes.name);
       expect(isSameDay(model.data.birthdate, p('1923-12-12')), 'Dates are serialized to Dates').to.be.ok;
       expect(model.data.address.street).to.equal(attributes.address.street);
@@ -79,7 +63,7 @@ if (process.env.COMPILER) {
     });
 
     it('.url on new card throws error', async function () {
-      let parentCard = await cards.loadData(`${realmURL}person`, 'isolated');
+      let parentCard = await cards.loadModel(`${realmURL}person`, 'isolated');
       let model = await parentCard.adoptIntoRealm(realmURL);
       try {
         model.url;
@@ -90,29 +74,29 @@ if (process.env.COMPILER) {
     });
 
     it('.save() created card', async function () {
-      let parentCard = await cards.loadData(`${realmURL}person`, 'isolated');
+      let parentCard = await cards.loadModel(`${realmURL}person`, 'isolated');
       let model = await parentCard.adoptIntoRealm(realmURL);
-      model.setData({ name: 'Kirito', address: { settlementDate: p('2022-02-22') } });
+      await model.setData({ name: 'Kirito', address: { settlementDate: p('2022-02-22') } });
       expect(model.data.address.settlementDate instanceof Date).to.be.true;
       expect(isSameDay(model.data.address.settlementDate, p('2022-02-22')), 'Dates are serialized to Dates').to.be.ok;
       await model.save();
 
-      let kirito = await cards.loadData(model.url, 'isolated');
+      let kirito = await cards.loadModel(model.url, 'isolated');
       expect(kirito.data.name).to.equal('Kirito');
       expect(kirito.data.address.settlementDate instanceof Date).to.be.true;
       expect(isSameDay(kirito.data.address.settlementDate, p('2022-02-22')), 'Dates are serialized to Dates').to.be.ok;
     });
 
     it('.save() loaded card - isolated', async function () {
-      let model = await cards.loadData(`${realmURL}bob-barker`, 'isolated');
-      model.setData({ name: 'Robert Barker' });
+      let model = await cards.loadModel(`${realmURL}bob-barker`, 'isolated');
+      await model.setData({ name: 'Robert Barker' });
       await model.save();
 
       expect(model.format).to.equal('isolated');
       expect(model.data.name).to.equal('Robert Barker');
       expect(isSameDay(model.data.birthdate, p('1923-12-12')), 'Dates are serialized to Dates').to.be.ok;
 
-      model.setData({ birthdate: p('2022-02-22') });
+      await model.setData({ birthdate: p('2022-02-22') });
 
       expect(isSameDay(model.data.birthdate, p('2022-02-22')), 'Dates are serialized to Dates').to.be.ok;
 
@@ -120,33 +104,33 @@ if (process.env.COMPILER) {
 
       expect(isSameDay(model.data.birthdate, p('2022-02-22')), 'Dates are serialized to Dates').to.be.ok;
 
-      let savedModel = await cards.loadData(`${realmURL}bob-barker`, 'isolated');
+      let savedModel = await cards.loadModel(`${realmURL}bob-barker`, 'isolated');
       expect(savedModel.data.name).to.equal('Robert Barker');
       expect(isSameDay(savedModel.data.birthdate, p('2022-02-22')), 'Dates are serialized to Dates').to.be.ok;
       // fields that were not specified in setData should be unchanged
       expect(savedModel.data.address.city).to.equal('Los Angeles');
-      let embedded = await cards.loadData(`${realmURL}bob-barker`, 'embedded');
+      let embedded = await cards.loadModel(`${realmURL}bob-barker`, 'embedded');
       expect(embedded.data.name).to.equal('Robert Barker');
       expect(isSameDay(embedded.data.birthdate, p('2022-02-22')), 'Dates are serialized to Dates').to.be.ok;
     });
 
     it('.save() loaded card - embedded', async function () {
-      let model = await cards.loadData(`${realmURL}bob-barker`, 'embedded');
-      model.setData({ name: 'Robert Barker' });
+      let model = await cards.loadModel(`${realmURL}bob-barker`, 'embedded');
+      await model.setData({ name: 'Robert Barker' });
       await model.save();
 
       expect(model.data.name).to.equal('Robert Barker');
       expect(model.format).to.equal('embedded');
 
-      let savedModel = await cards.loadData(`${realmURL}bob-barker`, 'embedded');
+      let savedModel = await cards.loadModel(`${realmURL}bob-barker`, 'embedded');
       expect(savedModel.data.name).to.equal('Robert Barker');
-      let isolated = await cards.loadData(`${realmURL}bob-barker`, 'isolated');
+      let isolated = await cards.loadModel(`${realmURL}bob-barker`, 'isolated');
       expect(isolated.data.name).to.equal('Robert Barker');
     });
 
     it('.save() on adopted card using pre-existing id', async function () {
       let id = 'bob-barker';
-      let parentCard = await cards.loadData(`${realmURL}person`, 'isolated');
+      let parentCard = await cards.loadModel(`${realmURL}person`, 'isolated');
       let model = await parentCard.adoptIntoRealm(realmURL, id);
       try {
         await model.save();
@@ -159,9 +143,9 @@ if (process.env.COMPILER) {
     // note that we have route tests that also assert that setting values on
     // non-existent fields should error
     it('setData of unused field', async function () {
-      let model = await cards.loadData(`${realmURL}bob-barker`, 'embedded');
+      let model = await cards.loadModel(`${realmURL}bob-barker`, 'embedded');
       try {
-        model.setData({
+        await model.setData({
           name: 'Robert Barker',
           pizza: 'pepperoni', // non-existent field
           address: { city: 'New York' }, // unused field
@@ -175,7 +159,7 @@ if (process.env.COMPILER) {
     });
 
     it('.serialize isolated card', async function () {
-      let model = await cards.loadData(`${realmURL}bob-barker`, 'isolated');
+      let model = await cards.loadModel(`${realmURL}bob-barker`, 'isolated');
       let result = model.serialize();
 
       expect(result.meta?.componentModule).to.include('@cardstack/compiled/https-cardstack.local-person/isolated-');
@@ -194,7 +178,7 @@ if (process.env.COMPILER) {
     });
 
     it('.serialize embedded card', async function () {
-      let model = await cards.loadData(`${realmURL}bob-barker`, 'embedded');
+      let model = await cards.loadModel(`${realmURL}bob-barker`, 'embedded');
       let result = model.serialize();
 
       expect(result.meta?.componentModule).to.include('@cardstack/compiled/https-cardstack.local-person/embedded-');
@@ -211,15 +195,13 @@ if (process.env.COMPILER) {
     });
 
     it('.serialize card model in created state', async function () {
-      let parent = await cards.loadData(`${realmURL}person`, 'isolated');
+      let parent = await cards.loadModel(`${realmURL}person`, 'isolated');
       let model = await parent.adoptIntoRealm(realmURL);
-      model.setData(attributes);
+      await model.setData(attributes);
       let result = model.serialize();
 
       let expectedAttributes = cloneDeep(attributes);
-      // TODO: We currently do not store enough info in the database
-      // to know this should be her
-      // set(expectedAttributes, 'address.zip', null);
+      set(expectedAttributes, 'address.zip', undefined);
 
       expect(result).to.deep.equal({
         id: undefined,

--- a/packages/hub/node-tests/@core/card-model-test.ts
+++ b/packages/hub/node-tests/@core/card-model-test.ts
@@ -85,7 +85,7 @@ if (process.env.COMPILER) {
         model.url;
         throw new Error('did not throw expected error');
       } catch (e: any) {
-        expect(e.message).to.equal(`bug: card in state created does not have a url`);
+        expect(e.message).to.equal(`bug: card in state created does not have a url yet`);
       }
     });
 

--- a/packages/hub/node-tests/@core/card-model-test.ts
+++ b/packages/hub/node-tests/@core/card-model-test.ts
@@ -7,7 +7,6 @@ import { configureHubWithCompiler } from '../helpers/cards';
 import merge from 'lodash/merge';
 import { templateOnlyComponentTemplate } from '@cardstack/core/tests/helpers';
 import cloneDeep from 'lodash/cloneDeep';
-import set from 'lodash/set';
 import { CardModel } from '@cardstack/core/src/interfaces';
 
 function p(dateString: string): Date {
@@ -64,18 +63,18 @@ if (process.env.COMPILER) {
 
     it('.url on new card throws error', async function () {
       let parentCard = await cards.loadModel(`${realmURL}person`, 'isolated');
-      let model = await parentCard.adoptIntoRealm(realmURL);
+      let model = parentCard.adoptIntoRealm(realmURL);
       try {
         model.url;
         throw new Error('did not throw expected error');
       } catch (e: any) {
-        expect(e.message).to.equal(`bug: card in state created does not have a url yet`);
+        expect(e.message).to.equal(`bug: card in state created does not have a url`);
       }
     });
 
     it('.save() created card', async function () {
       let parentCard = await cards.loadModel(`${realmURL}person`, 'isolated');
-      let model = await parentCard.adoptIntoRealm(realmURL);
+      let model = parentCard.adoptIntoRealm(realmURL);
       await model.setData({ name: 'Kirito', address: { settlementDate: p('2022-02-22') } });
       expect(model.data.address.settlementDate instanceof Date).to.be.true;
       expect(isSameDay(model.data.address.settlementDate, p('2022-02-22')), 'Dates are serialized to Dates').to.be.ok;
@@ -131,7 +130,7 @@ if (process.env.COMPILER) {
     it('.save() on adopted card using pre-existing id', async function () {
       let id = 'bob-barker';
       let parentCard = await cards.loadModel(`${realmURL}person`, 'isolated');
-      let model = await parentCard.adoptIntoRealm(realmURL, id);
+      let model = parentCard.adoptIntoRealm(realmURL, id);
       try {
         await model.save();
         throw new Error('did not throw expected error');
@@ -166,9 +165,6 @@ if (process.env.COMPILER) {
       delete result.meta;
 
       let expectedAttributes = cloneDeep(attributes);
-      // TODO: We currently do not store enough info in the database
-      // to know this should be her
-      // set(expectedAttributes, 'address.zip', null);
 
       expect(result).to.deep.equal({
         id: `${realmURL}bob-barker`,
@@ -196,12 +192,11 @@ if (process.env.COMPILER) {
 
     it('.serialize card model in created state', async function () {
       let parent = await cards.loadModel(`${realmURL}person`, 'isolated');
-      let model = await parent.adoptIntoRealm(realmURL);
+      let model = parent.adoptIntoRealm(realmURL);
       await model.setData(attributes);
       let result = model.serialize();
 
       let expectedAttributes = cloneDeep(attributes);
-      set(expectedAttributes, 'address.zip', undefined);
 
       expect(result).to.deep.equal({
         id: undefined,

--- a/packages/hub/node-tests/@core/compiler-test.ts
+++ b/packages/hub/node-tests/@core/compiler-test.ts
@@ -85,6 +85,9 @@ if (process.env.COMPILER) {
       expect(metaModuleSource).to.containsSource(`
         export const usedFields = ["name", "birthdate"];
       `);
+      expect(metaModuleSource).to.containsSource(`
+        export const allFields = ["name", "birthdate"];
+      `);
     });
 
     it('CompiledCard edit view', async function () {

--- a/packages/hub/node-tests/@core/computed-test.ts
+++ b/packages/hub/node-tests/@core/computed-test.ts
@@ -177,8 +177,6 @@ if (process.env.COMPILER) {
       );
     });
 
-    it('computes async computeds with data consistency');
-
     it('can access a field that requires deserialization');
     it('can have a field that is the same card as itself');
   });

--- a/packages/hub/node-tests/@core/computed-test.ts
+++ b/packages/hub/node-tests/@core/computed-test.ts
@@ -87,29 +87,29 @@ if (process.env.COMPILER) {
     });
 
     it(`can access a synchronous computed field`, async function () {
-      let card = await cards.loadData(`${realm}arthur`, 'isolated');
+      let card = await cards.loadModel(`${realm}arthur`, 'isolated');
       expect(await card.getField('fullName')).to.equal('Arthur Faulkner');
     });
 
     it(`can access a two-level-deep synchronous computed field`, async function () {
-      let card = await cards.loadData(`${realm}arthur`, 'isolated');
+      let card = await cards.loadModel(`${realm}arthur`, 'isolated');
       expect(await card.getField('summary')).to.equal('Arthur Faulkner is a person. Their story is: son of Ed');
     });
 
     it('can access a composite field', async function () {
-      let card = await cards.loadData(`${realm}arthur`, 'isolated');
+      let card = await cards.loadModel(`${realm}arthur`, 'isolated');
       let aboutMe = await card.getField('aboutMe');
       expect(aboutMe.short).to.equal('son of Ed');
       expect(aboutMe.favoriteColor).to.equal('blue');
     });
 
     it('can access an asynchronous computed field', async function () {
-      let card = await cards.loadData(`${realm}arthur`, 'isolated');
+      let card = await cards.loadModel(`${realm}arthur`, 'isolated');
       expect(await card.getField('slowSummary')).to.equal('Arthur Faulkner is a person. Their story is: son of Ed');
     });
 
     it('can indirectly access an asynchronous computed field', async function () {
-      let card = await cards.loadData(`${realm}arthur`, 'isolated');
+      let card = await cards.loadModel(`${realm}arthur`, 'isolated');
       expect(await card.getField('loudSummary')).to.equal('Arthur Faulkner is a person. Their story is: son of Ed!');
     });
 
@@ -139,7 +139,7 @@ if (process.env.COMPILER) {
           },
         },
       });
-      let card = await cards.loadData(`${realm}ains`, 'isolated');
+      let card = await cards.loadModel(`${realm}ains`, 'isolated');
       expect(await card.getField('fullName')).to.equal('Ains Ooal Gown');
       expect(await card.getField('seriesName')).to.equal('Overlord');
     });
@@ -170,12 +170,14 @@ if (process.env.COMPILER) {
           },
         },
       });
-      let card = await cards.loadData(`${realm}ains`, 'isolated');
+      let card = await cards.loadModel(`${realm}ains`, 'isolated');
       expect(await card.getField('fullName')).to.equal('Ains Ooal Gown');
       expect(await card.getField('loudSummary')).to.equal(
         'Ains Ooal Gown is a person. Their story is: Supreme overlord of darkness!'
       );
     });
+
+    it('computes async computeds with data consistency');
 
     it('can access a field that requires deserialization');
     it('can have a field that is the same card as itself');

--- a/packages/hub/node-tests/services/card-service-test.ts
+++ b/packages/hub/node-tests/services/card-service-test.ts
@@ -189,7 +189,7 @@ if (process.env.COMPILER) {
 
     describe('.load() & .loadData()', function () {
       it('returns a card thats been indexed', async function () {
-        let card = await cards.loadData(`${realmURL}post1`, 'isolated');
+        let card = await cards.loadModel(`${realmURL}post1`, 'isolated');
         expect(card.data.title).to.eq('Hello again');
         expect(card.url).to.eq(`${realmURL}post1`);
         let { compiled } = await cards.load(`${realmURL}post1`);
@@ -543,7 +543,7 @@ if (process.env.COMPILER) {
           },
         });
 
-        let card = await cards.loadData('https://cardstack.local/sue', 'isolated');
+        let card = await cards.loadModel('https://cardstack.local/sue', 'isolated');
         expect(card.data.author.name).to.equal('Sue');
         expect(card.data.author.id).to.equal('https://cardstack.local/sue');
       });

--- a/packages/hub/node-tests/services/search-index-test.ts
+++ b/packages/hub/node-tests/services/search-index-test.ts
@@ -51,7 +51,7 @@ if (process.env.COMPILER) {
         },
       });
 
-      let example = await cards.loadData(`${realmURL}example`, 'isolated');
+      let example = await cards.loadModel(`${realmURL}example`, 'isolated');
       expect(example.data.title).to.eq('Hello World');
     });
 
@@ -84,7 +84,7 @@ if (process.env.COMPILER) {
         },
       });
 
-      let grandChild = await cards.loadData(`${realmURL}grandchild`, 'isolated');
+      let grandChild = await cards.loadModel(`${realmURL}grandchild`, 'isolated');
       expect(grandChild.data.title).to.eq('Hello World');
     });
 
@@ -278,9 +278,9 @@ if (process.env.COMPILER) {
 
         // This child card gets created via adoptIntoRealm, which goes down the
         // code path that doesn't involve compiling cards
-        let cardModel = await cards.loadData(`${realmURL}greeting-card`, 'isolated');
+        let cardModel = await cards.loadModel(`${realmURL}greeting-card`, 'isolated');
         let sampleGreeting = await cardModel.adoptIntoRealm(realmURL, 'sample-greeting');
-        sampleGreeting.setData({
+        await sampleGreeting.setData({
           name: 'Jackie',
         });
         await sampleGreeting.save();
@@ -311,8 +311,8 @@ if (process.env.COMPILER) {
       });
 
       it('Can search for card computed field for card after updating data', async function () {
-        let cardModel = await cards.loadData(`${realmURL}sample-greeting`, 'isolated');
-        cardModel.setData({
+        let cardModel = await cards.loadModel(`${realmURL}sample-greeting`, 'isolated');
+        await cardModel.setData({
           name: 'Woody',
         });
         await cardModel.save();

--- a/packages/hub/node-tests/services/search-index-test.ts
+++ b/packages/hub/node-tests/services/search-index-test.ts
@@ -279,7 +279,7 @@ if (process.env.COMPILER) {
         // This child card gets created via adoptIntoRealm, which goes down the
         // code path that doesn't involve compiling cards
         let cardModel = await cards.loadModel(`${realmURL}greeting-card`, 'isolated');
-        let sampleGreeting = await cardModel.adoptIntoRealm(realmURL, 'sample-greeting');
+        let sampleGreeting = cardModel.adoptIntoRealm(realmURL, 'sample-greeting');
         await sampleGreeting.setData({
           name: 'Jackie',
         });

--- a/packages/hub/routes/card-routes.ts
+++ b/packages/hub/routes/card-routes.ts
@@ -63,7 +63,7 @@ export default class CardRoutes {
       throw noParentError;
     }
 
-    let card = await parentCard.adoptIntoRealm(realmURL, cardId);
+    let card = parentCard.adoptIntoRealm(realmURL, cardId);
     await card.setData(data.attributes);
     await card.save();
     ctx.body = { data: card.serialize() };

--- a/packages/hub/routes/card-routes.ts
+++ b/packages/hub/routes/card-routes.ts
@@ -27,7 +27,7 @@ export default class CardRoutes {
     } = ctx;
     let allFields = ctx.query.allFields !== undefined;
     let format = getCardFormatFromRequest(ctx.query.format);
-    let card = await (await this.cardService.as(INSECURE_CONTEXT)).loadData(url, format, allFields);
+    let card = await (await this.cardService.as(INSECURE_CONTEXT)).loadModel(url, format, allFields);
     ctx.body = { data: card.serialize() };
     ctx.status = 200;
   }
@@ -53,7 +53,7 @@ export default class CardRoutes {
 
     let parentCard;
     try {
-      parentCard = await (await this.cardService.as(INSECURE_CONTEXT)).loadData(parentCardURL, format);
+      parentCard = await (await this.cardService.as(INSECURE_CONTEXT)).loadModel(parentCardURL, format);
     } catch (e) {
       if (!isCardstackError(e) || e.status !== 404) {
         throw e;
@@ -64,7 +64,7 @@ export default class CardRoutes {
     }
 
     let card = await parentCard.adoptIntoRealm(realmURL, cardId);
-    card.setData(data.attributes);
+    await card.setData(data.attributes);
     await card.save();
     ctx.body = { data: card.serialize() };
     ctx.status = 201;
@@ -79,8 +79,8 @@ export default class CardRoutes {
     } = ctx;
 
     let format = getCardFormatFromRequest(ctx.query.format);
-    let card = await (await this.cardService.as(INSECURE_CONTEXT)).loadData(url, format);
-    card.setData(data.attributes);
+    let card = await (await this.cardService.as(INSECURE_CONTEXT)).loadModel(url, format);
+    await card.setData(data.attributes);
     await card.save();
     ctx.body = { data: card.serialize() };
     ctx.status = 200;
@@ -111,7 +111,7 @@ export default class CardRoutes {
       throw new NotFound(`No card defined for route ${pathname}`);
     }
 
-    let card = await (await this.cardService.as(INSECURE_CONTEXT)).loadData(url, 'isolated');
+    let card = await (await this.cardService.as(INSECURE_CONTEXT)).loadModel(url, 'isolated');
     ctx.body = { data: card.serialize() };
   }
 

--- a/packages/hub/services/search-index.ts
+++ b/packages/hub/services/search-index.ts
@@ -260,14 +260,14 @@ class IndexerRun implements IndexerHandle {
 
     let componentMetaModule = definedCard.componentInfos[format].metaModule.global;
     let componentMeta = await this.fileCache.loadModule(componentMetaModule);
+    let cardService = await this.cardService.as(INSECURE_CONTEXT);
 
     let cardModel = await getOwner(this).instantiate(
       CardModelForHub,
-      await this.cardService.as(INSECURE_CONTEXT),
+      cardService,
       {
         type: 'loaded',
         id: rawCard.id,
-        componentModule: definedCard.componentInfos[format].componentModule.global,
         allFields: false,
       },
       {
@@ -275,7 +275,9 @@ class IndexerRun implements IndexerHandle {
         realm: rawCard.realm,
         rawData: rawCard.data ?? {},
         schemaModule: definedCard.schemaModule.global,
+        componentModuleRef: definedCard.componentInfos[format].componentModule.global,
         componentMeta,
+        saveModel: cardService.saveModel.bind(cardService),
       }
     );
     return await this.writeToIndex(rawCard, definedCard, compiler, cardModel);

--- a/packages/hub/services/search-index.ts
+++ b/packages/hub/services/search-index.ts
@@ -253,7 +253,8 @@ class IndexerRun implements IndexerHandle {
     compiledCard: CompiledCard<Unsaved, ModuleRef>,
     compiler: Compiler<Unsaved>
   ): Promise<CompiledCard> {
-    let definedCard = makeGloballyAddressable(cardURL(rawCard), compiledCard, (local, type, src, ast) =>
+    let url = cardURL(rawCard);
+    let definedCard = makeGloballyAddressable(url, compiledCard, (local, type, src, ast) =>
       this.define(cardURL(rawCard), local, type, src, ast)
     );
     let format: Format = 'isolated';
@@ -262,12 +263,11 @@ class IndexerRun implements IndexerHandle {
     let componentMeta = await this.fileCache.loadModule(componentMetaModule);
     let cardService = await this.cardService.as(INSECURE_CONTEXT);
 
-    let cardModel = await getOwner(this).instantiate(
-      CardModelForHub,
+    let cardModel = new CardModelForHub(
       cardService,
       {
         type: 'loaded',
-        id: rawCard.id,
+        url,
         allFields: false,
       },
       {


### PR DESCRIPTION
This PR takes steps towards unifying the card services on the hub and browser by using a single interface for these, as well as to takes steps towards unifying the card model for the hub and browser. Also, we're moving fields that are not state specific out of the card model state, as well as updating the builder to use CardModels for mutation of the local realm.

both the `getField()` and the `save()` are very close to being the same. I think with a bit more effort we could make them the same. The unifying the setting of the fields I'll tackle in a subsequent PR