### PR TITLE
Fix/mobile card space layout

### DIFF
--- a/packages/ssr-web/app/components/card-space/user-page/index.css
+++ b/packages/ssr-web/app/components/card-space/user-page/index.css
@@ -42,6 +42,7 @@
     min-height: 100vh;
     min-width: 100%;
     border-radius: 0;
+    aspect-ratio: unset;
   }
 }
 

--- a/packages/ssr-web/app/components/card-space/user-page/index.css
+++ b/packages/ssr-web/app/components/card-space/user-page/index.css
@@ -14,19 +14,20 @@
   color: var(--card-space-text-color);
   padding: min(var(--boxel-sp-xl), 5vw);
   border-radius: 2rem;
-  min-height: max(90vh, 40rem);
+  height: max(90vh, 44rem);
+  width: max(90vh, 44rem);
   max-width: 90%;
   aspect-ratio: 1;
   display: grid;
-  grid-template-columns: [user-content-start header-start] 100% [header-end user-content-end];
-  grid-template-rows: [header-start user-content-start] 2.5rem [header-end] 1fr [user-content-end];
+  grid-template-columns: 100%;
+  grid-template-rows: 2.5rem 1fr 2.5rem;
+  grid-template-areas: "header" "user-content" "unused";
 }
 
 .card-space-user-page__user-content {
-  align-self: center;
+  align-self:center;
   grid-area: user-content;
   max-width: 100%;
-  padding: 2.5rem 0;
 }
 
 .card-space-user-page__header {
@@ -41,6 +42,7 @@
   .card-space-user-page__wrapper {
     min-height: 100vh;
     min-width: 100%;
+    height: auto;
     border-radius: 0;
     aspect-ratio: unset;
   }

--- a/packages/ssr-web/app/components/card-space/user-page/index.css
+++ b/packages/ssr-web/app/components/card-space/user-page/index.css
@@ -14,7 +14,7 @@
   color: var(--card-space-text-color);
   padding: min(var(--boxel-sp-xl), 5vw);
   border-radius: 2rem;
-  min-height: 90vh;
+  min-height: max(90vh, 40rem);
   max-width: 90%;
   aspect-ratio: 1;
   display: grid;

--- a/packages/ssr-web/app/components/card-space/user-page/index.css
+++ b/packages/ssr-web/app/components/card-space/user-page/index.css
@@ -70,7 +70,7 @@
   margin-left: auto;
   margin-right: auto;
   margin-bottom: var(--boxel-sp-xxl);
-  overflow-wrap: break-all;
+  overflow-wrap: break-word;
 }
 
 .card-space-user-page__url {


### PR DESCRIPTION
- Uncapping aspect ratio on short, small screens prevents this:

<img width="379" alt="The card space for merchie1 on a short small screen shows the content reaching vertical space of the Card Pay logo/link." src="https://user-images.githubusercontent.com/39579264/158347440-45dc40ff-69e6-4d5e-8e30-79312da9edf7.png">

-  Correction - `overflow-wrap: break-word;` is the correct value, not `break-all`

- Prevent resizing on large screens having a similar problem to the overlap problem on small screens by enforcing a min-height.