### PR TITLE
explicitly specify ember-test-selectors as dep

### DIFF
--- a/packages/ssr-web/package.json
+++ b/packages/ssr-web/package.json
@@ -164,6 +164,7 @@
     "@walletconnect/iso-crypto": "^1.6.0",
     "broadcastchannel-polyfill": "^1.0.1",
     "ember-elsewhere": "^1.2.1",
+    "ember-test-selectors": "^6.0.0",
     "node-fetch": "^2.6.7",
     "short-uuid": "^4.2.0",
     "typescript": "^4.2.3",

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -172,6 +172,7 @@
     "broadcastchannel-polyfill": "^1.0.1",
     "cropperjs": "^1.5.12",
     "ember-elsewhere": "^1.2.1",
+    "ember-test-selectors": "^6.0.0",
     "eth-block-tracker": "^5.0.1",
     "filesize": "^8.0.6",
     "json-rpc-random-id": "^1.0.1",


### PR DESCRIPTION
This seems to be required to strip out the data-test- selectors