### PR TITLE
Fix description for `rewards transfer-safe` command

### DIFF
--- a/packages/cardpay-cli/README.md
+++ b/packages/cardpay-cli/README.md
@@ -766,7 +766,7 @@ Options:
 
 ## `cardpay rewards transfer-safe <rewardSafe> <newOwner>`
 
-Withdraw from reward safe
+Transfer reward safe to a new owner
 
 ```
 Positionals:

--- a/packages/cardpay-cli/rewards/transfer-safe.ts
+++ b/packages/cardpay-cli/rewards/transfer-safe.ts
@@ -5,7 +5,7 @@ import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 
 export default {
   command: 'transfer-safe <rewardSafe> <newOwner>',
-  describe: 'Withdraw from reward safe',
+  describe: 'Transfer reward safe to a new owner',
   builder(yargs: Argv) {
     return yargs
       .positional('rewardSafe', {


### PR DESCRIPTION
Probably a copy/paste remnant.