### PR TITLE
Fix pool balance

### DIFF
--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -63,10 +63,6 @@ export default class RewardPool {
 
   constructor(private layer2Web3: Web3) {}
 
-  async getCurrentPaymentCycle(): Promise<number> {
-    return 2;
-  }
-
   async getBalance(address: string, rewardProgramId?: string, tokenAddress?: string): Promise<BN> {
     const unclaimedProofs = await this.getProofs(address, rewardProgramId, tokenAddress, false);
     return unclaimedProofs.reduce((total, { amount }) => {

--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -547,8 +547,8 @@ but the balance is the reward pool is ${fromWei(rewardPoolBalanceForRewardProgra
   }
 
   async get_reward_tokens(): Promise<string[]> {
-    let card_token_address = await getAddress('cardCpxd', this.layer2Web3)
-    return [card_token_address]
+    let card_token_address = await getAddress('cardCpxd', this.layer2Web3);
+    return [card_token_address];
   }
 
   async addTokenSymbol<T extends Proof | RewardTokenBalance>(arrWithTokenAddress: T[]): Promise<WithSymbol<T>[]> {

--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -523,7 +523,7 @@ but the balance is the reward pool is ${fromWei(rewardPoolBalanceForRewardProgra
   }
 
   async balances(rewardProgramId: string): Promise<WithSymbol<RewardTokenBalance>[]> {
-    const tokensAvailable = await this.rewardTokensAvailable(rewardProgramId);
+    const tokensAvailable = await this.get_reward_tokens();
     let promises = tokensAvailable.map((tokenAddress) => {
       return this.balance(rewardProgramId, tokenAddress);
     });
@@ -544,6 +544,11 @@ but the balance is the reward pool is ${fromWei(rewardPoolBalanceForRewardProgra
 
   async address(): Promise<string> {
     return await getAddress('rewardPool', this.layer2Web3);
+  }
+
+  async get_reward_tokens(): Promise<string[]> {
+    let card_token_address = await getAddress('cardCpxd', this.layer2Web3)
+    return [card_token_address]
   }
 
   async addTokenSymbol<T extends Proof | RewardTokenBalance>(arrWithTokenAddress: T[]): Promise<WithSymbol<T>[]> {

--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -63,7 +63,7 @@ export default class RewardPool {
 
   constructor(private layer2Web3: Web3) {}
 
-  async getBalance(address: string, rewardProgramId?: string, tokenAddress?: string): Promise<BN> {
+  async getBalance(address: string, tokenAddress: string, rewardProgramId?: string): Promise<BN> {
     const unclaimedProofs = await this.getProofs(address, rewardProgramId, tokenAddress, false);
     return unclaimedProofs.reduce((total, { amount }) => {
       return total.add(amount);
@@ -155,7 +155,7 @@ export default class RewardPool {
     tokenAddress: string,
     rewardProgramId?: string
   ): Promise<RewardTokenBalance> {
-    let balance = await this.getBalance(address, rewardProgramId, tokenAddress);
+    let balance = await this.getBalance(address, tokenAddress, rewardProgramId);
     return {
       rewardProgramId,
       tokenAddress,


### PR DESCRIPTION
Pool balance was not being displayed when triggered from cli. The origin of the issue is that was checking balance based of `rewardTokensAvailable` which is an API-specific to tally proofs (since we have not rewarded tokens, there are no reward tokens available). 

**Solution**

I have coded `get_reward_tokens` that are available in sdk. It should change depending on the network. I have restricted only to card tokens since they are the only reward tokens. 

![Screenshot 2022-03-17 at 11 40 29 AM](https://user-images.githubusercontent.com/8165111/158732449-4a4b6114-2308-4eb4-ae3c-c070ee86445b.png)


