### PR TITLE
The environment does not need to be set on koa context

### DIFF
--- a/packages/hub/config/test.cjs
+++ b/packages/hub/config/test.cjs
@@ -5,6 +5,7 @@ module.exports = {
     url: 'postgres://postgres:postgres@localhost:5432/hub_test',
     useTransactionalRollbacks: true,
   },
+  hubEnvironment: 'test',
   authSecret: '2Lhrsi7xSDMv1agfW+hghvQkdkTRSqW/JGApSjLT0NA=',
   cardDrop: {
     email: {

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -7,7 +7,7 @@ import './load-dotenv';
 import config from 'config';
 
 import Koa from 'koa';
-import { environment, httpLogging, errorMiddleware } from './middleware';
+import { httpLogging, errorMiddleware } from './middleware';
 import cors from '@koa/cors';
 import fetch from 'node-fetch';
 import * as Sentry from '@sentry/node';
@@ -231,7 +231,6 @@ export class HubServer {
   get app(): Koa<Koa.DefaultState, Koa.Context> {
     let app = new Koa<Koa.DefaultState, Koa.Context>()
       .use(errorMiddleware)
-      .use(environment)
       .use(cors({ origin: '*', allowHeaders: 'Authorization, Content-Type, If-Match, X-Requested-With' }))
       .use(httpLogging);
 

--- a/packages/hub/middleware/index.ts
+++ b/packages/hub/middleware/index.ts
@@ -6,11 +6,6 @@ const serverLog = logger('hub/server');
 
 export { default as errorMiddleware } from './error';
 
-export async function environment(ctx: Koa.Context, next: Koa.Next) {
-  ctx.environment = process.env.NODE_ENV || 'development';
-  return next();
-}
-
 export async function httpLogging(ctxt: Koa.Context, next: Koa.Next) {
   serverLog.info('start %s %s', ctxt.request.method, ctxt.request.originalUrl);
   await next();

--- a/packages/hub/routes/exchange-rates.ts
+++ b/packages/hub/routes/exchange-rates.ts
@@ -22,7 +22,10 @@ export default class ExchangeRatesRoute {
   }
 
   async get(ctx: Koa.Context) {
-    if (ctx.environment === 'development' || (ctx.headers.origin && allowedDomains.includes(ctx.headers.origin))) {
+    if (
+      config.get('hubEnvironment') === 'development' ||
+      (ctx.headers.origin && allowedDomains.includes(ctx.headers.origin))
+    ) {
       let exchangeRates = await this.exchangeRatesService.fetchExchangeRates();
       if (!exchangeRates?.success) {
         let detail = exchangeRates?.error


### PR DESCRIPTION
The setting was based on NODE_ENV, which was unset, which was resulting in the exchange-rates perceiving a development environment and not enforcing its origin restriction 