### PR TITLE
email-card-drop-requests get

### DIFF
--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -90,6 +90,8 @@ import ChecklyWebhookRoute from './routes/checkly-webhook';
 import { KnownRoutes, registerRoutes } from '@cardstack/hub/routes';
 import { registerServices } from '@cardstack/hub/services';
 import { registerQueries } from './queries';
+import EmailCardDropRequestsRoute from './routes/email-card-drop-requests';
+import EmailCardDropRequestSerializer from './services/serializers/email-card-drop-request-serializer';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -141,8 +143,10 @@ export function createRegistry(): Registry {
   registry.register('prepaid-card-patterns-route', PrepaidCardPatternsRoute);
   registry.register('prepaid-card-pattern-serializer', PrepaidCardPatternSerializer);
   registry.register('card-space-serializer', CardSpaceSerializer);
+  registry.register('email-card-drop-request-serializer', EmailCardDropRequestSerializer);
   registry.register('card-space-validator', CardSpaceValidator);
   registry.register('card-spaces-route', CardSpacesRoute);
+  registry.register('email-card-drop-requests-route', EmailCardDropRequestsRoute);
   registry.register('push-notification-registrations-route', PushNotificationRegistrationsRoute);
   registry.register('push-notification-registration-serializer', PushNotificationRegistrationSerializer);
   registry.register('firebase-push-notifications', FirebasePushNotifications);

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -1,0 +1,66 @@
+import type { EmailCardDropRequest } from '../../routes/email-card-drop-requests';
+import { setupHub } from '../helpers/server';
+
+let claimedEoa: EmailCardDropRequest = {
+  id: '2850a954-525d-499a-a5c8-3c89192ad40e',
+  ownerAddress: '0xclaimedAddress',
+  emailHash: 'claimedhash',
+  verificationCode: 'claimedverificationcode',
+  claimedAt: new Date(),
+  requestedAt: new Date(),
+  transactionHash: '0xclaimedAddressTxnHash',
+};
+let unclaimedEoa: EmailCardDropRequest = {
+  id: 'b176521d-6009-41ff-8472-147a413da450',
+  ownerAddress: '0xnotClaimedAddress',
+  emailHash: 'unclaimedhash',
+  verificationCode: 'unclaimedverificationcode',
+  requestedAt: new Date(),
+};
+
+describe('GET /api/email-card-drop-requests', function () {
+  let { request, getContainer } = setupHub(this);
+
+  this.beforeEach(async function () {
+    let emailCardDropRequestsQueries = await getContainer().lookup('email-card-drop-requests', { type: 'query' });
+    await emailCardDropRequestsQueries.insert(claimedEoa);
+    await emailCardDropRequestsQueries.insert(unclaimedEoa);
+  });
+
+  it('returns true if a known EOA has a transaction hash recorded for its card drop request', async function () {
+    let response = await request()
+      .get(`/api/email-card-drop-requests?eoa=${claimedEoa.ownerAddress}`)
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json');
+    expect(response.status).to.equal(200);
+    expect(response.body.data.type).to.equal('email-card-drop-request-claim-status');
+    expect(response.body.data.attributes['owner-address']).to.equal(claimedEoa.ownerAddress);
+    expect(response.body.data.attributes.claimed).to.equal(true);
+    expect(response.body.data.attributes.timestamp).to.not.be.undefined;
+  });
+
+  it('returns false if a known EOA does not have a transaction hash recorded for its card drop request', async function () {
+    let response = await request()
+      .get(`/api/email-card-drop-requests?eoa=${unclaimedEoa.ownerAddress}`)
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json');
+    expect(response.status).to.equal(200);
+    expect(response.body.data.type).to.equal('email-card-drop-request-claim-status');
+    expect(response.body.data.attributes['owner-address']).to.equal(unclaimedEoa.ownerAddress);
+    expect(response.body.data.attributes.claimed).to.equal(false);
+    expect(response.body.data.attributes.timestamp).to.not.be.undefined;
+  });
+
+  it('returns false if the EOA is not in the db', async function () {
+    let response = await request()
+      .get(`/api/email-card-drop-requests?eoa=notrecorded`)
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json');
+
+    expect(response.status).to.equal(200);
+    expect(response.body.data.type).to.equal('email-card-drop-request-claim-status');
+    expect(response.body.data.attributes['owner-address']).to.equal('notrecorded');
+    expect(response.body.data.attributes.claimed).to.equal(false);
+    expect(response.body.data.attributes.timestamp).to.not.be.undefined;
+  });
+});

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -83,4 +83,22 @@ describe('GET /api/email-card-drop-requests', function () {
     expect(response.body.data.attributes.claimed).to.equal(false);
     expect(response.body.data.attributes.timestamp).to.equal(fakeTimeString);
   });
+
+  it('errors if the EOA query parameter is not provided', async function () {
+    let response = await request()
+      .get(`/api/email-card-drop-requests`)
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json');
+
+    expect(response.status).to.equal(400);
+    expect(response.body).to.deep.equal({
+      errors: [
+        {
+          code: '400',
+          title: 'Missing required parameter: eoa',
+          detail: 'Please provide an ethereum address via the eoa query parameter',
+        },
+      ],
+    });
+  });
 });

--- a/packages/hub/queries/email-card-drop-requests.ts
+++ b/packages/hub/queries/email-card-drop-requests.ts
@@ -1,0 +1,58 @@
+import DatabaseManager from '@cardstack/db';
+import { inject } from '@cardstack/di';
+import { EmailCardDropRequest } from '../routes/email-card-drop-requests';
+import { buildConditions } from '../utils/queries';
+
+interface EmailCardDropRequestsQueriesFilter {
+  ownerAddress: string;
+}
+
+export default class EmailCardDropRequestsQueries {
+  databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
+
+  async insert(model: EmailCardDropRequest): Promise<EmailCardDropRequest> {
+    let db = await this.databaseManager.getClient();
+
+    let { rows } = await db.query(
+      'INSERT INTO email_card_drop_requests (id, owner_address, email_hash, verification_code, requested_at, claimed_at, transaction_hash) VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING *',
+      [
+        model.id,
+        model.ownerAddress,
+        model.emailHash,
+        model.verificationCode,
+        model.requestedAt,
+        model.claimedAt,
+        model.transactionHash,
+      ]
+    );
+
+    return rows[0];
+  }
+
+  async query(filter: EmailCardDropRequestsQueriesFilter): Promise<EmailCardDropRequest[]> {
+    let db = await this.databaseManager.getClient();
+
+    const conditions = buildConditions(filter);
+
+    const query = `SELECT * FROM email_card_drop_requests WHERE ${conditions.where}`;
+    const queryResult = await db.query(query, conditions.values);
+
+    return queryResult.rows.map((row) => {
+      return {
+        id: row['id'],
+        ownerAddress: row['owner_address'],
+        emailHash: row['email_hash'],
+        verificationCode: row['verification_code'],
+        claimedAt: row['claimed_at'],
+        requestedAt: row['requested_at'],
+        transactionHash: row['transaction_hash'],
+      };
+    });
+  }
+}
+
+declare module '@cardstack/hub/queries' {
+  interface KnownQueries {
+    'email-card-drop-requests': EmailCardDropRequestsQueries;
+  }
+}

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -1,0 +1,53 @@
+import Koa from 'koa';
+import autoBind from 'auto-bind';
+import { query } from '../queries';
+import { inject } from '@cardstack/di';
+
+export interface EmailCardDropRequest {
+  id: string;
+  ownerAddress: string;
+  emailHash: string;
+  verificationCode: string;
+  claimedAt?: Date;
+  requestedAt: Date;
+  transactionHash?: string;
+}
+
+export default class EmailCardDropRequestsRoute {
+  emailCardDropRequestQueries = query('email-card-drop-requests', { as: 'emailCardDropRequestQueries' });
+  emailCardDropRequestSerializer = inject('email-card-drop-request-serializer', {
+    as: 'emailCardDropRequestSerializer',
+  });
+
+  constructor() {
+    autoBind(this);
+  }
+
+  async get(ctx: Koa.Context) {
+    let timestamp = new Date();
+    let ownerAddress = ctx.request.query['eoa'] as string;
+
+    let previousRequests = await this.emailCardDropRequestQueries.query({
+      ownerAddress,
+    });
+
+    let claimed = Boolean(previousRequests[0]?.transactionHash);
+
+    let result = this.emailCardDropRequestSerializer.serializeEmailCardDropRequestStatus({
+      timestamp,
+      ownerAddress,
+      claimed,
+    });
+
+    ctx.status = 200;
+    ctx.body = result;
+    ctx.type = 'application/vnd.api+json';
+    return;
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'email-card-drop-requests-route': EmailCardDropRequestsRoute;
+  }
+}

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -28,6 +28,21 @@ export default class EmailCardDropRequestsRoute {
     let timestamp = new Date(this.clock.now());
     let ownerAddress = ctx.request.query['eoa'] as string;
 
+    if (!ownerAddress) {
+      ctx.status = 400;
+      ctx.body = {
+        errors: [
+          {
+            code: '400',
+            title: 'Missing required parameter: eoa',
+            detail: 'Please provide an ethereum address via the eoa query parameter',
+          },
+        ],
+      };
+      ctx.type = 'application/vnd.api+json';
+      return;
+    }
+
     let previousRequests = await this.emailCardDropRequestQueries.query({
       ownerAddress,
     });

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -18,13 +18,14 @@ export default class EmailCardDropRequestsRoute {
   emailCardDropRequestSerializer = inject('email-card-drop-request-serializer', {
     as: 'emailCardDropRequestSerializer',
   });
+  clock = inject('clock');
 
   constructor() {
     autoBind(this);
   }
 
   async get(ctx: Koa.Context) {
-    let timestamp = new Date();
+    let timestamp = new Date(this.clock.now());
     let ownerAddress = ctx.request.query['eoa'] as string;
 
     let previousRequests = await this.emailCardDropRequestQueries.query({

--- a/packages/hub/services/api-router.ts
+++ b/packages/hub/services/api-router.ts
@@ -28,6 +28,9 @@ export default class APIRouter {
   cardSpacesRoute = inject('card-spaces-route', {
     as: 'cardSpacesRoute',
   });
+  emailCardDropRequestsRoute = inject('email-card-drop-requests-route', {
+    as: 'emailCardDropRequestsRoute',
+  });
   pushNotificationRegistrationsRoute = inject('push-notification-registrations-route', {
     as: 'pushNotificationRegistrationsRoute',
   });
@@ -55,6 +58,7 @@ export default class APIRouter {
       reservationsRoute,
       inventoryRoute,
       cardSpacesRoute,
+      emailCardDropRequestsRoute,
       wyrePricesRoute,
       pushNotificationRegistrationsRoute,
       notificationPreferencesRoute,
@@ -78,6 +82,7 @@ export default class APIRouter {
     apiSubrouter.get('/orders/:order_id', ordersRoute.get);
     apiSubrouter.post('/reservations', parseBody, reservationsRoute.post);
     apiSubrouter.get('/reservations/:reservation_id', reservationsRoute.get);
+    apiSubrouter.get('/email-card-drop-requests', emailCardDropRequestsRoute.get);
 
     apiSubrouter.get('/card-spaces/:slug', cardSpacesRoute.get);
     apiSubrouter.post('/card-spaces', parseBody, cardSpacesRoute.post);

--- a/packages/hub/services/serializers/email-card-drop-request-serializer.ts
+++ b/packages/hub/services/serializers/email-card-drop-request-serializer.ts
@@ -18,7 +18,7 @@ export default class EmailCardDropRequestSerializer {
           timestamp: model.timestamp.toISOString(),
         },
       },
-    } as JSONAPIDocument;
+    };
   }
 }
 

--- a/packages/hub/services/serializers/email-card-drop-request-serializer.ts
+++ b/packages/hub/services/serializers/email-card-drop-request-serializer.ts
@@ -1,0 +1,29 @@
+import { JSONAPIDocument } from '../../utils/jsonapi-document';
+
+interface EmailCardDropRequestClaimStatus {
+  ownerAddress: string;
+  claimed: boolean;
+  timestamp: Date;
+}
+
+export default class EmailCardDropRequestSerializer {
+  serializeEmailCardDropRequestStatus(model: EmailCardDropRequestClaimStatus): JSONAPIDocument {
+    return {
+      data: {
+        type: 'email-card-drop-request-claim-status',
+        id: `${model.ownerAddress}-${model.timestamp.toISOString()}`,
+        attributes: {
+          'owner-address': model.ownerAddress,
+          claimed: model.claimed,
+          timestamp: model.timestamp.toISOString(),
+        },
+      },
+    } as JSONAPIDocument;
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'email-card-drop-request-serializer': EmailCardDropRequestSerializer;
+  }
+}


### PR DESCRIPTION
Add a GET endpoint to the hub to check if an EOA's card drop has been claimed

```
fetch("https://hub.cardstack.com/api/email-card-drop-requests?eoa=address", { 
  method: "GET",
  headers: {
   "Accept": "application/vnd.api+json"
  }
})
```

should return 

```
{
  "data": {
    "type": "email-card-drop-request-claim-status",
    "id": "address-2022-04-20T11:52:28.908Z",
    "attributes": {
      "owner-address": "address",
      "claimed": false, // true if there is a transaction hash in the db. false otherwise, or if there is no record of the request
      "timestamp": "2022-04-20T11:52:28.908Z"
    }
  }
}
```