### PR TITLE
Bump config versions to apply fix for extraction

### DIFF
--- a/packages/cardpay-subgraph-extraction/config/prepaid_card_payments.yaml
+++ b/packages/cardpay-subgraph-extraction/config/prepaid_card_payments.yaml
@@ -25,7 +25,7 @@ base: &base
         - 524288
         - 32768
         - 1024
-  version: 0.0.2
+  version: 0.0.3
 
 staging:
   <<: *base

--- a/packages/cardpay-subgraph-extraction/config/rewards.yaml
+++ b/packages/cardpay-subgraph-extraction/config/rewards.yaml
@@ -107,7 +107,7 @@ base: &base
         - 131072
         - 16384
         - 1024
-  version: 0.0.1
+  version: 0.0.2
 
 staging:
   <<: *base

--- a/packages/cardpay-subgraph-extraction/requirements.txt
+++ b/packages/cardpay-subgraph-extraction/requirements.txt
@@ -1,4 +1,4 @@
-subgraph_extractor>=0.1
+subgraph_extractor>=0.1.1
 click
 cloudpathlib[s3]
 schedule


### PR DESCRIPTION
Latest extractor should fix the varying _block_number column, this forces new outputs that use the fix.