### PR TITLE
Make `amount` as optional param for withdraw rewards

### DIFF
--- a/packages/cardpay-cli/rewards/withdraw-from-safe.ts
+++ b/packages/cardpay-cli/rewards/withdraw-from-safe.ts
@@ -5,7 +5,7 @@ import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 import { toWei } from 'web3-utils';
 
 export default {
-  command: 'withdraw-from-safe <rewardSafe> <recipient> <tokenAddress> <amount>',
+  command: 'withdraw-from-safe <rewardSafe> <recipient> <tokenAddress> [amount]',
   describe: 'Withdraw from reward safe',
   builder(yargs: Argv) {
     return yargs
@@ -21,7 +21,7 @@ export default {
         type: 'string',
         description: 'The address of the tokens that are being transferred from reward safe',
       })
-      .positional('amount', {
+      .option('amount', {
         type: 'string',
         description: 'The amount of tokens to transfer (not in units of wei, but in eth)',
       })
@@ -33,14 +33,21 @@ export default {
       rewardSafe: string;
       recipient: string;
       tokenAddress: string;
-      amount: string;
+      amount?: string;
     };
     let web3 = await getWeb3(network, getWeb3Opts(args));
     let rewardManagerAPI = await getSDK('RewardManager', web3);
     let blockExplorer = await getConstant('blockExplorer', web3);
-    await rewardManagerAPI.withdraw(rewardSafe, recipient, tokenAddress, toWei(amount), {
-      onTxnHash: (txnHash: string) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),
-    });
-    console.log(`Withdraw ${amount} of ${tokenAddress} out of ${rewardSafe} to ${recipient}`);
+    if (amount) {
+      await rewardManagerAPI.withdraw(rewardSafe, recipient, tokenAddress, toWei(amount), {
+        onTxnHash: (txnHash: string) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),
+      });
+      console.log(`Withdraw ${amount} of ${tokenAddress} out of ${rewardSafe} to ${recipient}`);
+    } else {
+      await rewardManagerAPI.withdraw(rewardSafe, recipient, tokenAddress, undefined, {
+        onTxnHash: (txnHash: string) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),
+      });
+      console.log(`Withdraw ALL of ${tokenAddress} out of ${rewardSafe} to ${recipient}`);
+    }
   },
 } as CommandModule;

--- a/packages/cardpay-cli/rewards/withdraw-gas-estimate.ts
+++ b/packages/cardpay-cli/rewards/withdraw-gas-estimate.ts
@@ -3,7 +3,7 @@ import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
 import Web3 from 'web3';
-const { fromWei } = Web3.utils;
+const { fromWei, toWei } = Web3.utils;
 
 export default {
   command: 'withdraw-gas-estimate <rewardSafe> <recipient> <tokenAddress> <amount>',
@@ -43,7 +43,7 @@ export default {
       rewardSafe,
       recipient,
       tokenAddress,
-      amount
+      toWei(amount)
     );
     let { symbol } = await assets.getTokenInfo(gasToken);
     console.log(`The gas estimate for withdrawing from reward safe ${rewardSafe} is ${fromWei(estimate)} ${symbol}`);

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -574,7 +574,7 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
     ).methods.withdraw(rewardManagerAddress, tokenAddress, to, weiAmount);
     let token = new this.layer2Web3.eth.Contract(ERC20ABI as AbiItem[], tokenAddress);
     let safeBalance = new BN(await token.methods.balanceOf(rewardSafeAddress).call());
-    if (safeBalance.lt(new BN(amount))) {
+    if (safeBalance.lt(weiAmount)) {
       throw new Error(
         `Reward safe does not have enough balance to withdraw. The rewardSafe safe ${rewardSafeAddress} balance for token ${tokenAddress} is ${fromWei(
           safeBalance

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -572,6 +572,15 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
     let withdraw = await (
       await this.getRewardSafeDelegate()
     ).methods.withdraw(rewardManagerAddress, tokenAddress, to, weiAmount);
+    let token = new this.layer2Web3.eth.Contract(ERC20ABI as AbiItem[], tokenAddress);
+    let safeBalance = new BN(await token.methods.balanceOf(rewardSafeAddress).call());
+    if (safeBalance.lt(new BN(amount))) {
+      throw new Error(
+        `Reward safe does not have enough balance to withdraw. The rewardSafe safe ${rewardSafeAddress} balance for token ${tokenAddress} is ${fromWei(
+          safeBalance
+        )}, amount being claimed is ${fromWei(weiAmount)}`
+      );
+    }
     let withdrawPayload = withdraw.encodeABI();
     let estimate = await gasEstimate(
       this.layer2Web3,


### PR DESCRIPTION
~This pr adds a check that the any calls to `withdrawGasEstimate` to ensure that the safe has enough balance for a withdraw. This helps us narrow down sentry errors. If we see this error, it is an indication that how we are moving `amount` as a param in the `withdrawGasEstimate` is wrong. If we don't see this error, issues with the withdraw is probably due to the deviations of gas estimation~

This PR makes sdk withdraw whole amount from the reward safe. This removes the burden of `amount-gasCost` in the cardwallet. Now, the `withdraw` function handles `amount-gasCost` within it.