### PR TITLE
hub: Add rate-limiting for card drops

### DIFF
--- a/packages/hub/config/custom-environment-variables.json
+++ b/packages/hub/config/custom-environment-variables.json
@@ -53,7 +53,14 @@
     "provisionerSecret": "PROVISIONER_SECRET"
   },
   "cardDrop": {
-    "sku": "CARD_DROP_SKU"
+    "sku": "CARD_DROP_SKU",
+    "email": {
+      "rateLimit": {
+        "count": "HUB_EMAIL_CARD_DROP_RATE_LIMIT_COUNT",
+        "periodMinutes": "HUB_EMAIL_CARD_DROP_RATE_LIMIT_PERIOD_MINUTES",
+        "fixme": "FIXME_ABOVE_NEEDED_IN_WAYPOINT_ETC"
+      }
+    }
   },
   "web3storage": {
     "token": "WEB3_STORAGE_TOKEN"

--- a/packages/hub/config/custom-environment-variables.json
+++ b/packages/hub/config/custom-environment-variables.json
@@ -56,9 +56,8 @@
     "sku": "CARD_DROP_SKU",
     "email": {
       "rateLimit": {
-        "count": "HUB_EMAIL_CARD_DROP_RATE_LIMIT_COUNT",
-        "periodMinutes": "HUB_EMAIL_CARD_DROP_RATE_LIMIT_PERIOD_MINUTES",
-        "fixme": "FIXME_ABOVE_NEEDED_IN_WAYPOINT_ETC"
+        "count": {"__name": "HUB_EMAIL_CARD_DROP_RATE_LIMIT_COUNT", "__format": "number"},
+        "periodMinutes": {"__name": "HUB_EMAIL_CARD_DROP_RATE_LIMIT_PERIOD_MINUTES", "__format": "number"}
       }
     }
   },

--- a/packages/hub/config/default.cjs
+++ b/packages/hub/config/default.cjs
@@ -73,6 +73,12 @@ module.exports = {
   },
   cardDrop: {
     sku: '0x5e0d8bbe3c8e4d9013509b469dabfa029270b38a5c55c9c94c095ec6199d7fda',
+    email: {
+      rateLimit: {
+        count: null,
+        periodMinutes: null,
+      },
+    },
   },
   walletConnect: {
     bridge: 'https://safe-walletconnect.gnosis.io/',

--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -908,6 +908,20 @@ CREATE TABLE public.email_card_drop_requests (
 ALTER TABLE public.email_card_drop_requests OWNER TO postgres;
 
 --
+-- Name: email_card_drop_state; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.email_card_drop_state (
+    id integer DEFAULT 1 NOT NULL,
+    rate_limited boolean NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT email_card_drop_state_singleton CHECK ((id = 1))
+);
+
+
+ALTER TABLE public.email_card_drop_state OWNER TO postgres;
+
+--
 -- Name: latest_event_block; Type: TABLE; Schema: public; Owner: postgres
 --
 
@@ -1262,6 +1276,14 @@ ALTER TABLE ONLY public.dm_channels
 
 ALTER TABLE ONLY public.email_card_drop_requests
     ADD CONSTRAINT email_card_drop_requests_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: email_card_drop_state email_card_drop_state_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.email_card_drop_state
+    ADD CONSTRAINT email_card_drop_state_pkey PRIMARY KEY (id);
 
 
 --
@@ -1661,6 +1683,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 30	20220301101637933_create-card-space-profiles-for-existing-merchants	2022-04-13 13:49:06.763103
 31	20220413090421591_card-space-unused-data-cleanup	2022-04-13 17:07:34.093762
 32	20220413215720902_create-email-card-drop-requests	2022-04-13 17:07:34.093762
+33	20220502174343477_create-email-card-drop-state	2022-05-02 12:57:33.181183
 \.
 
 
@@ -1668,7 +1691,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 -- Name: pgmigrations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.pgmigrations_id_seq', 32, true);
+SELECT pg_catalog.setval('public.pgmigrations_id_seq', 33, true);
 
 
 --

--- a/packages/hub/config/test.cjs
+++ b/packages/hub/config/test.cjs
@@ -6,6 +6,14 @@ module.exports = {
     useTransactionalRollbacks: true,
   },
   authSecret: '2Lhrsi7xSDMv1agfW+hghvQkdkTRSqW/JGApSjLT0NA=',
+  cardDrop: {
+    email: {
+      rateLimit: {
+        count: 10,
+        periodMinutes: 10,
+      },
+    },
+  },
   emailHashSalt: 'P91APjz3Ef6q3KAdOCfKa5hOcEmOyrPeRPG6+g380LY=',
   checkly: {
     handleWebhookRequests: true,

--- a/packages/hub/db/migrations/20220502174343477_create-email-card-drop-state.ts
+++ b/packages/hub/db/migrations/20220502174343477_create-email-card-drop-state.ts
@@ -1,0 +1,22 @@
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+const EMAIL_CARD_DROP_STATE_TABLE = 'email_card_drop_state';
+const EMAIL_CARD_DROP_STATE_SINGLETON_CONSTRAINT = 'email_card_drop_state_singleton';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable(EMAIL_CARD_DROP_STATE_TABLE, {
+    id: { type: 'integer', primaryKey: true, default: 1 },
+    rate_limited: { type: 'boolean', notNull: true },
+    updated_at: { type: 'timestamp', notNull: true, default: pgm.func('current_timestamp') },
+  });
+
+  // To restrict table to a single row: https://stackoverflow.com/a/29429083
+  pgm.addConstraint(EMAIL_CARD_DROP_STATE_TABLE, EMAIL_CARD_DROP_STATE_SINGLETON_CONSTRAINT, { check: 'id = 1' });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint(EMAIL_CARD_DROP_STATE_TABLE, EMAIL_CARD_DROP_STATE_SINGLETON_CONSTRAINT);
+  pgm.dropTable(EMAIL_CARD_DROP_STATE_TABLE);
+}

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -352,10 +352,10 @@ describe('POST /api/email-card-drop-requests', function () {
     let sentryReport = testkit.reports()[0];
 
     expect(sentryReport.tags).to.deep.equal({
-      action: 'email-card-drop-requests',
+      event: 'email-card-drop-rate-limit-reached',
     });
 
-    expect(sentryReport.level).to.equal('critical');
+    expect(sentryReport.level).to.equal('fatal');
     expect(sentryReport.error?.message).to.equal('Rate limit has been triggered');
   });
 

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -356,7 +356,7 @@ describe('POST /api/email-card-drop-requests', function () {
     });
 
     expect(sentryReport.level).to.equal('fatal');
-    expect(sentryReport.error?.message).to.equal('Rate limit has been triggered');
+    expect(sentryReport.error?.message).to.equal('Card drop rate limit has been triggered');
   });
 
   it('does not trigger the rate limit when the claims are outside the rate limit period', async function () {

--- a/packages/hub/queries/email-card-drop-requests.ts
+++ b/packages/hub/queries/email-card-drop-requests.ts
@@ -55,6 +55,19 @@ export default class EmailCardDropRequestsQueries {
     });
   }
 
+  async claimedInLastMinutes(minutes: number): Promise<EmailCardDropRequest[]> {
+    let db = await this.databaseManager.getClient();
+
+    let { rows } = await db.query(
+      `
+        SELECT COUNT(*) FROM email_card_drop_requests
+        WHERE claimed_at > NOW() - interval '${minutes} minutes'
+      `
+    );
+
+    return rows[0].count;
+  }
+
   async updateVerificationCode(id: string, verificationCode: string): Promise<EmailCardDropRequest> {
     let db = await this.databaseManager.getClient();
 

--- a/packages/hub/queries/email-card-drop-state.ts
+++ b/packages/hub/queries/email-card-drop-state.ts
@@ -22,7 +22,7 @@ export default class EmailCardDropStateQueries {
   async update(rateLimited: boolean) {
     let db = await this.databaseManager.getClient();
 
-    // Insert if empty, update but only if the block number is higher
+    // Insert if empty, update otherwise
     await db.query(
       `
       INSERT INTO ${EMAIL_CARD_DROP_STATE_TABLE} (id, rate_limited)
@@ -30,10 +30,7 @@ export default class EmailCardDropStateQueries {
 
       ON CONFLICT (id)
       DO UPDATE SET
-        rate_limited = GREATEST(
-          $2,
-          (SELECT rate_limited FROM ${EMAIL_CARD_DROP_STATE_TABLE} WHERE id = 1)
-        ),
+        rate_limited = $2,
         updated_at = NOW()
       `,
       [1, rateLimited]

--- a/packages/hub/queries/email-card-drop-state.ts
+++ b/packages/hub/queries/email-card-drop-state.ts
@@ -1,0 +1,48 @@
+import DatabaseManager from '@cardstack/db';
+import { inject } from '@cardstack/di';
+
+const EMAIL_CARD_DROP_STATE_TABLE = 'email_card_drop_state';
+
+export default class EmailCardDropStateQueries {
+  databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
+
+  async read(): Promise<boolean> {
+    let db = await this.databaseManager.getClient();
+
+    let queryResult = await db.query(`SELECT rate_limited from ${EMAIL_CARD_DROP_STATE_TABLE} WHERE id = 1`);
+
+    if (queryResult.rowCount) {
+      let row = queryResult.rows[0];
+      return row['rate_limited'];
+    } else {
+      return false;
+    }
+  }
+
+  async update(rateLimited: boolean) {
+    let db = await this.databaseManager.getClient();
+
+    // Insert if empty, update but only if the block number is higher
+    await db.query(
+      `
+      INSERT INTO ${EMAIL_CARD_DROP_STATE_TABLE} (id, rate_limited)
+      VALUES ($1, $2)
+
+      ON CONFLICT (id)
+      DO UPDATE SET
+        rate_limited = GREATEST(
+          $2,
+          (SELECT rate_limited FROM ${EMAIL_CARD_DROP_STATE_TABLE} WHERE id = 1)
+        ),
+        updated_at = NOW()
+      `,
+      [1, rateLimited]
+    );
+  }
+}
+
+declare module '@cardstack/hub/queries' {
+  interface KnownQueries {
+    'email-card-drop-state': EmailCardDropStateQueries;
+  }
+}

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -94,6 +94,7 @@ export default class EmailCardDropRequestsRoute {
     let countOfRecentClaims = await this.emailCardDropRequestQueries.claimedInLastMinutes(periodMinutes);
 
     if (countOfRecentClaims >= count) {
+      // The rate limit flag must be manually cleared by updating the database
       Sentry.captureException(new Error('Card drop rate limit has been triggered'), {
         level: Sentry.Severity.Fatal,
         tags: {

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -28,6 +28,7 @@ export default class EmailCardDropRequestsRoute {
   emailCardDropRequestSerializer = inject('email-card-drop-request-serializer', {
     as: 'emailCardDropRequestSerializer',
   });
+  emailCardDropStateQueries = query('email-card-drop-state', { as: 'emailCardDropStateQueries' });
   clock = inject('clock');
 
   workerClient = inject('worker-client', { as: 'workerClient' });
@@ -75,6 +76,14 @@ export default class EmailCardDropRequestsRoute {
 
   async post(ctx: Koa.Context) {
     if (!ensureLoggedIn(ctx)) {
+      return;
+    }
+
+    if (await this.emailCardDropStateQueries.read()) {
+      ctx.status = 503;
+      ctx.body = {
+        errors: [{ status: '503', title: 'Rate limit has been triggered' }],
+      };
       return;
     }
 

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -95,9 +95,9 @@ export default class EmailCardDropRequestsRoute {
 
     if (countOfRecentClaims >= count) {
       Sentry.captureException('Rate limit has been triggered', {
-        level: Sentry.Severity.Critical,
+        level: Sentry.Severity.Fatal,
         tags: {
-          action: 'email-card-drop-requests',
+          event: 'email-card-drop-rate-limit-reached',
         },
       });
 

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -94,7 +94,7 @@ export default class EmailCardDropRequestsRoute {
     let countOfRecentClaims = await this.emailCardDropRequestQueries.claimedInLastMinutes(periodMinutes);
 
     if (countOfRecentClaims >= count) {
-      Sentry.captureException('Rate limit has been triggered', {
+      Sentry.captureException(new Error('Rate limit has been triggered'), {
         level: Sentry.Severity.Fatal,
         tags: {
           event: 'email-card-drop-rate-limit-reached',
@@ -105,7 +105,7 @@ export default class EmailCardDropRequestsRoute {
 
       ctx.status = 503;
       ctx.body = {
-        errors: [{ status: '503', title: 'Rate limit has been triggered' }],
+        errors: [{ status: '503', title: 'Card drop rate limit has been triggered' }],
       };
       return;
     }

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -94,7 +94,7 @@ export default class EmailCardDropRequestsRoute {
     let countOfRecentClaims = await this.emailCardDropRequestQueries.claimedInLastMinutes(periodMinutes);
 
     if (countOfRecentClaims >= count) {
-      Sentry.captureException(new Error('Rate limit has been triggered'), {
+      Sentry.captureException(new Error('Card drop rate limit has been triggered'), {
         level: Sentry.Severity.Fatal,
         tags: {
           event: 'email-card-drop-rate-limit-reached',
@@ -105,7 +105,7 @@ export default class EmailCardDropRequestsRoute {
 
       ctx.status = 503;
       ctx.body = {
-        errors: [{ status: '503', title: 'Card drop rate limit has been triggered' }],
+        errors: [{ status: '503', title: 'Rate limit has been triggered' }],
       };
       return;
     }

--- a/waypoint.hcl
+++ b/waypoint.hcl
@@ -41,6 +41,8 @@ app "hub" {
                 LAYER2_RPC_NODE_HTTPS_URL = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_evm_full_node_url-NBKUCq"
                 LAYER2_RPC_NODE_WSS_URL = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_evm_full_node_wss_url-4RtEaG"
                 HUB_AUTH_SECRET = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_hub_auth_secret-50oF6K"
+                HUB_EMAIL_CARD_DROP_RATE_LIMIT_COUNT = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_hub_email_card_drop_rate_limit_count-RdAViY"
+                HUB_EMAIL_CARD_DROP_RATE_LIMIT_PERIOD_MINUTES = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_hub_email_card_drop_rate_limit_period_minutes-UKgldx"
                 HUB_EMAIL_HASH_SALT = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_hub_email_hash_salt-nJvKQH"
             }
         }

--- a/waypoint.prod.hcl
+++ b/waypoint.prod.hcl
@@ -41,6 +41,8 @@ app "hub" {
                 LAYER2_RPC_NODE_HTTPS_URL = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_evm_full_node_url-K67DON"
                 LAYER2_RPC_NODE_WSS_URL = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_evm_full_node_wss_url-BXGFlG"
                 HUB_AUTH_SECRET = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_hub_auth_secret-amva1E"
+                HUB_EMAIL_CARD_DROP_RATE_LIMIT_COUNT = "arn:aws:secretsmanager:ap-southeast-1:120317779495:secret:production_hub_email_card_drop_rate_limit_count-mdtxRC"
+                HUB_EMAIL_CARD_DROP_RATE_LIMIT_PERIOD_MINUTES = "arn:aws:secretsmanager:ap-southeast-1:120317779495:secret:production_hub_email_card_drop_rate_limit_period_minutes-m71GVI"
                 HUB_EMAIL_HASH_SALT = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_hub_email_hash_salt-6j6HZV"
             }
         }

--- a/waypoint.prod.hcl
+++ b/waypoint.prod.hcl
@@ -41,8 +41,8 @@ app "hub" {
                 LAYER2_RPC_NODE_HTTPS_URL = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_evm_full_node_url-K67DON"
                 LAYER2_RPC_NODE_WSS_URL = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_evm_full_node_wss_url-BXGFlG"
                 HUB_AUTH_SECRET = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_hub_auth_secret-amva1E"
-                HUB_EMAIL_CARD_DROP_RATE_LIMIT_COUNT = "arn:aws:secretsmanager:ap-southeast-1:120317779495:secret:production_hub_email_card_drop_rate_limit_count-mdtxRC"
-                HUB_EMAIL_CARD_DROP_RATE_LIMIT_PERIOD_MINUTES = "arn:aws:secretsmanager:ap-southeast-1:120317779495:secret:production_hub_email_card_drop_rate_limit_period_minutes-m71GVI"
+                HUB_EMAIL_CARD_DROP_RATE_LIMIT_COUNT = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_hub_email_card_drop_rate_limit_count-mdtxRC"
+                HUB_EMAIL_CARD_DROP_RATE_LIMIT_PERIOD_MINUTES = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_hub_email_card_drop_rate_limit_period_minutes-m71GVI"
                 HUB_EMAIL_HASH_SALT = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_hub_email_hash_salt-6j6HZV"
             }
         }


### PR DESCRIPTION
This inserts rate-limiting at the beginning of handling for `POST /api/email-card-drop-requests`.

It immediately 503s if the rate limit has been triggered, as stored in a `email_card_drop_state` table. If it has not, it checks whether the number of records with `claimed_at` in the rate limit period (`HUB_EMAIL_CARD_DROP_RATE_LIMIT_PERIOD_MINUTES`) exceeds the limit (`HUB_EMAIL_CARD_DROP_RATE_LIMIT_COUNT`) and triggers the rate limit and sends a `critical` error to Sentry if so.

Otherwise the request proceeds as previously implemented.