### PR TITLE
ci: Update default environment for deployments to staging

### DIFF
--- a/.github/workflows/manual-hub.yml
+++ b/.github/workflows/manual-hub.yml
@@ -6,7 +6,7 @@ on:
       environment:
         description: Deployment environment
         required: false
-        default: production
+        default: staging
 
 jobs:
   deploy:

--- a/.github/workflows/manual-reward-api.yml
+++ b/.github/workflows/manual-reward-api.yml
@@ -6,7 +6,7 @@ on:
       environment:
         description: Deployment environment
         required: false
-        default: production
+        default: staging
 
 jobs:
   deploy:

--- a/.github/workflows/manual-reward-root-submitter.yml
+++ b/.github/workflows/manual-reward-root-submitter.yml
@@ -6,7 +6,7 @@ on:
       environment:
         description: Deployment environment
         required: false
-        default: production
+        default: staging
 
 jobs:
   deploy:

--- a/.github/workflows/manual-ssr-web.yml
+++ b/.github/workflows/manual-ssr-web.yml
@@ -6,7 +6,7 @@ on:
       environment:
         description: Deployment environment
         required: false
-        default: production
+        default: staging
 
 jobs:
   deploy:

--- a/.github/workflows/manual-subgraph-extractor.yml
+++ b/.github/workflows/manual-subgraph-extractor.yml
@@ -6,7 +6,7 @@ on:
       environment:
         description: Deployment environment
         required: false
-        default: production
+        default: staging
 
 jobs:
   deploy:

--- a/.github/workflows/manual-web-client.yml
+++ b/.github/workflows/manual-web-client.yml
@@ -6,7 +6,7 @@ on:
       environment:
         description: Deployment environment
         required: false
-        default: production
+        default: staging
 
 jobs:
   deploy:

--- a/packages/cardie/config.json
+++ b/packages/cardie/config.json
@@ -3,7 +3,7 @@
   "allowedGuilds": ["584043165066199050"],
   "deploy": {
     "default": {
-      "environment": "production"
+      "environment": "staging"
     },
     "allowedChannels": ["866667164764471346"],
     "allowedRoles": ["Engineering Team", "Cardstack Core Team"]


### PR DESCRIPTION
There was an unintentional deploy to production via cardie in the #releases-internal channel.
Updating the default target environment to staging should bring us a few benefits:
- Deployments to staging happen more frequently than production, both manual and automatic ones
- Reduce chance of mistakenly deploy to production

Related discussion: https://discord.com/channels/584043165066199050/981170005611790366/981177982267838514

Closes [CS-3975](https://linear.app/cardstack/issue/CS-3975/update-default-environment-for-deployments-via-cardie-or-github)