### PR TITLE
Adding isValid for proofs 

### DIFF
--- a/packages/cardpay-cli/rewards/claimable-proofs.ts
+++ b/packages/cardpay-cli/rewards/claimable-proofs.ts
@@ -7,7 +7,7 @@ import { fromWei } from 'web3-utils';
 
 export default {
   command: 'claimable-proofs <address>',
-  describe: 'View proofs that are claimable. It will also display expired proofs',
+  describe: 'View proofs that are claimable',
   builder(yargs: Argv) {
     return yargs
       .positional('address', {
@@ -24,7 +24,7 @@ export default {
       })
       .option('isValidOnly', {
         type: 'boolean',
-        description: 'Filter only for proofs which are valid, i.e. validFrom <= currentBlock < validTo',
+        description: 'Filter proofs which are valid, i.e. validFrom <= currentBlock < validTo',
       })
       .option('network', NETWORK_OPTION_LAYER_2);
   },

--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -72,8 +72,7 @@ export default class RewardPool {
   constructor(private layer2Web3: Web3) {}
 
   async getBalance(address: string, tokenAddress: string, rewardProgramId?: string): Promise<BN> {
-    const unclaimedProofs = await this.getProofs(address, rewardProgramId, tokenAddress, false);
-    const unclaimedValidProofs = unclaimedProofs.filter((o) => {
+    const unclaimedValidProofs = (await this.getProofs(address, rewardProgramId, tokenAddress, false)).filter((o) => {
       o.isValid;
     });
     return unclaimedValidProofs.reduce((total, { amount }) => {
@@ -178,8 +177,7 @@ export default class RewardPool {
   }
 
   async rewardTokenBalances(address: string, rewardProgramId?: string): Promise<WithSymbol<RewardTokenBalance>[]> {
-    let unclaimedProofs = await this.getProofs(address, rewardProgramId, undefined, false);
-    const unclaimedValidProofs = unclaimedProofs.filter((o) => {
+    const unclaimedValidProofs = (await this.getProofs(address, rewardProgramId, undefined, false)).filter((o) => {
       o.isValid;
     });
     let tokenBalances = unclaimedValidProofs.map((o: Proof) => {


### PR DESCRIPTION
Adding `Proof` flag `isValid`. A proof `isValid` when `validFrom<= currentBlock < validTo`. [See here](https://github.com/cardstack/card-pay-protocol/blob/58c3d0a6e99a1f9fa1895d701318a420c55e58b6/contracts/RewardPool.sol#L118)

- All balance functions `rewardTokenBalances` and `getBalance` will compute balance only for proofs which are `isValid`
- `getProofs` will return proofs with the flag
- cli adds a `isValidOnly` flag that allows you to filter proofs via the `claimable-proofs` command
