### PR TITLE
hub: Add rate limit to GET /…card-drop-requests

### DIFF
--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -73,8 +73,22 @@ describe('GET /api/email-card-drop-requests', function () {
     expect(response.status).to.equal(200);
     expect(response.body.data.type).to.equal('email-card-drop-request-claim-status');
     expect(response.body.data.attributes['owner-address']).to.equal(claimedEoa.ownerAddress);
+    expect(response.body.data.attributes['rate-limited']).to.equal(false);
     expect(response.body.data.attributes.claimed).to.equal(true);
     expect(response.body.data.attributes.timestamp).to.equal(fakeTimeString);
+  });
+
+  it('reports if the rate limit has been reached', async function () {
+    let emailCardDropStateQueries = await getContainer().lookup('email-card-drop-state', { type: 'query' });
+    await emailCardDropStateQueries.update(true);
+
+    let response = await request()
+      .get(`/api/email-card-drop-requests?eoa=${claimedEoa.ownerAddress}`)
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json');
+
+    expect(response.status).to.equal(200);
+    expect(response.body.data.attributes['rate-limited']).to.equal(true);
   });
 
   it('returns false if a known EOA does not have a claim timestamp for its card drop request', async function () {

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -63,9 +63,12 @@ export default class EmailCardDropRequestsRoute {
 
     let claimed = previousRequests.some((request) => Boolean(request?.claimedAt));
 
+    let rateLimited = await this.emailCardDropStateQueries.read();
+
     let result = this.emailCardDropRequestSerializer.serializeEmailCardDropRequestStatus({
       timestamp,
       ownerAddress,
+      rateLimited,
       claimed,
     });
 

--- a/packages/hub/services/serializers/email-card-drop-request-serializer.ts
+++ b/packages/hub/services/serializers/email-card-drop-request-serializer.ts
@@ -4,6 +4,7 @@ import { JSONAPIDocument } from '../../utils/jsonapi-document';
 interface EmailCardDropRequestClaimStatus {
   ownerAddress: string;
   claimed: boolean;
+  rateLimited: boolean;
   timestamp: Date;
 }
 
@@ -28,6 +29,7 @@ export default class EmailCardDropRequestSerializer {
         attributes: {
           'owner-address': model.ownerAddress,
           claimed: model.claimed,
+          'rate-limited': model.rateLimited,
           timestamp: model.timestamp.toISOString(),
         },
       },


### PR DESCRIPTION
This can be used by Card Wallet to hide the card drop
invitation when the rate limit has been triggered.