### PR TITLE
[CS-3421]: Add --from option to rewards-register CLI commands

### DIFF
--- a/packages/cardpay-cli/README.md
+++ b/packages/cardpay-cli/README.md
@@ -319,6 +319,7 @@ Options:
   -m, --mnemonic       Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE  [string]
   -w, --walletConnect  A flag to indicate that wallet connect should be used for the wallet  [boolean]
       --force          Force the prepaid card to be created even when the DAI rate is not snapped to USD  [boolean] [default: false]
+      --from           The signing EOA. Defaults to the first derived EOA of the specified mnemonic  [string]
   -n, --network        The Layer 2 network to run this script on  [string] [required] [choices: "sokol", "xdai"]
 ```
 
@@ -349,6 +350,7 @@ Positionals:
 Options:
   -m, --mnemonic       Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE  [string]
   -w, --walletConnect  A flag to indicate that wallet connect should be used for the wallet  [boolean]
+      --from           The signing EOA. Defaults to the first derived EOA of the specified mnemonic  [string]
   -n, --network        The Layer 2 network to run this script on  [string] [required] [choices: "sokol", "xdai"]
 ```
 
@@ -391,6 +393,7 @@ Positionals:
 Options:
   -m, --mnemonic       Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE  [string]
   -w, --walletConnect  A flag to indicate that wallet connect should be used for the wallet  [boolean]
+  -f, --from           The signing EOA. Defaults to the first derived EOA of the specified mnemonic  [string]
   -n, --network        The Layer 2 network to run this script on  [string] [required] [choices: "sokol", "xdai"]
 ```
 
@@ -407,6 +410,7 @@ Positionals:
 Options:
   -m, --mnemonic       Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE  [string]
   -w, --walletConnect  A flag to indicate that wallet connect should be used for the wallet  [boolean]
+  -f, --from           The signing EOA. Defaults to the first derived EOA of the specified mnemonic  [string]
   -n, --network        The Layer 2 network to run this script on  [string] [required] [choices: "sokol", "xdai"]
 ```
 
@@ -422,6 +426,7 @@ Positionals:
 Options:
   -m, --mnemonic       Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE  [string]
   -w, --walletConnect  A flag to indicate that wallet connect should be used for the wallet  [boolean]
+  -f, --from           The signing EOA. Defaults to the first derived EOA of the specified mnemonic  [string]
   -n, --network        The Layer 2 network to run this script on  [string] [required] [choices: "sokol", "xdai"]
 ```
 
@@ -740,6 +745,7 @@ Positionals:
 Options:
   -m, --mnemonic       Phrase for mnemonic wallet. Also can be pulled from env using MNEMONIC_PHRASE  [string]
   -w, --walletConnect  A flag to indicate that wallet connect should be used for the wallet  [boolean]
+  -f, --from           The signing EOA. Defaults to the first derived EOA of the specified mnemonic  [string]
   -n, --network        The Layer 2 network to run this script on  [string] [required] [choices: "sokol", "xdai"]
 ```
 

--- a/packages/cardpay-cli/rewards/register.ts
+++ b/packages/cardpay-cli/rewards/register.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2 } from '../utils';
+import { FROM_OPTION, getWeb3, NETWORK_OPTION_LAYER_2 } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 
@@ -16,21 +16,28 @@ export default {
         type: 'string',
         description: 'Reward program id',
       })
+      .option('from', FROM_OPTION)
       .option('network', NETWORK_OPTION_LAYER_2);
   },
   async handler(args: Arguments) {
-    let { network, mnemonic, prepaidCard, rewardProgramId } = args as unknown as {
+    let { network, mnemonic, prepaidCard, rewardProgramId, from } = args as unknown as {
       network: string;
       prepaidCard: string;
       rewardProgramId: string;
       mnemonic?: string;
+      from?: string;
     };
     let web3 = await getWeb3(network, mnemonic);
     let rewardManagerAPI = await getSDK('RewardManager', web3);
     let blockExplorer = await getConstant('blockExplorer', web3);
-    let { rewardSafe } = await rewardManagerAPI.registerRewardee(prepaidCard, rewardProgramId, {
-      onTxnHash: (txnHash: string) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),
-    });
+    let { rewardSafe } = await rewardManagerAPI.registerRewardee(
+      prepaidCard,
+      rewardProgramId,
+      {
+        onTxnHash: (txnHash: string) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),
+      },
+      { from }
+    );
     console.log(`Registered rewardee for reward program ${rewardProgramId}. Created reward safe: ${rewardSafe}`);
   },
 } as CommandModule;

--- a/packages/cardpay-sdk/index.ts
+++ b/packages/cardpay-sdk/index.ts
@@ -11,6 +11,7 @@ export type {
   DepotSafe,
   MerchantSafe,
   PrepaidCardSafe,
+  RewardSafe,
   ExternalSafe,
   TokenInfo,
   ViewSafeResult,


### PR DESCRIPTION
- Adds--from option to rewards-register CLI commands
- Updates the docs 
- Exports RewardSafe type

Idk if there's any race condition where we need to validate if `from` exists or not, passing directly seems to work since the sdk validates it, but lmk if you'd like me to follow the `contractOptions` checking patterns, or even update the existing ones to pass `{ from }` directly, or if this is ok. 
