### PR TITLE
hub: Extract StubWorkerClient for tests

### DIFF
--- a/packages/hub/node-tests/helpers/stub-worker-client.ts
+++ b/packages/hub/node-tests/helpers/stub-worker-client.ts
@@ -1,0 +1,33 @@
+import { Job, TaskSpec } from 'graphile-worker';
+import { registry } from '../helpers/server';
+import { Suite } from 'mocha';
+
+let jobIdentifiers: string[] = [];
+let jobPayloads: any[] = [];
+
+export function setupStubWorkerClient(context: Suite) {
+  context.beforeEach(function () {
+    registry(this).register('worker-client', StubWorkerClient);
+  });
+}
+
+export function getJobIdentifiers() {
+  return jobIdentifiers;
+}
+
+export function getJobPayloads() {
+  return jobPayloads;
+}
+
+export class StubWorkerClient {
+  constructor() {
+    jobIdentifiers = [];
+    jobPayloads = [];
+  }
+
+  async addJob(identifier: string, payload?: any, _spec?: TaskSpec): Promise<Job> {
+    jobIdentifiers.push(identifier);
+    jobPayloads.push(payload);
+    return Promise.resolve({} as Job);
+  }
+}

--- a/packages/hub/node-tests/helpers/stub-worker-client.ts
+++ b/packages/hub/node-tests/helpers/stub-worker-client.ts
@@ -4,30 +4,39 @@ import { Suite } from 'mocha';
 
 let jobIdentifiers: string[] = [];
 let jobPayloads: any[] = [];
+let jobSpecs: (TaskSpec | undefined)[] = [];
 
 export function setupStubWorkerClient(context: Suite) {
   context.beforeEach(function () {
     registry(this).register('worker-client', StubWorkerClient);
   });
-}
 
-export function getJobIdentifiers() {
-  return jobIdentifiers;
-}
+  context.afterEach(function () {
+    jobIdentifiers = [];
+    jobPayloads = [];
+    jobSpecs = [];
+  });
 
-export function getJobPayloads() {
-  return jobPayloads;
+  return {
+    getJobIdentifiers: function () {
+      return jobIdentifiers;
+    },
+
+    getJobPayloads: function () {
+      return jobPayloads;
+    },
+
+    getJobSpecs: function () {
+      return jobSpecs;
+    },
+  };
 }
 
 export class StubWorkerClient {
-  constructor() {
-    jobIdentifiers = [];
-    jobPayloads = [];
-  }
-
-  async addJob(identifier: string, payload?: any, _spec?: TaskSpec): Promise<Job> {
+  async addJob(identifier: string, payload?: any, spec?: TaskSpec): Promise<Job> {
     jobIdentifiers.push(identifier);
     jobPayloads.push(payload);
+    jobSpecs.push(spec);
     return Promise.resolve({} as Job);
   }
 }

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -2,7 +2,7 @@ import type { EmailCardDropRequest } from '../../routes/email-card-drop-requests
 import { Clock } from '../../services/clock';
 import { registry, setupHub } from '../helpers/server';
 import { setupSentry, waitForSentryReport } from '../helpers/sentry';
-import { getJobIdentifiers, getJobPayloads, setupStubWorkerClient } from '../helpers/stub-worker-client';
+import { setupStubWorkerClient } from '../helpers/stub-worker-client';
 import crypto from 'crypto';
 import config from 'config';
 import shortUUID from 'short-uuid';
@@ -158,7 +158,7 @@ class StubCardpaySDK {
 
 describe('POST /api/email-card-drop-requests', function () {
   setupSentry(this);
-  setupStubWorkerClient(this);
+  let { getJobIdentifiers, getJobPayloads } = setupStubWorkerClient(this);
 
   this.beforeEach(function () {
     registry(this).register('authentication-utils', StubAuthenticationUtils);

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -2,8 +2,8 @@ import type { EmailCardDropRequest } from '../../routes/email-card-drop-requests
 import { Clock } from '../../services/clock';
 import { registry, setupHub } from '../helpers/server';
 import { setupSentry, waitForSentryReport } from '../helpers/sentry';
+import { getJobIdentifiers, getJobPayloads, setupStubWorkerClient } from '../helpers/stub-worker-client';
 import crypto from 'crypto';
-import { Job, TaskSpec } from 'graphile-worker';
 import config from 'config';
 import shortUUID from 'short-uuid';
 
@@ -139,16 +139,6 @@ function handleValidateAuthToken(encryptedString: string) {
   return stubUserAddress;
 }
 
-let jobIdentifiers: string[] = [];
-let jobPayloads: any[] = [];
-class StubWorkerClient {
-  async addJob(identifier: string, payload?: any, _spec?: TaskSpec): Promise<Job> {
-    jobIdentifiers.push(identifier);
-    jobPayloads.push(payload);
-    return Promise.resolve({} as Job);
-  }
-}
-
 let mockPrepaidCardMarketContractPaused = false;
 let mockPrepaidCardQuantity = 100;
 
@@ -168,11 +158,11 @@ class StubCardpaySDK {
 
 describe('POST /api/email-card-drop-requests', function () {
   setupSentry(this);
+  setupStubWorkerClient(this);
 
   this.beforeEach(function () {
     registry(this).register('authentication-utils', StubAuthenticationUtils);
     registry(this).register('cardpay', StubCardpaySDK);
-    registry(this).register('worker-client', StubWorkerClient);
     registry(this).register('clock', FrozenClock);
 
     mockPrepaidCardMarketContractPaused = false;
@@ -180,11 +170,6 @@ describe('POST /api/email-card-drop-requests', function () {
   });
 
   let { request, getContainer } = setupHub(this);
-
-  this.afterEach(async function () {
-    jobIdentifiers = [];
-    jobPayloads = [];
-  });
 
   it('persists an email card drop request and triggers jobs', async function () {
     let emailCardDropRequestsQueries = await getContainer().lookup('email-card-drop-requests', { type: 'query' });
@@ -237,8 +222,8 @@ describe('POST /api/email-card-drop-requests', function () {
 
     expect(emailCardDropRequest.emailHash).to.equal(emailHash);
 
-    expect(jobIdentifiers).to.deep.equal(['send-email-card-drop-verification', 'subscribe-email']);
-    expect(jobPayloads).to.deep.equal([{ id: resourceId, email }, { email }]);
+    expect(getJobIdentifiers()).to.deep.equal(['send-email-card-drop-verification', 'subscribe-email']);
+    expect(getJobPayloads()).to.deep.equal([{ id: resourceId, email }, { email }]);
   });
 
   it('sends an alert to web-team if getQuantity drops below notifyWhenQuantityBelow', async function () {
@@ -326,8 +311,8 @@ describe('POST /api/email-card-drop-requests', function () {
     expect(latestRequest.emailHash).to.equal(emailHash2);
     expect(Number(latestRequest.requestedAt)).to.equal(fakeTime);
 
-    expect(jobIdentifiers).to.deep.equal(['send-email-card-drop-verification', 'subscribe-email']);
-    expect(jobPayloads).to.deep.equal([{ id: resourceId, email: email2 }, { email: email2 }]);
+    expect(getJobIdentifiers()).to.deep.equal(['send-email-card-drop-verification', 'subscribe-email']);
+    expect(getJobPayloads()).to.deep.equal([{ id: resourceId, email: email2 }, { email: email2 }]);
   });
 
   it('returns 401 without bearer token', async function () {

--- a/packages/hub/node-tests/routes/merchant-infos-test.ts
+++ b/packages/hub/node-tests/routes/merchant-infos-test.ts
@@ -1,4 +1,3 @@
-import { Job, TaskSpec } from 'graphile-worker';
 import { registry, setupHub } from '../helpers/server';
 
 const stubNonce = 'abc:123';
@@ -21,17 +20,6 @@ class StubAuthenticationUtils {
   }
 }
 
-let jobIdentifiers: string[] = [];
-let jobPayloads: any[] = [];
-
-class StubWorkerClient {
-  async addJob(identifier: string, payload?: any, _spec?: TaskSpec): Promise<Job> {
-    jobIdentifiers.push(identifier);
-    jobPayloads.push(payload);
-    return Promise.resolve({} as Job);
-  }
-}
-
 let stubUserAddress = '0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13';
 function handleValidateAuthToken(encryptedString: string) {
   expect(encryptedString).to.equal('abc123--def456--ghi789');
@@ -41,15 +29,9 @@ function handleValidateAuthToken(encryptedString: string) {
 describe('POST /api/merchant-infos', function () {
   this.beforeEach(function () {
     registry(this).register('authentication-utils', StubAuthenticationUtils);
-    registry(this).register('worker-client', StubWorkerClient);
   });
 
   let { request, getContainer } = setupHub(this);
-
-  this.afterEach(async function () {
-    jobIdentifiers = [];
-    jobPayloads = [];
-  });
 
   it('persists merchant info', async function () {
     const payload = {
@@ -323,15 +305,9 @@ describe('POST /api/merchant-infos', function () {
 describe('GET /api/merchant-infos/validate-slug/:slug', function () {
   this.beforeEach(function () {
     registry(this).register('authentication-utils', StubAuthenticationUtils);
-    registry(this).register('worker-client', StubWorkerClient);
   });
 
   let { request } = setupHub(this);
-
-  this.afterEach(async function () {
-    jobIdentifiers = [];
-    jobPayloads = [];
-  });
 
   it('returns 401 without bearer token', async function () {
     const slug = 'slug';

--- a/packages/hub/node-tests/tasks/notify-merchant-claim-test.ts
+++ b/packages/hub/node-tests/tasks/notify-merchant-claim-test.ts
@@ -101,7 +101,6 @@ describe('NotifyMerchantClaimTask', function () {
     let task = (await getContainer().lookup('notify-merchant-claim')) as NotifyMerchantClaim;
 
     await task.perform({ transactionHash: 'a' } as EventData);
-    // debugger;
     expect(addedJobIdentifiers).to.deep.equal(['send-notifications', 'send-notifications']);
     expect(addedJobPayloads).to.deep.equal([
       {

--- a/packages/hub/node-tests/tasks/notify-prepaid-card-drop-test.ts
+++ b/packages/hub/node-tests/tasks/notify-prepaid-card-drop-test.ts
@@ -1,12 +1,9 @@
-import { Job, TaskSpec } from 'graphile-worker';
 import { registry, setupHub } from '../helpers/server';
 import NotifyPrepaidCardDrop from '../../tasks/notify-prepaid-card-drop';
 import { expect } from 'chai';
 import { setupSentry } from '../helpers/sentry';
+import { setupStubWorkerClient } from '../helpers/stub-worker-client';
 import { EventData } from 'web3-eth-contract';
-
-let addedJobIdentifiers: string[] = [];
-let addedJobPayloads: string[] = [];
 
 class StubNotificationPreferenceService {
   async getEligiblePushClientIds(_ownerAddress: string, notificationType: string) {
@@ -15,35 +12,22 @@ class StubNotificationPreferenceService {
   }
 }
 
-class StubWorkerClient {
-  async addJob(identifier: string, payload?: any, _spec?: TaskSpec): Promise<Job> {
-    addedJobIdentifiers.push(identifier);
-    addedJobPayloads.push(payload);
-    return Promise.resolve({} as Job);
-  }
-}
-
 describe('NotifyPrepaidCardDropTask', function () {
   setupSentry(this);
+  let { getJobIdentifiers, getJobPayloads } = setupStubWorkerClient(this);
 
   this.beforeEach(function () {
     registry(this).register('notification-preference-service', StubNotificationPreferenceService);
-    registry(this).register('worker-client', StubWorkerClient);
   });
   let { getContainer } = setupHub(this);
-
-  this.afterEach(async function () {
-    addedJobIdentifiers = [];
-    addedJobPayloads = [];
-  });
 
   it('adds send-notifications jobs', async function () {
     let task = (await getContainer().lookup('notify-prepaid-card-drop')) as NotifyPrepaidCardDrop;
 
     await task.perform({ returnValues: { owner: 'eoa-address' }, transactionHash: 'a' } as unknown as EventData);
 
-    expect(addedJobIdentifiers).to.deep.equal(['send-notifications', 'send-notifications']);
-    expect(addedJobPayloads).to.deep.equal([
+    expect(getJobIdentifiers()).to.deep.equal(['send-notifications', 'send-notifications']);
+    expect(getJobPayloads()).to.deep.equal([
       {
         notificationBody: 'You were issued a new prepaid card!',
         notificationId: 'sokol::a::123::eoa-address',


### PR DESCRIPTION
This replaces the `StubWorkerClient` implementations scattered around tests with an extracted function to set up a stub and return getters for checking on what jobs were queued. It’s not that elegant but still seems like an improvement to me!