### PR TITLE
ci: Include inline policies for waypoint secrets access verification

### DIFF
--- a/scripts/verify-waypoint-secrets.ts
+++ b/scripts/verify-waypoint-secrets.ts
@@ -20,15 +20,21 @@ for (const appSlug of appSlugs) {
   if (appConfig.secretArns.length === 0) {
     continue;
   }
-  let allowedSecretArns = queryPolicyForAllowedSecretAccess(appConfig);
+  let allowedSecretArns = [
+    ...queryAttachedPoliciesForAllowedSecretAccess(appConfig),
+    ...queryRolePoliciesForAllowedSecretAccess(appConfig),
+  ];
+  let valid = true;
   for (const neededSecretArn of appConfig.secretArns) {
     if (!allowedSecretArns.includes(neededSecretArn)) {
+      valid = false;
       errors.push({
         app: appSlug,
         missingSecretArn: neededSecretArn,
       });
     }
   }
+  console.log(`${valid ? '✓' : '✗'} ${appSlug}`);
 }
 
 if (errors.length > 0) {
@@ -62,20 +68,45 @@ function parseWaypointConfig(waypointConfigFile): RelevantWaypointConfigByApp {
 }
 
 function execute(command, options) {
-  // console.log(`executing: ${command}`);
   return execSync(command, options ?? {})
     .toString()
     .trim();
 }
 
-function queryPolicyForAllowedSecretAccess(appConfig: RelevantWaypointConfig) {
+function queryAttachedPoliciesForAllowedSecretAccess(appConfig: RelevantWaypointConfig) {
   const policiesCmd = `aws iam list-attached-role-policies --role-name ${appConfig.executionRoleName} | grep PolicyArn | grep secrets | awk '{ print $2 }' | sed 's/[",]//g'`;
   let secretsPolicyArn = execute(policiesCmd, { env: { ...process.env, PAGER: '' } });
+
+  if (secretsPolicyArn == '') return [];
 
   const policyVersionsCmd = `aws iam list-policy-versions --policy-arn ${secretsPolicyArn} --query 'Versions[?IsDefaultVersion].VersionId' | grep v | awk '{ print $1 }' | sed 's/[",]//g'`;
   let defaultVersion = execute(policyVersionsCmd, { env: { ...process.env, PAGER: '' } });
 
   const policyDocumentCmd = `aws iam get-policy-version --policy-arn ${secretsPolicyArn} --version-id ${defaultVersion} --query 'PolicyVersion.Document.Statement[0].Resource'`;
   let allowedSecretArns = execute(policyDocumentCmd, { env: { ...process.env, PAGER: '' } });
+
+  return JSON.parse(allowedSecretArns);
+}
+
+function queryRolePoliciesForAllowedSecretAccess(appConfig: RelevantWaypointConfig) {
+  let allowedSecretArns = [];
+
+  const policiesCmd = `aws iam list-role-policies --role-name ${appConfig.executionRoleName} --query 'PolicyNames'`;
+  const policiesNames = JSON.parse(execute(policiesCmd, { env: { ...process.env, PAGER: '' } }));
+
+  for (const policyName of policiesNames) {
+    const statementsCmd = `aws iam get-role-policy --role-name ${appConfig.executionRoleName} --policy-name ${policyName} --query 'PolicyDocument.Statement'`;
+    const statements = JSON.parse(execute(statementsCmd, { env: { ...process.env, PAGER: '' } }));
+    for (const statement of statements) {
+      if (
+        statement.Action.includes('ssm:GetParameters') &&
+        statement.Action.includes('secretsmanager:GetSecretValue')
+      ) {
+        const arnRegex = new RegExp('arn:aws:secretsmanager:[^:]+:[^:]+:secret:[^:]+');
+        allowedSecretArns = allowedSecretArns.concat(statement.Resource.filter((resource) => arnRegex.test(resource)));
+      }
+    }
+  }
+
   return allowedSecretArns;
 }

--- a/waypoint.hcl
+++ b/waypoint.hcl
@@ -436,8 +436,8 @@ app "reward-api" {
       }
 
       secrets = {
-        DB_STRING  = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_reward_api_database_url-dF3FDU"
-        SENTRY_DSN = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_reward_api_sentry_dsn-Ugaqpm"
+        DB_STRING         = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_reward_api_database_url-dF3FDU"
+        SENTRY_DSN        = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_reward_api_sentry_dsn-Ugaqpm"
         EVM_FULL_NODE_URL = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_evm_full_node_url-NBKUCq"
       }
     }
@@ -449,6 +449,7 @@ app "reward-api" {
   }
 }
 
+<<<<<<< HEAD
 app "reward-indexer" {
   path = "./packages/cardpay-reward-indexer"
 
@@ -503,13 +504,13 @@ app "reward-scheduler" {
 
   config {
     env = {
-      ENVIRONMENT    = "staging"
-      REWARDS_BUCKET = "s3://cardpay-staging-reward-programs"
-      SUBGRAPH_URL   = "https://graph-staging.stack.cards/subgraphs/name/habdelra/cardpay-sokol"
+      ENVIRONMENT                        = "staging"
+      REWARDS_BUCKET                     = "s3://tally-staging-reward-programs"
+      SUBGRAPH_URL                       = "https://graph-staging.stack.cards/subgraphs/name/habdelra/cardpay-sokol"
       REWARD_SCHEDULER_APPROVED_PROGRAMS = "0x2F57D4cf81c87A92dd5f0686fEc6e02887662d07,0x5E4E148baae93424B969a0Ea67FF54c315248BbA"
-      REWARD_MANAGER_ADDRESS = "0xaC47B293f836F3a64eb4AEF02Cb7d1428dCe815f"
-      REWARDS_SUBGRAPH_EXTRACTION = "s3://cardpay-staging-partitioned-graph-data/data/rewards/0.0.2/"
-      REWARD_SCHEDULER_UPDATE_FREQUENCY = "600"
+      REWARD_MANAGER_ADDRESS             = "0xaC47B293f836F3a64eb4AEF02Cb7d1428dCe815f"
+      REWARDS_SUBGRAPH_EXTRACTION        = "s3://cardpay-staging-partitioned-graph-data/data/rewards/0.0.2/"
+      REWARD_SCHEDULER_UPDATE_FREQUENCY  = "600"
     }
   }
 
@@ -539,7 +540,7 @@ app "reward-scheduler" {
       disable_alb         = true
 
       secrets = {
-        SENTRY_DSN = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_reward_programs_sentry_dsn-zAMOFo"
+        SENTRY_DSN        = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_reward_programs_sentry_dsn-zAMOFo"
         EVM_FULL_NODE_URL = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_evm_full_node_url-NBKUCq"
       }
     }

--- a/waypoint.hcl
+++ b/waypoint.hcl
@@ -449,7 +449,6 @@ app "reward-api" {
   }
 }
 
-<<<<<<< HEAD
 app "reward-indexer" {
   path = "./packages/cardpay-reward-indexer"
 

--- a/waypoint.hcl
+++ b/waypoint.hcl
@@ -504,7 +504,7 @@ app "reward-scheduler" {
   config {
     env = {
       ENVIRONMENT                        = "staging"
-      REWARDS_BUCKET                     = "s3://tally-staging-reward-programs"
+      REWARDS_BUCKET                     = "s3://cardpay-staging-reward-programs"
       SUBGRAPH_URL                       = "https://graph-staging.stack.cards/subgraphs/name/habdelra/cardpay-sokol"
       REWARD_SCHEDULER_APPROVED_PROGRAMS = "0x2F57D4cf81c87A92dd5f0686fEc6e02887662d07,0x5E4E148baae93424B969a0Ea67FF54c315248BbA"
       REWARD_MANAGER_ADDRESS             = "0xaC47B293f836F3a64eb4AEF02Cb7d1428dCe815f"


### PR DESCRIPTION
In the new `waypoint/aws-ecs` module, the policies for ECS IAM roles are attached via inline policies instead of customer managed policies. This update the secret access checking to include inline policies.