### PR TITLE
[Refactor]: Remove spd from native currencies

### DIFF
--- a/packages/cardpay-sdk/sdk/currencies.ts
+++ b/packages/cardpay-sdk/sdk/currencies.ts
@@ -5,7 +5,6 @@ enum CryptoCurrency {
 }
 
 enum NativeCurrency {
-  SPD = 'SPD',
   USD = 'USD',
   EUR = 'EUR',
   GBP = 'GBP',
@@ -76,17 +75,6 @@ const cryptoCurrencies: Record<CryptoCurrency, CurrencyInfo> = {
 };
 
 const nativeCurrencies: Record<NativeCurrency, CurrencyInfo> = {
-  SPD: {
-    alignment: 'left',
-    assetLimit: 1,
-    currency: 'SPD',
-    decimals: 0,
-    label: 'SPEND',
-    mask: '[099999999999]',
-    placeholder: '0',
-    smallThreshold: 1,
-    symbol: '§',
-  },
   USD: {
     alignment: 'left',
     assetLimit: 1,

--- a/packages/ssr-web/app/controllers/pay.ts
+++ b/packages/ssr-web/app/controllers/pay.ts
@@ -29,6 +29,7 @@ export default class PayController extends Controller {
   }
 
   get cleanedValues() {
+    let isCurrencySPD = this.currency === 'SPD';
     let hasValidAmount =
       !isNaN(this.amount) &&
       this.amount !== 0 &&
@@ -36,7 +37,7 @@ export default class PayController extends Controller {
       this.amount !== -Infinity;
     let hasValidCurrency =
       this.currency !== undefined &&
-      isSupportedCurrency(this.currency) &&
+      (isSupportedCurrency(this.currency) || isCurrencySPD) &&
       this.currency !== 'DAI' &&
       this.currency !== 'CARD' &&
       this.currency !== 'ETH';
@@ -51,7 +52,7 @@ export default class PayController extends Controller {
           secondaryAmount: '',
         },
       };
-    } else if (this.currency === 'SPD') {
+    } else if (isCurrencySPD) {
       let amount = Number(
         roundAmountToNativeCurrencyDecimals(
           spendToUsd(Math.max(this.amount, minSpendAmount))!,


### PR DESCRIPTION
As we moved away from using spend as currency on the wallet, we can remove this currency info, because it's a bit misleading to have spend as a nativeCurrency while the api doesn't really return it, if we were to still use it, we could make the api return SPD too, but since we don't need it anymore, removing seems the best bet to avoid the need of filtering out SPD on the mobile app.