### PR TITLE
hub: Add GET /api/job-tickets

### DIFF
--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -97,6 +97,8 @@ import EmailCardDropRequestsRoute from './routes/email-card-drop-requests';
 import EmailCardDropRequestSerializer from './services/serializers/email-card-drop-request-serializer';
 import SendEmailCardDropVerificationTask from './tasks/send-email-card-drop-verification';
 import SubscribeEmailTask from './tasks/subscribe-email';
+import JobTicketsRoute from './routes/job-tickets';
+import JobTicketSerializer from './services/serializers/job-ticket-serializer';
 import DiscordPostTask from './tasks/discord-post';
 import Email from './services/email';
 import Mailchimp from './services/mailchimp';
@@ -160,6 +162,8 @@ export function createRegistry(): Registry {
   registry.register('card-space-validator', CardSpaceValidator);
   registry.register('card-spaces-route', CardSpacesRoute);
   registry.register('email-card-drop-requests-route', EmailCardDropRequestsRoute);
+  registry.register('job-tickets-route', JobTicketsRoute);
+  registry.register('job-ticket-serializer', JobTicketSerializer);
   registry.register('push-notification-registrations-route', PushNotificationRegistrationsRoute);
   registry.register('push-notification-registration-serializer', PushNotificationRegistrationSerializer);
   registry.register('firebase-push-notifications', FirebasePushNotifications);

--- a/packages/hub/node-tests/routes/job-tickets-test.ts
+++ b/packages/hub/node-tests/routes/job-tickets-test.ts
@@ -1,0 +1,29 @@
+import { setupHub } from '../helpers/server';
+import shortUUID from 'short-uuid';
+
+describe('GET /api/job-tickets/:id', function () {
+  let { request, getContainer } = setupHub(this);
+  let jobTicketsQueries, jobTicketId: string;
+
+  this.beforeEach(async function () {
+    jobTicketsQueries = await getContainer().lookup('job-tickets', { type: 'query' });
+    jobTicketId = shortUUID.uuid();
+
+    await jobTicketsQueries.insert({ id: jobTicketId, jobType: 'a-job', ownerAddress: '0x000' });
+  });
+
+  it('returns the job ticket details', async function () {
+    await request()
+      .get(`/api/job-tickets/${jobTicketId}`)
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(200)
+      .expect({
+        data: {
+          id: jobTicketId,
+          type: 'job-tickets',
+          attributes: { state: 'pending' },
+        },
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+});

--- a/packages/hub/node-tests/routes/job-tickets-test.ts
+++ b/packages/hub/node-tests/routes/job-tickets-test.ts
@@ -26,6 +26,7 @@ describe('GET /api/job-tickets/:id', function () {
 
     jobTicketId = shortUUID.uuid();
     await jobTicketsQueries.insert({ id: jobTicketId, jobType: 'a-job', ownerAddress: stubUserAddress });
+    await jobTicketsQueries.update(jobTicketId, { 'a-result': 'yes' }, 'success');
 
     otherOwnerJobTicketId = shortUUID.uuid();
     await jobTicketsQueries.insert({ id: otherOwnerJobTicketId, jobType: 'a-job', ownerAddress: '0x111' });
@@ -41,7 +42,7 @@ describe('GET /api/job-tickets/:id', function () {
         data: {
           id: jobTicketId,
           type: 'job-tickets',
-          attributes: { state: 'pending' },
+          attributes: { state: 'success', result: { 'a-result': 'yes' } },
         },
       })
       .expect('Content-Type', 'application/vnd.api+json');

--- a/packages/hub/node-tests/routes/job-tickets-test.ts
+++ b/packages/hub/node-tests/routes/job-tickets-test.ts
@@ -26,4 +26,23 @@ describe('GET /api/job-tickets/:id', function () {
       })
       .expect('Content-Type', 'application/vnd.api+json');
   });
+
+  it('returns 404 for an unknown job', async function () {
+    let randomId = shortUUID.uuid();
+
+    await request()
+      .get(`/api/job-tickets/${randomId}`)
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(404)
+      .expect({
+        errors: [
+          {
+            status: '404',
+            title: 'Job ticket not found',
+            detail: `Could not find the job ticket ${randomId}`,
+          },
+        ],
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
 });

--- a/packages/hub/queries/job-tickets.ts
+++ b/packages/hub/queries/job-tickets.ts
@@ -1,0 +1,45 @@
+import DatabaseManager from '@cardstack/db';
+import { inject } from '@cardstack/di';
+import { JobTicket } from '../routes/job-tickets';
+
+export default class JobTicketsQueries {
+  databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
+
+  async find(id: string): Promise<JobTicket | null> {
+    let db = await this.databaseManager.getClient();
+
+    let query = `SELECT * FROM job_tickets WHERE ID = $1`;
+    let queryResult = await db.query(query, [id]);
+
+    if (queryResult.rows.length) {
+      let row = queryResult.rows[0];
+
+      return {
+        id: row['id'],
+        jobType: row['job_type'],
+        ownerAddress: row['owner_address'],
+        state: row['state'],
+        payload: row['payload'],
+        result: row['result'],
+      };
+    } else {
+      return null;
+    }
+  }
+
+  async insert(model: Partial<JobTicket>) {
+    let db = await this.databaseManager.getClient();
+
+    await db.query('INSERT INTO job_tickets (id, job_type, owner_address) VALUES($1, $2, $3)', [
+      model.id,
+      model.jobType,
+      model.ownerAddress,
+    ]);
+  }
+}
+
+declare module '@cardstack/hub/queries' {
+  interface KnownQueries {
+    'job-tickets': JobTicketsQueries;
+  }
+}

--- a/packages/hub/queries/job-tickets.ts
+++ b/packages/hub/queries/job-tickets.ts
@@ -36,6 +36,18 @@ export default class JobTicketsQueries {
       model.ownerAddress,
     ]);
   }
+
+  async update(id: string, result: any, state: string) {
+    let db = await this.databaseManager.getClient();
+
+    await db.query(
+      `UPDATE job_tickets SET
+        result = $2,
+        state = $3
+      WHERE ID = $1`,
+      [id, result, state]
+    );
+  }
 }
 
 declare module '@cardstack/hub/queries' {

--- a/packages/hub/routes/job-tickets.ts
+++ b/packages/hub/routes/job-tickets.ts
@@ -32,11 +32,7 @@ export default class JobTicketsRoute {
     let id = ctx.params.id;
     let jobTicket = await this.jobTicketsQueries.find(id);
 
-    if (jobTicket) {
-      ctx.body = this.jobTicketSerializer.serialize(jobTicket!);
-      ctx.type = 'application/vnd.api+json';
-      ctx.status = 200;
-    } else {
+    if (!jobTicket) {
       ctx.body = {
         errors: [
           {
@@ -48,7 +44,30 @@ export default class JobTicketsRoute {
       };
       ctx.type = 'application/vnd.api+json';
       ctx.status = 404;
+
+      return;
     }
+
+    let requestingUserAddress = ctx.state.userAddress;
+
+    if (jobTicket.ownerAddress !== requestingUserAddress) {
+      ctx.body = {
+        errors: [
+          {
+            status: '401',
+            title: 'No valid auth token',
+          },
+        ],
+      };
+      ctx.type = 'application/vnd.api+json';
+      ctx.status = 401;
+
+      return;
+    }
+
+    ctx.body = this.jobTicketSerializer.serialize(jobTicket!);
+    ctx.type = 'application/vnd.api+json';
+    ctx.status = 200;
   }
 }
 

--- a/packages/hub/routes/job-tickets.ts
+++ b/packages/hub/routes/job-tickets.ts
@@ -1,0 +1,39 @@
+import Koa from 'koa';
+import autoBind from 'auto-bind';
+import { query } from '@cardstack/hub/queries';
+import { inject } from '@cardstack/di';
+
+export interface JobTicket {
+  id: string;
+  jobType: string;
+  ownerAddress: string;
+  payload: any;
+  result: any;
+  state: string;
+}
+
+export default class JobTicketsRoute {
+  jobTicketSerializer = inject('job-ticket-serializer', {
+    as: 'jobTicketSerializer',
+  });
+
+  jobTicketsQueries = query('job-tickets', { as: 'jobTicketsQueries' });
+
+  constructor() {
+    autoBind(this);
+  }
+
+  async get(ctx: Koa.Context) {
+    let jobTicket = await this.jobTicketsQueries.find(ctx.params.id);
+
+    ctx.body = this.jobTicketSerializer.serialize(jobTicket!);
+    ctx.type = 'application/vnd.api+json';
+    ctx.status = 200;
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'job-tickets-route': JobTicketsRoute;
+  }
+}

--- a/packages/hub/routes/job-tickets.ts
+++ b/packages/hub/routes/job-tickets.ts
@@ -1,6 +1,7 @@
 import Koa from 'koa';
 import autoBind from 'auto-bind';
 import { query } from '@cardstack/hub/queries';
+import { ensureLoggedIn } from './utils/auth';
 import { inject } from '@cardstack/di';
 
 export interface JobTicket {
@@ -24,6 +25,10 @@ export default class JobTicketsRoute {
   }
 
   async get(ctx: Koa.Context) {
+    if (!ensureLoggedIn(ctx)) {
+      return;
+    }
+
     let id = ctx.params.id;
     let jobTicket = await this.jobTicketsQueries.find(id);
 

--- a/packages/hub/routes/job-tickets.ts
+++ b/packages/hub/routes/job-tickets.ts
@@ -24,11 +24,26 @@ export default class JobTicketsRoute {
   }
 
   async get(ctx: Koa.Context) {
-    let jobTicket = await this.jobTicketsQueries.find(ctx.params.id);
+    let id = ctx.params.id;
+    let jobTicket = await this.jobTicketsQueries.find(id);
 
-    ctx.body = this.jobTicketSerializer.serialize(jobTicket!);
-    ctx.type = 'application/vnd.api+json';
-    ctx.status = 200;
+    if (jobTicket) {
+      ctx.body = this.jobTicketSerializer.serialize(jobTicket!);
+      ctx.type = 'application/vnd.api+json';
+      ctx.status = 200;
+    } else {
+      ctx.body = {
+        errors: [
+          {
+            status: '404',
+            title: 'Job ticket not found',
+            detail: `Could not find the job ticket ${id}`,
+          },
+        ],
+      };
+      ctx.type = 'application/vnd.api+json';
+      ctx.status = 404;
+    }
   }
 }
 

--- a/packages/hub/services/api-router.ts
+++ b/packages/hub/services/api-router.ts
@@ -32,6 +32,7 @@ export default class APIRouter {
   emailCardDropRequestsRoute = inject('email-card-drop-requests-route', {
     as: 'emailCardDropRequestsRoute',
   });
+  jobTicketsRoute = inject('job-tickets-route', { as: 'jobTicketsRoute' });
   pushNotificationRegistrationsRoute = inject('push-notification-registrations-route', {
     as: 'pushNotificationRegistrationsRoute',
   });
@@ -61,6 +62,7 @@ export default class APIRouter {
       inventoryRoute,
       cardSpacesRoute,
       emailCardDropRequestsRoute,
+      jobTicketsRoute,
       wyrePricesRoute,
       pushNotificationRegistrationsRoute,
       notificationPreferencesRoute,
@@ -88,6 +90,8 @@ export default class APIRouter {
 
     apiSubrouter.get('/email-card-drop-requests', emailCardDropRequestsRoute.get);
     apiSubrouter.post('/email-card-drop-requests', parseBody, emailCardDropRequestsRoute.post);
+
+    apiSubrouter.get('/job-tickets/:id', jobTicketsRoute.get);
 
     apiSubrouter.get('/card-spaces/:slug', cardSpacesRoute.get);
     apiSubrouter.patch('/card-spaces/:id', parseBody, cardSpacesRoute.patch);

--- a/packages/hub/services/serializers/job-ticket-serializer.ts
+++ b/packages/hub/services/serializers/job-ticket-serializer.ts
@@ -1,0 +1,24 @@
+import { JSONAPIDocument } from '../../utils/jsonapi-document';
+import { JobTicket } from '../../routes/job-tickets';
+
+export default class JobTicketSerializer {
+  serialize(model: JobTicket): JSONAPIDocument {
+    const result = {
+      data: {
+        id: model.id,
+        type: 'job-tickets',
+        attributes: {
+          state: model.state,
+        },
+      },
+    };
+
+    return result as JSONAPIDocument;
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'job-ticket-serializer': JobTicketSerializer;
+  }
+}

--- a/packages/hub/services/serializers/job-ticket-serializer.ts
+++ b/packages/hub/services/serializers/job-ticket-serializer.ts
@@ -8,6 +8,7 @@ export default class JobTicketSerializer {
         id: model.id,
         type: 'job-tickets',
         attributes: {
+          result: model.result,
           state: model.state,
         },
       },


### PR DESCRIPTION
This includes something that wasn’t specified in the issue: 401 if the owner address connected to the bearer token doesn’t match the `owner_address` in the table row.