### PR TITLE
fix qr code poking out of allocated area

### DIFF
--- a/packages/ssr-web/app/components/card-space/user-page/index.css
+++ b/packages/ssr-web/app/components/card-space/user-page/index.css
@@ -98,28 +98,28 @@
   margin-top: var(--boxel-sp-lg);
 }
 
-.payment-link__qr {
+.card-space-user-payment-link__qr {
   max-width: 100%;
 }
 
-.payment-link__qr-container__actions {
+.card-space-user-payment-link__qr-container__actions {
   width: 100%;
   display: flex;
   flex-direction: column;
 }
 
-.payment-link__qr-container__actions > a {
+.card-space-user-payment-link__qr-container__actions > a {
   margin: var(--boxel-sp-lg);
 }
 
-.payment-link__qr-container__separator {
+.card-space-user-payment-link__qr-container__separator {
   width: 100%;
   height: 1px;
   background: var(--boxel-light-600);
   margin-top: var(--boxel-sp-xs);
 }
 
-.payment-link__qr-container__separator-or {
+.card-space-user-payment-link__qr-container__separator-or {
   margin: auto;
   color: #000;
   background: #fff;

--- a/packages/ssr-web/app/components/card-space/user-page/index.hbs
+++ b/packages/ssr-web/app/components/card-space/user-page/index.hbs
@@ -52,9 +52,9 @@
           </div>
         {{else}}
 
-          <div class="payment-link__qr-container">
+          <div class="card-space-user-payment-link__qr-container">
             <Boxel::StyledQrCode
-              class="payment-link__qr"
+              class="card-space-user-payment-link__qr"
               @data={{this.paymentURL}}
               @image={{this.cardstackLogoForQR}}
               @size={{340}}
@@ -67,9 +67,9 @@
               @imageMargin={{5}}
             >
               {{#if this.canDeepLink}}
-                <div class="payment-link__qr-container__actions">
-                  <div class="payment-link__qr-container__separator"></div>
-                  <div class="payment-link__qr-container__separator-or">OR</div>
+                <div class="card-space-user-payment-link__qr-container__actions">
+                  <div class="card-space-user-payment-link__qr-container__separator"></div>
+                  <div class="card-space-user-payment-link__qr-container__separator-or">OR</div>
 
                   <Boxel::Button @kind="primary-dark" @as="anchor" @size="large" href={{this.paymentURL}} data-test-payment-link-deep-link>
                     Pay with Card Wallet

--- a/packages/ssr-web/app/components/common/payment-link/index.css
+++ b/packages/ssr-web/app/components/common/payment-link/index.css
@@ -17,6 +17,10 @@
   max-width: 100%;
 }
 
+.payment-link__qr {
+  max-width: 100%;
+}
+
 .payment-link__error {
   margin: var(--boxel-sp-sm);
   color: var(--boxel-purple-500);

--- a/packages/ssr-web/app/components/common/payment-link/index.hbs
+++ b/packages/ssr-web/app/components/common/payment-link/index.hbs
@@ -2,6 +2,7 @@
   {{#if this.showingQR}}
     <div class="payment-link__qr-container">
       <Boxel::StyledQrCode
+        class="payment-link__qr"
         @data={{@paymentURL}}
         @image={{@image}}
         @size={{340}}


### PR DESCRIPTION
## Before
<img width="372" alt="Bug: QR Code in the mobile payment request page extends outside of its allocated width" src="https://user-images.githubusercontent.com/39579264/159039479-1bea0c08-b677-41fc-ac84-d7c422a20065.png">


## After
<img width="375" alt="QR code in the mobile payment request page now stays within its allocated width" src="https://user-images.githubusercontent.com/39579264/159039847-93cb176a-84d2-4a66-a9f3-46f362660bac.png">
