### PR TITLE
Use camel case instead of kebab case for status attribute

### DIFF
--- a/packages/hub/node-tests/routes/status-test.ts
+++ b/packages/hub/node-tests/routes/status-test.ts
@@ -107,7 +107,7 @@ describe('GET /api/status', function () {
               status: 'operational',
               subgraphBlockNumber: 19492428,
             },
-            'exchange-rates': {
+            exchangeRates: {
               status: 'operational',
               lastFetched: exchangeRatesLastFetched,
             },
@@ -135,7 +135,7 @@ describe('GET /api/status', function () {
               status: 'degraded',
               subgraphBlockNumber: 19492419,
             },
-            'exchange-rates': {
+            exchangeRates: {
               status: 'operational',
               lastFetched: exchangeRatesLastFetched,
             },
@@ -163,7 +163,7 @@ describe('GET /api/status', function () {
               status: 'unknown',
               subgraphBlockNumber: null,
             },
-            'exchange-rates': {
+            exchangeRates: {
               status: 'operational',
               lastFetched: exchangeRatesLastFetched,
             },
@@ -199,7 +199,7 @@ describe('GET /api/status', function () {
               status: 'unknown',
               subgraphBlockNumber: 19492428,
             },
-            'exchange-rates': {
+            exchangeRates: {
               status: 'operational',
               lastFetched: exchangeRatesLastFetched,
             },
@@ -234,7 +234,7 @@ describe('GET /api/status', function () {
               status: 'operational',
               subgraphBlockNumber: 19492428,
             },
-            'exchange-rates': {
+            exchangeRates: {
               status: 'unknown',
               lastFetched: exchangeRatesLastFetched,
             },

--- a/packages/hub/routes/status.ts
+++ b/packages/hub/routes/status.ts
@@ -81,7 +81,7 @@ export default class StatusRoute {
             subgraphBlockNumber,
             rpcBlockNumber,
           },
-          'exchange-rates': {
+          exchangeRates: {
             status: exchangeRatesStatus,
             lastFetched: exchangeRatesLastFetched,
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9715,7 +9715,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@^4.1.4:
+axe-core@4.1.4, axe-core@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.4.tgz#f19cd99a84ee32a318b9c5b5bb8ed373ad94f143"
   integrity sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==
@@ -14336,7 +14336,7 @@ elliptic@6.5.4, elliptic@^6.0.0, elliptic@^6.4.0, elliptic@^6.5.2:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-ember-a11y-testing@^4.0.3:
+ember-a11y-testing@4.0.3, ember-a11y-testing@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-4.0.3.tgz#1f5c91266d39ea5b20614b0d294a562079887ac7"
   integrity sha512-Q7nq2crC9+bT+sZi/BORAM4FUhI080edEhnpsvB6vdkD9Ro2Rg4DksQs5Be65/DM108VNDMtbHZtrPS060Mzcw==


### PR DESCRIPTION
Checkly's JSON Path implementation was not able to properly match the kebab case version