### PR TITLE
hub: Add entropy to code and email to verify

### DIFF
--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -38,6 +38,7 @@ The app uses a Postgresql-based background task queue built on [graphile/worker]
 Below is a list of the most common environment variables that the Hub accepts:
 
 - `HUB_AUTH_SECRET` (required) - to generate one for your machine, run `node --eval="console.log(crypto.randomBytes(32).toString('base64'))"`
+- `HUB_EMAIL_HASH_SALT` (required for /email-card-drop/verify) - generate similarly to auth secret
 - `FIXER_API_KEY` (required for `/api/exchange-rates`) - API key for currency exchange rates, we use https://fixer.io/
 - `EXCHANGE_RATES_ALLOWED_DOMAINS` - domains from which a request to `/api/exchange-rates` is allowed
 - `HUB_AWS_ACCESS_KEY_ID`

--- a/packages/hub/config/custom-environment-variables.json
+++ b/packages/hub/config/custom-environment-variables.json
@@ -71,5 +71,6 @@
     "privateKey": "FIREBASE_PRIVATE_KEY",
     "databaseURL": "FIREBASE_DATABASE_URL"
   },
-  "authSecret": "HUB_AUTH_SECRET"
+  "authSecret": "HUB_AUTH_SECRET",
+  "emailHashSalt": "HUB_EMAIL_HASH_SALT"
 }

--- a/packages/hub/config/default.cjs
+++ b/packages/hub/config/default.cjs
@@ -34,6 +34,7 @@ module.exports = {
     messageVerificationDelayMs: 1000 * 15,
   },
   authSecret: null,
+  emailHashSecret: null,
   sentry: {
     dsn: null,
     enabled: false,

--- a/packages/hub/config/default.cjs
+++ b/packages/hub/config/default.cjs
@@ -34,7 +34,7 @@ module.exports = {
     messageVerificationDelayMs: 1000 * 15,
   },
   authSecret: null,
-  emailHashSecret: null,
+  emailHashSalt: null,
   sentry: {
     dsn: null,
     enabled: false,

--- a/packages/hub/config/test.cjs
+++ b/packages/hub/config/test.cjs
@@ -6,6 +6,7 @@ module.exports = {
     useTransactionalRollbacks: true,
   },
   authSecret: '2Lhrsi7xSDMv1agfW+hghvQkdkTRSqW/JGApSjLT0NA=',
+  emailHashSalt: 'P91APjz3Ef6q3KAdOCfKa5hOcEmOyrPeRPG6+g380LY=',
   checkly: {
     handleWebhookRequests: true,
   },

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -175,7 +175,7 @@ describe('POST /api/email-card-drop-requests', function () {
     expect(emailCardDropRequest.ownerAddress).to.equal(stubUserAddress);
     expect(emailCardDropRequest.verificationCode).to.match(verificationCodeRegex);
 
-    let hash = crypto.createHmac('sha256', config.get('authSecret'));
+    let hash = crypto.createHmac('sha256', config.get('emailHashSalt'));
     hash.update(email);
     let emailHash = hash.digest('hex');
 
@@ -193,7 +193,7 @@ describe('POST /api/email-card-drop-requests', function () {
 
     let email = 'valid@example.com';
 
-    let hash = crypto.createHmac('sha256', config.get('authSecret'));
+    let hash = crypto.createHmac('sha256', config.get('emailHashSalt'));
     hash.update(email);
     let emailHash = hash.digest('hex');
 
@@ -327,7 +327,7 @@ describe('POST /api/email-card-drop-requests', function () {
 
     let email = 'example@gmail.com';
 
-    let hash = crypto.createHmac('sha256', config.get('authSecret'));
+    let hash = crypto.createHmac('sha256', config.get('emailHashSalt'));
     hash.update(email);
     let emailHash = hash.digest('hex');
 

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -127,6 +127,8 @@ class StubWorkerClient {
   }
 }
 
+const verificationCodeRegex = /^[.a-zA-Z0-9_-]{10}$/;
+
 describe('POST /api/email-card-drop-requests', function () {
   this.beforeEach(function () {
     registry(this).register('authentication-utils', StubAuthenticationUtils);
@@ -169,7 +171,7 @@ describe('POST /api/email-card-drop-requests', function () {
     let emailCardDropRequest = (await emailCardDropRequestsQueries.query({ ownerAddress: stubUserAddress }))[0];
 
     expect(emailCardDropRequest.ownerAddress).to.equal(stubUserAddress);
-    expect(emailCardDropRequest.verificationCode).to.match(/^\d{6}$/);
+    expect(emailCardDropRequest.verificationCode).to.match(verificationCodeRegex);
 
     let hash = crypto.createHash('sha256');
     hash.update(email);
@@ -196,7 +198,7 @@ describe('POST /api/email-card-drop-requests', function () {
     await emailCardDropRequestsQueries.insert({
       ownerAddress: stubUserAddress,
       emailHash,
-      verificationCode: 'xxxxxx',
+      verificationCode: 'xxxxxxyyyy',
       id: '2850a954-525d-499a-a5c8-3c89192ad40e',
       requestedAt: new Date(),
     });
@@ -225,7 +227,7 @@ describe('POST /api/email-card-drop-requests', function () {
 
     let emailCardDropRequest = (await emailCardDropRequestsQueries.query({ ownerAddress: stubUserAddress }))[0];
 
-    expect(emailCardDropRequest.verificationCode).to.match(/^\d{6}$/);
+    expect(emailCardDropRequest.verificationCode).to.match(verificationCodeRegex);
 
     expect(jobIdentifiers).to.deep.equal(['send-email-card-drop-verification']);
     expect(jobPayloads).to.deep.equal([{ id: resourceId, email }]);
@@ -284,7 +286,7 @@ describe('POST /api/email-card-drop-requests', function () {
     await emailCardDropRequestsQueries.insert({
       ownerAddress: stubUserAddress,
       emailHash: 'abc123',
-      verificationCode: '123456',
+      verificationCode: 'I4I.FX8OUx',
       id: '2850a954-525d-499a-a5c8-3c89192ad40e',
       requestedAt: new Date(),
       claimedAt: new Date(),
@@ -330,7 +332,7 @@ describe('POST /api/email-card-drop-requests', function () {
     await emailCardDropRequestsQueries.insert({
       ownerAddress: '0xanother-address',
       emailHash,
-      verificationCode: '123456',
+      verificationCode: 'I4I.FX8OUx',
       id: '2850a954-525d-499a-a5c8-3c89192ad40e',
       requestedAt: new Date(),
       claimedAt: new Date(),

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -24,6 +24,9 @@ let unclaimedEoa: EmailCardDropRequest = {
 
 let fakeTime = 1650440847689;
 let fakeTimeString = new Date(fakeTime).toISOString();
+
+const verificationCodeRegex = /^[~.a-zA-Z0-9_-]{10}$/;
+
 describe('GET /api/email-card-drop-requests', function () {
   let { request, getContainer } = setupHub(this);
 
@@ -127,8 +130,6 @@ class StubWorkerClient {
     return Promise.resolve({} as Job);
   }
 }
-
-const verificationCodeRegex = /^[~.a-zA-Z0-9_-]{10}$/;
 
 describe('POST /api/email-card-drop-requests', function () {
   this.beforeEach(function () {

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -3,6 +3,7 @@ import { Clock } from '../../services/clock';
 import { registry, setupHub } from '../helpers/server';
 import crypto from 'crypto';
 import { Job, TaskSpec } from 'graphile-worker';
+import config from 'config';
 
 let claimedEoa: EmailCardDropRequest = {
   id: '2850a954-525d-499a-a5c8-3c89192ad40e',
@@ -173,7 +174,7 @@ describe('POST /api/email-card-drop-requests', function () {
     expect(emailCardDropRequest.ownerAddress).to.equal(stubUserAddress);
     expect(emailCardDropRequest.verificationCode).to.match(verificationCodeRegex);
 
-    let hash = crypto.createHash('sha256');
+    let hash = crypto.createHmac('sha256', config.get('authSecret'));
     hash.update(email);
     let emailHash = hash.digest('hex');
 
@@ -191,7 +192,7 @@ describe('POST /api/email-card-drop-requests', function () {
 
     let email = 'valid@example.com';
 
-    let hash = crypto.createHash('sha256');
+    let hash = crypto.createHmac('sha256', config.get('authSecret'));
     hash.update(email);
     let emailHash = hash.digest('hex');
 
@@ -325,7 +326,7 @@ describe('POST /api/email-card-drop-requests', function () {
 
     let email = 'example@gmail.com';
 
-    let hash = crypto.createHash('sha256');
+    let hash = crypto.createHmac('sha256', config.get('authSecret'));
     hash.update(email);
     let emailHash = hash.digest('hex');
 

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -128,7 +128,7 @@ class StubWorkerClient {
   }
 }
 
-const verificationCodeRegex = /^[.a-zA-Z0-9_-]{10}$/;
+const verificationCodeRegex = /^[~.a-zA-Z0-9_-]{10}$/;
 
 describe('POST /api/email-card-drop-requests', function () {
   this.beforeEach(function () {

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -62,6 +62,7 @@
     "config": "^3.3.6",
     "corde": "^4.4.1",
     "crypto": "^1.0.1",
+    "crypto-random-string": "^4.0.0",
     "dag-map": "^2.0.2",
     "did-resolver": "^3.1.0",
     "dotenv": "^10.0.0",

--- a/packages/hub/queries/email-card-drop-requests.ts
+++ b/packages/hub/queries/email-card-drop-requests.ts
@@ -70,9 +70,11 @@ export default class EmailCardDropRequestsQueries {
   }
 
   async claim({
+    emailHash,
     ownerAddress,
     verificationCode,
   }: {
+    emailHash: string;
     ownerAddress: string;
     verificationCode: string;
   }): Promise<EmailCardDropRequest> {
@@ -82,10 +84,14 @@ export default class EmailCardDropRequestsQueries {
       `
         UPDATE email_card_drop_requests
         SET claimed_at = $1
-        WHERE owner_address = $2 AND verification_code = $3 AND claimed_at IS NULL
+        WHERE
+          email_hash = $2 AND
+          owner_address = $3 AND
+          verification_code = $4 AND
+          claimed_at IS NULL
         RETURNING *
       `,
-      [new Date(this.clock.now()), ownerAddress, verificationCode]
+      [new Date(this.clock.now()), emailHash, ownerAddress, verificationCode]
     );
 
     return rows[0];

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -7,6 +7,7 @@ import { ensureLoggedIn } from './utils/auth';
 import isEmail from 'validator/lib/isEmail';
 import normalizeEmail from 'validator/lib/normalizeEmail';
 import crypto from 'crypto';
+import cryptoRandomString from 'crypto-random-string';
 import { NOT_NULL } from '../utils/queries';
 
 export interface EmailCardDropRequest {
@@ -199,7 +200,7 @@ export default class EmailCardDropRequestsRoute {
 }
 
 function generateVerificationCode() {
-  return (crypto.randomInt(1000000) + '').padStart(6, '0');
+  return cryptoRandomString({ length: 10, type: 'url-safe' });
 }
 
 declare module '@cardstack/di' {

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -118,7 +118,7 @@ export default class EmailCardDropRequestsRoute {
       return;
     }
 
-    let hash = crypto.createHmac('sha256', config.get('authSecret'));
+    let hash = crypto.createHmac('sha256', config.get('emailHashSalt'));
     hash.update(normalizedEmail);
     let normalizedEmailHash = hash.digest('hex');
 

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -1,5 +1,6 @@
 import Koa from 'koa';
 import autoBind from 'auto-bind';
+import config from 'config';
 import { query } from '../queries';
 import { inject } from '@cardstack/di';
 import shortUuid from 'short-uuid';
@@ -117,7 +118,7 @@ export default class EmailCardDropRequestsRoute {
       return;
     }
 
-    let hash = crypto.createHash('sha256');
+    let hash = crypto.createHmac('sha256', config.get('authSecret'));
     hash.update(normalizedEmail);
     let normalizedEmailHash = hash.digest('hex');
 

--- a/packages/hub/routes/email-card-drop-verify.ts
+++ b/packages/hub/routes/email-card-drop-verify.ts
@@ -48,12 +48,12 @@ export default class EmailCardDropVerifyRoute {
 
     // If the claim query doesn’t return a record, there no matching record, now determine why
 
-    let claimedRequests = await this.emailCardDropRequestQueries.query({
+    let emailCardDropRequests = await this.emailCardDropRequestQueries.query({
       ownerAddress,
       verificationCode,
     });
 
-    let emailCardDropRequest = claimedRequests[0];
+    let emailCardDropRequest = emailCardDropRequests[0];
 
     if (!emailCardDropRequest) {
       ctx.status = 400;

--- a/waypoint.hcl
+++ b/waypoint.hcl
@@ -41,6 +41,7 @@ app "hub" {
                 LAYER2_RPC_NODE_HTTPS_URL = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_evm_full_node_url-NBKUCq"
                 LAYER2_RPC_NODE_WSS_URL = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_evm_full_node_wss_url-4RtEaG"
                 HUB_AUTH_SECRET = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_hub_auth_secret-50oF6K"
+                HUB_EMAIL_HASH_SALT = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_hub_email_hash_salt-nJvKQH"
             }
         }
 

--- a/waypoint.prod.hcl
+++ b/waypoint.prod.hcl
@@ -41,6 +41,7 @@ app "hub" {
                 LAYER2_RPC_NODE_HTTPS_URL = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_evm_full_node_url-K67DON"
                 LAYER2_RPC_NODE_WSS_URL = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_evm_full_node_wss_url-BXGFlG"
                 HUB_AUTH_SECRET = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_hub_auth_secret-amva1E"
+                HUB_EMAIL_HASH_SALT = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_hub_email_hash_salt-6j6HZV"
             }
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9375,7 +9375,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@4.1.4, axe-core@^4.1.4:
+axe-core@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.4.tgz#f19cd99a84ee32a318b9c5b5bb8ed373ad94f143"
   integrity sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==
@@ -12989,6 +12989,13 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
+crypto-random-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-4.0.0.tgz#5a3cc53d7dd86183df5da0312816ceeeb5bb1fc2"
+  integrity sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==
+  dependencies:
+    type-fest "^1.0.1"
+
 crypto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
@@ -13989,7 +13996,7 @@ elliptic@6.5.4, elliptic@^6.0.0, elliptic@^6.4.0, elliptic@^6.5.2:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-ember-a11y-testing@4.0.3, ember-a11y-testing@^4.0.3:
+ember-a11y-testing@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-4.0.3.tgz#1f5c91266d39ea5b20614b0d294a562079887ac7"
   integrity sha512-Q7nq2crC9+bT+sZi/BORAM4FUhI080edEhnpsvB6vdkD9Ro2Rg4DksQs5Be65/DM108VNDMtbHZtrPS060Mzcw==
@@ -30175,6 +30182,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^1.0.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
+  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
 type-fest@^2.3.2:
   version "2.12.0"


### PR DESCRIPTION
This changes the email card drop verification code from a 6-digit string to a 10-character random `url-safe` string (from `crypto-random-string`). It also changes the email hash to be salted and required as a parameter in the `GET /email-card-drop/verify` call.