### PR TITLE
Cs 3936 support empty payment lists

### DIFF
--- a/packages/reward-root-submitter/reward_root_submitter/submitter.py
+++ b/packages/reward-root-submitter/reward_root_submitter/submitter.py
@@ -7,7 +7,7 @@ from cloudpathlib import AnyPath
 from eth_utils import to_wei
 from hexbytes import HexBytes
 
-from .utils import get_all_reward_outputs, get_root_from_file
+from .utils import get_all_reward_outputs, get_root_from_file, NULL_HEX, EMPTY_MARKER_HEX
 
 
 class RootSubmitter:
@@ -61,9 +61,7 @@ class RootSubmitter:
             reward_program_id, payment_cycle
         )
         # This is like a null check, unsubmitted roots are blank
-        if existing_root != HexBytes(
-            "0x0000000000000000000000000000000000000000000000000000000000000000"
-        ):
+        if existing_root != NULL_HEX:
             # If it exists, and it's the same as before, it's safe and expected to just skip on
             if existing_root == root:
                 logging.info(
@@ -108,6 +106,7 @@ class RootSubmitter:
                 if root is not None:
                     self.submit_root(reward_program_id, payment_cycle, root)
                 else:
+                    self.submit_root(reward_program_id, payment_cycle, EMPTY_MARKER_HEX)
                     logging.info(
-                        f"No root found for reward program {reward_program_id} payment cycle {payment_cycle}"
+                        f"No root found for reward program {reward_program_id} payment cycle {payment_cycle}, submitted marker"
                     )

--- a/packages/reward-root-submitter/reward_root_submitter/utils.py
+++ b/packages/reward-root-submitter/reward_root_submitter/utils.py
@@ -6,6 +6,15 @@ from hexbytes import HexBytes
 from web3 import Web3
 
 
+NULL_HEX = HexBytes(
+    "0x0000000000000000000000000000000000000000000000000000000000000000"
+)
+
+EMPTY_MARKER_HEX = HexBytes(
+    "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+)
+
+
 def safe_regex_group_search(regex, string, group):
     """
     Returns None in the case of a missing group

--- a/packages/reward-root-submitter/reward_root_submitter/utils.py
+++ b/packages/reward-root-submitter/reward_root_submitter/utils.py
@@ -49,7 +49,7 @@ def get_all_reward_outputs(root: AnyPath):
         )
         if (
             web3.isChecksumAddress(reward_program_id)
-            and result_file.exists()
+            and result_file.is_file() # checks existence & is not a folder
             and (payment_cycle or "").isdigit()
         ):
             yield {

--- a/packages/reward-root-submitter/tests/test_submitter.py
+++ b/packages/reward-root-submitter/tests/test_submitter.py
@@ -212,7 +212,6 @@ def test_submits_all_roots(w3, reward_pool, deploy_address, deploy_key):
         "tests/resources/reward_output",
     )
     submitter.submit_all_roots()
-    # There is no root for  "0xA2e8225dE0385ebC20B3C0160864f4e20a750cfd" / 24098304
     for reward_program_id in reward_programs():
         for payment_cycle in [24000000, 24065536]:
             assert reward_pool.caller.payeeRoots(
@@ -220,6 +219,22 @@ def test_submits_all_roots(w3, reward_pool, deploy_address, deploy_key):
             ) != HexBytes(
                 "0x0000000000000000000000000000000000000000000000000000000000000000"
             )
+
+
+def test_submits_FF_for_empty_file(w3, reward_pool, deploy_address, deploy_key):
+    submitter = RootSubmitter(
+        w3,
+        deploy_address,
+        deploy_key,
+        reward_pool.address,
+        "tests/resources/reward_output",
+    )
+    empty_file_program_id = "0xA2e8225dE0385ebC20B3C0160864f4e20a750cfd"
+    empty_file_cycle = 24098304
+    submitter.submit_all_roots()
+    assert reward_pool.caller.payeeRoots(
+        empty_file_program_id, empty_file_cycle
+    ) == HexBytes("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
 
 
 def test_can_find_all_payment_cycles():
@@ -270,7 +285,9 @@ def test_returns_none_when_file_empty():
 def test_ignores_non_rewards_folders():
     s3_client = LocalS3Client(local_storage_dir="tests")
     all_cycles = list(
-        get_all_reward_outputs(s3_client.S3Path("s3://resources/rewards_with_other_folders/"))
+        get_all_reward_outputs(
+            s3_client.S3Path("s3://resources/rewards_with_other_folders/")
+        )
     )
     assert len(all_cycles) == 1
     assert {
@@ -285,7 +302,9 @@ def test_ignores_non_rewards_folders():
 def test_ignores_folders_without_parquet_results():
     s3_client = LocalS3Client(local_storage_dir="tests")
     all_cycles = list(
-        get_all_reward_outputs(s3_client.S3Path("s3://resources/rewards_with_missing_parquet/"))
+        get_all_reward_outputs(
+            s3_client.S3Path("s3://resources/rewards_with_missing_parquet/")
+        )
     )
     assert len(all_cycles) == 1
     assert {


### PR DESCRIPTION
When we don't have any payments to make, we still need something written on chain. I've chosen a marker of all Fs as a clear distinction, I'd normally use a 0 distinguished from NULL but the on chain structure is essentially already filled with 0s.

This should be written only when

* There is a results file
* The results file has no rows

The tests should cover  this distinction.

I've also added a small check that the results file not only exists but is actually a file - it was throwing an error on some badly written data before and crashing.