### PR TITLE
hub: Add handling for resending verification code

### DIFF
--- a/packages/hub/queries/email-card-drop-requests.ts
+++ b/packages/hub/queries/email-card-drop-requests.ts
@@ -51,6 +51,20 @@ export default class EmailCardDropRequestsQueries {
       };
     });
   }
+
+  async updateVerificationCode(id: string, verificationCode: string): Promise<EmailCardDropRequest> {
+    let db = await this.databaseManager.getClient();
+
+    let { rows } = await db.query(
+      `UPDATE email_card_drop_requests SET
+        verification_code = $2
+      WHERE ID = $1
+      RETURNING *`,
+      [id, verificationCode]
+    );
+
+    return rows[0];
+  }
 }
 
 declare module '@cardstack/hub/queries' {


### PR DESCRIPTION
If `POST /api/email-card-drop-requests` happens with an EOA and hashed email that already exists but `claimed_at` is absent, this updates the verification code and sends another email.