### PR TITLE
ssr: Update exchange-fetch for new Hub interface

### DIFF
--- a/packages/ssr-web/app/routes/pay.ts
+++ b/packages/ssr-web/app/routes/pay.ts
@@ -28,6 +28,7 @@ export default class PayRoute extends Route {
   }
 
   async model(params: {
+    currency: string;
     network: string;
     merchant_safe_id: string;
   }): Promise<PayRouteModel> {
@@ -46,7 +47,7 @@ export default class PayRoute extends Route {
         merchantSafe,
         merchantInfo,
         exchangeRates: this.shouldFetchExchangeRates
-          ? await this.fetchExchangeRates()
+          ? await this.fetchExchangeRates('USD', params.currency)
           : undefined,
       };
     } catch (e) {
@@ -62,16 +63,19 @@ export default class PayRoute extends Route {
     );
   }
 
-  async fetchExchangeRates() {
+  async fetchExchangeRates(from: string, to: string) {
     try {
       return (
         await (
-          await fetch(`${config.hubURL}/api/exchange-rates`, {
-            method: 'GET',
-            headers: {
-              'Content-Type': 'application/vnd.api+json',
-            },
-          })
+          await fetch(
+            `${config.hubURL}/api/exchange-rates?from=${from}&to=${to}`,
+            {
+              method: 'GET',
+              headers: {
+                'Content-Type': 'application/vnd.api+json',
+              },
+            }
+          )
         ).json()
       ).data.attributes.rates;
     } catch (e) {

--- a/packages/ssr-web/mirage/config.js
+++ b/packages/ssr-web/mirage/config.js
@@ -1,4 +1,3 @@
-import { nativeCurrencies } from '@cardstack/cardpay-sdk';
 import config from '@cardstack/ssr-web/config/environment';
 
 export default function () {
@@ -8,15 +7,15 @@ export default function () {
     return schema.cardSpaces.where({ slug }).models[0];
   });
 
-  this.get('/exchange-rates', function () {
+  this.get('/exchange-rates', function (schema, { queryParams: { from, to } }) {
     return {
       data: {
         type: 'exchange-rates',
         attributes: {
-          base: 'USD',
-          rates: Object.fromEntries(
-            Object.keys(nativeCurrencies).map((k) => [k, 2])
-          ),
+          base: from,
+          rates: {
+            [to]: 2,
+          },
         },
       },
     };


### PR DESCRIPTION
This updates payment request conversion to use the new
Hub CryptoCompare caching proxy in #2992.