### PR TITLE
card space user page clicked link should be universal too

### DIFF
--- a/packages/ssr-web/app/components/card-space/user-page/index.hbs
+++ b/packages/ssr-web/app/components/card-space/user-page/index.hbs
@@ -71,7 +71,7 @@
                   <div class="payment-link__qr-container__separator"></div>
                   <div class="payment-link__qr-container__separator-or">OR</div>
 
-                  <Boxel::Button @kind="primary-dark" @as="anchor" @size="large" href={{this.deepLinkPaymentURL}} data-test-payment-link-deep-link>
+                  <Boxel::Button @kind="primary-dark" @as="anchor" @size="large" href={{this.paymentURL}} data-test-payment-link-deep-link>
                     Pay with Card Wallet
                     {{svg-jar "card-pay-logo" height=20}}
                   </Boxel::Button>

--- a/packages/ssr-web/app/components/card-space/user-page/index.ts
+++ b/packages/ssr-web/app/components/card-space/user-page/index.ts
@@ -86,13 +86,4 @@ export default class CardSpaceUserPage extends Component<CardSpaceUserPageArgs> 
       network: config.chains.layer2,
     });
   }
-
-  get deepLinkPaymentURL() {
-    if (!this.address) return null;
-
-    return generateMerchantPaymentUrl({
-      merchantSafeID: this.address as string,
-      network: config.chains.layer2,
-    });
-  }
 }

--- a/packages/ssr-web/tests/acceptance/visit-card-space-test.ts
+++ b/packages/ssr-web/tests/acceptance/visit-card-space-test.ts
@@ -49,7 +49,6 @@ module('Acceptance | visit card space', function (hooks) {
 
   module('render', function (hooks) {
     let link: string;
-    let deepLink: string;
     hooks.beforeEach(function (this: MirageTestContext) {
       let cardSpace = this.server.create('card-space', {
         slug: 'slug',
@@ -64,10 +63,6 @@ module('Acceptance | visit card space', function (hooks) {
 
       link = generateMerchantPaymentUrl({
         domain: config.universalLinkDomain,
-        merchantSafeID: '0x1234',
-        network: config.chains.layer2,
-      });
-      deepLink = generateMerchantPaymentUrl({
         merchantSafeID: '0x1234',
         network: config.chains.layer2,
       });
@@ -137,7 +132,7 @@ module('Acceptance | visit card space', function (hooks) {
 
       assert
         .dom('[data-test-payment-link-deep-link]')
-        .hasAttribute('href', deepLink);
+        .hasAttribute('href', link);
 
       await percySnapshot(assert);
     });
@@ -163,7 +158,7 @@ module('Acceptance | visit card space', function (hooks) {
 
       assert
         .dom('[data-test-payment-link-deep-link]')
-        .hasAttribute('href', deepLink);
+        .hasAttribute('href', link);
 
       await percySnapshot(assert);
     });


### PR DESCRIPTION
This is more useful than the cardwallet:// scheme because it can open up the wallet payment page that prompts users to get card wallet if users don't already have card wallet. If users already have Card Wallet, the universal link opens up Card Wallet directly rather than first asking the user whether they want to open things in Card Wallet.

The payment request page needs to use cardwallet:// scheme because otherwise Safari just refreshes because Apple wants to respect a user's decision to stay on the universal link site (clicking on a link to `wallet.cardstack.com` while you are on `wallet.cardstack.com` will just send you that page in browser instead of opening the app).