### PR TITLE
ssr: Fix Fastboot safelist localhost pseudodomain

### DIFF
--- a/packages/ssr-web/config/environment.js
+++ b/packages/ssr-web/config/environment.js
@@ -103,7 +103,7 @@ module.exports = function (environment) {
     },
     fastboot: {
       hostWhitelist: hostWhitelistByTarget[process.env.SSR_WEB_ENVIRONMENT] ?? [
-        '/.+.card.space.localhost:\\d+$/',
+        '/.+.card.xyz.localhost:\\d+$/',
         '/^localhost:\\d+$/',
       ],
     },


### PR DESCRIPTION
I needed this locally to have the slug-extraction work
with being served by Fastboot.