### PR TITLE
add a responsive degraded service banner to the pay page

### DIFF
--- a/packages/ssr-web/app/components/card-pay/merchant-payment-request-header/index.css
+++ b/packages/ssr-web/app/components/card-pay/merchant-payment-request-header/index.css
@@ -2,6 +2,8 @@
   --boxel-org-header-background-color: none;
   --card-pay-logo-size: 2.5rem;
   --card-pay-logo-position: left center;
+
+  margin-top: var(--boxel-sp);
 }
 
 .merchant-payment-request-header__links {
@@ -22,12 +24,22 @@
   display: none;
 }
 
+.merchant-payment-request-header__degraded-service-banner--small {
+  display: none;
+}
+
 @media only screen and (max-width: 480px) {
-  .merchant-payment-request-header__links {
+  .merchant-payment-request-header__links,
+  .merchant-payment-request-header__degraded-service-banner--regular {
     display: none;
   }
 
   .merchant-payment-request-header__hamburger {
     display: initial;
+  }
+
+  .merchant-payment-request-header__degraded-service-banner--small {
+    display: flex;
+    margin-top: var(--boxel-sp-xs);
   }
 }

--- a/packages/ssr-web/app/components/card-pay/merchant-payment-request-header/index.hbs
+++ b/packages/ssr-web/app/components/card-pay/merchant-payment-request-header/index.hbs
@@ -3,45 +3,63 @@
   <meta property='og:image' content={{this.cardPayLogoPng}} />
   <meta name='twitter:image' content={{this.cardPayLogoPng}} />
 </InHead>
-<Boxel::OrgHeader
-  class="merchant-payment-request-header"
-  @iconURL={{this.cardPayLogo}}
-  @title="Card Pay"
-  style={{css-var
-    boxel-org-header-logo-size="var(--card-pay-logo-size)"
-    boxel-org-header-logo-position="var(--card-pay-logo-position)"
-    boxel-org-header-padding="0"
-  }}
->
-  <div class="merchant-payment-request-header__links-container">
-    <ul class="merchant-payment-request-header__links">
-      <li>
-        <a href={{config 'urls.about'}}>
-          About
-        </a>
-      </li>
-      <li>
-        <a href={{config 'urls.mailToSupportUrl'}}>
-          Help
-        </a>
-      </li>
-    </ul>
-    <CardPay::HamburgerMenu
-      class="merchant-payment-request-header__hamburger"
-      @headerIconURL={{this.cardPayLogo}}
-      @headerTitle="Card Pay"
-      @open={{this.hamburgerMenuOpen}}
-      @onOpen={{fn (mut this.hamburgerMenuOpen) true}}
-      @onClose={{fn (mut this.hamburgerMenuOpen) false}}
-    >
-      <:body as |MenuItem|>
-        <MenuItem @url={{config 'urls.about'}}>
-          About
-        </MenuItem>
-        <MenuItem @url={{config 'urls.mailToSupportUrl'}}>
-          Help
-        </MenuItem>
-      </:body>
-    </CardPay::HamburgerMenu>
-  </div>
-</Boxel::OrgHeader>
+{{!--
+  control via css whether we want to show a degraded service banner
+  on top (big screens) or below (small screens) when there is an incident.
+  showing on top is to be aligned with behaviour on other large screens on web
+  showing below is because it respects the navbar + the hamburger menu pattern
+  where the x is at the same spot as the hamburger.
+  hence this must use the same breakpoint as the hamburger
+--}}
+<div>
+  <Common::DegradedServiceBanner
+    @size="regular"
+    class="merchant-payment-request-header__degraded-service-banner--regular"
+  />
+  <Boxel::OrgHeader
+    class="merchant-payment-request-header"
+    @iconURL={{this.cardPayLogo}}
+    @title="Card Pay"
+    style={{css-var
+      boxel-org-header-logo-size="var(--card-pay-logo-size)"
+      boxel-org-header-logo-position="var(--card-pay-logo-position)"
+      boxel-org-header-padding="0"
+    }}
+  >
+    <div class="merchant-payment-request-header__links-container">
+      <ul class="merchant-payment-request-header__links">
+        <li>
+          <a href={{config 'urls.about'}}>
+            About
+          </a>
+        </li>
+        <li>
+          <a href={{config 'urls.mailToSupportUrl'}}>
+            Help
+          </a>
+        </li>
+      </ul>
+      <CardPay::HamburgerMenu
+        class="merchant-payment-request-header__hamburger"
+        @headerIconURL={{this.cardPayLogo}}
+        @headerTitle="Card Pay"
+        @open={{this.hamburgerMenuOpen}}
+        @onOpen={{fn (mut this.hamburgerMenuOpen) true}}
+        @onClose={{fn (mut this.hamburgerMenuOpen) false}}
+      >
+        <:body as |MenuItem|>
+          <MenuItem @url={{config 'urls.about'}}>
+            About
+          </MenuItem>
+          <MenuItem @url={{config 'urls.mailToSupportUrl'}}>
+            Help
+          </MenuItem>
+        </:body>
+      </CardPay::HamburgerMenu>
+    </div>
+  </Boxel::OrgHeader>
+  <Common::DegradedServiceBanner
+    @size="small"
+    class="merchant-payment-request-header__degraded-service-banner--small"
+  />
+</div>

--- a/packages/ssr-web/app/components/common/degraded-service-banner/index.css
+++ b/packages/ssr-web/app/components/common/degraded-service-banner/index.css
@@ -14,6 +14,7 @@
   max-width: var(--degraded-service-banner-content-max-width, 80ch);
   margin: auto;
   display: flex;
+  align-items: center;
   width: 100%;
 }
 
@@ -23,6 +24,7 @@
   display: flex;
   align-items: center;
   width: var(--degraded-service-banner-icon-area-width);
+  height: var(--degraded-service-banner-icon-area-width);
   margin-right: var(--boxel-sp-xxs);
 }
 

--- a/packages/ssr-web/app/components/common/degraded-service-banner/index.css
+++ b/packages/ssr-web/app/components/common/degraded-service-banner/index.css
@@ -4,20 +4,17 @@
   --icon-background-color: var(--degraded-service-banner-text-color);
   --icon-color: var(--degraded-service-banner-background-color);
 
-  width: 100%;
   min-height: 2rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: var(--boxel-sp-xxs);
   font: 600 var(--boxel-font-sm);
   background: var(--degraded-service-banner-background-color);
   color: var(--degraded-service-banner-text-color);
 }
 
 .degraded-service-banner__container {
-  max-width: calc(var(--degraded-service-banner-icon-area-width) + 80ch);
+  max-width: var(--degraded-service-banner-content-max-width, 80ch);
+  margin: auto;
   display: flex;
+  width: 100%;
 }
 
 .degraded-service-banner__icon-area {
@@ -26,6 +23,7 @@
   display: flex;
   align-items: center;
   width: var(--degraded-service-banner-icon-area-width);
+  margin-right: var(--boxel-sp-xxs);
 }
 
 .degraded-service-banner__container a {
@@ -39,8 +37,4 @@
 .degraded-service-banner.degraded-service-banner--severe {
   --degraded-service-banner-text-color: var(--boxel-light);
   --degraded-service-banner-background-color: var(--boxel-red);
-}
-
-.degraded-service-banner__icon {
-  margin-right: var(--boxel-sp-xxs);
 }

--- a/packages/ssr-web/app/components/common/degraded-service-banner/index.hbs
+++ b/packages/ssr-web/app/components/common/degraded-service-banner/index.hbs
@@ -1,18 +1,17 @@
 {{#if this.notificationShown}}
-  <div
-    class={{cn "degraded-service-banner" degraded-service-banner--severe=this.isSevere}}
-    data-test-degraded-service-banner
-    ...attributes
-  >
-    <div class="degraded-service-banner__container">
-      <div class="degraded-service-banner__icon-area">
-        {{svg-jar "failure-bordered" class="degraded-service-banner__icon"}}
-      </div>
-
-      <div>
-        {{this.notificationBody}}
-        For more details, check our <a href={{config 'urls.statusPageBase'}} target="_blank" rel="noopener noreferrer">status page</a>.
-      </div>
-    </div>
-  </div>
+  {{#if (or (not @size) (eq @size "regular"))}}
+    <Common::DegradedServiceBanner::Regular
+      @isSevere={{this.isSevere}}
+      @title={{this.title}}
+      @body={{this.body}}
+      ...attributes
+    />
+  {{else if (eq @size "small")}}
+    <Common::DegradedServiceBanner::Small
+      @isSevere={{this.isSevere}}
+      @title={{this.title}}
+      @body={{this.body}}
+      ...attributes
+    />
+  {{/if}}
 {{/if}}

--- a/packages/ssr-web/app/components/common/degraded-service-banner/index.ts
+++ b/packages/ssr-web/app/components/common/degraded-service-banner/index.ts
@@ -8,8 +8,7 @@ export default class DegradedServiceBannerComponent extends Component {
 
   @reads('degradedServiceDetector.notificationShown')
   declare notificationShown: boolean;
-  @reads('degradedServiceDetector.notificationBody') declare notificationBody:
-    | string
-    | null;
+  @reads('degradedServiceDetector.body') declare body: string | null;
+  @reads('degradedServiceDetector.title') declare title: string | null;
   @reads('degradedServiceDetector.isSevere') declare isSevere: boolean;
 }

--- a/packages/ssr-web/app/components/common/degraded-service-banner/regular/index.css
+++ b/packages/ssr-web/app/components/common/degraded-service-banner/regular/index.css
@@ -1,0 +1,10 @@
+/* full bleed styling https://css-tricks.com/full-bleed/ */
+.degraded-service-banner--regular {
+  position: relative;
+  width: 100vw;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
+  padding: var(--boxel-sp-xxxs) var(--boxel-sp);
+}

--- a/packages/ssr-web/app/components/common/degraded-service-banner/regular/index.hbs
+++ b/packages/ssr-web/app/components/common/degraded-service-banner/regular/index.hbs
@@ -1,0 +1,16 @@
+<div
+  class={{cn "degraded-service-banner" "degraded-service-banner--regular" degraded-service-banner--severe=@isSevere}}
+  data-test-degraded-service-banner
+  ...attributes
+>
+  <div class="degraded-service-banner__container">
+    <div class="degraded-service-banner__icon-area">
+      {{svg-jar "failure-bordered" class="degraded-service-banner__icon"}}
+    </div>
+
+    <div>
+      {{@title}}{{if @body (concat ": " @body)}}
+      For more details, check our <a href={{config 'urls.statusPageBase'}} target="_blank" rel="noopener noreferrer">status page</a>.
+    </div>
+  </div>
+</div>

--- a/packages/ssr-web/app/components/common/degraded-service-banner/small/index.css
+++ b/packages/ssr-web/app/components/common/degraded-service-banner/small/index.css
@@ -1,0 +1,4 @@
+.degraded-service-banner--small {
+  border-radius: 8px;
+  padding: var(--boxel-sp-xxxs);
+}

--- a/packages/ssr-web/app/components/common/degraded-service-banner/small/index.hbs
+++ b/packages/ssr-web/app/components/common/degraded-service-banner/small/index.hbs
@@ -1,0 +1,13 @@
+<a
+  class={{cn "degraded-service-banner" "degraded-service-banner--small" degraded-service-banner--severe=@isSevere}}
+  href={{config 'urls.statusPageBase'}} target="_blank" rel="noopener noreferrer"
+  data-test-degraded-service-banner="small"
+  ...attributes
+>
+  <div class="degraded-service-banner__container">
+    <div class="degraded-service-banner__icon-area">
+      {{svg-jar "failure-bordered" class="degraded-service-banner__icon"}}
+    </div>
+    {{@title}}
+  </div>
+</a>

--- a/packages/ssr-web/app/css/pay.css
+++ b/packages/ssr-web/app/css/pay.css
@@ -1,9 +1,12 @@
 .merchant-payment-request-page {
+  --page-content-max-width: 720px;
+  --degraded-service-banner-content-max-width: var(--page-content-max-width);
+
   position: relative;
   min-height: 100%;
   display: grid;
   grid-template-rows: auto 1fr;
-  grid-template-columns: minmax(200px, 720px);
+  grid-template-columns: minmax(200px, var(--page-content-max-width));
   gap: var(--boxel-sp);
   align-items: center;
   justify-content: center;
@@ -12,7 +15,7 @@
   font: var(--boxel-font);
   letter-spacing: var(--boxel-lsp-lg);
   z-index: 0;
-  padding: var(--boxel-sp) var(--boxel-sp) var(--boxel-sp-xxxl) var(--boxel-sp);
+  padding: 0 var(--boxel-sp) var(--boxel-sp-xxxl) var(--boxel-sp);
 }
 
 .merchant-payment-request-page__merchant-missing-message {

--- a/packages/ssr-web/app/services/degraded-service-detector.ts
+++ b/packages/ssr-web/app/services/degraded-service-detector.ts
@@ -7,7 +7,8 @@ import * as Sentry from '@sentry/browser';
 
 export default class DegradedServiceDetector extends Service {
   @tracked notificationShown: boolean = false;
-  @tracked notificationBody: string | null = null;
+  @tracked title: string | null = null;
+  @tracked body: string | null = null;
   @tracked impact: 'none' | 'minor' | 'major' | 'critical' | null = null;
 
   statusPageUrl = config.urls.statusPageUrl;
@@ -28,10 +29,12 @@ export default class DegradedServiceDetector extends Service {
       if (statusData) {
         this.notificationShown = true;
         this.impact = statusData.impact;
-        this.notificationBody = statusData.name;
+        this.title = statusData.title;
+        this.body = statusData.body;
       } else {
         this.notificationShown = false;
-        this.notificationBody = null;
+        this.title = null;
+        this.body = null;
         this.impact = null;
       }
 
@@ -88,7 +91,8 @@ export default class DegradedServiceDetector extends Service {
 
     return {
       status: incident.status,
-      name: `${incident.name}: ${this.addPunctuation(lastUpdate.body)}`,
+      title: incident.name,
+      body: this.addPunctuation(lastUpdate.body),
       impact: incident.impact,
     };
   }
@@ -120,7 +124,8 @@ type StatuspageIncidentOrMaintenance = {
 };
 
 type Incident = {
-  name: string;
   impact: string;
   status: string;
+  title: string;
+  body: string;
 };

--- a/packages/ssr-web/tests/acceptance/pay-test.ts
+++ b/packages/ssr-web/tests/acceptance/pay-test.ts
@@ -766,8 +766,6 @@ module('Acceptance | pay', function (hooks) {
       await waitFor(MERCHANT_MISSING_MESSAGE);
 
       assert.dom('[data-test-degraded-service-banner]').isVisible({ count: 1 });
-
-      await percySnapshot(assert);
     });
   });
 });

--- a/packages/ssr-web/tests/acceptance/pay-test.ts
+++ b/packages/ssr-web/tests/acceptance/pay-test.ts
@@ -719,4 +719,55 @@ module('Acceptance | pay', function (hooks) {
 
     assert.dom('[data-test-error]').includesText('404: Not Found');
   });
+
+  module('status page incidents', function () {
+    test('it renders a degraded service banner on the pay page', async function (this: MirageTestContext, assert) {
+      this.server.get(config.urls.statusPageUrl, function () {
+        return new MirageResponse(
+          200,
+          {},
+          {
+            incidents: [
+              {
+                name: 'Name',
+                impact: 'major',
+                incident_updates: [{ body: 'We are experiencing issues' }],
+              },
+            ],
+          }
+        );
+      });
+
+      await visit(`/pay/${network}/${merchantSafe.address}`);
+
+      assert.dom('[data-test-degraded-service-banner]').isVisible({ count: 1 });
+
+      await percySnapshot(assert);
+    });
+
+    test('it renders a degraded service banner on the pay error page', async function (this: MirageTestContext, assert) {
+      this.server.get(config.urls.statusPageUrl, function () {
+        return new MirageResponse(
+          200,
+          {},
+          {
+            incidents: [
+              {
+                name: 'Name',
+                impact: 'major',
+                incident_updates: [{ body: 'We are experiencing issues' }],
+              },
+            ],
+          }
+        );
+      });
+
+      await visit(`/pay/sok`);
+      await waitFor(MERCHANT_MISSING_MESSAGE);
+
+      assert.dom('[data-test-degraded-service-banner]').isVisible({ count: 1 });
+
+      await percySnapshot(assert);
+    });
+  });
 });

--- a/packages/ssr-web/tests/integration/components/degraded-service-banner-test.ts
+++ b/packages/ssr-web/tests/integration/components/degraded-service-banner-test.ts
@@ -227,4 +227,32 @@ module('Integration | Component | degraded-service-banner', function (hooks) {
         'Name: We are experiencing issues. For more details, check our status page'
       );
   });
+
+  test('it can display the small size', async function (this: Context, assert) {
+    this.server.get(statusPageUrl, function () {
+      return new MirageResponse(
+        200,
+        {},
+        {
+          incidents: [
+            {
+              name: 'Name',
+              impact: 'major',
+              incident_updates: [{ body: 'We are experiencing issues' }],
+            },
+          ],
+        }
+      );
+    });
+
+    await render(hbs`<Common::DegradedServiceBanner @size="small" />`);
+    await waitFor('[data-test-degraded-service-banner="small"]');
+    assert
+      .dom('[data-test-degraded-service-banner]')
+      .hasAttribute('href', config.urls.statusPageBase);
+    assert.dom('[data-test-degraded-service-banner]').containsText('Name');
+    assert
+      .dom('[data-test-degraded-service-banner]')
+      .doesNotContainText('We are experiencing issues');
+  });
 });


### PR DESCRIPTION
On the smaller screen, the entire banner is a link and we only display the incident's name, similar to the mobile app. It's placed below the hamburger because having the hamburger's X and the hamburger button in the same place seems good - having the degraded service banner appear on top will push the hamburger down meaning that it would be lower than the X. On the large screen, we're conforming to the DApp's way of displaying a degraded service banner.

Yet to get design feedback. This aims to solve CS-3431 for the pay page.

<img width="383" alt="small screen pay error page with a notice about degraded service below the top navbar." src="https://user-images.githubusercontent.com/39579264/160102309-295106ce-253f-40b6-9329-b076e2fb9925.png">

<img width="1386" alt="large screen pay error page with a notice about degraded service above the top navbar, at the top of the screen." src="https://user-images.githubusercontent.com/39579264/160102356-cb3e2e1c-fc4c-43ec-b480-44025e95c301.png">
