### PR TITLE
Prevent editing workflow cards that precede card that is executing/has executed transaction

### DIFF
--- a/packages/boxel/addon/components/boxel/action-chin/index.hbs
+++ b/packages/boxel/addon/components/boxel/action-chin/index.hbs
@@ -7,6 +7,7 @@
   }}
   ...attributes
   data-test-boxel-action-chin
+  data-test-boxel-action-chin-state={{@state}}
 >
   {{!-- Not accounting for 0 as a step number --}}
   {{#if @stepNumber}}
@@ -50,6 +51,7 @@
         ActionButton=(component
           "boxel/button"
           kind="secondary-light"
+          class="boxel-action-chin__memorialized-action-button"
           disabled=@disabled
         )
         ActionStatusArea=(component

--- a/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/create-merchant-workflow/index.ts
@@ -55,6 +55,9 @@ class CreateMerchantWorkflow extends Workflow {
   milestones = [
     new Milestone({
       title: MILESTONE_TITLES[0],
+      editableIf(session) {
+        return !session.getValue('txnHash');
+      },
       postables: [
         new WorkflowMessage({
           message: `Hello, nice to see you!`,
@@ -139,6 +142,9 @@ class CreateMerchantWorkflow extends Workflow {
     }),
     new Milestone({
       title: MILESTONE_TITLES[1],
+      editableIf(session) {
+        return !session.getValue('txnHash');
+      },
       postables: [
         new NetworkAwareWorkflowMessage({
           message: `To store data in the Cardstack Hub, you need to authenticate using your Card Wallet.

--- a/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/issue-prepaid-card-workflow/index.ts
@@ -61,6 +61,9 @@ class IssuePrepaidCardWorkflow extends Workflow {
   milestones = [
     new Milestone({
       title: MILESTONE_TITLES[0],
+      editableIf(session) {
+        return !session.getValue('txnHash');
+      },
       postables: [
         new WorkflowMessage({
           message: `Hello, it’s nice to see you!`,
@@ -138,6 +141,9 @@ class IssuePrepaidCardWorkflow extends Workflow {
     }),
     new Milestone({
       title: MILESTONE_TITLES[1],
+      editableIf(session) {
+        return !session.getValue('txnHash');
+      },
       postables: [
         new NetworkAwareWorkflowMessage({
           message: `To store card customization data in the Cardstack Hub, you need to authenticate using your Card Wallet.
@@ -167,6 +173,9 @@ class IssuePrepaidCardWorkflow extends Workflow {
     }),
     new Milestone({
       title: MILESTONE_TITLES[2],
+      editableIf(session) {
+        return !session.getValue('txnHash');
+      },
       postables: [
         new WorkflowMessage({
           message: 'Nice choice!',

--- a/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
+++ b/packages/web-client/app/components/card-pay/withdrawal-workflow/index.ts
@@ -147,6 +147,9 @@ export class WithdrawalWorkflow extends Workflow {
   milestones = [
     new Milestone({
       title: MILESTONE_TITLES[0],
+      editableIf(session) {
+        return !session.getValue('relayTokensTxnHash');
+      },
       postables: [
         new WorkflowMessage({
           message: 'Hi there, it’s good to see you!',
@@ -180,6 +183,9 @@ export class WithdrawalWorkflow extends Workflow {
     }),
     new Milestone({
       title: MILESTONE_TITLES[1],
+      editableIf(session) {
+        return !session.getValue('relayTokensTxnHash');
+      },
       postables: [
         new CheckBalanceWorkflowMessage(),
         new WorkflowCard({
@@ -191,6 +197,9 @@ export class WithdrawalWorkflow extends Workflow {
     }),
     new Milestone({
       title: MILESTONE_TITLES[2],
+      editableIf(session) {
+        return !session.getValue('relayTokensTxnHash');
+      },
       postables: [
         new NetworkAwareWorkflowMessage({
           message: `Looks like you’ve already connected your ${c.layer2.fullName} wallet, which you can see below.
@@ -230,6 +239,9 @@ with Card Pay.`,
         new WorkflowCard({
           cardName: 'CHOOSE_BALANCE',
           componentName: 'card-pay/withdrawal-workflow/choose-balance',
+          editableIf(session) {
+            return !session.getValue('relayTokensTxnHash');
+          },
         }),
         new WorkflowMessage({
           message: 'How much would you like to withdraw from your balance?',

--- a/packages/web-client/tests/acceptance/create-merchant-persistence-test.ts
+++ b/packages/web-client/tests/acceptance/create-merchant-persistence-test.ts
@@ -276,8 +276,6 @@ module('Acceptance | create merchant persistence', function (hooks) {
         merchantBgColor,
         merchantRegistrationFee,
         prepaidCardAddress,
-        txnHash:
-          '0x8bcc3e419d09a0403d1491b5bb8ac8bee7c67f85cc37e6e17ef8eb77f946497b',
         merchantSafe,
       });
 

--- a/packages/web-client/tests/acceptance/create-merchant-test.ts
+++ b/packages/web-client/tests/acceptance/create-merchant-test.ts
@@ -208,6 +208,12 @@ module('Acceptance | create merchant', function (hooks) {
     // eslint-disable-next-line ember/no-settled-after-test-helper
     await settled();
 
+    assert
+      .dom(
+        `[data-test-boxel-action-chin-state="memorialized"] [data-test-boxel-button].boxel-action-chin__memorialized-action-button[disabled]`
+      )
+      .doesNotExist();
+
     layer2Service.test__simulateRegisterMerchantForAddress(
       prepaidCardAddress,
       merchantAddress,
@@ -215,6 +221,13 @@ module('Acceptance | create merchant', function (hooks) {
     );
 
     await waitFor('[data-test-prepaid-card-choice-is-complete]');
+
+    assert
+      .dom(
+        `[data-test-boxel-action-chin-state="memorialized"] [data-test-boxel-button].boxel-action-chin__memorialized-action-button[disabled]`
+      )
+      .exists({ count: 2 });
+
     assert.dom(`[data-test-boxel-card-picker-dropdown]`).doesNotExist();
     assert
       .dom('[data-test-prepaid-card-choice-merchant-address]')

--- a/packages/web-client/tests/acceptance/deposit-test.ts
+++ b/packages/web-client/tests/acceptance/deposit-test.ts
@@ -44,7 +44,6 @@ module('Acceptance | deposit', function (hooks) {
   setupMirage(hooks);
 
   test('Initiating workflow without wallet connections', async function (assert) {
-    let ctaButtonsBeforeUnlock: Record<string, string> = {};
     await visit('/card-pay/deposit-withdrawal');
     assert.equal(currentURL(), '/card-pay/deposit-withdrawal');
     await click('[data-test-workflow-button="deposit"]');
@@ -65,8 +64,9 @@ module('Acceptance | deposit', function (hooks) {
 
     post = postableSel(0, 3);
     await click(`${post} [data-test-wallet-option="metamask"]`);
-    ctaButtonsBeforeUnlock.mainnetConnection = `${post} [data-test-mainnnet-connection-action-container] [data-test-boxel-button]`;
-    await click(ctaButtonsBeforeUnlock.mainnetConnection);
+    await click(
+      `${post} [data-test-mainnnet-connection-action-container] [data-test-boxel-button]`
+    );
 
     assert.dom(post).containsText(`Connect your ${c.layer1.fullName} wallet`);
 
@@ -152,12 +152,9 @@ module('Acceptance | deposit', function (hooks) {
       .hasText('0x1826...6E44');
 
     await settled();
-
-    ctaButtonsBeforeUnlock.layer2Connection = `${postableSel(
-      1,
-      2
-    )} [data-test-layer-2-wallet-disconnect-button]`;
-    assert.dom(ctaButtonsBeforeUnlock.layer2Connection).exists();
+    assert
+      .dom(`${postableSel(1, 2)} [data-test-layer-2-wallet-disconnect-button]`)
+      .exists();
 
     assert
       .dom(milestoneCompletedSel(1))
@@ -170,9 +167,10 @@ module('Acceptance | deposit', function (hooks) {
     post = postableSel(2, 1);
 
     // transaction-setup card
-    ctaButtonsBeforeUnlock.transactionSetup = `${post} [data-test-deposit-transaction-setup] [data-test-boxel-button]`;
     await waitFor(`${post} [data-test-balance="DAI"]`);
-    await click(ctaButtonsBeforeUnlock.transactionSetup);
+    await click(
+      `${post} [data-test-deposit-transaction-setup] [data-test-boxel-button]`
+    );
     assert
       .dom(
         `${post} [data-test-deposit-transaction-setup-from-balance="DAI"] [data-test-balance-display-amount]`
@@ -212,16 +210,20 @@ module('Acceptance | deposit', function (hooks) {
 
     assert.dom(`${post} [data-test-unlock-etherscan-button]`).doesNotExist();
 
-    for (let item in ctaButtonsBeforeUnlock) {
-      assert.dom(ctaButtonsBeforeUnlock[item]).isNotDisabled();
-    }
+    assert
+      .dom(
+        `[data-test-boxel-action-chin-state="memorialized"] [data-test-boxel-button].boxel-action-chin__memorialized-action-button[disabled]`
+      )
+      .doesNotExist();
 
     layer1Service.test__simulateUnlockTxnHash();
     await settled();
 
-    for (let item in ctaButtonsBeforeUnlock) {
-      assert.dom(ctaButtonsBeforeUnlock[item]).isDisabled();
-    }
+    assert
+      .dom(
+        `[data-test-boxel-action-chin-state="memorialized"] [data-test-boxel-button].boxel-action-chin__memorialized-action-button[disabled]`
+      )
+      .exists({ count: 3 });
 
     assert.dom(`${post} [data-test-unlock-etherscan-button]`).exists();
 

--- a/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
+++ b/packages/web-client/tests/acceptance/issue-prepaid-card-test.ts
@@ -461,6 +461,12 @@ module('Acceptance | issue prepaid card', function (hooks) {
 
     let prepaidCardAddress = '0xaeFbA62A2B3e90FD131209CC94480E722704E1F8';
 
+    assert
+      .dom(
+        `[data-test-boxel-action-chin-state="memorialized"] [data-test-boxel-button].boxel-action-chin__memorialized-action-button[disabled]`
+      )
+      .doesNotExist();
+
     layer2Service.test__simulateIssuePrepaidCardForAmountFromSource(
       10000,
       merchantSafe.address,
@@ -470,6 +476,13 @@ module('Acceptance | issue prepaid card', function (hooks) {
     );
 
     await waitFor(milestoneCompletedSel(3));
+
+    assert
+      .dom(
+        `[data-test-boxel-action-chin-state="memorialized"] [data-test-boxel-button].boxel-action-chin__memorialized-action-button[disabled]`
+      )
+      .exists({ count: 4 });
+
     assert.dom(milestoneCompletedSel(3)).containsText('Transaction confirmed');
 
     assert

--- a/packages/web-client/tests/acceptance/withdrawal-test.ts
+++ b/packages/web-client/tests/acceptance/withdrawal-test.ts
@@ -248,6 +248,12 @@ module('Acceptance | withdrawal', function (hooks) {
       )
       .isEnabled('Set amount button is enabled once amount has been entered');
     await waitFor(`${post} [data-test-withdrawal-transaction-amount]`);
+    assert
+      .dom(
+        `[data-test-boxel-action-chin-state="memorialized"] [data-test-boxel-button].boxel-action-chin__memorialized-action-button[disabled]`
+      )
+      .doesNotExist();
+
     await click(
       `${post} [data-test-withdrawal-transaction-amount] [data-test-boxel-button]`
     );
@@ -277,6 +283,12 @@ module('Acceptance | withdrawal', function (hooks) {
     assert
       .dom(milestoneCompletedSel(4))
       .containsText(`Tokens bridged to ${c.layer1.fullName}`);
+
+    assert
+      .dom(
+        `[data-test-boxel-action-chin-state="memorialized"] [data-test-boxel-button].boxel-action-chin__memorialized-action-button[disabled]`
+      )
+      .exists({ count: 3 });
 
     // // token claim step card
     assert


### PR DESCRIPTION
Have tested this out locally.