### PR TITLE
Subgraph : Update prepaid card balances & face values on eoa transactions as well

### DIFF
--- a/packages/cardpay-subgraph/src/utils.ts
+++ b/packages/cardpay-subgraph/src/utils.ts
@@ -248,17 +248,17 @@ export function toHex(bytes: string): string {
   return '0x' + bytes;
 }
 
+export function convertToSpend(issuingToken: Address, issuingTokenAmount: BigInt): BigInt {
+  let exchange = getExchange();
+  return exchange.convertToSpend(issuingToken, issuingTokenAmount);
+}
+
 function usdExchangeRate(issuingToken: Address): BigDecimal {
   let exchange = getExchange();
   let exchangeInfo = exchange.exchangeRateOf(issuingToken);
   let rawRate = BigDecimal.fromString(exchangeInfo.value0.toString());
   // @ts-ignore this is legit AssemblyScript that tsc doesn't understand
   return rawRate / BigDecimal.fromString('100000000');
-}
-
-function convertToSpend(issuingToken: Address, issuingTokenAmount: BigInt): BigInt {
-  let exchange = getExchange();
-  return exchange.convertToSpend(issuingToken, issuingTokenAmount);
 }
 
 function getExchange(): Exchange {

--- a/packages/cardpay-subgraph/subgraph-template.yaml
+++ b/packages/cardpay-subgraph/subgraph-template.yaml
@@ -542,10 +542,14 @@ dataSources:
           file: ./abis/ERC20SymbolBytes.json
         - name: ERC20NameBytes
           file: ./abis/ERC20NameBytes.json
+        - name: Exchange
+          file: ./abis/generated/Exchange.json
         - name: GnosisSafe
           file: ./abis/GnosisSafe.json
         - name: RevenuePool
           file: ./abis/generated/RevenuePool.json
+        - name: PrepaidCardManager
+          file: ./abis/generated/PrepaidCardManager.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
@@ -580,10 +584,14 @@ dataSources:
           file: ./abis/ERC20SymbolBytes.json
         - name: ERC20NameBytes
           file: ./abis/ERC20NameBytes.json
+        - name: Exchange
+          file: ./abis/generated/Exchange.json
         - name: GnosisSafe
           file: ./abis/GnosisSafe.json
         - name: RevenuePool
           file: ./abis/generated/RevenuePool.json
+        - name: PrepaidCardManager
+          file: ./abis/generated/PrepaidCardManager.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer


### PR DESCRIPTION
Tested with a local sync of gnosis chain.

The face value & issuingTokenBalance were not being updated when there were transactions occurring outside of the prepaid card process, this should update the information in subgraph when there are card / dai cpxd transactions outside of that.