### PR TITLE
ssr: Update for Card Space domains

### DIFF
--- a/packages/ssr-web/README.md
+++ b/packages/ssr-web/README.md
@@ -35,13 +35,13 @@ This app is actually two apps in one:
 1. Wallet (Universal Link): An app that hosts a page for folks to request payments from others (wallet.cardstack.com), and acts as a fallback for the universal link.
 2. Card Space: An app to view profiles of businesses.
 
-The fastboot server differentiates which app is being served via host. We follow this behaviour in local development, matching the `.card.space.localhost:4210` suffix to recognize a request's intention to visit card space. When developing locally, you can view a user's Card Space at `${businessId}.card.space.localhost:4210`.  Requests that do not match this pattern will be treated as intending to visit the wallet domain.
+The fastboot server differentiates which app is being served via host. We follow this behaviour in local development, matching the `.card.xyz.localhost:4210` suffix to recognize a request's intention to visit card space. When developing locally, you can view a user's Card Space at `${businessId}.card.xyz.localhost:4210`.  Requests that do not match this pattern will be treated as intending to visit the wallet domain.
 
 **IMPORTANT: This does not work on Safari, only Firefox and Chrome. Instructions for Safari setup below.**
 
 If you want to develop Card Space on Safari with the behaviour described above, you should:
-1. Add `card.space.localhost` to your `/etc/hosts` as an alias of `127.0.0.1`
-2. Install `dnsmasq` with Homebrew. Wildcard DNS support does not come by default, so the entry in step 1 will only match `card.space.localhost`, not `${spaceId}.card.space.localhost`. `dnsmasq` fixes this.
+1. Add `card.xyz.localhost` to your `/etc/hosts` as an alias of `127.0.0.1`
+2. Install `dnsmasq` with Homebrew. Wildcard DNS support does not come by default, so the entry in step 1 will only match `card.xyz.localhost`, not `${spaceId}.card.xyz.localhost`. `dnsmasq` fixes this.
 3. Make a directory for `dnsmasq` config to live: `sudo mkdir -p $(brew --prefix)/etc/dnsmasq.d`
 4. Make sure that the `dnsmasq` config points to your new directory:
 ```
@@ -50,32 +50,32 @@ brew --prefix # assume returns /opt/homebrew/
 # Use it to point dnsmasq to your config
 sudo echo 'conf-dir=/opt/homebrew/etc/dnsmasq.d,*.conf' >> $(brew --prefix)/etc/dnsmasq.conf
 ```
-5. Configure `card.space.localhost` for `dnsmasq`: 
+5. Configure `card.xyz.localhost` for `dnsmasq`: 
 ```
-sudo echo 'address=/.card.space.localhost/127.0.0.1' > $(brew --
-prefix)/etc/dnsmasq.d/card.space.localhost.conf
+sudo echo 'address=/.card.xyz.localhost/127.0.0.1' > $(brew --
+prefix)/etc/dnsmasq.d/card.xyz.localhost.conf
 ```
-6. Add a resolver for `card.space.localhost`:
+6. Add a resolver for `card.xyz.localhost`:
 ```
 sudo mkdir -p /etc/resolver
-sudo touch /etc/resolver/card.space.localhost
-sudo bash -c 'echo "nameserver 127.0.0.1" > /etc/resolver/card.space.localhost'
+sudo touch /etc/resolver/card.xyz.localhost
+sudo bash -c 'echo "nameserver 127.0.0.1" > /etc/resolver/card.xyz.localhost'
 ```
 7. You may need to restart `dnsmasq` to make sure it gets the new changes:
 ```
 sudo launchctl stop homebrew.mxcl.dnsmasq
 sudo launchctl start homebrew.mxcl.dnsmasq
 ```
-8. Confirm via `scutil --dns` that there is a resolver for `card.space.localhost`. It should look similar to:
+8. Confirm via `scutil --dns` that there is a resolver for `card.xyz.localhost`. It should look similar to:
 ```
 resolver #8
-  domain   : card.space.localhost
+  domain   : card.xyz.localhost
   nameserver[0] : 127.0.0.1
   flags    : Request A records, Request AAAA records
   reach    : 0x00030002 (Reachable,Local Address,Directly Reachable Address)
 ```
 
-You may need to specifically type the full url in Safari: `http://someone.card.space.localhost:4210`.
+You may need to specifically type the full url in Safari: `http://someone.card.xyz.localhost:4210`.
 
 ### Running Tests
 

--- a/packages/ssr-web/app/routes/index.ts
+++ b/packages/ssr-web/app/routes/index.ts
@@ -68,6 +68,14 @@ export default class IndexRoute extends Route {
         Sentry.captureException(e);
         throw e;
       }
+    } else {
+      return {
+        did: '',
+        id: '',
+        name: '',
+        backgroundColor: '',
+        textColor: '',
+      };
     }
     // FIXME this is perhaps interfering with health checks
     // else {

--- a/packages/ssr-web/app/routes/index.ts
+++ b/packages/ssr-web/app/routes/index.ts
@@ -68,11 +68,13 @@ export default class IndexRoute extends Route {
         Sentry.captureException(e);
         throw e;
       }
-    } else {
-      if (this.fastboot.isFastBoot) {
-        this.fastboot.response.statusCode = 404;
-      }
-      throw new Error("Oops! We couldn't find the page you were looking for");
     }
+    // FIXME this is perhaps interfering with health checks
+    // else {
+    //   if (this.fastboot.isFastBoot) {
+    //     this.fastboot.response.statusCode = 404;
+    //   }
+    //   throw new Error("Oops! We couldn't find the page you were looking for");
+    // }
   }
 }

--- a/packages/ssr-web/app/routes/index.ts
+++ b/packages/ssr-web/app/routes/index.ts
@@ -69,20 +69,10 @@ export default class IndexRoute extends Route {
         throw e;
       }
     } else {
-      return {
-        did: '',
-        id: '',
-        name: '',
-        backgroundColor: '',
-        textColor: '',
-      };
+      if (this.fastboot.isFastBoot) {
+        this.fastboot.response.statusCode = 404;
+      }
+      throw new Error("Oops! We couldn't find the page you were looking for");
     }
-    // FIXME this is perhaps interfering with health checks
-    // else {
-    //   if (this.fastboot.isFastBoot) {
-    //     this.fastboot.response.statusCode = 404;
-    //   }
-    //   throw new Error("Oops! We couldn't find the page you were looking for");
-    // }
   }
 }

--- a/packages/ssr-web/config/environment.js
+++ b/packages/ssr-web/config/environment.js
@@ -23,6 +23,7 @@ const hostWhitelistByTarget = {
   staging: [
     MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,
     /.+\.pouty\.pizza$/,
+    /^10.91.\d+.\d+:4000$/, // FIXME if this is needed, it’s in infra 🤔
   ],
   production: [MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME, /.+\.card\.xyz$/],
 };

--- a/packages/ssr-web/config/environment.js
+++ b/packages/ssr-web/config/environment.js
@@ -22,7 +22,7 @@ const cardSpaceHostnameSuffixByTarget = {
 const hostWhitelistByTarget = {
   staging: [
     MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,
-    /.+\.pouty\.pizza$/,
+    '/.+\\.pouty\\.pizza$/',
   ],
   production: [MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME, /.+\.card\.xyz$/],
 };

--- a/packages/ssr-web/config/environment.js
+++ b/packages/ssr-web/config/environment.js
@@ -11,7 +11,7 @@ const universalLinkHostnamesByTarget = {
   production: MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME,
 };
 
-const CARD_SPACE_LOCAL_DEV_HOSTNAME_SUFFIX = '.card.space.localhost';
+const CARD_SPACE_LOCAL_DEV_HOSTNAME_SUFFIX = '.card.xyz.localhost';
 const CARD_SPACE_STAGING_HOSTNAME_SUFFIX = '.pouty.pizza';
 const CARD_SPACE_HOSTNAME_SUFFIX = '.card.xyz';
 
@@ -92,7 +92,7 @@ module.exports = function (environment) {
     },
     fastboot: {
       hostWhitelist: hostWhitelistByTarget[process.env.SSR_WEB_ENVIRONMENT] ?? [
-        '/.+.card.space.localhost:\\d+$/',
+        '/.+.card.xyz.localhost:\\d+$/',
         '/^localhost:\\d+$/',
       ],
     },

--- a/packages/ssr-web/config/environment.js
+++ b/packages/ssr-web/config/environment.js
@@ -24,7 +24,7 @@ const hostWhitelistByTarget = {
     MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,
     '/.+\\.pouty\\.pizza$/',
   ],
-  production: [MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME, /.+\.card\.xyz$/],
+  production: [MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME, '/.+\\.card\\.xyz$/'],
 };
 
 const pkg = require('../package.json');
@@ -92,9 +92,8 @@ module.exports = function (environment) {
     },
     fastboot: {
       hostWhitelist: hostWhitelistByTarget[process.env.SSR_WEB_ENVIRONMENT] ?? [
-        // FIXME if these were strings before, did they work?
-        /.+.card.xyz.localhost:\\d+$/,
-        /^localhost:\\d+$/,
+        '/.+.card.space.localhost:\\d+$/',
+        '/^localhost:\\d+$/',
       ],
     },
     cardSpaceHostnameSuffix:

--- a/packages/ssr-web/config/environment.js
+++ b/packages/ssr-web/config/environment.js
@@ -23,7 +23,6 @@ const hostWhitelistByTarget = {
   staging: [
     MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,
     /.+\.pouty\.pizza$/,
-    /^10.91.\d+.\d+:4000$/, // FIXME if this is needed, it’s in infra 🤔
   ],
   production: [MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME, /.+\.card\.xyz$/],
 };

--- a/packages/ssr-web/config/environment.js
+++ b/packages/ssr-web/config/environment.js
@@ -22,9 +22,9 @@ const cardSpaceHostnameSuffixByTarget = {
 const hostWhitelistByTarget = {
   staging: [
     MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,
-    '/.+\\.pouty\\.pizza$/',
+    /.+\.pouty\.pizza$/,
   ],
-  production: [MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME, '/.+\\.card\\.xyz$/'],
+  production: [MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME, /.+\.card\.xyz$/],
 };
 
 const pkg = require('../package.json');
@@ -92,8 +92,9 @@ module.exports = function (environment) {
     },
     fastboot: {
       hostWhitelist: hostWhitelistByTarget[process.env.SSR_WEB_ENVIRONMENT] ?? [
-        '/.+.card.xyz.localhost:\\d+$/',
-        '/^localhost:\\d+$/',
+        // FIXME if these were strings before, did they work?
+        /.+.card.xyz.localhost:\\d+$/,
+        /^localhost:\\d+$/,
       ],
     },
     cardSpaceHostnameSuffix:

--- a/packages/ssr-web/config/environment.js
+++ b/packages/ssr-web/config/environment.js
@@ -19,12 +19,20 @@ const cardSpaceHostnameSuffixByTarget = {
   staging: CARD_SPACE_STAGING_HOSTNAME_SUFFIX,
   production: CARD_SPACE_HOSTNAME_SUFFIX,
 };
+
+function convertHostnameSuffixToRegex(suffix) {
+  return `/^.+\\${suffix}$/`;
+}
+
 const hostWhitelistByTarget = {
   staging: [
     MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,
-    '/.+\\.pouty\\.pizza$/',
+    convertHostnameSuffixToRegex(CARD_SPACE_STAGING_HOSTNAME_SUFFIX),
   ],
-  production: [MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME, '/.+\\.card\\.xyz$/'],
+  production: [
+    MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME,
+    convertHostnameSuffixToRegex(CARD_SPACE_HOSTNAME_SUFFIX),
+  ],
 };
 
 const pkg = require('../package.json');

--- a/packages/ssr-web/config/environment.js
+++ b/packages/ssr-web/config/environment.js
@@ -21,7 +21,8 @@ const cardSpaceHostnameSuffixByTarget = {
 };
 
 function convertHostnameSuffixToRegex(suffix) {
-  return `/^.+\\${suffix}$/`;
+  // .pouty.pizza → /^.+\.pouty\.pizza$/
+  return `/^.+${suffix.replace(/\./g, '\\.')}$/`;
 }
 
 const hostWhitelistByTarget = {

--- a/packages/web-client/app/templates/card-space/profile-card-temp.hbs
+++ b/packages/web-client/app/templates/card-space/profile-card-temp.hbs
@@ -9,7 +9,7 @@
   Preview card:
   <CardSpace::ProfileCard
     @name='Amazing Emily'
-    @host='emily.card.space'
+    @host='emily.card.xyz'
     @category='Health'
     @description='Welcome to a healthy & happy life!'
     @buttonText='Visit this Creator'

--- a/packages/web-client/config/environment.js
+++ b/packages/web-client/config/environment.js
@@ -16,8 +16,8 @@ const universalLinkHostnamesByTarget = {
   production: MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME,
 };
 
-const CARD_SPACE_HOSTNAME_LOCAL_DEV_SUFFIX = 'card.space.test';
-const CARD_SPACE_HOSTNAME_SUFFIX = 'card.space';
+const CARD_SPACE_HOSTNAME_LOCAL_DEV_SUFFIX = 'card.xyz.test';
+const CARD_SPACE_HOSTNAME_SUFFIX = 'card.xyz';
 const CARD_SPACE_HOSTNAME_STAGING_SUFFIX = 'pouty.pizza';
 const CARD_SPACE_HOSTNAME_TEST_SUFFIX = 'space.example.com';
 

--- a/packages/web-client/tests/acceptance/create-card-space-test.ts
+++ b/packages/web-client/tests/acceptance/create-card-space-test.ts
@@ -72,7 +72,7 @@ module('Acceptance | create card space', function (hooks) {
         .containsText('Name');
       assert
         .dom('[data-test-sidebar-preview-body] [data-test-profile-card-host]')
-        .containsText('blank.card.space.test');
+        .containsText('blank.card.xyz.test');
       assert
         .dom(
           '[data-test-sidebar-preview-body] [data-test-profile-card-category]'
@@ -158,7 +158,7 @@ module('Acceptance | create card space', function (hooks) {
         .exists();
       assert
         .dom('[data-test-profile-card-host]')
-        .hasText('vandelay.card.space.test');
+        .hasText('vandelay.card.xyz.test');
 
       // Display name
       await waitFor(postableSel(2, 1));

--- a/packages/web-client/tests/integration/components/card-space/profile-card-test.ts
+++ b/packages/web-client/tests/integration/components/card-space/profile-card-test.ts
@@ -18,7 +18,7 @@ module('Integration | Component | card-space/profile-card', function (hooks) {
     assert.dom('[data-test-profile-card-name]').containsText('Name');
     assert
       .dom('[data-test-profile-card-host]')
-      .containsText('blank.card.space.test');
+      .containsText('blank.card.xyz.test');
     assert.dom('[data-test-profile-card-category]').containsText('Category');
     assert
       .dom('[data-test-profile-card-description]')
@@ -38,7 +38,7 @@ module('Integration | Component | card-space/profile-card', function (hooks) {
     await render(hbs`
       <CardSpace::ProfileCard
         @name='Amazing Emily'
-        @host='emily.card.space'
+        @host='emily.card.xyz'
         @category='Health'
         @description='Welcome to a healthy & happy life!'
         @buttonText='Visit this Creator'
@@ -63,9 +63,7 @@ module('Integration | Component | card-space/profile-card', function (hooks) {
       .hasAttribute('src', '/images/logos/metamask-logo.svg');
 
     assert.dom('[data-test-profile-card-name]').containsText('Amazing Emily');
-    assert
-      .dom('[data-test-profile-card-host]')
-      .containsText('emily.card.space');
+    assert.dom('[data-test-profile-card-host]').containsText('emily.card.xyz');
     assert.dom('[data-test-profile-card-category]').containsText('Health');
     assert
       .dom('[data-test-profile-card-description]')

--- a/waypoint.hcl
+++ b/waypoint.hcl
@@ -261,7 +261,7 @@ app "ssr-web" {
             task_role_name = "ssr-web-staging-ecr-task"
 
             alb {
-                listener_arn = "arn:aws:elasticloadbalancing:us-east-1:680542703984:listener/app/ssr-web-staging/c0a4414517c7acb4/496043d250eb05f7"
+                listener_arn = "arn:aws:elasticloadbalancing:us-east-1:680542703984:listener/app/ssr-web-staging/c0a4414517c7acb4/1b6996d108e2cbca"
             }
         }
 


### PR DESCRIPTION
This updates the host list to serve `*.card.xyz` and changes `card.space` in favour of that new suffix. It includes a Waypoint tweak from Terraform changes.