### PR TITLE
Add script dependency to python subpackages

### DIFF
--- a/.github/actions/deploy-reward-api/action.yml
+++ b/.github/actions/deploy-reward-api/action.yml
@@ -20,6 +20,11 @@ runs:
         sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
         sudo apt-get install awscli waypoint=${{ inputs.waypoint_version }}
 
+    - uses: volta-cli/action@v1
+
+    - run: yarn add js-hcl-parser -W --prefer-offline
+      shell: bash
+
     - name: Deploy reward api
       run: waypoint up -app=reward-api -plain
       shell: bash

--- a/.github/actions/deploy-reward-root-submitter/action.yml
+++ b/.github/actions/deploy-reward-root-submitter/action.yml
@@ -20,6 +20,11 @@ runs:
         sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
         sudo apt-get install awscli waypoint=${{ inputs.waypoint_version }}
 
+    - uses: volta-cli/action@v1
+
+    - run: yarn add js-hcl-parser -W --prefer-offline
+      shell: bash
+
     - name: Deploy reward submitter
       run: waypoint up -app=reward-submit -prune-retain=0 -plain
       shell: bash

--- a/.github/actions/deploy-subgraph-extractor/action.yml
+++ b/.github/actions/deploy-subgraph-extractor/action.yml
@@ -17,6 +17,11 @@ runs:
         sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
         sudo apt-get install awscli waypoint=${{ inputs.waypoint_version }}
 
+    - uses: volta-cli/action@v1
+
+    - run: yarn add js-hcl-parser -W --prefer-offline
+      shell: bash
+
     - name: Deploy subgraph extractor
       run: waypoint up -app=cardpay-subg-ext -prune-retain=0 -plain
       shell: bash


### PR DESCRIPTION
It looks like the dependency `js-hcl-parser` in the `wait-service-stable` script is unavailable to python subpackages. This pr adds `js-hcl-parser` within the github action so the script can run. I didn't want to install the entire monorepo since it seemed unnecessary for now.
