### PR TITLE
Fix no SDP default currency in generateMerchantPaymentUrl

### DIFF
--- a/packages/cardpay-sdk/sdk/utils/merchant.ts
+++ b/packages/cardpay-sdk/sdk/utils/merchant.ts
@@ -31,12 +31,13 @@ export const generateMerchantPaymentUrl = ({
   merchantSafeID,
   amount,
   network,
-  currency = 'SPD',
+  currency,
 }: MerchantPaymentURLParams) => {
   const handleAmount = amount ? `amount=${amount}&` : '';
+  const handleCurrency = currency ? `${handleAmount ? '&' : ''}currency=${currency}` : '';
   const https = isUniversalDomain(domain) ? 'https://' : '';
 
-  return `${https}${domain}/pay/${network}/${merchantSafeID}?${handleAmount}currency=${currency}`;
+  return `${https}${domain}/pay/${network}/${merchantSafeID}?${handleAmount}${handleCurrency}`;
 };
 
 // see https://github.com/cardstack/cardstack/pull/2095 for test cases used during dev


### PR DESCRIPTION
Fixed `generateMerchantPaymentUrl` generates payment url with SPD currency when currency parameter is not provided which forces users to pay with SPD.