### PR TITLE
hub: Add availability flag for card drop requests

### DIFF
--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -73,9 +73,22 @@ export default class EmailCardDropRequestsRoute {
 
     let rateLimited = await this.emailCardDropStateQueries.read();
 
+    let prepaidCardMarketV2 = await this.cardpay.getSDK('PrepaidCardMarketV2', this.web3.getInstance());
+    let quantityAvailable = await prepaidCardMarketV2.getQuantity(cardDropSku);
+    let activeReservations = await this.emailCardDropRequestQueries.activeReservations();
+
+    let available = true;
+
+    if (await prepaidCardMarketV2.isPaused()) {
+      available = false;
+    } else if (quantityAvailable < activeReservations) {
+      available = false;
+    }
+
     let result = this.emailCardDropRequestSerializer.serializeEmailCardDropRequestStatus({
       timestamp,
       ownerAddress,
+      available,
       rateLimited,
       claimed,
     });

--- a/packages/hub/services/serializers/email-card-drop-request-serializer.ts
+++ b/packages/hub/services/serializers/email-card-drop-request-serializer.ts
@@ -3,6 +3,7 @@ import { JSONAPIDocument } from '../../utils/jsonapi-document';
 
 interface EmailCardDropRequestClaimStatus {
   ownerAddress: string;
+  available: boolean;
   claimed: boolean;
   rateLimited: boolean;
   timestamp: Date;
@@ -28,6 +29,7 @@ export default class EmailCardDropRequestSerializer {
         id: `${model.ownerAddress}-${model.timestamp.toISOString()}`,
         attributes: {
           'owner-address': model.ownerAddress,
+          available: model.available,
           claimed: model.claimed,
           'rate-limited': model.rateLimited,
           timestamp: model.timestamp.toISOString(),


### PR DESCRIPTION
This adds another attribute to `GET /api/email-card-drop-requests`, `available`. When `available: false`, Card Wallet should not show the invitation banner. It can be `false` if `getQuantity` is less than active reservations or the market contract is paused.

While we’re revisiting this interface, is there any reason to have the logic for assessing whether to show the banner within Card Wallet? What if all the flags were combined in the API response and Card Wallet just had to look at the one? 🤔