### PR TITLE
Add optional ethers.js signing for signing of typed data

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -458,9 +458,9 @@
         "0x22d0ea6Ba8842Ae1355F842a9fAc32F035F18Ca6", // Hassan's prepaid card --feel free to use your own
         "50",
         "--network",
-        "sokol",
-        "--ethersMnemonic",
-        "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
       ]
     },
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -454,13 +454,13 @@
         "index.ts",
         "prepaid-card",
         "pay-merchant",
-        "0x3e6C2b2c3a842b6492F9F43349D77A40568e3d7E", // safe for Hassan's merchant (whose address the correlates with the mnemenoic 0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13)
-        "0x70fdd952d8b4DC0E3E91d2e7392bdb600d637b40", // Hassan's prepaid card --feel free to use your own
-        "100",
+        "0x08a4F4fB9938940FA49A4F7dC43B2fb2cd5B3b87", // safe for Hassan's merchant (whose address the correlates with the mnemenoic 0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13)
+        "0x22d0ea6Ba8842Ae1355F842a9fAc32F035F18Ca6", // Hassan's prepaid card --feel free to use your own
+        "50",
         "--network",
-        "${config:cardCli.network.l2.name}",
-        "--mnemonic",
-        "${config:cardCli.mnemonic}"
+        "sokol",
+        "--ethersMnemonic",
+        "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream"
       ]
     },
     {

--- a/packages/cardpay-cli/assets/token-balance.ts
+++ b/packages/cardpay-cli/assets/token-balance.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_ANY, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_ANY, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getConstantByNetwork, getSDK, ERC20ABI } from '@cardstack/cardpay-sdk';
 import { AbiItem } from 'web3-utils';
@@ -22,7 +22,7 @@ export default {
       network: string;
       tokenAddress?: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
     let assets = await getSDK('Assets', web3);
 
     if (!tokenAddress) {

--- a/packages/cardpay-cli/assets/token-balance.ts
+++ b/packages/cardpay-cli/assets/token-balance.ts
@@ -22,7 +22,7 @@ export default {
       network: string;
       tokenAddress?: string;
     };
-    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let assets = await getSDK('Assets', web3);
 
     if (!tokenAddress) {

--- a/packages/cardpay-cli/bridge/await-to-l1.ts
+++ b/packages/cardpay-cli/bridge/await-to-l1.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 
 export default {
@@ -25,7 +25,7 @@ export default {
       txnHash: string;
     };
 
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let tokenBridge = await getSDK('TokenBridgeHomeSide', web3);
 
     console.log(`Waiting for bridge validation to complete for ${txnHash}...`);

--- a/packages/cardpay-cli/bridge/await-to-l2.ts
+++ b/packages/cardpay-cli/bridge/await-to-l2.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 
 export default {
@@ -24,7 +24,7 @@ export default {
       fromBlock: string;
       recipient?: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let tokenBridge = await getSDK('TokenBridgeHomeSide', web3);
     recipient = recipient ?? (await web3.eth.getAccounts())[0];
 

--- a/packages/cardpay-cli/bridge/claim-on-l1.ts
+++ b/packages/cardpay-cli/bridge/claim-on-l1.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
-import { getWeb3, NETWORK_OPTION_LAYER_1, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_1, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 
 export default {
@@ -33,7 +33,7 @@ export default {
       signatures: string[];
     };
 
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let tokenBridge = await getSDK('TokenBridgeForeignSide', web3);
     let blockExplorer = await getConstant('blockExplorer', web3);
 

--- a/packages/cardpay-cli/bridge/to-l1.ts
+++ b/packages/cardpay-cli/bridge/to-l1.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import Web3 from 'web3';
 const { toWei } = Web3.utils;
@@ -39,8 +39,8 @@ export default {
 
     const amountInWei = toWei(amount);
 
-    let web3 = await getWeb3(network, getWeb3Opts(args));
-    let tokenBridge = await getSDK('TokenBridgeHomeSide', web3);
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let tokenBridge = await getSDK('TokenBridgeHomeSide', web3, signer);
     let assets = await getSDK('Assets', web3);
     let { symbol } = await assets.getTokenInfo(tokenAddress);
     receiver = receiver ?? (await web3.eth.getAccounts())[0];

--- a/packages/cardpay-cli/bridge/to-l2.ts
+++ b/packages/cardpay-cli/bridge/to-l2.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
-import { getWeb3, NETWORK_OPTION_LAYER_1, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_1, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import Web3 from 'web3';
 const { toWei } = Web3.utils;
@@ -35,7 +35,7 @@ export default {
     };
     const amountInWei = toWei(amount);
 
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let tokenBridge = await getSDK('TokenBridgeForeignSide', web3);
     let assets = await getSDK('Assets', web3);
     let { symbol } = await assets.getTokenInfo(tokenAddress);

--- a/packages/cardpay-cli/bridge/withdrawal-limits.ts
+++ b/packages/cardpay-cli/bridge/withdrawal-limits.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { fromWei, getSDK } from '@cardstack/cardpay-sdk';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 
 export default {
@@ -19,7 +19,7 @@ export default {
       network: string;
       token: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let tokenBridge = await getSDK('TokenBridgeHomeSide', web3);
     let { max, min } = await tokenBridge.getWithdrawalLimits(token);
     let assets = await getSDK('Assets', web3);

--- a/packages/cardpay-cli/builder.ts
+++ b/packages/cardpay-cli/builder.ts
@@ -25,18 +25,30 @@ export function buildYargs(args: string[]) {
         type: 'string',
         description: 'Phrase for mnemonic wallet',
       },
+      ethersMnemonic: {
+        alias: 'e',
+        default: process.env.MNEMONIC_PHRASE,
+        type: 'string',
+        description: 'Phrase for mnemonic wallet using ethers.js signer',
+      },
     })
     .check((argv) => {
       if (process.env.BUILDING_README) {
         return true;
       }
-      if (!argv.mnemonic && !argv.walletConnect && !argv.trezor) {
+      if (!argv.mnemonic && !argv.ethersMnemonic && !argv.walletConnect && !argv.trezor) {
         return 'Wallet is not specified. Either specify that wallet connect or trezor should be used for the wallet, or specify the mnemonic as a positional arg, or pass the mnemonic in using the MNEMONIC_PHRASE env var';
       }
       if (argv.trezor) {
         argv.connectionType = 'trezor';
         argv.walletConnect = undefined;
         argv.mnemonic = undefined;
+        return true;
+      }
+      if (argv.ethersMnemonic) {
+        argv.connectionType = 'ethers-mnemonic';
+        argv.walletConnect = undefined;
+        argv.trezor = undefined;
         return true;
       }
       if (argv.mnemonic) {

--- a/packages/cardpay-cli/builder.ts
+++ b/packages/cardpay-cli/builder.ts
@@ -27,7 +27,7 @@ export function buildYargs(args: string[]) {
       },
       ethersMnemonic: {
         alias: 'e',
-        default: process.env.MNEMONIC_PHRASE,
+        default: process.env.ETHERS_MNEMONIC_PHRASE,
         type: 'string',
         description: 'Phrase for mnemonic wallet using ethers.js signer',
       },

--- a/packages/cardpay-cli/hub/auth.ts
+++ b/packages/cardpay-cli/hub/auth.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 
 export default {
@@ -19,7 +19,7 @@ export default {
       hubRootUrl: string;
       network: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let authToken = await (await getSDK('HubAuth', web3, hubRootUrl)).authenticate();
     console.log(`Authentication token for ${hubRootUrl}: ${authToken}`);
   },

--- a/packages/cardpay-cli/merchant/claim-revenue-gas-estimate.ts
+++ b/packages/cardpay-cli/merchant/claim-revenue-gas-estimate.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
 import { fromWei, toWei } from 'web3-utils';
@@ -30,7 +30,7 @@ export default {
       tokenAddress: string;
       amount: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let revenuePool = await getSDK('RevenuePool', web3);
     let assets = await getSDK('Assets', web3);
     let { symbol } = await assets.getTokenInfo(tokenAddress);

--- a/packages/cardpay-cli/merchant/claim-revenue.ts
+++ b/packages/cardpay-cli/merchant/claim-revenue.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 import { toWei } from 'web3-utils';
@@ -30,8 +30,8 @@ export default {
       tokenAddress: string;
       amount: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
-    let revenuePool = await getSDK('RevenuePool', web3);
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let revenuePool = await getSDK('RevenuePool', web3, signer);
     let assets = await getSDK('Assets', web3);
     let { symbol } = await assets.getTokenInfo(tokenAddress);
     let weiAmount = toWei(amount);

--- a/packages/cardpay-cli/merchant/register.ts
+++ b/packages/cardpay-cli/merchant/register.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 
@@ -24,8 +24,8 @@ export default {
       fundingCard: string;
       infoDID: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
-    let revenuePool = await getSDK('RevenuePool', web3);
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let revenuePool = await getSDK('RevenuePool', web3, signer);
     let blockExplorer = await getConstant('blockExplorer', web3);
 
     console.log(

--- a/packages/cardpay-cli/merchant/revenue-balances.ts
+++ b/packages/cardpay-cli/merchant/revenue-balances.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
 import { fromWei } from 'web3-utils';
@@ -20,7 +20,7 @@ export default {
       network: string;
       merchantSafe: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let revenuePool = await getSDK('RevenuePool', web3);
     let balanceInfo = await revenuePool.balances(merchantSafe);
     console.log(`Merchant revenue balance for merchant safe ${merchantSafe}:`);

--- a/packages/cardpay-cli/package.json
+++ b/packages/cardpay-cli/package.json
@@ -35,6 +35,7 @@
     "@types/semver": "^7.3.9",
     "@walletconnect/web3-provider": "^1.6.0",
     "did-resolver": "^3.1.0",
+    "ethers": "5.6.4",
     "jsonapi-typescript": "^0.1.3",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",

--- a/packages/cardpay-cli/prepaid-card-market/add.ts
+++ b/packages/cardpay-cli/prepaid-card-market/add.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 
@@ -24,9 +24,9 @@ export default {
       fundingCard: string;
       prepaidCard: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
     let blockExplorer = await getConstant('blockExplorer', web3);
-    let prepaidCardMarket = await getSDK('PrepaidCardMarket', web3);
+    let prepaidCardMarket = await getSDK('PrepaidCardMarket', web3, signer);
 
     console.log(`Adding prepaid card to inventory ${prepaidCard}...`);
     await prepaidCardMarket.addToInventory(fundingCard, prepaidCard, undefined, {

--- a/packages/cardpay-cli/prepaid-card-market/inventories.ts
+++ b/packages/cardpay-cli/prepaid-card-market/inventories.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import Web3 from 'web3';
 const { fromWei } = Web3.utils;
@@ -46,7 +46,7 @@ export default {
       network: string;
       environment: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let query = `
   {
     skuinventories {

--- a/packages/cardpay-cli/prepaid-card-market/inventory.ts
+++ b/packages/cardpay-cli/prepaid-card-market/inventory.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
 
@@ -19,7 +19,7 @@ export default {
       network: string;
       sku: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let prepaidCardMarket = await getSDK('PrepaidCardMarket', web3);
     let inventory = await prepaidCardMarket.getInventory(sku);
     console.log(`Inventory for SKU ${sku} (${inventory.length} items):

--- a/packages/cardpay-cli/prepaid-card-market/provision.ts
+++ b/packages/cardpay-cli/prepaid-card-market/provision.ts
@@ -1,7 +1,7 @@
 /*global fetch */
 import { Argv } from 'yargs';
 import { getConstant, getConstantByNetwork, getSDK } from '@cardstack/cardpay-sdk';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getInventoriesFromAPI } from './utils';
 import Web3 from 'web3';
@@ -38,8 +38,8 @@ export default {
       environment: string;
       provisionerSecret: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
-    let prepaidCardMarket = await getSDK('PrepaidCardMarket', web3);
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let prepaidCardMarket = await getSDK('PrepaidCardMarket', web3, signer);
     let inventories = await getInventoriesFromAPI(web3, environment);
     let blockExplorer = await getConstant('blockExplorer', web3);
     let inventory = inventories.find((inventory) => inventory.id === sku);

--- a/packages/cardpay-cli/prepaid-card-market/remove.ts
+++ b/packages/cardpay-cli/prepaid-card-market/remove.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 
@@ -25,9 +25,9 @@ export default {
       prepaidCards: string[];
     };
 
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
     let blockExplorer = await getConstant('blockExplorer', web3);
-    let prepaidCardMarket = await getSDK('PrepaidCardMarket', web3);
+    let prepaidCardMarket = await getSDK('PrepaidCardMarket', web3, signer);
 
     console.log(`Removing prepaid cards from inventory ${prepaidCards.join(', ')}...`);
     await prepaidCardMarket.removeFromInventory(fundingCard, prepaidCards, undefined, {

--- a/packages/cardpay-cli/prepaid-card-market/set-ask.ts
+++ b/packages/cardpay-cli/prepaid-card-market/set-ask.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 import Web3 from 'web3';
@@ -33,9 +33,9 @@ export default {
       sku: string;
       askPrice: number;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
     let blockExplorer = await getConstant('blockExplorer', web3);
-    let prepaidCardMarket = await getSDK('PrepaidCardMarket', web3);
+    let prepaidCardMarket = await getSDK('PrepaidCardMarket', web3, signer);
     let assets = await getSDK('Assets', web3);
     let skuInfo = await prepaidCardMarket.getSKUInfo(sku);
     if (!skuInfo) {

--- a/packages/cardpay-cli/prepaid-card-market/sku-info.ts
+++ b/packages/cardpay-cli/prepaid-card-market/sku-info.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import Web3 from 'web3';
 import { getSDK } from '@cardstack/cardpay-sdk';
@@ -21,7 +21,7 @@ export default {
       network: string;
       sku: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let prepaidCardMarket = await getSDK('PrepaidCardMarket', web3);
     let assets = await getSDK('Assets', web3);
     let skuInfo = await prepaidCardMarket.getSKUInfo(sku);

--- a/packages/cardpay-cli/prepaid-card/create.ts
+++ b/packages/cardpay-cli/prepaid-card/create.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { ContractOptions } from 'web3-eth-contract';
 
@@ -46,9 +46,9 @@ export default {
       customizationDID?: string;
       from?: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
 
-    let prepaidCard = await getSDK('PrepaidCard', web3);
+    let prepaidCard = await getSDK('PrepaidCard', web3, signer);
     let blockExplorer = await getConstant('blockExplorer', web3);
     let assets = await getSDK('Assets', web3);
     let { symbol } = await assets.getTokenInfo(tokenAddress);

--- a/packages/cardpay-cli/prepaid-card/creation-gas-fee.ts
+++ b/packages/cardpay-cli/prepaid-card/creation-gas-fee.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { fromWei, getSDK } from '@cardstack/cardpay-sdk';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 
 export default {
@@ -19,7 +19,7 @@ export default {
       network: string;
       tokenAddress: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let prepaidCard = await getSDK('PrepaidCard', web3);
     let weiAmount = await prepaidCard.gasFee(tokenAddress);
     console.log(`The gas fee for a new prepaid card in units of this token is ${fromWei(weiAmount)}`);

--- a/packages/cardpay-cli/prepaid-card/pay-merchant.ts
+++ b/packages/cardpay-cli/prepaid-card/pay-merchant.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { ContractOptions } from 'web3-eth-contract';
 
@@ -28,6 +28,7 @@ export default {
       .option('network', NETWORK_OPTION_LAYER_2);
   },
   async handler(args: Arguments) {
+    console.log('args: ' + JSON.stringify(args, null, 2));
     let { network, merchantSafe, prepaidCard, spendAmount, from } = args as unknown as {
       network: string;
       merchantSafe: string;
@@ -35,8 +36,8 @@ export default {
       spendAmount: number;
       from?: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
-    let prepaidCardSdk = await getSDK('PrepaidCard', web3);
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let prepaidCardSdk = await getSDK('PrepaidCard', web3, signer);
     let blockExplorer = await getConstant('blockExplorer', web3);
 
     console.log(

--- a/packages/cardpay-cli/prepaid-card/payment-limits.ts
+++ b/packages/cardpay-cli/prepaid-card/payment-limits.ts
@@ -1,5 +1,5 @@
 import { getSDK } from '@cardstack/cardpay-sdk';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, Argv, CommandModule } from 'yargs';
 
 export default {
@@ -14,7 +14,7 @@ export default {
     let { network } = args as unknown as {
       network: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let prepaidCard = await getSDK('PrepaidCard', web3);
     let { min, max } = await prepaidCard.getPaymentLimits();
     console.log(`The prepaid card payments limits are:

--- a/packages/cardpay-cli/prepaid-card/price-for-face-value.ts
+++ b/packages/cardpay-cli/prepaid-card/price-for-face-value.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { fromWei, getSDK } from '@cardstack/cardpay-sdk';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 
 export default {
@@ -25,7 +25,7 @@ export default {
       tokenAddress: string;
       spendFaceValue: number;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let prepaidCard = await getSDK('PrepaidCard', web3);
     let weiAmount = await prepaidCard.priceForFaceValue(tokenAddress, spendFaceValue);
     console.log(

--- a/packages/cardpay-cli/prepaid-card/split-equally.ts
+++ b/packages/cardpay-cli/prepaid-card/split-equally.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
-import { FROM_OPTION, getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { FROM_OPTION, getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { formatPrepaidCards, inventoryInfo } from './utils';
 import { ContractOptions } from 'web3-eth-contract';
@@ -33,9 +33,9 @@ export default {
       quantity: number;
       from?: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
 
-    let prepaidCardAPI = await getSDK('PrepaidCard', web3);
+    let prepaidCardAPI = await getSDK('PrepaidCard', web3, signer);
     let blockExplorer = await getConstant('blockExplorer', web3);
     let customizationDID = await prepaidCardAPI.customizationDID(prepaidCard);
     console.log(

--- a/packages/cardpay-cli/prepaid-card/split.ts
+++ b/packages/cardpay-cli/prepaid-card/split.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
-import { FROM_OPTION, getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { FROM_OPTION, getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { formatPrepaidCards, inventoryInfo } from './utils';
 import { ContractOptions } from 'web3-eth-contract';
@@ -33,8 +33,8 @@ export default {
       customizationDID: string;
       from?: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
-    let prepaidCardAPI = await getSDK('PrepaidCard', web3);
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let prepaidCardAPI = await getSDK('PrepaidCard', web3, signer);
     let blockExplorer = await getConstant('blockExplorer', web3);
     console.log(
       `Splitting prepaid card ${prepaidCard} into face value(s) §${faceValues.join(

--- a/packages/cardpay-cli/prepaid-card/transfer.ts
+++ b/packages/cardpay-cli/prepaid-card/transfer.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
-import { FROM_OPTION, getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { FROM_OPTION, getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { ContractOptions } from 'web3-eth-contract';
 
@@ -27,9 +27,9 @@ export default {
       newOwner: string;
       from?: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
 
-    let prepaidCardAPI = await getSDK('PrepaidCard', web3);
+    let prepaidCardAPI = await getSDK('PrepaidCard', web3, signer);
     let blockExplorer = await getConstant('blockExplorer', web3);
 
     console.log(`Transferring prepaid card ${prepaidCard} to new owner ${newOwner}...`);

--- a/packages/cardpay-cli/price/eth.ts
+++ b/packages/cardpay-cli/price/eth.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import Web3 from 'web3';
 import { fromWei, getSDK } from '@cardstack/cardpay-sdk';
@@ -27,7 +27,7 @@ export default {
       token: string;
       amount: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let amountInWei = toWei(amount);
     let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
     let ethWeiPrice = await layerTwoOracle.getETHPrice(token, amountInWei);

--- a/packages/cardpay-cli/price/updated-at.ts
+++ b/packages/cardpay-cli/price/updated-at.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_ANY, getWeb3Opts, Web3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_ANY, getConnectionType, Web3Opts } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
 
@@ -21,7 +21,7 @@ export default {
       network: string;
       token: string;
     };
-    let web3Opts = getWeb3Opts(args);
+    let web3Opts = getConnectionType(args);
     if (token.toUpperCase() === 'ETH') {
       await layer1PriceOracleUpdatedAt(network, web3Opts);
     } else {
@@ -31,14 +31,14 @@ export default {
 } as CommandModule;
 
 export async function layer1PriceOracleUpdatedAt(network: string, web3Opts: Web3Opts): Promise<void> {
-  let web3 = await getWeb3(network, web3Opts);
+  let { web3 } = await getEthereumClients(network, web3Opts);
   let layerOneOracle = await getSDK('LayerOneOracle', web3);
   let date = await layerOneOracle.getEthToUsdUpdatedAt();
   console.log(`The ETH / USD rate was last updated at ${date.toString()}`);
 }
 
 export async function layer2PriceOracleUpdatedAt(network: string, token: string, web3Opts: Web3Opts): Promise<void> {
-  let web3 = await getWeb3(network, web3Opts);
+  let { web3 } = await getEthereumClients(network, web3Opts);
   let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
   let date = await layerTwoOracle.getUpdatedAt(token);
   console.log(`The ${token} rate was last updated at ${date.toString()}`);

--- a/packages/cardpay-cli/price/usd.ts
+++ b/packages/cardpay-cli/price/usd.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_ANY, Web3Opts, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_ANY, Web3Opts, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import Web3 from 'web3';
 import { getSDK } from '@cardstack/cardpay-sdk';
@@ -29,7 +29,7 @@ export default {
       token: string;
       amount: string;
     };
-    let web3Opts = getWeb3Opts(args);
+    let web3Opts = getConnectionType(args);
     if (token.toUpperCase() === 'ETH') {
       await ethToUsdPrice(network, amount, web3Opts);
     } else {
@@ -39,7 +39,7 @@ export default {
 } as CommandModule;
 
 async function ethToUsdPrice(network: string, ethAmount: string, web3Opts: Web3Opts): Promise<void> {
-  let web3 = await getWeb3(network, web3Opts);
+  let { web3 } = await getEthereumClients(network, web3Opts);
   let ethAmountInWei = toWei(ethAmount);
   let layerOneOracle = await getSDK('LayerOneOracle', web3);
   let usdPrice = await layerOneOracle.ethToUsd(ethAmountInWei);
@@ -47,7 +47,7 @@ async function ethToUsdPrice(network: string, ethAmount: string, web3Opts: Web3O
 }
 
 async function usdPrice(network: string, token: string, amount: string, web3Opts: Web3Opts): Promise<void> {
-  let web3 = await getWeb3(network, web3Opts);
+  let { web3 } = await getEthereumClients(network, web3Opts);
   let amountInWei = toWei(amount);
   let layerTwoOracle = await getSDK('LayerTwoOracle', web3);
   let usdPrice = await layerTwoOracle.getUSDPrice(token, amountInWei);

--- a/packages/cardpay-cli/rewards/admin/add-rule.ts
+++ b/packages/cardpay-cli/rewards/admin/add-rule.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 
@@ -29,8 +29,8 @@ export default {
       rewardProgramId: string;
       blob: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
-    let rewardManagerAPI = await getSDK('RewardManager', web3);
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let rewardManagerAPI = await getSDK('RewardManager', web3, signer);
     let blockExplorer = await getConstant('blockExplorer', web3);
     await rewardManagerAPI.addRewardRule(fundingCard, rewardProgramId, blob, {
       onTxnHash: (txnHash: string) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),

--- a/packages/cardpay-cli/rewards/admin/add-tokens.ts
+++ b/packages/cardpay-cli/rewards/admin/add-tokens.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 
@@ -34,8 +34,8 @@ export default {
       tokenAddress: string;
       amount: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
-    let rewardPool = await getSDK('RewardPool', web3);
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let rewardPool = await getSDK('RewardPool', web3, signer);
     let assets = await getSDK('Assets', web3);
     let blockExplorer = await getConstant('blockExplorer', web3);
     await rewardPool.addRewardTokens(safeAddress, rewardProgramId, tokenAddress, amount, {

--- a/packages/cardpay-cli/rewards/admin/create-program.ts
+++ b/packages/cardpay-cli/rewards/admin/create-program.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 
@@ -24,8 +24,8 @@ export default {
       prepaidCard: string;
       admin: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
-    let rewardManagerAPI = await getSDK('RewardManager', web3);
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let rewardManagerAPI = await getSDK('RewardManager', web3, signer);
     let blockExplorer = await getConstant('blockExplorer', web3);
     let { rewardProgramId } = await rewardManagerAPI.registerRewardProgram(prepaidCard, admin, {
       onTxnHash: (txnHash: string) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),

--- a/packages/cardpay-cli/rewards/admin/lock.ts
+++ b/packages/cardpay-cli/rewards/admin/lock.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 
@@ -24,8 +24,8 @@ export default {
       fundingCard: string;
       rewardProgramId: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
-    let rewardManagerAPI = await getSDK('RewardManager', web3);
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let rewardManagerAPI = await getSDK('RewardManager', web3, signer);
     let blockExplorer = await getConstant('blockExplorer', web3);
     await rewardManagerAPI.lockRewardProgram(fundingCard, rewardProgramId, {
       onTxnHash: (txnHash: string) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),

--- a/packages/cardpay-cli/rewards/admin/recover-reward-tokens.ts
+++ b/packages/cardpay-cli/rewards/admin/recover-reward-tokens.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 
@@ -34,8 +34,8 @@ export default {
       safeAddress: string;
       amount?: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
-    let rewardPool = await getSDK('RewardPool', web3);
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let rewardPool = await getSDK('RewardPool', web3, signer);
     let assets = await getSDK('Assets', web3);
     let blockExplorer = await getConstant('blockExplorer', web3);
     await rewardPool.recoverTokens(safeAddress, rewardProgramId, tokenAddress, amount, {

--- a/packages/cardpay-cli/rewards/admin/set-admin.ts
+++ b/packages/cardpay-cli/rewards/admin/set-admin.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 
@@ -29,8 +29,8 @@ export default {
       rewardProgramId: string;
       newAdmin: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
-    let rewardManagerAPI = await getSDK('RewardManager', web3);
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let rewardManagerAPI = await getSDK('RewardManager', web3, signer);
     let blockExplorer = await getConstant('blockExplorer', web3);
     await rewardManagerAPI.updateRewardProgramAdmin(fundingCard, rewardProgramId, newAdmin, {
       onTxnHash: (txnHash: string) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),

--- a/packages/cardpay-cli/rewards/check-claim-params.ts
+++ b/packages/cardpay-cli/rewards/check-claim-params.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { fromProof } from './utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
@@ -37,7 +37,7 @@ export default {
       proof: string;
       acceptPartialClaim: boolean;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let rewardPool = await getSDK('RewardPool', web3);
     let rewardManager = await getSDK('RewardManager', web3);
     let proofArray = fromProof(proof);

--- a/packages/cardpay-cli/rewards/claim-reward-gas-estimate.ts
+++ b/packages/cardpay-cli/rewards/claim-reward-gas-estimate.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { fromProof } from './utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
@@ -38,7 +38,7 @@ export default {
       proof: string;
       acceptPartialClaim: boolean;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let rewardPool = await getSDK('RewardPool', web3);
     let proofArray = fromProof(proof);
     let assets = await getSDK('Assets', web3);

--- a/packages/cardpay-cli/rewards/claim.ts
+++ b/packages/cardpay-cli/rewards/claim.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { fromProof } from './utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getSDK, getConstant } from '@cardstack/cardpay-sdk';
@@ -36,8 +36,8 @@ export default {
       proof: string;
       acceptPartialClaim: boolean;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
-    let rewardPool = await getSDK('RewardPool', web3);
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let rewardPool = await getSDK('RewardPool', web3, signer);
     let blockExplorer = await getConstant('blockExplorer', web3);
     let proofArray = fromProof(proof);
     await rewardPool.claim(rewardSafe, leaf, proofArray, acceptPartialClaim, {

--- a/packages/cardpay-cli/rewards/claimable-proofs.ts
+++ b/packages/cardpay-cli/rewards/claimable-proofs.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { Proof, getSDK, WithSymbol } from '@cardstack/cardpay-sdk';
 import groupBy from 'lodash/groupBy';
@@ -36,7 +36,7 @@ export default {
       tokenAddress?: string;
       isValidOnly?: boolean;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let rewardPool = await getSDK('RewardPool', web3);
     const proofs = await rewardPool.getProofs(address, rewardProgramId, tokenAddress, false);
     if (isValidOnly) {

--- a/packages/cardpay-cli/rewards/list.ts
+++ b/packages/cardpay-cli/rewards/list.ts
@@ -1,4 +1,4 @@
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, Argv, CommandModule } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
 import { displayRewardProgramInfo } from './utils';
@@ -15,7 +15,7 @@ export default {
     let { network } = args as unknown as {
       network: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let rewardManagerAPI = await getSDK('RewardManager', web3);
     let rewardProgramInfos = await rewardManagerAPI.getRewardProgramsInfo();
     rewardProgramInfos.map((rewardProgramInfo) => displayRewardProgramInfo(rewardProgramInfo));

--- a/packages/cardpay-cli/rewards/pool-balances.ts
+++ b/packages/cardpay-cli/rewards/pool-balances.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
 import { displayRewardTokenBalance } from './utils';
@@ -20,7 +20,7 @@ export default {
       network: string;
       rewardProgramId: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let rewardPool = await getSDK('RewardPool', web3);
     let rewardTokenBalances = await rewardPool.balances(rewardProgramId);
     displayRewardTokenBalance(rewardTokenBalances);

--- a/packages/cardpay-cli/rewards/register-rewardee-gas-estimate.ts
+++ b/packages/cardpay-cli/rewards/register-rewardee-gas-estimate.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts, FROM_OPTION } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType, FROM_OPTION } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
 import { fromWei } from 'web3-utils';
@@ -26,7 +26,7 @@ export default {
       prepaidCard: string;
       rewardProgramId: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let rewardManager = await getSDK('RewardManager', web3);
     let assets = await getSDK('Assets', web3);
     let { gasToken, amount } = await rewardManager.registerRewardeeGasEstimate(prepaidCard, rewardProgramId);

--- a/packages/cardpay-cli/rewards/register.ts
+++ b/packages/cardpay-cli/rewards/register.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { FROM_OPTION, getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { FROM_OPTION, getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 
@@ -26,8 +26,8 @@ export default {
       rewardProgramId: string;
       from?: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
-    let rewardManagerAPI = await getSDK('RewardManager', web3);
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let rewardManagerAPI = await getSDK('RewardManager', web3, signer);
     let blockExplorer = await getConstant('blockExplorer', web3);
     let { rewardSafe } = await rewardManagerAPI.registerRewardee(
       prepaidCard,

--- a/packages/cardpay-cli/rewards/reward-balances.ts
+++ b/packages/cardpay-cli/rewards/reward-balances.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
 import { displayRewardTokenBalance } from './utils';
@@ -25,7 +25,7 @@ export default {
       address: string;
       rewardProgramId?: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let rewardPool = await getSDK('RewardPool', web3);
     const tokenBalances = await rewardPool.rewardTokenBalances(address, rewardProgramId);
     console.log(`Reward balances for ${address}`);

--- a/packages/cardpay-cli/rewards/transfer-safe.ts
+++ b/packages/cardpay-cli/rewards/transfer-safe.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 
@@ -24,8 +24,8 @@ export default {
       rewardSafe: string;
       newOwner: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
-    let rewardManagerAPI = await getSDK('RewardManager', web3);
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let rewardManagerAPI = await getSDK('RewardManager', web3, signer);
     let blockExplorer = await getConstant('blockExplorer', web3);
     await rewardManagerAPI.transfer(rewardSafe, newOwner, {
       onTxnHash: (txnHash: string) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),

--- a/packages/cardpay-cli/rewards/view.ts
+++ b/packages/cardpay-cli/rewards/view.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
 import { displayRewardProgramInfo } from './utils';
@@ -20,7 +20,7 @@ export default {
       network: string;
       rewardProgramId: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let rewardManagerAPI = await getSDK('RewardManager', web3);
     const rewardProgramInfo = await rewardManagerAPI.getRewardProgramInfo(rewardProgramId);
     displayRewardProgramInfo(rewardProgramInfo);

--- a/packages/cardpay-cli/rewards/withdraw-from-safe.ts
+++ b/packages/cardpay-cli/rewards/withdraw-from-safe.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
 import { toWei } from 'web3-utils';
@@ -35,8 +35,8 @@ export default {
       tokenAddress: string;
       amount?: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
-    let rewardManagerAPI = await getSDK('RewardManager', web3);
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let rewardManagerAPI = await getSDK('RewardManager', web3, signer);
     let blockExplorer = await getConstant('blockExplorer', web3);
     if (amount) {
       await rewardManagerAPI.withdraw(rewardSafe, recipient, tokenAddress, toWei(amount), {

--- a/packages/cardpay-cli/rewards/withdraw-gas-estimate.ts
+++ b/packages/cardpay-cli/rewards/withdraw-gas-estimate.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
 import Web3 from 'web3';
@@ -36,8 +36,8 @@ export default {
       tokenAddress: string;
       amount: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
-    let rewardManagerAPI = await getSDK('RewardManager', web3);
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let rewardManagerAPI = await getSDK('RewardManager', web3, signer);
     let assets = await getSDK('Assets', web3);
     let { gasToken, amount: estimate } = await rewardManagerAPI.withdrawGasEstimate(
       rewardSafe,

--- a/packages/cardpay-cli/safe/debug-sign-typed-data.ts
+++ b/packages/cardpay-cli/safe/debug-sign-typed-data.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { signTypedData } from '@cardstack/cardpay-sdk';
 
@@ -29,13 +29,13 @@ export default {
       address?: string;
     };
     let data = JSON.parse(dataStr);
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
     address = address ?? (await web3.eth.getAccounts())[0];
     console.log(`Signing typed data for address ${address}:
     ${JSON.stringify(data, null, 2)}
     `);
 
-    let signature = await signTypedData(web3, address, data);
+    let signature = await signTypedData(signer ?? web3, address, data);
     console.log(`Signature for the typed data is: ${signature}`);
   },
 } as CommandModule;

--- a/packages/cardpay-cli/safe/list.ts
+++ b/packages/cardpay-cli/safe/list.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { getSDK, Safe } from '@cardstack/cardpay-sdk';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { displaySafe } from './utils';
 
@@ -32,7 +32,7 @@ export default {
     if (safeType && !['depot', 'merchant', 'prepaid-card', 'reward'].includes(safeType)) {
       throw new Error(`Invalid safe type: ${safeType}`);
     }
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     address = address || undefined;
 
     let safesApi = await getSDK('Safes', web3);

--- a/packages/cardpay-cli/safe/transfer-tokens-gas-estimate.ts
+++ b/packages/cardpay-cli/safe/transfer-tokens-gas-estimate.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import Web3 from 'web3';
 const { toWei, fromWei } = Web3.utils;
@@ -36,7 +36,7 @@ export default {
       recipient: string;
       amount: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let weiAmount = toWei(amount);
 
     let safes = await getSDK('Safes', web3);

--- a/packages/cardpay-cli/safe/transfer-tokens.ts
+++ b/packages/cardpay-cli/safe/transfer-tokens.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import Web3 from 'web3';
 const { toWei } = Web3.utils;
@@ -36,7 +36,7 @@ export default {
       recipient: string;
       amount?: string;
     };
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
     let safes = await getSDK('Safes', web3);
     let assets = await getSDK('Assets', web3);
     let { symbol } = await assets.getTokenInfo(token);

--- a/packages/cardpay-cli/safe/view.ts
+++ b/packages/cardpay-cli/safe/view.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { getSDK } from '@cardstack/cardpay-sdk';
-import { getWeb3, NETWORK_OPTION_LAYER_2, getWeb3Opts } from '../utils';
+import { getEthereumClients, NETWORK_OPTION_LAYER_2, getConnectionType } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { displaySafe } from './utils';
 
@@ -21,7 +21,7 @@ export default {
       safeAddress: string;
     };
 
-    let web3 = await getWeb3(network, getWeb3Opts(args));
+    let { web3 } = await getEthereumClients(network, getConnectionType(args));
 
     let safesApi = await getSDK('Safes', web3);
     console.log(`Getting safe ${safeAddress}`);

--- a/packages/cardpay-cli/utils.ts
+++ b/packages/cardpay-cli/utils.ts
@@ -1,5 +1,6 @@
 import HDWalletProvider from 'parity-hdwallet-provider';
 import Web3 from 'web3';
+import { Wallet, Signer } from 'ethers';
 import { AbstractProvider } from 'web3-core';
 import { HttpProvider, networkIds, getConstantByNetwork, HubConfig } from '@cardstack/cardpay-sdk';
 import WalletConnectProvider from '@walletconnect/web3-provider';
@@ -9,10 +10,15 @@ const TrezorWalletProvider = require('trezor-cli-wallet-provider');
 
 const BRIDGE = 'https://safe-walletconnect.gnosis.io/';
 
-export type ConnectionType = 'mnemonic' | 'trezor' | 'wallet-connect';
+export type ConnectionType = 'mnemonic' | 'ethers-mnemonic' | 'trezor' | 'wallet-connect';
 
 interface Web3OptsMnemonic {
   connectionType: 'mnemonic';
+  mnemonic: string;
+}
+
+interface EthersOptsMnemonic {
+  connectionType: 'ethers-mnemonic';
   mnemonic: string;
 }
 
@@ -24,9 +30,9 @@ interface Web3OptsWalletConnect {
   connectionType: 'wallet-connect';
 }
 
-export type Web3Opts = Web3OptsMnemonic | Web3OptsTrezor | Web3OptsWalletConnect;
+export type Web3Opts = Web3OptsMnemonic | Web3OptsTrezor | Web3OptsWalletConnect | EthersOptsMnemonic;
 
-export function getWeb3Opts(args: Arguments): Web3Opts {
+export function getConnectionType(args: Arguments): Web3Opts {
   switch (args.connectionType as ConnectionType) {
     case 'wallet-connect':
       return {
@@ -36,6 +42,11 @@ export function getWeb3Opts(args: Arguments): Web3Opts {
       return {
         connectionType: 'trezor',
       } as Web3OptsTrezor;
+    case 'ethers-mnemonic':
+      return {
+        connectionType: 'ethers-mnemonic',
+        mnemonic: args.ethersMnemonic,
+      } as EthersOptsMnemonic;
     case 'mnemonic':
       return {
         connectionType: 'mnemonic',
@@ -44,7 +55,7 @@ export function getWeb3Opts(args: Arguments): Web3Opts {
   }
 }
 
-export async function getWeb3(network: string, opts: Web3Opts): Promise<Web3> {
+export async function getEthereumClients(network: string, opts: Web3Opts): Promise<{ web3: Web3; signer?: Signer }> {
   let rpcNodeHttpsUrl!: string;
   let hubConfigResponse;
   let hubUrl = process.env.HUB_URL || getConstantByNetwork('hubUrl', network);
@@ -78,24 +89,41 @@ export async function getWeb3(network: string, opts: Web3Opts): Promise<Web3> {
         bridge: BRIDGE,
       });
       await provider.enable();
-      return new Web3(provider as unknown as AbstractProvider);
+      return { web3: new Web3(provider as unknown as AbstractProvider) };
     }
     case 'mnemonic':
-      return new Web3(
-        new HDWalletProvider({
-          chainId: networkIds[network],
-          mnemonic: {
-            phrase: opts.mnemonic,
-          },
-          providerOrUrl: new HttpProvider(rpcNodeHttpsUrl),
-        })
-      );
+      return {
+        web3: new Web3(
+          new HDWalletProvider({
+            chainId: networkIds[network],
+            mnemonic: {
+              phrase: opts.mnemonic,
+            },
+            providerOrUrl: new HttpProvider(rpcNodeHttpsUrl),
+          })
+        ),
+      };
+    case 'ethers-mnemonic':
+      return {
+        web3: new Web3(
+          new HDWalletProvider({
+            chainId: networkIds[network],
+            mnemonic: {
+              phrase: opts.mnemonic,
+            },
+            providerOrUrl: new HttpProvider(rpcNodeHttpsUrl),
+          })
+        ),
+        signer: Wallet.fromMnemonic(opts.mnemonic),
+      };
     case 'trezor':
-      return new Web3(
-        new TrezorWalletProvider(rpcNodeHttpsUrl, {
-          chainId: networkIds[network],
-        })
-      );
+      return {
+        web3: new Web3(
+          new TrezorWalletProvider(rpcNodeHttpsUrl, {
+            chainId: networkIds[network],
+          })
+        ),
+      };
   }
 }
 

--- a/packages/cardpay-sdk/package.json
+++ b/packages/cardpay-sdk/package.json
@@ -25,6 +25,7 @@
     "eth-sig-util": "^3.0.1",
     "ethereum-cryptography": "^0.1.3",
     "ethereumjs-wallet": "^1.0.1",
+    "ethers": "5.6.4",
     "fs-extra": "^10.0.0",
     "glob": "^7.1.7",
     "lodash": "^4.17.21",

--- a/packages/cardpay-sdk/sdk/prepaid-card-market/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card-market/base.ts
@@ -25,9 +25,10 @@ import { ZERO_ADDRESS } from '../constants';
 import { PrepaidCardSafe } from '../safes';
 import { getSDK } from '../version-resolver';
 import { MAX_PREPAID_CARD_AMOUNT } from '../prepaid-card/base';
+import { Signer } from 'ethers';
 
 export default class PrepaidCardMarket {
-  constructor(private layer2Web3: Web3) {}
+  constructor(private layer2Web3: Web3, private layer2Signer?: Signer) {}
 
   async getInventory(sku: string, marketAddress?: string): Promise<PrepaidCardSafe[]> {
     let prepaidCardAPI = await getSDK('PrepaidCard', this.layer2Web3);
@@ -125,7 +126,8 @@ export default class PrepaidCardMarket {
       ZERO_ADDRESS,
       transferNonce,
       from,
-      prepaidCardToAdd
+      prepaidCardToAdd,
+      this.layer2Signer
     );
     let gnosisResult = await executeSendWithRateLock(this.layer2Web3, fundingPrepaidCard, async (rateLock) => {
       let payload = await this.getAddToInventoryPayload(
@@ -148,7 +150,7 @@ export default class PrepaidCardMarket {
         marketAddress!,
         rateLock,
         payload,
-        await signPrepaidCardSendTx(this.layer2Web3, fundingPrepaidCard, payload, nonce, from),
+        await signPrepaidCardSendTx(this.layer2Web3, fundingPrepaidCard, payload, nonce, from, this.layer2Signer),
         nonce
       );
     });
@@ -215,7 +217,7 @@ export default class PrepaidCardMarket {
         marketAddress!,
         rateLock,
         payload,
-        await signPrepaidCardSendTx(this.layer2Web3, fundingPrepaidCard, payload, nonce, from),
+        await signPrepaidCardSendTx(this.layer2Web3, fundingPrepaidCard, payload, nonce, from, this.layer2Signer),
         nonce
       );
     });
@@ -280,7 +282,7 @@ export default class PrepaidCardMarket {
         marketAddress!,
         rateLock,
         payload,
-        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from),
+        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from, this.layer2Signer),
         nonce
       );
     });

--- a/packages/cardpay-sdk/sdk/prepaid-card/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card/base.ts
@@ -1,5 +1,6 @@
 import BN from 'bn.js';
 import Web3 from 'web3';
+import { Signer } from 'ethers';
 import { AbiItem } from 'web3-utils';
 import { Contract, ContractOptions } from 'web3-eth-contract';
 import ERC677ABI from '../../contracts/abi/erc-677';
@@ -41,7 +42,7 @@ export const MAX_PREPAID_CARD_AMOUNT = 10;
 
 export default class PrepaidCard {
   private prepaidCardManager: Contract | undefined;
-  constructor(private layer2Web3: Web3) {}
+  constructor(private layer2Web3: Web3, private layer2Signer?: Signer) {}
 
   async priceForFaceValue(tokenAddress: string, spendFaceValue: number): Promise<string> {
     return await (await this.getPrepaidCardMgr()).methods
@@ -146,7 +147,7 @@ export default class PrepaidCard {
         spendAmount,
         rateLock,
         payload,
-        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from),
+        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from, this.layer2Signer),
         nonce
       );
     });
@@ -223,7 +224,8 @@ export default class PrepaidCard {
       ZERO_ADDRESS,
       transferNonce,
       from,
-      prepaidCardAddress
+      prepaidCardAddress,
+      this.layer2Signer
     );
     let gnosisResult = await executeSendWithRateLock(this.layer2Web3, prepaidCardAddress, async (rateLock) => {
       let payload = await this.getTransferPayload(prepaidCardAddress, newOwner, previousOwnerSignature, rateLock);
@@ -239,7 +241,7 @@ export default class PrepaidCard {
         previousOwnerSignature,
         rateLock,
         payload,
-        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from),
+        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from, this.layer2Signer),
         nonce
       );
     });
@@ -355,7 +357,7 @@ export default class PrepaidCard {
         faceValues,
         rateLock,
         payload,
-        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from),
+        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from, this.layer2Signer),
         nonce,
         customizationDID
       );
@@ -506,7 +508,7 @@ export default class PrepaidCard {
       Operation.CALL,
       estimate,
       nonce,
-      await signSafeTx(this.layer2Web3, safeAddress, tokenAddress, payload, estimate, nonce, from)
+      await signSafeTx(this.layer2Web3, safeAddress, tokenAddress, payload, estimate, nonce, from, this.layer2Signer)
     );
 
     if (typeof onTxnHash === 'function') {

--- a/packages/cardpay-sdk/sdk/revenue-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/revenue-pool/base.ts
@@ -24,6 +24,7 @@ import { getSDK } from '../version-resolver';
 import BN from 'bn.js';
 import type { SuccessfulTransactionReceipt } from '../utils/successful-transaction-receipt';
 import { MerchantSafe, Safe } from '../safes';
+import { Signer } from 'ethers';
 
 const { fromWei } = Web3.utils;
 const POLL_INTERVAL = 500;
@@ -38,7 +39,7 @@ interface RevenueTokenBalance {
 export default class RevenuePool {
   private revenuePool: Contract | undefined;
 
-  constructor(private layer2Web3: Web3) {}
+  constructor(private layer2Web3: Web3, private layer2Signer?: Signer) {}
 
   async merchantRegistrationFee(): Promise<number> {
     // this is a SPEND amount which is a safe number to represent in javascript
@@ -165,7 +166,16 @@ export default class RevenuePool {
       Operation.CALL,
       estimate,
       nonce,
-      await signSafeTx(this.layer2Web3, merchantSafeAddress, revenuePoolAddress, payload, estimate, nonce, from)
+      await signSafeTx(
+        this.layer2Web3,
+        merchantSafeAddress,
+        revenuePoolAddress,
+        payload,
+        estimate,
+        nonce,
+        from,
+        this.layer2Signer
+      )
     );
 
     let txnHash = gnosisResult.ethereumTx.txHash;
@@ -232,7 +242,7 @@ export default class RevenuePool {
         rateLock,
         infoDID!,
         payload,
-        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from),
+        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from, this.layer2Signer),
         nonce
       );
     });

--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -31,6 +31,7 @@ import { signRewardSafe, createEIP1271VerifyingData } from '../utils/signing-uti
 import { ZERO_ADDRESS } from '../constants';
 import { WithSymbol, RewardTokenBalance } from '@cardstack/cardpay-sdk';
 import { query } from '../utils/graphql';
+import { Signer } from 'ethers';
 
 export interface RewardProgramInfo {
   rewardProgramId: string;
@@ -57,7 +58,7 @@ export default class RewardManager {
   private rewardManager: Contract | undefined;
   private rewardSafeDelegate: Contract | undefined;
 
-  constructor(private layer2Web3: Web3) {}
+  constructor(private layer2Web3: Web3, private layer2Signer?: Signer) {}
 
   async registerRewardProgram(
     txnHash: string
@@ -126,7 +127,7 @@ export default class RewardManager {
         rewardProgramRegistrationFees,
         rateLock,
         payload,
-        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from),
+        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from, this.layer2Signer),
         nonce
       );
     });
@@ -192,7 +193,7 @@ export default class RewardManager {
         rewardProgramId,
         rateLock,
         payload,
-        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from),
+        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from, this.layer2Signer),
         nonce
       );
     });
@@ -272,7 +273,7 @@ export default class RewardManager {
         rewardProgramId,
         rateLock,
         payload,
-        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from),
+        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from, this.layer2Signer),
         nonce
       );
     });
@@ -344,7 +345,7 @@ export default class RewardManager {
         newAdmin,
         rateLock,
         payload,
-        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from),
+        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from, this.layer2Signer),
         nonce
       );
     });
@@ -411,7 +412,7 @@ export default class RewardManager {
         blob,
         rateLock,
         payload,
-        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from),
+        await signPrepaidCardSendTx(this.layer2Web3, prepaidCardAddress, payload, nonce, from, this.layer2Signer),
         nonce
       );
     });
@@ -566,7 +567,8 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
       nonce,
       rewardSafeOwner,
       safeAddress,
-      rewardManagerAddress
+      rewardManagerAddress,
+      this.layer2Signer
     );
 
     let eip1271Data = createEIP1271VerifyingData(
@@ -734,7 +736,8 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
       nonce,
       rewardSafeOwner,
       safeAddress,
-      rewardManagerAddress
+      rewardManagerAddress,
+      this.layer2Signer
     );
 
     let eip1271Data = createEIP1271VerifyingData(

--- a/packages/cardpay-sdk/sdk/safes.ts
+++ b/packages/cardpay-sdk/sdk/safes.ts
@@ -15,6 +15,7 @@ import BN from 'bn.js';
 import { query } from './utils/graphql';
 import type { SuccessfulTransactionReceipt } from './utils/successful-transaction-receipt';
 import { TransactionOptions, waitForTransactionConsistency, isTransactionHash } from './utils/general-utils';
+import { Signer } from 'ethers';
 const { fromWei } = Web3.utils;
 
 export interface ISafes {
@@ -214,7 +215,7 @@ export async function viewSafe(network: 'xdai' | 'sokol', safeAddress: string): 
 }
 
 export default class Safes implements ISafes {
-  constructor(private layer2Web3: Web3) {}
+  constructor(private layer2Web3: Web3, private layer2Signer?: Signer) {}
 
   async viewSafe(safeAddress: string): Promise<ViewSafeResult> {
     let {
@@ -426,7 +427,7 @@ export default class Safes implements ISafes {
       Operation.CALL,
       estimate,
       nonce,
-      await signSafeTx(this.layer2Web3, safeAddress, tokenAddress, payload, estimate, nonce, from)
+      await signSafeTx(this.layer2Web3, safeAddress, tokenAddress, payload, estimate, nonce, from, this.layer2Signer)
     );
 
     let txnHash = result.ethereumTx.txHash;

--- a/packages/cardpay-sdk/sdk/token-bridge-home-side.ts
+++ b/packages/cardpay-sdk/sdk/token-bridge-home-side.ts
@@ -16,6 +16,7 @@ import {
   isTransactionHash,
   waitUntilTransactionMined,
 } from './utils/general-utils';
+import { Signer } from 'ethers';
 
 // The TokenBridge is created between 2 networks, referred to as a Native (or Home) Network and a Foreign network.
 // The Native or Home network has fast and inexpensive operations. All bridge operations to collect validator confirmations are performed on this side of the bridge.
@@ -50,7 +51,7 @@ const bridgedTokensQuery = `
 `;
 
 export default class TokenBridgeHomeSide implements ITokenBridgeHomeSide {
-  constructor(private layer2Web3: Web3) {}
+  constructor(private layer2Web3: Web3, private layer2Signer?: Signer) {}
 
   async getWithdrawalLimits(tokenAddress: string): Promise<{ min: string; max: string }> {
     let homeBridge = new this.layer2Web3.eth.Contract(
@@ -138,7 +139,7 @@ export default class TokenBridgeHomeSide implements ITokenBridgeHomeSide {
       Operation.CALL,
       estimate,
       nonce,
-      await signSafeTx(this.layer2Web3, safeAddress, tokenAddress, payload, estimate, nonce, from)
+      await signSafeTx(this.layer2Web3, safeAddress, tokenAddress, payload, estimate, nonce, from, this.layer2Signer)
     );
 
     let txnHash = result.ethereumTx.txHash;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3776,6 +3776,21 @@
     "@ethersproject/properties" "^5.3.0"
     "@ethersproject/strings" "^5.3.0"
 
+"@ethersproject/abi@5.6.1", "@ethersproject/abi@^5.6.0":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.6.1.tgz#f7de888edeb56b0a657b672bdd1b3a1135cd14f7"
+  integrity sha512-0cqssYh6FXjlwKWBmLm3+zH2BNARoS5u/hxbz+LpQmcDB3w0W553h2btWui1/uZp2GBM/SI3KniTuMcYyHpA5w==
+  dependencies:
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+
 "@ethersproject/abi@^5.1.2", "@ethersproject/abi@^5.3.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.5.0.tgz#fb52820e22e50b854ff15ce1647cc508d6660613"
@@ -3803,6 +3818,19 @@
     "@ethersproject/properties" "^5.3.0"
     "@ethersproject/transactions" "^5.3.0"
     "@ethersproject/web" "^5.3.0"
+
+"@ethersproject/abstract-provider@5.6.0", "@ethersproject/abstract-provider@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.6.0.tgz#0c4ac7054650dbd9c476cf5907f588bbb6ef3061"
+  integrity sha512-oPMFlKLN+g+y7a79cLK3WiLcjWFnZQtXWgnLAbHZcN3s7L4v90UHpTOrLk+m3yr0gt+/h9STTM6zrr7PM8uoRw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/networks" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/web" "^5.6.0"
 
 "@ethersproject/abstract-provider@^5.0.8":
   version "5.0.10"
@@ -3841,6 +3869,17 @@
     "@ethersproject/logger" "^5.3.0"
     "@ethersproject/properties" "^5.3.0"
 
+"@ethersproject/abstract-signer@5.6.0", "@ethersproject/abstract-signer@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.6.0.tgz#9cd7ae9211c2b123a3b29bf47aab17d4d016e3e7"
+  integrity sha512-WOqnG0NJKtI8n0wWZPReHtaLkDByPL67tn4nBaDAhmVq8sjHTPbCdz4DRhVu/cfTOvfy9w3iq5QZ7BX7zw56BQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+
 "@ethersproject/abstract-signer@^5.0.10":
   version "5.0.14"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.0.14.tgz#30ef912b0f86599d90fdffc65c110452e7b55cf1"
@@ -3874,6 +3913,17 @@
     "@ethersproject/logger" "^5.3.0"
     "@ethersproject/rlp" "^5.3.0"
 
+"@ethersproject/address@5.6.0", "@ethersproject/address@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.6.0.tgz#13c49836d73e7885fc148ad633afad729da25012"
+  integrity sha512-6nvhYXjbXsHPS+30sHZ+U4VMagFC/9zAk6Gd/h3S21YW4+yfb0WfRtaAIZ4kfM4rrVwqiy284LP0GtL5HXGLxQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
+
 "@ethersproject/address@^5.0.4", "@ethersproject/address@^5.0.9":
   version "5.0.11"
   resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.0.11.tgz#12022e8c590c33939beb5ab18b401ecf585eac59"
@@ -3903,6 +3953,13 @@
   dependencies:
     "@ethersproject/bytes" "^5.3.0"
 
+"@ethersproject/base64@5.6.0", "@ethersproject/base64@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.6.0.tgz#a12c4da2a6fb86d88563216b0282308fc15907c9"
+  integrity sha512-2Neq8wxJ9xHxCF9TUgmKeSh9BXJ6OAxWfeGWvbauPh8FuHEjamgHilllx8KkSd5ErxyHIX7Xv3Fkcud2kY9ezw==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+
 "@ethersproject/base64@^5.0.7":
   version "5.0.9"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.0.9.tgz#bb1f35d3dba92082a574d5e2418f9202a0a1a7e6"
@@ -3925,6 +3982,14 @@
     "@ethersproject/bytes" "^5.3.0"
     "@ethersproject/properties" "^5.3.0"
 
+"@ethersproject/basex@5.6.0", "@ethersproject/basex@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.6.0.tgz#9ea7209bf0a1c3ddc2a90f180c3a7f0d7d2e8a69"
+  integrity sha512-qN4T+hQd/Md32MoJpc69rOwLYRUXwjTlhHDIeUkUmiN/JyWkkLLMoG0TqvSQKNqZOMgN5stbUYN6ILC+eD7MEQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+
 "@ethersproject/basex@^5.3.0", "@ethersproject/basex@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.5.0.tgz#e40a53ae6d6b09ab4d977bd037010d4bed21b4d3"
@@ -3940,6 +4005,15 @@
   dependencies:
     "@ethersproject/bytes" "^5.3.0"
     "@ethersproject/logger" "^5.3.0"
+    bn.js "^4.11.9"
+
+"@ethersproject/bignumber@5.6.0", "@ethersproject/bignumber@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.6.0.tgz#116c81b075c57fa765a8f3822648cf718a8a0e26"
+  integrity sha512-VziMaXIUHQlHJmkv1dlcd6GY2PmT0khtAqaMctCIDogxkrarMzA9L94KN1NeXqqOfFD6r0sJT3vCTOFSmZ07DA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
     bn.js "^4.11.9"
 
 "@ethersproject/bignumber@^5.0.13", "@ethersproject/bignumber@^5.0.7":
@@ -3967,6 +4041,13 @@
   dependencies:
     "@ethersproject/logger" "^5.3.0"
 
+"@ethersproject/bytes@5.6.1", "@ethersproject/bytes@^5.6.0":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.6.1.tgz#24f916e411f82a8a60412344bf4a813b917eefe7"
+  integrity sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
+
 "@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.0.9":
   version "5.0.11"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.0.11.tgz#21118e75b1d00db068984c15530e316021101276"
@@ -3987,6 +4068,13 @@
   integrity sha512-4y1feNOwEpgjAfiCFWOHznvv6qUF/H6uI0UKp8xdhftb+H+FbKflXg1pOgH5qs4Sr7EYBL+zPyPb+YD5g1aEyw==
   dependencies:
     "@ethersproject/bignumber" "^5.3.0"
+
+"@ethersproject/constants@5.6.0", "@ethersproject/constants@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.6.0.tgz#55e3eb0918584d3acc0688e9958b0cedef297088"
+  integrity sha512-SrdaJx2bK0WQl23nSpV/b1aq293Lh0sUaZT/yYKPDKn4tlAbkH96SPJwIhwSwTsoQQZxuh1jnqsKwyymoiBdWA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
 
 "@ethersproject/constants@^5.0.4", "@ethersproject/constants@^5.0.8":
   version "5.0.10"
@@ -4018,6 +4106,22 @@
     "@ethersproject/properties" "^5.3.0"
     "@ethersproject/transactions" "^5.3.0"
 
+"@ethersproject/contracts@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.6.0.tgz#60f2cfc7addd99a865c6c8cfbbcec76297386067"
+  integrity sha512-74Ge7iqTDom0NX+mux8KbRUeJgu1eHZ3iv6utv++sLJG80FVuU9HnHeKVPfjd9s3woFhaFoQGf3B3iH/FrQmgw==
+  dependencies:
+    "@ethersproject/abi" "^5.6.0"
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+
 "@ethersproject/hash@5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.3.0.tgz#f65e3bf3db3282df4da676db6cfa049535dd3643"
@@ -4031,6 +4135,20 @@
     "@ethersproject/logger" "^5.3.0"
     "@ethersproject/properties" "^5.3.0"
     "@ethersproject/strings" "^5.3.0"
+
+"@ethersproject/hash@5.6.0", "@ethersproject/hash@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.6.0.tgz#d24446a5263e02492f9808baa99b6e2b4c3429a2"
+  integrity sha512-fFd+k9gtczqlr0/BruWLAu7UAOas1uRRJvOR84uDf4lNZ+bTkGl366qvniUZHKtlqxBRU65MkOobkmvmpHU+jA==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
 
 "@ethersproject/hash@^5.0.4":
   version "5.0.12"
@@ -4078,6 +4196,24 @@
     "@ethersproject/transactions" "^5.3.0"
     "@ethersproject/wordlists" "^5.3.0"
 
+"@ethersproject/hdnode@5.6.0", "@ethersproject/hdnode@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.6.0.tgz#9dcbe8d629bbbcf144f2cae476337fe92d320998"
+  integrity sha512-61g3Jp3nwDqJcL/p4nugSyLrpl/+ChXIOtCEM8UDmWeB3JCAt5FoLdOMXQc3WWkc0oM2C0aAn6GFqqMcS/mHTw==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/basex" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/pbkdf2" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+    "@ethersproject/signing-key" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/wordlists" "^5.6.0"
+
 "@ethersproject/hdnode@^5.3.0", "@ethersproject/hdnode@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.5.0.tgz#4a04e28f41c546f7c978528ea1575206a200ddf6"
@@ -4115,6 +4251,25 @@
     aes-js "3.0.0"
     scrypt-js "3.0.1"
 
+"@ethersproject/json-wallets@5.6.0", "@ethersproject/json-wallets@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.6.0.tgz#4c2fc27f17e36c583e7a252fb938bc46f98891e5"
+  integrity sha512-fmh86jViB9r0ibWXTQipxpAGMiuxoqUf78oqJDlCAJXgnJF024hOOX7qVgqsjtbeoxmcLwpPsXNU0WEe/16qPQ==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/hdnode" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/pbkdf2" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
 "@ethersproject/json-wallets@^5.3.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.5.0.tgz#dd522d4297e15bccc8e1427d247ec8376b60e325"
@@ -4142,6 +4297,14 @@
     "@ethersproject/bytes" "^5.3.0"
     js-sha3 "0.5.7"
 
+"@ethersproject/keccak256@5.6.0", "@ethersproject/keccak256@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.6.0.tgz#fea4bb47dbf8f131c2e1774a1cecbfeb9d606459"
+  integrity sha512-tk56BJ96mdj/ksi7HWZVWGjCq0WVl/QvfhFQNeL8fxhBlGoP+L80uDCiQcpJPd+2XxkivS3lwRm3E0CXTfol0w==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    js-sha3 "0.8.0"
+
 "@ethersproject/keccak256@^5.0.3", "@ethersproject/keccak256@^5.0.7":
   version "5.0.9"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.0.9.tgz#ca0d86e4af56c13b1ef25e533bde3e96d28f647d"
@@ -4163,6 +4326,11 @@
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.3.0.tgz#7a69fa1d4ca0d4b7138da1627eb152f763d84dd0"
   integrity sha512-8bwJ2gxJGkZZnpQSq5uSiZSJjyVTWmlGft4oH8vxHdvO1Asy4TwVepAhPgxIQIMxXZFUNMych1YjIV4oQ4I7dA==
 
+"@ethersproject/logger@5.6.0", "@ethersproject/logger@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.6.0.tgz#d7db1bfcc22fd2e4ab574cba0bb6ad779a9a3e7a"
+  integrity sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==
+
 "@ethersproject/logger@^5.0.5", "@ethersproject/logger@^5.0.8":
   version "5.0.10"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.0.10.tgz#fd884688b3143253e0356ef92d5f22d109d2e026"
@@ -4179,6 +4347,13 @@
   integrity sha512-6uQKHkYChlsfeiZhQ8IHIqGE/sQsf25o9ZxAYpMxi15dLPzz3IxOEF5KiSD32aHwsjXVBKBSlo+teAXLlYJybw==
   dependencies:
     "@ethersproject/logger" "^5.3.0"
+
+"@ethersproject/networks@5.6.2", "@ethersproject/networks@^5.6.0":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.6.2.tgz#2bacda62102c0b1fcee408315f2bed4f6fbdf336"
+  integrity sha512-9uEzaJY7j5wpYGTojGp8U89mSsgQLc40PCMJLMCnFXTs7nhBveZ0t7dbqWUNrepWTszDbFkYD6WlL8DKx5huHA==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/networks@^5.0.7":
   version "5.0.9"
@@ -4202,6 +4377,14 @@
     "@ethersproject/bytes" "^5.3.0"
     "@ethersproject/sha2" "^5.3.0"
 
+"@ethersproject/pbkdf2@5.6.0", "@ethersproject/pbkdf2@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.6.0.tgz#04fcc2d7c6bff88393f5b4237d906a192426685a"
+  integrity sha512-Wu1AxTgJo3T3H6MIu/eejLFok9TYoSdgwRr5oGY1LTLfmGesDoSx05pemsbrPT2gG4cQME+baTSCp5sEo2erZQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+
 "@ethersproject/pbkdf2@^5.3.0", "@ethersproject/pbkdf2@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.5.0.tgz#e25032cdf02f31505d47afbf9c3e000d95c4a050"
@@ -4216,6 +4399,13 @@
   integrity sha512-PaHxJyM5/bfusk6vr3yP//JMnm4UEojpzuWGTmtL5X4uNhNnFNvlYilZLyDr4I9cTkIbipCMsAuIcXWsmdRnEw==
   dependencies:
     "@ethersproject/logger" "^5.3.0"
+
+"@ethersproject/properties@5.6.0", "@ethersproject/properties@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.6.0.tgz#38904651713bc6bdd5bdd1b0a4287ecda920fa04"
+  integrity sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/properties@^5.0.3", "@ethersproject/properties@^5.0.7":
   version "5.0.9"
@@ -4256,6 +4446,31 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
+"@ethersproject/providers@5.6.4":
+  version "5.6.4"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.6.4.tgz#1a49c211b57b0b2703c320819abbbfa35c83dff7"
+  integrity sha512-WAdknnaZ52hpHV3qPiJmKx401BLpup47h36Axxgre9zT+doa/4GC/Ne48ICPxTm0BqndpToHjpLP1ZnaxyE+vw==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/basex" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/networks" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/web" "^5.6.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
 "@ethersproject/random@5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.3.0.tgz#7c46bf36e50cb0d0550bc8c666af8e1d4496dc1a"
@@ -4263,6 +4478,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.3.0"
     "@ethersproject/logger" "^5.3.0"
+
+"@ethersproject/random@5.6.0", "@ethersproject/random@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.6.0.tgz#1505d1ab6a250e0ee92f436850fa3314b2cb5ae6"
+  integrity sha512-si0PLcLjq+NG/XHSZz90asNf+YfKEqJGVdxoEkSukzbnBgC8rydbgbUgBbBGLeHN4kAJwUFEKsu3sCXT93YMsw==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/random@^5.3.0", "@ethersproject/random@^5.5.0":
   version "5.5.0"
@@ -4279,6 +4502,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.3.0"
     "@ethersproject/logger" "^5.3.0"
+
+"@ethersproject/rlp@5.6.0", "@ethersproject/rlp@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.6.0.tgz#55a7be01c6f5e64d6e6e7edb6061aa120962a717"
+  integrity sha512-dz9WR1xpcTL+9DtOT/aDO+YyxSSdO8YIS0jyZwHHSlAmnxA6cKU3TrTd4Xc/bHayctxTgGLYNuVVoiXE4tTq1g==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/rlp@^5.0.7":
   version "5.0.9"
@@ -4305,6 +4536,15 @@
     "@ethersproject/logger" "^5.3.0"
     hash.js "1.1.7"
 
+"@ethersproject/sha2@5.6.0", "@ethersproject/sha2@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.6.0.tgz#364c4c11cc753bda36f31f001628706ebadb64d9"
+  integrity sha512-1tNWCPFLu1n3JM9t4/kytz35DkuF9MxqkGGEHNauEbaARdm2fafnOyw1s0tIQDPKF/7bkP1u3dbrmjpn5CelyA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    hash.js "1.1.7"
+
 "@ethersproject/sha2@^5.3.0", "@ethersproject/sha2@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.5.0.tgz#a40a054c61f98fd9eee99af2c3cc6ff57ec24db7"
@@ -4322,6 +4562,18 @@
     "@ethersproject/bytes" "^5.3.0"
     "@ethersproject/logger" "^5.3.0"
     "@ethersproject/properties" "^5.3.0"
+    bn.js "^4.11.9"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@5.6.0", "@ethersproject/signing-key@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.6.0.tgz#4f02e3fb09e22b71e2e1d6dc4bcb5dafa69ce042"
+  integrity sha512-S+njkhowmLeUu/r7ir8n78OUKx63kBdMCPssePS89So1TH4hZqnWFsThEd/GiXYp9qMxVrydf7KdM9MTGPFukA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
     bn.js "^4.11.9"
     elliptic "6.5.4"
     hash.js "1.1.7"
@@ -4359,6 +4611,18 @@
     "@ethersproject/sha2" "^5.3.0"
     "@ethersproject/strings" "^5.3.0"
 
+"@ethersproject/solidity@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.6.0.tgz#64657362a596bf7f5630bdc921c07dd78df06dc3"
+  integrity sha512-YwF52vTNd50kjDzqKaoNNbC/r9kMDPq3YzDWmsjFTRBcIF1y4JCQJ8gB30wsTfHbaxgxelI5BfxQSxD/PbJOww==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+
 "@ethersproject/strings@5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.3.0.tgz#a6b640aab56a18e0909f657da798eef890968ff0"
@@ -4367,6 +4631,15 @@
     "@ethersproject/bytes" "^5.3.0"
     "@ethersproject/constants" "^5.3.0"
     "@ethersproject/logger" "^5.3.0"
+
+"@ethersproject/strings@5.6.0", "@ethersproject/strings@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.6.0.tgz#9891b26709153d996bf1303d39a7f4bc047878fd"
+  integrity sha512-uv10vTtLTZqrJuqBZR862ZQjTIa724wGPWQqZrofaPI/kUsf53TBG0I0D+hQ1qyNtllbNzaW+PDPHHUI6/65Mg==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/strings@^5.0.4", "@ethersproject/strings@^5.0.8":
   version "5.0.10"
@@ -4400,6 +4673,21 @@
     "@ethersproject/properties" "^5.3.0"
     "@ethersproject/rlp" "^5.3.0"
     "@ethersproject/signing-key" "^5.3.0"
+
+"@ethersproject/transactions@5.6.0", "@ethersproject/transactions@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.6.0.tgz#4b594d73a868ef6e1529a2f8f94a785e6791ae4e"
+  integrity sha512-4HX+VOhNjXHZyGzER6E/LVI2i6lf9ejYeWD6l4g50AdmimyuStKc39kvKf1bXWQMg7QNVh+uC7dYwtaZ02IXeg==
+  dependencies:
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
+    "@ethersproject/signing-key" "^5.6.0"
 
 "@ethersproject/transactions@^5.0.0-beta.135", "@ethersproject/transactions@^5.0.9":
   version "5.0.11"
@@ -4440,6 +4728,15 @@
     "@ethersproject/constants" "^5.3.0"
     "@ethersproject/logger" "^5.3.0"
 
+"@ethersproject/units@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.6.0.tgz#e5cbb1906988f5740254a21b9ded6bd51e826d9c"
+  integrity sha512-tig9x0Qmh8qbo1w8/6tmtyrm/QQRviBh389EQ+d8fP4wDsBrJBf08oZfoiz1/uenKK9M78yAP4PoR7SsVoTjsw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+
 "@ethersproject/wallet@5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.3.0.tgz#91946b470bd279e39ade58866f21f92749d062af"
@@ -4461,6 +4758,27 @@
     "@ethersproject/transactions" "^5.3.0"
     "@ethersproject/wordlists" "^5.3.0"
 
+"@ethersproject/wallet@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.6.0.tgz#33d11a806d783864208f348709a5a3badac8e22a"
+  integrity sha512-qMlSdOSTyp0MBeE+r7SUhr1jjDlC1zAXB8VD84hCnpijPQiSNbxr6GdiLXxpUs8UKzkDiNYYC5DRI3MZr+n+tg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/hdnode" "^5.6.0"
+    "@ethersproject/json-wallets" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.0"
+    "@ethersproject/signing-key" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/wordlists" "^5.6.0"
+
 "@ethersproject/web@5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.3.0.tgz#7959c403f6476c61515008d8f92da51c553a8ee1"
@@ -4471,6 +4789,17 @@
     "@ethersproject/logger" "^5.3.0"
     "@ethersproject/properties" "^5.3.0"
     "@ethersproject/strings" "^5.3.0"
+
+"@ethersproject/web@5.6.0", "@ethersproject/web@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.6.0.tgz#4bf8b3cbc17055027e1a5dd3c357e37474eaaeb8"
+  integrity sha512-G/XHj0hV1FxI2teHRfCGvfBUHFmU+YOSbCxlAMqJklxSa7QMiHFQfAxvwY2PFqgvdkxEKwRNr/eCjfAPEm2Ctg==
+  dependencies:
+    "@ethersproject/base64" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
 
 "@ethersproject/web@^5.0.12":
   version "5.0.14"
@@ -4504,6 +4833,17 @@
     "@ethersproject/logger" "^5.3.0"
     "@ethersproject/properties" "^5.3.0"
     "@ethersproject/strings" "^5.3.0"
+
+"@ethersproject/wordlists@5.6.0", "@ethersproject/wordlists@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.6.0.tgz#79e62c5276e091d8575f6930ba01a29218ded032"
+  integrity sha512-q0bxNBfIX3fUuAo9OmjlEYxP40IB8ABgb7HjEZCL5IKubzV3j30CWi2rqQbjTS2HfoyQbfINoKcTVWP4ejwR7Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
 
 "@ethersproject/wordlists@^5.3.0", "@ethersproject/wordlists@^5.5.0":
   version "5.5.0"
@@ -11421,7 +11761,7 @@ buffer@4.9.2, buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.0.5, buffer@^5.2.1, buffer@^5.4.2, buffer@^5.4.3, buffer@^5.5.0, buffer@^5.6.0:
+buffer@^5.0.5, buffer@^5.2.1, buffer@^5.4.2, buffer@^5.4.3, buffer@^5.5.0, buffer@^5.6.0, buffer@^5.7.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -17003,6 +17343,42 @@ ethers@5.3.1:
     "@ethersproject/wallet" "5.3.0"
     "@ethersproject/web" "5.3.0"
     "@ethersproject/wordlists" "5.3.0"
+
+ethers@5.6.4:
+  version "5.6.4"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.6.4.tgz#23629e9a7d4bc5802dfb53d4da420d738744b53c"
+  integrity sha512-62UIfxAQXdf67TeeOaoOoPctm5hUlYgfd0iW3wxfj7qRYKDcvvy0f+sJ3W2/Pyx77R8dblvejA8jokj+lS+ATQ==
+  dependencies:
+    "@ethersproject/abi" "5.6.1"
+    "@ethersproject/abstract-provider" "5.6.0"
+    "@ethersproject/abstract-signer" "5.6.0"
+    "@ethersproject/address" "5.6.0"
+    "@ethersproject/base64" "5.6.0"
+    "@ethersproject/basex" "5.6.0"
+    "@ethersproject/bignumber" "5.6.0"
+    "@ethersproject/bytes" "5.6.1"
+    "@ethersproject/constants" "5.6.0"
+    "@ethersproject/contracts" "5.6.0"
+    "@ethersproject/hash" "5.6.0"
+    "@ethersproject/hdnode" "5.6.0"
+    "@ethersproject/json-wallets" "5.6.0"
+    "@ethersproject/keccak256" "5.6.0"
+    "@ethersproject/logger" "5.6.0"
+    "@ethersproject/networks" "5.6.2"
+    "@ethersproject/pbkdf2" "5.6.0"
+    "@ethersproject/properties" "5.6.0"
+    "@ethersproject/providers" "5.6.4"
+    "@ethersproject/random" "5.6.0"
+    "@ethersproject/rlp" "5.6.0"
+    "@ethersproject/sha2" "5.6.0"
+    "@ethersproject/signing-key" "5.6.0"
+    "@ethersproject/solidity" "5.6.0"
+    "@ethersproject/strings" "5.6.0"
+    "@ethersproject/transactions" "5.6.0"
+    "@ethersproject/units" "5.6.0"
+    "@ethersproject/wallet" "5.6.0"
+    "@ethersproject/web" "5.6.0"
+    "@ethersproject/wordlists" "5.6.0"
 
 ethjs-unit@0.1.6:
   version "0.1.6"
@@ -29262,6 +29638,14 @@ sync-disk-cache@^2.0.0:
     mkdirp "^0.5.0"
     rimraf "^3.0.0"
     username-sync "^1.0.2"
+
+sync-fetch@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/sync-fetch/-/sync-fetch-0.3.1.tgz#62aa82c4b4d43afd6906bfd7b5f92056458509f0"
+  integrity sha512-xj5qiCDap/03kpci5a+qc5wSJjc8ZSixgG2EUmH1B8Ea2sfWclQA7eH40hiHPCtkCn6MCk4Wb+dqcXdCy2PP3g==
+  dependencies:
+    buffer "^5.7.0"
+    node-fetch "^2.6.1"
 
 tabbable@^5.2.0:
   version "5.2.0"


### PR DESCRIPTION
Fixes #CS-3789
For many months we have been suffering from a mysterious failure to sign typed data from web3 that seems to happen randomly. This update provides an optional capability to use ethers.js for signing typed data instead which looks like a completely different implementation from web3. In order to use this, you need to pass an ethers.js `Signer` into the `getSDK()` function like this:

```ts
    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
    let prepaidCardSdk = await getSDK('PrepaidCard', web3, signer);
```
Creating an ethers.js signer is _very_ simple. Here are some docs: https://docs.ethers.io/v5/api/signer/#Wallet. If you have access to the mnemonic you can create one this this:
```ts
let signer = ethers.Wallet.fromMnemonic("mnemonic phrase goes here");
```
or if you have a private key you can create one like this:
```ts
let signer = new ethers.Wallet("private_key");
```

then just pass that signer into the `getSDK()` and it will use the ethers signer for any safe transaction signing.

This PR also update the CLI so that you can specify a command line option: `--ethersMnemonic="your mnemonic phrase goes here"` so that you can also use the an ethers signer from the CLI when you provide a mnemonic phrase. An ethers signer cannot be used for wallet connect since wallet connect inherently does the signing in that case (and doesn't expose to the outside world the private key). However, we have seen our issues in the mobile app during non-wallet connect signing, e.g. merchant payments.

I split the commits so that you can view just the SDK changes in their own commit and not have to deal with the CLI noise.

I was able to successfully perform a merchant payment in sokol using the CLI with an `--ethersMnemonic` flag, which i confirmed signed a txn using ethers.js: https://blockscout.com/poa/sokol/tx/0x8f8a7ac1b7e5083f66a66f5821878f6a5c7e7265cfe3c33e6b16fb5572993d43/token-transfers