### PR TITLE
Expiry of card drop requests

### DIFF
--- a/packages/hub/config/default.cjs
+++ b/packages/hub/config/default.cjs
@@ -84,6 +84,7 @@ module.exports = {
   cardDrop: {
     sku: '0x5e0d8bbe3c8e4d9013509b469dabfa029270b38a5c55c9c94c095ec6199d7fda',
     email: {
+      expiryMinutes: 60,
       rateLimit: {
         count: null,
         periodMinutes: null,

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -43,6 +43,7 @@ class FrozenClock implements Clock {
 }
 
 const verificationCodeRegex = /^[~.a-zA-Z0-9_-]{10}$/;
+const emailVerificationLinkExpiryMinutes = config.get('cardDrop.email.expiryMinutes') as number;
 
 describe('GET /api/email-card-drop-requests', function () {
   let { request, getContainer } = setupHub(this);
@@ -220,7 +221,7 @@ describe('POST /api/email-card-drop-requests', function () {
     let emailHash = hash.digest('hex');
     let emailHash2 = crypto.createHmac('sha256', config.get('emailHashSalt')).update(email2).digest('hex');
 
-    let insertionTimeInMs = fakeTime - 50 * 60 * 1000;
+    let insertionTimeInMs = fakeTime - (emailVerificationLinkExpiryMinutes / 2) * 60 * 1000;
     await emailCardDropRequestsQueries.insert({
       ownerAddress: stubUserAddress,
       emailHash,

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -258,8 +258,8 @@ describe('POST /api/email-card-drop-requests', function () {
     expect(emailCardDropRequest.emailHash).to.equal(emailHash2);
     expect(Number(emailCardDropRequest.requestedAt)).to.equal(fakeTime);
 
-    expect(jobIdentifiers).to.deep.equal(['send-email-card-drop-verification']);
-    expect(jobPayloads).to.deep.equal([{ id: resourceId, email: email2 }]);
+    expect(jobIdentifiers).to.deep.equal(['send-email-card-drop-verification', 'subscribe-email']);
+    expect(jobPayloads).to.deep.equal([{ id: resourceId, email: email2 }, { email: email2 }]);
   });
 
   it('returns 401 without bearer token', async function () {

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -229,6 +229,8 @@ describe('POST /api/email-card-drop-requests', function () {
       requestedAt: new Date(insertionTimeInMs),
     });
 
+    expect((await emailCardDropRequestsQueries.query({ ownerAddress: stubUserAddress })).length).to.equal(1);
+
     const payload = {
       data: {
         type: 'email-card-drop-requests',

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -209,7 +209,7 @@ describe('POST /api/email-card-drop-requests', function () {
     expect(jobPayloads).to.deep.equal([{ id: resourceId, email }, { email }]);
   });
 
-  it('sends another email if a request is present but has not been claimed', async function () {
+  it('persists a new request for a given EOA and runs jobs if a request is present but has not been claimed', async function () {
     let emailCardDropRequestsQueries = await getContainer().lookup('email-card-drop-requests', { type: 'query' });
 
     let email = 'valid@example.com';

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -224,7 +224,7 @@ describe('POST /api/email-card-drop-requests', function () {
     await emailCardDropRequestsQueries.insert({
       ownerAddress: stubUserAddress,
       emailHash,
-      verificationCode: 'xxxxxxyyyy',
+      verificationCode: 'x',
       id: '2850a954-525d-499a-a5c8-3c89192ad40e',
       requestedAt: new Date(insertionTimeInMs),
     });
@@ -254,7 +254,7 @@ describe('POST /api/email-card-drop-requests', function () {
     let emailCardDropRequest = (await emailCardDropRequestsQueries.query({ ownerAddress: stubUserAddress }))[0];
 
     expect(emailCardDropRequest.verificationCode).to.match(verificationCodeRegex);
-    expect(emailCardDropRequest.verificationCode).to.not.equal('xxxxxxyyyy');
+    expect(emailCardDropRequest.verificationCode).to.not.equal('x');
     expect(emailCardDropRequest.emailHash).to.equal(emailHash2);
     expect(Number(emailCardDropRequest.requestedAt)).to.equal(fakeTime);
 

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -246,17 +246,20 @@ describe('POST /api/email-card-drop-requests', function () {
       .set('Authorization', 'Bearer abc123--def456--ghi789')
       .set('Content-Type', 'application/vnd.api+json')
       .send(payload)
-      .expect(200)
+      .expect(201)
       .expect(function (res) {
         resourceId = res.body.data.id;
       });
 
-    let emailCardDropRequest = (await emailCardDropRequestsQueries.query({ ownerAddress: stubUserAddress }))[0];
+    let allRequests = await emailCardDropRequestsQueries.query({ ownerAddress: stubUserAddress });
+    let latestRequest = await emailCardDropRequestsQueries.latestRequest(stubUserAddress);
 
-    expect(emailCardDropRequest.verificationCode).to.match(verificationCodeRegex);
-    expect(emailCardDropRequest.verificationCode).to.not.equal('x');
-    expect(emailCardDropRequest.emailHash).to.equal(emailHash2);
-    expect(Number(emailCardDropRequest.requestedAt)).to.equal(fakeTime);
+    expect(allRequests.length).to.equal(2);
+    expect(allRequests.find((v) => v.id === '2850a954-525d-499a-a5c8-3c89192ad40e')).to.not.be.undefined;
+    expect(latestRequest.id).to.not.equal('2850a954-525d-499a-a5c8-3c89192ad40e');
+    expect(latestRequest.verificationCode).to.match(verificationCodeRegex);
+    expect(latestRequest.emailHash).to.equal(emailHash2);
+    expect(Number(latestRequest.requestedAt)).to.equal(fakeTime);
 
     expect(jobIdentifiers).to.deep.equal(['send-email-card-drop-verification', 'subscribe-email']);
     expect(jobPayloads).to.deep.equal([{ id: resourceId, email: email2 }, { email: email2 }]);

--- a/packages/hub/node-tests/routes/email-card-drop-verify-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-verify-test.ts
@@ -7,6 +7,7 @@ import { setupSentry, waitForSentryReport } from '../helpers/sentry';
 const { sku } = config.get('cardDrop');
 const { url: webClientUrl } = config.get('webClient');
 const { alreadyClaimed, error, success } = config.get('webClient.paths.cardDrop');
+const emailVerificationLinkExpiryMinutes = config.get('cardDrop.email.expiryMinutes') as number;
 
 let claimedEoa: EmailCardDropRequest = {
   id: '2850a954-525d-499a-a5c8-3c89192ad40e',
@@ -36,7 +37,7 @@ let unclaimedButExpiredEoa: EmailCardDropRequest = {
   ownerAddress: '0xunclaimedButExpiredAddress',
   emailHash: 'unclaimedButExpiredhash',
   verificationCode: 'unclaimedButExpiredverificationcode',
-  requestedAt: new Date(Date.now() - 61 * 60 * 1000),
+  requestedAt: new Date(Date.now() - (emailVerificationLinkExpiryMinutes + 1) * 60 * 1000),
 };
 let unclaimedEoaWithClaimedEmailHash: EmailCardDropRequest = {
   id: 'f0847258-9326-4e08-8043-f9def30c6359',

--- a/packages/hub/node-tests/tasks/send-email-card-drop-verification-test.ts
+++ b/packages/hub/node-tests/tasks/send-email-card-drop-verification-test.ts
@@ -8,6 +8,8 @@ import EmailCardDropRequestsQueries from '../../queries/email-card-drop-requests
 import config from 'config';
 import { EmailCardDropRequest } from '../../routes/email-card-drop-requests';
 
+const emailVerificationLinkExpiryMinutes = config.get('cardDrop.email.expiryMinutes') as number;
+
 // https://github.com/graphile/worker/blob/e3176eab42ada8f4f3718192bada776c22946583/__tests__/helpers.ts#L135
 function makeMockJob(taskIdentifier: string): Job {
   const createdAt = new Date(Date.now() - 12345678);
@@ -59,7 +61,7 @@ const expiredCardDropRequest: EmailCardDropRequest = {
   ownerAddress: '0xexpiredAddress2',
   emailHash: 'expiredhash2',
   verificationCode: 'expiredverificationcode2',
-  requestedAt: new Date(Date.now() - 61 * 60 * 1000),
+  requestedAt: new Date(Date.now() - (emailVerificationLinkExpiryMinutes + 1) * 60 * 1000),
 };
 
 describe('SendEmailCardDropVerificationTask', function () {
@@ -93,6 +95,11 @@ describe('SendEmailCardDropVerificationTask', function () {
     expect(StubEmail.lastSent.from).to.equal(config.get('aws.ses.supportEmail'));
     expect(StubEmail.lastSent.text).to.contain(link);
     expect(StubEmail.lastSent.html).to.contain(link);
+
+    let durationString = `${emailVerificationLinkExpiryMinutes} minutes`;
+
+    expect(StubEmail.lastSent.text).to.contain(durationString);
+    expect(StubEmail.lastSent.html).to.contain(durationString);
   });
 
   it('fails silently if the row does not exist', async function () {

--- a/packages/hub/node-tests/tasks/send-email-card-drop-verification-test.ts
+++ b/packages/hub/node-tests/tasks/send-email-card-drop-verification-test.ts
@@ -126,7 +126,7 @@ describe('SendEmailCardDropVerificationTask', function () {
       alert: 'web-team',
     });
     expect(sentryReport.error?.message).to.equal(
-      `Request with ${expiredCardDropRequest.id} expired before sending verification link`
+      `Request with id ${expiredCardDropRequest.id} expired before sending verification link`
     );
   });
 

--- a/packages/hub/queries/email-card-drop-requests.ts
+++ b/packages/hub/queries/email-card-drop-requests.ts
@@ -45,7 +45,7 @@ export default class EmailCardDropRequestsQueries {
 
     const conditions = buildConditions(filter);
 
-    const query = `SELECT * FROM email_card_drop_requests WHERE ${conditions.where}`;
+    const query = `SELECT ${RETURN_VALUE} FROM email_card_drop_requests WHERE ${conditions.where}`;
     const queryResult = await db.query(query, conditions.values);
 
     return queryResult.rows.map(mapRowToObject);

--- a/packages/hub/queries/email-card-drop-requests.ts
+++ b/packages/hub/queries/email-card-drop-requests.ts
@@ -75,29 +75,6 @@ export default class EmailCardDropRequestsQueries {
     return rows[0].count;
   }
 
-  async refreshRequest(
-    id: string,
-    values: {
-      verificationCode: string;
-      emailHash: string;
-      requestedAt: Date;
-    }
-  ): Promise<EmailCardDropRequest & { isExpired: boolean }> {
-    let db = await this.databaseManager.getClient();
-
-    let { rows } = await db.query(
-      `UPDATE email_card_drop_requests SET
-        verification_code = $2,
-        email_hash = $3,
-        requested_at = $4
-      WHERE ID = $1
-      RETURNING ${RETURN_VALUE}`,
-      [id, values.verificationCode, values.emailHash, values.requestedAt]
-    );
-
-    return mapRowToObject(rows[0])!;
-  }
-
   async claim(id: string): Promise<void> {
     let db = await this.databaseManager.getClient();
 

--- a/packages/hub/queries/email-card-drop-requests.ts
+++ b/packages/hub/queries/email-card-drop-requests.ts
@@ -2,6 +2,7 @@ import DatabaseManager from '@cardstack/db';
 import { inject } from '@cardstack/di';
 import { EmailCardDropRequest } from '../routes/email-card-drop-requests';
 import { buildConditions } from '../utils/queries';
+import config from 'config';
 
 interface EmailCardDropRequestsQueriesFilter {
   id?: string;
@@ -11,7 +12,9 @@ interface EmailCardDropRequestsQueriesFilter {
   verificationCode?: string;
 }
 
-const IS_OLD = `requested_at <= now() - interval '60 minutes'`;
+const emailVerificationLinkExpiryMinutes = config.get('cardDrop.email.expiryMinutes');
+
+const IS_OLD = `requested_at <= now() - interval '${emailVerificationLinkExpiryMinutes} minutes'`;
 const IS_EXPIRED = `${IS_OLD} AND claimed_at IS NULL`;
 const RETURN_VALUE = `*, (${IS_EXPIRED}) as is_expired`;
 

--- a/packages/hub/queries/email-card-drop-requests.ts
+++ b/packages/hub/queries/email-card-drop-requests.ts
@@ -51,6 +51,19 @@ export default class EmailCardDropRequestsQueries {
     return queryResult.rows.map(mapRowToObject);
   }
 
+  async latestRequest(ownerAddress: string) {
+    let db = await this.databaseManager.getClient();
+    const query = `
+      SELECT ${RETURN_VALUE}
+      FROM  email_card_drop_requests AS t1
+      WHERE owner_address=$1 AND requested_at=(SELECT MAX(requested_at) FROM email_card_drop_requests WHERE t1.owner_address=email_card_drop_requests.owner_address)
+    `;
+
+    const queryResult = await db.query(query, [ownerAddress]);
+
+    return queryResult.rows.map(mapRowToObject)[0];
+  }
+
   async claimedInLastMinutes(minutes: number): Promise<(EmailCardDropRequest & { isExpired: boolean })[]> {
     let db = await this.databaseManager.getClient();
 

--- a/packages/hub/queries/email-card-drop-requests.ts
+++ b/packages/hub/queries/email-card-drop-requests.ts
@@ -21,7 +21,7 @@ export default class EmailCardDropRequestsQueries {
   clock = inject('clock');
   databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
 
-  async insert(model: EmailCardDropRequest): Promise<EmailCardDropRequest> {
+  async insert(model: EmailCardDropRequest): Promise<EmailCardDropRequest & { isExpired: boolean }> {
     let db = await this.databaseManager.getClient();
 
     let { rows } = await db.query(
@@ -40,7 +40,7 @@ export default class EmailCardDropRequestsQueries {
     return rows[0];
   }
 
-  async query(filter: EmailCardDropRequestsQueriesFilter): Promise<EmailCardDropRequest[]> {
+  async query(filter: EmailCardDropRequestsQueriesFilter): Promise<(EmailCardDropRequest & { isExpired: boolean })[]> {
     let db = await this.databaseManager.getClient();
 
     const conditions = buildConditions(filter);
@@ -51,7 +51,7 @@ export default class EmailCardDropRequestsQueries {
     return queryResult.rows.map(mapRowToObject);
   }
 
-  async claimedInLastMinutes(minutes: number): Promise<EmailCardDropRequest[]> {
+  async claimedInLastMinutes(minutes: number): Promise<(EmailCardDropRequest & { isExpired: boolean })[]> {
     let db = await this.databaseManager.getClient();
 
     let { rows } = await db.query(
@@ -64,7 +64,10 @@ export default class EmailCardDropRequestsQueries {
     return rows[0].count;
   }
 
-  async updateVerificationCode(id: string, verificationCode: string): Promise<EmailCardDropRequest> {
+  async updateVerificationCode(
+    id: string,
+    verificationCode: string
+  ): Promise<EmailCardDropRequest & { isExpired: boolean }> {
     let db = await this.databaseManager.getClient();
 
     let { rows } = await db.query(
@@ -86,7 +89,7 @@ export default class EmailCardDropRequestsQueries {
     emailHash: string;
     ownerAddress: string;
     verificationCode: string;
-  }): Promise<EmailCardDropRequest | null> {
+  }): Promise<(EmailCardDropRequest & { isExpired: boolean }) | null> {
     let db = await this.databaseManager.getClient();
 
     let { rows } = await db.query(
@@ -106,7 +109,10 @@ export default class EmailCardDropRequestsQueries {
     return rows[0] ? mapRowToObject(rows[0]) : null;
   }
 
-  async updateTransactionHash(id: string, transactionHash: string): Promise<EmailCardDropRequest | null> {
+  async updateTransactionHash(
+    id: string,
+    transactionHash: string
+  ): Promise<(EmailCardDropRequest & { isExpired: boolean }) | null> {
     let db = await this.databaseManager.getClient();
 
     let { rows } = await db.query(
@@ -130,7 +136,7 @@ function mapRowToObject(row: any) {
     claimedAt: row['claimed_at'],
     requestedAt: row['requested_at'],
     transactionHash: row['transaction_hash'],
-    isExpired: row['is_expired'],
+    isExpired: row['is_expired'] as boolean,
   };
 }
 

--- a/packages/hub/queries/email-card-drop-requests.ts
+++ b/packages/hub/queries/email-card-drop-requests.ts
@@ -64,18 +64,24 @@ export default class EmailCardDropRequestsQueries {
     return rows[0].count;
   }
 
-  async updateVerificationCode(
+  async refreshRequest(
     id: string,
-    verificationCode: string
+    values: {
+      verificationCode: string;
+      emailHash: string;
+      requestedAt: Date;
+    }
   ): Promise<EmailCardDropRequest & { isExpired: boolean }> {
     let db = await this.databaseManager.getClient();
 
     let { rows } = await db.query(
       `UPDATE email_card_drop_requests SET
-        verification_code = $2
+        verification_code = $2,
+        email_hash = $3,
+        requested_at = $4
       WHERE ID = $1
       RETURNING ${RETURN_VALUE}`,
-      [id, verificationCode]
+      [id, values.verificationCode, values.emailHash, values.requestedAt]
     );
 
     return mapRowToObject(rows[0])!;

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -176,47 +176,6 @@ export default class EmailCardDropRequestsRoute {
       return;
     }
 
-    let unclaimedButExisting = await this.emailCardDropRequestQueries.query({
-      ownerAddress: ctx.state.userAddress,
-    });
-
-    if (unclaimedButExisting.length > 0) {
-      let existingRequest = unclaimedButExisting[0];
-      let updatedEmailCardDropRequest = await this.emailCardDropRequestQueries.refreshRequest(existingRequest.id, {
-        verificationCode: generateVerificationCode(),
-        emailHash: normalizedEmailHash,
-        requestedAt: new Date(this.clock.now()),
-      });
-
-      await this.workerClient.addJob('send-email-card-drop-verification', {
-        id: updatedEmailCardDropRequest.id,
-        email,
-      });
-
-      await this.workerClient.addJob(
-        'subscribe-email',
-        { email },
-        // for the most part, Mailchimp errors will not be retriable
-        // because of that we limit maxAttempts to 1
-        // this prevents us from retrying where we cannot do anything
-        // and also leaves dead jobs in the db that we can check later
-        // this should be supplemented by the Mailchimp errors being sent
-        // to Sentry and having appropriate alerts, especially for rate limiting
-        // could consider permanently failing the job from within conditionally, instead. probably as a utility function?
-        // https://github.com/graphile/worker/blob/e3176eab42ada8f4f3718192bada776c22946583/sql/000004.sql#L122-L126
-        {
-          maxAttempts: 1,
-        }
-      );
-
-      let serialized = this.emailCardDropRequestSerializer.serialize(updatedEmailCardDropRequest);
-
-      ctx.status = 200;
-      ctx.body = serialized;
-
-      return;
-    }
-
     let verificationCode = generateVerificationCode();
 
     const emailCardDropRequest: EmailCardDropRequest = {

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -182,10 +182,11 @@ export default class EmailCardDropRequestsRoute {
 
     if (unclaimedButExisting.length > 0) {
       let existingRequest = unclaimedButExisting[0];
-      let updatedEmailCardDropRequest = await this.emailCardDropRequestQueries.updateVerificationCode(
-        existingRequest.id,
-        generateVerificationCode()
-      );
+      let updatedEmailCardDropRequest = await this.emailCardDropRequestQueries.refreshRequest(existingRequest.id, {
+        verificationCode: generateVerificationCode(),
+        emailHash: normalizedEmailHash,
+        requestedAt: new Date(this.clock.now()),
+      });
 
       await this.workerClient.addJob('send-email-card-drop-verification', {
         id: updatedEmailCardDropRequest.id,

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -177,7 +177,6 @@ export default class EmailCardDropRequestsRoute {
     }
 
     let unclaimedButExisting = await this.emailCardDropRequestQueries.query({
-      emailHash: normalizedEmailHash,
       ownerAddress: ctx.state.userAddress,
     });
 

--- a/packages/hub/routes/email-card-drop-verify.ts
+++ b/packages/hub/routes/email-card-drop-verify.ts
@@ -103,6 +103,9 @@ export default class EmailCardDropVerifyRoute {
         ctx.redirect(`${webClientUrl}${error}?message=${encodeURIComponent(e.toString())}`);
         return;
       }
+    } else {
+      ctx.status = 400;
+      ctx.body = 'Invalid verification link';
     }
   }
 }

--- a/packages/hub/routes/email-card-drop-verify.ts
+++ b/packages/hub/routes/email-card-drop-verify.ts
@@ -61,6 +61,12 @@ export default class EmailCardDropVerifyRoute {
       return;
     }
 
+    if (emailCardDropRequest.isExpired) {
+      ctx.status = 400;
+      ctx.body = 'Verification link is expired';
+      return;
+    }
+
     if (!(emailCardDropRequest.verificationCode === verificationCode && emailCardDropRequest.emailHash === emailHash)) {
       ctx.status = 400;
       ctx.body = 'Invalid verification link';

--- a/packages/hub/routes/email-card-drop-verify.ts
+++ b/packages/hub/routes/email-card-drop-verify.ts
@@ -43,19 +43,25 @@ export default class EmailCardDropVerifyRoute {
     let verificationCode = (ctx.request.query['verification-code'] as string) || '';
     let emailHash = (ctx.request.query['email-hash'] as string) || '';
 
-    let emailCardDropRequests = await this.emailCardDropRequestQueries.query({
-      ownerAddress,
-    });
+    let emailCardDropRequest = (
+      await this.emailCardDropRequestQueries.query({
+        ownerAddress,
+      })
+    )[0];
+
+    if (!emailCardDropRequest) {
+      ctx.status = 400;
+      ctx.body = 'Invalid verification link';
+      return;
+    }
 
     // this eoa has already claimed
-    if (emailCardDropRequests.filter((v) => v.claimedAt).length) {
+    if (emailCardDropRequest.claimedAt) {
       ctx.redirect(`${webClientUrl}${alreadyClaimed}`);
       return;
     }
 
-    if (
-      !emailCardDropRequests.filter((v) => v.verificationCode === verificationCode && v.emailHash === emailHash).length
-    ) {
+    if (!(emailCardDropRequest.verificationCode === verificationCode && emailCardDropRequest.emailHash === emailHash)) {
       ctx.status = 400;
       ctx.body = 'Invalid verification link';
       return;

--- a/packages/hub/tasks/send-email-card-drop-verification.ts
+++ b/packages/hub/tasks/send-email-card-drop-verification.ts
@@ -33,7 +33,7 @@ export default class SendEmailCardDropVerification {
     }
 
     if (request.isExpired) {
-      let e = new Error(`Request with ${payload.id} expired before sending verification link`);
+      let e = new Error(`Request with id ${payload.id} expired before sending verification link`);
       Sentry.captureException(e, {
         tags: {
           event: 'send-email-card-drop-verification',

--- a/packages/hub/tasks/send-email-card-drop-verification.ts
+++ b/packages/hub/tasks/send-email-card-drop-verification.ts
@@ -50,10 +50,11 @@ export default class SendEmailCardDropVerification {
     const verificationLink = config.get('cardDrop.verificationUrl') + '?' + params.toString();
 
     const senderEmailAddress = config.get('aws.ses.supportEmail') as string;
+    const expirationMinutes = config.get('cardDrop.email.expiryMinutes') as number;
 
     const emailTitle = 'Claim your Card Drop';
-    const emailBodyHtml = `<h1></h1> This is your verification link: <a href="${verificationLink}">${verificationLink}</a>`;
-    const emailBodyText = `This is your verification link: ${verificationLink}`;
+    const emailBodyHtml = `<h1></h1> This is your verification link: <a href="${verificationLink}">${verificationLink}</a> It will expire in ${expirationMinutes} minutes.`;
+    const emailBodyText = `This is your verification link: ${verificationLink} It will expire in ${expirationMinutes} minutes.`;
 
     try {
       await this.email.send({

--- a/packages/hub/tasks/send-email-card-drop-verification.ts
+++ b/packages/hub/tasks/send-email-card-drop-verification.ts
@@ -32,6 +32,17 @@ export default class SendEmailCardDropVerification {
       return;
     }
 
+    if (request.isExpired) {
+      let e = new Error(`Request with ${payload.id} expired before sending verification link`);
+      Sentry.captureException(e, {
+        tags: {
+          event: 'send-email-card-drop-verification',
+          alert: 'web-team',
+        },
+      });
+      return;
+    }
+
     const params = new URLSearchParams();
     params.append('eoa', request.ownerAddress);
     params.append('verification-code', request.verificationCode);


### PR DESCRIPTION
CS-3915

### Requirements
`POST /api/email-card-drop-requests` - make sure that we don't send an expired link to users since jobs may be delayed
`GET /api/email-card-drop-requests` - N/A
`GET /email-card-drop/verify` - don't allow expired links to claim a card, only allow latest request for a given EOA

### Implementation
1. Defines expiry as `requested_at` being greater than 60 mins before time of a db query, returns this as a derived `isExpired` property wherever we perform a db query returning values
2. Catches expiry when verifying and when sending verification link
3. A `POST /api/email-card-drop-requests` for an EOA with an existing request will add a new row to the DB
4. When verifying, we only look at the latest request

<details>
<summary> PREVIOUS IMPLEMENTATION</summary>
Simplifies the cases we have to handle by applying a unique constraint to `owner_address`. This means that we have a single row in the db for each EOA that requests a card drop, and any repeated `POST /api/email-card-drop-requests` for that EOA simply update that row
<br>
<br>
One consequence of this implementation is it becomes harder to find older information for the EOA since each new `POST` will overwrite the previous request.
</details>