### PR TITLE
remove s3-index plugin to fix failed deployments

### DIFF
--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -94,7 +94,6 @@
     "ember-cli-deploy-display-revisions": "^2.1.2",
     "ember-cli-deploy-revision-data": "^1.0.0",
     "ember-cli-deploy-s3": "^3.0.0",
-    "ember-cli-deploy-s3-index": "^1.3.1",
     "ember-cli-deprecation-workflow": "^1.0.1",
     "ember-cli-dotenv": "^3.1.0",
     "ember-cli-htmlbars": "^5.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14390,7 +14390,7 @@ ember-cli-deploy-revision-data@^1.0.0:
     rsvp "^3.5.0"
     simple-git "^1.57.0"
 
-ember-cli-deploy-s3-index@^1.2.0, ember-cli-deploy-s3-index@^1.3.1:
+ember-cli-deploy-s3-index@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ember-cli-deploy-s3-index/-/ember-cli-deploy-s3-index-1.3.1.tgz#5c5904d48791ef4e5d2daadc380da3dfb02701d6"
   integrity sha512-obzVLcnNnqll4bkTx/CkCMnNt4qomSOUxhcU7LgxHtL1IsGUJ62fYXDAP4ymbzZl26MditV4+r3bi8F1nzw/SA==


### PR DESCRIPTION
ember-cli-deploy is picking up this installed plugin and trying to use it for the staging deploy (and I guess it will for the prod deployment too?)