### PR TITLE
Freestyle:Usage cleanup

### DIFF
--- a/packages/boxel/addon/components/boxel/action-chin/usage.hbs
+++ b/packages/boxel/addon/components/boxel/action-chin/usage.hbs
@@ -2,6 +2,104 @@
   <:description>
       Bottom action area for an action card, a.k.a the "Chin".<br><br>
       Use the API controls below to change <code>state</code> and <code>stepNumber</code>.
+
+      <h2>ActionChin Explanation</h2>
+      <div class="usage-cta-block-explanation">
+        CTAs are meant to guide users to take a single action.
+        There are a few different states for this component:
+        <table class="usage-cta-block-explanation-table">
+          <tbody>
+            <tr><td>State</td><td>Explanation</td></tr>
+            <tr><td>default</td> <td>When the user has not met the requirements for the cta to be considered done</td></tr>
+            <tr><td>in-progress</td> <td>When the action is in progress</td></tr>
+            <tr><td>memorialized</td> <td>When the action is done</td></tr>
+          </tbody>
+        </table>
+        CtaBlock provides components to use within it - these components have appropriate classes to place them in the correct spots in the layout, and have correct states.
+        The ActionButton and CancelButton components use the Button component and should accept all arguments it does.
+        The InfoArea and ActionStatusArea components are essentially divs, which you can put your custom contents in.
+        <table class="usage-cta-block-explanation-table">
+          <tbody>
+            <tr>
+              <td>
+                Component
+              </td>
+              <td>
+                What it does
+              </td>
+              <td>
+                Provided in states
+              </td>
+            </tr>
+            <tr>
+              <td>
+                ActionButton
+              </td>
+              <td>
+                The button that's used to perform the main action for this CTA. It undergoes a few changes in styling in between states.
+              </td>
+              <td>
+                <ul>
+                  <li>default</li>
+                  <li>memorialized</li>
+                  <li>in-progress</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                ActionStatusArea
+              </td>
+              <td>
+                Memorialized state status update area for the main action, that is built to accept a small descriptive statement - eg. "Unlocked".
+                It should be used when an action is completed, replacing the ActionButton.
+                <br>
+                <br>
+                It accepts a `@icon` argument. By default, it shows a checkmark as the icon.
+                <br>
+                <br>
+                <strong>Don't use this and ActionButton together, they occupy the same grid area!</strong>
+              </td>
+              <td>
+                <ul>
+                  <li>default</li>
+                  <li>memorialized</li>
+                  <li>in-progress</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                CancelButton
+              </td>
+              <td>
+                Button to cancel the main action. It should only appear in the 'in-progress' state.
+              </td>
+              <td>
+                <ul>
+                  <li>in-progress</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                InfoArea
+              </td>
+              <td>
+                An area used for any relevant information to the action (eg for status updates)
+                If provided, it replaces the text:  "Actions only visible to you".
+              </td>
+              <td>
+                <ul>
+                  <li>default</li>
+                  <li>memorialized</li>
+                  <li>in-progress</li>
+                </ul>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
   </:description>
   <:example>
     <Boxel::ActionChin
@@ -173,103 +271,3 @@
     </Boxel::ActionChin>
   </:example>
 </Freestyle::Usage>
-
-<FreestyleAnnotation>
-  <h2>ActionChin Explanation</h2>
-  <div class="usage-cta-block-explanation">
-    CTAs are meant to guide users to take a single action.
-    There are a few different states for this component:
-    <table class="usage-cta-block-explanation-table">
-      <tbody>
-        <tr><td>State</td><td>Explanation</td></tr>
-        <tr><td>default</td> <td>When the user has not met the requirements for the cta to be considered done</td></tr>
-        <tr><td>in-progress</td> <td>When the action is in progress</td></tr>
-        <tr><td>memorialized</td> <td>When the action is done</td></tr>
-      </tbody>
-    </table>
-    CtaBlock provides components to use within it - these components have appropriate classes to place them in the correct spots in the layout, and have correct states.
-    The ActionButton and CancelButton components use the Button component and should accept all arguments it does.
-    The InfoArea and ActionStatusArea components are essentially divs, which you can put your custom contents in.
-    <table class="usage-cta-block-explanation-table">
-      <tbody>
-        <tr>
-          <td>
-            Component
-          </td>
-          <td>
-            What it does
-          </td>
-          <td>
-            Provided in states
-          </td>
-        </tr>
-        <tr>
-          <td>
-            ActionButton
-          </td>
-          <td>
-            The button that's used to perform the main action for this CTA. It undergoes a few changes in styling in between states.
-          </td>
-          <td>
-            <ul>
-              <li>default</li>
-              <li>memorialized</li>
-              <li>in-progress</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            ActionStatusArea
-          </td>
-          <td>
-            Memorialized state status update area for the main action, that is built to accept a small descriptive statement - eg. "Unlocked".
-            It should be used when an action is completed, replacing the ActionButton.
-            <br>
-            <br>
-            It accepts a `@icon` argument. By default, it shows a checkmark as the icon.
-            <br>
-            <br>
-            <strong>Don't use this and ActionButton together, they occupy the same grid area!</strong>
-          </td>
-          <td>
-            <ul>
-              <li>default</li>
-              <li>memorialized</li>
-              <li>in-progress</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            CancelButton
-          </td>
-          <td>
-            Button to cancel the main action. It should only appear in the 'in-progress' state.
-          </td>
-          <td>
-            <ul>
-              <li>in-progress</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            InfoArea
-          </td>
-          <td>
-            An area used for any relevant information to the action (eg for status updates)
-            If provided, it replaces the text:  "Actions only visible to you".
-          </td>
-          <td>
-            <ul>
-              <li>default</li>
-              <li>memorialized</li>
-              <li>in-progress</li>
-            </ul>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</FreestyleAnnotation>

--- a/packages/boxel/addon/components/boxel/button/usage.hbs
+++ b/packages/boxel/addon/components/boxel/button/usage.hbs
@@ -1,76 +1,3 @@
-<FreestyleAnnotation>
-  <h2>Button</h2>
-    Depending on the value of `@as`, the button will accept different arguments.
-    <table class="usage-button-explanation">
-      <tbody>
-        <tr>
-        <td>
-          <code>
-            @as
-          </code>
-        </td>
-        <td>
-          Accepted arguments
-        </td>
-        <td>
-          Used for
-        </td>
-      </tr>
-      <tr>
-        <td>
-          button
-        </td>
-        <td>
-          <ul>
-            <li><code>@size</code></li>
-            <li><code>@kind</code></li>
-            <li><code>@disabled</code></li>
-            <li><code>@loading</code></li>
-          </ul>
-        </td>
-        <td>
-          Actions
-        </td>
-      </tr>
-        <tr>
-        <td>
-          anchor
-        </td>
-        <td>
-          <ul>
-            <li><code>@size</code></li>
-            <li><code>@kind</code></li>
-            <li><code>@disabled</code></li>
-            <li><code>@href</code></li>
-          </ul>
-        </td>
-        <td>
-          Any navigation, e.g. external CTA
-        </td>
-      </tr>
-      <tr>
-        <td>
-          link-to
-        </td>
-        <td>
-          <ul>
-            <li><code>@size</code></li>
-            <li><code>@kind</code></li>
-            <li><code>@disabled</code></li>
-            <li><code>@route</code></li>
-            <li><code>@models</code></li>
-            <li><code>@query</code></li>
-          </ul>
-          <br>
-          <code>@route, @models,</code> and <code>@query</code> are passed to <code>LinkTo</code> directly
-        </td>
-        <td>
-          Navigation within the app
-        </td>
-      </tr>
-      </tbody>
-    </table>
-</FreestyleAnnotation>
 <Freestyle::Usage @name="Button">
   <:example>
     <div class={{cn "usage-button-centers-component" usage-button-dark-mode-background=(eq this.kind "secondary-dark")}}>
@@ -156,6 +83,78 @@
     />
     <Args.Yield @description="Contents of the button" />
   </:api>
+  <:description>
+    Depending on the value of `@as`, the button will accept different arguments.
+    <table class="usage-button-explanation">
+      <tbody>
+        <tr>
+        <td>
+          <code>
+            @as
+          </code>
+        </td>
+        <td>
+          Accepted arguments
+        </td>
+        <td>
+          Used for
+        </td>
+      </tr>
+      <tr>
+        <td>
+          button
+        </td>
+        <td>
+          <ul>
+            <li><code>@size</code></li>
+            <li><code>@kind</code></li>
+            <li><code>@disabled</code></li>
+            <li><code>@loading</code></li>
+          </ul>
+        </td>
+        <td>
+          Actions
+        </td>
+      </tr>
+        <tr>
+        <td>
+          anchor
+        </td>
+        <td>
+          <ul>
+            <li><code>@size</code></li>
+            <li><code>@kind</code></li>
+            <li><code>@disabled</code></li>
+            <li><code>@href</code></li>
+          </ul>
+        </td>
+        <td>
+          Any navigation, e.g. external CTA
+        </td>
+      </tr>
+      <tr>
+        <td>
+          link-to
+        </td>
+        <td>
+          <ul>
+            <li><code>@size</code></li>
+            <li><code>@kind</code></li>
+            <li><code>@disabled</code></li>
+            <li><code>@route</code></li>
+            <li><code>@models</code></li>
+            <li><code>@query</code></li>
+          </ul>
+          <br>
+          <code>@route, @models,</code> and <code>@query</code> are passed to <code>LinkTo</code> directly
+        </td>
+        <td>
+          Navigation within the app
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </:description>
 </Freestyle::Usage>
 
 <Freestyle::Usage @name="LinkTo button" @description="This button links you to the media registry page">

--- a/packages/boxel/addon/components/boxel/card-catalog-tray-item/usage.hbs
+++ b/packages/boxel/addon/components/boxel/card-catalog-tray-item/usage.hbs
@@ -34,7 +34,7 @@
   </:api>
 </Freestyle::Usage>
 
-<Freestyle::Usage @description="dragging example">
+<Freestyle::Usage @name="dragging example">
     {{!--
       note - drop shadow does not actually follow this in the example.
       right now the browser has control over styles of the drag image
@@ -59,7 +59,7 @@
   </:example>
 </Freestyle::Usage>
 
-<Freestyle::Usage @description="Usage in tray">
+<Freestyle::Usage @name="Usage in tray">
   <:example>
     <div class="boxel-card-catalog-tray-example">
       <header class="boxel-card-catalog-tray-example__header-container">

--- a/packages/boxel/addon/components/boxel/card-container/usage.hbs
+++ b/packages/boxel/addon/components/boxel/card-container/usage.hbs
@@ -37,12 +37,14 @@
   </:api>
 </Freestyle::Usage>
 
-<FreestyleAnnotation>
-  <Boxel::CardContainer @displayBoundaries={{true}}>
-    <div style="display:grid; grid-template-rows: 5rem;">
-      <div style="margin: auto">
-        One strategy to consider is using a root element with `display: grid` to layout the contents of your card.
+<Freestyle::Usage @name="CardContainer layout example">
+  <:example>
+    <Boxel::CardContainer @displayBoundaries={{true}}>
+      <div style="display:grid; grid-template-rows: 5rem;">
+        <div style="margin: auto">
+          One strategy to consider is using a root element with `display: grid` to layout the contents of your card.
+        </div>
       </div>
-    </div>
-  </Boxel::CardContainer>
-</FreestyleAnnotation>
+    </Boxel::CardContainer>
+  </:example>
+</Freestyle::Usage>

--- a/packages/boxel/addon/components/boxel/field/usage.hbs
+++ b/packages/boxel/addon/components/boxel/field/usage.hbs
@@ -67,7 +67,7 @@
   </:api>
 </Freestyle::Usage>
 
-<Freestyle::Usage @description="Usage with Boxel::Input">
+<Freestyle::Usage @name="Usage with Boxel::Input">
   <:example>
     <Boxel::Field
       @tag="label"
@@ -78,7 +78,7 @@
   </:example>
 </Freestyle::Usage>
 
-<Freestyle::Usage @description="Usage with Boxel::Input::ValidationState (invalid state)">
+<Freestyle::Usage @name="Usage with Boxel::Input::ValidationState (invalid state)">
   <:example>
     <Boxel::Field
       @tag="label"

--- a/packages/boxel/addon/components/boxel/input/usage.hbs
+++ b/packages/boxel/addon/components/boxel/input/usage.hbs
@@ -65,7 +65,7 @@
   </:api>
 </Freestyle::Usage>
 
-<Freestyle::Usage class="remove-in-percy" @description="Use the @onInput argument to access the input's value in the callback directly.">
+<Freestyle::Usage class="remove-in-percy" @name="Use the @onInput argument to access the input's value in the callback directly.">
   <:example>
     <label for="onInputExample" class="boxel-sr-only">onInput example input</label>
     <Boxel::Input
@@ -76,9 +76,9 @@
   </:example>
 </Freestyle::Usage>
 
-<Freestyle::Usage class="remove-in-percy">
+<Freestyle::Usage class="remove-in-percy" @name="Use `on &ldquo;input&rdquo; your-function-here` as an escape hatch to get the input event">
   <:description>
-    Use `on "input" your-function-here` as an escape hatch to get the input event
+    
   </:description>
   <:example>
     <label for="modifierExample" class="boxel-sr-only">event example input</label>

--- a/packages/boxel/addon/components/boxel/modal/usage.hbs
+++ b/packages/boxel/addon/components/boxel/modal/usage.hbs
@@ -58,7 +58,7 @@
 
 
 <Freestyle::Usage
-  @description="Modals have two different layers, urgent and default"
+  @name="Modals have two different layers, urgent and default"
 >
 <:example>
 <Boxel::Button @kind="primary" {{on "click" this.openDefault}}>Open</Boxel::Button>

--- a/packages/boxel/addon/components/boxel/thread-message/usage.hbs
+++ b/packages/boxel/addon/components/boxel/thread-message/usage.hbs
@@ -89,26 +89,25 @@
   </:example>
 </Freestyle::Usage>
 
-<FreestyleAnnotation>
-  <p>
-    The examples with embedded cards below are using the <code>@fullWidth</code> argument to
-    have access to the full-width content area. Smaller cards have a left margin the size of
-    <code>var(--boxel-thread-message-margin-left)</code> css variable for alignment.
-  </p>
-  <p>
-    Using the <code>@fullWidth</code> argument:
-    <ul>
-      <li>Allows the content to have access to the full-width content area</li>
-      <li>Adds spacing between the timestamp and the content</li>
-      <li>Vertically centers the timestamp in relation to the avatar</li>
-    </ul>
-  </p>
-  <p>
-    (Note: The messages below also have custom css applied which restricts their max-width. See <code>usage.css</code> file.)
-  </p>
-</FreestyleAnnotation>
-
 <Freestyle::Usage @slug="with-cards">
+  <:description>
+    <p>
+      These examples with embedded cards are using the <code>@fullWidth</code> argument to
+      have access to the full-width content area. Smaller cards have a left margin the size of
+      <code>var(--boxel-thread-message-margin-left)</code> css variable for alignment.
+    </p>
+    <p>
+      Using the <code>@fullWidth</code> argument:
+      <ul>
+        <li>Allows the content to have access to the full-width content area</li>
+        <li>Adds spacing between the timestamp and the content</li>
+        <li>Vertically centers the timestamp in relation to the avatar</li>
+      </ul>
+    </p>
+    <p>
+      (Note: The messages below also have custom css applied which restricts their max-width. See <code>usage.css</code> file.)
+    </p>
+  </:description>
   <:example>
     <div class="thread-message-usage">
       <Boxel::ThreadMessage


### PR DESCRIPTION
This commit fixes two incorrect usages:

1) Standalone cases of FreestyleAnnotation -- moved to <:description> block of Freestyle::Usage
2) Case of Freestyle::Usage with an @description property -- use an @name property instead

This results in all content being associated with a component so filtering to a particular component works more successfully.