### PR TITLE
ci: Use hcl2-parser

### DIFF
--- a/.github/actions/deploy-cardie/action.yml
+++ b/.github/actions/deploy-cardie/action.yml
@@ -21,7 +21,6 @@ runs:
         curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
         sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
         sudo apt-get install awscli waypoint=${{ inputs.waypoint_version }}
-        yarn add hcl2-parser @actions/core -W --prefer-offline
 
     - name: Deploy cardie
       run: waypoint up --app=cardie -prune-retain=0 -plain

--- a/.github/actions/deploy-cardie/action.yml
+++ b/.github/actions/deploy-cardie/action.yml
@@ -10,17 +10,18 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install apt packages including waypoint
+    - uses: volta-cli/action@v1
+
+    - run: yarn --prefer-offline
+      shell: bash
+
+    - name: Install dependencies
       shell: bash
       run: |
         curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
         sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
         sudo apt-get install awscli waypoint=${{ inputs.waypoint_version }}
-
-    - uses: volta-cli/action@v1
-
-    - run: yarn --prefer-offline
-      shell: bash
+        yarn add hcl2-parser @actions/core -W --prefer-offline
 
     - name: Deploy cardie
       run: waypoint up --app=cardie -prune-retain=0 -plain

--- a/.github/actions/deploy-hub/action.yml
+++ b/.github/actions/deploy-hub/action.yml
@@ -10,17 +10,18 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install apt packages including waypoint
+    - uses: volta-cli/action@v1
+
+    - run: yarn --prefer-offline
+      shell: bash
+
+    - name: Install dependencies
       shell: bash
       run: |
         curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
         sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
         sudo apt-get install awscli waypoint=${{ inputs.waypoint_version }}
-
-    - uses: volta-cli/action@v1
-
-    - run: yarn --prefer-offline
-      shell: bash
+        yarn add hcl2-parser @actions/core -W --prefer-offline
 
     - name: Webpack build
       run: yarn build

--- a/.github/actions/deploy-hub/action.yml
+++ b/.github/actions/deploy-hub/action.yml
@@ -21,7 +21,6 @@ runs:
         curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
         sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
         sudo apt-get install awscli waypoint=${{ inputs.waypoint_version }}
-        yarn add hcl2-parser @actions/core -W --prefer-offline
 
     - name: Webpack build
       run: yarn build

--- a/.github/actions/deploy-reward-api/action.yml
+++ b/.github/actions/deploy-reward-api/action.yml
@@ -13,17 +13,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install apt packages including waypoint
+    - uses: volta-cli/action@v1
+
+    - name: Install dependencies
       shell: bash
       run: |
         curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
         sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
         sudo apt-get install awscli waypoint=${{ inputs.waypoint_version }}
-
-    - uses: volta-cli/action@v1
-
-    - run: yarn add js-hcl-parser -W --prefer-offline
-      shell: bash
+        yarn add hcl2-parser @actions/core -W --prefer-offline
 
     - name: Deploy reward api
       run: waypoint up -app=reward-api -plain

--- a/.github/actions/deploy-reward-root-submitter/action.yml
+++ b/.github/actions/deploy-reward-root-submitter/action.yml
@@ -13,17 +13,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install apt packages including waypoint
+    - uses: volta-cli/action@v1
+
+    - name: Install dependencies
       shell: bash
       run: |
         curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
         sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
         sudo apt-get install awscli waypoint=${{ inputs.waypoint_version }}
-
-    - uses: volta-cli/action@v1
-
-    - run: yarn add js-hcl-parser -W --prefer-offline
-      shell: bash
+        yarn add hcl2-parser @actions/core -W --prefer-offline
 
     - name: Deploy reward submitter
       run: waypoint up -app=reward-submit -prune-retain=0 -plain

--- a/.github/actions/deploy-reward-scheduler/action.yml
+++ b/.github/actions/deploy-reward-scheduler/action.yml
@@ -15,13 +15,13 @@ runs:
   steps:
     - uses: volta-cli/action@v1
 
-    - name: Install apt packages including waypoint
+    - name: Install dependencies
       shell: bash
       run: |
         curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
         sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
         sudo apt-get install awscli waypoint=${{ inputs.waypoint_version }}
-        yarn add js-hcl-parser -W --prefer-offline
+        yarn add hcl2-parser @actions/core -W --prefer-offline
 
     - name: Deploy reward scheduler
       run: waypoint up -app=reward-scheduler -prune-retain=0 -plain

--- a/.github/actions/deploy-ssr-web/action.yml
+++ b/.github/actions/deploy-ssr-web/action.yml
@@ -13,17 +13,18 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install apt packages including waypoint
+    - uses: volta-cli/action@v1
+
+    - run: yarn --prefer-offline
+      shell: bash
+
+    - name: Install dependencies
       shell: bash
       run: |
         curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
         sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
         sudo apt-get install awscli waypoint=${{ inputs.waypoint_version }}
-
-    - uses: volta-cli/action@v1
-
-    - run: yarn --prefer-offline
-      shell: bash
+        yarn add hcl2-parser @actions/core -W --prefer-offline
 
     - name: Build
       run: SSR_WEB_ENVIRONMENT=${{ inputs.environment }} yarn build:ssr-web:${{ inputs.environment }}

--- a/.github/actions/deploy-ssr-web/action.yml
+++ b/.github/actions/deploy-ssr-web/action.yml
@@ -24,7 +24,6 @@ runs:
         curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
         sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
         sudo apt-get install awscli waypoint=${{ inputs.waypoint_version }}
-        yarn add hcl2-parser @actions/core -W --prefer-offline
 
     - name: Build
       run: SSR_WEB_ENVIRONMENT=${{ inputs.environment }} yarn build:ssr-web:${{ inputs.environment }}

--- a/.github/actions/deploy-subgraph-extractor/action.yml
+++ b/.github/actions/deploy-subgraph-extractor/action.yml
@@ -10,17 +10,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install apt packages including waypoint
+    - uses: volta-cli/action@v1
+
+    - name: Install dependencies
       shell: bash
       run: |
         curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
         sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
         sudo apt-get install awscli waypoint=${{ inputs.waypoint_version }}
-
-    - uses: volta-cli/action@v1
-
-    - run: yarn add js-hcl-parser -W --prefer-offline
-      shell: bash
+        yarn add hcl2-parser @actions/core -W --prefer-offline
 
     - name: Deploy subgraph extractor
       run: waypoint up -app=cardpay-subg-ext -prune-retain=0 -plain

--- a/.github/actions/waypoint-prune-dangling-resources/index.js
+++ b/.github/actions/waypoint-prune-dangling-resources/index.js
@@ -1,5 +1,5 @@
 const core = require('@actions/core');
-const hcl = require('js-hcl-parser');
+const hcl = require('hcl2-parser');
 const fs = require('fs');
 const { execSync } = require('child_process');
 
@@ -9,11 +9,10 @@ function execute(command, options = {}) {
 
 function getAppConfig(waypointConfigFilePath, appName) {
   const waypointHcl = fs.readFileSync(waypointConfigFilePath, 'utf8');
-  const waypointJson = hcl.parse(waypointHcl);
-  const waypointConfig = JSON.parse(waypointJson);
-  const waypointApp = waypointConfig.app.find((app) => Object.keys(app)[0] === appName);
-  const cluster = waypointApp[appName][0].deploy[0].use[0]['aws-ecs'][0].cluster;
-  const disableAlb = Boolean(waypointApp[appName][0].deploy[0].use[0]['aws-ecs'][0].disable_alb);
+  const waypointConfig = hcl.parseToObject(waypointHcl)[0];
+  const waypointApp = waypointConfig.app[appName][0];
+  const cluster = waypointApp.deploy[0].use['aws-ecs'][0].cluster;
+  const disableAlb = Boolean(waypointApp.deploy[0].use['aws-ecs'][0].disable_alb);
 
   return { cluster, disableAlb };
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@typescript-eslint/eslint-plugin": "^5.9.1",
     "@typescript-eslint/parser": "^5.9.1",
     "babel-eslint": "^10.1.0",
+    "cli-table3": "^0.6.1",
     "discord.js": "^12.5.3",
     "ember-template-lint": "^3.1.1",
     "eslint": "^7.32.0",
@@ -25,12 +26,12 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "glob": "^7.1.7",
+    "hcl2-parser": "^1.0.3",
     "js-hcl-parser": "^1.0.1",
     "lerna": "4.0.0",
     "prettier": "^2.3.2",
     "start-server-and-test": "^1.12.0",
-    "typescript": "4.2.3",
-    "cli-table3": "^0.6.1"
+    "typescript": "4.2.3"
   },
   "scripts": {
     "clean": "git clean -x -f --exclude=packages/*/.env --exclude=cardstack.code-workspace && lerna run clean",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20745,6 +20745,11 @@ hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
+hcl2-parser@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/hcl2-parser/-/hcl2-parser-1.0.3.tgz#096d0ff5a3c46707ace54fcb7571317f5828ff0e"
+  integrity sha512-NQUm/BFF+2nrBfeqDhhsy4DxxiLHgkeE3FywtjFiXnjSUaio3w4Tz1MQ3vGJBUhyArzOXJ24pO7JwE5LAn7Ncg==
+
 he@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"


### PR DESCRIPTION
HCL parser
-
Replace `js-hcl-parser` with `hcl2-parser` due to the fact that `js-hcl-parser` is unable to parse the new hcl2 syntax (eg: [gitrefpretty](https://tip.waypointproject.io/docs/waypoint-hcl/functions/all#gitrefpretty))

Non Javascript services hook and action dependencies
-

All deploy workflows are updated to install `hcl2-parser` and `@actions/core` as part of their dependencies. Some non javascript services (such as python ones) does not require `yarn` to fetch all the dependencies for the entire monorepo, thus a separate `yarn add <dependency> -W` makes more sense.