### PR TITLE
Fix/ember power select selector

### DIFF
--- a/packages/web-client/app/components/card-pay/balance-chooser-dropdown/index.css
+++ b/packages/web-client/app/components/card-pay/balance-chooser-dropdown/index.css
@@ -5,7 +5,7 @@
   min-height: var(--field-height);
 }
 
-.balance-chooser-dropdown > .ember-power-select-trigger {
+.balance-chooser-dropdown .ember-power-select-trigger {
   background: url("/images/icons/caret-dropdown.svg") right 1.125rem center/auto 0.5rem no-repeat;
   background-color: var(--boxel-light);
   border: 1px solid var(--boxel-purple-300);
@@ -13,7 +13,7 @@
   transition: border-color var(--boxel-transition);
 }
 
-.balance-chooser-dropdown > .ember-power-select-trigger:hover {
+.balance-chooser-dropdown .ember-power-select-trigger:hover {
   border-color: var(--boxel-dark);
   cursor: pointer;
 }

--- a/packages/web-client/app/components/card-pay/balance-chooser-dropdown/index.hbs
+++ b/packages/web-client/app/components/card-pay/balance-chooser-dropdown/index.hbs
@@ -1,21 +1,22 @@
-<PowerSelect
-  class="balance-chooser-dropdown"
-  @options={{@tokens}}
-  @selected={{@selectedToken}}
-  @onChange={{@chooseToken}}
-  @renderInPlace={{true}}
-  @verticalPosition="below"
-  data-test-balance-chooser-dropdown={{@selectedTokenSymbol}}
-as |token|>
-  <CardPay::BalanceDisplay
-    class={{cn
-      "balance-chooser-dropdown__option"
-      balance-chooser-dropdown__option--selected=(eq token.symbol @selectedTokenSymbol)
-    }}
-    @size="small"
-    @icon={{token.icon}}
-    @name={{token.symbol}}
-    @balance={{format-wei-amount token.balance}}
-    @symbol={{token.symbol}}
-  />
-</PowerSelect>
+<div class="balance-chooser-dropdown">
+  <PowerSelect
+    @options={{@tokens}}
+    @selected={{@selectedToken}}
+    @onChange={{@chooseToken}}
+    @renderInPlace={{true}}
+    @verticalPosition="below"
+    data-test-balance-chooser-dropdown={{@selectedTokenSymbol}}
+  as |token|>
+    <CardPay::BalanceDisplay
+      class={{cn
+        "balance-chooser-dropdown__option"
+        balance-chooser-dropdown__option--selected=(eq token.symbol @selectedTokenSymbol)
+      }}
+      @size="small"
+      @icon={{token.icon}}
+      @name={{token.symbol}}
+      @balance={{format-wei-amount token.balance}}
+      @symbol={{token.symbol}}
+    />
+  </PowerSelect>
+</div>

--- a/packages/web-client/app/components/card-pay/safe-chooser-dropdown/index.css
+++ b/packages/web-client/app/components/card-pay/safe-chooser-dropdown/index.css
@@ -5,7 +5,7 @@
   min-height: var(--field-height);
 }
 
-.safe-chooser-dropdown > .ember-power-select-trigger {
+.safe-chooser-dropdown .ember-power-select-trigger {
   background: url("/images/icons/caret-dropdown.svg") right 1.125rem center/auto 0.5rem no-repeat;
   background-color: var(--boxel-light);
   border: 1px solid var(--boxel-purple-300);
@@ -13,7 +13,7 @@
   transition: border-color var(--boxel-transition);
 }
 
-.safe-chooser-dropdown > .ember-power-select-trigger:hover {
+.safe-chooser-dropdown .ember-power-select-trigger:hover {
   border-color: var(--boxel-dark);
   cursor: pointer;
 }

--- a/packages/web-client/app/components/card-pay/safe-chooser-dropdown/index.hbs
+++ b/packages/web-client/app/components/card-pay/safe-chooser-dropdown/index.hbs
@@ -1,22 +1,22 @@
-{{#let (or @selectedSafe @safes.firstObject) as |selectedSafe|}}
-  <PowerSelect
-    class="safe-chooser-dropdown"
-    @options={{@safes}}
-    @selected={{selectedSafe}}
-    @onChange={{@onChooseSafe}}
-    @renderInPlace={{true}}
-    @eventType="click" {{!-- to prevent auto-selection of first item, as discussed at https://github.com/cardstack/cardstack/pull/2051 --}}
-    @verticalPosition="below"
-    data-test-safe-chooser-dropdown
-    ...attributes
-  as |safe|>
-    <CardPay::SafeChooserDropdown::SafeOption
-        class={{cn
-        "safe-chooser-dropdown__option"
-        safe-chooser-dropdown__option--selected=(eq safe.address selectedSafe.address)
-      }}
-      @safe={{safe}}
-      @showSafeId={{@showSafeId}}
-    />
-  </PowerSelect>
-{{/let}}
+<div class="safe-chooser-dropdown" ...attributes>
+  {{#let (or @selectedSafe @safes.firstObject) as |selectedSafe|}}
+    <PowerSelect
+      @options={{@safes}}
+      @selected={{selectedSafe}}
+      @onChange={{@onChooseSafe}}
+      @renderInPlace={{true}}
+      @eventType="click" {{!-- to prevent auto-selection of first item, as discussed at https://github.com/cardstack/cardstack/pull/2051 --}}
+      @verticalPosition="below"
+      data-test-safe-chooser-dropdown
+    as |safe|>
+      <CardPay::SafeChooserDropdown::SafeOption
+          class={{cn
+          "safe-chooser-dropdown__option"
+          safe-chooser-dropdown__option--selected=(eq safe.address selectedSafe.address)
+        }}
+        @safe={{safe}}
+        @showSafeId={{@showSafeId}}
+      />
+    </PowerSelect>
+  {{/let}}
+</div>


### PR DESCRIPTION
ember-power-select 4.1.7 moves splattributes to the trigger, which breaks our styling. This is unfortunately not marked as a breaking change in their changelog. I went for a simple fix, which is to move our class to a containing div. This looks ok for the components in web client (ed34e7a94298535425d8d46d2c33169a4501e327).

Some dropdowns in Boxel demos are affected by this. @burieberry are these still used, and/or maintained? (Boxel::CardPicker, Boxel::FieldRenderer, CsCardSelect, Queue)