### PR TITLE
Basic auth UI

### DIFF
--- a/packages/web-client/app/components/auth/index.css
+++ b/packages/web-client/app/components/auth/index.css
@@ -1,0 +1,3 @@
+.auth {
+  width: max-content;
+}

--- a/packages/web-client/app/components/auth/index.hbs
+++ b/packages/web-client/app/components/auth/index.hbs
@@ -2,7 +2,7 @@
   {{#if (eq this.currentStep this.AUTH_STEPS.WALLET_CONNECT)}}
       <Auth::Step
         @header="1. Connect your wallet"
-        @description="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Porro, suscipit!"
+        @description="Use your unique blockchain address to verify your identity"
         {{did-insert this.resetHubAuthState}}
       >
       {{#if this.canDeepLink}}
@@ -30,7 +30,7 @@
     {{else if (eq this.currentStep this.AUTH_STEPS.HUB_AUTH)}}
       <Auth::Step
         @header="2. Authenticate with hub"
-        @description="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Porro, suscipit!"
+        @description="Authenticate to access and modify off-chain data for your account."
       >
         <Boxel::Button
           @kind="primary"

--- a/packages/web-client/app/components/auth/index.hbs
+++ b/packages/web-client/app/components/auth/index.hbs
@@ -5,6 +5,14 @@
         @description="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Porro, suscipit!"
         {{did-insert this.resetHubAuthState}}
       >
+      {{#if this.canDeepLink}}
+        <Boxel::Button
+          @as="anchor"
+          @href={{concat "cardwallet://wc?uri=" this.walletConnectUri}}
+        >
+          Connect
+        </Boxel::Button>
+      {{else}}
         <Boxel::StyledQrCode
           @data={{this.walletConnectUri}}
           {{!-- @image={{@logo}} --}}
@@ -17,6 +25,7 @@
           @cornerSquareType="extra-rounded"
           @imageMargin={{5}}
         />
+      {{/if}}
       </Auth::Step>
     {{else if (eq this.currentStep this.AUTH_STEPS.HUB_AUTH)}}
       <Auth::Step

--- a/packages/web-client/app/components/auth/index.hbs
+++ b/packages/web-client/app/components/auth/index.hbs
@@ -8,7 +8,7 @@
       {{#if this.canDeepLink}}
         <Boxel::Button
           @as="anchor"
-          @href={{concat "https://wallet.cardstack.com/wc?uri=" this.walletConnectUri}}
+          @href={{concat "https://" this.universalLinkDomain "/wc?uri=" this.walletConnectUri}}
         >
           Connect
         </Boxel::Button>

--- a/packages/web-client/app/components/auth/index.hbs
+++ b/packages/web-client/app/components/auth/index.hbs
@@ -51,6 +51,7 @@
       <Auth::Step
         @header="You're authenticated!"
         @description="We'll send you back to where you came from now."
+        {{did-insert this.onComplete}}
       >
         You're done!
       </Auth::Step>

--- a/packages/web-client/app/components/auth/index.hbs
+++ b/packages/web-client/app/components/auth/index.hbs
@@ -1,0 +1,63 @@
+<div>
+  {{#if (eq this.currentStep this.AUTH_STEPS.WALLET_CONNECT)}}
+      <Auth::Step
+        @header="1. Connect your wallet"
+        @description="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Porro, suscipit!"
+        {{did-insert this.resetHubAuthState}}
+      >
+        <Boxel::StyledQrCode
+          @data={{this.walletConnectUri}}
+          {{!-- @image={{@logo}} --}}
+          @size={{340}}
+          @margin={{15}}
+          @backgroundColor="#ffffff"
+          @dotType="dots"
+          @dotColor="#000"
+          @cornerDotType="dot"
+          @cornerSquareType="extra-rounded"
+          @imageMargin={{5}}
+        />
+      </Auth::Step>
+    {{else if (eq this.currentStep this.AUTH_STEPS.HUB_AUTH)}}
+      <Auth::Step
+        @header="2. Authenticate with hub"
+        @description="Lorem ipsum dolor sit amet consectetur, adipisicing elit. Porro, suscipit!"
+      >
+        <Boxel::Button
+          @kind="primary"
+          {{on "click" (perform this.authenticate)}}
+        >
+          Authenticate with Hub
+        </Boxel::Button>
+
+        {{#if (eq this.hubError "AUTH_TIMEOUT")}}
+          <span>
+            Authentication with Card Wallet timed out. If you didn't receive a confirmation request on your device, try again, or contact <a href={{config 'urls.mailToSupportUrl'}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
+          </span>
+        {{else if this.hubError}}
+          Authentication failed or was canceled.
+        {{/if}}
+      </Auth::Step>
+    {{else if (eq this.currentStep this.AUTH_STEPS.DONE)}}
+      <Auth::Step
+        @header="You're authenticated!"
+        @description="We'll send you back to where you came from now."
+      >
+        You're done!
+      </Auth::Step>
+    {{else if (eq this.currentStep this.AUTH_STEPS.LOADING)}}
+      <Auth::Step
+        @header="Loading"
+        @description="Checking your current authentication status"
+      >
+        <Boxel::LoadingIndicator/>
+      </Auth::Step>
+    {{else}}
+      An error occurred.
+      <Boxel::Button
+        {{on "click" this.restart}}
+      >
+        Contact Support
+      </Boxel::Button>
+  {{/if}}
+</div>

--- a/packages/web-client/app/components/auth/index.hbs
+++ b/packages/web-client/app/components/auth/index.hbs
@@ -8,7 +8,7 @@
       {{#if this.canDeepLink}}
         <Boxel::Button
           @as="anchor"
-          @href={{concat "cardwallet://wc?uri=" this.walletConnectUri}}
+          @href={{concat "https://wallet.cardstack.com/wc?uri=" this.walletConnectUri}}
         >
           Connect
         </Boxel::Button>

--- a/packages/web-client/app/components/auth/index.hbs
+++ b/packages/web-client/app/components/auth/index.hbs
@@ -40,9 +40,7 @@
         </Boxel::Button>
 
         {{#if (eq this.hubError "AUTH_TIMEOUT")}}
-          <span>
-            Authentication with Card Wallet timed out. If you didn't receive a confirmation request on your device, try again, or contact <a href={{config 'urls.mailToSupportUrl'}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
-          </span>
+          Authentication with Card Wallet timed out. If you didn't receive a confirmation request on your device, try again, or contact <a href={{config 'urls.mailToSupportUrl'}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
         {{else if this.hubError}}
           Authentication failed or was canceled.
         {{/if}}

--- a/packages/web-client/app/components/auth/index.hbs
+++ b/packages/web-client/app/components/auth/index.hbs
@@ -3,12 +3,14 @@
       <Auth::Step
         @header="Connect your wallet"
         @description="Use your unique blockchain address to verify your identity"
+        data-test-auth-step={{this.currentStep}}
         {{did-insert this.resetHubAuthState}}
       >
       {{#if this.canDeepLink}}
         <Boxel::Button
           @as="anchor"
           @href={{concat "https://" this.universalLinkDomain "/wc?uri=" this.walletConnectUri}}
+          data-test-auth-connect-link
         >
           Connect
         </Boxel::Button>
@@ -24,6 +26,7 @@
           @cornerDotType="dot"
           @cornerSquareType="extra-rounded"
           @imageMargin={{5}}
+          data-test-auth-connect-qr-code
         />
       {{/if}}
       </Auth::Step>
@@ -31,24 +34,31 @@
       <Auth::Step
         @header="Authenticate with hub"
         @description="Authenticate to access and modify off-chain data for your account."
+        data-test-auth-step={{this.currentStep}}
       >
         <Boxel::Button
           @kind="primary"
           {{on "click" (perform this.authenticate)}}
+          data-test-hub-auth-button
         >
           Authenticate with Hub
         </Boxel::Button>
 
-        {{#if (eq this.hubError "AUTH_TIMEOUT")}}
-          Authentication with Card Wallet timed out. If you didn't receive a confirmation request on your device, try again, or contact <a href={{config 'urls.mailToSupportUrl'}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
-        {{else if this.hubError}}
-          Authentication failed or was canceled.
+        {{#if this.hubError}}
+          <span data-test-hub-auth-error>
+            {{#if (eq this.hubError "AUTH_TIMEOUT")}}
+              Authentication with Card Wallet timed out. If you didn't receive a confirmation request on your device, try again, or contact <a href={{config 'urls.mailToSupportUrl'}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
+            {{else}}
+              Authentication failed or was canceled.
+            {{/if}}
+          </span>
         {{/if}}
       </Auth::Step>
     {{else if (eq this.currentStep this.AUTH_STEPS.DONE)}}
       <Auth::Step
         @header="You're authenticated!"
         @description="We'll send you back to where you came from now."
+        data-test-auth-step={{this.currentStep}}
         {{did-insert this.onComplete}}
       >
         You're done!
@@ -56,8 +66,9 @@
     {{else if (eq this.currentStep this.AUTH_STEPS.LOADING)}}
       <Auth::Step
         @header="Checking your authentication status"
+        data-test-auth-step={{this.currentStep}}
       >
-        <Boxel::LoadingIndicator/>
+        <Boxel::LoadingIndicator data-test-auth-loading-indicator/>
       </Auth::Step>
     {{else}}
       An error occurred.

--- a/packages/web-client/app/components/auth/index.hbs
+++ b/packages/web-client/app/components/auth/index.hbs
@@ -1,7 +1,7 @@
 <div>
   {{#if (eq this.currentStep this.AUTH_STEPS.WALLET_CONNECT)}}
       <Auth::Step
-        @header="1. Connect your wallet"
+        @header="Connect your wallet"
         @description="Use your unique blockchain address to verify your identity"
         {{did-insert this.resetHubAuthState}}
       >
@@ -29,7 +29,7 @@
       </Auth::Step>
     {{else if (eq this.currentStep this.AUTH_STEPS.HUB_AUTH)}}
       <Auth::Step
-        @header="2. Authenticate with hub"
+        @header="Authenticate with hub"
         @description="Authenticate to access and modify off-chain data for your account."
       >
         <Boxel::Button
@@ -57,8 +57,7 @@
       </Auth::Step>
     {{else if (eq this.currentStep this.AUTH_STEPS.LOADING)}}
       <Auth::Step
-        @header="Loading"
-        @description="Checking your current authentication status"
+        @header="Checking your authentication status"
       >
         <Boxel::LoadingIndicator/>
       </Auth::Step>

--- a/packages/web-client/app/components/auth/index.hbs
+++ b/packages/web-client/app/components/auth/index.hbs
@@ -72,10 +72,5 @@
       </Auth::Step>
     {{else}}
       An error occurred.
-      <Boxel::Button
-        {{on "click" this.restart}}
-      >
-        Contact Support
-      </Boxel::Button>
   {{/if}}
 </div>

--- a/packages/web-client/app/components/auth/index.hbs
+++ b/packages/web-client/app/components/auth/index.hbs
@@ -1,4 +1,4 @@
-<div>
+<div class="auth" ...attributes>
   {{#if (eq this.currentStep this.AUTH_STEPS.WALLET_CONNECT)}}
       <Auth::Step
         @header="Connect your wallet"

--- a/packages/web-client/app/components/auth/index.ts
+++ b/packages/web-client/app/components/auth/index.ts
@@ -3,7 +3,7 @@
 import Component from '@glimmer/component';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import HubAuthentication from '@cardstack/web-client/services/hub-authentication';
-// import UA from '@cardstack/web-client/services/ua';
+import UA from '@cardstack/web-client/services/ua';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
@@ -23,7 +23,7 @@ const A_WHILE = config.environment === 'test' ? 100 : 1000 * 60; //@*!
 export default class AuthComponent extends Component {
   @service declare layer2Network: Layer2Network; //@*!
   @service('hub-authentication') declare hubAuthentication: HubAuthentication; //@*!
-  // @service declare ua: UA; //@*!
+  @service('ua') declare UAService: UA; //@*!
   @tracked hubError: '' | 'AUTH_TIMEOUT' | 'ERROR' = '';
 
   AUTH_STEPS = AUTH_STEPS;
@@ -42,6 +42,10 @@ export default class AuthComponent extends Component {
     } else {
       return this.AUTH_STEPS.DONE;
     }
+  }
+
+  get canDeepLink() {
+    return this.UAService.isIOS() || this.UAService.isAndroid();
   }
 
   get walletConnectUri() {

--- a/packages/web-client/app/components/auth/index.ts
+++ b/packages/web-client/app/components/auth/index.ts
@@ -1,0 +1,79 @@
+// marked @*! - implementation may be different in ssr-web
+
+import Component from '@glimmer/component';
+import Layer2Network from '@cardstack/web-client/services/layer2-network';
+import HubAuthentication from '@cardstack/web-client/services/hub-authentication';
+// import UA from '@cardstack/web-client/services/ua';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { race, rawTimeout, task, TaskGenerator } from 'ember-concurrency';
+import { taskFor } from 'ember-concurrency-ts';
+import config from '@cardstack/web-client/config/environment';
+
+const AUTH_STEPS = {
+  WALLET_CONNECT: 'WALLET_CONNECT',
+  HUB_AUTH: 'HUB_AUTH',
+  DONE: 'DONE',
+  LOADING: 'LOADING',
+};
+
+const A_WHILE = config.environment === 'test' ? 100 : 1000 * 60; //@*!
+
+export default class AuthComponent extends Component {
+  @service declare layer2Network: Layer2Network; //@*!
+  @service('hub-authentication') declare hubAuthentication: HubAuthentication; //@*!
+  // @service declare ua: UA; //@*!
+  @tracked hubError: '' | 'AUTH_TIMEOUT' | 'ERROR' = '';
+
+  AUTH_STEPS = AUTH_STEPS;
+  authTaskRunningForAWhile: boolean = false;
+
+  get currentStep(): typeof AUTH_STEPS[keyof typeof AUTH_STEPS] {
+    if (
+      this.layer2Network.isInitializing ||
+      this.hubAuthentication.isInitializing
+    ) {
+      return this.AUTH_STEPS.LOADING;
+    } else if (!this.layer2Network.isConnected) {
+      return this.AUTH_STEPS.WALLET_CONNECT;
+    } else if (!this.hubAuthentication.isAuthenticated) {
+      return this.AUTH_STEPS.HUB_AUTH;
+    } else {
+      return this.AUTH_STEPS.DONE;
+    }
+  }
+
+  get walletConnectUri() {
+    return this.layer2Network.walletConnectUri;
+  }
+
+  @task *authenticate(): TaskGenerator<void> {
+    try {
+      this.hubError = '';
+      yield race([
+        taskFor(this.timerTask).perform(),
+        this.hubAuthentication.ensureAuthenticated(),
+      ]);
+      if (this.hubAuthentication.isAuthenticated) {
+        return;
+      } else if (this.authTaskRunningForAWhile) {
+        this.hubError = 'AUTH_TIMEOUT';
+      }
+    } catch (e) {
+      console.error(e);
+      this.hubError = 'ERROR';
+    }
+  }
+
+  @task *timerTask(): TaskGenerator<void> {
+    this.authTaskRunningForAWhile = false;
+    yield rawTimeout(A_WHILE);
+    this.authTaskRunningForAWhile = true;
+  }
+
+  @action resetHubAuthState() {
+    this.hubError = '';
+    this.authTaskRunningForAWhile = false;
+  }
+}

--- a/packages/web-client/app/components/auth/index.ts
+++ b/packages/web-client/app/components/auth/index.ts
@@ -20,7 +20,9 @@ const AUTH_STEPS = {
 
 const A_WHILE = config.environment === 'test' ? 100 : 1000 * 60; //@*!
 
-export default class AuthComponent extends Component {
+export default class AuthComponent extends Component<{
+  onComplete: Function;
+}> {
   @service declare layer2Network: Layer2Network; //@*!
   @service('hub-authentication') declare hubAuthentication: HubAuthentication; //@*!
   @service('ua') declare UAService: UA; //@*!
@@ -79,5 +81,10 @@ export default class AuthComponent extends Component {
   @action resetHubAuthState() {
     this.hubError = '';
     this.authTaskRunningForAWhile = false;
+  }
+
+  @action onComplete() {
+    console.log('completed auth flow');
+    this.args.onComplete?.();
   }
 }

--- a/packages/web-client/app/components/auth/index.ts
+++ b/packages/web-client/app/components/auth/index.ts
@@ -1,5 +1,3 @@
-// marked @*! - implementation may be different in ssr-web
-
 import Component from '@glimmer/component';
 import Layer2Network from '@cardstack/web-client/services/layer2-network';
 import HubAuthentication from '@cardstack/web-client/services/hub-authentication';
@@ -18,14 +16,14 @@ const AUTH_STEPS = {
   LOADING: 'LOADING',
 };
 
-const A_WHILE = config.environment === 'test' ? 100 : 1000 * 60; //@*!
+const A_WHILE = config.environment === 'test' ? 100 : 1000 * 60;
 
 export default class AuthComponent extends Component<{
   onComplete: Function;
 }> {
-  @service declare layer2Network: Layer2Network; //@*!
-  @service('hub-authentication') declare hubAuthentication: HubAuthentication; //@*!
-  @service('ua') declare UAService: UA; //@*!
+  @service declare layer2Network: Layer2Network;
+  @service('hub-authentication') declare hubAuthentication: HubAuthentication;
+  @service('ua') declare UAService: UA;
   @tracked hubError: '' | 'AUTH_TIMEOUT' | 'ERROR' = '';
 
   AUTH_STEPS = AUTH_STEPS;

--- a/packages/web-client/app/components/auth/index.ts
+++ b/packages/web-client/app/components/auth/index.ts
@@ -31,6 +31,10 @@ export default class AuthComponent extends Component<{
   AUTH_STEPS = AUTH_STEPS;
   authTaskRunningForAWhile: boolean = false;
 
+  get universalLinkDomain() {
+    return config.universalLinkDomain;
+  }
+
   get currentStep(): typeof AUTH_STEPS[keyof typeof AUTH_STEPS] {
     if (
       this.layer2Network.isInitializing ||

--- a/packages/web-client/app/components/auth/step/index.css
+++ b/packages/web-client/app/components/auth/step/index.css
@@ -1,0 +1,4 @@
+.auth-step {
+  color: black;
+  text-align: center;
+}

--- a/packages/web-client/app/components/auth/step/index.css
+++ b/packages/web-client/app/components/auth/step/index.css
@@ -1,6 +1,11 @@
 .auth-step {
   color: black;
   text-align: center;
+  height: min(100vh, 40rem);
+  padding: var(--boxel-sp-lg);
+  display: flex;
+  flex-direction: column;
+  max-width: min(100vw, 40rem);
 }
 
 .auth-step__header {
@@ -10,4 +15,15 @@
 
 .auth-step__description {
   font: var(--boxel-font);
+  margin: var(--boxel-sp-lg) 0;
+}
+
+.auth-step__body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--boxel-sp);
+  width: 100%;
+  height: 100%;
 }

--- a/packages/web-client/app/components/auth/step/index.css
+++ b/packages/web-client/app/components/auth/step/index.css
@@ -2,3 +2,12 @@
   color: black;
   text-align: center;
 }
+
+.auth-step__header {
+  font: var(--boxel-font-lg);
+  font-weight: 600;
+}
+
+.auth-step__description {
+  font: var(--boxel-font);
+}

--- a/packages/web-client/app/components/auth/step/index.hbs
+++ b/packages/web-client/app/components/auth/step/index.hbs
@@ -1,14 +1,15 @@
 <Boxel::CardContainer
   class="auth-step"
+  data-test-auth-step
   ...attributes
 >
   {{#if @header}}
-    <header class="auth-step__header">
+    <header class="auth-step__header" data-test-auth-step-header>
       {{@header}}
     </header>
   {{/if}}
   {{#if @description}}
-    <div class="auth-step__description">
+    <div class="auth-step__description" data-test-auth-step-description>
       {{@description}}
     </div>
   {{/if}}

--- a/packages/web-client/app/components/auth/step/index.hbs
+++ b/packages/web-client/app/components/auth/step/index.hbs
@@ -12,7 +12,7 @@
       {{@description}}
     </div>
   {{/if}}
-  <div>
+  <div class="auth-step__body">
     {{yield}}
   </div>
 </Boxel::CardContainer>

--- a/packages/web-client/app/components/auth/step/index.hbs
+++ b/packages/web-client/app/components/auth/step/index.hbs
@@ -1,0 +1,14 @@
+<Boxel::CardContainer
+  class="auth-step"
+  ...attributes
+>
+  <header>
+    {{@header}}
+  </header>
+  <div>
+    {{@description}}
+  </div>
+  <div>
+    {{yield}}
+  </div>
+</Boxel::CardContainer>

--- a/packages/web-client/app/components/auth/step/index.hbs
+++ b/packages/web-client/app/components/auth/step/index.hbs
@@ -2,12 +2,16 @@
   class="auth-step"
   ...attributes
 >
-  <header>
-    {{@header}}
-  </header>
-  <div>
-    {{@description}}
-  </div>
+  {{#if @header}}
+    <header class="auth-step__header">
+      {{@header}}
+    </header>
+  {{/if}}
+  {{#if @description}}
+    <div class="auth-step__description">
+      {{@description}}
+    </div>
+  {{/if}}
   <div>
     {{yield}}
   </div>

--- a/packages/web-client/tests/integration/components/auth-test.ts
+++ b/packages/web-client/tests/integration/components/auth-test.ts
@@ -42,7 +42,6 @@ const WALLET_CONNECT_QR = '[data-test-boxel-styled-qr-code]';
 const WALLET_CONNECT_LINK = '[data-test-auth-connect-link]';
 const HUB_AUTH_BUTTON = '[data-test-hub-auth-button]';
 const HUB_AUTH_ERROR_MESSAGE = '[data-test-hub-auth-error]';
-// const DONE_MESSAGE = '';
 
 module('Integration | Component | auth', function (hooks) {
   setupRenderingTest(hooks);

--- a/packages/web-client/tests/integration/components/auth-test.ts
+++ b/packages/web-client/tests/integration/components/auth-test.ts
@@ -1,0 +1,297 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render, waitFor } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import config from '@cardstack/web-client/config/environment';
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import sinon from 'sinon';
+
+const universalLinkForWC = (walletConnectUri: string) =>
+  'https://' + config.universalLinkDomain + '/wc?uri=' + walletConnectUri;
+
+class StubLayerTwoNetwork extends Service {
+  @tracked isInitializing = false;
+  @tracked isConnected = false;
+  @tracked walletConnectUri = '';
+}
+
+class StubHubAuthentication extends Service {
+  @tracked isInitializing = false;
+  @tracked isAuthenticated = false;
+  async ensureAuthenticated() {
+    return;
+  }
+}
+
+class StubUA extends Service {
+  isIOS() {
+    return false;
+  }
+
+  isAndroid() {
+    return false;
+  }
+}
+
+const _STEP_WITH_NAME = (stepName: string) =>
+  `[data-test-auth-step="${stepName}"]`;
+const HEADER = '[data-test-auth-step-header]';
+const LOADING_INDICATOR = '[data-test-auth-loading-indicator]';
+const WALLET_CONNECT_QR = '[data-test-boxel-styled-qr-code]';
+const WALLET_CONNECT_LINK = '[data-test-auth-connect-link]';
+const HUB_AUTH_BUTTON = '[data-test-hub-auth-button]';
+const HUB_AUTH_ERROR_MESSAGE = '[data-test-hub-auth-error]';
+// const DONE_MESSAGE = '';
+
+module('Integration | Component | auth', function (hooks) {
+  setupRenderingTest(hooks);
+  let hubAuthenticationService: StubHubAuthentication;
+  let layer2NetworkService: StubLayerTwoNetwork;
+  let uaService: StubUA;
+
+  hooks.beforeEach(function () {
+    this.owner.register('service:hub-authentication', StubHubAuthentication);
+    this.owner.register('service:layer2-network', StubLayerTwoNetwork);
+    this.owner.register('service:ua', StubUA);
+    hubAuthenticationService = this.owner.lookup('service:hub-authentication');
+    layer2NetworkService = this.owner.lookup('service:layer2-network');
+    uaService = this.owner.lookup('service:ua');
+  });
+
+  test('it can show a LOADING state when layer 2 is initializing', async function (assert) {
+    layer2NetworkService.isInitializing = true;
+
+    await render(hbs`<Auth/>`);
+
+    assert.dom(_STEP_WITH_NAME('LOADING')).exists();
+    assert.dom(HEADER).containsText('Checking your authentication status');
+    assert.dom(LOADING_INDICATOR).exists();
+  });
+
+  test('it can show a LOADING state when hub auth is initializing', async function (assert) {
+    hubAuthenticationService.isInitializing = true;
+
+    await render(hbs`<Auth/>`);
+
+    assert.dom(_STEP_WITH_NAME('LOADING')).exists();
+    assert.dom(HEADER).containsText('Checking your authentication status');
+    assert.dom(LOADING_INDICATOR).exists();
+  });
+
+  test('it can show the WALLET_CONNECT state', async function (assert) {
+    hubAuthenticationService.isInitializing = true;
+    layer2NetworkService.isConnected = false;
+    hubAuthenticationService.isAuthenticated = false;
+    await render(hbs`<Auth/>`);
+
+    assert.dom(_STEP_WITH_NAME('LOADING')).exists();
+
+    hubAuthenticationService.isInitializing = false;
+
+    await waitFor(_STEP_WITH_NAME('WALLET_CONNECT'));
+
+    assert.dom(HEADER).containsText('Connect your wallet');
+    assert
+      .dom(WALLET_CONNECT_QR)
+      .hasAttribute(
+        'data-test-boxel-styled-qr-code',
+        layer2NetworkService.walletConnectUri
+      );
+  });
+
+  test('it can show the WALLET_CONNECT state with a link, in iOS', async function (assert) {
+    sinon.stub(uaService, 'isIOS').callsFake(() => true);
+
+    hubAuthenticationService.isInitializing = true;
+    layer2NetworkService.isConnected = false;
+    hubAuthenticationService.isAuthenticated = false;
+
+    await render(hbs`<Auth/>`);
+
+    assert.dom(_STEP_WITH_NAME('LOADING')).exists();
+
+    hubAuthenticationService.isInitializing = false;
+
+    await waitFor(_STEP_WITH_NAME('WALLET_CONNECT'));
+
+    assert.dom(HEADER).containsText('Connect your wallet');
+    assert
+      .dom(WALLET_CONNECT_LINK)
+      .hasAttribute(
+        'href',
+        universalLinkForWC(layer2NetworkService.walletConnectUri)
+      );
+  });
+
+  test('it can show the WALLET_CONNECT state with a link, in Android', async function (assert) {
+    sinon.stub(uaService, 'isAndroid').callsFake(() => true);
+
+    hubAuthenticationService.isInitializing = true;
+    layer2NetworkService.isConnected = false;
+    hubAuthenticationService.isAuthenticated = false;
+
+    await render(hbs`<Auth/>`);
+
+    assert.dom(_STEP_WITH_NAME('LOADING')).exists();
+
+    hubAuthenticationService.isInitializing = false;
+
+    await waitFor(_STEP_WITH_NAME('WALLET_CONNECT'));
+
+    assert.dom(HEADER).containsText('Connect your wallet');
+    assert
+      .dom(WALLET_CONNECT_LINK)
+      .hasAttribute(
+        'href',
+        universalLinkForWC(layer2NetworkService.walletConnectUri)
+      );
+  });
+
+  test('it can show the HUB_AUTH state', async function (assert) {
+    hubAuthenticationService.isInitializing = true;
+    layer2NetworkService.isConnected = true;
+    hubAuthenticationService.isAuthenticated = false;
+
+    await render(hbs`<Auth/>`);
+
+    assert.dom(_STEP_WITH_NAME('LOADING')).exists();
+
+    hubAuthenticationService.isInitializing = false;
+
+    await waitFor(_STEP_WITH_NAME('HUB_AUTH'));
+
+    assert.dom(HEADER).containsText('Authenticate with hub');
+    assert
+      .dom(HUB_AUTH_BUTTON)
+      .isEnabled()
+      .containsText('Authenticate with Hub');
+  });
+
+  test('it can show the DONE state', async function (assert) {
+    hubAuthenticationService.isInitializing = true;
+    layer2NetworkService.isConnected = true;
+    hubAuthenticationService.isAuthenticated = true;
+
+    let completed = false;
+    this.set('onComplete', () => (completed = true));
+
+    await render(hbs`<Auth
+      @onComplete={{this.onComplete}}
+    />`);
+
+    assert.dom(_STEP_WITH_NAME('LOADING')).exists();
+
+    hubAuthenticationService.isInitializing = false;
+
+    await waitFor(_STEP_WITH_NAME('DONE'));
+
+    assert.dom(HEADER).containsText("You're authenticated!");
+    assert.ok(completed);
+  });
+
+  test('it can move from the WALLET_CONNECT state to the HUB_AUTH state', async function (assert) {
+    layer2NetworkService.isConnected = false;
+    hubAuthenticationService.isAuthenticated = false;
+    await render(hbs`<Auth/>`);
+
+    assert.dom(_STEP_WITH_NAME('WALLET_CONNECT')).exists();
+
+    layer2NetworkService.isConnected = true;
+
+    await waitFor(_STEP_WITH_NAME('HUB_AUTH'));
+
+    assert.dom(HEADER).containsText('Authenticate with hub');
+  });
+
+  test('it can move from the HUB_AUTH state to the DONE state', async function (assert) {
+    layer2NetworkService.isConnected = true;
+    hubAuthenticationService.isAuthenticated = false;
+
+    await render(hbs`<Auth/>`);
+
+    assert.dom(_STEP_WITH_NAME('HUB_AUTH')).exists();
+
+    hubAuthenticationService.isAuthenticated = true;
+
+    await waitFor(_STEP_WITH_NAME('DONE'));
+
+    assert.dom(HEADER).containsText("You're authenticated!");
+  });
+
+  test('it can move from the HUB_AUTH state to the WALLET_CONNECT state (disconnect)', async function (assert) {
+    layer2NetworkService.isConnected = true;
+    hubAuthenticationService.isAuthenticated = false;
+
+    await render(hbs`<Auth/>`);
+
+    assert.dom(_STEP_WITH_NAME('HUB_AUTH')).exists();
+
+    layer2NetworkService.isConnected = false;
+
+    await waitFor(_STEP_WITH_NAME('WALLET_CONNECT'));
+
+    assert.dom(HEADER).containsText('Connect your wallet');
+  });
+
+  test('it can trigger a hub auth request by clicking the authentication button', async function (assert) {
+    layer2NetworkService.isConnected = true;
+    hubAuthenticationService.isAuthenticated = false;
+    let authenticateSpy = sinon.spy(
+      hubAuthenticationService,
+      'ensureAuthenticated'
+    );
+
+    await render(hbs`<Auth/>`);
+
+    assert.dom(_STEP_WITH_NAME('HUB_AUTH')).exists();
+    assert.ok(authenticateSpy.notCalled);
+
+    await click(HUB_AUTH_BUTTON);
+
+    assert.ok(authenticateSpy.calledOnce);
+  });
+
+  test('it can show an error message if the call to authenticate in the HUB_AUTH state fails', async function (assert) {
+    layer2NetworkService.isConnected = true;
+    hubAuthenticationService.isAuthenticated = false;
+    sinon
+      .stub(hubAuthenticationService, 'ensureAuthenticated')
+      .throws('no way');
+
+    await render(hbs`<Auth/>`);
+
+    assert.dom(_STEP_WITH_NAME('HUB_AUTH')).exists();
+
+    await click(HUB_AUTH_BUTTON);
+
+    assert
+      .dom(HUB_AUTH_ERROR_MESSAGE)
+      .containsText('Authentication failed or was canceled.');
+  });
+  test('it resets a HUB_AUTH error when the WALLET_CONNECT state is shown', async function (assert) {
+    layer2NetworkService.isConnected = true;
+    hubAuthenticationService.isAuthenticated = false;
+    sinon
+      .stub(hubAuthenticationService, 'ensureAuthenticated')
+      .throws('no way');
+
+    await render(hbs`<Auth/>`);
+
+    assert.dom(_STEP_WITH_NAME('HUB_AUTH')).exists();
+
+    await click(HUB_AUTH_BUTTON);
+
+    assert
+      .dom(HUB_AUTH_ERROR_MESSAGE)
+      .containsText('Authentication failed or was canceled.');
+
+    layer2NetworkService.isConnected = false;
+
+    await waitFor(_STEP_WITH_NAME('WALLET_CONNECT'));
+
+    layer2NetworkService.isConnected = true;
+
+    assert.dom(HUB_AUTH_ERROR_MESSAGE).doesNotExist();
+  });
+});


### PR DESCRIPTION
Basic auth UI + tests to ensure that correct UI is shown in response to various states of services, and events trigger the correct callbacks. Styling improvements to come in a separate PR.

The auth steps in order are `WALLET_CONNECT` -> `HUB_AUTH` -> `DONE`, with a `LOADING` state to prevent weird transitions at first load, and a fallback state for any unknown errors.

This is to provide an auth flow that brings the user through connecting to layer 2 and authenticating with hub, in a way that is usable on mobile. The component (and services it depends on) may be moved or copied to SSR web depending on the auth method we settle on.