### PR TITLE
Disable MetaMask when there is no extension

### DIFF
--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
@@ -48,9 +48,7 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
        , otherwise focus leaves the page
      - selecting a radio makes the connect button enabled and focusable.
    */
-  // pick the first enabled option
-  @tracked radioWalletProviderId: WalletProvider['id'] =
-    this.walletProviders[0].id;
+  @tracked radioWalletProviderId: WalletProvider['id'] = 'wallet-connect';
 
   constructor(
     owner: unknown,

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
@@ -23,7 +23,20 @@ interface CardPayDepositWorkflowConnectLayer1ComponentArgs
 class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepositWorkflowConnectLayer1ComponentArgs> {
   cardstackLogo = cardstackLogo;
   connectionSymbol = connectionSymbol;
-  walletProviders = walletProviders;
+  walletProviders = walletProviders
+    .map((w) =>
+      w.id === 'metamask'
+        ? {
+            ...w,
+            enabled: !!window.ethereum?.isMetaMask,
+            explanation: window.ethereum?.isMetaMask
+              ? ''
+              : 'MetaMask extension not detected',
+          }
+        : { ...w, enabled: true, explanation: '' }
+    )
+    // sort stuff so that the enabled options always appear first
+    .sort((a, b) => Number(b.enabled) - Number(a.enabled));
 
   @service declare layer1Network: Layer1Network;
   @reads('layer1Network.isConnected') declare isConnected: boolean;
@@ -35,7 +48,9 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
        , otherwise focus leaves the page
      - selecting a radio makes the connect button enabled and focusable.
    */
-  @tracked radioWalletProviderId = 'metamask';
+  // pick the first enabled option
+  @tracked radioWalletProviderId: WalletProvider['id'] =
+    this.walletProviders[0].id;
 
   constructor(
     owner: unknown,
@@ -101,7 +116,7 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
     ].filter((o) => !o.amount?.isZero());
   }
 
-  @action changeWalletProvider(id: string): void {
+  @action changeWalletProvider(id: WalletProvider['id']): void {
     this.radioWalletProviderId = id;
   }
 

--- a/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
+++ b/packages/web-client/app/components/card-pay/layer-one-connect-card/index.ts
@@ -35,8 +35,7 @@ class CardPayDepositWorkflowConnectLayer1Component extends Component<CardPayDepo
           }
         : { ...w, enabled: true, explanation: '' }
     )
-    // sort stuff so that the enabled options always appear first
-    .sort((a, b) => Number(b.enabled) - Number(a.enabled));
+    .sortBy('enabled:desc');
 
   @service declare layer1Network: Layer1Network;
   @reads('layer1Network.isConnected') declare isConnected: boolean;

--- a/packages/web-client/app/components/card-pay/layer-one-wallet-provider-selection/index.css
+++ b/packages/web-client/app/components/card-pay/layer-one-wallet-provider-selection/index.css
@@ -1,12 +1,7 @@
-.card-pay-layer-one-wallet-provider-selection-body {
-  padding: 0 var(--horizontal-padding);
-}
-
-.card-pay-layer-one-wallet-provider-selection-body-header {
-  padding: var(--boxel-sp-xl) 0;
-  max-height: 6rem;
-  font-size: 1.125rem;
-  font-weight: 600;
+.card-pay-layer-one-wallet-provider-selection__group .boxel-radio-option--disabled {
+  background: var(--boxel-purple-100);
+  filter:grayscale(0.8);
+  cursor: not-allowed;
 }
 
 .card-pay-layer-one-wallet-provider-selection__item {

--- a/packages/web-client/app/components/card-pay/layer-one-wallet-provider-selection/index.hbs
+++ b/packages/web-client/app/components/card-pay/layer-one-wallet-provider-selection/index.hbs
@@ -4,6 +4,7 @@
   @disabled={{@isConnecting}}
   @checkedId={{@currentWalletProviderId}}
   @hideRadio={{true}}
+  class="card-pay-layer-one-wallet-provider-selection__group"
   ...attributes
   data-test-wallet-selection
   as |option|
@@ -12,12 +13,15 @@
     <option.component
       @name="wallet-provider-selection"
       @onChange={{fn (optional @changeWalletProvider) item.id}}
+      @disabled={{not item.enabled}}
       data-test-wallet-option={{item.id}}
     >
       <div class="card-pay-layer-one-wallet-provider-selection__item">
         <img src={{item.logo}} alt="" role="presentation" class="card-pay-layer-one-wallet-provider-selection__item-image">
         <span class="card-pay-layer-one-wallet-provider-selection__item-name">{{item.name}}</span>
-        <span class="card-pay-layer-one-wallet-provider-selection__item-description" aria-hidden="true">{{item.description}}</span>
+        {{#if item.explanation}}
+          <span class="card-pay-layer-one-wallet-provider-selection__item-description">{{item.explanation}}</span>
+        {{/if}}
       </div>
     </option.component>
   {{/let}}

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/token-claim/index.ts
@@ -13,13 +13,10 @@ import {
 import { WorkflowCardComponentArgs } from '@cardstack/web-client/models/workflow';
 import { BridgeValidationResult } from '@cardstack/cardpay-sdk';
 import { taskFor } from 'ember-concurrency-ts';
-import walletProviders, {
-  WalletProvider,
-} from '@cardstack/web-client/utils/wallet-providers';
+import { WalletProvider } from '@cardstack/web-client/utils/wallet-providers';
 import { TransactionHash } from '@cardstack/web-client/utils/web3-strategies/types';
 
 class CardPayWithdrawalWorkflowTokenClaimComponent extends Component<WorkflowCardComponentArgs> {
-  walletProviders = walletProviders;
   @service declare layer1Network: Layer1Network;
   @reads('layer1Network.walletProvider') declare walletProvider: WalletProvider;
 

--- a/packages/web-client/app/utils/wallet-providers.ts
+++ b/packages/web-client/app/utils/wallet-providers.ts
@@ -11,16 +11,16 @@ export interface WalletProvider {
 
 const walletProviders: WalletProvider[] = [
   {
-    id: 'metamask',
-    name: 'MetaMask',
-    logo: metamaskLogo,
-    iconName: 'metamask-logo',
-  },
-  {
     id: 'wallet-connect',
     name: 'WalletConnect',
     logo: walletConnectLogo,
     iconName: 'wallet-connect-logo',
+  },
+  {
+    id: 'metamask',
+    name: 'MetaMask',
+    logo: metamaskLogo,
+    iconName: 'metamask-logo',
   },
 ];
 

--- a/packages/web-client/tests/integration/components/layer-one-connect-card-test.ts
+++ b/packages/web-client/tests/integration/components/layer-one-connect-card-test.ts
@@ -16,6 +16,10 @@ const WALLET_SELECTION_SELECTOR = '[data-test-wallet-selection]';
 module('Integration | Component | layer-one-connect-card', function (hooks) {
   setupRenderingTest(hooks);
 
+  hooks.afterEach(function () {
+    window.ethereum = undefined;
+  });
+
   test('It should show a selection UI if layer 1 is not connected', async function (assert) {
     await render(hbs`
         <CardPay::LayerOneConnectCard/>
@@ -25,7 +29,32 @@ module('Integration | Component | layer-one-connect-card', function (hooks) {
       .dom(HEADER_SELECTOR)
       .containsText(`Connect your ${c.layer1.fullName} wallet`);
 
+    assert
+      .dom('[data-test-wallet-option="wallet-connect"] > input[type="radio"]')
+      .isEnabled();
+    assert.notOk(window.ethereum);
+    // MetaMask is disabled because window.ethereum is not available
+    assert
+      .dom('[data-test-wallet-option="metamask"] > input[type="radio"]')
+      .isDisabled();
+    assert
+      .dom('[data-test-wallet-option="metamask"]')
+      .containsText('MetaMask extension not detected');
+
     assert.dom(WALLET_SELECTION_SELECTOR).isVisible();
+  });
+
+  test('It should enable MetaMask if window.ethereum.isMetaMask is true', async function (assert) {
+    window.ethereum = {};
+    window.ethereum.isMetaMask = true;
+    await render(hbs`
+    <CardPay::LayerOneConnectCard/>
+  `);
+
+    assert.ok(window.ethereum?.isMetaMask);
+    assert
+      .dom('[data-test-wallet-option="metamask"] > input[type="radio"]')
+      .isEnabled();
   });
 
   test('It should show card summary if card is completed and user disconnects the wallet', async function (assert) {
@@ -106,10 +135,11 @@ module('Integration | Component | layer-one-connect-card', function (hooks) {
     await render(hbs`
         <CardPay::LayerOneConnectCard/>
       `);
-    await click('[data-test-wallet-option="metamask"]');
+
+    await click('[data-test-wallet-option="wallet-connect"]');
     await click(CONNECT_BUTTON_SELECTOR);
 
-    // the card should not be assuming it is connected to metamask before connection is completed
+    // the card should not be assuming it is connected to wallet-connect before connection is completed
     assert
       .dom('[data-test-boxel-action-chin-action-status-area]')
       .containsText('Waiting for you to connect');
@@ -117,11 +147,11 @@ module('Integration | Component | layer-one-connect-card', function (hooks) {
       .dom(HEADER_SELECTOR)
       .containsText(`Connect your ${c.layer1.fullName} wallet`);
 
-    layer1Service.test__simulateAccountsChanged(['address'], 'metamask');
+    layer1Service.test__simulateAccountsChanged(['address'], 'wallet-connect');
     // waiting for the downstream effects of resolving a promise in test__simulateAccountsChanged
     await settled();
 
-    assert.dom(HEADER_SELECTOR).containsText('MetaMask');
+    assert.dom(HEADER_SELECTOR).containsText('WalletConnect');
     assert.dom(CONNECT_BUTTON_SELECTOR).doesNotExist();
     assert.dom(DISCONNECT_BUTTON_SELECTOR).isVisible();
 

--- a/packages/web-client/tests/integration/components/layer-one-connect-card-test.ts
+++ b/packages/web-client/tests/integration/components/layer-one-connect-card-test.ts
@@ -16,7 +16,11 @@ const WALLET_SELECTION_SELECTOR = '[data-test-wallet-selection]';
 module('Integration | Component | layer-one-connect-card', function (hooks) {
   setupRenderingTest(hooks);
 
-  hooks.afterEach(function () {
+  hooks.beforeEach(function () {
+    window.ethereum = undefined;
+  });
+
+  hooks.after(function () {
     window.ethereum = undefined;
   });
 


### PR DESCRIPTION
Browsers that don't have an extension, + people who don't have the extension should not be able to select this option because nothing will happen. Not hiding the option, because it seems better to inform people that they have this choice if they do install the extension.

# If browser has MetaMask extension
<img width="725" alt="Layer one connection wallet selection showing both MetaMask and WalletConnect enabled. MetaMask is selected as the method of connection." src="https://user-images.githubusercontent.com/39579264/156568378-8e6e39ef-b7c0-4005-8f79-186cf6856f2b.png">

# If browser does not have MetaMask extension
<img width="719" alt="Layer one connection wallet selection showing WalletConnect enabled, and MetaMask disabled. MetaMask is placed 2nd since it is disabled. WalletConnect is selected as the method of connection." src="https://user-images.githubusercontent.com/39579264/156568457-105a3546-fa27-4371-af45-7a009fd747a2.png">
