### PR TITLE
Add extraction of spend accumulation table

### DIFF
--- a/packages/cardpay-subgraph-extraction/config/spend_accumulation.yaml
+++ b/packages/cardpay-subgraph-extraction/config/spend_accumulation.yaml
@@ -1,0 +1,43 @@
+base: &base
+  name: spend_accumulation
+  tables:
+    spend_accumulation:
+      column_mappings:
+        amount:
+          amount_uint64:
+            default: 0
+            max_value: 18446744073709551615
+            type: uint64
+            validity_column: amount_uint64_valid
+        block_number:
+          block_number_uint64:
+            default: 0
+            max_value: 18446744073709551615
+            type: uint64
+            validity_column: block_number_uint64_valid
+        historic_spend_balance:
+          historic_spend_balance_uint64:
+            default: 0
+            max_value: 18446744073709551615
+            type: uint64
+            validity_column: historic_spend_balance_uint64_valid
+        timestamp:
+          timestamp_uint64:
+            default: 0
+            max_value: 18446744073709551615
+            type: uint64
+            validity_column: timestamp_uint64_valid
+      partition_sizes:
+      - 524288
+      - 131072
+      - 16384
+      - 1024
+  version: 0.0.1
+
+staging:
+  <<: *base
+  subgraph: habdelra/cardpay-sokol
+
+production:
+  <<: *base
+  subgraph: habdelra/cardpay-xdai


### PR DESCRIPTION
Required for the testing of the DummyRule. Run locally to extract the data but not in production.