### PR TITLE
Card drop waiting UI

### DIFF
--- a/packages/web-client/app/components/card-drop-page/card/index.hbs
+++ b/packages/web-client/app/components/card-drop-page/card/index.hbs
@@ -13,26 +13,14 @@
     {{#if (has-block 'action')}}
       {{yield to='action'}}
     {{else}}
-      {{#if this.ua.canInstallWallet}}
-        <Boxel::Button
-          @as='anchor'
-          @kind='primary'
-          @href={{concat 'https://' (config 'universalLinkDomain') '/FIXME'}}
-          target='_blank'
-          rel='noopener'
-        >
-          Open Card Wallet
-        </Boxel::Button>
-      {{else}}
-        <Boxel::Button
-          @as='anchor'
-          href='https://cardstack.com'
-          target='_blank'
-          rel='noopener'
-        >
-          Visit Cardstack.com
-        </Boxel::Button>
-      {{/if}}
+      <Boxel::Button
+        @as='anchor'
+        href='https://cardstack.com'
+        target='_blank'
+        rel='noopener'
+      >
+        Visit Cardstack.com
+      </Boxel::Button>
     {{/if}}
   </div>
 </Boxel::CardContainer>

--- a/packages/web-client/app/components/card-drop-page/card/index.ts
+++ b/packages/web-client/app/components/card-drop-page/card/index.ts
@@ -1,7 +1,0 @@
-import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
-import UA from '@cardstack/web-client/services/ua';
-
-export default class CardDropPageCardComponent extends Component {
-  @service('ua') declare ua: UA;
-}

--- a/packages/web-client/app/templates/card-drop/already-claimed.hbs
+++ b/packages/web-client/app/templates/card-drop/already-claimed.hbs
@@ -5,5 +5,8 @@
 
   <:explanation>
     Looks like you’ve already claimed your prepaid card.
+    <br>
+    <br>
+    If you haven't received it yet, watch out for a notification from Card Wallet. We'll let you know when it's ready.
   </:explanation>
 </CardDropPage::Card>

--- a/packages/web-client/app/templates/card-drop/already-claimed.hbs
+++ b/packages/web-client/app/templates/card-drop/already-claimed.hbs
@@ -7,6 +7,6 @@
     Looks like you’ve already claimed your prepaid card.
     <br>
     <br>
-    If you haven't received it yet, watch out for a notification from Card Wallet. We'll let you know when it's ready.
+    If you haven’t received it yet, watch out for a notification from Card Wallet. We’ll let you know when it's ready.
   </:explanation>
 </CardDropPage::Card>

--- a/packages/web-client/app/templates/card-drop/success.hbs
+++ b/packages/web-client/app/templates/card-drop/success.hbs
@@ -18,6 +18,6 @@
   </:heading>
 
   <:explanation>
-    Soon you will receive a confirmation email to join our newsletter mailing list.
+    Watch out for a notification from Card Wallet - we'll let you know when it's ready.
   </:explanation>
 </CardDropPage::Card>

--- a/packages/web-client/app/templates/card-drop/success.hbs
+++ b/packages/web-client/app/templates/card-drop/success.hbs
@@ -18,6 +18,6 @@
   </:heading>
 
   <:explanation>
-    Watch out for a notification from Card Wallet - we'll let you know when it's ready.
+    Watch out for a notification from Card Wallet - we’ll let you know when it’s ready.
   </:explanation>
 </CardDropPage::Card>


### PR DESCRIPTION
We don't have any UI in Card Wallet to wait for the card, and no guarantee of card delivery in time, so:
- Don't show the "Open Card Wallet" button
- Copy adjustments to let people know we will notify them.