### PR TITLE
Fix gas estimation issue

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -267,6 +267,7 @@
         "0xD669AC924eb6812C48afA984B5efFd776d035001", // source safe address
         "0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1", // DAI.CPXD
         "0x00F0FBDEEa1cDEc029Ba6025ca726Fdcf43E9025", // destination addrress
+        "--amount",
         "500", // amount (in ether units)
         "--network",
         "${config:cardCli.network.l2.name}",
@@ -1007,6 +1008,7 @@
         "0xA29C835C67C13Cd6a06FfEB39a6812124A9841F0", //reward safe
         "0x159ADe032073d930E85f95AbBAB9995110c43C71", //recipient (justin's depot)
         "0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee", //token address
+        "--amount",
         "1", // amount (in ether units)
         "--network",
         "${config:cardCli.network.l2.name}",

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -480,7 +480,6 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
 
     let estimate;
     let withdrawPayload;
-    let weiAmount: BN;
     if (amount) {
       let weiAmount = new BN(amount);
       if (weiAmount.gt(safeBalance)) {
@@ -531,7 +530,7 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
           )}, the gas cost is ${fromWei(gasCost)}`
         );
       }
-      weiAmount = safeBalance.sub(gasCost);
+      let weiAmount = safeBalance.sub(gasCost);
       withdraw = await rewardSafeDelegate.methods.withdraw(rewardManagerAddress, tokenAddress, to, weiAmount);
       withdrawPayload = withdraw.encodeABI();
       // We must still compute a new gasEstimate based upon the adjusted amount for gas

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -22,6 +22,7 @@ import {
   Operation,
   gasInToken,
   GasEstimate,
+  baseGasBuffer,
 } from '../utils/safe-utils';
 import { Signature, signPrepaidCardSendTx } from '../utils/signing-utils';
 import BN from 'bn.js';
@@ -520,6 +521,7 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
         Operation.DELEGATECALL,
         tokenAddress
       );
+      preEstimate.baseGas = new BN(preEstimate.baseGas).add(baseGasBuffer).toString();
       let gasCost = gasInToken(preEstimate);
       if (safeBalance.lt(gasCost)) {
         throw new Error(

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -514,9 +514,8 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
       weiAmount = safeBalance;
       let withdraw = await rewardSafeDelegate.methods.withdraw(rewardManagerAddress, tokenAddress, to, weiAmount);
       withdrawPayload = withdraw.encodeABI();
-      // The preEstimate is used to estimate the gasCost mainly to check that the safeBalance has sufficient leftover to pay for gas after withdrawing a specified amount
-      // This is preEstimate is typically used when withdrawing full balances from a safe
-      // It is recommeended that for any preEstimate that we avoid using it
+      // The preEstimate is used to estimate the gasCost to check that the safeBalance has sufficient leftover to pay for gas after withdrawing a specified amount
+      // The preEstimate is typically used when withdrawing full balances from a safe
       let preEstimate = await gasEstimate(
         this.layer2Web3,
         safeAddress,

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -482,7 +482,6 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
     let withdrawPayload;
     let weiAmount;
     if (amount) {
-      //when amount is given, we assume that amount is string in wei that has already had gasCost deducted from it
       let weiAmount = new BN(amount);
       if (weiAmount.gt(safeBalance)) {
         throw new Error(
@@ -500,7 +499,7 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
         Operation.DELEGATECALL,
         tokenAddress
       );
-      let gasCost = new BN(estimate.safeTxGas).add(new BN(estimate.baseGas)).mul(new BN(estimate.gasPrice));
+      let gasCost = gasInToken(estimate);
       if (safeBalance.lt(gasCost.add(weiAmount))) {
         throw new Error(
           `Reward safe does not have enough to pay for gas when withdrawing rewards. The reward safe ${safeAddress} balance for token ${tokenAddress} is ${fromWei(
@@ -525,7 +524,7 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
         Operation.DELEGATECALL,
         tokenAddress
       );
-      let gasCost = new BN(preEstimate.safeTxGas).add(new BN(preEstimate.baseGas)).mul(new BN(preEstimate.gasPrice));
+      let gasCost = gasInToken(preEstimate);
       if (weiAmount.lt(gasCost)) {
         throw new Error(
           `Reward safe does not have enough to pay for gas when withdrawing rewards. The reward safe ${safeAddress} balance for token ${tokenAddress} is ${fromWei(

--- a/packages/cardpay-sdk/sdk/safes.ts
+++ b/packages/cardpay-sdk/sdk/safes.ts
@@ -368,7 +368,7 @@ export default class Safes implements ISafes {
     } else {
       //when amount is NOT given, we use safeBalance - gasCost as the transfer amount
       //Note: gasCost is estimated with safeBalance not the actual transfer amount
-      payload = this.transferTokenPayload(tokenAddress, recipient, safeBalance);
+      let prePayload = this.transferTokenPayload(tokenAddress, recipient, safeBalance);
       // The preEstimate is used to estimate the gasCost to check that the safeBalance has sufficient leftover to pay for gas after transferring a specified amount
       // The preEstimate is typically used when transferring full balances from a safe
       let preEstimate = await gasEstimate(
@@ -376,7 +376,7 @@ export default class Safes implements ISafes {
         safeAddress,
         tokenAddress,
         '0',
-        payload,
+        prePayload,
         Operation.CALL,
         tokenAddress
       );

--- a/packages/cardpay-sdk/sdk/safes.ts
+++ b/packages/cardpay-sdk/sdk/safes.ts
@@ -338,9 +338,8 @@ export default class Safes implements ISafes {
 
     let estimate;
     let payload;
-    let weiAmount: BN;
     if (amount) {
-      weiAmount = new BN(amount);
+      let weiAmount = new BN(amount);
       if (safeBalance.lt(weiAmount)) {
         throw new Error(
           `Safe does not have enough balance to transfer tokens. The token ${tokenAddress} balance of safe ${safeAddress} is ${fromWei(
@@ -389,7 +388,7 @@ export default class Safes implements ISafes {
           )}, the gas cost is ${fromWei(gasCost)}`
         );
       }
-      weiAmount = safeBalance.sub(gasCost);
+      let weiAmount = safeBalance.sub(gasCost);
       payload = this.transferTokenPayload(tokenAddress, recipient, weiAmount);
       // We must still compute a new gasEstimate based upon the adjusted amount for gas
       // This is beecause the relayer will do the estimation with the same exact parameters

--- a/packages/cardpay-sdk/sdk/safes.ts
+++ b/packages/cardpay-sdk/sdk/safes.ts
@@ -2,7 +2,14 @@ import Web3 from 'web3';
 import ERC20ABI from '../contracts/abi/erc-20';
 import { AbiItem } from 'web3-utils';
 import { ContractOptions } from 'web3-eth-contract';
-import { gasEstimate, executeTransaction, getNextNonceFromEstimate, Operation, gasInToken } from './utils/safe-utils';
+import {
+  gasEstimate,
+  executeTransaction,
+  getNextNonceFromEstimate,
+  Operation,
+  gasInToken,
+  baseGasBuffer,
+} from './utils/safe-utils';
 import { signSafeTx } from './utils/signing-utils';
 import BN from 'bn.js';
 import { query } from './utils/graphql';
@@ -380,6 +387,7 @@ export default class Safes implements ISafes {
         Operation.CALL,
         tokenAddress
       );
+      preEstimate.baseGas = new BN(preEstimate.baseGas).add(baseGasBuffer).toString();
       let gasCost = gasInToken(preEstimate);
       if (safeBalance.lt(gasCost)) {
         throw new Error(

--- a/packages/cardpay-sdk/sdk/utils/safe-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/safe-utils.ts
@@ -276,3 +276,12 @@ export function gasInToken(estimate: Estimate): BN {
   let gasUnits = new BN(String(estimate.baseGas)).add(new BN(String(estimate.safeTxGas)));
   return gasUnits.mul(new BN(String(estimate.gasPrice)));
 }
+
+// In the relayer, there is a check for sufficient funds inside the safe
+// The issue with occurs when want to withdraw/transfer full balances from the safe
+// The full amount has to be deducted for gas (usually it is pre-estimated).
+// This gas is estimated and can be inaccurate so we intentionally over-estimate the gas
+// to avoid a discrepancy between gas estimation of the relayer and the sdk.
+// The number is based off empirical observation of sentry errors; the baseGas difference is usually 12
+// https://github.com/cardstack/card-protocol-relay-service/blob/master/safe.py#L303-L316
+export const baseGasBuffer: BN = new BN('30');


### PR DESCRIPTION
- had to include fix to estimate gas AGAIN after subtracting gas. This applies only to max withdrawals.
- had to include a buffer because the estimate of the relayer has a tendency to have a higher base gas. Typically, 56528(relayer or estimate) vs 56516(preEstimate). The buffer ensures that when we want a max withdrawal, we overestimate the baseGas so the relayer doesn't error out. The only concern here is really if your buffer is TOO HIGH, then a user might still be able to see balance within his safe even after full withdrawal -- I think 30 is reasonable for CARD. 

- [x] check relayeer doesn't have any checks for `amount+gas < safeBalance`. 
   - [x] if so need to add buffer somewhere
- [x] check that failed addresses in sentry pass gas estimation checks
- [x] do hypothesis check that the previous bug that was fixed before was failing because of this. base gas should defere
- [x] test normal withdraw
- [x] test normal safe transfer
- [x] test full withdraw
- [x] test full safe transfer