### PR TITLE
Compiler simplifications

### DIFF
--- a/packages/core/src/analyze.ts
+++ b/packages/core/src/analyze.ts
@@ -66,7 +66,7 @@ function getMeta(obj: State['opts']): FileMeta {
   return meta;
 }
 
-export default function (source: string): {
+export default function analyzeCardModule(source: string): {
   code: BabelFileResult['code'];
   ast: BabelFileResult['ast'];
   meta: FileMeta;

--- a/packages/core/src/babel-plugin-card-schema-transform.ts
+++ b/packages/core/src/babel-plugin-card-schema-transform.ts
@@ -3,7 +3,7 @@ import type { types as t } from '@babel/core';
 import { NodePath } from '@babel/traverse';
 import { ImportUtil } from 'babel-import-util';
 import { error, unusedClassMember } from './utils/babel';
-import { FieldMeta, FileMeta, VALID_FIELD_DECORATORS } from './babel-plugin-card-file-analyze';
+import { FieldMeta, FileMeta, VALID_FIELD_DECORATORS } from './analyze';
 import { CompiledCard, ComponentInfo, Field, ModuleRef } from './interfaces';
 import camelCase from 'lodash/camelCase';
 import upperFirst from 'lodash/upperFirst';

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -7,7 +7,7 @@ import isEqual from 'lodash/isEqual';
 import partition from 'lodash/partition';
 import differenceWith from 'lodash/differenceWith';
 
-import analyzeFileBabelPlugin, { ExportMeta, FileMeta } from './babel-plugin-card-file-analyze';
+import analyzeCardModule, { ExportMeta, FileMeta } from './analyze';
 import cardSchemaTransformPlugin, { Options } from './babel-plugin-card-schema-transform';
 import transformCardComponent from './babel-plugin-card-template';
 import {
@@ -257,7 +257,7 @@ export class Compiler<Identity extends Saved | Unsaved = Saved> {
         source,
       };
     } else {
-      let { code, ast, meta } = analyzeFileBabelPlugin(source);
+      let { code, ast, meta } = analyzeCardModule(source);
 
       return {
         type: 'js',

--- a/packages/core/src/glimmer-plugin-component-analyze.ts
+++ b/packages/core/src/glimmer-plugin-component-analyze.ts
@@ -24,27 +24,32 @@ type ScopeValue =
   | { type: 'stringLiteral'; value: string }
   | { type: 'pathExpression'; value: string };
 
-export default function glimmerTemplateAnalyze(source: string, options: Options) {
+export default function glimmerTemplateAnalyze(
+  source: string,
+  debugPath: string
+): Pick<ComponentMeta, 'fields' | 'model'> {
+  let output: Pick<ComponentMeta, 'fields' | 'model'> = {
+    fields: new Map(),
+    model: new Set(),
+  };
   try {
-    return syntax.print(
-      syntax.preprocess(source, {
-        mode: 'codemod',
-        plugins: {
-          ast: [cardTransformPlugin(options)],
-        },
-        meta: {
-          moduleName: options.debugPath,
-        },
-      })
-    );
+    syntax.preprocess(source, {
+      mode: 'codemod',
+      plugins: {
+        ast: [cardTransformPlugin(output)],
+      },
+      meta: {
+        moduleName: debugPath,
+      },
+    });
   } catch (error: any) {
     throw augmentBadRequest(error);
   }
+  return output;
 }
 
-export function cardTransformPlugin(options: Options): syntax.ASTPluginBuilder {
+export function cardTransformPlugin(meta: Pick<ComponentMeta, 'fields' | 'model'>): syntax.ASTPluginBuilder {
   return function transform(_env: syntax.ASTPluginEnvironment): syntax.ASTPlugin {
-    let { meta } = options;
     let handledPathExpressions: HandledPathExpressions = new WeakSet();
     let scopeTracker = new ScopeTracker<ScopeValue>();
 

--- a/packages/hub/node-tests/@core/analyze-test.ts
+++ b/packages/hub/node-tests/@core/analyze-test.ts
@@ -1,10 +1,10 @@
-import cardAnalyze, { ExportMeta } from '@cardstack/core/src/babel-plugin-card-file-analyze';
+import cardAnalyze, { ExportMeta } from '@cardstack/core/src/analyze';
 import { analyzeComponent as fullAnalyzeComponent } from '@cardstack/core/src/babel-plugin-card-template';
 import { InvalidFieldsUsageError, InvalidModelUsageError } from '@cardstack/core/src/glimmer-plugin-component-analyze';
 import { templateOnlyComponentTemplate } from '@cardstack/core/tests/helpers';
 
 if (process.env.COMPILER) {
-  describe('BabelPluginCardAnalyze', function () {
+  describe('card analyze', function () {
     it('Returns empty meta information when there is nothing of note in the file', function () {
       let source = `function serializer() {}`;
       let out = cardAnalyze(source);
@@ -153,7 +153,7 @@ if (process.env.COMPILER) {
     });
   });
 
-  describe('BabelPluginCardAnalyze components', function () {
+  describe('card analyze: components', function () {
     function analyzeComponent(template: string) {
       return fullAnalyzeComponent(templateOnlyComponentTemplate(template), 'test.js');
     }


### PR DESCRIPTION
Some followups to recent PRs:
 - flattens two types into one type
 - avoids unnecessary use of side effects
 - renames babel-plugin-card-file-analyze because it's public API has nothing to do with babel plugins 