### PR TITLE
Comments on why we have focus states for platters

### DIFF
--- a/packages/boxel/addon/components/boxel/thread/index.hbs
+++ b/packages/boxel/addon/components/boxel/thread/index.hbs
@@ -4,6 +4,7 @@
   </div>
 
   <div class="boxel-thread__content-wrapper">
+    {{!-- Note that tabindex=0 is applied to ensure that this scroll context can be reached and operated by keyboard --}}
     <div class="boxel-thread__scroll-wrapper" tabindex="0" {{autoscroll enabled=@autoscroll}}>
       <div class="boxel-thread__sticky-container">
         {{yield to="taskbar"}}
@@ -13,6 +14,7 @@
       </section>
     </div>
 
+    {{!-- Note that tabindex=0 is applied to ensure that this scroll context can be reached and operated by keyboard --}}
     <div class="boxel-thread__scroll-wrapper" tabindex="0">
       <Boxel::Sidebar class="boxel-thread__sidebar" as |SidebarSection|>
         {{yield SidebarSection to="sidebar"}}

--- a/packages/web-client/app/components/workflow-thread/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/index.hbs
@@ -3,13 +3,14 @@
   its content. See examples at https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html
   Much of our content is gradually loaded and animated
   so it doesn't seem good for us to delay focus till then,
-  hence the root of the workflow has tabindex=0 to make it focusable
-  and we focus it when it's rendered.
+  hence the root of the workflow has tabindex=-1 to make it focusable
+  and we focus it when it's rendered. We don't want it to be focusable
+  after that.
 --}}
 <Boxel::Thread
   @autoscroll={{this.autoscroll}}
   class="workflow-thread workflow-thread-animated"
-  tabindex="0"
+  tabindex="-1"
   {{did-insert this.focus}}
   {{did-insert this.scrollToEnd}}
   data-test-workflow-thread

--- a/packages/web-client/app/components/workflow-thread/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/index.hbs
@@ -1,3 +1,11 @@
+{{!--
+  It's important for the modal to have focus at the start of
+  its content. See examples at https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html
+  Much of our content is gradually loaded and animated
+  so it doesn't seem good for us to delay focus till then,
+  hence the root of the workflow has tabindex=0 to make it focusable
+  and we focus it when it's rendered.
+--}}
 <Boxel::Thread
   @autoscroll={{this.autoscroll}}
   class="workflow-thread workflow-thread-animated"


### PR DESCRIPTION
@burieberry did some thoughtful work to help keyboard/non-pointer-device users in web client, so I did not apply any changes to address CS-3198, I believe that keyboard users will still want these focus states, and focus-visible by default is coming to Safari soon, making these states only appear to users who would like to see them. Some work could be done on the design side to make them more aesthetically pleasing. This PR just adds comments to explain why these focus states are necessary.

## Focus for modal UX
The focus on the workflow thread body (first image) is to ensure that focus starts at the right place, and that tabbing will bring the users to a region at the top of the modal. 

<img width="808" alt="Freshly opened workflow with a blue focus outline on the outside of the thread" src="https://user-images.githubusercontent.com/39579264/157080407-560696f9-49c0-4b89-9c21-94235adf3b85.png">


## Focus to allow scrolling via keyboard
The focus on these 2 areas is to ensure that keyboard users can get there and scroll. Because of the generic nature of the workflow thread scrollable areas, there is no guarantee when a focusable element will show up so it seems good to allow focusing of the scrollable areas for now. 

<img width="530" alt="Workflow scrollable content with focus received, showing a blue focus outline" src="https://user-images.githubusercontent.com/39579264/157080929-c5b51e4c-62ef-465a-9ac5-c684a6300521.png">

<img width="299" alt="Workflow sidebar scrollable content with focus received, showing a blue focus outline" src="https://user-images.githubusercontent.com/39579264/157081103-8267e527-2012-41cc-ba06-2c4d8ee3024d.png">
