### PR TITLE
pay route: render fallback description if no amount is specified

### DIFF
--- a/packages/ssr-web/app/controllers/pay.ts
+++ b/packages/ssr-web/app/controllers/pay.ts
@@ -109,6 +109,20 @@ export default class PayController extends Controller {
     return this.model.merchantInfo;
   }
 
+  get meta() {
+    let title = this.merchantInfo.name
+      ? this.merchantInfo.name + ' requests payment'
+      : 'Payment Requested';
+    let paySubject =
+      this.cleanedAmounts.displayed.amount ||
+      this.merchantInfo.name ||
+      'Payment Request';
+    return {
+      title,
+      description: `Use Card Wallet to pay ${paySubject}`,
+    };
+  }
+
   // This is necessary because iOS respects users' decisions to visit your site
   // and will stay on the site if the link has the same domain
   // see https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html

--- a/packages/ssr-web/app/templates/pay.hbs
+++ b/packages/ssr-web/app/templates/pay.hbs
@@ -1,6 +1,6 @@
 {{#let
   (concat (or this.merchantInfo.name @model.merchantSafe.address) ' requests payment')
-  (concat 'Pay ' this.cleanedAmounts.displayed.amount)
+  (if this.cleanedAmounts.displayed.amount (concat 'Pay ' this.cleanedAmounts.displayed.amount))
   as |title description|
 }}
   {{page-title title replace=true}}
@@ -10,10 +10,15 @@
     <meta property='og:title' content={{title}} />
     <meta property='og:type' content='website' />
     <meta property='og:url' content={{this.paymentURL}} />
-    <meta property='og:description' content={{description}} />
+    {{#if description}}
+      <meta property='og:description' content={{description}} />
+    {{/if}}
+
     <meta name='twitter:title' content={{title}} />
     <meta name='twitter:card' content='summary' />
-    <meta name='twitter:description' content={{description}} />
+    {{#if description}}
+      <meta name='twitter:description' content={{description}} />
+    {{/if}}
     <meta name='twitter:url' content={{this.paymentURL}} />
     {{!-- template-lint-disable no-potential-path-strings --}}
     <meta name='twitter:site' content='@cardstack' />

--- a/packages/ssr-web/app/templates/pay.hbs
+++ b/packages/ssr-web/app/templates/pay.hbs
@@ -1,30 +1,19 @@
-{{#let
-  (or this.merchantInfo.name @model.merchantSafe.address)
-  as |business|
-}}
-  {{#let
-    (concat business ' requests payment')
-    (concat 'Use Card Wallet to pay ' (or this.cleanedAmounts.displayed.amount business))
-    as |title description|
-  }}
-    {{page-title title replace=true}}
+{{page-title this.meta.title replace=true}}
 
-    <InHead>
-      {{!-- template-lint-disable no-forbidden-elements --}}
-      <meta property='og:title' content={{title}} />
-      <meta property='og:type' content='website' />
-      <meta property='og:url' content={{this.paymentURL}} />
-      <meta property='og:description' content={{description}} />
+<InHead>
+  {{!-- template-lint-disable no-forbidden-elements --}}
+  <meta property='og:title' content={{this.meta.title}} />
+  <meta property='og:type' content='website' />
+  <meta property='og:url' content={{this.paymentURL}} />
+  <meta property='og:description' content={{this.meta.description}} />
 
-      <meta name='twitter:title' content={{title}} />
-      <meta name='twitter:card' content='summary' />
-      <meta name='twitter:description' content={{description}} />
-      <meta name='twitter:url' content={{this.paymentURL}} />
-      {{!-- template-lint-disable no-potential-path-strings --}}
-      <meta name='twitter:site' content='@cardstack' />
-    </InHead>
-  {{/let}}
-{{/let}}
+  <meta name='twitter:title' content={{this.meta.title}} />
+  <meta name='twitter:card' content='summary' />
+  <meta name='twitter:description' content={{this.meta.description}} />
+  <meta name='twitter:url' content={{this.paymentURL}} />
+  {{!-- template-lint-disable no-potential-path-strings --}}
+  <meta name='twitter:site' content='@cardstack' />
+</InHead>
 
 <div class="merchant-payment-request-page">
   <CardPay::MerchantPaymentRequestHeader/>

--- a/packages/ssr-web/app/templates/pay.hbs
+++ b/packages/ssr-web/app/templates/pay.hbs
@@ -1,28 +1,29 @@
 {{#let
-  (concat (or this.merchantInfo.name @model.merchantSafe.address) ' requests payment')
-  (if this.cleanedAmounts.displayed.amount (concat 'Pay ' this.cleanedAmounts.displayed.amount))
-  as |title description|
+  (or this.merchantInfo.name @model.merchantSafe.address)
+  as |business|
 }}
-  {{page-title title replace=true}}
+  {{#let
+    (concat business ' requests payment')
+    (concat 'Use Card Wallet to pay ' (or this.cleanedAmounts.displayed.amount business))
+    as |title description|
+  }}
+    {{page-title title replace=true}}
 
-  <InHead>
-    {{!-- template-lint-disable no-forbidden-elements --}}
-    <meta property='og:title' content={{title}} />
-    <meta property='og:type' content='website' />
-    <meta property='og:url' content={{this.paymentURL}} />
-    {{#if description}}
+    <InHead>
+      {{!-- template-lint-disable no-forbidden-elements --}}
+      <meta property='og:title' content={{title}} />
+      <meta property='og:type' content='website' />
+      <meta property='og:url' content={{this.paymentURL}} />
       <meta property='og:description' content={{description}} />
-    {{/if}}
 
-    <meta name='twitter:title' content={{title}} />
-    <meta name='twitter:card' content='summary' />
-    {{#if description}}
+      <meta name='twitter:title' content={{title}} />
+      <meta name='twitter:card' content='summary' />
       <meta name='twitter:description' content={{description}} />
-    {{/if}}
-    <meta name='twitter:url' content={{this.paymentURL}} />
-    {{!-- template-lint-disable no-potential-path-strings --}}
-    <meta name='twitter:site' content='@cardstack' />
-  </InHead>
+      <meta name='twitter:url' content={{this.paymentURL}} />
+      {{!-- template-lint-disable no-potential-path-strings --}}
+      <meta name='twitter:site' content='@cardstack' />
+    </InHead>
+  {{/let}}
 {{/let}}
 
 <div class="merchant-payment-request-page">

--- a/packages/ssr-web/tests/acceptance/pay-test.ts
+++ b/packages/ssr-web/tests/acceptance/pay-test.ts
@@ -657,6 +657,37 @@ module('Acceptance | pay', function (hooks) {
     assert.dom(PAYMENT_URL).containsText(expectedUrl);
   });
 
+  test('it renders appropriate meta tags when merchant info is not fetched', async function (assert) {
+    await visit(`/pay/${network}/${merchantSafeWithoutInfo.address}`);
+
+    let title = 'Payment Requested';
+    let description = `Use Card Wallet to pay Payment Request`;
+    assert
+      .dom(
+        `meta[property='og:title'][content="${title}"]`,
+        document.documentElement
+      )
+      .exists();
+    assert
+      .dom(
+        `meta[name='twitter:title'][content="${title}"]`,
+        document.documentElement
+      )
+      .exists();
+    assert
+      .dom(
+        `meta[property='og:description'][content="${description}"]`,
+        document.documentElement
+      )
+      .exists();
+    assert
+      .dom(
+        `meta[name='twitter:description'][content="${description}"]`,
+        document.documentElement
+      )
+      .exists();
+  });
+
   test('it renders appropriate UI when merchant safe is not fetched', async function (assert) {
     await visit(
       `/pay/${network}/${nonexistentMerchantId}?amount=${spendAmount}&currency=${spendSymbol}`

--- a/packages/ssr-web/tests/acceptance/pay-test.ts
+++ b/packages/ssr-web/tests/acceptance/pay-test.ts
@@ -234,7 +234,7 @@ module('Acceptance | pay', function (hooks) {
       spendToUsd(roundedSpendAmount)!,
       'USD'
     );
-    let description = `Pay ${amountInUSD}`;
+    let description = `Use Card Wallet to pay ${amountInUSD}`;
 
     assert
       .dom(
@@ -251,16 +251,23 @@ module('Acceptance | pay', function (hooks) {
       .exists();
   });
 
-  test('it does not render the description if there is no amount param specified', async function (assert) {
+  test('it has a fallback meta description if there is no amount param specified', async function (assert) {
     await visit(`/pay/${network}/${merchantSafe.address}`);
     await waitFor(MERCHANT);
 
+    let description = `Use Card Wallet to pay ${merchantName}`;
     assert
-      .dom(`meta[property='og:description']`, document.documentElement)
-      .doesNotExist();
+      .dom(
+        `meta[property='og:description'][content="${description}"]`,
+        document.documentElement
+      )
+      .exists();
     assert
-      .dom(`meta[name='twitter:description']`, document.documentElement)
-      .doesNotExist();
+      .dom(
+        `meta[name='twitter:description'][content="${description}"]`,
+        document.documentElement
+      )
+      .exists();
   });
 
   test('it rounds floating point SPEND amounts', async function (assert) {

--- a/packages/ssr-web/tests/acceptance/pay-test.ts
+++ b/packages/ssr-web/tests/acceptance/pay-test.ts
@@ -251,6 +251,18 @@ module('Acceptance | pay', function (hooks) {
       .exists();
   });
 
+  test('it does not render the description if there is no amount param specified', async function (assert) {
+    await visit(`/pay/${network}/${merchantSafe.address}`);
+    await waitFor(MERCHANT);
+
+    assert
+      .dom(`meta[property='og:description']`, document.documentElement)
+      .doesNotExist();
+    assert
+      .dom(`meta[name='twitter:description']`, document.documentElement)
+      .doesNotExist();
+  });
+
   test('it rounds floating point SPEND amounts', async function (assert) {
     const floatingSpendAmount = 279.17;
     const roundedSpendAmount = Math.ceil(floatingSpendAmount);


### PR DESCRIPTION
# With amount
<img width="451" alt="Preview shown on twitter for a link shared by 'Kiel's NFT Market' to request payment, with an amount" src="https://user-images.githubusercontent.com/39579264/156723248-25a69202-6946-4181-a6ee-2ce73305c64a.png">

# Without amount
<img width="445" alt="Preview shown on twitter for a link shared by 'Kiel's NFT Market' to request payment, with no amount." src="https://user-images.githubusercontent.com/39579264/156723316-4eedc397-bb54-4d61-bbc5-ea59ec398c69.png">

# Without amount, missing merchant customization
<img width="449" alt="Preview shown on twitter for a link shared by an unknown business to request payment, with no amount." src="https://user-images.githubusercontent.com/39579264/156723663-c2e7464b-742a-41be-a62b-4dfffebac1bc.png">
