### PR TITLE
hub: Add reservation/quantity check for drop requests

### DIFF
--- a/packages/cardpay-sdk/sdk/prepaid-card-market-v-2/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card-market-v-2/base.ts
@@ -28,6 +28,12 @@ import { getAddress } from '../..';
 export default class PrepaidCardMarketV2 {
   constructor(private layer2Web3: Web3, private layer2Signer?: Signer) {}
 
+  // FIXME remove when implemented
+  async getQuantity(sku: string): Promise<number> {
+    console.log(`Not implemented; sku: ${sku}`);
+    return 0;
+  }
+
   async isPaused(marketAddress?: string): Promise<boolean> {
     marketAddress = marketAddress ?? (await getAddress('prepaidCardMarketV2', this.layer2Web3));
     let contract = new this.layer2Web3.eth.Contract(PrepaidCardMarketV2ABI as AbiItem[], marketAddress);

--- a/packages/cardpay-sdk/sdk/prepaid-card-market-v-2/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card-market-v-2/base.ts
@@ -28,12 +28,6 @@ import { getAddress } from '../..';
 export default class PrepaidCardMarketV2 {
   constructor(private layer2Web3: Web3, private layer2Signer?: Signer) {}
 
-  // FIXME remove when implemented
-  async getQuantity(sku: string): Promise<number> {
-    console.log(`Not implemented; sku: ${sku}`);
-    return 0;
-  }
-
   async isPaused(marketAddress?: string): Promise<boolean> {
     marketAddress = marketAddress ?? (await getAddress('prepaidCardMarketV2', this.layer2Web3));
     let contract = new this.layer2Web3.eth.Contract(PrepaidCardMarketV2ABI as AbiItem[], marketAddress);

--- a/packages/hub/config/default.cjs
+++ b/packages/hub/config/default.cjs
@@ -85,6 +85,7 @@ module.exports = {
     sku: '0x5e0d8bbe3c8e4d9013509b469dabfa029270b38a5c55c9c94c095ec6199d7fda',
     email: {
       expiryMinutes: 60,
+      notifyWhenQuantityBelow: 25,
       rateLimit: {
         count: null,
         periodMinutes: null,

--- a/packages/hub/config/staging.json
+++ b/packages/hub/config/staging.json
@@ -6,7 +6,6 @@
   },
   "cardDrop": {
     "sku": "0x18367eee0b96d5f6e46e172ee78585d22f464884e27e7e843031c03a05af16d2",
-    "FIXME": "remove the above?",
     "verificationUrl": "https://hub-staging.stack.cards/email-card-drop/verify"
   },
   "mailchimp": {

--- a/packages/hub/config/staging.json
+++ b/packages/hub/config/staging.json
@@ -5,7 +5,7 @@
     "allowedChannels": "898941895525425172"
   },
   "cardDrop": {
-    "sku": "0x18367eee0b96d5f6e46e172ee78585d22f464884e27e7e843031c03a05af16d2",
+    "sku": "0x905b1faa1a56a0fd8447a469f8aa558665d550e56d60d106cd1096c526df4bdd",
     "verificationUrl": "https://hub-staging.stack.cards/email-card-drop/verify"
   },
   "mailchimp": {

--- a/packages/hub/config/staging.json
+++ b/packages/hub/config/staging.json
@@ -5,6 +5,8 @@
     "allowedChannels": "898941895525425172"
   },
   "cardDrop": {
+    "sku": "0x18367eee0b96d5f6e46e172ee78585d22f464884e27e7e843031c03a05af16d2",
+    "FIXME": "remove the above?",
     "verificationUrl": "https://hub-staging.stack.cards/email-card-drop/verify"
   },
   "mailchimp": {

--- a/packages/hub/config/test.cjs
+++ b/packages/hub/config/test.cjs
@@ -10,7 +10,7 @@ module.exports = {
   cardDrop: {
     email: {
       rateLimit: {
-        count: 10,
+        count: 100,
         periodMinutes: 10,
       },
     },

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -400,7 +400,7 @@ describe('POST /api/email-card-drop-requests', function () {
       let sentryReport = await waitForSentryReport();
 
       expect(sentryReport.error?.message).to.equal(
-        `Prepaid card quantity (${mockPrepaidCardQuantity}) less reservations (${reservationCount}) is below cardDrop.email.notifyWhenQuantityBelow threshold of ${notifyWhenQuantityBelow}`
+        `https://app.gitbook.com/o/-MlRBKglR9VL1a7e4w85/s/05zPo3R26oH9uKrNVxni/hub/email-card-drop#quantity-threshold-warning Prepaid card quantity (${mockPrepaidCardQuantity}) less reservations (${reservationCount}) is below cardDrop.email.notifyWhenQuantityBelow threshold of ${notifyWhenQuantityBelow}`
       );
       expect(sentryReport.tags).to.deep.equal({
         action: 'drop-card',

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -192,18 +192,17 @@ describe('POST /api/email-card-drop-requests', function () {
 
   it('persists an email card drop request and triggers jobs', async function () {
     let emailCardDropRequestsQueries = await getContainer().lookup('email-card-drop-requests', { type: 'query' });
-    let insertionTimeInMs = fakeTime - emailVerificationLinkExpiryMinutes * 2 * 60 * 1000;
+    let insertionTimeInMs = Date.now() - emailVerificationLinkExpiryMinutes * 2 * 60 * 1000;
 
     // Create no-longer-active reservations
 
     for (let i = 0; i < mockPrepaidCardQuantity + 1; i++) {
       await emailCardDropRequestsQueries.insert({
-        ownerAddress: '0xother',
-        emailHash: 'other-email-hash',
+        ownerAddress: `0xother${i}`,
+        emailHash: `other-email-hash-${i}`,
         verificationCode: 'x',
         id: shortUUID.uuid(),
         requestedAt: new Date(insertionTimeInMs),
-        claimedAt: new Date(),
       });
     }
 
@@ -257,6 +256,7 @@ describe('POST /api/email-card-drop-requests', function () {
     let emailHash = hash.digest('hex');
     let emailHash2 = crypto.createHmac('sha256', config.get('emailHashSalt')).update(email2).digest('hex');
 
+    // FIXME is there something off with this…?
     let insertionTimeInMs = fakeTime - (emailVerificationLinkExpiryMinutes / 2) * 60 * 1000;
     await emailCardDropRequestsQueries.insert({
       ownerAddress: stubUserAddress,
@@ -355,15 +355,16 @@ describe('POST /api/email-card-drop-requests', function () {
     mockPrepaidCardQuantity = 5;
 
     let emailCardDropRequestsQueries = await getContainer().lookup('email-card-drop-requests', { type: 'query' });
-    let insertionTimeInMs = fakeTime - (emailVerificationLinkExpiryMinutes / 2) * 60 * 1000;
+    let insertionTimeInMs = Date.now() - (emailVerificationLinkExpiryMinutes / 2) * 60 * 1000;
 
     for (let i = 0; i < mockPrepaidCardQuantity + 1; i++) {
       await emailCardDropRequestsQueries.insert({
-        ownerAddress: stubUserAddress,
-        emailHash: 'other-email-hash',
+        ownerAddress: `0xother${i}`,
+        emailHash: `other-email-hash-${i}`,
         verificationCode: 'x',
         id: `2850a954-525d-499a-a5c8-3c89192ad40${i}`,
         requestedAt: new Date(insertionTimeInMs),
+        claimedAt: undefined,
       });
     }
 

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -265,10 +265,11 @@ describe('POST /api/email-card-drop-requests', function () {
       .set('Content-Type', 'application/vnd.api+json')
       .send(payload);
 
-
     let sentryReport = await waitForSentryReport();
 
-    expect(sentryReport.error?.message).to.equal(`Prepaid card quantity (${mockPrepaidCardQuantity}) is below cardDrop.email.notifyWhenQuantityBelow threshold of ${notifyWhenQuantityBelow}`);
+    expect(sentryReport.error?.message).to.equal(
+      `Prepaid card quantity (${mockPrepaidCardQuantity}) is below cardDrop.email.notifyWhenQuantityBelow threshold of ${notifyWhenQuantityBelow}`
+    );
     expect(sentryReport.tags).to.deep.equal({
       action: 'drop-card',
       alert: 'web-team',

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -256,8 +256,7 @@ describe('POST /api/email-card-drop-requests', function () {
     let emailHash = hash.digest('hex');
     let emailHash2 = crypto.createHmac('sha256', config.get('emailHashSalt')).update(email2).digest('hex');
 
-    // FIXME is there something off with this…?
-    let insertionTimeInMs = fakeTime - (emailVerificationLinkExpiryMinutes / 2) * 60 * 1000;
+    let insertionTimeInMs = fakeTime - 60 * 1000;
     await emailCardDropRequestsQueries.insert({
       ownerAddress: stubUserAddress,
       emailHash,

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -364,7 +364,6 @@ describe('POST /api/email-card-drop-requests', function () {
         verificationCode: 'x',
         id: `2850a954-525d-499a-a5c8-3c89192ad40${i}`,
         requestedAt: new Date(insertionTimeInMs),
-        claimedAt: undefined,
       });
     }
 

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -192,7 +192,7 @@ describe('POST /api/email-card-drop-requests', function () {
 
   it('persists an email card drop request and triggers jobs', async function () {
     let emailCardDropRequestsQueries = await getContainer().lookup('email-card-drop-requests', { type: 'query' });
-    let insertionTimeInMs = Date.now() - emailVerificationLinkExpiryMinutes * 2 * 60 * 1000;
+    let insertionTimeBeyondExpiry = Date.now() - emailVerificationLinkExpiryMinutes * 2 * 60 * 1000;
 
     // Create no-longer-active reservations
 
@@ -202,7 +202,7 @@ describe('POST /api/email-card-drop-requests', function () {
         emailHash: `other-email-hash-${i}`,
         verificationCode: 'x',
         id: shortUUID.uuid(),
-        requestedAt: new Date(insertionTimeInMs),
+        requestedAt: new Date(insertionTimeBeyondExpiry),
       });
     }
 
@@ -356,7 +356,7 @@ describe('POST /api/email-card-drop-requests', function () {
     mockPrepaidCardQuantity = 5;
 
     let emailCardDropRequestsQueries = await getContainer().lookup('email-card-drop-requests', { type: 'query' });
-    let insertionTimeInMs = Date.now() - (emailVerificationLinkExpiryMinutes / 2) * 60 * 1000;
+    let insertionTimeBeforeExpiry = Date.now() - (emailVerificationLinkExpiryMinutes / 2) * 60 * 1000;
 
     for (let i = 0; i < mockPrepaidCardQuantity + 1; i++) {
       await emailCardDropRequestsQueries.insert({
@@ -364,7 +364,7 @@ describe('POST /api/email-card-drop-requests', function () {
         emailHash: `other-email-hash-${i}`,
         verificationCode: 'x',
         id: `2850a954-525d-499a-a5c8-3c89192ad40${i}`,
-        requestedAt: new Date(insertionTimeInMs),
+        requestedAt: new Date(insertionTimeBeforeExpiry),
       });
     }
 

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -325,7 +325,6 @@ describe('POST /api/email-card-drop-requests', function () {
 
     expect(allRequests.length).to.equal(2);
     expect(allRequests.find((v) => v.id === '2850a954-525d-499a-a5c8-3c89192ad40e')).to.not.be.undefined;
-
     expect(latestRequest.id).to.not.equal('2850a954-525d-499a-a5c8-3c89192ad40e');
     expect(latestRequest.verificationCode).to.match(verificationCodeRegex);
     expect(latestRequest.emailHash).to.equal(emailHash2);

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -325,8 +325,6 @@ describe('POST /api/email-card-drop-requests', function () {
     expect(allRequests.length).to.equal(2);
     expect(allRequests.find((v) => v.id === '2850a954-525d-499a-a5c8-3c89192ad40e')).to.not.be.undefined;
 
-    console.log('allrequests', allRequests);
-
     expect(latestRequest.id).to.not.equal('2850a954-525d-499a-a5c8-3c89192ad40e');
     expect(latestRequest.verificationCode).to.match(verificationCodeRegex);
     expect(latestRequest.emailHash).to.equal(emailHash2);

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -192,7 +192,7 @@ describe('POST /api/email-card-drop-requests', function () {
 
   it('persists an email card drop request and triggers jobs', async function () {
     let emailCardDropRequestsQueries = await getContainer().lookup('email-card-drop-requests', { type: 'query' });
-    let insertionTimeInMs = fakeTime - 50 * 60 * 1000;
+    let insertionTimeInMs = fakeTime - emailVerificationLinkExpiryMinutes * 2 * 60 * 1000;
 
     // Create no-longer-active reservations
 
@@ -355,7 +355,7 @@ describe('POST /api/email-card-drop-requests', function () {
     mockPrepaidCardQuantity = 5;
 
     let emailCardDropRequestsQueries = await getContainer().lookup('email-card-drop-requests', { type: 'query' });
-    let insertionTimeInMs = fakeTime - 50 * 60 * 1000;
+    let insertionTimeInMs = fakeTime - (emailVerificationLinkExpiryMinutes / 2) * 60 * 1000;
 
     for (let i = 0; i < mockPrepaidCardQuantity + 1; i++) {
       await emailCardDropRequestsQueries.insert({

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -272,7 +272,7 @@ describe('POST /api/email-card-drop-requests', function () {
     );
     expect(sentryReport.tags).to.deep.equal({
       action: 'drop-card',
-      alert: 'web-team',
+      alert: 'prepaid-card-supply',
     });
   });
 

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -268,7 +268,7 @@ describe('POST /api/email-card-drop-requests', function () {
     let sentryReport = await waitForSentryReport();
 
     expect(sentryReport.error?.message).to.equal(
-      `Prepaid card quantity (${mockPrepaidCardQuantity}) less reservations (0) is below cardDrop.email.notifyWhenQuantityBelow threshold of ${notifyWhenQuantityBelow}`
+      `https://app.gitbook.com/o/-MlRBKglR9VL1a7e4w85/s/05zPo3R26oH9uKrNVxni/hub/email-card-drop#quantity-threshold-warning Prepaid card quantity (${mockPrepaidCardQuantity}) less reservations (0) is below cardDrop.email.notifyWhenQuantityBelow threshold of ${notifyWhenQuantityBelow}`
     );
     expect(sentryReport.tags).to.deep.equal({
       action: 'drop-card',

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -397,16 +397,16 @@ describe('POST /api/email-card-drop-requests', function () {
         ],
       });
 
-      let sentryReport = await waitForSentryReport();
+    let sentryReport = await waitForSentryReport();
 
-      expect(sentryReport.error?.message).to.equal(
-        `https://app.gitbook.com/o/-MlRBKglR9VL1a7e4w85/s/05zPo3R26oH9uKrNVxni/hub/email-card-drop#quantity-threshold-warning Prepaid card quantity (${mockPrepaidCardQuantity}) less reservations (${reservationCount}) is below cardDrop.email.notifyWhenQuantityBelow threshold of ${notifyWhenQuantityBelow}`
-      );
-      expect(sentryReport.tags).to.deep.equal({
-        action: 'drop-card',
-        alert: 'prepaid-card-supply',
-      });
+    expect(sentryReport.error?.message).to.equal(
+      `https://app.gitbook.com/o/-MlRBKglR9VL1a7e4w85/s/05zPo3R26oH9uKrNVxni/hub/email-card-drop#quantity-threshold-warning Prepaid card quantity (${mockPrepaidCardQuantity}) less reservations (${reservationCount}) is below cardDrop.email.notifyWhenQuantityBelow threshold of ${notifyWhenQuantityBelow}`
+    );
+    expect(sentryReport.tags).to.deep.equal({
+      action: 'drop-card',
+      alert: 'prepaid-card-supply',
     });
+  });
 
   it('rejects with 503 when the contract is paused', async function () {
     mockPrepaidCardMarketContractPaused = true;

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -321,35 +321,6 @@ describe('POST /api/email-card-drop-requests', function () {
       .expect('Content-Type', 'application/vnd.api+json');
   });
 
-  it('rejects with 503 when getQuantity is zero', async function () {
-    mockPrepaidCardQuantity = 0;
-
-    const payload = {
-      data: {
-        type: 'email-card-drop-requests',
-        attributes: {
-          email: 'valid@example.com',
-        },
-      },
-    };
-
-    await request()
-      .post('/api/email-card-drop-requests')
-      .set('Accept', 'application/vnd.api+json')
-      .set('Authorization', 'Bearer abc123--def456--ghi789')
-      .set('Content-Type', 'application/vnd.api+json')
-      .send(payload)
-      .expect(503)
-      .expect({
-        errors: [
-          {
-            status: '503',
-            title: 'There are no prepaid cards available',
-          },
-        ],
-      });
-  });
-
   it('rejects with 503 when getQuantity is less than active reservations', async function () {
     mockPrepaidCardQuantity = 5;
 

--- a/packages/hub/queries/email-card-drop-requests.ts
+++ b/packages/hub/queries/email-card-drop-requests.ts
@@ -71,7 +71,9 @@ export default class EmailCardDropRequestsQueries {
     const query = `
       SELECT COUNT(*)
       FROM  email_card_drop_requests AS t1
-      WHERE requested_at=(SELECT MAX(requested_at) FROM email_card_drop_requests WHERE t1.owner_address=email_card_drop_requests.owner_address)
+      WHERE
+        requested_at=(SELECT MAX(requested_at) FROM email_card_drop_requests WHERE t1.owner_address=email_card_drop_requests.owner_address)
+        AND claimed_at IS NULL
     `;
 
     const queryResult = await db.query(query);

--- a/packages/hub/queries/email-card-drop-requests.ts
+++ b/packages/hub/queries/email-card-drop-requests.ts
@@ -65,6 +65,19 @@ export default class EmailCardDropRequestsQueries {
     return queryResult.rows.map(mapRowToObject)[0];
   }
 
+  // TODO does this cover everything? 🤔
+  async activeReservations() {
+    let db = await this.databaseManager.getClient();
+    const query = `
+      SELECT COUNT(*)
+      FROM  email_card_drop_requests AS t1
+      WHERE requested_at=(SELECT MAX(requested_at) FROM email_card_drop_requests WHERE t1.owner_address=email_card_drop_requests.owner_address)
+    `;
+
+    const queryResult = await db.query(query);
+    return queryResult.rows[0].count;
+  }
+
   async claimedInLastMinutes(minutes: number): Promise<(EmailCardDropRequest & { isExpired: boolean })[]> {
     let db = await this.databaseManager.getClient();
 

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -11,6 +11,9 @@ import crypto from 'crypto';
 import cryptoRandomString from 'crypto-random-string';
 import * as Sentry from '@sentry/node';
 import { NOT_NULL } from '../utils/queries';
+import logger from '@cardstack/logger';
+
+const log = logger('hub/email-card-drop-requests');
 
 const cardDropSku = config.get('cardDrop.sku') as string;
 const notifyWhenQuantityBelow = config.get('cardDrop.email.notifyWhenQuantityBelow') as number;
@@ -103,6 +106,8 @@ export default class EmailCardDropRequestsRoute {
 
     let quantityIsBelowNotificationThreshold = quantityAvailable < notifyWhenQuantityBelow;
     let notificationHasNotBeenSentRecently = !lastNotifiedOnQuantity || lastNotifiedOnQuantity < (Date.now() - millisToWaitBeforeNotifying);
+
+    log.trace(`${cardDropSku} has ${quantityAvailable} available, notification threshold is ${notifyWhenQuantityBelow}`);
 
     if (quantityIsBelowNotificationThreshold && notificationHasNotBeenSentRecently) {
       Sentry.captureException(new Error(`Prepaid card quantity (${quantityAvailable}) is below cardDrop.email.notifyWhenQuantityBelow threshold of ${notifyWhenQuantityBelow}`), {

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -104,7 +104,7 @@ export default class EmailCardDropRequestsRoute {
 
     let supplyIsBelowNotificationThreshold = (quantityAvailable - activeReservations) < notifyWhenQuantityBelow;
 
-    log.trace(
+    log.info(
       `${cardDropSku} has ${quantityAvailable} available and ${activeReservations} reserved, notification threshold is ${notifyWhenQuantityBelow}`
     );
 

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -99,7 +99,10 @@ export default class EmailCardDropRequestsRoute {
       return;
     }
 
-    if ((await prepaidCardMarketV2.getQuantity(cardDropSku)) === 0) {
+    let quantityAvailable = await prepaidCardMarketV2.getQuantity(cardDropSku);
+    let activeReservations = await this.emailCardDropRequestQueries.activeReservations();
+
+    if (quantityAvailable <= activeReservations) {
       ctx.status = 503;
       ctx.body = {
         errors: [{ status: '503', title: 'There are no prepaid cards available' }],

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -105,17 +105,25 @@ export default class EmailCardDropRequestsRoute {
     let quantityAvailable = await prepaidCardMarketV2.getQuantity(cardDropSku);
 
     let quantityIsBelowNotificationThreshold = quantityAvailable < notifyWhenQuantityBelow;
-    let notificationHasNotBeenSentRecently = !lastNotifiedOnQuantity || lastNotifiedOnQuantity < (Date.now() - millisToWaitBeforeNotifying);
+    let notificationHasNotBeenSentRecently =
+      !lastNotifiedOnQuantity || lastNotifiedOnQuantity < Date.now() - millisToWaitBeforeNotifying;
 
-    log.trace(`${cardDropSku} has ${quantityAvailable} available, notification threshold is ${notifyWhenQuantityBelow}`);
+    log.trace(
+      `${cardDropSku} has ${quantityAvailable} available, notification threshold is ${notifyWhenQuantityBelow}`
+    );
 
     if (quantityIsBelowNotificationThreshold && notificationHasNotBeenSentRecently) {
-      Sentry.captureException(new Error(`Prepaid card quantity (${quantityAvailable}) is below cardDrop.email.notifyWhenQuantityBelow threshold of ${notifyWhenQuantityBelow}`), {
-        tags: {
-          action: 'drop-card',
-          alert: 'web-team',
-        },
-      });
+      Sentry.captureException(
+        new Error(
+          `Prepaid card quantity (${quantityAvailable}) is below cardDrop.email.notifyWhenQuantityBelow threshold of ${notifyWhenQuantityBelow}`
+        ),
+        {
+          tags: {
+            action: 'drop-card',
+            alert: 'web-team',
+          },
+        }
+      );
 
       lastNotifiedOnQuantity = Date.now();
     }

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -111,7 +111,7 @@ export default class EmailCardDropRequestsRoute {
     if (supplyIsBelowNotificationThreshold ) {
       Sentry.captureException(
         new Error(
-          `Prepaid card quantity (${quantityAvailable}) less reservations (${activeReservations}) is below cardDrop.email.notifyWhenQuantityBelow threshold of ${notifyWhenQuantityBelow}`
+          `https://app.gitbook.com/o/-MlRBKglR9VL1a7e4w85/s/05zPo3R26oH9uKrNVxni/hub/email-card-drop#quantity-threshold-warning Prepaid card quantity (${quantityAvailable}) less reservations (${activeReservations}) is below cardDrop.email.notifyWhenQuantityBelow threshold of ${notifyWhenQuantityBelow}`
         ),
         {
           tags: {

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -120,7 +120,7 @@ export default class EmailCardDropRequestsRoute {
         {
           tags: {
             action: 'drop-card',
-            alert: 'web-team',
+            alert: 'prepaid-card-supply',
           },
         }
       );

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -102,13 +102,13 @@ export default class EmailCardDropRequestsRoute {
     let quantityAvailable = await prepaidCardMarketV2.getQuantity(cardDropSku);
     let activeReservations = await this.emailCardDropRequestQueries.activeReservations();
 
-    let supplyIsBelowNotificationThreshold = (quantityAvailable - activeReservations) < notifyWhenQuantityBelow;
+    let supplyIsBelowNotificationThreshold = quantityAvailable - activeReservations < notifyWhenQuantityBelow;
 
     log.info(
       `${cardDropSku} has ${quantityAvailable} available and ${activeReservations} reserved, notification threshold is ${notifyWhenQuantityBelow}`
     );
 
-    if (supplyIsBelowNotificationThreshold ) {
+    if (supplyIsBelowNotificationThreshold) {
       Sentry.captureException(
         new Error(
           `https://app.gitbook.com/o/-MlRBKglR9VL1a7e4w85/s/05zPo3R26oH9uKrNVxni/hub/email-card-drop#quantity-threshold-warning Prepaid card quantity (${quantityAvailable}) less reservations (${activeReservations}) is below cardDrop.email.notifyWhenQuantityBelow threshold of ${notifyWhenQuantityBelow}`
@@ -121,7 +121,6 @@ export default class EmailCardDropRequestsRoute {
         }
       );
     }
-
 
     if (quantityAvailable <= activeReservations) {
       return respondWith503(ctx, 'There are no prepaid cards available');

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -91,7 +91,13 @@ export default class EmailCardDropRequestsRoute {
 
     let prepaidCardMarketV2 = await this.cardpay.getSDK('PrepaidCardMarketV2', this.web3.getInstance());
 
-    // FIXME check isPaused also
+    if (await prepaidCardMarketV2.isPaused()) {
+      ctx.status = 503;
+      ctx.body = {
+        errors: [{ status: '503', title: 'The prepaid card market contract is paused' }],
+      };
+      return;
+    }
 
     if ((await prepaidCardMarketV2.getQuantity(cardDropSku)) === 0) {
       ctx.status = 503;

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -105,7 +105,7 @@ export default class EmailCardDropRequestsRoute {
     let supplyIsBelowNotificationThreshold = (quantityAvailable - activeReservations) < notifyWhenQuantityBelow;
 
     log.trace(
-      `${cardDropSku} has ${quantityAvailable} available, notification threshold is ${notifyWhenQuantityBelow}`
+      `${cardDropSku} has ${quantityAvailable} available and ${activeReservations} reserved, notification threshold is ${notifyWhenQuantityBelow}`
     );
 
     if (supplyIsBelowNotificationThreshold ) {


### PR DESCRIPTION
This adds a 503 response from `POST /api/email-card-drop-requests` if SDK’s `PrepaidCardMarketV2.getQuantity` ≤ the number of “active” reservations, as in new records in the table from the past 60 minutes that haven’t been claimed. It also 503s if the contract is paused.

There’s a Sentry alert to `web-team` if `getQuantity` is < 25 (in `config`).