### PR TITLE
ssr: Remove console warning in Fastboot context

### DIFF
--- a/packages/ssr-web/app/routes/application.ts
+++ b/packages/ssr-web/app/routes/application.ts
@@ -35,7 +35,7 @@ export default class ApplicationRoute extends Route {
   }
 
   afterModel() {
-    if (!isTesting()) {
+    if (!isTesting() && !this.fastboot.isFastBoot) {
       console.warn(
         '%cBe careful!',
         'color: red; font-size: 20px;   font-weight: bold;'


### PR DESCRIPTION
This is an oversight in #3000: the Fastboot logs for `ssr-web` have this warning for every request.