### PR TITLE
Automatic posting of PagerDuty incident status changes to Discord

### DIFF
--- a/packages/hub/config/custom-environment-variables.json
+++ b/packages/hub/config/custom-environment-variables.json
@@ -20,7 +20,8 @@
     "cordeBotToken": "CORDE_BOT_TOKEN",
     "commandPrefix": "CARDBOT_COMMAND_PREFIX",
     "allowedGuilds": "CARDBOT_ALLOWED_GUILDS",
-    "allowedChannels": "CARDBOT_ALLOWED_CHANNELS"
+    "allowedChannels": "CARDBOT_ALLOWED_CHANNELS",
+    "onCallInternalWebhook": "DISCORD_ON_CALL_INTERNAL_WEBHOOK"
   },
   "sentry": {
     "dsn": "HUB_SENTRY_DSN",
@@ -57,6 +58,9 @@
   },
   "web3storage": {
     "token": "WEB3_STORAGE_TOKEN"
+  },
+  "pagerduty": {
+    "token": "PAGERDUTY_TOKEN"
   },
   "statuspage": {
     "pageId": "STATUSPAGE_PAGE_ID",

--- a/packages/hub/config/default.cjs
+++ b/packages/hub/config/default.cjs
@@ -32,6 +32,7 @@ module.exports = {
     allowedGuilds: '958136276559753266',
     allowedChannels: '958136277096620084,958137087641661450',
     messageVerificationDelayMs: 1000 * 15,
+    onCallInternalWebhook: null,
   },
   authSecret: null,
   emailHashSalt: null,
@@ -94,5 +95,8 @@ module.exports = {
   statuspage: {
     apiKey: null,
     pageId: null,
+  },
+  pagerDuty: {
+    token: null,
   },
 };

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -84,8 +84,10 @@ import WyreTransferTask from './tasks/wyre-transfer';
 import { ContractSubscriptionEventHandler } from './services/contract-subscription-event-handler';
 import { HubWorker } from './worker';
 import HubBot from './services/discord-bots/hub-bot';
+import PagerdutyApi from './services/pagerduty-api';
 import StatuspageApi from './services/statuspage-api';
 import ChecklyWebhookRoute from './routes/checkly-webhook';
+import PagerdutyIncidentsWebhookRoute from './routes/pagerduty-incidents-webhook';
 import { KnownRoutes, registerRoutes } from '@cardstack/hub/routes';
 import { registerServices } from '@cardstack/hub/services';
 import { registerQueries } from './queries';
@@ -95,6 +97,7 @@ import EmailCardDropRequestSerializer from './services/serializers/email-card-dr
 import SendEmailCardDropVerificationTask from './tasks/send-email-card-drop-verification';
 import DropCardTask from './tasks/drop-card';
 import SubscribeEmailTask from './tasks/subscribe-email';
+import DiscordPostTask from './tasks/discord-post';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -137,6 +140,7 @@ export function createRegistry(): Registry {
   registry.register('send-email-card-drop-verification', SendEmailCardDropVerificationTask);
   registry.register('subscribe-email', SubscribeEmailTask);
   registry.register('drop-card', DropCardTask);
+  registry.register('discord-post', DiscordPostTask);
   registry.register('order', OrderService);
   registry.register('orders-route', OrdersRoute);
   registry.register('persist-off-chain-prepaid-card-customization', PersistOffChainPrepaidCardCustomizationTask);
@@ -173,8 +177,10 @@ export function createRegistry(): Registry {
   registry.register('wyre-prices-route', WyrePricesRoute);
   registry.register('wyre-transfer', WyreTransferTask);
   registry.register('web3-storage', Web3Storage);
+  registry.register('pagerduty-api', PagerdutyApi);
   registry.register('statuspage-api', StatuspageApi);
   registry.register('checkly-webhook-route', ChecklyWebhookRoute);
+  registry.register('pagerduty-incidents-webhook-route', PagerdutyIncidentsWebhookRoute);
   registry.register('email-card-drop-router', EmailCardDropRouter);
 
   if (process.env.COMPILER) {

--- a/packages/hub/node-tests/routes/checkly-webhook-test.ts
+++ b/packages/hub/node-tests/routes/checkly-webhook-test.ts
@@ -18,7 +18,7 @@ class StubStatuspageApi {
   }
 }
 
-describe('POST /api/checkly-webhook', async function () {
+describe('POST /callbacks/checkly', async function () {
   this.beforeEach(function () {
     createdIncident = null;
     resolvedIncident = null;

--- a/packages/hub/node-tests/routes/pagerduty-incidents-webhook-test.ts
+++ b/packages/hub/node-tests/routes/pagerduty-incidents-webhook-test.ts
@@ -1,0 +1,150 @@
+import { Job, TaskSpec } from 'graphile-worker';
+import { PagerdutyIncident } from '../../services/pagerduty-api';
+import { registry, setupHub } from '../helpers/server';
+
+class StubPagerdutyApi {
+  async fetchIncident(id: string): Promise<PagerdutyIncident> {
+    return {
+      id: id,
+      html_url: 'https://acme.pagerduty.com/incidents/PGR0VU2',
+      title: 'A little bump in the road',
+      status: 'triggered',
+    };
+  }
+}
+
+let jobIdentifiers: string[] = [];
+let jobPayloads: any[] = [];
+
+class StubWorkerClient {
+  async addJob(identifier: string, payload?: any, _spec?: TaskSpec): Promise<Job> {
+    jobIdentifiers.push(identifier);
+    jobPayloads.push(payload);
+    return Promise.resolve({} as Job);
+  }
+}
+
+const EXAMPLE_INCIDENT_TRIGGERED_REQUEST_BODY = {
+  event: {
+    id: '5ac64822-4adc-4fda-ade0-410becf0de4f',
+    event_type: 'incident.triggered',
+    resource_type: 'incident',
+    occurred_at: '2020-10-02T18:45:22.169Z',
+    agent: {
+      html_url: 'https://acme.pagerduty.com/users/PLH1HKV',
+      id: 'PLH1HKV',
+      self: 'https://api.pagerduty.com/users/PLH1HKV',
+      summary: 'Tenex Engineer',
+      type: 'user_reference',
+    },
+    client: {
+      name: 'PagerDuty',
+    },
+    data: {
+      id: 'PGR0VU2',
+      type: 'incident',
+      self: 'https://api.pagerduty.com/incidents/PGR0VU2',
+      html_url: 'https://acme.pagerduty.com/incidents/PGR0VU2',
+      number: 2,
+      status: 'triggered',
+      incident_key: 'd3640fbd41094207a1c11e58e46b1662',
+      created_at: '2020-04-09T15:16:27Z',
+      title: 'A little bump in the road',
+      service: {
+        html_url: 'https://acme.pagerduty.com/services/PF9KMXH',
+        id: 'PF9KMXH',
+        self: 'https://api.pagerduty.com/services/PF9KMXH',
+        summary: 'API Service',
+        type: 'service_reference',
+      },
+      assignees: [
+        {
+          html_url: 'https://acme.pagerduty.com/users/PTUXL6G',
+          id: 'PTUXL6G',
+          self: 'https://api.pagerduty.com/users/PTUXL6G',
+          summary: 'User 123',
+          type: 'user_reference',
+        },
+      ],
+      escalation_policy: {
+        html_url: 'https://acme.pagerduty.com/escalation_policies/PUS0KTE',
+        id: 'PUS0KTE',
+        self: 'https://api.pagerduty.com/escalation_policies/PUS0KTE',
+        summary: 'Default',
+        type: 'escalation_policy_reference',
+      },
+      teams: [
+        {
+          html_url: 'https://acme.pagerduty.com/teams/PFCVPS0',
+          id: 'PFCVPS0',
+          self: 'https://api.pagerduty.com/teams/PFCVPS0',
+          summary: 'Engineering',
+          type: 'team_reference',
+        },
+      ],
+      priority: {
+        html_url: 'https://acme.pagerduty.com/account/incident_priorities',
+        id: 'PSO75BM',
+        self: 'https://api.pagerduty.com/priorities/PSO75BM',
+        summary: 'P1',
+        type: 'priority_reference',
+      },
+      urgency: 'high',
+      conference_bridge: {
+        conference_number: '+1 1234123412,,987654321#',
+        conference_url: 'https://example.com',
+      },
+      resolve_reason: null,
+    },
+  },
+};
+
+describe('POST /callbacks/pagerduty-incidents', async function () {
+  this.beforeEach(function () {
+    jobIdentifiers = [];
+    jobPayloads = [];
+    registry(this).register('pagerduty-api', StubPagerdutyApi);
+    registry(this).register('worker-client', StubWorkerClient);
+  });
+
+  let { request } = setupHub(this);
+
+  it('queues a job to post to discord', async function () {
+    await request()
+      .post('/callbacks/pagerduty-incidents')
+      .set('Accept', 'application/json')
+      .set('Content-Type', 'application/json')
+      .send(EXAMPLE_INCIDENT_TRIGGERED_REQUEST_BODY)
+      .expect(200);
+
+    expect(jobIdentifiers).to.deep.equal(['discord-post']);
+    expect(jobPayloads).to.deep.equal([
+      {
+        channel: 'on-call-internal',
+        message: 'incident.triggered: A little bump in the road (https://acme.pagerduty.com/incidents/PGR0VU2)',
+      },
+    ]);
+  });
+
+  it('skips events where the resource_type is not incident', async function () {
+    await request()
+      .post('/callbacks/pagerduty-incidents')
+      .set('Accept', 'application/json')
+      .set('Content-Type', 'application/json')
+      .send({ event: { event_type: 'incident.acknowledged', resource_type: 'not-incident' } })
+      .expect(422);
+    expect(jobIdentifiers).to.deep.equal([]);
+    expect(jobPayloads).to.deep.equal([]);
+  });
+
+  it('skips events where the type is not supported', async function () {
+    await request()
+      .post('/callbacks/pagerduty-incidents')
+      .set('Accept', 'application/json')
+      .set('Content-Type', 'application/json')
+      .send({ event: { event_type: 'incident.unsupported', resource_type: 'incident' } })
+      .expect(422);
+    expect(jobIdentifiers).to.deep.equal([]);
+    expect(jobPayloads).to.deep.equal([]);
+  });
+});

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -47,6 +47,7 @@
     "@graphile/logger": "^0.2.0",
     "@koa/cors": "^3.1.0",
     "@koa/router": "^10.0.0",
+    "@pagerduty/pdjs": "^2.2.4",
     "@sentry/node": "^6.10.0",
     "@types/fs-extra": "^9.0.11",
     "@types/json-stable-stringify": "^1.0.32",

--- a/packages/hub/routes/pagerduty-incidents-webhook.ts
+++ b/packages/hub/routes/pagerduty-incidents-webhook.ts
@@ -1,0 +1,61 @@
+import Koa from 'koa';
+import autoBind from 'auto-bind';
+import { inject } from '@cardstack/di';
+import PagerdutyApi from '../services/pagerduty-api';
+import Logger from '@cardstack/logger';
+
+const SUPPORTED_EVENT_TYPES = [
+  'incident.acknowledged',
+  'incident.resolved',
+  'incident.triggered',
+  'incident.unacknowledged',
+];
+
+let log = Logger('pagerduty-incidents-webhook');
+
+export default class PagerdutyIncidentsWebhookRoute {
+  pagerdutyApi: PagerdutyApi = inject('pagerduty-api', { as: 'pagerdutyApi' });
+  workerClient = inject('worker-client', { as: 'workerClient' });
+
+  constructor() {
+    autoBind(this);
+  }
+
+  async post(ctx: Koa.Context) {
+    let eventType = ctx.request.body.event?.event_type;
+    log.info('Received pagerduty webhook', eventType);
+    if (!SUPPORTED_EVENT_TYPES.includes(eventType)) {
+      log.info(`Skipping handling PagerDuty request, unsupported event type ${eventType}`);
+      ctx.status = 422;
+      ctx.body = 'Unsupported event type';
+      return;
+    }
+
+    let resourceType = ctx.request.body.event?.resource_type;
+    if (resourceType !== 'incident') {
+      log.info('Skipping handling PagerDuty request, unsupported resource type');
+      ctx.status = 422;
+      ctx.body = 'Unsupported resource type';
+      return;
+    }
+
+    let incidentId = ctx.request.body.event.data.id;
+    let incident = await this.pagerdutyApi.fetchIncident(incidentId);
+
+    await this.workerClient.addJob('discord-post', {
+      channel: 'on-call-internal',
+      message: `${eventType}: ${incident.title} (${incident.html_url})`,
+    });
+
+    ctx.status = 200;
+    ctx.body = {};
+
+    ctx.type = 'application/json';
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'pagerduty-incidents-webhook-route': PagerdutyIncidentsWebhookRoute;
+  }
+}

--- a/packages/hub/services/callbacks-router.ts
+++ b/packages/hub/services/callbacks-router.ts
@@ -11,12 +11,16 @@ import { parseBody } from '../middleware';
 export default class CallbacksRouter {
   wyreCallbackRoute: WyreCallbackRoute = inject('wyre-callback-route', { as: 'wyreCallbackRoute' });
   checklyWebhookRoute = inject('checkly-webhook-route', { as: 'checklyWebhookRoute' });
+  pagerdutyIncidentsWebhookRoute = inject('pagerduty-incidents-webhook-route', {
+    as: 'pagerdutyIncidentsWebhookRoute',
+  });
 
   routes() {
-    let { wyreCallbackRoute, checklyWebhookRoute } = this;
+    let { checklyWebhookRoute, pagerdutyIncidentsWebhookRoute, wyreCallbackRoute } = this;
     let callbacksSubrouter = new Router();
-    callbacksSubrouter.post('/wyre', parseBody, wyreCallbackRoute.post);
     callbacksSubrouter.post('/checkly', parseBody, checklyWebhookRoute.post);
+    callbacksSubrouter.post('/wyre', parseBody, wyreCallbackRoute.post);
+    callbacksSubrouter.post('/pagerduty-incidents', parseBody, pagerdutyIncidentsWebhookRoute.post);
     callbacksSubrouter.all('/(.*)', notFound);
 
     let callbacksRouter = new Router();

--- a/packages/hub/services/pagerduty-api.ts
+++ b/packages/hub/services/pagerduty-api.ts
@@ -1,0 +1,35 @@
+import config from 'config';
+import { api as createPageDutyApiClient } from '@pagerduty/pdjs';
+import { APIResponse } from '@pagerduty/pdjs/build/src/api';
+
+export interface PagerdutyIncident {
+  id: string;
+  html_url: string;
+  title: string;
+  status: string;
+}
+
+export default class PagerdutyApi {
+  private get token(): string | null {
+    return config.has('pagerduty.token') ? config.get('pagerduty.token') : null;
+  }
+
+  private get apiClient() {
+    let { token } = this;
+    if (!token) {
+      throw new Error('Pagerduty token not configured');
+    }
+    return createPageDutyApiClient({ token });
+  }
+
+  async fetchIncident(incidentId: string): Promise<PagerdutyIncident> {
+    let apiResponse: APIResponse = await this.apiClient.get(`/incidents/${incidentId}`);
+    return apiResponse.resource as PagerdutyIncident;
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'pagerduty-api': PagerdutyApi;
+  }
+}

--- a/packages/hub/tasks/discord-post.ts
+++ b/packages/hub/tasks/discord-post.ts
@@ -1,0 +1,23 @@
+import config from 'config';
+import fetch from 'node-fetch';
+import { Helpers } from 'graphile-worker';
+
+export default class DiscordPost {
+  async perform(payload: any, _helpers: Helpers) {
+    let { channel, message } = payload;
+    if (channel === 'on-call-internal') {
+      let discordWebhook = config.get('discord.onCallInternalWebhook') as string;
+      await fetch(discordWebhook, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          content: message,
+        }),
+      });
+    } else {
+      throw new Error(`Unsupported channel ${channel}`);
+    }
+  }
+}

--- a/packages/hub/worker.ts
+++ b/packages/hub/worker.ts
@@ -11,6 +11,7 @@ import PersistOffChainPrepaidCardCustomizationTask from './tasks/persist-off-cha
 import PersistOffChainMerchantInfoTask from './tasks/persist-off-chain-merchant-info';
 import boom from './tasks/boom';
 import s3PutJson from './tasks/s3-put-json';
+import DiscordPostTask from './tasks/discord-post';
 import DropCardTask from './tasks/drop-card';
 import NotifyMerchantClaimTask from './tasks/notify-merchant-claim';
 import NotifyCustomerPaymentTask from './tasks/notify-customer-payment';
@@ -61,6 +62,7 @@ export class HubWorker {
       connectionString: dbConfig.url,
       taskList: {
         boom: boom,
+        'discord-post': this.instantiateTask(DiscordPostTask),
         'drop-card': this.instantiateTask(DropCardTask),
         'send-email-card-drop-verification': this.instantiateTask(SendEmailCardDropVerification),
         'send-notifications': this.instantiateTask(SendNotificationsTask),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6600,6 +6600,14 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.1.0.tgz#43f23a0892affdd4809a1a41396b25be919cc84a"
   integrity sha512-GzmijkVr3T00+VSeKBVK0uoVMSkmxUD6x6GQ3ZTBLDVYc9RCsr40KGdnPWZ5RdKl+/1mfrpthRSrzpfVUikKbA==
 
+"@pagerduty/pdjs@^2.2.4":
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/@pagerduty/pdjs/-/pdjs-2.2.4.tgz#62af1ec60bb3076b0ec07af05133c1f8c9af420b"
+  integrity sha512-MMZvxos7PJnGJ8z3ijsu/gsMQLIfO8peeigKCjUDmviXk8FIaZZjX0X889NIKuFDhGirYbJVwGTaDYCEw4baLg==
+  dependencies:
+    browser-or-node "^2.0.0"
+    cross-fetch "^3.0.6"
+
 "@panva/asn1.js@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@panva/asn1.js/-/asn1.js-1.0.0.tgz#dd55ae7b8129e02049f009408b97c61ccf9032f6"
@@ -11538,6 +11546,11 @@ brorand@^1.0.1, brorand@^1.1.0:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
+browser-or-node@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/browser-or-node/-/browser-or-node-2.0.0.tgz#808ea90282a670931cdc0ea98166538a50dd0d89"
+  integrity sha512-3Lrks/Okgof+/cRguUNG+qRXSeq79SO3hY4QrXJayJofwJwHiGC0qi99uDjsfTwULUFSr1OGVsBkdIkygKjTUA==
+
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
@@ -13288,6 +13301,13 @@ cross-fetch@^2.1.0, cross-fetch@^2.1.1:
   dependencies:
     node-fetch "2.1.2"
     whatwg-fetch "2.0.4"
+
+cross-fetch@^3.0.6:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
 
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -24628,7 +24648,7 @@ node-fetch@2.1.2:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
-node-fetch@^2.3.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7, "node-fetch@https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz":
+node-fetch@2.6.7, node-fetch@^2.3.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7, "node-fetch@https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz":
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==


### PR DESCRIPTION
Note: PagerDuty has a signature header on webhooks, which can be validated using a secret that is shown to one time upon creation of the webhook subscription. However, we are creating the webhook via terraform, which doesn't allow for the capture of that secret. So, in order to prevent negative impact from spoofed requests to this callback URL, we fetch the incident via PagerDuty's API after receiving a request.