### PR TITLE
update readme for amount 

### DIFF
--- a/packages/cardpay-sdk/README.md
+++ b/packages/cardpay-sdk/README.md
@@ -390,8 +390,10 @@ This method is invoked with the following parameters:
 - the address of the gnosis safe
 - the address of the token contract
 - the address of the recipient
-- the amount of tokens to send as a string in units of `wei`
+- optionally,  amount of tokens to send as a string in units of `wei`
 - optionally the address of a safe owner. If no address is supplied, then the default account in your web3 provider's wallet will be used.
+
+`amount` is an optional param. When `amount` is included, one must ensure that there is sufficient balance leftover to pay for gas of the transaction, .i.e `safeBalance < amount - estimatedGasCost`. The scenario which this occurs is when the user specifies `amount` that is close to `safeBalance`. The client should make this check.  When `amount` is excluded, the whole balance of the safe is withdrawn which is automatically taxed for gas, .i.e the gas deduction occurs internally within the sdk function. It is recommended when the client expects to withdraw the "max" balance that it doesn't specify `amount`. 
 
 ```js
 let cardCpxd = await getAddress('cardCpxd', web3);
@@ -404,6 +406,7 @@ let result = await safes.sendTokens(
 ```
 
 This method returns a promise for a web3 transaction receipt.
+
 
 ### `Safes.setSupplierInfoDID`
 This call will allow a supplier to customize their appearance within the cardpay ecosystem by letting them set an info DID, that when used with a DID resolver can retrieve supplier info, such as their name, logo, URL, etc.
@@ -886,7 +889,7 @@ await rewardManagerAPI.updateRewardProgramAdmin(prepaidCard , rewardProgramId, n
 
 The `Withdraw` API is used to withdraw ERC677 tokens earned in a reward safe to any other destination address -- it is simlar to a transfer function. The gas fees in the withdrawal will be paid out of the balance of the safe -- similar to `Safe.sendTokens`. 
 
-`amount` is an optional param. When included, `amount = amountOfTokensToBeWithdrawn - estimatedGasCost` -- this ensures there is balance in the safe allocated for gas. When excluded, the whole balance of the safe is expected to withdrawn which is automatically taxed for gas, .i.e the gas deduction occurs internally within the sdk function. 
+`amount` is an optional param. When `amount` is included, one must ensure that there is sufficient balance leftover to pay for gas of the transaction, .i.e `safeBalance < amount - estimatedGasCost`. The scenario which this occurs is when the user specifies `amount` that is close to `safeBalance`. The client should make this check. When `amount` is excluded, the whole balance of the safe is withdrawn which is automatically taxed for gas, .i.e the gas deduction occurs internally within the sdk function. It is recommended when the client expects to withdraw the "max" balance that it doesn't specify `amount`. 
 
 ```js
 let rewardManagerAPI = await getSDK(RewardManager, web3);
@@ -895,7 +898,7 @@ await rewardManagerAPI.withdraw(rewardSafe , to, token, amount)
 
 ### `RewardManager.withdrawGasEstimate`
 
-The `withdrawGasEstimate` returns a gas estimate for withdrawing a reward. When estimating gas for purpose of display, we recommend just using `amount = amountOfTokensToBeWithdrawn`. 
+The `withdrawGasEstimate` returns a gas estimate for withdrawing a reward. 
 
 ```ts
 interface GasEstimate {


### PR DESCRIPTION
Was some confusion on how to use `amount`. The client. should use `amount` when it is confident that `amount` is not too close to the `safeBalance`.  Otherwise, it should really just exclude `amount`. 