### PR TITLE
Unifying card model data set

### DIFF
--- a/packages/cardhost/app/lib/builder.ts
+++ b/packages/cardhost/app/lib/builder.ts
@@ -111,7 +111,7 @@ export default class LocalRealm implements Builder {
         saveModel: this.saveModel,
       }
     );
-    await model.computeData();
+    await model.recompute();
     return model;
   }
 

--- a/packages/cardhost/app/lib/card-model-for-browser.ts
+++ b/packages/cardhost/app/lib/card-model-for-browser.ts
@@ -23,6 +23,7 @@ export default class CardModelForBrowser
   extends BaseCardModel
   implements CardModel
 {
+  private _componentModule: CardComponentModule | undefined;
   private wrapperComponent: unknown | undefined;
 
   constructor(

--- a/packages/cardhost/app/lib/card-model-for-browser.ts
+++ b/packages/cardhost/app/lib/card-model-for-browser.ts
@@ -33,7 +33,7 @@ export default class CardModelForBrowser
   ) {
     super(cards, state, args);
 
-    registerDestructor(this, this.flushUpdates.bind(this));
+    registerDestructor(this, this.didRecompute.bind(this));
 
     let prop = tracked(this, '_schemaInstance', {
       enumerable: true,
@@ -45,10 +45,9 @@ export default class CardModelForBrowser
     }
   }
 
-  async computeData(schemaInstance?: any): Promise<Record<string, any>> {
+  protected async beginRecompute(): Promise<void> {
     // need to load component module since usedFields originates from there
     await this.componentModule();
-    return super.computeData(schemaInstance);
   }
 
   serialize(): ResourceObject<Saved | Unsaved> {
@@ -66,7 +65,7 @@ export default class CardModelForBrowser
       'edit'
     )) as CardModelForBrowser;
 
-    await editable.computeData();
+    await editable.recompute();
 
     return editable;
   }
@@ -76,7 +75,7 @@ export default class CardModelForBrowser
       let innerComponent = (await this.componentModule()).default;
       let self = this;
 
-      await this.computeData();
+      await this.recompute();
 
       this.wrapperComponent = setComponentTemplate(
         hbs`<this.component @model={{this.data}} @set={{this.set}} />`,

--- a/packages/cardhost/app/lib/card-model-for-browser.ts
+++ b/packages/cardhost/app/lib/card-model-for-browser.ts
@@ -121,7 +121,7 @@ export default class CardModelForBrowser
     return this._componentModule.usedFields;
   }
 
-  protected async componentModule() {
+  private async componentModule() {
     if (!this._componentModule) {
       this._componentModule = await this.cards.loadModule<CardComponentModule>(
         this.componentModuleRef

--- a/packages/cardhost/app/services/cards.ts
+++ b/packages/cardhost/app/services/cards.ts
@@ -81,7 +81,7 @@ export default class Cards extends Service implements CardService {
     return await Promise.all(
       data.map(async (cardResponse) => {
         let model = await this.makeCardModelFromResponse(cardResponse, format);
-        await model.computeData();
+        await model.recompute();
         return model;
       })
     );
@@ -173,7 +173,7 @@ export default class Cards extends Service implements CardService {
       }
     );
 
-    await model.computeData();
+    await model.recompute();
     return model;
   }
 

--- a/packages/core/src/card-model.ts
+++ b/packages/core/src/card-model.ts
@@ -10,7 +10,6 @@ import {
   CardService,
   CardModelArgs,
   CardSchemaModule,
-  CardComponentModule,
   CardModel as CardModelInterface,
   Setter,
   SerializerMap,
@@ -73,7 +72,6 @@ export default abstract class CardModel implements CardModelInterface {
   protected abstract get serializerMap(): SerializerMap;
   protected abstract get usedFields(): string[];
   protected abstract get allFields(): string[];
-  protected abstract componentModule(): Promise<CardComponentModule | void>;
 
   adoptIntoRealm(realm: string, id?: string): CardModelInterface {
     if (this.state.type !== 'loaded') {

--- a/packages/core/src/card-model.ts
+++ b/packages/core/src/card-model.ts
@@ -45,7 +45,6 @@ export default abstract class CardModel implements CardModelInterface {
   protected componentModuleRef: ComponentInfo['componentModule']['global'];
   protected rawData: RawCardData;
   protected state: CreatedState | LoadedState;
-  protected _componentModule: CardComponentModule | undefined;
   protected componentMeta: CardComponentMetaModule | undefined;
 
   private _realm: string;

--- a/packages/core/src/card-model.ts
+++ b/packages/core/src/card-model.ts
@@ -201,8 +201,7 @@ export default abstract class CardModel implements CardModelInterface {
       );
     }
 
-    let serializedData = serializeAttributes(data, this.serializerMap, 'serialize');
-    this.rawData = merge({}, this.rawData, serializedData);
+    this.rawData = merge({}, this.rawData, serializeAttributes(data, this.serializerMap, 'serialize'));
     await this.recompute();
   }
 
@@ -311,8 +310,7 @@ export default abstract class CardModel implements CardModelInterface {
         cursor = nextCursor;
       }
       cursor[lastSegment] = value;
-      let serializedData = serializeAttributes(data, this.serializerMap, 'serialize');
-      this.rawData = serializedData;
+      this.rawData = serializeAttributes(data, this.serializerMap, 'serialize');
       this.recompute();
     };
     (s as any).setters = new Proxy(

--- a/packages/core/src/card-model.ts
+++ b/packages/core/src/card-model.ts
@@ -216,7 +216,7 @@ export default abstract class CardModel implements CardModelInterface {
   // we have a few places that are very sensitive to the shape of the data, and
   // won't be able to deal with a schema instance that has additional properties
   // and methods beyond just the data itself, so this method is for those places
-  protected shapeData(shape: 'used-fields' | 'all-fields') {
+  private shapeData(shape: 'used-fields' | 'all-fields') {
     let syncData: Record<string, any> = {};
 
     let fields = shape === 'used-fields' ? this.usedFields : this.allFields;
@@ -230,7 +230,7 @@ export default abstract class CardModel implements CardModelInterface {
     return syncData;
   }
 
-  protected async createSchemaInstance() {
+  private async createSchemaInstance() {
     let klass = await this.schemaClass();
     // We can't await the instance creation in a separate, as it's thenable and confuses async methods
     return new klass(this.getRawField.bind(this)) as any;

--- a/packages/core/src/card-model.ts
+++ b/packages/core/src/card-model.ts
@@ -67,11 +67,16 @@ export default abstract class CardModel implements CardModelInterface {
     this.setters = this.makeSetter();
   }
 
-  abstract editable(): Promise<CardModelInterface>;
-  abstract component(): Promise<unknown>;
   protected abstract get serializerMap(): SerializerMap;
   protected abstract get usedFields(): string[];
   protected abstract get allFields(): string[];
+
+  editable(): Promise<CardModelInterface> {
+    throw new Error('editable() is unsupported');
+  }
+  component(): Promise<unknown> {
+    throw new Error('component() is unsupported');
+  }
 
   adoptIntoRealm(realm: string, id?: string): CardModelInterface {
     if (this.state.type !== 'loaded') {

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -75,7 +75,7 @@ export class Compiler<Identity extends Saved | Unsaved = Saved> {
     this.schemaSourceModule = this.getLocalSchema();
 
     if (isBaseCard(cardSource)) {
-      schemaModuleRef = { global: 'todo' };
+      schemaModuleRef = { global: `${BASE_CARD_URL}/schema` };
     } else {
       parentCard = await this.getParentCard();
 

--- a/packages/hub/lib/card-model-for-hub.ts
+++ b/packages/hub/lib/card-model-for-hub.ts
@@ -2,6 +2,8 @@ import { CardModel, SerializerMap, CardComponentMetaModule } from '@cardstack/co
 import BaseCardModel from '@cardstack/core/src/card-model';
 
 export default class CardModelForHub extends BaseCardModel implements CardModel {
+  // TODO these are things that we can teach the schema instance during
+  // compilation, so that eventually this implementation can go away
   protected get serializerMap(): SerializerMap {
     if (!this.componentMeta) {
       throw new Error(`bug: CardModelForHub has no componentMeta`);

--- a/packages/hub/lib/card-model-for-hub.ts
+++ b/packages/hub/lib/card-model-for-hub.ts
@@ -6,7 +6,6 @@ export default class CardModelForHub extends BaseCardModel implements CardModel 
     throw new Error('Hub does not have use of editable');
   }
 
-  // TODO in the future when we do SSR, we'll have a need for this
   async component(): Promise<unknown> {
     throw new Error('Hub does not have use of component');
   }

--- a/packages/hub/lib/card-model-for-hub.ts
+++ b/packages/hub/lib/card-model-for-hub.ts
@@ -1,13 +1,7 @@
-import { CardModel, SerializerMap, RawCardData, CardComponentMetaModule } from '@cardstack/core/src/interfaces';
+import { CardModel, SerializerMap, CardComponentMetaModule } from '@cardstack/core/src/interfaces';
 import BaseCardModel from '@cardstack/core/src/card-model';
-import { serializeAttributes } from '@cardstack/core/src/serializers';
-import merge from 'lodash/merge';
-import isPlainObject from 'lodash/isPlainObject';
-import { BadRequest } from '@cardstack/core/src/utils/errors';
 
 export default class CardModelForHub extends BaseCardModel implements CardModel {
-  setters: undefined;
-
   async editable(): Promise<CardModel> {
     throw new Error('Hub does not have use of editable');
   }
@@ -15,23 +9,6 @@ export default class CardModelForHub extends BaseCardModel implements CardModel 
   // TODO in the future when we do SSR, we'll have a need for this
   async component(): Promise<unknown> {
     throw new Error('Hub does not have use of component');
-  }
-
-  // TODO refactor to use CardModelForBrowser's setter
-  async setData(data: RawCardData): Promise<void> {
-    let nonExistentFields = this.assertFieldsExists(data);
-    if (nonExistentFields.length) {
-      throw new BadRequest(
-        `the field(s) ${nonExistentFields.map((f) => `'${f}'`).join(', ')} are not allowed to be set for the card ${
-          this.state.type === 'loaded' ? this.url : 'that adopts from ' + this.state.parentCardURL
-        } in format '${this.format}'`
-      );
-    }
-
-    this.rawData = serializeAttributes(merge({}, this.rawData, data), this.serializerMap);
-    let newSchemaInstance = await this.createSchemaInstance();
-    await this.computeData(newSchemaInstance);
-    this._schemaInstance = newSchemaInstance;
   }
 
   protected get serializerMap(): SerializerMap {
@@ -55,22 +32,7 @@ export default class CardModelForHub extends BaseCardModel implements CardModel 
     return this.componentMeta.allFields;
   }
 
-  protected componentModule() {
-    return Promise.resolve();
-  }
-
-  // TODO: we need to really use a validation mechanism which will use code from
-  // the schema.js module to validate the fields
-  private assertFieldsExists(data: RawCardData, path = ''): string[] {
-    let nonExistentFields: string[] = [];
-    for (let [field, value] of Object.entries(data)) {
-      let fieldPath = path ? `${path}.${field}` : field;
-      if (isPlainObject(value)) {
-        nonExistentFields = [...nonExistentFields, ...this.assertFieldsExists(value, fieldPath)];
-      } else if (!this.usedFields.includes(fieldPath)) {
-        nonExistentFields.push(fieldPath);
-      }
-    }
-    return nonExistentFields;
+  protected componentModule(): Promise<void> {
+    throw new Error('Hub does not have use of component');
   }
 }

--- a/packages/hub/lib/card-model-for-hub.ts
+++ b/packages/hub/lib/card-model-for-hub.ts
@@ -2,14 +2,6 @@ import { CardModel, SerializerMap, CardComponentMetaModule } from '@cardstack/co
 import BaseCardModel from '@cardstack/core/src/card-model';
 
 export default class CardModelForHub extends BaseCardModel implements CardModel {
-  async editable(): Promise<CardModel> {
-    throw new Error('Hub does not have use of editable');
-  }
-
-  async component(): Promise<unknown> {
-    throw new Error('Hub does not have use of component');
-  }
-
   protected get serializerMap(): SerializerMap {
     if (!this.componentMeta) {
       throw new Error(`bug: CardModelForHub has no componentMeta`);

--- a/packages/hub/lib/card-model-for-hub.ts
+++ b/packages/hub/lib/card-model-for-hub.ts
@@ -31,8 +31,4 @@ export default class CardModelForHub extends BaseCardModel implements CardModel 
     }
     return this.componentMeta.allFields;
   }
-
-  protected componentModule(): Promise<void> {
-    throw new Error('Hub does not have use of component');
-  }
 }

--- a/packages/hub/node-tests/@core/card-model-test.ts
+++ b/packages/hub/node-tests/@core/card-model-test.ts
@@ -139,21 +139,17 @@ if (process.env.COMPILER) {
       }
     });
 
-    // note that we have route tests that also assert that setting values on
-    // non-existent fields should error
     it('setData of unused field', async function () {
       let model = await cards.loadModel(`${realmURL}bob-barker`, 'embedded');
       try {
         await model.setData({
           name: 'Robert Barker',
           pizza: 'pepperoni', // non-existent field
-          address: { city: 'New York' }, // unused field
+          address: { city: 'New York' }, // unused field (which is ok to set)
         });
         throw new Error('did not throw expected error');
       } catch (e: any) {
-        expect(e.message).to.equal(
-          `the field(s) 'pizza', 'address.city' are not allowed to be set for the card ${realmURL}bob-barker in format 'embedded'`
-        );
+        expect(e.message).to.equal(`the field(s) 'pizza' are not allowed to be set for the card ${realmURL}bob-barker`);
       }
     });
 

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -34,6 +34,7 @@
     "@babel/core": "^7.12.13",
     "@babel/plugin-proposal-class-properties": "^7.16.0",
     "@babel/plugin-transform-modules-commonjs": "^7.16.0",
+    "@cardstack/base-cards": "0.28.21",
     "@cardstack/cardpay-sdk": "0.28.21",
     "@cardstack/compiled": "0.28.21",
     "@cardstack/core": "0.28.21",

--- a/packages/hub/services/card-service.ts
+++ b/packages/hub/services/card-service.ts
@@ -73,7 +73,7 @@ export class CardService implements CardServiceInterface {
 
     let result = await this.loadCardFromDB(['url', 'data', 'schemaModule', 'componentInfos'], cardURL);
     let model = await this.makeCardModelFromDatabase(format, result, allFields);
-    await model.computeData();
+    await model.recompute();
     return model;
   }
 
@@ -140,7 +140,7 @@ export class CardService implements CardServiceInterface {
       return await Promise.all(
         result.rows.map(async (row) => {
           let model = await this.makeCardModelFromDatabase(format, row);
-          await model.computeData();
+          await model.recompute();
           return model;
         })
       );

--- a/packages/hub/services/file-cache.ts
+++ b/packages/hub/services/file-cache.ts
@@ -21,6 +21,7 @@ declare global {
 
 import logger from '@cardstack/logger';
 import { service } from '@cardstack/hub/services';
+import { BASE_CARD_URL } from '@cardstack/core/src/compiler';
 const log = logger('hub/file-cache');
 
 export default class FileCache {
@@ -135,6 +136,15 @@ export default class FileCache {
       moduleIdentifier = moduleIdentifier.replace('@cardstack/core/src/', '');
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       return require(`@cardstack/core/src/${moduleIdentifier}`);
+    }
+
+    // TODO this is currently focusing specifically on the schema.js module of
+    // the base card since it is compatible with node. Eventually we'll probably
+    // want to extend this to the template components too, as well as other
+    // cards from base...
+    if (moduleIdentifier === `${BASE_CARD_URL}/schema`) {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      return require(`@cardstack/base-cards/base/schema`);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-require-imports


### PR DESCRIPTION
This unifies the means by which the card model data is set between the hub and browser.

I was able to _almost_ completely eliminate the `CardModelForHub` implementation. The only extra part is related to what @mattmcmanus  mentioned in discord where in the hub we use the `componentMeta` module vs in the browser where we use the component module. So the `CardModelForHub` needs to provide it's own accessors for things that use the `componentMeta` module. `CardModelForHub` is now just 25 lines of code, and drop dead simple.