### PR TITLE
hub: Add retry endpoint for job tickets

### DIFF
--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -948,7 +948,8 @@ CREATE TABLE public.job_tickets (
     result jsonb,
     state text DEFAULT 'pending'::text NOT NULL,
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    spec jsonb
 );
 
 
@@ -1743,6 +1744,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 36	20220527195553987_add-prepaid-notification-type	2022-05-27 15:09:36.826839
 37	20220527204632100_create-exchange-rates	2022-05-27 15:47:21.944976
 39	20220610203119883_create-job-tickets	2022-06-13 09:56:55.438506
+40	20220622235635327_add-job-ticket-spec	2022-06-22 19:02:28.256468
 \.
 
 
@@ -1750,7 +1752,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 -- Name: pgmigrations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.pgmigrations_id_seq', 39, true);
+SELECT pg_catalog.setval('public.pgmigrations_id_seq', 40, true);
 
 
 --

--- a/packages/hub/db/migrations/20220610203119883_create-job-tickets.ts
+++ b/packages/hub/db/migrations/20220610203119883_create-job-tickets.ts
@@ -1,7 +1,6 @@
 import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
 
 const JOB_TICKETS_TABLE = 'job_tickets';
-export const JOB_TICKETS_STATE_DEFAULT = 'pending';
 
 export const shorthands: ColumnDefinitions | undefined = undefined;
 
@@ -12,7 +11,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     owner_address: { type: 'string', notNull: true },
     payload: { type: 'jsonb' },
     result: { type: 'jsonb' },
-    state: { type: 'string', notNull: true, default: JOB_TICKETS_STATE_DEFAULT },
+    state: { type: 'string', notNull: true, default: 'pending' },
     created_at: { type: 'timestamp', notNull: true, default: pgm.func('current_timestamp') },
     updated_at: { type: 'timestamp', notNull: true, default: pgm.func('current_timestamp') },
   });

--- a/packages/hub/db/migrations/20220610203119883_create-job-tickets.ts
+++ b/packages/hub/db/migrations/20220610203119883_create-job-tickets.ts
@@ -1,6 +1,7 @@
 import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
 
 const JOB_TICKETS_TABLE = 'job_tickets';
+export const JOB_TICKETS_STATE_DEFAULT = 'pending';
 
 export const shorthands: ColumnDefinitions | undefined = undefined;
 
@@ -11,7 +12,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     owner_address: { type: 'string', notNull: true },
     payload: { type: 'jsonb' },
     result: { type: 'jsonb' },
-    state: { type: 'string', notNull: true, default: 'pending' },
+    state: { type: 'string', notNull: true, default: JOB_TICKETS_STATE_DEFAULT },
     created_at: { type: 'timestamp', notNull: true, default: pgm.func('current_timestamp') },
     updated_at: { type: 'timestamp', notNull: true, default: pgm.func('current_timestamp') },
   });

--- a/packages/hub/db/migrations/20220622235635327_add-job-ticket-spec.ts
+++ b/packages/hub/db/migrations/20220622235635327_add-job-ticket-spec.ts
@@ -1,0 +1,16 @@
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+const JOB_TICKETS_TABLE = 'job_tickets';
+const SPEC_COLUMN_NAME = 'spec';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumns(JOB_TICKETS_TABLE, {
+    [SPEC_COLUMN_NAME]: { type: 'jsonb' },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumns(JOB_TICKETS_TABLE, [SPEC_COLUMN_NAME]);
+}

--- a/packages/hub/node-tests/routes/job-tickets-test.ts
+++ b/packages/hub/node-tests/routes/job-tickets-test.ts
@@ -1,5 +1,6 @@
 import { registry, setupHub } from '../helpers/server';
 import shortUUID from 'short-uuid';
+import JobTicketsQueries from '../../queries/job-tickets';
 
 class StubAuthenticationUtils {
   validateAuthToken(encryptedAuthToken: string) {
@@ -86,6 +87,134 @@ describe('GET /api/job-tickets/:id', function () {
 
     await request()
       .get(`/api/job-tickets/${randomId}`)
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(404)
+      .expect({
+        errors: [
+          {
+            status: '404',
+            title: 'Job ticket not found',
+            detail: `Could not find the job ticket ${randomId}`,
+          },
+        ],
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+});
+
+describe('POST /api/job-tickets/:id/retry', function () {
+  this.beforeEach(function () {
+    registry(this).register('authentication-utils', StubAuthenticationUtils);
+  });
+
+  let { request, getContainer } = setupHub(this);
+  let jobTicketsQueries: JobTicketsQueries,
+    jobTicketId: string,
+    otherOwnerJobTicketId: string,
+    notFailedJobTicketId: string;
+  let ticketIds: string[];
+
+  this.beforeEach(async function () {
+    jobTicketsQueries = await getContainer().lookup('job-tickets', { type: 'query' });
+
+    jobTicketId = shortUUID.uuid();
+    await jobTicketsQueries.insert({
+      id: jobTicketId,
+      jobType: 'a-job',
+      ownerAddress: stubUserAddress,
+      payload: { 'a-payload': 'yes' },
+    });
+    await jobTicketsQueries.update(jobTicketId, { 'a-result': 'yes' }, 'failed');
+
+    otherOwnerJobTicketId = shortUUID.uuid();
+    await jobTicketsQueries.insert({ id: otherOwnerJobTicketId, jobType: 'a-job', ownerAddress: '0x111' });
+
+    notFailedJobTicketId = shortUUID.uuid();
+    await jobTicketsQueries.insert({ id: notFailedJobTicketId, jobType: 'a-job', ownerAddress: stubUserAddress });
+
+    ticketIds = [jobTicketId, otherOwnerJobTicketId, notFailedJobTicketId];
+  });
+
+  it('adds a new job, adds a job ticket for it, and returns its details', async function () {
+    await request()
+      .post(`/api/job-tickets/${jobTicketId}/retry`)
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(201)
+      .expect(function (res) {
+        expect(res.body.data.id).to.not.equal(jobTicketId);
+        expect(res.body.data.attributes).to.deep.equal({
+          'job-type': 'a-job',
+          state: 'pending',
+        });
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+
+    let allTickets = await jobTicketsQueries.findAll();
+
+    let newTicket = allTickets.find((ticket) => !ticketIds.includes(ticket.id));
+
+    expect(newTicket?.ownerAddress).to.equal(stubUserAddress);
+    expect(newTicket?.jobType).to.equal('a-job');
+    expect(newTicket?.payload).to.deep.equal({ 'a-payload': 'yes' });
+  });
+
+  it('returns 401 without bearer token', async function () {
+    await request()
+      .post(`/api/job-tickets/${jobTicketId}/retry`)
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(401)
+      .expect({
+        errors: [
+          {
+            status: '401',
+            title: 'No valid auth token',
+          },
+        ],
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('returns 401 when the job ticket requested is for a different owner', async function () {
+    await request()
+      .post(`/api/job-tickets/${otherOwnerJobTicketId}/retry`)
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(401)
+      .expect({
+        errors: [
+          {
+            status: '401',
+            title: 'No valid auth token',
+          },
+        ],
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('returns 422 when the job ticket state is not failed', async function () {
+    await request()
+      .post(`/api/job-tickets/${notFailedJobTicketId}/retry`)
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(422)
+      .expect({
+        errors: [
+          {
+            status: '422',
+            title: 'Job ticket state is not failed',
+          },
+        ],
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('returns 404 for an unknown job', async function () {
+    let randomId = shortUUID.uuid();
+
+    await request()
+      .post(`/api/job-tickets/${randomId}/retry`)
       .set('Authorization', 'Bearer abc123--def456--ghi789')
       .set('Content-Type', 'application/vnd.api+json')
       .expect(404)

--- a/packages/hub/node-tests/routes/job-tickets-test.ts
+++ b/packages/hub/node-tests/routes/job-tickets-test.ts
@@ -149,7 +149,6 @@ describe('POST /api/job-tickets/:id/retry', function () {
       .expect(function (res) {
         expect(res.body.data.id).to.not.equal(jobTicketId);
         expect(res.body.data.attributes).to.deep.equal({
-          'job-type': 'a-job',
           state: 'pending',
         });
       })

--- a/packages/hub/node-tests/routes/job-tickets-test.ts
+++ b/packages/hub/node-tests/routes/job-tickets-test.ts
@@ -105,7 +105,7 @@ describe('GET /api/job-tickets/:id', function () {
 });
 
 describe('POST /api/job-tickets/:id/retry', function () {
-  let { getJobIdentifiers, getJobPayloads } = setupStubWorkerClient(this);
+  let { getJobIdentifiers, getJobPayloads, getJobSpecs } = setupStubWorkerClient(this);
 
   this.beforeEach(function () {
     registry(this).register('authentication-utils', StubAuthenticationUtils);
@@ -127,6 +127,7 @@ describe('POST /api/job-tickets/:id/retry', function () {
       jobType: 'a-job',
       ownerAddress: stubUserAddress,
       payload: { 'a-payload': 'yes' },
+      spec: { 'a-spec': 'yes' },
     });
     await jobTicketsQueries.update(jobTicketId, { 'a-result': 'yes' }, 'failed');
 
@@ -156,6 +157,7 @@ describe('POST /api/job-tickets/:id/retry', function () {
 
     expect(getJobIdentifiers()).to.deep.equal(['a-job']);
     expect(getJobPayloads()).to.deep.equal([{ 'a-payload': 'yes' }]);
+    expect(getJobSpecs()).to.deep.equal([{ 'a-spec': 'yes' }]);
 
     let allTickets = await jobTicketsQueries.findAll();
 
@@ -164,6 +166,7 @@ describe('POST /api/job-tickets/:id/retry', function () {
     expect(newTicket?.ownerAddress).to.equal(stubUserAddress);
     expect(newTicket?.jobType).to.equal('a-job');
     expect(newTicket?.payload).to.deep.equal({ 'a-payload': 'yes' });
+    expect(newTicket?.spec).to.deep.equal({ 'a-spec': 'yes' });
   });
 
   it('returns 401 without bearer token', async function () {

--- a/packages/hub/node-tests/routes/job-tickets-test.ts
+++ b/packages/hub/node-tests/routes/job-tickets-test.ts
@@ -214,7 +214,7 @@ describe('POST /api/job-tickets/:id/retry', function () {
         errors: [
           {
             status: '422',
-            title: 'Job ticket state is not failed',
+            title: 'Can only retry a job with failed state (current state: pending)',
           },
         ],
       })

--- a/packages/hub/queries/job-tickets.ts
+++ b/packages/hub/queries/job-tickets.ts
@@ -39,6 +39,8 @@ export default class JobTicketsQueries {
       model.payload,
       model.spec,
     ]);
+
+    return this.find(model.id!);
   }
 
   async update(id: string, result: any, state: string) {

--- a/packages/hub/queries/job-tickets.ts
+++ b/packages/hub/queries/job-tickets.ts
@@ -20,15 +20,6 @@ export default class JobTicketsQueries {
     }
   }
 
-  async findAll(): Promise<JobTicket[]> {
-    let db = await this.databaseManager.getClient();
-
-    let query = `SELECT * FROM job_tickets`;
-    let queryResult = await db.query(query);
-
-    return queryResult.rows.map((row) => mapRowToModel(row));
-  }
-
   async insert(model: Partial<JobTicket>) {
     let db = await this.databaseManager.getClient();
 

--- a/packages/hub/queries/job-tickets.ts
+++ b/packages/hub/queries/job-tickets.ts
@@ -14,26 +14,29 @@ export default class JobTicketsQueries {
     if (queryResult.rows.length) {
       let row = queryResult.rows[0];
 
-      return {
-        id: row['id'],
-        jobType: row['job_type'],
-        ownerAddress: row['owner_address'],
-        state: row['state'],
-        payload: row['payload'],
-        result: row['result'],
-      };
+      return mapRowToModel(row);
     } else {
       return null;
     }
   }
 
+  async findAll(): Promise<JobTicket[]> {
+    let db = await this.databaseManager.getClient();
+
+    let query = `SELECT * FROM job_tickets`;
+    let queryResult = await db.query(query);
+
+    return queryResult.rows.map((row) => mapRowToModel(row));
+  }
+
   async insert(model: Partial<JobTicket>) {
     let db = await this.databaseManager.getClient();
 
-    await db.query('INSERT INTO job_tickets (id, job_type, owner_address) VALUES($1, $2, $3)', [
+    await db.query('INSERT INTO job_tickets (id, job_type, owner_address, payload) VALUES($1, $2, $3, $4)', [
       model.id,
       model.jobType,
       model.ownerAddress,
+      model.payload,
     ]);
   }
 
@@ -48,6 +51,17 @@ export default class JobTicketsQueries {
       [id, result, state]
     );
   }
+}
+
+function mapRowToModel(row: any): JobTicket {
+  return {
+    id: row['id'],
+    jobType: row['job_type'],
+    ownerAddress: row['owner_address'],
+    state: row['state'],
+    payload: row['payload'],
+    result: row['result'],
+  };
 }
 
 declare module '@cardstack/hub/queries' {

--- a/packages/hub/queries/job-tickets.ts
+++ b/packages/hub/queries/job-tickets.ts
@@ -32,11 +32,12 @@ export default class JobTicketsQueries {
   async insert(model: Partial<JobTicket>) {
     let db = await this.databaseManager.getClient();
 
-    await db.query('INSERT INTO job_tickets (id, job_type, owner_address, payload) VALUES($1, $2, $3, $4)', [
+    await db.query('INSERT INTO job_tickets (id, job_type, owner_address, payload, spec) VALUES($1, $2, $3, $4, $5)', [
       model.id,
       model.jobType,
       model.ownerAddress,
       model.payload,
+      model.spec,
     ]);
   }
 
@@ -58,6 +59,7 @@ function mapRowToModel(row: any): JobTicket {
     id: row['id'],
     jobType: row['job_type'],
     ownerAddress: row['owner_address'],
+    spec: row['spec'],
     state: row['state'],
     payload: row['payload'],
     result: row['result'],

--- a/packages/hub/routes/job-tickets.ts
+++ b/packages/hub/routes/job-tickets.ts
@@ -3,6 +3,7 @@ import autoBind from 'auto-bind';
 import { query } from '@cardstack/hub/queries';
 import { ensureLoggedIn } from './utils/auth';
 import { inject } from '@cardstack/di';
+import shortUUID from 'short-uuid';
 
 export interface JobTicket {
   id: string;
@@ -68,6 +69,63 @@ export default class JobTicketsRoute {
     ctx.body = this.jobTicketSerializer.serialize(jobTicket!);
     ctx.type = 'application/vnd.api+json';
     ctx.status = 200;
+  }
+
+  async retry(ctx: Koa.Context) {
+    if (!ensureLoggedIn(ctx)) {
+      return;
+    }
+
+    let id = ctx.params.id;
+    let jobTicketToRetry = await this.jobTicketsQueries.find(id);
+
+    if (!jobTicketToRetry) {
+      ctx.body = {
+        errors: [
+          {
+            status: '404',
+            title: 'Job ticket not found',
+            detail: `Could not find the job ticket ${id}`,
+          },
+        ],
+      };
+      ctx.type = 'application/vnd.api+json';
+      ctx.status = 404;
+
+      return;
+    }
+
+    let requestingUserAddress = ctx.state.userAddress;
+
+    if (jobTicketToRetry.ownerAddress !== requestingUserAddress) {
+      ctx.body = {
+        errors: [
+          {
+            status: '401',
+            title: 'No valid auth token',
+          },
+        ],
+      };
+      ctx.type = 'application/vnd.api+json';
+      ctx.status = 401;
+
+      return;
+    }
+
+    let newJobTicket = {
+      id: shortUUID.uuid(),
+      jobType: jobTicketToRetry.jobType,
+      ownerAddress: jobTicketToRetry.ownerAddress,
+      payload: jobTicketToRetry.payload,
+      result: null,
+      state: 'pending', // FIXME hmm
+    };
+
+    await this.jobTicketsQueries.insert(newJobTicket);
+
+    ctx.body = this.jobTicketSerializer.serialize(newJobTicket!);
+    ctx.type = 'application/vnd.api+json';
+    ctx.status = 201;
   }
 }
 

--- a/packages/hub/routes/job-tickets.ts
+++ b/packages/hub/routes/job-tickets.ts
@@ -4,7 +4,6 @@ import { query } from '@cardstack/hub/queries';
 import { ensureLoggedIn } from './utils/auth';
 import { inject } from '@cardstack/di';
 import shortUUID from 'short-uuid';
-import { JOB_TICKETS_STATE_DEFAULT } from '../db/migrations/20220610203119883_create-job-tickets';
 
 export interface JobTicket {
   id: string;
@@ -13,7 +12,7 @@ export interface JobTicket {
   payload: any;
   result: any;
   spec: any;
-  state: string;
+  state?: string;
 }
 
 export default class JobTicketsRoute {
@@ -132,17 +131,16 @@ export default class JobTicketsRoute {
 
     this.workerClient.addJob(jobTicketToRetry.jobType, jobTicketToRetry.payload, jobTicketToRetry.spec);
 
-    let newJobTicket = {
+    let newJobTicket: JobTicket | null = {
       id: shortUUID.uuid(),
       jobType: jobTicketToRetry.jobType,
       ownerAddress: jobTicketToRetry.ownerAddress,
       payload: jobTicketToRetry.payload,
       result: null,
       spec: jobTicketToRetry.spec,
-      state: JOB_TICKETS_STATE_DEFAULT,
     };
 
-    await this.jobTicketsQueries.insert(newJobTicket);
+    newJobTicket = await this.jobTicketsQueries.insert(newJobTicket);
 
     ctx.body = this.jobTicketSerializer.serialize(newJobTicket!);
     ctx.type = 'application/vnd.api+json';

--- a/packages/hub/routes/job-tickets.ts
+++ b/packages/hub/routes/job-tickets.ts
@@ -4,6 +4,7 @@ import { query } from '@cardstack/hub/queries';
 import { ensureLoggedIn } from './utils/auth';
 import { inject } from '@cardstack/di';
 import shortUUID from 'short-uuid';
+import { JOB_TICKETS_STATE_DEFAULT } from '../db/migrations/20220610203119883_create-job-tickets';
 
 export interface JobTicket {
   id: string;
@@ -138,7 +139,7 @@ export default class JobTicketsRoute {
       payload: jobTicketToRetry.payload,
       result: null,
       spec: jobTicketToRetry.spec,
-      state: 'pending', // FIXME hmm
+      state: JOB_TICKETS_STATE_DEFAULT,
     };
 
     await this.jobTicketsQueries.insert(newJobTicket);

--- a/packages/hub/routes/job-tickets.ts
+++ b/packages/hub/routes/job-tickets.ts
@@ -11,6 +11,7 @@ export interface JobTicket {
   ownerAddress: string;
   payload: any;
   result: any;
+  spec: any;
   state: string;
 }
 
@@ -128,7 +129,7 @@ export default class JobTicketsRoute {
       return;
     }
 
-    this.workerClient.addJob(jobTicketToRetry.jobType, jobTicketToRetry.payload);
+    this.workerClient.addJob(jobTicketToRetry.jobType, jobTicketToRetry.payload, jobTicketToRetry.spec);
 
     let newJobTicket = {
       id: shortUUID.uuid(),
@@ -136,6 +137,7 @@ export default class JobTicketsRoute {
       ownerAddress: jobTicketToRetry.ownerAddress,
       payload: jobTicketToRetry.payload,
       result: null,
+      spec: jobTicketToRetry.spec,
       state: 'pending', // FIXME hmm
     };
 

--- a/packages/hub/routes/job-tickets.ts
+++ b/packages/hub/routes/job-tickets.ts
@@ -119,7 +119,7 @@ export default class JobTicketsRoute {
         errors: [
           {
             status: '422',
-            title: 'Job ticket state is not failed',
+            title: `Can only retry a job with failed state (current state: ${jobTicketToRetry.state})`,
           },
         ],
       };

--- a/packages/hub/routes/job-tickets.ts
+++ b/packages/hub/routes/job-tickets.ts
@@ -112,6 +112,21 @@ export default class JobTicketsRoute {
       return;
     }
 
+    if (jobTicketToRetry.state !== 'failed') {
+      ctx.body = {
+        errors: [
+          {
+            status: '422',
+            title: 'Job ticket state is not failed',
+          },
+        ],
+      };
+      ctx.type = 'application/vnd.api+json';
+      ctx.status = 422;
+
+      return;
+    }
+
     let newJobTicket = {
       id: shortUUID.uuid(),
       jobType: jobTicketToRetry.jobType,

--- a/packages/hub/routes/job-tickets.ts
+++ b/packages/hub/routes/job-tickets.ts
@@ -20,6 +20,7 @@ export default class JobTicketsRoute {
   });
 
   jobTicketsQueries = query('job-tickets', { as: 'jobTicketsQueries' });
+  workerClient = inject('worker-client', { as: 'workerClient' });
 
   constructor() {
     autoBind(this);
@@ -126,6 +127,8 @@ export default class JobTicketsRoute {
 
       return;
     }
+
+    this.workerClient.addJob(jobTicketToRetry.jobType, jobTicketToRetry.payload);
 
     let newJobTicket = {
       id: shortUUID.uuid(),

--- a/packages/hub/services/api-router.ts
+++ b/packages/hub/services/api-router.ts
@@ -92,6 +92,7 @@ export default class APIRouter {
     apiSubrouter.post('/email-card-drop-requests', parseBody, emailCardDropRequestsRoute.post);
 
     apiSubrouter.get('/job-tickets/:id', jobTicketsRoute.get);
+    apiSubrouter.post('/job-tickets/:id/retry', jobTicketsRoute.retry);
 
     apiSubrouter.get('/card-spaces/:slug', cardSpacesRoute.get);
     apiSubrouter.patch('/card-spaces/:id', parseBody, cardSpacesRoute.patch);

--- a/packages/hub/services/serializers/job-ticket-serializer.ts
+++ b/packages/hub/services/serializers/job-ticket-serializer.ts
@@ -4,7 +4,6 @@ import { JobTicket } from '../../routes/job-tickets';
 export default class JobTicketSerializer {
   serialize(model: JobTicket): JSONAPIDocument {
     let attributes: any = {
-      'job-type': model.jobType,
       state: model.state,
     };
 

--- a/packages/hub/services/serializers/job-ticket-serializer.ts
+++ b/packages/hub/services/serializers/job-ticket-serializer.ts
@@ -3,14 +3,20 @@ import { JobTicket } from '../../routes/job-tickets';
 
 export default class JobTicketSerializer {
   serialize(model: JobTicket): JSONAPIDocument {
+    let attributes: any = {
+      'job-type': model.jobType,
+      state: model.state,
+    };
+
+    if (model.result) {
+      attributes.result = model.result;
+    }
+
     const result = {
       data: {
         id: model.id,
         type: 'job-tickets',
-        attributes: {
-          result: model.result,
-          state: model.state,
-        },
+        attributes,
       },
     };
 


### PR DESCRIPTION
`POST /api/job-tickets/:id/retry` queues a duplicate of the retried job and returns the id and attributes of the new job ticket for that job.

The `CreateProfile` job is intended to be queued with spec `maxAttempts: 1`. I added the `job_tickets.spec` column to preserve the spec a job was started with so it can be used again when retrying.