### PR TITLE
Fix: scientific numbers string being 

### DIFF
--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -157,7 +157,7 @@ export default class RewardPool {
         return {
           ...o,
           isValid: validFrom <= currentBlock && validTo > currentBlock,
-          amount: new BN(o.amount.toString()),
+          amount: new BN(o.amount.toLocaleString('fullwide', { useGrouping: false })),
         };
       })
     );


### PR DESCRIPTION
BN cant read scientific number string. 

Fix using [localeString](https://stackoverflow.com/questions/1685680/how-to-avoid-scientific-notation-for-large-numbers-in-javascript)

