### PR TITLE
publish: Update key to break cache

### DIFF
--- a/.github/workflows/manual-publish.yaml
+++ b/.github/workflows/manual-publish.yaml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-v2-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            ${{ runner.os }}-yarn-v2-
 
       - uses: volta-cli/action@v1
 


### PR DESCRIPTION
This is an attempt to solve a [mysterious Boxel failure](https://github.com/cardstack/cardstack/runs/5604977632?check_suite_focus=true) when publishing.