### PR TITLE
Add rewards gas estimation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -804,6 +804,26 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Cardpay testnet: Register Rewardee Gas Estimate",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "rewards",
+        "register-rewardee-gas-estimate",
+        "0xE4EA6a40a91F424428c599AAbAb4D06579DbC027", //prepaid card
+        "0x5E4E148baae93424B969a0Ea67FF54c315248BbA", //reward program
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Cardpay testnet: Add Reward Tokens",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -887,6 +887,27 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Cardpay testnet: Claim Rewards Gas Estimate",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "rewards",
+        "claim-reward-gas-estimate",
+        "0x0cFE5B031781CF1999b7AbDD887863E7f52A913d",
+        "0x0000000000000000000000005e4e148baae93424b969a0ea67ff54c315248bba00000000000000000000000000000000000000000000000000000000000000dd0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000174876e8000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000159ade032073d930e85f95abbab9995110c43c7100000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000040000000000000000000000000b236ca8dbab0644ffcd32518ebf4924ba866f7ee0000000000000000000000000000000000000000000000001bc16d674ec80000",
+        "0x138782a670e98567aa477631a43fcbf9e3701181a3bdbb3b60b1e131f5f7054d",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Cardpay testnet: Get Claimable Reward Proofs",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],

--- a/packages/cardpay-cli/rewards/claim-reward-gas-estimate.ts
+++ b/packages/cardpay-cli/rewards/claim-reward-gas-estimate.ts
@@ -41,7 +41,9 @@ export default {
     let web3 = await getWeb3(network, getWeb3Opts(args));
     let rewardPool = await getSDK('RewardPool', web3);
     let proofArray = fromProof(proof);
-    let estimate = await rewardPool.claimGasEstimate(rewardSafe, leaf, proofArray, acceptPartialClaim);
-    console.log(`The gas estimate for claiming reward to ${rewardSafe} is ${fromWei(estimate)} `);
+    let assets = await getSDK('Assets', web3);
+    let { gasToken, amount } = await rewardPool.claimGasEstimate(rewardSafe, leaf, proofArray, acceptPartialClaim);
+    let { symbol } = await assets.getTokenInfo(gasToken);
+    console.log(`The gas estimate for claiming reward to reward safe ${rewardSafe} is ${fromWei(amount)} ${symbol}`);
   },
 } as CommandModule;

--- a/packages/cardpay-cli/rewards/claim-reward-gas-estimate.ts
+++ b/packages/cardpay-cli/rewards/claim-reward-gas-estimate.ts
@@ -1,0 +1,47 @@
+import { Argv } from 'yargs';
+import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { fromProof } from './utils';
+import { Arguments, CommandModule } from 'yargs';
+import { getSDK } from '@cardstack/cardpay-sdk';
+import Web3 from 'web3';
+const { fromWei } = Web3.utils;
+
+export default {
+  command: 'claim-reward-gas-estimate <rewardSafe> <leaf> <proof> [acceptPartialClaim]',
+  describe: 'Obtain a gas estimate to claim rewards to a reward safe',
+  builder(yargs: Argv) {
+    return yargs
+      .positional('rewardSafe', {
+        type: 'string',
+        description: 'The address of the rewardSafe which will receive the rewards',
+      })
+      .positional('leaf', {
+        type: 'string',
+        description: 'The encoded the encoded bytes of merkle tree',
+      })
+      .positional('proof', {
+        type: 'string',
+        description: 'The proof used to claim reward',
+      })
+      .option('acceptPartialClaim', {
+        type: 'boolean',
+        description: 'Boolean if user is fine to accept partial claim of reward',
+        default: false,
+      })
+      .option('network', NETWORK_OPTION_LAYER_2);
+  },
+  async handler(args: Arguments) {
+    let { network, rewardSafe, leaf, proof, acceptPartialClaim } = args as unknown as {
+      network: string;
+      rewardSafe: string;
+      leaf: string;
+      proof: string;
+      acceptPartialClaim: boolean;
+    };
+    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let rewardPool = await getSDK('RewardPool', web3);
+    let proofArray = fromProof(proof);
+    let estimate = await rewardPool.claimGasEstimate(rewardSafe, leaf, proofArray, acceptPartialClaim);
+    console.log(`The gas estimate for claiming reward to ${rewardSafe} is ${fromWei(estimate)} `);
+  },
+} as CommandModule;

--- a/packages/cardpay-cli/rewards/claim.ts
+++ b/packages/cardpay-cli/rewards/claim.ts
@@ -1,5 +1,6 @@
 import { Argv } from 'yargs';
 import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { fromProof } from './utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getSDK, getConstant } from '@cardstack/cardpay-sdk';
 
@@ -45,25 +46,3 @@ export default {
     console.log(`Claimed reward to safe ${rewardSafe}`);
   },
 } as CommandModule;
-
-const fromProof = (proof: string): any => {
-  if (proof == '0x') {
-    return [];
-  }
-  let bytesSize = 32;
-  let hexChunkSize = bytesSize * 2;
-  let hexStr = proof.replace('0x', '');
-  if (hexStr.length % hexChunkSize != 0) {
-    throw new Error('proof array is wrong size');
-  }
-  return chunkString(hexStr, hexChunkSize).map((s) => '0x' + s);
-};
-
-function chunkString(str: string, chunkSize: number) {
-  let arr = str.match(new RegExp('.{1,' + chunkSize + '}', 'g'));
-  if (arr) {
-    return arr;
-  } else {
-    throw new Error('proof cannot be converted to proof array  split properly');
-  }
-}

--- a/packages/cardpay-cli/rewards/index.ts
+++ b/packages/cardpay-cli/rewards/index.ts
@@ -9,6 +9,7 @@ import rewardBalances from './reward-balances';
 import transferSafe from './transfer-safe';
 import withdrawFromSafe from './withdraw-from-safe';
 import view from './view';
+import registerRewardeeGasEstimate from './register-rewardee-gas-estimate'
 
 export const command = 'rewards <command>';
 export const desc = 'Commands to get interact with the reward programs and the reward manager contract';
@@ -26,6 +27,7 @@ export const builder = function (yargs: Argv) {
       transferSafe,
       withdrawFromSafe,
       view,
+      registerRewardeeGasEstimate
     ] as any)
     .demandCommand(1, 'You must specify a valid subcommand');
 };

--- a/packages/cardpay-cli/rewards/index.ts
+++ b/packages/cardpay-cli/rewards/index.ts
@@ -9,7 +9,8 @@ import rewardBalances from './reward-balances';
 import transferSafe from './transfer-safe';
 import withdrawFromSafe from './withdraw-from-safe';
 import view from './view';
-import registerRewardeeGasEstimate from './register-rewardee-gas-estimate'
+import registerRewardeeGasEstimate from './register-rewardee-gas-estimate';
+import claimRewardGasEstimate from './claim-reward-gas-estimate';
 
 export const command = 'rewards <command>';
 export const desc = 'Commands to get interact with the reward programs and the reward manager contract';
@@ -27,7 +28,8 @@ export const builder = function (yargs: Argv) {
       transferSafe,
       withdrawFromSafe,
       view,
-      registerRewardeeGasEstimate
+      registerRewardeeGasEstimate,
+      claimRewardGasEstimate,
     ] as any)
     .demandCommand(1, 'You must specify a valid subcommand');
 };

--- a/packages/cardpay-cli/rewards/register-rewardee-gas-estimate.ts
+++ b/packages/cardpay-cli/rewards/register-rewardee-gas-estimate.ts
@@ -2,7 +2,7 @@ import { Argv } from 'yargs';
 import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts, FROM_OPTION } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
-import { fromWei} from 'web3-utils';
+import { fromWei } from 'web3-utils';
 
 export default {
   command: 'register-rewardee-gas-estimate <prepaidCard> <rewardProgramId>',
@@ -28,14 +28,10 @@ export default {
     };
     let web3 = await getWeb3(network, getWeb3Opts(args));
     let rewardManager = await getSDK('RewardManager', web3);
-    let estimate = await rewardManager.registerRewardeeGasEstimate(
-        prepaidCard, rewardProgramId
-    )
+    let estimate = await rewardManager.registerRewardeeGasEstimate(prepaidCard, rewardProgramId);
     console.log(
       `The gas estimate for registering a rewardee for ${rewardProgramId} is
-      ${fromWei(
-        estimate
-      )}`
+      ${fromWei(estimate)}`
     );
   },
 } as CommandModule;

--- a/packages/cardpay-cli/rewards/register-rewardee-gas-estimate.ts
+++ b/packages/cardpay-cli/rewards/register-rewardee-gas-estimate.ts
@@ -28,10 +28,9 @@ export default {
     };
     let web3 = await getWeb3(network, getWeb3Opts(args));
     let rewardManager = await getSDK('RewardManager', web3);
-    let estimate = await rewardManager.registerRewardeeGasEstimate(prepaidCard, rewardProgramId);
-    console.log(
-      `The gas estimate for registering a rewardee for ${rewardProgramId} is
-      ${fromWei(estimate)}`
-    );
+    let assets = await getSDK('Assets', web3);
+    let { gasToken, amount } = await rewardManager.registerRewardeeGasEstimate(prepaidCard, rewardProgramId);
+    let { symbol } = await assets.getTokenInfo(gasToken);
+    console.log(`The gas estimate for registering a rewardee is ${fromWei(amount)} ${symbol}`);
   },
 } as CommandModule;

--- a/packages/cardpay-cli/rewards/register-rewardee-gas-estimate.ts
+++ b/packages/cardpay-cli/rewards/register-rewardee-gas-estimate.ts
@@ -1,0 +1,41 @@
+import { Argv } from 'yargs';
+import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts, FROM_OPTION } from '../utils';
+import { Arguments, CommandModule } from 'yargs';
+import { getSDK } from '@cardstack/cardpay-sdk';
+import { fromWei} from 'web3-utils';
+
+export default {
+  command: 'register-rewardee-gas-estimate <prepaidCard> <rewardProgramId>',
+  describe: 'Obtain a gas estimate to register rewardee from prepaid card payments',
+  builder(yargs: Argv) {
+    return yargs
+      .positional('prepaidCard', {
+        type: 'string',
+        description: 'The address of the prepaid card that is being used to pay the merchant',
+      })
+      .positional('rewardProgramId', {
+        type: 'string',
+        description: 'Reward program id',
+      })
+      .option('from', FROM_OPTION)
+      .option('network', NETWORK_OPTION_LAYER_2);
+  },
+  async handler(args: Arguments) {
+    let { network, prepaidCard, rewardProgramId } = args as unknown as {
+      network: string;
+      prepaidCard: string;
+      rewardProgramId: string;
+    };
+    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let rewardManager = await getSDK('RewardManager', web3);
+    let estimate = await rewardManager.registerRewardeeGasEstimate(
+        prepaidCard, rewardProgramId
+    )
+    console.log(
+      `The gas estimate for registering a rewardee for ${rewardProgramId} is
+      ${fromWei(
+        estimate
+      )}`
+    );
+  },
+} as CommandModule;

--- a/packages/cardpay-cli/rewards/utils.ts
+++ b/packages/cardpay-cli/rewards/utils.ts
@@ -29,3 +29,25 @@ export function displayRewardProgramInfo(rewardProgramInfo: RewardProgramInfo): 
     console.log(`    ${tokenSymbol} : ${fromWei(balance)}`);
   });
 }
+
+export const fromProof = (proof: string): any => {
+  if (proof == '0x') {
+    return [];
+  }
+  let bytesSize = 32;
+  let hexChunkSize = bytesSize * 2;
+  let hexStr = proof.replace('0x', '');
+  if (hexStr.length % hexChunkSize != 0) {
+    throw new Error('proof array is wrong size');
+  }
+  return chunkString(hexStr, hexChunkSize).map((s) => '0x' + s);
+};
+
+function chunkString(str: string, chunkSize: number) {
+  let arr = str.match(new RegExp('.{1,' + chunkSize + '}', 'g'));
+  if (arr) {
+    return arr;
+  } else {
+    throw new Error('proof cannot be converted to proof array  split properly');
+  }
+}

--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -67,6 +67,7 @@ This is a package that provides an SDK to use the Cardpay protocol.
   - [`RewardManager.withdraw`](#rewardmanagerwithdraw)
   - [`RewardManager.addRewardRule`](#rewardmanageraddrewardrule)
   - [`RewardManager.getRewardProgramsInfo`](#rewardmanagergetrewardprogramsinfo)
+  - [`RewardManager.getRegisterRewardeeGasEstimate`](#rewardmanagergetregisterrewardeegasestimate)
 - [`LayerOneOracle`](#layeroneoracle)
   - [`LayerOneOracle.ethToUsd`](#layeroneoracleethtousd)
   - [LayerOneOracle.getEthToUsdConverter](#layeroneoraclegetethtousdconverter)
@@ -881,6 +882,22 @@ interface RewardProgramInfo {
 ```js
 let rewardManagerAPI = await getSDK('RewardManager', web3);
 await rewardManagerAPI.getRewardProgramsInfo()
+```
+
+### `RewardManager.getRegisterRewardeeGasEstimate`
+
+The `getRegisterRewardeeGasEstimate` returns a gas estimate for the prepaid card send transaction when registering a rewardee. 
+
+```ts
+interface GasEstimate {
+  gasToken: string 
+  amount: string; // tokens in unit of wei
+}
+```
+
+```js
+let rewardManagerAPI = await getSDK('RewardManager', web3);
+await rewardManagerAPI.getRegisterRewardeeGasEstimate(prepaidCard, rewardProgramId)
 ```
 
 ## `LayerOneOracle`

--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -764,13 +764,18 @@ The `Claim` API is used by the rewardee to claim rewards for a reward program id
 Pre-requisite for this action:
 - reward program has to be registered
 - rewardee has to register and create safe for that particular reward program. The funds will be claimed into this safe -- reward safe
-- rewardee must get an existing proof from tally api  -- look at `rewardPool.getProofs` 
+- rewardee must get an existing proof and leaf from tally api  -- look at `rewardPool.getProofs`
 - reward pool has to be filled with reward token for that reward program
 
 ```js
 let rewardPool = await getSDK('RewardPool', web3);
-await rewardPool.claim(safe, rewardProgramId, tokenAddress, proof,amount)
+await rewardPool.claim(safe, leaf, proofArray, acceptPartialClaim)
 ```
+
+The leaf item contains most information about the claim, such as the reward program (`rewardProgramId`), the expiry of the proof (`validFrom`, `validTo`), the type of token of the reward (`tokenType`, `transferData`), the eoa owner of the safe (`payee`). This information can be decoded easily. 
+
+`acceptPartialClaim` is a special scenario whereby a rewardee is willing to compromise his full reward compensation for a partial one. This scneario occurs, for example, when rewardee has 10 card in his proof but the reward pool only has 5 card, the rewardee may opt to just accepting that 5 card by setting `acceptPartialClaim=true`.
+
 
 ### `RewardPool.claimGasEstimate`
 

--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -771,6 +771,22 @@ let rewardPool = await getSDK('RewardPool', web3);
 await rewardPool.claim(safe, rewardProgramId, tokenAddress, proof,amount)
 ```
 
+### `RewardManager.getClaimGasEstimate`
+
+The `getClaimGasEstimate` returns a gas estimate a claim of a reward. The gas is paid out in tokens of the reward received. For example, if a person recieves 10 CARD, they will receive 10 CARD - (gas fees in CARD) into their reward safe. 
+
+```ts
+interface GasEstimate {
+  gasToken: string 
+  amount: string; // tokens in unit of wei
+}
+```
+
+```js
+let rewardManagerAPI = await getSDK('RewardManager', web3);
+await rewardManagerAPI.getClaimGasEstimate(rewardSafeAddress, leaf, proofArray, acceptPartialClaim)
+```
+
 ### `RewardPool.getProofs`
 
 The `GetProofs` API is used to retrieve proofs that are used to claim rewards from tally; proofs are similar arcade coupons that are collected to claim a prize. A proof can only be used by the EOA-owner; Once a proof is used it cannot be it will be `knownClaimed=true` and it cannot be re-used.
@@ -899,6 +915,7 @@ interface GasEstimate {
 let rewardManagerAPI = await getSDK('RewardManager', web3);
 await rewardManagerAPI.getRegisterRewardeeGasEstimate(prepaidCard, rewardProgramId)
 ```
+
 
 ## `LayerOneOracle`
 The `LayerOneOracle` API is used to get the current exchange rates in USD of ETH. This rate us fed by the Chainlink price feeds. Please supply a layer 1 web3 instance obtaining an `LayerOneOracle` API from `getSDK()`.

--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -57,17 +57,18 @@ This is a package that provides an SDK to use the Cardpay protocol.
   - [`RewardPool.addRewardTokens`](#rewardpooladdrewardtokens)
   - [`RewardPool.balances`](#rewardpoolbalances)
   - [`RewardPool.claim`](#rewardpoolclaim)
+  - [`RewardPool.claimGasEstimate`](#rewardpoolclaimgasestimate)
   - [`RewardPool.getProofs`](#rewardpoolgetproofs)
   - [`RewardPool.recoverTokens`](#rewardpoolrecovertokens)
 - [`RewardManager`](#rewardmanager)
   - [`RewardManager.registerRewardProgram`](#rewardmanagerregisterrewardprogram)
   - [`RewardManager.registerRewardee`](#rewardmanagerregisterrewardee)
+  - [`RewardManager.registerRewardeeGasEstimate`](#rewardmanagerregisterrewardeegasestimate)
   - [`RewardManager.lockRewardProgram`](#rewardmanagerlockrewardprogram)
   - [`RewardManager.updateRewardProgramAdmin`](#rewardmanagerupdaterewardprogramadmin)
   - [`RewardManager.withdraw`](#rewardmanagerwithdraw)
   - [`RewardManager.addRewardRule`](#rewardmanageraddrewardrule)
   - [`RewardManager.getRewardProgramsInfo`](#rewardmanagergetrewardprogramsinfo)
-  - [`RewardManager.getRegisterRewardeeGasEstimate`](#rewardmanagergetregisterrewardeegasestimate)
 - [`LayerOneOracle`](#layeroneoracle)
   - [`LayerOneOracle.ethToUsd`](#layeroneoracleethtousd)
   - [LayerOneOracle.getEthToUsdConverter](#layeroneoraclegetethtousdconverter)
@@ -771,7 +772,7 @@ let rewardPool = await getSDK('RewardPool', web3);
 await rewardPool.claim(safe, rewardProgramId, tokenAddress, proof,amount)
 ```
 
-### `RewardManager.getClaimGasEstimate`
+### `RewardPool.claimGasEstimate`
 
 The `getClaimGasEstimate` returns a gas estimate a claim of a reward. The gas is paid out in tokens of the reward received. For example, if a person recieves 10 CARD, they will receive 10 CARD - (gas fees in CARD) into their reward safe. 
 
@@ -900,9 +901,9 @@ let rewardManagerAPI = await getSDK('RewardManager', web3);
 await rewardManagerAPI.getRewardProgramsInfo()
 ```
 
-### `RewardManager.getRegisterRewardeeGasEstimate`
+### `RewardManager.registerRewardeeGasEstimate`
 
-The `getRegisterRewardeeGasEstimate` returns a gas estimate for the prepaid card send transaction when registering a rewardee. 
+The `registerRewardeeGasEstimate` returns a gas estimate for the prepaid card send transaction when registering a rewardee. 
 
 ```ts
 interface GasEstimate {
@@ -913,7 +914,7 @@ interface GasEstimate {
 
 ```js
 let rewardManagerAPI = await getSDK('RewardManager', web3);
-await rewardManagerAPI.getRegisterRewardeeGasEstimate(prepaidCard, rewardProgramId)
+await rewardManagerAPI.registerRewardeeGasEstimate(prepaidCard, rewardProgramId)
 ```
 
 

--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -779,7 +779,7 @@ The leaf item contains most information about the claim, such as the reward prog
 
 ### `RewardPool.claimGasEstimate`
 
-The `getClaimGasEstimate` returns a gas estimate a claim of a reward. The gas is paid out in tokens of the reward received. For example, if a person recieves 10 CARD, they will receive 10 CARD - (gas fees in CARD) into their reward safe. 
+The `claimGasEstimate` returns a gas estimate a claim of a reward. The gas is paid out in tokens of the reward received. For example, if a person recieves 10 CARD, they will receive 10 CARD - (gas fees in CARD) into their reward safe. 
 
 ```ts
 interface GasEstimate {
@@ -790,7 +790,7 @@ interface GasEstimate {
 
 ```js
 let rewardManagerAPI = await getSDK('RewardManager', web3);
-await rewardManagerAPI.getClaimGasEstimate(rewardSafeAddress, leaf, proofArray, acceptPartialClaim)
+await rewardManagerAPI.claimGasEstimate(rewardSafeAddress, leaf, proofArray, acceptPartialClaim)
 ```
 
 ### `RewardPool.getProofs`

--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -759,7 +759,7 @@ await rewardPool.balances(rewardProgramId)
 
 ### `RewardPool.claim`
 
-The `Claim` API is used by the rewardee to claim rewards for a reward program id.
+The `Claim` API is used by the rewardee to claim rewards from an associated reward program. 
 
 Pre-requisite for this action:
 - reward program has to be registered

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -20,7 +20,7 @@ import {
   gasEstimate,
   executeTransaction,
   Operation,
-  gasInToken
+  gasInToken,
 } from '../utils/safe-utils';
 import { Signature, signPrepaidCardSendTx } from '../utils/signing-utils';
 import BN from 'bn.js';
@@ -220,9 +220,8 @@ export default class RewardManager {
     );
     let issuingToken = (await prepaidCardManager.methods.cardDetails(prepaidCardAddress).call()).issueToken;
     let rateLock = await layerTwoOracle.getRateLock(issuingToken);
-    let payload = await this.getRegisterRewardeePayload(prepaidCardAddress, rewardProgramId, rateLock)
+    let payload = await this.getRegisterRewardeePayload(prepaidCardAddress, rewardProgramId, rateLock);
     return gasInToken(payload).toString();
-
   }
 
   async lockRewardProgram(txnHash: string): Promise<SuccessfulTransactionReceipt>;

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -224,7 +224,7 @@ export default class RewardManager {
     let payload = await this.getRegisterRewardeePayload(prepaidCardAddress, rewardProgramId, rateLock);
     return {
       gasToken: payload.gasToken,
-      amount: gasInToken(payload).toString(),
+      amount: gasInToken(payload),
     };
   }
 

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -21,6 +21,7 @@ import {
   executeTransaction,
   Operation,
   gasInToken,
+  GasEstimate,
 } from '../utils/safe-utils';
 import { Signature, signPrepaidCardSendTx } from '../utils/signing-utils';
 import BN from 'bn.js';
@@ -212,7 +213,7 @@ export default class RewardManager {
     };
   }
 
-  async registerRewardeeGasEstimate(prepaidCardAddress: string, rewardProgramId: string): Promise<string> {
+  async registerRewardeeGasEstimate(prepaidCardAddress: string, rewardProgramId: string): Promise<GasEstimate> {
     let layerTwoOracle = await getSDK('LayerTwoOracle', this.layer2Web3);
     let prepaidCardManager = new this.layer2Web3.eth.Contract(
       PrepaidCardManagerABI as AbiItem[],
@@ -221,7 +222,10 @@ export default class RewardManager {
     let issuingToken = (await prepaidCardManager.methods.cardDetails(prepaidCardAddress).call()).issueToken;
     let rateLock = await layerTwoOracle.getRateLock(issuingToken);
     let payload = await this.getRegisterRewardeePayload(prepaidCardAddress, rewardProgramId, rateLock);
-    return gasInToken(payload).toString();
+    return {
+      gasToken: payload.gasToken,
+      amount: gasInToken(payload).toString(),
+    };
   }
 
   async lockRewardProgram(txnHash: string): Promise<SuccessfulTransactionReceipt>;

--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -11,7 +11,14 @@ import { getConstant, ZERO_ADDRESS } from '../constants';
 import BN from 'bn.js';
 import ERC20ABI from '../../contracts/abi/erc-20';
 import ERC677ABI from '../../contracts/abi/erc-677';
-import { gasEstimate, executeTransaction, getNextNonceFromEstimate, Operation, gasInToken } from '../utils/safe-utils';
+import {
+  gasEstimate,
+  executeTransaction,
+  getNextNonceFromEstimate,
+  Operation,
+  gasInToken,
+  GasEstimate,
+} from '../utils/safe-utils';
 import { isTransactionHash, TransactionOptions, waitForSubgraphIndexWithTxnReceipt } from '../utils/general-utils';
 import type { SuccessfulTransactionReceipt } from '../utils/successful-transaction-receipt';
 import GnosisSafeABI from '../../contracts/abi/gnosis-safe';
@@ -424,7 +431,7 @@ The reward program ${rewardProgramId} has balance equals ${fromWei(
     leaf: string,
     proofArray: string[],
     acceptPartialClaim?: boolean
-  ): Promise<string> {
+  ): Promise<GasEstimate> {
     let payload = (await this.getRewardPool()).methods.claim(leaf, proofArray, acceptPartialClaim).encodeABI();
     let o: FullLeaf = this.decodeLeaf(leaf) as FullLeaf;
     if (!o.token) {
@@ -440,7 +447,10 @@ The reward program ${rewardProgramId} has balance equals ${fromWei(
       Operation.CALL,
       o.token
     );
-    return gasInToken(estimate).toString();
+    return {
+      gasToken: estimate.gasToken,
+      amount: gasInToken(estimate),
+    };
   }
 
   async recoverTokens(txnHash: string): Promise<SuccessfulTransactionReceipt>;

--- a/packages/cardpay-sdk/sdk/utils/safe-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/safe-utils.ts
@@ -30,7 +30,7 @@ export interface SendPayload extends Estimate {
 }
 
 export interface GasEstimate {
-  amount: string;
+  amount: BN;
   gasToken: string;
 }
 

--- a/packages/cardpay-sdk/sdk/utils/safe-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/safe-utils.ts
@@ -29,6 +29,11 @@ export interface SendPayload extends Estimate {
   data: any;
 }
 
+export interface GasEstimate {
+  amount: string;
+  gasToken: string;
+}
+
 export enum Operation {
   CALL = 0,
   DELEGATECALL = 1,


### PR DESCRIPTION
This pr adds two gas estimation methods for our rewards sdk:
- `claimGasEstimate`: Estimates the gas tokens needed for a reward claim. The gas consumed by this is from a generic safe transaction, the code mirrors that of `claimGasEsimate` for [merchant claims](https://github.com/cardstack/cardstack/blob/add-rewards-gas-estimation/packages/cardpay-sdk/sdk/revenue-pool/base.ts#L74-L96 ).                                                                                                                        
- `registerRewardeeGasEstimate`: Estimates the gas tokens needed for registering a rewardee with a prepaid card. This is a new way to estimate for gas because it uses a prepaid card send transaction. We obtain the estimate from the [`getSendPayload method`](https://github.com/cardstack/cardstack/blob/e8dff01e97bb8975a497058714e9c21c0d6aed28/packages/cardpay-sdk/sdk/utils/safe-utils.ts#L145-L173)