### PR TITLE
add fine print to app name

### DIFF
--- a/packages/ssr-web/app/components/card-pay/merchant-payment-request-card/index.css
+++ b/packages/ssr-web/app/components/card-pay/merchant-payment-request-card/index.css
@@ -37,14 +37,14 @@
 .merchant-payment-request-card__card-wallet-text {
   display: flex;
   flex-direction: column;
-  font-weight: bold;
+  font-weight: 700;
   line-height: 1.36;
   font-size: 0.875rem;
   letter-spacing: 0.11px;
 }
 
 .merchant-payment-request-card__card-wallet-fine-print {
-  font-weight: normal;
+  font-weight: 400;
 }
 
 @media only screen and (max-width: 480px) {

--- a/packages/ssr-web/app/components/card-pay/merchant-payment-request-card/index.css
+++ b/packages/ssr-web/app/components/card-pay/merchant-payment-request-card/index.css
@@ -34,6 +34,19 @@
   flex-shrink: 0;
 }
 
+.merchant-payment-request-card__card-wallet-text {
+  display: flex;
+  flex-direction: column;
+  font-weight: bold;
+  line-height: 1.36;
+  font-size: 0.875rem;
+  letter-spacing: 0.11px;
+}
+
+.merchant-payment-request-card__card-wallet-fine-print {
+  font-weight: normal;
+}
+
 @media only screen and (max-width: 480px) {
   .merchant-payment-request-card {
     --horizontal-padding: var(--boxel-sp-lg);

--- a/packages/ssr-web/app/components/card-pay/merchant-payment-request-card/index.hbs
+++ b/packages/ssr-web/app/components/card-pay/merchant-payment-request-card/index.hbs
@@ -10,9 +10,14 @@
         width='40'
         height='40'
       }}
-      <span class='merchant-payment-request-card__card-wallet-text'>
-        Card Wallet
-      </span>
+      <div class='merchant-payment-request-card__card-wallet-text'>
+        <span>
+          Card Wallet
+        </span>
+        <span class='merchant-payment-request-card__card-wallet-fine-print'>
+          by Cardstack
+        </span>
+      </div>
     </div>
     <Common::CardWalletBadges />
   </div>


### PR DESCRIPTION
Design notes that we should refer to the wallet as "Card Wallet by Cardstack"

<img width="166" alt="Screenshot of the app name used on the merchant payment request page. App name now reads 'Card Wallet by Cardstack', where before it read 'Card Wallet'" src="https://user-images.githubusercontent.com/39579264/159426383-ebfbcfd4-7a20-4326-82fb-65ca65683b41.png">
