### PR TITLE
Better withdrawal waiting UX

### DIFF
--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.hbs
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.hbs
@@ -49,7 +49,13 @@
         <a href={{this.bridgeExplorerUrl}} target="_blank" rel="noopener noreferrer">here</a>.
       </p>
     {{/if}}
-    {{#if this.error}}
+    {{#if (eq this.error this.TIMEOUT_ERROR)}}
+      <CardPay::ErrorMessage data-test-withdrawal-transaction-status-error>
+        It took too long to confirm your transaction, this could be caused by network issues.
+        Please refresh this tab - you'll be brought back to this step in the workflow and we'll try to confirm it again.
+        If that doesn't work, please contact <a href={{config 'urls.mailToSupportUrl'}} target="_blank" rel="noopener noreferrer">Cardstack support</a>.
+      </CardPay::ErrorMessage>
+    {{else if this.error}}
       <CardPay::ErrorMessage data-test-withdrawal-transaction-status-error>
         There was a problem completing the bridging of your tokens to {{network-display-info "layer1" "fullName"}}. Please contact <a href={{config 'urls.mailToSupportUrl'}} target="_blank" rel="noopener noreferrer">Cardstack support</a> so that we can investigate and resolve this issue for you.
       </CardPay::ErrorMessage>

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.ts
@@ -57,7 +57,7 @@ class CardPayWithdrawalWorkflowTransactionStatusComponent extends Component<Work
     this.blockCount = 1;
     let blockNumber = transactionReceipt.blockNumber;
     while (this.blockCount <= this.totalBlockCount) {
-      // the expected block time for a single block on Gnosis chain is 10-20s.
+      // the average block time for a single block on Gnosis chain is 5s.
       // we are only incrementing block by 1, so giving 120s is already a fair amount of time
       // if it times out even then, the user probably needs to refresh
       yield this.layer2Network.getBlockConfirmation(

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/transaction-status/index.ts
@@ -54,7 +54,13 @@ class CardPayWithdrawalWorkflowTransactionStatusComponent extends Component<Work
     this.blockCount = 1;
     let blockNumber = transactionReceipt.blockNumber;
     while (this.blockCount <= this.totalBlockCount) {
-      yield this.layer2Network.getBlockConfirmation(blockNumber++);
+      // the expected block time for a single block on Gnosis chain is 10-20s.
+      // we are only incrementing block by 1, so giving 120s is already a fair amount of time
+      // if it times out even then, the user probably needs to refresh
+      yield this.layer2Network.getBlockConfirmation(
+        blockNumber++,
+        2 * 60 * 1000
+      );
       this.blockCount++;
     }
   }

--- a/packages/web-client/app/services/layer2-network.ts
+++ b/packages/web-client/app/services/layer2-network.ts
@@ -240,8 +240,11 @@ export default class Layer2Network
     return this.simpleEmitter.on(event, cb);
   }
 
-  async getBlockConfirmation(blockNumber: TxnBlockNumber): Promise<void> {
-    return this.strategy.getBlockConfirmation(blockNumber);
+  async getBlockConfirmation(
+    blockNumber: TxnBlockNumber,
+    duration?: number
+  ): Promise<void> {
+    return this.strategy.getBlockConfirmation(blockNumber, duration);
   }
 
   getBlockHeight() {

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -491,10 +491,13 @@ export default abstract class Layer2ChainWeb3Strategy
     )}/tx/${txnHash}`;
   }
 
-  async getBlockConfirmation(blockNumber: TxnBlockNumber): Promise<void> {
+  async getBlockConfirmation(
+    blockNumber: TxnBlockNumber,
+    duration?: number
+  ): Promise<void> {
     if (!this.web3)
       throw new Error('Cannot get block confirmations without web3');
-    return await waitUntilBlock(this.web3, blockNumber);
+    return await waitUntilBlock(this.web3, blockNumber, duration);
   }
 
   async getBlockHeight(): Promise<BN> {

--- a/packages/web-client/app/utils/web3-strategies/test-layer2.ts
+++ b/packages/web-client/app/utils/web3-strategies/test-layer2.ts
@@ -133,7 +133,10 @@ export default class TestLayer2Web3Strategy implements Layer2Web3Strategy {
     };
   }
 
-  async getBlockConfirmation(_blockNumber: TxnBlockNumber): Promise<void> {
+  async getBlockConfirmation(
+    _blockNumber: TxnBlockNumber,
+    _duration?: number
+  ): Promise<void> {
     if (this.test__autoResolveBlockConfirmations) {
       return Promise.resolve();
     } else {

--- a/packages/web-client/app/utils/web3-strategies/types.ts
+++ b/packages/web-client/app/utils/web3-strategies/types.ts
@@ -116,7 +116,7 @@ export interface Layer2Web3Strategy
     symbolsToUpdate: UsdConvertibleSymbol[]
   ): Promise<Record<UsdConvertibleSymbol, ConversionFunction>>;
   blockExplorerUrl(txnHash: TransactionHash): string;
-  getBlockConfirmation(blockNumber: number): Promise<void>;
+  getBlockConfirmation(blockNumber: number, duration?: number): Promise<void>;
   getBlockHeight(): Promise<BN>;
   awaitBridgedToLayer2(
     fromBlock: BN,


### PR DESCRIPTION
Lower timeout duration since Gnosis chain only needs 5s per new block. Identify the timeout error when it happens, and ask users to try refreshing their browser as a first course of action.