### PR TITLE
hub: Remove expired push client ids

### DIFF
--- a/packages/hub/queries/push-notification-registration.ts
+++ b/packages/hub/queries/push-notification-registration.ts
@@ -52,6 +52,14 @@ export default class PushNotificationRegistrationQueries {
     );
   }
 
+  async disable(pushClientId: string) {
+    let db = await this.databaseManager.getClient();
+
+    await db.query('UPDATE push_notification_registrations SET disabled_at = now() WHERE push_client_id = $1', [
+      pushClientId,
+    ]);
+  }
+
   async delete(model: PushNotificationRegistration) {
     let db = await this.databaseManager.getClient();
 

--- a/packages/hub/worker.ts
+++ b/packages/hub/worker.ts
@@ -54,6 +54,7 @@ export class HubWorker {
   async boot() {
     let runner = await runWorkers({
       logger: new Logger(workerLogFactory),
+      concurrency: 10,
       connectionString: dbConfig.url,
       taskList: {
         boom: boom,


### PR DESCRIPTION
There are some EOAs now-invalid push client ids, which rejects a notification attempt with this error:

```
Uncaught FirebaseMessagingError: Requested entity was not found.
…
  errorInfo: {
    code: 'messaging/registration-token-not-registered',
    message: 'Requested entity was not found.'
  },
  codePrefix: 'messaging'
}
```

This updates `send-notification-task` to set `disabled_at` when this error is encountered so we stop trying to send notifications to that client.

This also configures `hub-worker` to start 10 concurrent jobs to process tasks.