### PR TITLE
Reward programs - use standard name for output files

### DIFF
--- a/packages/cardpay-reward-programs/cardpay_reward_programs/utils.py
+++ b/packages/cardpay-reward-programs/cardpay_reward_programs/utils.py
@@ -91,8 +91,8 @@ def write_parquet_file(file_location, table):
     # and upload directly
     if isinstance(file_location, CloudPath):
         with tempfile.TemporaryDirectory() as temp_dir:
-            pq_file_location = AnyPath(temp_dir).joinpath("data.parquet")
+            pq_file_location = AnyPath(temp_dir) / "results.parquet"
             pq.write_table(table, pq_file_location)
-            file_location.joinpath("data.parquet").upload_from(pq_file_location)
+            file_location.joinpath("results.parquet").upload_from(pq_file_location)
     else:
         pq.write_table(table, file_location / "results.parquet")


### PR DESCRIPTION
Fixes a big in how we write data to s3, the file name compared to locally was inconsistent.