### PR TITLE
Show focus outline rect on details element of Boxel::ExpandableBanner when open

### DIFF
--- a/packages/boxel/addon/components/boxel/expandable-banner/index.css
+++ b/packages/boxel/addon/components/boxel/expandable-banner/index.css
@@ -80,6 +80,15 @@
   outline: transparent;
 }
 
+.boxel-expandable-banner__details[open]:focus-within {
+  outline: var(--boxel-outline);
+  outline-offset: -4px;
+}
+
+.boxel-expandable-banner__details[open]:focus-within .boxel-expandable-banner__summary:focus {
+  outline: none;
+}
+
 /* style our custom markers */
 .boxel-expandable-banner__summary-marker::before {
   display: block;


### PR DESCRIPTION
- hides focus on summary element when open
- sub-optimal treatment when elements within details that are not the summary have focus

Examples:

BEFORE open state

![Screen Shot 2022-05-25 at 4 54 18 PM](https://user-images.githubusercontent.com/353/170365564-49af1df4-42dd-4774-aa3c-67155d82adeb.png)

AFTER

Safari closed
![Screen Shot 2022-05-25 at 4 48 45 PM](https://user-images.githubusercontent.com/353/170365223-13ba39ae-c860-4714-bb9c-22d7fe8015b5.png)

Safari open
![Screen Shot 2022-05-25 at 4 48 50 PM](https://user-images.githubusercontent.com/353/170365231-b846a9f7-2de7-4449-8dd7-e8ce20b389d7.png)

Firefox closed
![Screen Shot 2022-05-25 at 4 48 31 PM](https://user-images.githubusercontent.com/353/170365178-7acba41e-66a9-42fc-8f9f-bca6d6eddf61.png)

Firefox open
![Screen Shot 2022-05-25 at 4 48 36 PM](https://user-images.githubusercontent.com/353/170365194-0b9dd40c-c2ba-42fb-a562-4090bef84520.png)

Chrome closed
![Screen Shot 2022-05-25 at 4 48 14 PM](https://user-images.githubusercontent.com/353/170365077-18391b86-91a8-4926-a72e-98d7cd6dba26.png)

Chrome open
![Screen Shot 2022-05-25 at 4 48 19 PM](https://user-images.githubusercontent.com/353/170365103-03d0f1cd-2d30-42ae-8389-315c0247a400.png)

Chrome open with focus on link inside
![Screen Shot 2022-05-25 at 4 49 34 PM](https://user-images.githubusercontent.com/353/170365132-f0a2c736-b28d-426f-a01c-c1902911d08a.png)

