### PR TITLE
expandable banner focus shown on details

### DIFF
--- a/packages/boxel/addon/components/boxel/expandable-banner/index.css
+++ b/packages/boxel/addon/components/boxel/expandable-banner/index.css
@@ -71,13 +71,26 @@
   content: "";
 }
 
-.boxel-expandable-banner__summary:focus {
-  outline: var(--boxel-outline);
-  outline-offset: -4px;
+@supports not selector(:has(.boxel-expandable-banner:focus-visible)) {
+  .boxel-expandable-banner__summary:focus {
+    outline: var(--boxel-outline);
+    outline-offset: -4px;
+  }
+
+  .boxel-expandable-banner__summary:focus:not(:focus-visible) {
+    outline: transparent;
+  }
 }
 
-.boxel-expandable-banner__summary:focus:not(:focus-visible) {
-  outline: transparent;
+@supports selector(:has(.boxel-expandable-banner:focus-visible)) {
+  /* hide the focus outline here, but keep it visible for high contrast color schemes */
+  .boxel-expandable-banner__summary:focus {
+    outline: transparent;
+  }
+
+  .boxel-expandable-banner__details:has(.boxel-expandable-banner__summary:focus-visible) {
+    outline: var(--boxel-outline);
+  }
 }
 
 /* style our custom markers */


### PR DESCRIPTION
Will follow up by checking whether this works properly when Chrome 105 is released, in https://linear.app/cardstack/issue/CS-3969/check-whether-fix-works-properly-on-chrome-105. The screenshots below are taken in Safari 15.5, demonstrating the fix that takes into account non-summary elements being focused.
 
<img width="986" alt="ExpandableBanner component opened. Focus outline sits outside the whole element." src="https://user-images.githubusercontent.com/39579264/171003830-98ee2507-e01b-4044-8654-fa270f2a50ad.png">
<img width="985" alt="ExpandableBanner component closed. Focus outline sits outside the whole element." src="https://user-images.githubusercontent.com/39579264/171003864-c968cf10-fd6a-4b8b-b1be-a3561135b344.png">
<img width="975" alt="ExpandableBanner component opened. Focus outline is on a link within the component." src="https://user-images.githubusercontent.com/39579264/171003896-8a28c49f-56e7-4e30-8e59-deb57e1aea1a.png">
