### PR TITLE
boxel: Add explicit import of qunit-dom

### DIFF
--- a/packages/boxel/types/global.d.ts
+++ b/packages/boxel/types/global.d.ts
@@ -4,3 +4,8 @@ declare module '@cardstack/boxel/templates/*' {
   const tmpl: TemplateFactory;
   export default tmpl;
 }
+
+// Needed because `yarn prepack` was not recognising assert.dom
+// and this fix caused other typing problems:
+// https://github.com/simplabs/qunit-dom#typescript
+import 'qunit-dom';


### PR DESCRIPTION
This is an attempt to address this mysterious Boxel failure
when publishing:
https://github.com/cardstack/cardstack/runs/5605597962?check_suite_focus=true#step:6:66