### PR TITLE
fix fastboot URLSearchParams not being defined

### DIFF
--- a/packages/ssr-web/config/fastboot.js
+++ b/packages/ssr-web/config/fastboot.js
@@ -11,6 +11,7 @@ module.exports = function (/* environment */) {
         // has to be done here instead of assigning global.fetch
         // because the server runs the ember app within a sandbox
         fetch,
+        URLSearchParams,
       });
     },
   };

--- a/packages/ssr-web/deployment/fastboot-server.js
+++ b/packages/ssr-web/deployment/fastboot-server.js
@@ -32,6 +32,7 @@ let server = new FastBootAppServer({
         return Buffer.from(str).toString('base64');
       },
       fetch,
+      URLSearchParams,
     });
   },
   // This should be false for Twitter/Linkedin according to https://github.com/ember-fastboot/ember-cli-fastboot/tree/master/packages/fastboot-app-server#twitter-and-linkedin


### PR DESCRIPTION
tried this locally w `ember s` and also with the node server in the deployment package, this fixes the error we saw:

```
Error occurred:

- While rendering:
  -top-level
    application
      card-space/user-page


There was an error running your app in fastboot. More info about the error: 
 ReferenceError: URLSearchParams is not defined
```