### PR TITLE
Don't allow editing of previous fields once unlock is done

### DIFF
--- a/packages/web-client/app/components/card-pay/deposit-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/deposit-workflow/index.ts
@@ -47,6 +47,9 @@ class DepositWorkflow extends Workflow {
   milestones = [
     new Milestone({
       title: MILESTONE_TITLES[0],
+      editableIf(session) {
+        return !session.getValue('unlockTxnHash');
+      },
       postables: [
         new WorkflowMessage({
           message: 'Hi there, we’re happy to see you!',
@@ -85,6 +88,9 @@ class DepositWorkflow extends Workflow {
     }),
     new Milestone({
       title: MILESTONE_TITLES[1],
+      editableIf(session) {
+        return !session.getValue('unlockTxnHash');
+      },
       postables: [
         new NetworkAwareWorkflowMessage({
           message: `Looks like you’ve already connected your ${c.layer2.fullName} wallet, which you can see below.
@@ -125,6 +131,9 @@ class DepositWorkflow extends Workflow {
         new WorkflowCard({
           cardName: 'TXN_SETUP',
           componentName: 'card-pay/deposit-workflow/transaction-setup',
+          editableIf(session) {
+            return !session.getValue('unlockTxnHash');
+          },
         }),
         new WorkflowMessage({
           message: 'How many tokens would you like to deposit?',

--- a/packages/web-client/app/components/workflow-thread/index.hbs
+++ b/packages/web-client/app/components/workflow-thread/index.hbs
@@ -40,7 +40,7 @@
         <WorkflowThread::Postable
           @postable={{postable}}
           @previous={{object-at milestone.visiblePostables (dec j)}}
-          @frozen={{this.frozen}}
+          @frozen={{or this.frozen (not milestone.isEditable) (not postable.isEditable)}}
           @index={{j}}
           data-test-milestone={{i}}
         />

--- a/packages/web-client/app/models/animated-workflow.ts
+++ b/packages/web-client/app/models/animated-workflow.ts
@@ -22,6 +22,7 @@ class AnimatedMilestone {
   model: Milestone;
   @reads('model.completedDetail') declare completedDetail: string;
   @reads('model.title') declare title: string;
+  @reads('model.isEditable') declare isEditable: boolean;
   @tracked isCompletionRevealed = false;
   @reads('postableCollection.visiblePostables')
   declare visiblePostables: WorkflowPostable[];

--- a/packages/web-client/app/models/workflow/milestone.ts
+++ b/packages/web-client/app/models/workflow/milestone.ts
@@ -1,4 +1,4 @@
-import { Workflow } from '../workflow';
+import { IWorkflowSession, Workflow } from '../workflow';
 import PostableCollection from './postable-collection';
 import { WorkflowPostable } from './workflow-postable';
 
@@ -6,16 +6,21 @@ interface MilestoneOptions {
   title: string;
   postables: WorkflowPostable[];
   completedDetail: string;
+  editableIf?(session: IWorkflowSession): boolean;
 }
 export class Milestone {
   title: string;
   postableCollection: PostableCollection = new PostableCollection();
+  editableIf?(session: IWorkflowSession): boolean;
+
   setWorkflow(wf: Workflow) {
     this.postableCollection.setWorkflow(wf);
   }
+
   get workflow() {
     return this.postableCollection.workflow;
   }
+
   get visiblePostables() {
     return this.postableCollection.visiblePostables;
   }
@@ -24,12 +29,17 @@ export class Milestone {
     return this.postableCollection.isComplete;
   }
 
+  get isEditable() {
+    return this.editableIf ? this.editableIf(this.workflow!.session) : true;
+  }
+
   completedDetail;
 
   constructor(opts: MilestoneOptions) {
     this.title = opts.title;
     this.postableCollection.postables = opts.postables;
     this.completedDetail = opts.completedDetail;
+    this.editableIf = opts.editableIf;
   }
 
   peekAtVisiblePostables() {

--- a/packages/web-client/app/models/workflow/workflow-card.ts
+++ b/packages/web-client/app/models/workflow/workflow-card.ts
@@ -25,6 +25,7 @@ interface WorkflowCardOptions<T extends string> {
   author?: Participant;
   componentName: T; // this should eventually become a card reference
   includeIf?(this: WorkflowCard<T>): boolean;
+  editableIf?(session: IWorkflowSession): boolean;
   check?(this: WorkflowCard<T>): Promise<CheckResult>;
 }
 
@@ -45,6 +46,7 @@ export class WorkflowCard<T extends string = string> extends WorkflowPostable {
   cardName: string;
   componentName: T;
   config?: any;
+  editableIf?: (session: IWorkflowSession) => boolean;
   check: (this: WorkflowCard<T>) => Promise<CheckResult> = () => {
     return Promise.resolve({ success: true });
   };
@@ -106,6 +108,7 @@ export class WorkflowCard<T extends string = string> extends WorkflowPostable {
     super(options.author, options.includeIf);
     this.componentName = options.componentName!;
     this.cardName = options.cardName || '';
+    this.editableIf = options.editableIf;
     if (this.hasConfig(options)) this.config = options.config;
 
     this.reset = () => {
@@ -117,8 +120,13 @@ export class WorkflowCard<T extends string = string> extends WorkflowPostable {
       this.check = options.check as this['check'];
     }
   }
+
   get session(): IWorkflowSession | undefined {
     return this.workflow?.session;
+  }
+
+  get isEditable() {
+    return this.editableIf ? this.editableIf(this.workflow!.session) : true;
   }
 
   get completedCardNames(): Array<string> {

--- a/packages/web-client/tests/unit/models/workflow/milestone-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/milestone-test.ts
@@ -85,4 +85,51 @@ module('Unit | Milestone model', function (hooks) {
       assert.strictEqual(subject.workflow, workflow);
     });
   });
+
+  module('editable state', function () {
+    let author: Participant;
+    let postable1: WorkflowPostable;
+
+    hooks.beforeEach(function () {
+      author = { name: 'cardbot' };
+      postable1 = new WorkflowPostable(author);
+      (postable1 as any).name = 'postable1';
+      (postable1 as any).name = 'postable1';
+    });
+
+    test('isEditable is true by default', function (assert) {
+      let subject = new Milestone({
+        title: 'First Milestone',
+        postables: [postable1],
+        completedDetail: 'First in da bag',
+      });
+      assert.equal(subject.isEditable, true);
+    });
+
+    test('isEditable is false if editableIf returns false', function (assert) {
+      let subject = new Milestone({
+        title: 'First Milestone',
+        postables: [postable1],
+        completedDetail: 'First in da bag',
+        editableIf() {
+          return false;
+        },
+      });
+      subject.setWorkflow(new WorkflowStub(this.owner));
+      assert.equal(subject.isEditable, false);
+    });
+
+    test('isEditable is true if editableIf returns true', function (assert) {
+      let subject = new Milestone({
+        title: 'First Milestone',
+        postables: [postable1],
+        completedDetail: 'First in da bag',
+        editableIf() {
+          return true;
+        },
+      });
+      subject.setWorkflow(new WorkflowStub(this.owner));
+      assert.equal(subject.isEditable, true);
+    });
+  });
 });

--- a/packages/web-client/tests/unit/models/workflow/workflow-card-test.ts
+++ b/packages/web-client/tests/unit/models/workflow/workflow-card-test.ts
@@ -92,4 +92,36 @@ module('Unit | WorkflowCard model', function (hooks) {
     subject.onIncomplete();
     assert.equal(subject.isComplete, false);
   });
+
+  test('isEditable is true by default', function (assert) {
+    let subject = new WorkflowCard({
+      author: participant,
+      componentName: 'foo/bar',
+    });
+    assert.equal(subject.isEditable, true);
+  });
+
+  test('isEditable is false if editableIf returns false', function (assert) {
+    let subject = new WorkflowCard({
+      author: participant,
+      componentName: 'foo/bar',
+      editableIf() {
+        return false;
+      },
+    });
+    subject.setWorkflow(new WorkflowStub(this.owner));
+    assert.equal(subject.isEditable, false);
+  });
+
+  test('isEditable is true if editableIf returns true', function (assert) {
+    let subject = new WorkflowCard({
+      author: participant,
+      componentName: 'foo/bar',
+      editableIf() {
+        return true;
+      },
+    });
+    subject.setWorkflow(new WorkflowStub(this.owner));
+    assert.equal(subject.isEditable, true);
+  });
 });


### PR DESCRIPTION
This doesn't catch the case where the user is in the middle of unlocking but has not completed the signing request yet. It could, but unsure if worth it?

If this seems ok, the same should apply to the withdrawal flow.