### PR TITLE
Fix bug when using multiple proofs

### DIFF
--- a/packages/cardpay-reward-api/cardpay_reward_api/indexer.py
+++ b/packages/cardpay-reward-api/cardpay_reward_api/indexer.py
@@ -78,7 +78,7 @@ class Indexer:
                 proofArray=payment["proof"],
                 rewardProgramId=payment["rewardProgramID"],
                 amount=amount,
-                leaf="0x" + payment["leaf"],
+                leaf=payment["leaf"],
                 validFrom=payment["validFrom"],
                 validTo=payment["validTo"],
             )

--- a/packages/cardpay-reward-api/cardpay_reward_api/schemas.py
+++ b/packages/cardpay-reward-api/cardpay_reward_api/schemas.py
@@ -2,7 +2,8 @@
 
 from typing import List, Optional
 
-from pydantic import BaseModel
+from hexbytes import HexBytes
+from pydantic import BaseModel, validator
 
 
 class Proof(BaseModel):
@@ -16,6 +17,14 @@ class Proof(BaseModel):
     leaf: str
     validFrom: int
     validTo: int
+
+    @validator("leaf", pre=True)
+    def leaf_as_hex_string(cls, v):
+        return HexBytes(v).hex()
+
+    @validator("proofArray", pre=True, each_item=True)
+    def proof_as_hex_string(cls, v):
+        return HexBytes(v).hex()
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
Get [error](https://sentry.io/share/issue/5f591c76ffbe44a29194efa2959f8050/) whenever attempting to claim their reward. This error is only seen when doing airdrop to multiple addresses.

Main reason is that 

new tally tally dont used 0x prefix in proofArray

![Screenshot 2022-05-30 at 4 26 08 PM](https://user-images.githubusercontent.com/8165111/170950722-6682a82e-d762-4f38-a1e1-e608c5eeaadd.png)

old tally use 0x prefix proofArray (changed back to this)

![Screenshot 2022-05-30 at 4 26 42 PM](https://user-images.githubusercontent.com/8165111/170950693-1585ae6f-0d63-47b1-82aa-f1ba570e517c.png)

- this error occurs only when rewarding multiple multiple addresses otherwise the proofArray would be empty
- this change requires no sdk updates




