### PR TITLE
ci: Use AWS IAM assumable OIDC role [CS-3948]

### DIFF
--- a/.github/workflows/manual-cardie.yml
+++ b/.github/workflows/manual-cardie.yml
@@ -30,11 +30,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::680542703984:role/waypoint
+          aws-region: us-east-1
+
       - name: Deploy cardie
         uses: ./.github/actions/deploy-cardie
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_WAYPOINT_AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_WAYPOINT_AWS_SECRET }}
           WAYPOINT_SERVER_TOKEN: ${{ secrets.STAGING_WAYPOINT_SERVER_TOKEN }}
           WAYPOINT_SERVER_ADDR: ${{ secrets.STAGING_WAYPOINT_SERVER_ADDR }}
 

--- a/.github/workflows/manual-cardie.yml
+++ b/.github/workflows/manual-cardie.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: staging
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/manual-cardpay-reward-program-rules.yml
+++ b/.github/workflows/manual-cardpay-reward-program-rules.yml
@@ -19,6 +19,10 @@ on:
           - MinOtherMerchantsPaid
           - SafeOwnership
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -30,18 +34,22 @@ jobs:
           RULE_NAME: ${{ github.event.inputs.rule }}
         run: |
           if [ "$INPUT_ENVIRONMENT" = "staging" ]; then
-            echo "AWS_ACCESS_KEY_ID=${{ secrets.STAGING_REWARDS_ECR_WRITER_AWS_ACCESS_KEY}}" >> $GITHUB_ENV
-            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.STAGING_REWARDS_ECR_WRITER_AWS_ACCESS_SECRET }}" >> $GITHUB_ENV
-            echo "AWS_REGION"=us-east-1 >> $GITHUB_ENV
+            echo "AWS_ROLE_ARN=arn:aws:iam::680542703984:role/reward-programs" >> $GITHUB_ENV
+            echo "AWS_REGION=us-east-1" >> $GITHUB_ENV
           elif [ "$INPUT_ENVIRONMENT" = "production" ]; then
-            echo "AWS_ACCESS_KEY_ID=${{ secrets.PRODUCTION_REWARDS_ECR_WRITER_AWS_ACCESS_KEY}}" >> $GITHUB_ENV
-            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.PRODUCTION_REWARDS_ECR_WRITER_AWS_ACCESS_SECRET }}" >> $GITHUB_ENV
-            echo "AWS_REGION"=ap-southeast-1 >> $GITHUB_ENV
+            echo "AWS_ROLE_ARN=arn:aws:iam::120317779495:role/reward-programs" >> $GITHUB_ENV
+            echo "AWS_REGION=ap-southeast-1" >> $GITHUB_ENV
           else
             echo "unrecognized environment"
             exit 1;
           fi
           echo "RULE_NAME"=${RULE_NAME} >> $GITHUB_ENV
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Convert rule name (pascal case) to ECR repo name (snake case)
         shell: bash

--- a/.github/workflows/manual-hub.yml
+++ b/.github/workflows/manual-hub.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: production
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -18,14 +22,12 @@ jobs:
           INPUT_ENVIRONMENT: ${{ github.event.inputs.environment }}
         run: |
           if [ "$INPUT_ENVIRONMENT" = "production" ]; then
-            echo "AWS_ACCESS_KEY_ID=${{ secrets.PRODUCTION_WAYPOINT_AWS_ACCESS_KEY }}" >> $GITHUB_ENV
-            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.PRODUCTION_WAYPOINT_AWS_SECRET }}" >> $GITHUB_ENV
+            echo "AWS_ROLE_ARN=arn:aws:iam::120317779495:role/waypoint" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_TOKEN=${{ secrets.PRODUCTION_WAYPOINT_SERVER_TOKEN }}" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_ADDR=${{ secrets.PRODUCTION_WAYPOINT_SERVER_ADDR }}" >> $GITHUB_ENV
             cp waypoint.prod.hcl waypoint.hcl
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
-            echo "AWS_ACCESS_KEY_ID=${{ secrets.STAGING_WAYPOINT_AWS_ACCESS_KEY }}" >> $GITHUB_ENV
-            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.STAGING_WAYPOINT_AWS_SECRET }}" >> $GITHUB_ENV
+            echo "AWS_ROLE_ARN=arn:aws:iam::680542703984:role/waypoint" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_TOKEN=${{ secrets.STAGING_WAYPOINT_SERVER_TOKEN }}" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_ADDR=${{ secrets.STAGING_WAYPOINT_SERVER_ADDR }}" >> $GITHUB_ENV
           else
@@ -40,6 +42,12 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: us-east-1
 
       - name: Deploy hub
         uses: ./.github/actions/deploy-hub

--- a/.github/workflows/manual-reward-api.yml
+++ b/.github/workflows/manual-reward-api.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: production
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -18,20 +22,24 @@ jobs:
           INPUT_ENVIRONMENT: ${{ github.event.inputs.environment }}
         run: |
           if [ "$INPUT_ENVIRONMENT" = "production" ]; then
-            echo "AWS_ACCESS_KEY_ID=${{ secrets.PRODUCTION_WAYPOINT_AWS_ACCESS_KEY }}" >> $GITHUB_ENV
-            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.PRODUCTION_WAYPOINT_AWS_SECRET }}" >> $GITHUB_ENV
+            echo "AWS_ROLE_ARN=arn:aws:iam::120317779495:role/waypoint" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_TOKEN=${{ secrets.PRODUCTION_WAYPOINT_SERVER_TOKEN }}" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_ADDR=${{ secrets.PRODUCTION_WAYPOINT_SERVER_ADDR }}" >> $GITHUB_ENV
             cp waypoint.prod.hcl waypoint.hcl
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
-            echo "AWS_ACCESS_KEY_ID=${{ secrets.STAGING_WAYPOINT_AWS_ACCESS_KEY }}" >> $GITHUB_ENV
-            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.STAGING_WAYPOINT_AWS_SECRET }}" >> $GITHUB_ENV
+            echo "AWS_ROLE_ARN=arn:aws:iam::680542703984:role/waypoint" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_TOKEN=${{ secrets.STAGING_WAYPOINT_SERVER_TOKEN }}" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_ADDR=${{ secrets.STAGING_WAYPOINT_SERVER_ADDR }}" >> $GITHUB_ENV
           else
             echo "unrecognized environment"
             exit 1;
           fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: us-east-1
 
       - name: Deploy reward api
         uses: ./.github/actions/deploy-reward-api

--- a/.github/workflows/manual-reward-root-submitter.yml
+++ b/.github/workflows/manual-reward-root-submitter.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: production
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -18,20 +22,24 @@ jobs:
           INPUT_ENVIRONMENT: ${{ github.event.inputs.environment }}
         run: |
           if [ "$INPUT_ENVIRONMENT" = "production" ]; then
-            echo "AWS_ACCESS_KEY_ID=${{ secrets.PRODUCTION_WAYPOINT_AWS_ACCESS_KEY }}" >> $GITHUB_ENV
-            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.PRODUCTION_WAYPOINT_AWS_SECRET }}" >> $GITHUB_ENV
+            echo "AWS_ROLE_ARN=arn:aws:iam::120317779495:role/waypoint" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_TOKEN=${{ secrets.PRODUCTION_WAYPOINT_SERVER_TOKEN }}" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_ADDR=${{ secrets.PRODUCTION_WAYPOINT_SERVER_ADDR }}" >> $GITHUB_ENV
             cp waypoint.prod.hcl waypoint.hcl
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
-            echo "AWS_ACCESS_KEY_ID=${{ secrets.STAGING_WAYPOINT_AWS_ACCESS_KEY }}" >> $GITHUB_ENV
-            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.STAGING_WAYPOINT_AWS_SECRET }}" >> $GITHUB_ENV
+            echo "AWS_ROLE_ARN=arn:aws:iam::680542703984:role/waypoint" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_TOKEN=${{ secrets.STAGING_WAYPOINT_SERVER_TOKEN }}" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_ADDR=${{ secrets.STAGING_WAYPOINT_SERVER_ADDR }}" >> $GITHUB_ENV
           else
             echo "unrecognized environment"
             exit 1;
           fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: us-east-1
 
       - name: Deploy reward root submitter
         uses: ./.github/actions/deploy-reward-root-submitter

--- a/.github/workflows/manual-ssr-web.yml
+++ b/.github/workflows/manual-ssr-web.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: production
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -18,15 +22,13 @@ jobs:
           INPUT_ENVIRONMENT: ${{ github.event.inputs.environment }}
         run: |
           if [ "$INPUT_ENVIRONMENT" = "production" ]; then
-            echo "AWS_ACCESS_KEY_ID=${{ secrets.PRODUCTION_WAYPOINT_AWS_ACCESS_KEY }}" >> $GITHUB_ENV
-            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.PRODUCTION_WAYPOINT_AWS_SECRET }}" >> $GITHUB_ENV
+            echo "AWS_ROLE_ARN=arn:aws:iam::120317779495:role/waypoint" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_TOKEN=${{ secrets.PRODUCTION_WAYPOINT_SERVER_TOKEN }}" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_ADDR=${{ secrets.PRODUCTION_WAYPOINT_SERVER_ADDR }}" >> $GITHUB_ENV
             echo "HUB_URL=https://hub.cardstack.com" >> $GITHUB_ENV
             cp waypoint.prod.hcl waypoint.hcl
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
-            echo "AWS_ACCESS_KEY_ID=${{ secrets.STAGING_WAYPOINT_AWS_ACCESS_KEY }}" >> $GITHUB_ENV
-            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.STAGING_WAYPOINT_AWS_SECRET }}" >> $GITHUB_ENV
+            echo "AWS_ROLE_ARN=arn:aws:iam::680542703984:role/waypoint" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_TOKEN=${{ secrets.STAGING_WAYPOINT_SERVER_TOKEN }}" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_ADDR=${{ secrets.STAGING_WAYPOINT_SERVER_ADDR }}" >> $GITHUB_ENV
             echo "HUB_URL=https://hub-staging.stack.cards" >> $GITHUB_ENV
@@ -42,6 +44,12 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: us-east-1
 
       - name: Deploy ssr-web
         uses: ./.github/actions/deploy-ssr-web

--- a/.github/workflows/manual-subgraph-extractor.yml
+++ b/.github/workflows/manual-subgraph-extractor.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: production
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -18,20 +22,24 @@ jobs:
           INPUT_ENVIRONMENT: ${{ github.event.inputs.environment }}
         run: |
           if [ "$INPUT_ENVIRONMENT" = "production" ]; then
-            echo "AWS_ACCESS_KEY_ID=${{ secrets.PRODUCTION_WAYPOINT_AWS_ACCESS_KEY }}" >> $GITHUB_ENV
-            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.PRODUCTION_WAYPOINT_AWS_SECRET }}" >> $GITHUB_ENV
+            echo "AWS_ROLE_ARN=arn:aws:iam::120317779495:role/waypoint" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_TOKEN=${{ secrets.PRODUCTION_WAYPOINT_SERVER_TOKEN }}" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_ADDR=${{ secrets.PRODUCTION_WAYPOINT_SERVER_ADDR }}" >> $GITHUB_ENV
             cp waypoint.prod.hcl waypoint.hcl
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
-            echo "AWS_ACCESS_KEY_ID=${{ secrets.STAGING_WAYPOINT_AWS_ACCESS_KEY }}" >> $GITHUB_ENV
-            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.STAGING_WAYPOINT_AWS_SECRET }}" >> $GITHUB_ENV
+            echo "AWS_ROLE_ARN=arn:aws:iam::680542703984:role/waypoint" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_TOKEN=${{ secrets.STAGING_WAYPOINT_SERVER_TOKEN }}" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_ADDR=${{ secrets.STAGING_WAYPOINT_SERVER_ADDR }}" >> $GITHUB_ENV
           else
             echo "unrecognized environment"
             exit 1;
           fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: us-east-1
 
       - name: Deploy subgraph extractor
         uses: ./.github/actions/deploy-subgraph-extractor

--- a/.github/workflows/manual-web-client.yml
+++ b/.github/workflows/manual-web-client.yml
@@ -18,12 +18,10 @@ jobs:
           INPUT_ENVIRONMENT: ${{ github.event.inputs.environment }}
         run: |
           if [ "$INPUT_ENVIRONMENT" = "production" ]; then
-            echo "EMBER_DEPLOY_AWS_ACCESS_KEY=${{ secrets.PRODUCTION_EMBER_DEPLOY_AWS_ACCESS_KEY }}" >> $GITHUB_ENV
-            echo "EMBER_DEPLOY_AWS_ACCESS_SECRET=${{ secrets.PRODUCTION_EMBER_DEPLOY_AWS_ACCESS_SECRET }}" >> $GITHUB_ENV
+            echo "AWS_ROLE_ARN=arn:aws:iam::120317779495:role/web-client" >> $GITHUB_ENV
             echo "HUB_URL=https://hub.cardstack.com" >> $GITHUB_ENV
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
-            echo "EMBER_DEPLOY_AWS_ACCESS_KEY=${{ secrets.STAGING_EMBER_DEPLOY_AWS_ACCESS_KEY }}" >> $GITHUB_ENV
-            echo "EMBER_DEPLOY_AWS_ACCESS_SECRET=${{ secrets.STAGING_EMBER_DEPLOY_AWS_ACCESS_SECRET }}" >> $GITHUB_ENV
+            echo "AWS_ROLE_ARN=arn:aws:iam::680542703984:role/web-client" >> $GITHUB_ENV
             echo "HUB_URL=https://hub-staging.stack.cards" >> $GITHUB_ENV
           else
             echo "unrecognized environment"
@@ -37,6 +35,12 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: us-east-1
 
       - name: Deploy web-client
         uses: ./.github/actions/deploy-web-client

--- a/.github/workflows/manual-web-client.yml
+++ b/.github/workflows/manual-web-client.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: production
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-boxel.yml
+++ b/.github/workflows/pr-boxel.yml
@@ -50,7 +50,6 @@ jobs:
         with:
           files: |
             ^packages/boxel
-            ^.github/workflows/pr-boxel.yml
 
   deploy-boxel-preview:
     name: Deploy a preview to S3

--- a/.github/workflows/pr-boxel.yml
+++ b/.github/workflows/pr-boxel.yml
@@ -10,6 +10,9 @@ on:
 
 permissions:
   contents: read
+  issues: read
+  checks: write
+  pull-requests: write
   id-token: write
 
 jobs:

--- a/.github/workflows/pr-boxel.yml
+++ b/.github/workflows/pr-boxel.yml
@@ -2,12 +2,15 @@ name: CI [boxel]
 
 on:
   pull_request:
-    branches: [main]
     paths:
-      - 'packages/boxel/**'
-      - '.github/workflows/pr-boxel.yml'
-      - 'package.json'
-      - 'yarn.lock'
+      - "packages/boxel/**"
+      - ".github/workflows/pr-boxel.yml"
+      - "package.json"
+      - "yarn.lock"
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   test:
@@ -75,11 +78,13 @@ jobs:
         run: yarn test:boxel:percy
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_BOXEL }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::680542703984:role/boxel
+          aws-region: us-east-1
       - name: Deploy preview
         run: yarn deploy:boxel:preview
-        env:
-          PREVIEW_DEPLOY_AWS_ACCESS_KEY: ${{ secrets.PREVIEW_DEPLOY_AWS_ACCESS_KEY }}
-          PREVIEW_DEPLOY_AWS_ACCESS_SECRET: ${{ secrets.PREVIEW_DEPLOY_AWS_ACCESS_SECRET }}
 
   comment-on-boxel-pr:
     name: Comment on PR

--- a/.github/workflows/pr-boxel.yml
+++ b/.github/workflows/pr-boxel.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           files: |
             ^packages/boxel
+            ^.github/workflows/pr-boxel.yml
 
   deploy-boxel-preview:
     name: Deploy a preview to S3

--- a/.github/workflows/pr-cardpay-subgraph.yml
+++ b/.github/workflows/pr-cardpay-subgraph.yml
@@ -1,14 +1,14 @@
 name: CI [cardpay-subgraph]
+
 on:
   pull_request:
-    branches: [main]
     paths:
-      - 'packages/cardpay-sdk/**'
-      - 'packages/cardpay-subgraph/**'
-      - 'packages/eslint-config/**'
-      - '.github/workflows/pr-cardpay-subgraph.yml'
-      - 'package.json'
-      - 'yarn.lock'
+      - "packages/cardpay-sdk/**"
+      - "packages/cardpay-subgraph/**"
+      - "packages/eslint-config/**"
+      - ".github/workflows/pr-cardpay-subgraph.yml"
+      - "package.json"
+      - "yarn.lock"
 
 jobs:
   test:

--- a/.github/workflows/pr-did-resolver.yml
+++ b/.github/workflows/pr-did-resolver.yml
@@ -2,14 +2,13 @@ name: CI [did-resolver]
 
 on:
   pull_request:
-    branches: [main]
     paths:
-      - 'packages/did-resolver/**'
-      - 'packages/test-support/**'
-      - 'packages/eslint-config/**'
-      - '.github/workflows/pr-did-resolver.yml'
-      - 'package.json'
-      - 'yarn.lock'
+      - "packages/did-resolver/**"
+      - "packages/test-support/**"
+      - "packages/eslint-config/**"
+      - ".github/workflows/pr-did-resolver.yml"
+      - "package.json"
+      - "yarn.lock"
 
 jobs:
   test:

--- a/.github/workflows/pr-discord-bot.yml
+++ b/.github/workflows/pr-discord-bot.yml
@@ -2,14 +2,13 @@ name: CI [discord-bot]
 
 on:
   pull_request:
-    branches: [main]
     paths:
-      - 'packages/discord-bot/**'
-      - 'packages/test-support/**'
-      - 'packages/eslint-config/**'
-      - '.github/workflows/pr-discord-bot.yml'
-      - 'package.json'
-      - 'yarn.lock'
+      - "packages/discord-bot/**"
+      - "packages/test-support/**"
+      - "packages/eslint-config/**"
+      - ".github/workflows/pr-discord-bot.yml"
+      - "package.json"
+      - "yarn.lock"
 
 jobs:
   test:

--- a/.github/workflows/pr-hub.yml
+++ b/.github/workflows/pr-hub.yml
@@ -2,19 +2,18 @@ name: CI [hub]
 
 on:
   pull_request:
-    branches: [main]
     paths:
-      - 'packages/hub/**'
-      - 'packages/cardpay-sdk/**'
-      - 'packages/discord-bot/**'
-      - 'packages/did-resolver/**'
-      - 'packages/wc-provider/**'
-      - 'packages/test-support/**'
-      - 'packages/core/**'
-      - 'packages/eslint-config/**'
-      - '.github/workflows/hub.yml'
-      - 'package.json'
-      - 'yarn.lock'
+      - "packages/hub/**"
+      - "packages/cardpay-sdk/**"
+      - "packages/discord-bot/**"
+      - "packages/did-resolver/**"
+      - "packages/wc-provider/**"
+      - "packages/test-support/**"
+      - "packages/core/**"
+      - "packages/eslint-config/**"
+      - ".github/workflows/hub.yml"
+      - "package.json"
+      - "yarn.lock"
 
 jobs:
   test:

--- a/.github/workflows/pr-linter-check.yml
+++ b/.github/workflows/pr-linter-check.yml
@@ -2,6 +2,10 @@ name: CI [linter-check]
 
 on:
   pull_request:
+    paths:
+      - "**.js"
+      - "**.ts"
+      - "**.json"
 
 jobs:
   test:

--- a/.github/workflows/pr-ssr-web.yml
+++ b/.github/workflows/pr-ssr-web.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           files: |
             ^packages/ssr-web
-            ^.github/workflows/pr-ssr-web.yml
 
   deploy-ssr-preview-staging:
     name: Deploy a ssr-web staging preview to S3

--- a/.github/workflows/pr-ssr-web.yml
+++ b/.github/workflows/pr-ssr-web.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           files: |
             ^packages/ssr-web
+            ^.github/workflows/pr-ssr-web.yml
 
   deploy-ssr-preview-staging:
     name: Deploy a ssr-web staging preview to S3

--- a/.github/workflows/pr-ssr-web.yml
+++ b/.github/workflows/pr-ssr-web.yml
@@ -14,6 +14,9 @@ on:
 
 permissions:
   contents: read
+  issues: read
+  checks: write
+  pull-requests: write
   id-token: write
 
 jobs:

--- a/.github/workflows/pr-ssr-web.yml
+++ b/.github/workflows/pr-ssr-web.yml
@@ -3,14 +3,18 @@ name: CI [ssr-web]
 on:
   pull_request:
     paths:
-      - 'packages/ssr-web/**'
-      - 'packages/boxel/**'
-      - 'packages/cardpay-sdk/**'
-      - 'packages/did-resolver/**'
-      - 'packages/eslint-config/**'
-      - '.github/workflows/pr-ssr-web.yml'
-      - 'package.json'
-      - 'yarn.lock'
+      - "packages/ssr-web/**"
+      - "packages/boxel/**"
+      - "packages/cardpay-sdk/**"
+      - "packages/did-resolver/**"
+      - "packages/eslint-config/**"
+      - ".github/workflows/pr-ssr-web.yml"
+      - "package.json"
+      - "yarn.lock"
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   test:
@@ -43,7 +47,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v1.28
         if: always()
         with:
-          check_name: 'ssr-web test results'
+          check_name: "ssr-web test results"
           files: ci-xml-test-results/ssr-web.xml
 
   check-if-requires-preview:
@@ -71,11 +75,14 @@ jobs:
     needs: check-if-requires-preview
     steps:
       - uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::680542703984:role/ssr-web
+          aws-region: us-east-1
       - name: Deploy ssr-web preview
         uses: ./.github/actions/deploy-ember-preview
         env:
-          PREVIEW_DEPLOY_AWS_ACCESS_KEY: ${{ secrets.SSR_WEB_STAGING_EMBER_DEPLOY_AWS_ACCESS_KEY }}
-          PREVIEW_DEPLOY_AWS_ACCESS_SECRET: ${{ secrets.SSR_WEB_STAGING_EMBER_DEPLOY_AWS_SECRET }}
           HUB_URL: https://hub-staging.stack.cards
           SENTRY_AUTH_TOKEN: ${{ secrets.SSR_WEB_SENTRY_AUTH_TOKEN }}
           SENTRY_DSN: ${{ secrets.SSR_WEB_SENTRY_DSN }}
@@ -95,11 +102,14 @@ jobs:
     needs: check-if-requires-preview
     steps:
       - uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::120317779495:role/ssr-web
+          aws-region: us-east-1
       - name: Deploy ssr-web preview
         uses: ./.github/actions/deploy-ember-preview
         env:
-          PREVIEW_DEPLOY_AWS_ACCESS_KEY: ${{ secrets.SSR_WEB_PROD_EMBER_DEPLOY_AWS_ACCESS_KEY }}
-          PREVIEW_DEPLOY_AWS_ACCESS_SECRET: ${{ secrets.SSR_WEB_PROD_EMBER_DEPLOY_AWS_SECRET }}
           HUB_URL: https://hub.cardstack.com
           SENTRY_AUTH_TOKEN: ${{ secrets.SSR_WEB_SENTRY_AUTH_TOKEN }}
           SENTRY_DSN: ${{ secrets.SSR_WEB_SENTRY_DSN }}

--- a/.github/workflows/pr-waypoint.yml
+++ b/.github/workflows/pr-waypoint.yml
@@ -2,13 +2,16 @@ name: CI [waypoint]
 
 on:
   pull_request:
-    branches: [main]
     paths:
-      - '.github/workflows/pr-waypoint.yml'
-      - 'package.json'
-      - 'waypoint.hcl'
-      - 'waypoint.prod.hcl'
-      - 'yarn.lock'
+      - ".github/workflows/pr-waypoint.yml"
+      - "package.json"
+      - "waypoint.hcl"
+      - "waypoint.prod.hcl"
+      - "yarn.lock"
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   check:
@@ -27,19 +30,22 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn --prefer-offline
+      - name: Configure staging AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::680542703984:role/waypoint
+          aws-region: us-east-1
       - name: Check access to secrets specified in waypoint.hcl
         uses: ./.github/actions/check-secrets
         with:
           waypoint_config_file: waypoint.hcl
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_WAYPOINT_AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_WAYPOINT_AWS_SECRET }}
+      - name: Configure prod AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::120317779495:role/waypoint
+          aws-region: us-east-1
       - name: Check access to secrets specified in waypoint.prod.hcl
         uses: ./.github/actions/check-secrets
         with:
           waypoint_config_file: waypoint.prod.hcl
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_WAYPOINT_AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_WAYPOINT_AWS_SECRET }}
+

--- a/.github/workflows/pr-wc-provider.yml
+++ b/.github/workflows/pr-wc-provider.yml
@@ -2,12 +2,11 @@ name: CI [wc-provider]
 
 on:
   pull_request:
-    branches: [main]
     paths:
-      - 'packages/wc-provider/**'
-      - 'packages/eslint-config/**'
-      - 'package.json'
-      - 'yarn.lock'
+      - "packages/wc-provider/**"
+      - "packages/eslint-config/**"
+      - "package.json"
+      - "yarn.lock"
 
 jobs:
   test:

--- a/.github/workflows/pr-web-client.yml
+++ b/.github/workflows/pr-web-client.yml
@@ -70,6 +70,7 @@ jobs:
         with:
           files: |
             ^packages/web-client
+            ^.github/workflows/pr-web-client.yml
 
   deploy-web-client-preview-staging:
     name: Deploy a staging preview to S3

--- a/.github/workflows/pr-web-client.yml
+++ b/.github/workflows/pr-web-client.yml
@@ -3,16 +3,20 @@ name: CI [web-client]
 on:
   pull_request:
     paths:
-      - 'packages/web-client/**'
-      - 'packages/boxel/**'
-      - 'packages/cardpay-sdk/**'
-      - 'packages/did-resolver/**'
-      - 'packages/wc-provider/**'
-      - 'packages/test-support/**'
-      - 'packages/eslint-config/**'
-      - '.github/workflows/pr-web-client.yml'
-      - 'package.json'
-      - 'yarn.lock'
+      - "packages/web-client/**"
+      - "packages/boxel/**"
+      - "packages/cardpay-sdk/**"
+      - "packages/did-resolver/**"
+      - "packages/wc-provider/**"
+      - "packages/test-support/**"
+      - "packages/eslint-config/**"
+      - ".github/workflows/pr-web-client.yml"
+      - "package.json"
+      - "yarn.lock"
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   test:
@@ -45,7 +49,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v1.28
         if: always()
         with:
-          check_name: 'web-client test results'
+          check_name: "web-client test results"
           files: ci-xml-test-results/web-client.xml
 
   check-if-requires-preview:
@@ -73,11 +77,14 @@ jobs:
     needs: check-if-requires-preview
     steps:
       - uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::680542703984:role/web-client
+          aws-region: us-east-1
       - name: Deploy web-client preview
         uses: ./.github/actions/deploy-web-client-preview
         env:
-          PREVIEW_DEPLOY_AWS_ACCESS_KEY: ${{ secrets.STAGING_EMBER_DEPLOY_AWS_ACCESS_KEY }}
-          PREVIEW_DEPLOY_AWS_ACCESS_SECRET: ${{ secrets.STAGING_EMBER_DEPLOY_AWS_ACCESS_SECRET }}
           HUB_URL: https://hub-staging.stack.cards
           SENTRY_AUTH_TOKEN: ${{ secrets.WEB_CLIENT_SENTRY_AUTH_TOKEN }}
           SENTRY_DSN: ${{ secrets.WEB_CLIENT_SENTRY_DSN }}
@@ -95,11 +102,14 @@ jobs:
     needs: check-if-requires-preview
     steps:
       - uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::120317779495:role/web-client
+          aws-region: us-east-1
       - name: Deploy web-client preview
         uses: ./.github/actions/deploy-web-client-preview
         env:
-          PREVIEW_DEPLOY_AWS_ACCESS_KEY: ${{ secrets.PRODUCTION_EMBER_DEPLOY_AWS_ACCESS_KEY }}
-          PREVIEW_DEPLOY_AWS_ACCESS_SECRET: ${{ secrets.PRODUCTION_EMBER_DEPLOY_AWS_ACCESS_SECRET }}
           HUB_URL: https://hub-staging.stack.cards
           SENTRY_AUTH_TOKEN: ${{ secrets.WEB_CLIENT_SENTRY_AUTH_TOKEN }}
           SENTRY_DSN: ${{ secrets.WEB_CLIENT_SENTRY_DSN }}

--- a/.github/workflows/pr-web-client.yml
+++ b/.github/workflows/pr-web-client.yml
@@ -70,7 +70,6 @@ jobs:
         with:
           files: |
             ^packages/web-client
-            ^.github/workflows/pr-web-client.yml
 
   deploy-web-client-preview-staging:
     name: Deploy a staging preview to S3

--- a/.github/workflows/pr-web-client.yml
+++ b/.github/workflows/pr-web-client.yml
@@ -16,6 +16,9 @@ on:
 
 permissions:
   contents: read
+  issues: read
+  checks: write
+  pull-requests: write
   id-token: write
 
 jobs:

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -6,6 +6,9 @@ on:
 
 permissions:
   contents: read
+  issues: read
+  checks: write
+  pull-requests: write
   id-token: write
 
 jobs:

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   lint:
     name: Lint All
@@ -43,23 +47,25 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn --prefer-offline
+      - name: Configure staging AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::680542703984:role/waypoint
+          aws-region: us-east-1
       - name: Check access to secrets specified in waypoint.hcl
         uses: ./.github/actions/check-secrets
         with:
           waypoint_config_file: waypoint.hcl
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_WAYPOINT_AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_WAYPOINT_AWS_SECRET }}
+      - name: Configure prod AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::120317779495:role/waypoint
+          aws-region: us-east-1
       - name: Check access to secrets specified in waypoint.prod.hcl
         uses: ./.github/actions/check-secrets
         with:
           waypoint_config_file: waypoint.prod.hcl
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_WAYPOINT_AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_WAYPOINT_AWS_SECRET }}
-          
+
   test_all_but_web_client:
     name: hub, did-resolver Build/Test
     needs: lint
@@ -141,13 +147,13 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v1.28
         if: always()
         with:
-          check_name: 'web-client test results'
+          check_name: "web-client test results"
           files: ci-xml-test-results/web-client.xml
       - name: Publish ssr-web test results
         uses: EnricoMi/publish-unit-test-result-action@v1.28
         if: always()
         with:
-          check_name: 'ssr-web test results'
+          check_name: "ssr-web test results"
           files: ci-xml-test-results/ssr-web.xml
 
   change_check:
@@ -219,12 +225,14 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::680542703984:role/waypoint
+          aws-region: us-east-1
       - name: Deploy hub
         uses: ./.github/actions/deploy-hub
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_WAYPOINT_AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_WAYPOINT_AWS_SECRET }}
-          AWS_DEFAULT_REGION: us-east-1
           WAYPOINT_SERVER_TOKEN: ${{ secrets.STAGING_WAYPOINT_SERVER_TOKEN }}
           WAYPOINT_SERVER_ADDR: ${{ secrets.STAGING_WAYPOINT_SERVER_ADDR }}
         with:
@@ -262,11 +270,14 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::680542703984:role/web-client
+          aws-region: us-east-1
       - name: Deploy web-client
         uses: ./.github/actions/deploy-web-client
         env:
-          EMBER_DEPLOY_AWS_ACCESS_KEY: ${{ secrets.STAGING_EMBER_DEPLOY_AWS_ACCESS_KEY }}
-          EMBER_DEPLOY_AWS_ACCESS_SECRET: ${{ secrets.STAGING_EMBER_DEPLOY_AWS_ACCESS_SECRET }}
           HUB_URL: https://hub-staging.stack.cards
           SENTRY_AUTH_TOKEN: ${{ secrets.WEB_CLIENT_SENTRY_AUTH_TOKEN }}
           SENTRY_DSN: ${{ secrets.WEB_CLIENT_SENTRY_DSN }}
@@ -305,13 +316,15 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::680542703984:role/waypoint
+          aws-region: us-east-1
       - name: Deploy ssr-web
         uses: ./.github/actions/deploy-ssr-web
         env:
           HUB_URL: https://hub-staging.stack.cards
-          AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_WAYPOINT_AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_WAYPOINT_AWS_SECRET }}
-          AWS_DEFAULT_REGION: us-east-1
           WAYPOINT_SERVER_TOKEN: ${{ secrets.STAGING_WAYPOINT_SERVER_TOKEN }}
           WAYPOINT_SERVER_ADDR: ${{ secrets.STAGING_WAYPOINT_SERVER_ADDR }}
           SENTRY_DSN: ${{ secrets.SSR_WEB_CLIENT_SENTRY_DSN }}
@@ -352,6 +365,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn --prefer-offline
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::680542703984:role/boxel
+          aws-region: us-east-1
       - name: Deploy preview
         run: yarn deploy:boxel
         env:
@@ -359,8 +377,24 @@ jobs:
           S3_PREVIEW_ASSET_BUCKET_NAME: boxel-preview-assets.cardstack.com
           S3_PREVIEW_ASSET_BUCKET_ENDPOINT: https://s3.us-east-1.amazonaws.com/boxel-preview-assets.cardstack.com
           S3_PREVIEW_REGION: us-east-1
-          PREVIEW_DEPLOY_AWS_ACCESS_KEY: ${{ secrets.PREVIEW_DEPLOY_AWS_ACCESS_KEY }}
-          PREVIEW_DEPLOY_AWS_ACCESS_SECRET: ${{ secrets.PREVIEW_DEPLOY_AWS_ACCESS_SECRET }}
+      - name: Send success notification to Discord
+        if: ${{ success() }}
+        uses: ./.github/actions/discord-message
+        with:
+          token: ${{ secrets.DISCORD_TOKEN }}
+          channel: ${{ secrets.DISCORD_CHANNEL }}
+          message: |
+            :checkered_flag: **boxel** [main] has been successfully deployed to *staging*
+            :arrow_forward: Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      - name: Send failure notification to Discord
+        if: ${{ failure() }}
+        uses: ./.github/actions/discord-message
+        with:
+          token: ${{ secrets.DISCORD_TOKEN }}
+          channel: ${{ secrets.DISCORD_CHANNEL }}
+          message: |
+            :warning: **boxel** [main] has failed to deploy to *staging*
+            :arrow_forward: Workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   deploy-cardie:
     name: Deploy cardie via waypoint
@@ -376,12 +410,14 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::680542703984:role/waypoint
+          aws-region: us-east-1
       - name: Deploy cardie
         uses: ./.github/actions/deploy-cardie
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_WAYPOINT_AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_WAYPOINT_AWS_SECRET }}
-          AWS_DEFAULT_REGION: us-east-1
           WAYPOINT_SERVER_TOKEN: ${{ secrets.STAGING_WAYPOINT_SERVER_TOKEN }}
           WAYPOINT_SERVER_ADDR: ${{ secrets.STAGING_WAYPOINT_SERVER_ADDR }}
         with:


### PR DESCRIPTION
This PR removes all the usage of `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, replacing them with [AWS assumable OIDC role](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) via [aws-configure-credentials](https://github.com/marketplace/actions/configure-aws-credentials-action-for-github-actions).

Also remove allow all PR workflows to run on all target branches instead of `main` only.
[CS-3948](https://linear.app/cardstack/issue/CS-3948/use-oidc-auth-for-aws-in-github-actions-instead-of-credentials)