### PR TITLE
Add debug util for signing typed data

### DIFF
--- a/packages/cardpay-cli/safe/debug-sign-typed-data.ts
+++ b/packages/cardpay-cli/safe/debug-sign-typed-data.ts
@@ -1,0 +1,41 @@
+import { Argv } from 'yargs';
+import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { Arguments, CommandModule } from 'yargs';
+import { signTypedData } from '@cardstack/cardpay-sdk';
+
+export default {
+  command: 'debug-sign-typed-data [data] [address]',
+  describe: 'Perform a typed data signature on the provided typed data',
+  builder(yargs: Argv) {
+    return yargs
+      .positional('data', {
+        type: 'string',
+        description: 'The typed data to sign (as a JSON string)',
+      })
+      .positional('address', {
+        type: 'string',
+        description: '(optional) The address of the signer, defaults to the first HD derived path for the seed',
+      })
+      .option('network', NETWORK_OPTION_LAYER_2);
+  },
+  async handler(args: Arguments) {
+    let {
+      network,
+      data: dataStr,
+      address,
+    } = args as unknown as {
+      network: string;
+      data: string;
+      address?: string;
+    };
+    let data = JSON.parse(dataStr);
+    let web3 = await getWeb3(network, getWeb3Opts(args));
+    address = address ?? (await web3.eth.getAccounts())[0];
+    console.log(`Signing typed data for address ${address}:
+    ${dataStr}
+    `);
+
+    let signature = await signTypedData(web3, address, data);
+    console.log(`Signature for the typed data is: ${signature}`);
+  },
+} as CommandModule;

--- a/packages/cardpay-cli/safe/debug-sign-typed-data.ts
+++ b/packages/cardpay-cli/safe/debug-sign-typed-data.ts
@@ -32,7 +32,7 @@ export default {
     let web3 = await getWeb3(network, getWeb3Opts(args));
     address = address ?? (await web3.eth.getAccounts())[0];
     console.log(`Signing typed data for address ${address}:
-    ${dataStr}
+    ${JSON.stringify(data, null, 2)}
     `);
 
     let signature = await signTypedData(web3, address, data);

--- a/packages/cardpay-cli/safe/index.ts
+++ b/packages/cardpay-cli/safe/index.ts
@@ -5,9 +5,10 @@ import list from './list';
 import view from './view';
 import transferTokens from './transfer-tokens';
 import transferTokensGasEstimate from './transfer-tokens-gas-estimate';
+import debugSignTypedData from './debug-sign-typed-data';
 
 export const builder = function (yargs: Argv) {
-  return yargs.command([list, transferTokens, transferTokensGasEstimate, view] as any);
+  return yargs.command([list, transferTokens, transferTokensGasEstimate, view, debugSignTypedData] as any);
 };
 
 export function handler(/* argv: Argv */) {

--- a/packages/cardpay-sdk/index.ts
+++ b/packages/cardpay-sdk/index.ts
@@ -36,6 +36,7 @@ export {
   MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,
 } from './sdk/constants';
 export { waitUntilBlock, waitUntilTransactionMined, waitForSubgraphIndex } from './sdk/utils/general-utils';
+export { signTypedData } from './sdk/utils/signing-utils';
 export * from './sdk/currency-utils';
 export * from './sdk/currencies';
 export { query as gqlQuery } from './sdk/utils/graphql';


### PR DESCRIPTION
This is to hopefully help to debug issues around signing typed data. it can be invoked like: 
```
cardpay safe debug-sign-typed-data --data='{"types":{"EIP712Domain":[{"type":"uint256","name":"chainId"},{"type":"address","name":"verifyingContract"}],"SafeTx":[{"type":"address","name":"to"},{"type":"uint256","name":"value"},{"type":"bytes","name":"data"},{"type":"uint8","name":"operation"},{"type":"uint256","name":"safeTxGas"},{"type":"uint256","name":"baseGas"},{"type":"uint256","name":"gasPrice"},{"type":"address","name":"gasToken"},{"type":"address","name":"refundReceiver"},{"type":"uint256","name":"nonce"}]},"domain":{"verifyingContract":"0x40e736E1931E72CE095dE078D449837f7fbcef36","chainId":100},"primaryType":"SafeTx","message":{"to":"0x340EB99eB9aC7DB3a3eb68dB76c6F62738DB656a","value":0,"data":"0x9e7b0814000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000140000000000000000000000000979c9f171fb6e9bc501aa7eed71ca8dc27cf1185000000000000000000000000000000000000000000000000000000000144ee54000000000000000000000000000000000000000000000000000000000144ee54000000000000000000000000000000000000000000000000000000000150cbd400000000000000000000000000000000000000000000000000000000000000010000000000000000000000008a40afffb53f4f953a204cae087219a28771df9d00000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000004000000000000000000000000052031d287bb58e26a379a7fec2c84acb54f54fe30000000000000000000000000000000000000000000000008ac7230489e800000000000000000000000000000000000000000000000000000000000000000004d883766f811a3f24913379c651bc45d5cfa55cbfd3d22936993f5eb4ad5bb6c2a1c60aae8f2c7984da55e8d592ea67fd058df8c9c101471b528e37e3446a5761e4521fc6a0e83aa651eded4351ab7f41c995d32c2eadcffd9a545c8fe1a4f83981817fadb2fbe6482e03eb218380800c6452cbac946979dab2d7107632dba303","operation":0,"safeTxGas":"176345","baseGas":"75224","gasPrice":"798780741077","gasToken":"0x52031d287Bb58E26A379A7Fec2c84acB54f54fe3","refundReceiver":"0x0000000000000000000000000000000000000000","nonce":0}}' --network=xdai --walletConnect
```