### PR TITLE
add execution role for secrets read access

### DIFF
--- a/waypoint.prod.hcl
+++ b/waypoint.prod.hcl
@@ -176,6 +176,7 @@ app "hub-event-listener" {
           count = 1
           subnets = ["subnet-0c22641bd41cbdd1e", "subnet-01d36d7bcd0334fc0"]
           task_role_name = "hub-ecr-task"
+          execution_role_name = "hub-ecr-task-executor-role"
           disable_alb = true
             secrets = {
                 LAYER1_RPC_NODE_HTTPS_URL = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_evm_infura_https_url-p9kYAu"


### PR DESCRIPTION
Without this we default to the default ECS task execution role ([AmazonECSTaskExecutionRolePolicy](https://us-east-1.console.aws.amazon.com/iam/home#/policies/arn%3Aaws%3Aiam%3A%3Aaws%3Apolicy%2Fservice-role%2FAmazonECSTaskExecutionRolePolicy)). It has no access to AWS Secrets Manager.