### PR TITLE
Mailchimp

### DIFF
--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -52,8 +52,9 @@ Below is a list of the most common environment variables that the Hub accepts:
 - `LAYER1_RPC_NODE_WSS_URL`
 - `LAYER2_RPC_NODE_HTTPS_URL`
 - `LAYER2_RPC_NODE_WSS_URL`
+- `MAILCHIMP_API_KEY`
 
-Search the mono-repo for `process.env` and check the config directory to see these variables referenced.
+Search the mono-repo for `process.env` and check the `custom-environment-variables.json` file in the config directory to see these variables referenced.
 
 To use the variables, create a file named `.env` in the hub's folder, and put in the variables you want to use.
 

--- a/packages/hub/config/custom-environment-variables.json
+++ b/packages/hub/config/custom-environment-variables.json
@@ -27,6 +27,11 @@
     "allowedChannels": "CARDBOT_ALLOWED_CHANNELS",
     "onCallInternalWebhook": "DISCORD_ON_CALL_INTERNAL_WEBHOOK"
   },
+  "mailchimp": {
+    "apiKey": "MAILCHIMP_API_KEY",
+    "serverPrefix": "MAILCHIMP_SERVER_PREFIX",
+    "newsletterListId": "MAILCHIMP_NEWSLETTER_LIST_ID"
+  },
   "sentry": {
     "dsn": "HUB_SENTRY_DSN",
     "environment": "HUB_ENVIRONMENT"

--- a/packages/hub/config/custom-environment-variables.json
+++ b/packages/hub/config/custom-environment-variables.json
@@ -28,9 +28,7 @@
     "onCallInternalWebhook": "DISCORD_ON_CALL_INTERNAL_WEBHOOK"
   },
   "mailchimp": {
-    "apiKey": "MAILCHIMP_API_KEY",
-    "serverPrefix": "MAILCHIMP_SERVER_PREFIX",
-    "newsletterListId": "MAILCHIMP_NEWSLETTER_LIST_ID"
+    "apiKey": "MAILCHIMP_API_KEY"
   },
   "sentry": {
     "dsn": "HUB_SENTRY_DSN",

--- a/packages/hub/config/default.cjs
+++ b/packages/hub/config/default.cjs
@@ -38,6 +38,11 @@ module.exports = {
     messageVerificationDelayMs: 1000 * 15,
     onCallInternalWebhook: null,
   },
+  mailchimp: {
+    apiKey: null,
+    serverPrefix: null,
+    newsletterListId: null,
+  },
   authSecret: null,
   emailHashSalt: null,
   sentry: {

--- a/packages/hub/config/development.json
+++ b/packages/hub/config/development.json
@@ -10,6 +10,10 @@
   "compiler": {
     "routeCard": "https://demo.com/routes"
   },
+  "mailchimp": {
+    "serverPrefix": "us-8",
+    "newsletterListId": "c2b7a36f2d"
+  },
   "discord": {
     "allowedChannels": "958136277096620084"
   }

--- a/packages/hub/config/development.json
+++ b/packages/hub/config/development.json
@@ -11,7 +11,7 @@
     "routeCard": "https://demo.com/routes"
   },
   "mailchimp": {
-    "serverPrefix": "us-8",
+    "serverPrefix": "us8",
     "newsletterListId": "c2b7a36f2d"
   },
   "discord": {

--- a/packages/hub/config/production.json
+++ b/packages/hub/config/production.json
@@ -14,6 +14,10 @@
     "allowedGuilds": "584043165066199050",
     "allowedChannels": "898954606242054185"
   },
+  "mailchimp": {
+    "serverPrefix": "us-8",
+    "newsletterListId": "f2fe559998"
+  },
   "web3": {
     "layer1Network": "mainnet",
     "layer2Network": "xdai"

--- a/packages/hub/config/production.json
+++ b/packages/hub/config/production.json
@@ -15,7 +15,7 @@
     "allowedChannels": "898954606242054185"
   },
   "mailchimp": {
-    "serverPrefix": "us-8",
+    "serverPrefix": "us8",
     "newsletterListId": "f2fe559998"
   },
   "web3": {

--- a/packages/hub/config/staging.json
+++ b/packages/hub/config/staging.json
@@ -7,6 +7,10 @@
   "cardDrop": {
     "verificationUrl": "https://hub-staging.stack.cards/email-card-drop/verify"
   },
+  "mailchimp": {
+    "serverPrefix": "us-8",
+    "newsletterListId": "c2b7a36f2d"
+  },
   "wyre": {
     "callbackUrl": "https://hub-staging.stack.cards/callbacks/wyre"
   },

--- a/packages/hub/config/staging.json
+++ b/packages/hub/config/staging.json
@@ -8,7 +8,7 @@
     "verificationUrl": "https://hub-staging.stack.cards/email-card-drop/verify"
   },
   "mailchimp": {
-    "serverPrefix": "us-8",
+    "serverPrefix": "us8",
     "newsletterListId": "c2b7a36f2d"
   },
   "wyre": {

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -98,6 +98,7 @@ import SendEmailCardDropVerificationTask from './tasks/send-email-card-drop-veri
 import SubscribeEmailTask from './tasks/subscribe-email';
 import DiscordPostTask from './tasks/discord-post';
 import Email from './services/email';
+import Mailchimp from './services/mailchimp';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -141,6 +142,7 @@ export function createRegistry(): Registry {
   registry.register('subscribe-email', SubscribeEmailTask);
   registry.register('discord-post', DiscordPostTask);
   registry.register('email', Email);
+  registry.register('mailchimp', Mailchimp);
   registry.register('order', OrderService);
   registry.register('orders-route', OrdersRoute);
   registry.register('persist-off-chain-prepaid-card-customization', PersistOffChainPrepaidCardCustomizationTask);

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -207,10 +207,7 @@ describe('POST /api/email-card-drop-requests', function () {
     expect(emailCardDropRequest.emailHash).to.equal(emailHash);
 
     expect(jobIdentifiers).to.deep.equal(['send-email-card-drop-verification', 'subscribe-email']);
-    expect(jobPayloads).to.deep.equal([
-      { id: resourceId, email },
-      { id: resourceId, email },
-    ]);
+    expect(jobPayloads).to.deep.equal([{ id: resourceId, email }, { email }]);
   });
 
   it('sends another email if a request is present but has not been claimed', async function () {

--- a/packages/hub/node-tests/tasks/subscribe-email-test.ts
+++ b/packages/hub/node-tests/tasks/subscribe-email-test.ts
@@ -1,0 +1,93 @@
+import { Job } from 'graphile-worker';
+import { registry, setupHub } from '../helpers/server';
+import { expect } from 'chai';
+import { makeJobHelpers } from 'graphile-worker/dist/helpers';
+import waitFor from '../utils/wait-for';
+import * as Sentry from '@sentry/node';
+import sentryTestkit from 'sentry-testkit';
+import SubscribeEmail from '../../tasks/subscribe-email';
+
+const { testkit, sentryTransport } = sentryTestkit();
+
+// https://github.com/graphile/worker/blob/e3176eab42ada8f4f3718192bada776c22946583/__tests__/helpers.ts#L135
+function makeMockJob(taskIdentifier: string): Job {
+  const createdAt = new Date(Date.now() - 12345678);
+  return {
+    id: String(Math.floor(Math.random() * 4294967296)),
+    queue_name: null,
+    task_identifier: taskIdentifier,
+    payload: {},
+    priority: 0,
+    run_at: new Date(Date.now() - Math.random() * 2000),
+    attempts: 0,
+    max_attempts: 25,
+    last_error: null,
+    created_at: createdAt,
+    updated_at: createdAt,
+    locked_at: null,
+    locked_by: null,
+    revision: 0,
+    key: null,
+    flags: null,
+  };
+}
+
+let helpers = makeJobHelpers({}, makeMockJob('subscribe-email'), {
+  withPgClient: () => {
+    throw new Error('withPgClient is not implemented in test');
+  },
+});
+
+class StubMailchimp {
+  static lastSubscribed: string | null = null;
+  static shouldThrow = false;
+
+  async subscribe(email: string) {
+    if (StubMailchimp.shouldThrow) throw new Error('intentional error during test');
+    StubMailchimp.lastSubscribed = email;
+  }
+}
+
+describe('SubscribeEmailTask', function () {
+  let subject: SubscribeEmail;
+
+  this.beforeAll(async function () {
+    registry(this).register('mailchimp', StubMailchimp);
+  });
+
+  let { getContainer } = setupHub(this);
+
+  this.beforeEach(async function () {
+    StubMailchimp.lastSubscribed = null;
+    StubMailchimp.shouldThrow = false;
+    Sentry.init({
+      dsn: 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001',
+      release: 'test',
+      tracesSampleRate: 1,
+      transport: sentryTransport,
+    });
+    testkit.reset();
+    subject = (await getContainer().lookup('subscribe-email')) as SubscribeEmail;
+  });
+
+  it('will try to subscribe the provided email to the Mailchimp newsletter', async function () {
+    await subject.perform({ email: 'anyone@test.test' }, helpers);
+
+    expect(StubMailchimp.lastSubscribed).to.equal('anyone@test.test');
+  });
+  it('will throw the error and report to Sentry if an error happens while trying to subscribe', async function () {
+    StubMailchimp.shouldThrow = true;
+
+    await expect(subject.perform({ email: 'anyone@test.test' }, helpers)).to.be.rejectedWith(
+      'intentional error during test'
+    );
+
+    await waitFor(() => testkit.reports().length > 0);
+
+    let sentryReport = testkit.reports()[0];
+    expect(sentryReport.error?.message).to.equal('intentional error during test');
+    expect(sentryReport.tags).to.deep.equal({
+      event: 'subscribe-email',
+    });
+  });
+});

--- a/packages/hub/node-tests/tasks/subscribe-email-test.ts
+++ b/packages/hub/node-tests/tasks/subscribe-email-test.ts
@@ -87,7 +87,7 @@ describe('SubscribeEmailTask', function () {
     let sentryReport = testkit.reports()[0];
     expect(sentryReport.error?.message).to.equal('intentional error during test');
     expect(sentryReport.tags).to.deep.equal({
-      event: 'subscribe-email',
+      action: 'subscribe-email',
     });
   });
 });

--- a/packages/hub/node-tests/tasks/subscribe-email-test.ts
+++ b/packages/hub/node-tests/tasks/subscribe-email-test.ts
@@ -88,6 +88,7 @@ describe('SubscribeEmailTask', function () {
     expect(sentryReport.error?.message).to.equal('intentional error during test');
     expect(sentryReport.tags).to.deep.equal({
       action: 'subscribe-email',
+      alert: 'web-team',
     });
   });
 });

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -48,6 +48,7 @@
     "@graphile/logger": "^0.2.0",
     "@koa/cors": "^3.1.0",
     "@koa/router": "^10.0.0",
+    "@mailchimp/mailchimp_marketing": "^3.0.75",
     "@pagerduty/pdjs": "^2.2.4",
     "@sentry/node": "^6.10.0",
     "@types/fs-extra": "^9.0.11",

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -222,10 +222,21 @@ export default class EmailCardDropRequestsRoute {
       email,
     });
 
-    await this.workerClient.addJob('subscribe-email', {
-      id: emailCardDropRequest.id,
-      email,
-    });
+    await this.workerClient.addJob(
+      'subscribe-email',
+      { email },
+      // for the most part, Mailchimp errors will not be retriable
+      // because of that we limit maxAttempts to 1
+      // this prevents us from retrying where we cannot do anything
+      // and also leaves dead jobs in the db that we can check later
+      // this should be supplemented by the Mailchimp errors being sent
+      // to Sentry and having appropriate alerts, especially for rate limiting
+      // could consider permanently failing the job from within conditionally, instead. probably as a utility function?
+      // https://github.com/graphile/worker/blob/e3176eab42ada8f4f3718192bada776c22946583/sql/000004.sql#L122-L126
+      {
+        maxAttempts: 1,
+      }
+    );
 
     let serialized = this.emailCardDropRequestSerializer.serialize(emailCardDropRequest);
 

--- a/packages/hub/services/mailchimp.ts
+++ b/packages/hub/services/mailchimp.ts
@@ -1,0 +1,57 @@
+// the types from Definitely Typed are not good enough.
+// Mailchimp docs seem more reliable though the examples have the wrong node package name
+// https://mailchimp.com/developer/marketing/api
+// @ts-ignore
+import client from '@mailchimp/mailchimp_marketing';
+import config from 'config';
+
+export default class Mailchimp {
+  client = client;
+  newsletterListId = config.get('mailchimp.newsletterListId') as string;
+
+  constructor() {
+    client.setConfig({
+      apiKey: config.get('mailchimp.apiKey'),
+      server: config.get('mailchimp.serverPrefix'),
+    });
+  }
+
+  private async isSubscribed(email: string) {
+    try {
+      let member: { status: string } = await client.lists.getListMember(this.newsletterListId, email, {
+        fields: ['status'],
+      });
+      return member.status === 'subscribed';
+    } catch (e) {
+      // mailchimp gives us a 404 if the member doesn't exist
+      if ((e as Error & { status: number })?.status === 404) {
+        return false;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * If email is already subscribed, do nothing.
+   * If email has previously been subscribed, resend confirmation email.
+   * If email has never been subscribed, send confirmation email.
+   */
+  async subscribe(email: string) {
+    if (await this.isSubscribed(email)) return;
+
+    // this adds an audience member if they aren't already in the list,
+    // and updates the existing one if they do exist
+    await client.lists.setListMember(this.newsletterListId, email, {
+      email_address: email,
+      status_if_new: 'pending', // pending status is needed to trigger a confirmation email
+      status: 'pending',
+    });
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    mailchimp: Mailchimp;
+  }
+}

--- a/packages/hub/services/mailchimp.ts
+++ b/packages/hub/services/mailchimp.ts
@@ -5,6 +5,18 @@
 import client from '@mailchimp/mailchimp_marketing';
 import config from 'config';
 
+/**
+ * # CONVENIENCES SCRIPTS WHILE DEVELOPING/DEBUGGING MAILCHIMP THINGS
+ *
+ * 1. check what the current list looks like (remove the fields option if you want all the data):
+ *    client.lists.getListMembersInfo(listId, {fields: ['members.email_address', 'members.status', 'members.last_changed']}).then(v => console.log(v))
+ *
+ * 2. remove an email from the list:
+ *    client.lists.deleteListMember(listId, email);
+ *
+ * 3. unsubscribe an email
+ *    client.lists.setListMember(listId, email, { status: 'unsubscribed' });
+ */
 export default class Mailchimp {
   client = client;
   newsletterListId = config.get('mailchimp.newsletterListId') as string;
@@ -40,7 +52,7 @@ export default class Mailchimp {
   async subscribe(email: string) {
     if (await this.isSubscribed(email)) return;
 
-    // this adds an audience member if they aren't already in the list,
+    // this adds a list member if they aren't already in the list,
     // and updates the existing one if they do exist
     await client.lists.setListMember(this.newsletterListId, email, {
       email_address: email,

--- a/packages/hub/tasks/subscribe-email.ts
+++ b/packages/hub/tasks/subscribe-email.ts
@@ -14,6 +14,7 @@ export default class SubscribeEmail {
       Sentry.captureException(e, {
         tags: {
           action: 'subscribe-email',
+          alert: 'web-team',
         },
       });
       throw e;

--- a/packages/hub/tasks/subscribe-email.ts
+++ b/packages/hub/tasks/subscribe-email.ts
@@ -13,7 +13,7 @@ export default class SubscribeEmail {
       helpers.logger.error(JSON.stringify(e, null, 2));
       Sentry.captureException(e, {
         tags: {
-          event: 'subscribe-email',
+          action: 'subscribe-email',
         },
       });
       throw e;

--- a/packages/hub/tasks/subscribe-email.ts
+++ b/packages/hub/tasks/subscribe-email.ts
@@ -1,7 +1,22 @@
+import { inject } from '@cardstack/di';
 import { Helpers } from 'graphile-worker';
+import * as Sentry from '@sentry/node';
 
 export default class SubscribeEmail {
-  async perform(_payload: any, helpers: Helpers) {
-    helpers.logger.info(`Placeholder for SubscribeEmail`);
+  mailchimp = inject('mailchimp');
+
+  async perform(payload: { email: string }, helpers: Helpers) {
+    try {
+      await this.mailchimp.subscribe(payload.email);
+    } catch (e) {
+      helpers.logger.error('Failed to subscribe user to newsletter');
+      helpers.logger.error(JSON.stringify(e, null, 2));
+      Sentry.captureException(e, {
+        tags: {
+          event: 'newsletter-subscription',
+        },
+      });
+      throw e;
+    }
   }
 }

--- a/packages/hub/tasks/subscribe-email.ts
+++ b/packages/hub/tasks/subscribe-email.ts
@@ -13,7 +13,7 @@ export default class SubscribeEmail {
       helpers.logger.error(JSON.stringify(e, null, 2));
       Sentry.captureException(e, {
         tags: {
-          event: 'newsletter-subscription',
+          event: 'subscribe-email',
         },
       });
       throw e;

--- a/waypoint.hcl
+++ b/waypoint.hcl
@@ -46,6 +46,7 @@ app "hub" {
                 HUB_EMAIL_HASH_SALT = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_hub_email_hash_salt-nJvKQH"
                 DISCORD_ON_CALL_INTERNAL_WEBHOOK = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_discord_on_call_internal_webhook-4ylxfM"
                 PAGERDUTY_TOKEN= "arn:aws:secretsmanager:us-east-1:680542703984:secret:PAGERDUTY_TOKEN-kTxFxL"
+                MAILCHIMP_API_KEY= "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_MAILCHIMP_API_KEY-lkxsEk"
             }
         }
 
@@ -104,6 +105,7 @@ app "hub-worker" {
                 HUB_AUTH_SECRET = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_hub_auth_secret-50oF6K"
                 DISCORD_ON_CALL_INTERNAL_WEBHOOK = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_discord_on_call_internal_webhook-4ylxfM"
                 PAGERDUTY_TOKEN= "arn:aws:secretsmanager:us-east-1:680542703984:secret:PAGERDUTY_TOKEN-kTxFxL"
+                MAILCHIMP_API_KEY= "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_MAILCHIMP_API_KEY-lkxsEk"
             }
         }
 

--- a/waypoint.prod.hcl
+++ b/waypoint.prod.hcl
@@ -46,6 +46,7 @@ app "hub" {
                 HUB_EMAIL_HASH_SALT = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_hub_email_hash_salt-6j6HZV"
                 DISCORD_ON_CALL_INTERNAL_WEBHOOK = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_discord_on_call_internal_webhook-n7SCZC"
                 PAGERDUTY_TOKEN = "arn:aws:secretsmanager:us-east-1:120317779495:secret:PAGERDUTY_TOKEN-1L68JJ"
+                MAILCHIMP_API_KEY= "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_MAILCHIMP_API_KEY-XCGDUW"
             }
         }
 
@@ -99,6 +100,7 @@ app "hub-worker" {
                 HUB_AUTH_SECRET = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_hub_auth_secret-amva1E"
                 DISCORD_ON_CALL_INTERNAL_WEBHOOK = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_discord_on_call_internal_webhook-n7SCZC"
                 PAGERDUTY_TOKEN = "arn:aws:secretsmanager:us-east-1:120317779495:secret:PAGERDUTY_TOKEN-1L68JJ"
+                MAILCHIMP_API_KEY= "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_MAILCHIMP_API_KEY-XCGDUW"
             }
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7156,6 +7156,14 @@
     npmlog "^4.1.2"
     write-file-atomic "^3.0.3"
 
+"@mailchimp/mailchimp_marketing@^3.0.75":
+  version "3.0.75"
+  resolved "https://registry.yarnpkg.com/@mailchimp/mailchimp_marketing/-/mailchimp_marketing-3.0.75.tgz#8b0d79d9da4fa3b8c8d43d87494c7a75e081f1d2"
+  integrity sha512-UWg3zHd1XMIbXEWlhZpuJiUi1jQ5z3MumJwa5RKjf9/iKboz39X8v4Goq4isi2/mFf07dgftkt/zOSChY32eqg==
+  dependencies:
+    dotenv "^8.2.0"
+    superagent "3.8.1"
+
 "@metamask/detect-provider@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@metamask/detect-provider/-/detect-provider-1.2.0.tgz#3667a7531f2a682e3c3a43eaf3a1958bdb42a696"
@@ -10598,7 +10606,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@4.1.4, axe-core@^4.1.4:
+axe-core@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.4.tgz#f19cd99a84ee32a318b9c5b5bb8ed373ad94f143"
   integrity sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==
@@ -13631,7 +13639,7 @@ component-emitter@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
-component-emitter@^1.2.1, component-emitter@^1.3.0, component-emitter@~1.3.0:
+component-emitter@^1.2.0, component-emitter@^1.2.1, component-emitter@^1.3.0, component-emitter@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
@@ -13932,6 +13940,11 @@ cookie@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
+cookiejar@^2.1.0:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.3.tgz#fc7a6216e408e74414b90230050842dacda75acc"
+  integrity sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==
 
 cookiejar@^2.1.1, cookiejar@^2.1.2:
   version "2.1.2"
@@ -15108,6 +15121,11 @@ dotenv@^8.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
+dotenv@^8.2.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
+  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
+
 drbg.js@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/drbg.js/-/drbg.js-1.0.1.tgz#3e36b6c42b37043823cdbc332d58f31e2445480b"
@@ -15244,7 +15262,7 @@ elliptic@6.5.4, elliptic@^6.0.0, elliptic@^6.4.0, elliptic@^6.5.2:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-ember-a11y-testing@4.0.3, ember-a11y-testing@^4.0.3:
+ember-a11y-testing@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-4.0.3.tgz#1f5c91266d39ea5b20614b0d294a562079887ac7"
   integrity sha512-Q7nq2crC9+bT+sZi/BORAM4FUhI080edEhnpsvB6vdkD9Ro2Rg4DksQs5Be65/DM108VNDMtbHZtrPS060Mzcw==
@@ -19374,6 +19392,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^2.3.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
 
 form-data@^3.0.0:
   version "3.0.1"
@@ -24615,7 +24642,7 @@ merkle-patricia-tree@^4.2.0, merkle-patricia-tree@^4.2.2:
     rlp "^2.2.4"
     semaphore-async-await "^1.5.1"
 
-methods@^1.1.2, methods@~1.1.2:
+methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
@@ -24696,7 +24723,7 @@ mime-types@~2.1.34:
   dependencies:
     mime-db "1.52.0"
 
-mime@1.6.0:
+mime@1.6.0, mime@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
@@ -27819,7 +27846,7 @@ qs@^6.10.1, qs@^6.4.0, qs@^6.5.2, qs@^6.7.0, qs@^6.9.4:
   dependencies:
     side-channel "^1.0.4"
 
-qs@^6.6.0:
+qs@^6.5.1, qs@^6.6.0:
   version "6.10.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
   integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
@@ -30471,6 +30498,22 @@ sum-up@^1.0.1:
   resolved "https://registry.yarnpkg.com/sum-up/-/sum-up-1.0.3.tgz#1c661f667057f63bcb7875aa1438bc162525156e"
   dependencies:
     chalk "^1.0.0"
+
+superagent@3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.1.tgz#2571fd921f3fcdba43ac68c3b35c91951532701f"
+  integrity sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.1.1"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.0.5"
 
 superagent@^6.1.0:
   version "6.1.0"


### PR DESCRIPTION
Posting to `/api/email-card-drop-requests` will now subscribe the provided email to our newsletter in Mailchimp.

To try this out locally, get the dev api key and assign it to `MAILCHIMP_API_KEY`:

``` 
# use staging AWS credentials
aws secretsmanager get-secret-value --secret-id dev_MAILCHIMP_API_KEY  
```

TODO:
- [x] Add `MAILCHIMP_API_KEY` variable to waypoint config for prod and staging hub + worker. There are already secrets in staging and prod AWS Secrets Manager for this