### PR TITLE
fix(cardie): Pin nodejs version and add typescript as well as @types/node to package.json

### DIFF
--- a/packages/cardie/package.json
+++ b/packages/cardie/package.json
@@ -8,7 +8,10 @@
     "start": "ts-node server.ts"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
+  "engines": {
+    "node": "^14.0.0"
+  },
   "dependencies": {
     "@octokit/openapi-types": "^9.4.0",
     "@octokit/rest": "^18.7.1",

--- a/packages/cardie/package.json
+++ b/packages/cardie/package.json
@@ -10,13 +10,14 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": "^17.0.0"
+    "node": "^14.0.0"
   },
   "dependencies": {
     "@octokit/openapi-types": "^9.4.0",
     "@octokit/rest": "^18.7.1",
     "discord.js": "^12.5.3",
     "dotenv": "^10.0.0",
-    "ts-node": "^10.3.0"
+    "ts-node": "^10.3.0",
+    "typescript": "4.2.3"
   }
 }

--- a/packages/cardie/package.json
+++ b/packages/cardie/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": "^14.0.0"
+    "node": "^17.0.0"
   },
   "dependencies": {
     "@octokit/openapi-types": "^9.4.0",

--- a/packages/cardie/package.json
+++ b/packages/cardie/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@octokit/openapi-types": "^9.4.0",
     "@octokit/rest": "^18.7.1",
+    "@types/node": "14.14.35",
     "discord.js": "^12.5.3",
     "dotenv": "^10.0.0",
     "ts-node": "^10.3.0",


### PR DESCRIPTION
There was an [update](https://github.com/heroku/pack-images/pull/247) to `buildpacks` to include Node 18. The Node version for `cardie` was not pinned, so buildpacks usually defaults to the latest version. This causes our `cardie`'s builds to fail when it attempts to build with Node 18: https://github.com/cardstack/cardstack/runs/6577154263?check_suite_focus=true

This PR pins the Node version for `cardie` to `^14.0.0`, as well as adding `typescript` and `@types/node` as dependencies (required for the build to work).
