### PR TITLE
hub: Fix card drop availability calculation

### DIFF
--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -49,7 +49,8 @@ class StubCardpaySDK {
     switch (sdk) {
       case 'PrepaidCardMarketV2':
         return Promise.resolve({
-          getQuantity: () => Promise.resolve(mockPrepaidCardQuantity),
+          // getQuantity is returned as a string
+          getQuantity: () => Promise.resolve(mockPrepaidCardQuantity.toString()),
           isPaused: () => Promise.resolve(mockPrepaidCardMarketContractPaused),
         });
       default:
@@ -105,9 +106,11 @@ describe('GET /api/email-card-drop-requests', function () {
   });
 
   it('reports no availability if there is insufficient funding for a card drop to be initiated', async function () {
-    let reservationCount = mockPrepaidCardQuantity + 1;
+    // Since these values are returned as strings, quantity '50' < reservations '100' is false, checking for true number comparison
+    let reservationCount = 100;
 
     let emailCardDropRequestsQueries = await getContainer().lookup('email-card-drop-requests', { type: 'query' });
+    let insertionTimeBeforeExpiry = new Date(fakeTime - emailVerificationLinkExpiryMinutes / 2);
 
     for (let i = 0; i < reservationCount; i++) {
       await emailCardDropRequestsQueries.insert({
@@ -115,7 +118,7 @@ describe('GET /api/email-card-drop-requests', function () {
         emailHash: `other-email-hash-${i}`,
         verificationCode: 'x',
         id: shortUUID.uuid(),
-        requestedAt: new Date(),
+        requestedAt: insertionTimeBeforeExpiry,
       });
     }
 

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -217,7 +217,7 @@ describe('POST /api/email-card-drop-requests', function () {
 
   it('persists an email card drop request and triggers jobs', async function () {
     let emailCardDropRequestsQueries = await getContainer().lookup('email-card-drop-requests', { type: 'query' });
-    let insertionTimeBeyondExpiry = Date.now() - emailVerificationLinkExpiryMinutes * 2 * 60 * 1000;
+    let insertionTimeBeyondExpiry = fakeTime - emailVerificationLinkExpiryMinutes * 2 * 60 * 1000;
 
     // Create no-longer-active reservations
 
@@ -499,7 +499,7 @@ describe('POST /api/email-card-drop-requests', function () {
 
     for (let i = 0; i <= count; i++) {
       let claim = Object.assign({}, claimedEoa);
-      claim.claimedAt = new Date(Date.now() - periodMinutes * 60 * 1000);
+      claim.claimedAt = new Date(fakeTime - periodMinutes * 60 * 1000);
       claim.id = shortUUID.uuid();
       await emailCardDropRequestsQueries.insert(claim);
     }
@@ -551,7 +551,7 @@ describe('POST /api/email-card-drop-requests', function () {
 
     for (let i = 0; i <= count * 2; i++) {
       let claim = Object.assign({}, claimedEoa);
-      claim.claimedAt = new Date(Date.now() - 2 * periodMinutes * 60 * 1000);
+      claim.claimedAt = new Date(fakeTime - 2 * periodMinutes * 60 * 1000);
       claim.id = shortUUID.uuid();
       await emailCardDropRequestsQueries.insert(claim);
     }

--- a/packages/hub/node-tests/routes/email-card-drop-request-test.ts
+++ b/packages/hub/node-tests/routes/email-card-drop-request-test.ts
@@ -110,7 +110,7 @@ describe('GET /api/email-card-drop-requests', function () {
     let reservationCount = 100;
 
     let emailCardDropRequestsQueries = await getContainer().lookup('email-card-drop-requests', { type: 'query' });
-    let insertionTimeBeforeExpiry = new Date(fakeTime - emailVerificationLinkExpiryMinutes / 2);
+    let insertionTimeBeforeExpiry = new Date(fakeTime - (emailVerificationLinkExpiryMinutes / 2) * 60 * 1000);
 
     for (let i = 0; i < reservationCount; i++) {
       await emailCardDropRequestsQueries.insert({

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -53,6 +53,7 @@
     "@sentry/node": "^6.10.0",
     "assert-never": "^1.2.1",
     "auto-bind": "^4.0.0",
+    "bn.js": "^5.2.0",
     "config": "^3.3.6",
     "corde": "^4.4.1",
     "crypto": "^1.0.1",
@@ -104,6 +105,7 @@
   "devDependencies": {
     "@cardstack/eslint-config": "1.0.5",
     "@cardstack/test-support": "1.0.5",
+    "@types/bn.js": "^5.1.0",
     "@types/chai": "^4.2.15",
     "@types/chai-as-promised": "^7.1.3",
     "@types/config": "^0.0.38",

--- a/packages/hub/queries/email-card-drop-requests.ts
+++ b/packages/hub/queries/email-card-drop-requests.ts
@@ -89,7 +89,7 @@ export default class EmailCardDropRequestsQueries {
     let { rows } = await db.query(
       `
         SELECT COUNT(*) FROM email_card_drop_requests
-        WHERE claimed_at > NOW() - interval '${minutes} minutes'
+        WHERE claimed_at > timestamp '${this.clock.postgresTimestampNow()}' - interval '${minutes} minutes'
       `
     );
 

--- a/packages/hub/queries/email-card-drop-requests.ts
+++ b/packages/hub/queries/email-card-drop-requests.ts
@@ -76,7 +76,7 @@ export default class EmailCardDropRequestsQueries {
           FROM email_card_drop_requests
           WHERE claimed_at IS NOT NULL
         ) AND
-        requested_at > (now() - interval '${emailVerificationLinkExpiryMinutes} minutes')
+        requested_at > (timestamp '${this.clock.postgresTimestampNow()}' - interval '${emailVerificationLinkExpiryMinutes} minutes')
     `;
 
     const queryResult = await db.query(query);

--- a/packages/hub/routes/email-card-drop-requests.ts
+++ b/packages/hub/routes/email-card-drop-requests.ts
@@ -111,10 +111,11 @@ export default class EmailCardDropRequestsRoute {
       return respondWith503(ctx, 'The prepaid card market contract is paused');
     }
 
-    let quantityAvailable = await prepaidCardMarketV2.getQuantity(cardDropSku);
-    let activeReservations = await this.emailCardDropRequestQueries.activeReservations();
+    let quantityAvailable = await this.getPrepaidCardQuantityAvailable();
+    let activeReservations = await this.getActiveReservations();
+    let unreserved = quantityAvailable.sub(activeReservations);
 
-    let supplyIsBelowNotificationThreshold = quantityAvailable - activeReservations < notifyWhenQuantityBelow;
+    let supplyIsBelowNotificationThreshold = unreserved.lt(new BN(notifyWhenQuantityBelow));
 
     log.info(
       `${cardDropSku} has ${quantityAvailable} available and ${activeReservations} reserved, notification threshold is ${notifyWhenQuantityBelow}`

--- a/packages/hub/services/clock.ts
+++ b/packages/hub/services/clock.ts
@@ -10,6 +10,9 @@ export class Clock {
   dateStringNow() {
     return format(this.now(), 'yyyy-MM-dd');
   }
+  postgresTimestampNow() {
+    return format(this.now(), 'yyyy-MM-dd HH:mm');
+  }
 }
 
 declare module '@cardstack/di' {


### PR DESCRIPTION
A combination of discrepancy in mock response types and test setup coincidences were masking a bug in the determination of whether there are sufficient funds for a user to initiate the card drop process. To exercise #3025 in staging, I checked `getQuantity` (48) and added 100 `email_card_drop_requests` records to simulate the number of reserved cards exceeding available funds and found that it was still showing `available: true`:

![image](https://user-images.githubusercontent.com/43280/174328885-404c0308-b066-4b22-9ffc-887e50f8a9f7.png)

With this change, `available: false` was the result in the same circumstances.

This updates SQL queries to not use `NOW()`, instead passing in `this.clock.now()`, which gets around the [difficulty in mocking `NOW()`](https://github.com/cardstack/cardstack/pull/2974#discussion_r882664945). So a few tests now use `fakeTime`.