### PR TITLE
throw subgraph errors in query

### DIFF
--- a/packages/cardpay-sdk/sdk/utils/graphql.ts
+++ b/packages/cardpay-sdk/sdk/utils/graphql.ts
@@ -35,5 +35,15 @@ export async function query(
       variables,
     }),
   });
-  return await response.json();
+
+  let result = await response.json();
+
+  if (result.errors) {
+    let e = new Error('GraphQL query to subgraph failed');
+    // @ts-ignore
+    e.detail = result.errors;
+    throw e;
+  } else {
+    return result;
+  }
 }


### PR DESCRIPTION
Part of improving visibility into the problems around CS-3429

Currently subgraph errors are not recognised and thrown since graphQL returns 200 for [GraphQL errors](https://www.apollographql.com/docs/react/data/error-handling/#graphql-errors), which means that we might get misleading results sometimes. See the [GraphQL spec on partial responses](https://spec.graphql.org/June2018/#sec-Response:~:text=A%20response%20may%20contain%20both%20a%20partial%20response%20as%20well%20as%20encountered%20errors%20in%20the%20case%20that%20a%20field%20error%20occurred%20on%20a%20field%20which%20was%20replaced%20with%20null.)

List of errors that subgraph could return: https://github.com/graphprotocol/graph-node/blob/82fd8de382a97081e3030d1243510cd6dac39f40/graph/src/data/query/error.rs

I don't know how to simulate a resolver error with a partial response, but used a ValidationError to demonstrate what this change means.

```js
const { gqlQuery } = require('@cardstack/cardpay-sdk');
const fetch = require('node-fetch')
let query = `query($account: ID!) {
    account(id: $account) {
      safes(orderBy:ownershipChangedAt orderDirection:desc) {
        safe {
          nosuchfield
        }
      }
    }

    _meta {
      block {
        number
      }
    }
  }`;

gqlQuery("xdai", query, { account: "0xF3a07FB1ad06582dda876E9aeb5059d88C83C9D" }).then((v) => console.log('success', v)).catch((e) => console.error('failure', e, JSON.stringify(e.detail)));
/**
 *
 * BEFORE
 * > success {
 *   errors: [
 *     {
 *       locations: [Array],
 *       message: 'Type `Safe` has no field `nosuchfield`'
 *     }
 *   ]
 * }
 *
 * AFTER:
 * > failure Error: GraphQL query to subgraph failed
 *     at query (/Users/michael/Documents/cardstack/cardstack/packages/cardpay-sdk/dist/index.js:1552:13)
 *     at processTicksAndRejections (internal/process/task_queues.js:95:5) {
 *   detail: [
 *     {
 *       locations: [Array],
 *       message: 'Type `Safe` has no field `nosuchfield`'
 *     }
 *   ]
 * } [{"locations":[{"line":5,"column":11}],"message":"Type `Safe` has no field `nosuchfield`"}]
 */
```