### PR TITLE
Use a custom logger to include a hostname in FastBoot server logs

### DIFF
--- a/packages/ssr-web/deployment/fastboot-server.js
+++ b/packages/ssr-web/deployment/fastboot-server.js
@@ -19,6 +19,7 @@ Sentry.init({
 });
 
 let server = new FastBootAppServer({
+  log: false,
   distPath: 'dist',
   gzip: true, // Optional - Enables gzip compression.
   host: '0.0.0.0', // Optional - Sets the host the server listens on.
@@ -38,6 +39,23 @@ let server = new FastBootAppServer({
   beforeMiddleware: function (app) {
     app.use(Sentry.Handlers.requestHandler());
     app.use(healthCheckMiddleware);
+
+    let ignoreUrlPattern = /^\/(assets\/|images\/).*(\..*)/;
+
+    let logger = function (req, res, next) {
+      if (!ignoreUrlPattern.test(req.url)) {
+        let fullUrl = req.get('host') + req.originalUrl;
+
+        console.log(
+          `${new Date().toISOString()}: ${req.method} ${fullUrl} ${
+            res.statusCode
+          }`
+        );
+      }
+      next();
+    };
+
+    app.use(logger);
   },
 
   afterMiddleware: function (app) {

--- a/packages/ssr-web/package.json
+++ b/packages/ssr-web/package.json
@@ -86,7 +86,7 @@
     "ember-cli-dependency-lint": "^2.0.1",
     "ember-cli-deprecation-workflow": "^1.0.1",
     "ember-cli-dotenv": "^3.1.0",
-    "ember-cli-fastboot": "^3.2.0",
+    "ember-cli-fastboot": "^3.3.0",
     "ember-cli-htmlbars": "^5.3.2",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-mirage": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13867,10 +13867,10 @@ ember-cli-dotenv@^3.1.0:
     ember-cli-babel "^7.1.2"
     minimist "^1.2.0"
 
-ember-cli-fastboot@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-fastboot/-/ember-cli-fastboot-3.2.0.tgz#ef6605b82a7bb1410d058c4404b04eeef252c698"
-  integrity sha512-wBywPO377TFxNt8y2FFvUnWXa/rFuDDw1geY6BRIR2Plo+bYUS1E9PC/0hUGuLu+GTpKJaKl7we0794smQlsAQ==
+ember-cli-fastboot@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-fastboot/-/ember-cli-fastboot-3.3.0.tgz#c0438c17a19bef704d9d62b68b5049fc017c9581"
+  integrity sha512-PgTAFWI47sLIJCl4yN7/v5PhzawSXb5ih/YPQQR6K0CX+5i17XYxKjhKE4Mp0Jtu/huURv7uACFKytmKVkcEZg==
   dependencies:
     broccoli-concat "^4.2.5"
     broccoli-file-creator "^2.1.1"
@@ -13882,8 +13882,8 @@ ember-cli-fastboot@^3.2.0:
     ember-cli-lodash-subset "^2.0.1"
     ember-cli-preprocess-registry "^3.3.0"
     ember-cli-version-checker "^5.1.2"
-    fastboot "3.2.0"
-    fastboot-express-middleware "3.2.0"
+    fastboot "3.3.0"
+    fastboot-express-middleware "3.3.0"
     fastboot-transform "^0.1.3"
     fs-extra "^10.0.0"
     json-stable-stringify "^1.0.1"
@@ -16796,13 +16796,13 @@ fast-xml-parser@3.19.0:
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz#cb637ec3f3999f51406dd8ff0e6fc4d83e520d01"
   integrity sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==
 
-fastboot-express-middleware@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/fastboot-express-middleware/-/fastboot-express-middleware-3.2.0.tgz#86efd6452426efb4f73a0344d37f11b5736de09c"
-  integrity sha512-R6lXqmjJRZ+BWCIJL+amHecVoyi9+usZQkCj1VSM+qRf3wjPfhApv26atD6rJTvKrC3OPdI0E0O0ZtkcyXH+xQ==
+fastboot-express-middleware@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/fastboot-express-middleware/-/fastboot-express-middleware-3.3.0.tgz#a3da82533383331bb32c6cd921a0e99705b06740"
+  integrity sha512-iLr4ncGi0gb+40O0D9VOmJ0MI/ROESuolsfNyasDHCdnz7eT+gloT9KG3h6efscCuCQ1IviuE1ynuAVTp9vX8Q==
   dependencies:
     chalk "^4.1.2"
-    fastboot "3.2.0"
+    fastboot "3.3.0"
 
 fastboot-transform@^0.1.3:
   version "0.1.3"
@@ -16812,10 +16812,10 @@ fastboot-transform@^0.1.3:
     broccoli-stew "^1.5.0"
     convert-source-map "^1.5.1"
 
-fastboot@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/fastboot/-/fastboot-3.2.0.tgz#1f7e93605c744a32457588d01471a0d2969b346a"
-  integrity sha512-NUy1No6KfGvkrzCRJ7Xy0ooFMEJeEqD2F/ccsjm2kQCEbHeGPWPBadYSSJTUm9xnLDZQzwcJrR+q0uCMarvW+g==
+fastboot@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/fastboot/-/fastboot-3.3.0.tgz#e0b1cafb3fb6e89095acade221ccfbfe327b3462"
+  integrity sha512-WXgR/uKM/r6TCb99Q97vuxH16bhF1scF4LL7Uckel5dNqvvlNVpKEeuggOJafx/JtfIyrldfo7Cn9Xpaoltp7A==
   dependencies:
     chalk "^4.1.2"
     cookie "^0.4.1"


### PR DESCRIPTION
Ticket: [CS-3318](https://linear.app/cardstack/issue/CS-3318/ssr-web-logs-should-show-hostname)

The idea is to disable FastBoot's default logging and add a custom logger so that we can include the hostname which will help us to debug card space related requests and see for which card space the requests are for. 

Currently, this produces doubled logging (one from FastBoot and one from the added middleware). I believe we'll have to make a trivial change to FastBoot to add the option to disable logging (more info [here](https://linear.app/cardstack/issue/CS-3318/ssr-web-logs-should-show-hostname)). This PR should be parked until we are able to tell FastBoot to turn off the default logger. I'm currently researching how to develop FastBoot locally so I can add that change.

Before:

```
2022-03-09T15:40:47-06:00: 2022-03-09T21:40:47.716Z 200 OK /
2022-03-09T15:43:16-06:00: 2022-03-09T21:43:16.147Z 200 OK /pay/sokol/0x3a31B39bECf64aF7713CDF63aE5C760166E2CF21
```

After:
```
2022-03-14T16:12:27.023Z: GET localhost:4000/ 200
2022-03-14T16:11:22.793Z: GET vandelayindustries.card.xyz.localhost:4000/ 200
2022-03-14T16:11:44.572Z: GET localhost:4000/pay/sokol/0x3a31B39bECf64aF7713CDF63aE5C760166E2CF21?amount=100&currency=USD 200
```

An alternative would be to add a 3rd party logger, such as [winston](https://github.com/winstonjs/winston) which seems the most popular but I think the simple custom logger should suffice.

Suggestions to beautify the new log welcome! 💅