### PR TITLE
Retro airdrop, adds test accounts

### DIFF
--- a/.github/workflows/pr-cardpay-reward-programs.yml
+++ b/.github/workflows/pr-cardpay-reward-programs.yml
@@ -25,8 +25,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pdm setuptools
+          python -m pip install --upgrade pdm
           pdm install -d
       - name: Test with pytest
         run: |
-          pdm run pytest tests
+          pdm run -s pytest tests

--- a/.github/workflows/pr-cardpay-reward-programs.yml
+++ b/.github/workflows/pr-cardpay-reward-programs.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pdm
+          python -m pip install --upgrade pdm setuptools
           pdm install -d
       - name: Test with pytest
         run: |

--- a/packages/cardpay-reward-programs/cardpay_reward_programs/rules/retro_airdrop.py
+++ b/packages/cardpay-reward-programs/cardpay_reward_programs/rules/retro_airdrop.py
@@ -1,5 +1,4 @@
 import pandas as pd
-from cardpay_reward_programs.config import default_payment_list
 from cardpay_reward_programs.rule import Rule
 
 
@@ -19,14 +18,14 @@ class RetroAirdrop(Rule):
         duration,
         start_snapshot_block,
         end_snapshot_block,
-        excluded_accounts
+        test_accounts
     ):
         self.token = token
         self.duration = duration
         self.total_reward = total_reward
         self.start_snapshot_block = start_snapshot_block
         self.end_snapshot_block = end_snapshot_block
-        self.excluded_accounts = set(account.lower() for account in excluded_accounts)
+        self.test_accounts = set(account.lower() for account in test_accounts)
 
     def sql(self, table_query):
         return f"""
@@ -49,7 +48,7 @@ class RetroAirdrop(Rule):
     def df_to_payment_list(
         self, df, payment_cycle, reward_program_id
     ):
-        mask = df['payee'].str.lower().isin(self.excluded_accounts)
+        mask = df['payee'].str.lower().isin(self.test_accounts)
         new_df = df[~mask].copy()
         reward_per_transaction = int(self.total_reward // new_df["transactions"].sum())
         new_df["rewardProgramID"] = reward_program_id

--- a/packages/cardpay-reward-programs/pdm.lock
+++ b/packages/cardpay-reward-programs/pdm.lock
@@ -852,7 +852,7 @@ summary = "Send file to trash natively under Mac OS X, Windows and Linux."
 
 [[package]]
 name = "setuptools"
-version = "61.0.0"
+version = "61.2.0"
 requires_python = ">=3.7"
 summary = "Easily download, build, install, upgrade, and uninstall Python packages"
 
@@ -1041,7 +1041,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "3.1"
-content_hash = "sha256:b3bbc21db0d6f67c129969196cc1e758def88e0412e1d2dfbbc8c1a90d003c41"
+content_hash = "sha256:f88bffbe36a3656ca87390a82865e6cd7edc5eac347a70ac2cd5bb0805be2a59"
 
 [metadata.files]
 "altair 4.2.0" = [
@@ -1902,9 +1902,9 @@ content_hash = "sha256:b3bbc21db0d6f67c129969196cc1e758def88e0412e1d2dfbbc8c1a90
     {file = "Send2Trash-1.8.0-py3-none-any.whl", hash = "sha256:f20eaadfdb517eaca5ce077640cb261c7d2698385a6a0f072a4a5447fd49fa08"},
     {file = "Send2Trash-1.8.0.tar.gz", hash = "sha256:d2c24762fd3759860a0aff155e45871447ea58d2be6bdd39b5c8f966a0c99c2d"},
 ]
-"setuptools 61.0.0" = [
-    {file = "setuptools-61.0.0-py3-none-any.whl", hash = "sha256:ad88b13f3dc60420259c9877486908ddad12c7befaff0d624c7190f742abd64f"},
-    {file = "setuptools-61.0.0.tar.gz", hash = "sha256:6221e37dc86fcdc9dad9d9eb2002e9f9798fe4aca1bf18f280e66e50c0eb7fca"},
+"setuptools 61.2.0" = [
+    {file = "setuptools-61.2.0-py3-none-any.whl", hash = "sha256:8f4813dd6a4d6cc17bde85fb2e635fe19763f96efbb0ddf5575562e5ee0bc47a"},
+    {file = "setuptools-61.2.0.tar.gz", hash = "sha256:c3d4e2ab578fbf83775755cd76dae73627915a22832cf4ea5de895978767833b"},
 ]
 "six 1.16.0" = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/packages/cardpay-reward-programs/pdm.lock
+++ b/packages/cardpay-reward-programs/pdm.lock
@@ -1041,7 +1041,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "3.1"
-content_hash = "sha256:f88bffbe36a3656ca87390a82865e6cd7edc5eac347a70ac2cd5bb0805be2a59"
+content_hash = "sha256:b3bbc21db0d6f67c129969196cc1e758def88e0412e1d2dfbbc8c1a90d003c41"
 
 [metadata.files]
 "altair 4.2.0" = [

--- a/packages/cardpay-reward-programs/tests/rules/test_retro_airdrop.py
+++ b/packages/cardpay-reward-programs/tests/rules/test_retro_airdrop.py
@@ -18,12 +18,12 @@ summaries = [
 
 payment_cycle_length_ls = [1024, 1024 * 32, 1024 * 512]
 total_reward_ls = [6_000_000 * 1_000_000_000_000_000_000]
-excluded_accounts_ls = [[]]
+test_accounts_ls = [[]]
 
 
 @pytest.fixture
 def rule(request):
-    payment_cycle_length, total_reward, excluded_accounts = request.param
+    payment_cycle_length, total_reward, test_accounts = request.param
     core_config = {
         "start_block": 23592960,
         "end_block": 24859648,
@@ -38,7 +38,7 @@ def rule(request):
         "duration": 43200,
         "start_snapshot_block": 23592960,
         "end_snapshot_block": 24859648,
-        "excluded_accounts": excluded_accounts,
+        "test_accounts": test_accounts,
     }
     return RetroAirdrop(core_config, user_config)
 
@@ -48,7 +48,7 @@ class TestRetroAirdropSingle:
         "rule,summary",
         zip(
             itertools.product(
-                payment_cycle_length_ls, total_reward_ls, excluded_accounts_ls
+                payment_cycle_length_ls, total_reward_ls, test_accounts_ls
             ),
             summaries,
         ),

--- a/packages/cardpay-reward-programs/tests/rules/test_retro_airdrop.py
+++ b/packages/cardpay-reward-programs/tests/rules/test_retro_airdrop.py
@@ -9,21 +9,25 @@ from cardpay_reward_programs.rules import RetroAirdrop
 
 from .fixture import indexed_data
 
+AIRDROP_AMOUNT = 6_000_000 * 1_000_000_000_000_000_000
+TEST_AMOUNT = 100 * 1_000_000_000_000_000_000
+
 summaries = [
-    {"total_reward": 6_000_000 * 1_000_000_000_000_000_000, "unique_payee": 12},
-    {"total_reward": 6_000_000 * 1_000_000_000_000_000_000, "unique_payee": 12},
-    {"total_reward": 6_000_000 * 1_000_000_000_000_000_000, "unique_payee": 12},
+    {"total_reward": AIRDROP_AMOUNT, "unique_payee": 12},
+    {"total_reward": AIRDROP_AMOUNT, "unique_payee": 12},
+    {"total_reward": AIRDROP_AMOUNT, "unique_payee": 12},
 ]
 
 
 payment_cycle_length_ls = [1024, 1024 * 32, 1024 * 512]
-total_reward_ls = [6_000_000 * 1_000_000_000_000_000_000]
+total_reward_ls = [AIRDROP_AMOUNT]
 test_accounts_ls = [[]]
+test_amount_ls = [0]
 
 
 @pytest.fixture
 def rule(request):
-    payment_cycle_length, total_reward, test_accounts = request.param
+    payment_cycle_length, total_reward, test_accounts, test_amount = request.param
     core_config = {
         "start_block": 23592960,
         "end_block": 24859648,
@@ -39,6 +43,7 @@ def rule(request):
         "start_snapshot_block": 23592960,
         "end_snapshot_block": 24859648,
         "test_accounts": test_accounts,
+        "test_reward": test_amount,
     }
     return RetroAirdrop(core_config, user_config)
 
@@ -48,7 +53,10 @@ class TestRetroAirdropSingle:
         "rule,summary",
         zip(
             itertools.product(
-                payment_cycle_length_ls, total_reward_ls, test_accounts_ls
+                payment_cycle_length_ls,
+                total_reward_ls,
+                test_accounts_ls,
+                test_amount_ls,
             ),
             summaries,
         ),
@@ -67,24 +75,26 @@ class TestRetroAirdropSingle:
     @pytest.mark.parametrize(
         "rule,expected_payees",
         [
-            ((1024, 6_000_000 * 1_000_000_000_000_000_000, []), 12),
+            ((1024, AIRDROP_AMOUNT, [], 0), 12),
             # we should use checksummed addresses
             (
                 (
                     1024,
-                    6_000_000 * 1_000_000_000_000_000_000,
+                    AIRDROP_AMOUNT,
                     ["0x41149498EAc53F8C15Fe848bC5f010039A130963"],
+                    0,
                 ),
                 11,
             ),
             (
                 (
                     1024,
-                    6_000_000 * 1_000_000_000_000_000_000,
+                    AIRDROP_AMOUNT,
                     [
                         "0x41149498EAc53F8C15Fe848bC5f010039A130963",
                         "0x76271cb51c7e5C0F0E9d2f1e4d6DFCD621e99eB7",
                     ],
+                    0,
                 ),
                 10,
             ),
@@ -92,30 +102,97 @@ class TestRetroAirdropSingle:
             (
                 (
                     1024,
-                    6_000_000 * 1_000_000_000_000_000_000,
+                    AIRDROP_AMOUNT,
                     ["0x41149498EAc53F8C15Fe848bC5f010039A130963".lower()],
+                    0,
                 ),
                 11,
             ),
             (
                 (
                     1024,
-                    6_000_000 * 1_000_000_000_000_000_000,
+                    AIRDROP_AMOUNT,
                     ["0x41149498EAc53F8C15Fe848bC5f010039A130963".upper()],
+                    0,
                 ),
                 11,
             ),
         ],
         indirect=["rule"],
     )
-    def test_removes_payee(self, rule, expected_payees, indexed_data):
+    def test_removes_payee_when_no_test_reward(
+        self, rule, expected_payees, indexed_data
+    ):
         payment_cycle = 24859648
         payment_list = rule.run(
             payment_cycle, "0x41149498EAc53F8C15Fe848bC5f010039A130963"
         )
         computed_summary = rule.get_summary(payment_list)
         assert computed_summary["unique_payee"][0] == expected_payees
-        assert (
-            pytest.approx(computed_summary["total_reward"][0])
-            == 6_000_000 * 1_000_000_000_000_000_000
+        assert pytest.approx(computed_summary["total_reward"][0]) == AIRDROP_AMOUNT
+
+    @pytest.mark.parametrize(
+        "rule,expected_payees,test_accounts",
+        [
+            ((1024, AIRDROP_AMOUNT, [], 0), 12, []),
+            # we should use checksummed addresses
+            (
+                (
+                    1024,
+                    AIRDROP_AMOUNT,
+                    ["0x41149498EAc53F8C15Fe848bC5f010039A130963"],
+                    TEST_AMOUNT,
+                ),
+                12,
+                ["0x41149498EAc53F8C15Fe848bC5f010039A130963"],
+            ),
+            (
+                (
+                    1024,
+                    AIRDROP_AMOUNT,
+                    [
+                        "0x41149498EAc53F8C15Fe848bC5f010039A130963",
+                        "0x76271cb51c7e5C0F0E9d2f1e4d6DFCD621e99eB7",
+                    ],
+                    TEST_AMOUNT,
+                ),
+                12,
+                [
+                    "0x41149498EAc53F8C15Fe848bC5f010039A130963",
+                    "0x76271cb51c7e5C0F0E9d2f1e4d6DFCD621e99eB7",
+                ],
+            ),
+            # we should use checksummed addresses but it shouldn't break if we don't
+            (
+                (
+                    1024,
+                    AIRDROP_AMOUNT,
+                    ["0x41149498EAc53F8C15Fe848bC5f010039A130963".lower()],
+                    TEST_AMOUNT,
+                ),
+                12,
+                ["0x41149498EAc53F8C15Fe848bC5f010039A130963".lower()],
+            ),
+            (
+                (
+                    1024,
+                    AIRDROP_AMOUNT,
+                    ["0x41149498EAc53F8C15Fe848bC5f010039A130963".upper()],
+                    TEST_AMOUNT,
+                ),
+                12,
+                ["0x41149498EAc53F8C15Fe848bC5f010039A130963".upper()],
+            ),
+        ],
+        indirect=["rule"],
+    )
+    def test_add_payee_reward(self, rule, expected_payees, test_accounts, indexed_data):
+        payment_cycle = 24859648
+        payment_list = rule.run(
+            payment_cycle, "0x41149498EAc53F8C15Fe848bC5f010039A130963"
+        )
+        computed_summary = rule.get_summary(payment_list)
+        assert computed_summary["unique_payee"][0] == expected_payees
+        assert pytest.approx(computed_summary["total_reward"][0]) == AIRDROP_AMOUNT + (
+            TEST_AMOUNT * len(test_accounts)
         )


### PR DESCRIPTION
The test accounts get a reward specified by an additional parameter, this does not reduce the total paid to the intended rewardees and will work even if the test accounts have no payments. Test accounts are excluded from the initial calculation as before (renamed from excluded accounts to test_accounts)

I made it a bit stricter to require checksummed addresses, which I think is reasonable.