### PR TITLE
hub: Add duplication rejections for drop requests

### DIFF
--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -230,4 +230,44 @@ describe('POST /api/email-card-drop-requests', function () {
         ],
       });
   });
+
+  it('rejects when the owner address has already claimed', async function () {
+    let emailCardDropRequestsQueries = await getContainer().lookup('email-card-drop-requests', { type: 'query' });
+
+    await emailCardDropRequestsQueries.insert({
+      ownerAddress: stubUserAddress,
+      emailHash: 'abc123',
+      verificationCode: '123456',
+      id: '2850a954-525d-499a-a5c8-3c89192ad40e',
+      requestedAt: new Date(),
+      claimedAt: new Date(),
+    });
+
+    let email = 'valid@example.com';
+
+    const payload = {
+      data: {
+        type: 'email-card-drop-requests',
+        attributes: {
+          email,
+        },
+      },
+    };
+
+    await request()
+      .post('/api/email-card-drop-requests')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Content-Type', 'application/vnd.api+json')
+      .send(payload)
+      .expect(422)
+      .expect({
+        errors: [
+          {
+            status: '422',
+            title: 'Address has already claimed a prepaid card',
+          },
+        ],
+      });
+  });
 });

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -274,7 +274,7 @@ describe('POST /api/email-card-drop-requests', function () {
   it('rejects when the email has already claimed', async function () {
     let emailCardDropRequestsQueries = await getContainer().lookup('email-card-drop-requests', { type: 'query' });
 
-    let email = 'valid@example.com';
+    let email = 'example@gmail.com';
 
     let hash = crypto.createHash('sha256');
     hash.update(email);
@@ -293,7 +293,7 @@ describe('POST /api/email-card-drop-requests', function () {
       data: {
         type: 'email-card-drop-requests',
         attributes: {
-          email,
+          email: email.replace('@', '+subaddress@'),
         },
       },
     };

--- a/packages/hub/node-tests/utils/queries-test.ts
+++ b/packages/hub/node-tests/utils/queries-test.ts
@@ -1,4 +1,4 @@
-import { buildConditions } from '../../utils/queries';
+import { NOT_NULL, buildConditions } from '../../utils/queries';
 
 describe('Queries utils', function () {
   describe('buildConditions', function () {
@@ -7,6 +7,11 @@ describe('Queries utils', function () {
 
       expect(buildConditions({ a: 1, b: null, c: 2 })).to.deep.equal({
         where: 'a=$1 AND c=$2 AND b IS NULL',
+        values: [1, 2],
+      });
+
+      expect(buildConditions({ a: 1, b: NOT_NULL, c: 2 })).to.deep.equal({
+        where: 'a=$1 AND c=$2 AND b IS NOT NULL',
         values: [1, 2],
       });
 

--- a/packages/hub/queries/email-card-drop-requests.ts
+++ b/packages/hub/queries/email-card-drop-requests.ts
@@ -4,8 +4,9 @@ import { EmailCardDropRequest } from '../routes/email-card-drop-requests';
 import { buildConditions } from '../utils/queries';
 
 interface EmailCardDropRequestsQueriesFilter {
-  ownerAddress: string;
   claimedAt?: Date | string;
+  emailHash?: string;
+  ownerAddress?: string;
 }
 
 export default class EmailCardDropRequestsQueries {

--- a/packages/hub/queries/email-card-drop-requests.ts
+++ b/packages/hub/queries/email-card-drop-requests.ts
@@ -5,6 +5,7 @@ import { buildConditions } from '../utils/queries';
 
 interface EmailCardDropRequestsQueriesFilter {
   ownerAddress: string;
+  claimedAt?: Date | string;
 }
 
 export default class EmailCardDropRequestsQueries {

--- a/packages/hub/queries/email-card-drop-requests.ts
+++ b/packages/hub/queries/email-card-drop-requests.ts
@@ -4,7 +4,7 @@ import { EmailCardDropRequest } from '../routes/email-card-drop-requests';
 import { buildConditions } from '../utils/queries';
 
 interface EmailCardDropRequestsQueriesFilter {
-  claimedAt?: Date | string;
+  claimedAt?: Date | Symbol;
   emailHash?: string;
   ownerAddress?: string;
 }

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -102,6 +102,26 @@ export default class EmailCardDropRequestsRoute {
     hash.update(email);
     let emailHash = hash.digest('hex');
 
+    let claimedWithUserEmail = await this.emailCardDropRequestQueries.query({
+      emailHash,
+      claimedAt: NOT_NULL,
+    });
+
+    if (claimedWithUserEmail.length > 0) {
+      ctx.status = 422;
+      ctx.body = {
+        errors: [
+          {
+            status: '422',
+            title: 'Email has already claimed a prepaid card',
+            pointer: '/data/attributes/email',
+          },
+        ],
+      };
+
+      return;
+    }
+
     let verificationCode = (crypto.randomInt(1000000) + '').padStart(6, '0');
 
     if (isEmail(email)) {

--- a/packages/hub/utils/queries.ts
+++ b/packages/hub/utils/queries.ts
@@ -1,6 +1,6 @@
 import { pickBy } from 'lodash';
 
-export const NOT_NULL = '!NOT NULL!';
+export const NOT_NULL = Symbol.for('NOT_NULL');
 
 const camelToSnakeCase = (str: string) => str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
 
@@ -14,7 +14,7 @@ export function buildConditions(params: any, tableName?: string) {
   // Only allow nulls, strings and numbers in the params
   let filteredParams = Object.fromEntries(
     Object.entries(params).filter(
-      ([_key, value]) => value == null || typeof value === 'number' || typeof value === 'string'
+      ([_key, value]) => value == null || typeof value === 'number' || typeof value === 'string' || value === NOT_NULL
     )
   );
 


### PR DESCRIPTION
This builds on #2902 to add rejection of `POST /api/email-card-drop-requests` when either:
* the authenticated EOA has been used to claim
* the hashed normalised email has been used to claim

Included is a `NOT_NULL` symbol to allow the existing `buildConditions` query builder to support querying for `IS NOT NULL`.