### PR TITLE
hub: Extract test helpers for Sentry Testkit

### DIFF
--- a/packages/hub/node-tests/helpers/sentry.ts
+++ b/packages/hub/node-tests/helpers/sentry.ts
@@ -1,0 +1,31 @@
+import sentryTestkit from 'sentry-testkit';
+import * as Sentry from '@sentry/node';
+import waitFor from '../utils/wait-for';
+import { Suite } from 'mocha';
+
+const { testkit, sentryTransport } = sentryTestkit();
+const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001';
+
+export function setupSentry(context: Suite) {
+  context.beforeEach(function () {
+    Sentry.init({
+      dsn: DUMMY_DSN,
+      release: 'test',
+      tracesSampleRate: 1,
+      transport: sentryTransport,
+    });
+    testkit.reset();
+  });
+}
+
+export async function fetchSentryReport() {
+  await waitFor(() => testkit.reports().length > 0);
+  return testkit.reports()[0];
+}
+
+export async function fetchSentryReports(timeout: number) {
+  await waitFor(() => {
+    return !!testkit.reports().length;
+  }, timeout);
+  return testkit.reports();
+}

--- a/packages/hub/node-tests/helpers/sentry.ts
+++ b/packages/hub/node-tests/helpers/sentry.ts
@@ -7,13 +7,16 @@ const { testkit, sentryTransport } = sentryTestkit();
 const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001';
 
 export function setupSentry(context: Suite) {
-  context.beforeEach(function () {
+  context.beforeAll(function () {
     Sentry.init({
       dsn: DUMMY_DSN,
       release: 'test',
       tracesSampleRate: 1,
       transport: sentryTransport,
     });
+  });
+
+  context.beforeEach(function () {
     testkit.reset();
   });
 }

--- a/packages/hub/node-tests/helpers/sentry.ts
+++ b/packages/hub/node-tests/helpers/sentry.ts
@@ -21,12 +21,12 @@ export function setupSentry(context: Suite) {
   });
 }
 
-export async function fetchSentryReport() {
+export async function waitForSentryReport() {
   await waitFor(() => testkit.reports().length > 0);
   return testkit.reports()[0];
 }
 
-export async function fetchSentryReports(timeout: number) {
+export async function waitForSentryReports(timeout: number) {
   await waitFor(() => {
     return !!testkit.reports().length;
   }, timeout);

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -1,15 +1,11 @@
 import type { EmailCardDropRequest } from '../../routes/email-card-drop-requests';
 import { Clock } from '../../services/clock';
 import { registry, setupHub } from '../helpers/server';
+import { fetchSentryReport, setupSentry } from '../helpers/sentry';
 import crypto from 'crypto';
 import { Job, TaskSpec } from 'graphile-worker';
 import config from 'config';
 import shortUUID from 'short-uuid';
-import sentryTestkit from 'sentry-testkit';
-import * as Sentry from '@sentry/node';
-import waitFor from '../utils/wait-for';
-
-const { testkit, sentryTransport } = sentryTestkit();
 
 let claimedEoa: EmailCardDropRequest = {
   id: '2850a954-525d-499a-a5c8-3c89192ad40e',
@@ -159,16 +155,9 @@ class StubWorkerClient {
 }
 
 describe('POST /api/email-card-drop-requests', function () {
+  setupSentry(this);
+
   this.beforeEach(function () {
-    Sentry.init({
-      dsn: 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001',
-      release: 'test',
-      tracesSampleRate: 1,
-      transport: sentryTransport,
-    });
-
-    testkit.reset();
-
     registry(this).register('authentication-utils', StubAuthenticationUtils);
     registry(this).register('worker-client', StubWorkerClient);
   });
@@ -361,9 +350,7 @@ describe('POST /api/email-card-drop-requests', function () {
 
     expect(limited).to.equal(true);
 
-    await waitFor(() => testkit.reports().length > 0);
-
-    let sentryReport = testkit.reports()[0];
+    let sentryReport = await fetchSentryReport();
 
     expect(sentryReport.tags).to.deep.equal({
       event: 'email-card-drop-rate-limit-reached',

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -1,7 +1,7 @@
 import type { EmailCardDropRequest } from '../../routes/email-card-drop-requests';
 import { Clock } from '../../services/clock';
 import { registry, setupHub } from '../helpers/server';
-import { fetchSentryReport, setupSentry } from '../helpers/sentry';
+import { setupSentry, waitForSentryReport } from '../helpers/sentry';
 import crypto from 'crypto';
 import { Job, TaskSpec } from 'graphile-worker';
 import config from 'config';
@@ -350,7 +350,7 @@ describe('POST /api/email-card-drop-requests', function () {
 
     expect(limited).to.equal(true);
 
-    let sentryReport = await fetchSentryReport();
+    let sentryReport = await waitForSentryReport();
 
     expect(sentryReport.tags).to.deep.equal({
       event: 'email-card-drop-rate-limit-reached',

--- a/packages/hub/node-tests/routes/status-test.ts
+++ b/packages/hub/node-tests/routes/status-test.ts
@@ -1,9 +1,5 @@
 import { registry, setupHub } from '../helpers/server';
-import sentryTestkit from 'sentry-testkit';
-import * as Sentry from '@sentry/node';
-import waitFor from '../utils/wait-for';
-
-const { testkit, sentryTransport } = sentryTestkit();
+import { fetchSentryReport, setupSentry } from '../helpers/sentry';
 
 let stubWeb3Available = true;
 
@@ -69,16 +65,9 @@ class StubExchangeRates {
 }
 
 describe('GET /api/status', function () {
+  setupSentry(this);
+
   this.beforeEach(function () {
-    Sentry.init({
-      dsn: 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001',
-      release: 'test',
-      tracesSampleRate: 1,
-      transport: sentryTransport,
-    });
-
-    testkit.reset();
-
     registry(this).register('exchange-rates', StubExchangeRates);
     registry(this).register('subgraph', StubSubgraph);
     registry(this).register('web3-http', StubWeb3);
@@ -172,13 +161,13 @@ describe('GET /api/status', function () {
       })
       .expect('Content-Type', 'application/vnd.api+json');
 
-    await waitFor(() => testkit.reports().length > 0);
+    let sentryReport = await fetchSentryReport();
 
-    expect(testkit.reports()[0].tags).to.deep.equal({
+    expect(sentryReport.tags).to.deep.equal({
       action: 'status-route',
     });
 
-    expect(testkit.reports()[0].error?.message).to.equal('Mock subgraph error');
+    expect(sentryReport.error?.message).to.equal('Mock subgraph error');
   });
 
   it('reports degraded status when web3 throws an error', async function () {
@@ -208,13 +197,13 @@ describe('GET /api/status', function () {
       })
       .expect('Content-Type', 'application/vnd.api+json');
 
-    await waitFor(() => testkit.reports().length > 0);
+    let sentryReport = await fetchSentryReport();
 
-    expect(testkit.reports()[0].tags).to.deep.equal({
+    expect(sentryReport.tags).to.deep.equal({
       action: 'status-route',
     });
 
-    expect(testkit.reports()[0].error?.message).to.equal('Mock Web3 error');
+    expect(sentryReport.error?.message).to.equal('Mock Web3 error');
   });
 
   it('reports unknown status when exchangeRates service throws an error', async function () {
@@ -243,12 +232,12 @@ describe('GET /api/status', function () {
       })
       .expect('Content-Type', 'application/vnd.api+json');
 
-    await waitFor(() => testkit.reports().length > 0);
+    let sentryReport = await fetchSentryReport();
 
-    expect(testkit.reports()[0].tags).to.deep.equal({
+    expect(sentryReport.tags).to.deep.equal({
       action: 'status-route',
     });
 
-    expect(testkit.reports()[0].error?.message).to.equal('Mock exchange rates error');
+    expect(sentryReport.error?.message).to.equal('Mock exchange rates error');
   });
 });

--- a/packages/hub/node-tests/routes/status-test.ts
+++ b/packages/hub/node-tests/routes/status-test.ts
@@ -1,5 +1,5 @@
 import { registry, setupHub } from '../helpers/server';
-import { fetchSentryReport, setupSentry } from '../helpers/sentry';
+import { setupSentry, waitForSentryReport } from '../helpers/sentry';
 
 let stubWeb3Available = true;
 
@@ -161,7 +161,7 @@ describe('GET /api/status', function () {
       })
       .expect('Content-Type', 'application/vnd.api+json');
 
-    let sentryReport = await fetchSentryReport();
+    let sentryReport = await waitForSentryReport();
 
     expect(sentryReport.tags).to.deep.equal({
       action: 'status-route',
@@ -197,7 +197,7 @@ describe('GET /api/status', function () {
       })
       .expect('Content-Type', 'application/vnd.api+json');
 
-    let sentryReport = await fetchSentryReport();
+    let sentryReport = await waitForSentryReport();
 
     expect(sentryReport.tags).to.deep.equal({
       action: 'status-route',
@@ -232,7 +232,7 @@ describe('GET /api/status', function () {
       })
       .expect('Content-Type', 'application/vnd.api+json');
 
-    let sentryReport = await fetchSentryReport();
+    let sentryReport = await waitForSentryReport();
 
     expect(sentryReport.tags).to.deep.equal({
       action: 'status-route',

--- a/packages/hub/node-tests/services/contract-subscription-event-handler-test.ts
+++ b/packages/hub/node-tests/services/contract-subscription-event-handler-test.ts
@@ -1,6 +1,6 @@
 import { Job, TaskSpec } from 'graphile-worker';
 import { expect } from 'chai';
-import { fetchSentryReport, setupSentry } from '../helpers/sentry';
+import { setupSentry, waitForSentryReport } from '../helpers/sentry';
 import Web3 from 'web3';
 
 import { setupHub, registry } from '../helpers/server';
@@ -123,7 +123,7 @@ describe('ContractSubscriptionEventHandler', function () {
     let error = new Error('Mock CustomerPayment error');
     this.contracts.handlers.CustomerPayment(error);
 
-    let sentryReport = await fetchSentryReport();
+    let sentryReport = await waitForSentryReport();
 
     expect(sentryReport.tags).to.deep.equal({
       action: 'contract-subscription-event-handler',
@@ -151,7 +151,7 @@ describe('ContractSubscriptionEventHandler', function () {
     let error = new Error('Mock MerchantClaim error');
     this.contracts.handlers.MerchantClaim(error);
 
-    let sentryReport = await fetchSentryReport();
+    let sentryReport = await waitForSentryReport();
 
     expect(sentryReport.tags).to.deep.equal({
       action: 'contract-subscription-event-handler',

--- a/packages/hub/node-tests/services/web3-socket-test.ts
+++ b/packages/hub/node-tests/services/web3-socket-test.ts
@@ -1,5 +1,5 @@
 import Web3SocketService from '../../services/web3-socket';
-import { fetchSentryReport, fetchSentryReports, setupSentry } from '../helpers/sentry';
+import { setupSentry, waitForSentryReport, waitForSentryReports } from '../helpers/sentry';
 import { server as WebsocketServer } from 'websocket';
 import http from 'http';
 
@@ -38,7 +38,7 @@ describe('Web3Socket', function () {
 
     expect(() => subject.getInstance()).to.throw('mock web3 initialization failure');
 
-    expect((await fetchSentryReport()).tags).to.deep.equal({
+    expect((await waitForSentryReport()).tags).to.deep.equal({
       action: 'web3-socket-connection',
     });
   });
@@ -58,7 +58,7 @@ describe('Web3Socket', function () {
     });
     provider.emit(provider.ERROR, new Error('A test error'));
 
-    let sentryReport = await fetchSentryReport();
+    let sentryReport = await waitForSentryReport();
     expect(sentryReport.error?.message).to.equal('A test error');
     expect(sentryReport.tags).to.deep.equal({
       action: 'web3-socket-connection',
@@ -84,7 +84,7 @@ describe('Web3Socket', function () {
       wasClean: false,
     });
 
-    let sentryReports = await fetchSentryReports(150000);
+    let sentryReports = await waitForSentryReports(150000);
 
     let testCaseReport = sentryReports.find(
       (v) => (v?.originalReport?.extra?.__serialized__ as any).reason === 'Testing'

--- a/packages/hub/node-tests/services/web3-socket-test.ts
+++ b/packages/hub/node-tests/services/web3-socket-test.ts
@@ -1,17 +1,14 @@
 import Web3SocketService from '../../services/web3-socket';
-import sentryTestkit from 'sentry-testkit';
-import * as Sentry from '@sentry/node';
-import waitFor from '../utils/wait-for';
+import { fetchSentryReport, fetchSentryReports, setupSentry } from '../helpers/sentry';
 import { server as WebsocketServer } from 'websocket';
 import http from 'http';
-
-const { testkit, sentryTransport } = sentryTestkit();
-const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001';
 
 describe('Web3Socket', function () {
   let subject: Web3SocketService;
   let wsServer: WebsocketServer;
   let httpServer: http.Server;
+
+  setupSentry(this);
 
   this.beforeEach(function () {
     httpServer = http.createServer(function (_, response) {
@@ -27,13 +24,6 @@ describe('Web3Socket', function () {
     });
     subject = new Web3SocketService();
     subject.rpcURL = 'ws://localhost:8545';
-    Sentry.init({
-      dsn: DUMMY_DSN,
-      release: 'test',
-      tracesSampleRate: 1,
-      transport: sentryTransport,
-    });
-    testkit.reset();
   });
   this.afterEach(async function () {
     (subject.web3?.currentProvider as any)?.disconnect?.();
@@ -48,9 +38,7 @@ describe('Web3Socket', function () {
 
     expect(() => subject.getInstance()).to.throw('mock web3 initialization failure');
 
-    await waitFor(() => testkit.reports().length > 0);
-
-    expect(testkit.reports()[0].tags).to.deep.equal({
+    expect((await fetchSentryReport()).tags).to.deep.equal({
       action: 'web3-socket-connection',
     });
   });
@@ -70,10 +58,9 @@ describe('Web3Socket', function () {
     });
     provider.emit(provider.ERROR, new Error('A test error'));
 
-    await waitFor(() => testkit.reports().length > 0);
-
-    expect(testkit.reports()[0].error?.message).to.equal('A test error');
-    expect(testkit.reports()[0].tags).to.deep.equal({
+    let sentryReport = await fetchSentryReport();
+    expect(sentryReport.error?.message).to.equal('A test error');
+    expect(sentryReport.tags).to.deep.equal({
       action: 'web3-socket-connection',
     });
   });
@@ -97,13 +84,11 @@ describe('Web3Socket', function () {
       wasClean: false,
     });
 
-    await waitFor(() => {
-      return !!testkit.reports().length;
-    }, 15000);
+    let sentryReports = await fetchSentryReports(150000);
 
-    let testCaseReport = testkit
-      .reports()
-      .find((v) => (v?.originalReport?.extra?.__serialized__ as any).reason === 'Testing')!;
+    let testCaseReport = sentryReports.find(
+      (v) => (v?.originalReport?.extra?.__serialized__ as any).reason === 'Testing'
+    )!;
     expect(testCaseReport?.extra?.__serialized__).to.deep.equal({
       code: 1000,
       reason: 'Testing',

--- a/packages/hub/node-tests/tasks/notify-customer-payment-test.ts
+++ b/packages/hub/node-tests/tasks/notify-customer-payment-test.ts
@@ -2,7 +2,7 @@ import { Job, TaskSpec } from 'graphile-worker';
 import { registry, setupHub } from '../helpers/server';
 import NotifyCustomerPayment, { PrepaidCardPaymentsQueryResult } from '../../tasks/notify-customer-payment';
 import { expect } from 'chai';
-import { fetchSentryReport, setupSentry } from '../helpers/sentry';
+import { setupSentry, waitForSentryReport } from '../helpers/sentry';
 
 type TransactionInformation = PrepaidCardPaymentsQueryResult['data']['prepaidCardPayments'][number];
 
@@ -264,7 +264,7 @@ describe('NotifyCustomerPaymentTask', function () {
       },
     ]);
 
-    let sentryReport = await fetchSentryReport();
+    let sentryReport = await waitForSentryReport();
 
     expect(sentryReport.tags).to.deep.equal({
       action: 'notify-customer-payment',

--- a/packages/hub/node-tests/tasks/notify-merchant-claim-test.ts
+++ b/packages/hub/node-tests/tasks/notify-merchant-claim-test.ts
@@ -5,7 +5,7 @@ import NotifyMerchantClaim, {
   MERCHANT_CLAIM_EXPIRY_TIME,
 } from '../../tasks/notify-merchant-claim';
 import { expect } from 'chai';
-import { fetchSentryReport, setupSentry } from '../helpers/sentry';
+import { setupSentry, waitForSentryReport } from '../helpers/sentry';
 
 type TransactionInformation = MerchantClaimsQueryResult['data']['merchantClaims'][number];
 
@@ -192,7 +192,7 @@ describe('NotifyMerchantClaimTask', function () {
       },
     ]);
 
-    let sentryReport = await fetchSentryReport();
+    let sentryReport = await waitForSentryReport();
 
     expect(sentryReport.tags).to.deep.equal({
       action: 'notify-merchant-claim',

--- a/packages/hub/node-tests/tasks/send-email-card-drop-verification-test.ts
+++ b/packages/hub/node-tests/tasks/send-email-card-drop-verification-test.ts
@@ -1,7 +1,7 @@
 import { Helpers, Job } from 'graphile-worker';
 import { registry, setupHub } from '../helpers/server';
 import { expect } from 'chai';
-import { fetchSentryReport, setupSentry } from '../helpers/sentry';
+import { setupSentry, waitForSentryReport } from '../helpers/sentry';
 import SendEmailCardDropVerification from '../../tasks/send-email-card-drop-verification';
 import { makeJobHelpers } from 'graphile-worker/dist/helpers';
 import EmailCardDropRequestsQueries from '../../queries/email-card-drop-requests';
@@ -95,7 +95,7 @@ describe('SendEmailCardDropVerificationTask', function () {
 
     expect(StubEmail.lastSent).to.equal(null);
 
-    let sentryReport = await fetchSentryReport();
+    let sentryReport = await waitForSentryReport();
 
     expect(sentryReport.tags).to.deep.equal({
       event: 'send-email-card-drop-verification',
@@ -114,7 +114,7 @@ describe('SendEmailCardDropVerificationTask', function () {
 
     expect(StubEmail.lastSent).to.equal(null);
 
-    let sentryReport = await fetchSentryReport();
+    let sentryReport = await waitForSentryReport();
 
     expect(sentryReport.tags).to.deep.equal({
       event: 'send-email-card-drop-verification',

--- a/packages/hub/node-tests/tasks/send-email-card-drop-verification-test.ts
+++ b/packages/hub/node-tests/tasks/send-email-card-drop-verification-test.ts
@@ -1,16 +1,12 @@
 import { Helpers, Job } from 'graphile-worker';
 import { registry, setupHub } from '../helpers/server';
 import { expect } from 'chai';
-import sentryTestkit from 'sentry-testkit';
-import * as Sentry from '@sentry/node';
-import waitFor from '../utils/wait-for';
+import { fetchSentryReport, setupSentry } from '../helpers/sentry';
 import SendEmailCardDropVerification from '../../tasks/send-email-card-drop-verification';
 import { makeJobHelpers } from 'graphile-worker/dist/helpers';
 import EmailCardDropRequestsQueries from '../../queries/email-card-drop-requests';
 import config from 'config';
 import { EmailCardDropRequest } from '../../routes/email-card-drop-requests';
-
-const { testkit, sentryTransport } = sentryTestkit();
 
 // https://github.com/graphile/worker/blob/e3176eab42ada8f4f3718192bada776c22946583/__tests__/helpers.ts#L135
 function makeMockJob(taskIdentifier: string): Job {
@@ -65,15 +61,10 @@ describe('SendEmailCardDropVerificationTask', function () {
   });
 
   let { getContainer } = setupHub(this);
+  setupSentry(this);
   this.beforeEach(async function () {
     StubEmail.shouldThrow = false;
     StubEmail.lastSent = null;
-    Sentry.init({
-      dsn: 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001',
-      release: 'test',
-      tracesSampleRate: 1,
-      transport: sentryTransport,
-    });
     let cardDropQueries = (await getContainer().lookup('email-card-drop-requests', {
       type: 'query',
     })) as EmailCardDropRequestsQueries;
@@ -104,9 +95,8 @@ describe('SendEmailCardDropVerificationTask', function () {
 
     expect(StubEmail.lastSent).to.equal(null);
 
-    await waitFor(() => testkit.reports().length > 0);
+    let sentryReport = await fetchSentryReport();
 
-    let sentryReport = testkit.reports()[0];
     expect(sentryReport.tags).to.deep.equal({
       event: 'send-email-card-drop-verification',
     });
@@ -124,9 +114,8 @@ describe('SendEmailCardDropVerificationTask', function () {
 
     expect(StubEmail.lastSent).to.equal(null);
 
-    await waitFor(() => testkit.reports().length > 0);
+    let sentryReport = await fetchSentryReport();
 
-    let sentryReport = testkit.reports()[0];
     expect(sentryReport.tags).to.deep.equal({
       event: 'send-email-card-drop-verification',
     });

--- a/packages/hub/node-tests/tasks/send-notifications-test.ts
+++ b/packages/hub/node-tests/tasks/send-notifications-test.ts
@@ -4,7 +4,7 @@ import SendNotifications, { PushNotificationData } from '../../tasks/send-notifi
 import { expect } from 'chai';
 import { makeJobHelpers } from 'graphile-worker/dist/helpers';
 import SentPushNotificationsQueries from '../../queries/sent-push-notifications';
-import { fetchSentryReport, setupSentry } from '../helpers/sentry';
+import { setupSentry, waitForSentryReport } from '../helpers/sentry';
 import shortUUID from 'short-uuid';
 
 // https://github.com/graphile/worker/blob/e3176eab42ada8f4f3718192bada776c22946583/__tests__/helpers.ts#L135
@@ -173,7 +173,7 @@ describe('SendNotificationsTask deduplication errors', async function () {
     });
     expect(notificationSent).equal(true);
 
-    let sentryReport = await fetchSentryReport();
+    let sentryReport = await waitForSentryReport();
 
     expect(sentryReport.tags).to.deep.equal({
       action: 'send-notifications-deduplication',
@@ -197,7 +197,7 @@ describe('SendNotificationsTask firebase errors', function () {
       ErroredFirebasePushNotifications.message
     );
 
-    let sentryReport = await fetchSentryReport();
+    let sentryReport = await waitForSentryReport();
 
     expect(sentryReport.tags).to.deep.equal({
       action: 'send-notifications',
@@ -256,7 +256,7 @@ describe('SendNotificationsTask expired notifications', function () {
     expect(lastSentData).to.equal(undefined);
     expect(notificationSent).to.equal(false);
 
-    let sentryReport = await fetchSentryReport();
+    let sentryReport = await waitForSentryReport();
 
     expect(sentryReport.error?.message).to.equal('Notification is too old to send');
     expect(sentryReport.tags).to.deep.equal({

--- a/packages/hub/node-tests/tasks/send-notifications-test.ts
+++ b/packages/hub/node-tests/tasks/send-notifications-test.ts
@@ -4,9 +4,7 @@ import SendNotifications, { PushNotificationData } from '../../tasks/send-notifi
 import { expect } from 'chai';
 import { makeJobHelpers } from 'graphile-worker/dist/helpers';
 import SentPushNotificationsQueries from '../../queries/sent-push-notifications';
-import waitFor from '../utils/wait-for';
-import * as Sentry from '@sentry/node';
-import sentryTestkit from 'sentry-testkit';
+import { fetchSentryReport, setupSentry } from '../helpers/sentry';
 import shortUUID from 'short-uuid';
 
 // https://github.com/graphile/worker/blob/e3176eab42ada8f4f3718192bada776c22946583/__tests__/helpers.ts#L135
@@ -139,17 +137,9 @@ describe('SendNotificationsTask', function () {
 describe('SendNotificationsTask deduplication errors', async function () {
   let { getContainer } = setupHub(this);
 
-  const { testkit, sentryTransport } = sentryTestkit();
+  setupSentry(this);
 
   this.beforeEach(async function () {
-    Sentry.init({
-      dsn: 'https://SendNotificationsTaskErrors@sentry.io/000001',
-      release: 'test',
-      tracesSampleRate: 1,
-      transport: sentryTransport,
-    });
-    testkit.reset();
-
     registry(this).register(
       'sent-push-notifications',
       class ErroredSentPushNotificationsQueries {
@@ -183,9 +173,9 @@ describe('SendNotificationsTask deduplication errors', async function () {
     });
     expect(notificationSent).equal(true);
 
-    await waitFor(() => testkit.reports().length > 0);
+    let sentryReport = await fetchSentryReport();
 
-    expect(testkit.reports()[0].tags).to.deep.equal({
+    expect(sentryReport.tags).to.deep.equal({
       action: 'send-notifications-deduplication',
       notificationId: newlyAddedNotification.notificationId,
       notificationType: newlyAddedNotification.notificationType,
@@ -197,16 +187,7 @@ describe('SendNotificationsTask deduplication errors', async function () {
 describe('SendNotificationsTask firebase errors', function () {
   let { getContainer } = setupHub(this);
 
-  const { testkit, sentryTransport } = sentryTestkit();
-
-  this.beforeEach(async function () {
-    Sentry.init({
-      dsn: 'https://SendNotificationsTaskErrors@sentry.io/000001',
-      release: 'test',
-      tracesSampleRate: 1,
-      transport: sentryTransport,
-    });
-  });
+  setupSentry(this);
 
   it('should throw if sending a notification fails, and still log to sentry', async function () {
     registry(this).register('firebase-push-notifications', ErroredFirebasePushNotifications);
@@ -216,9 +197,9 @@ describe('SendNotificationsTask firebase errors', function () {
       ErroredFirebasePushNotifications.message
     );
 
-    await waitFor(() => testkit.reports().length > 0);
+    let sentryReport = await fetchSentryReport();
 
-    expect(testkit.reports()[0].tags).to.deep.equal({
+    expect(sentryReport.tags).to.deep.equal({
       action: 'send-notifications',
       notificationId: newlyAddedNotification.notificationId,
       notificationType: newlyAddedNotification.notificationType,
@@ -259,16 +240,9 @@ describe('SendNotificationsTask expired notifications', function () {
   let { getContainer } = setupHub(this);
   let subject: SendNotifications;
 
-  const { testkit, sentryTransport } = sentryTestkit();
+  setupSentry(this);
 
   this.beforeEach(async function () {
-    Sentry.init({
-      dsn: 'https://SendNotificationsTaskErrors@sentry.io/000001',
-      release: 'test',
-      tracesSampleRate: 1,
-      transport: sentryTransport,
-    });
-    testkit.reset();
     lastSentData = undefined;
     notificationSent = false;
     registry(this).register('firebase-push-notifications', StubFirebasePushNotifications);
@@ -282,10 +256,10 @@ describe('SendNotificationsTask expired notifications', function () {
     expect(lastSentData).to.equal(undefined);
     expect(notificationSent).to.equal(false);
 
-    await waitFor(() => testkit.reports().length > 0);
+    let sentryReport = await fetchSentryReport();
 
-    expect(testkit.reports()[0].error?.message).to.equal('Notification is too old to send');
-    expect(testkit.reports()[0].tags).to.deep.equal({
+    expect(sentryReport.error?.message).to.equal('Notification is too old to send');
+    expect(sentryReport.tags).to.deep.equal({
       action: 'send-notifications',
       notificationId: expiredNotification.notificationId,
       notificationType: expiredNotification.notificationType,


### PR DESCRIPTION
This reduces setup and assertion code currently duplicated across many tests. The names are a bit awkward maybe, I’m open to suggestions 🤓