### PR TITLE
sdk/web: Restore withdrawal with dynamic estimation

### DIFF
--- a/packages/cardpay-sdk/sdk/token-bridge-foreign-side.ts
+++ b/packages/cardpay-sdk/sdk/token-bridge-foreign-side.ts
@@ -231,14 +231,17 @@ export default class TokenBridgeForeignSide implements ITokenBridgeForeignSide {
     const packedSignatures = prepSignaturesForExecution(signatures);
     let nextNonce = await this.getNextNonce(from);
     let { nonce, onNonce, onTxnHash } = txnOptions ?? {};
+    let executeSignatures = foreignAmb.methods.executeSignatures(encodedData, packedSignatures);
+    let data = executeSignatures.encodeABI();
+    let gas = await executeSignatures.estimateGas();
+
     return await new Promise((resolve, reject) => {
-      let data = foreignAmb.methods.executeSignatures(encodedData, packedSignatures).encodeABI();
       let tx: TransactionConfig = {
         ...contractOptions,
         from,
         to: foreignAmbAddress,
         data,
-        gas: CLAIM_BRIDGED_TOKENS_GAS_LIMIT,
+        gas,
       };
       if (nonce != null) {
         tx.nonce = parseInt(nonce.toString()); // the web3 API requires this be a number, it should be ok to downcast this

--- a/packages/web-client/app/routes/card-pay/deposit-withdrawal.ts
+++ b/packages/web-client/app/routes/card-pay/deposit-withdrawal.ts
@@ -34,8 +34,6 @@ const SUPPLIERS_PANEL = {
         `Bridge tokens from ${c.layer2.fullName} to ${c.layer1.fullName}`,
       ],
       cta: 'Withdraw Tokens',
-      isCtaDisabled: config.environment !== 'test', // TODO remove/improve as part of CS-3613
-      ctaDisabledReason: 'Withdrawal is temporarily unavailable',
     },
   ],
 };

--- a/packages/web-client/app/routes/card-pay/deposit-withdrawal.ts
+++ b/packages/web-client/app/routes/card-pay/deposit-withdrawal.ts
@@ -3,7 +3,6 @@ import '../../css/card-pay/deposit-withdrawal.css';
 import heroImageUrl from '@cardstack/web-client/images/dashboard/suppliers-hero.svg';
 import summaryHeroImageUrl from '@cardstack/web-client/images/dashboard/suppliers-summary-hero.svg';
 import { currentNetworkDisplayInfo as c } from '@cardstack/web-client/utils/web3-strategies/network-display-info';
-import config from '@cardstack/web-client/config/environment';
 
 const SUPPLIERS_PANEL = {
   title: 'Easy Deposits & Withdrawals',

--- a/packages/web-client/app/templates/card-pay/deposit-withdrawal.hbs
+++ b/packages/web-client/app/templates/card-pay/deposit-withdrawal.hbs
@@ -34,12 +34,7 @@
               @disabled={{section.isCtaDisabled}}
               data-test-workflow-button={{section.workflow}}
             >
-              {{!-- TODO remove/fix after CS-3613 is better handled --}}
-              {{#if section.ctaDisabledReason}}
-                <span {{tippy section.ctaDisabledReason}}>{{section.cta}}</span>
-              {{else}}
-                <span>{{section.cta}}</span>
-              {{/if}}
+              <span>{{section.cta}}</span>
               {{svg-jar section.buttonIcon
                 class="card-pay-dashboard__payments-section-header-button-icon"
                 role="presentation"

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -41,6 +41,7 @@ import { task } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import { action } from '@ember/object';
 import { UsdConvertibleSymbol } from '@cardstack/web-client/services/token-to-usd';
+import { toWei } from 'web3-utils';
 
 export default abstract class Layer1ChainWeb3Strategy
   implements Layer1Web3Strategy, Emitter<Layer1ChainEvent>
@@ -335,7 +336,8 @@ export default abstract class Layer1ChainWeb3Strategy
     return tokenBridge.unlockTokens(
       new TokenContractInfo(tokenSymbol, this.networkSymbol).address,
       amountInWei.toString(),
-      { onTxnHash }
+      { onTxnHash },
+      { gasPrice: toWei('350000') } // FIXME this probably belongs elsewhere…? and is it even at all correct
     );
   }
 

--- a/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer1-chain.ts
@@ -41,7 +41,6 @@ import { task } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import { action } from '@ember/object';
 import { UsdConvertibleSymbol } from '@cardstack/web-client/services/token-to-usd';
-import { toWei } from 'web3-utils';
 
 export default abstract class Layer1ChainWeb3Strategy
   implements Layer1Web3Strategy, Emitter<Layer1ChainEvent>
@@ -336,8 +335,7 @@ export default abstract class Layer1ChainWeb3Strategy
     return tokenBridge.unlockTokens(
       new TokenContractInfo(tokenSymbol, this.networkSymbol).address,
       amountInWei.toString(),
-      { onTxnHash },
-      { gasPrice: toWei('350000') } // FIXME this probably belongs elsewhere…? and is it even at all correct
+      { onTxnHash }
     );
   }
 


### PR DESCRIPTION
This is a reversal of the web client changes in #2875 and an SDK change to dynamically estimate withdrawal gas. When run with this, the gas limit calculated was higher than the previously hardcoded gas value of 350k:

![image](https://user-images.githubusercontent.com/43280/162783851-cd1f6376-d75f-46a9-93d2-cab8e6bf3319.png)

This leaves [another use](https://github.com/cardstack/cardstack/blob/b60d516096cc3bf5afe60076ed00654a8b464c88/packages/cardpay-sdk/sdk/token-bridge-foreign-side.ts#L187-L194) of the hardcoded value intact in `getEstimatedGasForWithdrawalClaim`, which is used at the beginning of the withdrawal workflow to ensure the user has enough in their wallet to cover gas. This should be updated when possible.