### PR TITLE
ssr: Change profile contents to be vertically centred

### DIFF
--- a/packages/ssr-web/app/components/card-space/user-page/index.css
+++ b/packages/ssr-web/app/components/card-space/user-page/index.css
@@ -17,11 +17,23 @@
   min-height: 90vh;
   max-width: 90%;
   aspect-ratio: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.card-space-user-page__header {
+  position: absolute;
+  top: calc(min(var(--boxel-sp-xl), 5vw) + 3rem);
 }
 
 @media only screen and (max-width: 992px) {
   .card-space-user-page {
     padding: 0;
+  }
+
+  .card-space-user-page__header {
+    top: min(var(--boxel-sp-xl), 5vw);
   }
 
   .card-space-user-page__wrapper {

--- a/packages/ssr-web/app/components/card-space/user-page/index.css
+++ b/packages/ssr-web/app/components/card-space/user-page/index.css
@@ -63,7 +63,7 @@
   text-align: center;
   font-size: var(--boxel-font-size-xl);
   font-weight: 600;
-  margin: var(--boxel-sp-xxl) auto;
+  margin-bottom: var(--boxel-sp-xxl);
   word-break: break-all;
 }
 

--- a/packages/ssr-web/app/components/card-space/user-page/index.css
+++ b/packages/ssr-web/app/components/card-space/user-page/index.css
@@ -17,23 +17,25 @@
   min-height: 90vh;
   max-width: 90%;
   aspect-ratio: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: [user-content-start header-start] 100% [header-end user-content-end];
+  grid-template-rows: [header-start user-content-start] 2.5rem [header-end] 1fr [user-content-end];
+}
+
+.card-space-user-page__user-content {
+  align-self: center;
+  grid-area: user-content;
+  max-width: 100%;
+  padding: 2.5rem 0;
 }
 
 .card-space-user-page__header {
-  position: absolute;
-  top: calc(min(var(--boxel-sp-xl), 5vw) + 3rem);
+  grid-area: header;
 }
 
 @media only screen and (max-width: 992px) {
   .card-space-user-page {
     padding: 0;
-  }
-
-  .card-space-user-page__header {
-    top: min(var(--boxel-sp-xl), 5vw);
   }
 
   .card-space-user-page__wrapper {
@@ -63,8 +65,11 @@
   text-align: center;
   font-size: var(--boxel-font-size-xl);
   font-weight: 600;
+  max-width: 30rem;
+  margin-left: auto;
+  margin-right: auto;
   margin-bottom: var(--boxel-sp-xxl);
-  word-break: break-all;
+  overflow-wrap: break-all;
 }
 
 .card-space-user-page__url {

--- a/packages/ssr-web/app/components/card-space/user-page/index.hbs
+++ b/packages/ssr-web/app/components/card-space/user-page/index.hbs
@@ -32,53 +32,55 @@
       </a>
     </div>
 
-    <div class="card-space-user-page__title" data-test-merchant-name>
-      {{@model.name}}
-    </div>
+    <div class="card-space-user-page__user-content">
+      <div class="card-space-user-page__title" data-test-merchant-name>
+        {{@model.name}}
+      </div>
 
-    <div class="card-space-user-page__description">
-      Scan this code to pay
-    </div>
+      <div class="card-space-user-page__description">
+        Scan this code to pay
+      </div>
 
-    <div class="card-space-user-page__url" data-test-merchant-url>
-      {{@model.id}}{{config 'cardSpaceHostnameSuffix'}}
-    </div>
+      <div class="card-space-user-page__url" data-test-merchant-url>
+        {{@model.id}}{{config 'cardSpaceHostnameSuffix'}}
+      </div>
 
-    <div class="card-space-user-payment-link">
-      {{#if this.addressFetchingError}}
-        <div class="card-space-user-page-payment-link__error" data-test-address-fetching-error>
-          {{this.addressFetchingError}}
-        </div>
-      {{else}}
+      <div class="card-space-user-payment-link">
+        {{#if this.addressFetchingError}}
+          <div class="card-space-user-page-payment-link__error" data-test-address-fetching-error>
+            {{this.addressFetchingError}}
+          </div>
+        {{else}}
 
-        <div class="payment-link__qr-container">
-          <Boxel::StyledQrCode
-            class="payment-link__qr"
-            @data={{this.paymentURL}}
-            @image={{this.cardstackLogoForQR}}
-            @size={{340}}
-            @margin={{15}}
-            @backgroundColor="#ffffff"
-            @dotType="dots"
-            @dotColor="#000"
-            @cornerDotType="dot"
-            @cornerSquareType="extra-rounded"
-            @imageMargin={{5}}
-          >
-            {{#if this.canDeepLink}}
-              <div class="payment-link__qr-container__actions">
-                <div class="payment-link__qr-container__separator"></div>
-                <div class="payment-link__qr-container__separator-or">OR</div>
+          <div class="payment-link__qr-container">
+            <Boxel::StyledQrCode
+              class="payment-link__qr"
+              @data={{this.paymentURL}}
+              @image={{this.cardstackLogoForQR}}
+              @size={{340}}
+              @margin={{15}}
+              @backgroundColor="#ffffff"
+              @dotType="dots"
+              @dotColor="#000"
+              @cornerDotType="dot"
+              @cornerSquareType="extra-rounded"
+              @imageMargin={{5}}
+            >
+              {{#if this.canDeepLink}}
+                <div class="payment-link__qr-container__actions">
+                  <div class="payment-link__qr-container__separator"></div>
+                  <div class="payment-link__qr-container__separator-or">OR</div>
 
-                <Boxel::Button @kind="primary-dark" @as="anchor" @size="large" href={{this.deepLinkPaymentURL}} data-test-payment-link-deep-link>
-                  Pay with Card Wallet
-                  {{svg-jar "card-pay-logo" height=20}}
-                </Boxel::Button>
-              </div>
-            {{/if}}
-          </Boxel::StyledQrCode>
-        </div>
-      {{/if}}
+                  <Boxel::Button @kind="primary-dark" @as="anchor" @size="large" href={{this.deepLinkPaymentURL}} data-test-payment-link-deep-link>
+                    Pay with Card Wallet
+                    {{svg-jar "card-pay-logo" height=20}}
+                  </Boxel::Button>
+                </div>
+              {{/if}}
+            </Boxel::StyledQrCode>
+          </div>
+        {{/if}}
+      </div>
     </div>
   </div>
 </div>

--- a/packages/ssr-web/tests/acceptance/visit-card-space-test.ts
+++ b/packages/ssr-web/tests/acceptance/visit-card-space-test.ts
@@ -55,7 +55,12 @@ module('Acceptance | visit card space', function (hooks) {
         slug: 'slug',
       });
 
-      cardSpace.createMerchantInfo({ name: 'merchant name', slug: 'slug' });
+      cardSpace.createMerchantInfo({
+        name: 'merchant name',
+        slug: 'slug',
+        color: 'blue',
+        textColor: 'hotpink',
+      });
 
       link = generateMerchantPaymentUrl({
         domain: config.universalLinkDomain,


### PR DESCRIPTION
This is an improvement, IMO:

![image](https://user-images.githubusercontent.com/43280/157775024-e21ceef3-c4da-4068-9a3e-a8f2db6b370a.png)

I made the judgment call to add colours to the Mirage response so the Percy snapshot would have the roundrect wrapper, suggestions welcome if the colour scheme is too garish 😆

![image](https://user-images.githubusercontent.com/43280/157936411-0567da6f-ffd2-4a60-9755-4dae98b575f8.png)
