### PR TITLE
Add safe ownership rule

### DIFF
--- a/.github/workflows/manual-cardpay-reward-program-rules.yml
+++ b/.github/workflows/manual-cardpay-reward-program-rules.yml
@@ -17,6 +17,7 @@ on:
           - RetroAirdrop
           - WeightedUsage
           - MinOtherMerchantsPaid
+          - SafeOwnership
 
 jobs:
   build:

--- a/packages/cardpay-reward-programs/cardpay_reward_programs/rules/__init__.py
+++ b/packages/cardpay-reward-programs/cardpay_reward_programs/rules/__init__.py
@@ -3,3 +3,4 @@ from .min_spend import MinSpend
 from .weighted_usage import WeightedUsage
 from .retro_airdrop import RetroAirdrop
 from .flat_payment import FlatPayment
+from .safe_ownership import SafeOwnership

--- a/packages/cardpay-reward-programs/cardpay_reward_programs/rules/safe_ownership.py
+++ b/packages/cardpay-reward-programs/cardpay_reward_programs/rules/safe_ownership.py
@@ -1,0 +1,77 @@
+from cardpay_reward_programs.rule import Rule
+import pandas as pd
+
+
+class SafeOwnership(Rule):
+    """
+    This rule rewards the ownwership of a specific safe type with a fixed reward per safe, with a cap.
+    """
+
+    def __init__(self, core_parameters, user_defined_parameters):
+        super(SafeOwnership, self).__init__(core_parameters, user_defined_parameters)
+
+    def set_user_defined_parameters(
+        self,
+        reward_per_safe,
+        token,
+        duration,
+        start_analysis_block,
+        safe_type,
+        max_rewards,
+    ):
+        self.token = token
+        self.duration = duration
+        self.reward_per_safe = reward_per_safe
+        self.start_analysis_block = start_analysis_block
+        self.safe_type = safe_type
+        self.max_rewards = max_rewards
+
+    def sql(self, table_query):
+        return f"""
+        with total_safes as (select 
+                owner as payee,
+                count(distinct safe) as total_safe_count
+                from {table_query}
+                where _block_number > $1::integer and _block_number <= $2::integer
+                and type = $4::text
+                group by owner
+                ),
+            new_safes as (select 
+                owner as payee,
+                count(distinct safe) as new_safe_count
+                from {table_query}
+                where _block_number > ($2 - $3) and _block_number <= $2::integer
+                and type = $4::text
+                group by owner
+            )
+        select new_safes.payee as payee,
+        -- Reward is the least out of remaining allowed rewards and the total number of new safes
+        least($5 - total_safe_count + new_safe_count, new_safe_count) as payable_safes
+        from new_safes
+        left join total_safes on total_safes.payee = new_safes.payee
+        where payable_safes > 0
+        """
+
+    def run(self, payment_cycle: int, reward_program_id: str):
+        vars = [
+            self.start_analysis_block,
+            payment_cycle,
+            self.payment_cycle_length,
+            self.safe_type,
+            self.max_rewards,
+        ]
+        table_query = self._get_table_query(
+            "safe_owner", "safe_owner", self.start_analysis_block, payment_cycle
+        )
+        if table_query == "parquet_scan([])":
+            df = pd.DataFrame(columns=["payee", "payable_safes"])
+        else:
+            df = self.run_query(table_query, vars)
+        df["rewardProgramID"] = reward_program_id
+        df["paymentCycle"] = payment_cycle
+        df["validFrom"] = payment_cycle
+        df["validTo"] = payment_cycle + self.duration
+        df["token"] = self.token
+        df["amount"] = df["payable_safes"] * self.reward_per_safe
+        df = df.drop(["payable_safes"], axis=1)
+        return df

--- a/packages/cardpay-reward-programs/tests/rules/test_retro_airdrop.py
+++ b/packages/cardpay-reward-programs/tests/rules/test_retro_airdrop.py
@@ -1,5 +1,4 @@
 import itertools
-from audioop import mul
 
 import pandas as pd
 import pytest

--- a/packages/cardpay-reward-programs/tests/rules/test_safe_ownership.py
+++ b/packages/cardpay-reward-programs/tests/rules/test_safe_ownership.py
@@ -1,0 +1,168 @@
+import pandas as pd
+import duckdb
+
+from cardpay_reward_programs.rules import safe_ownership
+
+
+def create_rule(
+    monkeypatch, fake_data, core_config_overrides={}, user_config_overrides={}
+):
+    core_config = {
+        "start_block": 0,
+        "end_block": 10000,
+        "payment_cycle_length": 1000,
+        "subgraph_config_locations": {
+            "safe_owner": "s3://partitioned-graph-data/data/safe_owner/0.0.1/"
+        },
+    }
+    core_config.update(core_config_overrides)
+    user_config = {
+        "reward_per_safe": 1,
+        "token": "0x0000000000000000000000000000000000000000",
+        "duration": 43200,
+        "start_analysis_block": 0,
+        "safe_type": "type_a",
+        "max_rewards": 10,
+    }
+    user_config.update(user_config_overrides)
+    con = duckdb.connect(database=":memory:", read_only=False)
+    con.execute("create table TEST_TABLE as select * from fake_data")
+
+    def table_query(
+        self, config_name, table_name, min_partition: int, max_partition: int
+    ):
+        return "TEST_TABLE"
+
+    def run_query(self, table_query, vars):
+        con.execute(self.sql("TEST_TABLE"), vars)
+        return con.fetchdf()
+
+    monkeypatch.setattr(safe_ownership.SafeOwnership, "_get_table_query", table_query)
+    monkeypatch.setattr(safe_ownership.SafeOwnership, "run_query", run_query)
+
+    rule = safe_ownership.SafeOwnership(core_config, user_config)
+    return rule
+
+
+def get_amount(result, payee):
+    return result.where(result["payee"] == payee)["amount"][0]
+
+
+def test_identifies_correct_safe_type(monkeypatch):
+    fake_data = pd.DataFrame(
+        [
+            {"owner": "0xA", "safe": "0x1", "type": "type_a", "_block_number": 150},
+            {"owner": "0xA", "safe": "0x2", "type": "type_b", "_block_number": 150},
+        ]
+    )
+
+    rule = create_rule(monkeypatch, fake_data)
+    result = rule.run(200, "0x0")
+    assert len(result) == 1
+
+
+def test_users_can_be_rewarded_multiple_times(monkeypatch):
+    fake_data = pd.DataFrame(
+        [
+            {"owner": "0xA", "safe": "0x1", "type": "type_a", "_block_number": 150},
+            {"owner": "0xA", "safe": "0x2", "type": "type_a", "_block_number": 151},
+        ]
+    )
+
+    rule = create_rule(
+        monkeypatch, fake_data, {"payment_cycle_length": 100}, {"max_rewards": 2}
+    )
+    result = rule.run(200, "0x0")
+    assert len(result) == 1
+    assert get_amount(result, "0xA") == 2
+
+
+def test_users_cant_be_rewarded_more_than_max_times_in_one_cycle(monkeypatch):
+    fake_data = pd.DataFrame(
+        [
+            {"owner": "0xA", "safe": "0x1", "type": "type_a", "_block_number": 150},
+            {"owner": "0xA", "safe": "0x2", "type": "type_a", "_block_number": 151},
+            {"owner": "0xA", "safe": "0x3", "type": "type_a", "_block_number": 152},
+            {"owner": "0xA", "safe": "0x4", "type": "type_a", "_block_number": 153},
+        ]
+    )
+
+    rule = create_rule(
+        monkeypatch, fake_data, {"payment_cycle_length": 100}, {"max_rewards": 2}
+    )
+    result = rule.run(200, "0x0")
+    assert len(result) == 1
+    assert get_amount(result, "0xA") == 2
+
+
+def test_users_cant_be_rewarded_more_than_max_times_in_multiple_cycles(monkeypatch):
+    fake_data = pd.DataFrame(
+        [
+            {"owner": "0xA", "safe": "0x1", "type": "type_a", "_block_number": 20},
+            {"owner": "0xA", "safe": "0x2", "type": "type_a", "_block_number": 151},
+            {"owner": "0xA", "safe": "0x3", "type": "type_a", "_block_number": 152},
+            {"owner": "0xA", "safe": "0x4", "type": "type_a", "_block_number": 153},
+        ]
+    )
+
+    rule = create_rule(
+        monkeypatch, fake_data, {"payment_cycle_length": 100}, {"max_rewards": 3}
+    )
+    result = rule.run(200, "0x0")
+    assert len(result) == 1
+    assert get_amount(result, "0xA") == 2
+
+
+def test_users_are_only_rewarded_for_current_cycle(monkeypatch):
+    fake_data = pd.DataFrame(
+        [
+            {"owner": "0xA", "safe": "0x1", "type": "type_a", "_block_number": 20},
+            {"owner": "0xA", "safe": "0x2", "type": "type_a", "_block_number": 21},
+            {"owner": "0xA", "safe": "0x3", "type": "type_a", "_block_number": 153},
+            {"owner": "0xA", "safe": "0x4", "type": "type_a", "_block_number": 153},
+        ]
+    )
+
+    rule = create_rule(
+        monkeypatch, fake_data, {"payment_cycle_length": 100}, {"max_rewards": 3}
+    )
+    result = rule.run(200, "0x0")
+    assert len(result) == 1
+    assert get_amount(result, "0xA") == 1
+
+
+def test_users_are_only_rewarded_for_distinct_safe_ownerships(monkeypatch):
+    fake_data = pd.DataFrame(
+        [
+            {"owner": "0xA", "safe": "0x1", "type": "type_a", "_block_number": 150},
+            {"owner": "0xA", "safe": "0x1", "type": "type_a", "_block_number": 151},
+            {"owner": "0xA", "safe": "0x1", "type": "type_a", "_block_number": 152},
+            {"owner": "0xA", "safe": "0x1", "type": "type_a", "_block_number": 153},
+        ]
+    )
+
+    rule = create_rule(
+        monkeypatch, fake_data, {"payment_cycle_length": 100}, {"max_rewards": 3}
+    )
+    result = rule.run(200, "0x0")
+    assert len(result) == 1
+    assert get_amount(result, "0xA") == 1
+
+
+def test_users_are_only_rewarded_if_in_current_cycle(monkeypatch):
+    fake_data = pd.DataFrame(
+        [
+            {"owner": "0xA", "safe": "0x1", "type": "type_a", "_block_number": 20},
+            {"owner": "0xA", "safe": "0x1", "type": "type_a", "_block_number": 21},
+            {"owner": "0xA", "safe": "0x1", "type": "type_a", "_block_number": 22},
+            {"owner": "0xB", "safe": "0x1", "type": "type_a", "_block_number": 153},
+        ]
+    )
+
+    rule = create_rule(
+        monkeypatch, fake_data, {"payment_cycle_length": 100}, {"max_rewards": 3}
+    )
+    result = rule.run(200, "0x0")
+    # Only 0xB was in the latest cycle
+    assert len(result) == 1
+    assert get_amount(result, "0xB") == 1


### PR DESCRIPTION
This is a reward rule based on safe ownership, allowing rewards for owning a specific type of safe with a cap on the total rewards allowed.