### PR TITLE
hub: Add Sentry tag to notify on card drop errors

### DIFF
--- a/packages/hub/node-tests/routes/email-card-drop-verify-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-verify-test.ts
@@ -149,6 +149,7 @@ describe('GET /email-card-drop/verify', function () {
     expect(sentryReport.error?.message).to.equal('provisioning should error');
     expect(sentryReport.tags).to.deep.equal({
       action: 'drop-card',
+      alert: 'web-team',
     });
   });
 

--- a/packages/hub/node-tests/tasks/send-email-card-drop-verification-test.ts
+++ b/packages/hub/node-tests/tasks/send-email-card-drop-verification-test.ts
@@ -99,6 +99,7 @@ describe('SendEmailCardDropVerificationTask', function () {
 
     expect(sentryReport.tags).to.deep.equal({
       event: 'send-email-card-drop-verification',
+      alert: 'web-team',
     });
     expect(sentryReport.error?.message).to.equal(`Unable to find card drop request with id ${nonexistentId}`);
   });
@@ -118,6 +119,7 @@ describe('SendEmailCardDropVerificationTask', function () {
 
     expect(sentryReport.tags).to.deep.equal({
       event: 'send-email-card-drop-verification',
+      alert: 'web-team',
     });
   });
 });

--- a/packages/hub/routes/email-card-drop-verify.ts
+++ b/packages/hub/routes/email-card-drop-verify.ts
@@ -63,6 +63,7 @@ export default class EmailCardDropVerifyRoute {
         Sentry.captureException(e, {
           tags: {
             action: 'drop-card',
+            alert: 'web-team',
           },
         });
 

--- a/packages/hub/tasks/send-email-card-drop-verification.ts
+++ b/packages/hub/tasks/send-email-card-drop-verification.ts
@@ -26,6 +26,7 @@ export default class SendEmailCardDropVerification {
       Sentry.captureException(e, {
         tags: {
           event: 'send-email-card-drop-verification',
+          alert: 'web-team',
         },
       });
       return;
@@ -59,6 +60,7 @@ export default class SendEmailCardDropVerification {
       Sentry.captureException(e, {
         tags: {
           event: 'send-email-card-drop-verification',
+          alert: 'web-team',
         },
       });
       throw e;


### PR DESCRIPTION
This should help surface when things go wrong but don’t reach the urgency of an on-call incident. There’s an alert in Sentry configured to email `#web` team when a new issue arrives with tag `alert: web-team`. I deployed this branch to staging and deliberately tripped errors (while the alert was set to email only me):

![image](https://user-images.githubusercontent.com/43280/168142550-a4743a2f-972a-4fd1-8413-89bfa929c906.png)
