### PR TITLE
[CS-4070]: Add ethers signer to hubAuth module

### DIFF
--- a/packages/cardpay-sdk/sdk/hub-auth.ts
+++ b/packages/cardpay-sdk/sdk/hub-auth.ts
@@ -3,6 +3,7 @@ import { signTypedData } from './utils/signing-utils';
 import { networkName } from './utils/general-utils';
 import { networkIds } from './constants';
 import { ContractOptions } from 'web3-eth-contract';
+import { Signer } from 'ethers';
 
 export interface IHubAuth {
   getNonce(): Promise<NonceResponse>;
@@ -15,7 +16,7 @@ interface NonceResponse {
 }
 
 export default class HubAuth implements IHubAuth {
-  constructor(private layer2Web3: Web3, private hubRootUrl: string) {}
+  constructor(private layer2Web3: Web3, private hubRootUrl: string, private layer2Signer?: Signer) {}
 
   async checkValidAuth(authToken: string): Promise<boolean> {
     let response = await this.httpGetSession(authToken);
@@ -60,7 +61,7 @@ export default class HubAuth implements IHubAuth {
         nonce,
       },
     };
-    let signature = await signTypedData(this.layer2Web3, ownerAddress, typedData);
+    let signature = await signTypedData(this.layer2Signer ?? this.layer2Web3, ownerAddress, typedData);
     let postBody = JSON.stringify({
       data: {
         attributes: {

--- a/packages/cardpay-sdk/sdk/hub-auth.ts
+++ b/packages/cardpay-sdk/sdk/hub-auth.ts
@@ -1,7 +1,7 @@
 import Web3 from 'web3';
 import { signTypedData } from './utils/signing-utils';
 import { networkName } from './utils/general-utils';
-import { networkIds } from './constants';
+import { getConstantByNetwork, networkIds } from './constants';
 import { ContractOptions } from 'web3-eth-contract';
 import { Signer } from 'ethers';
 
@@ -16,7 +16,7 @@ interface NonceResponse {
 }
 
 export default class HubAuth implements IHubAuth {
-  constructor(private layer2Web3: Web3, private hubRootUrl: string, private layer2Signer?: Signer) {}
+  constructor(private layer2Web3: Web3, private hubRootUrl?: string, private layer2Signer?: Signer) {}
 
   async checkValidAuth(authToken: string): Promise<boolean> {
     let response = await this.httpGetSession(authToken);
@@ -36,8 +36,12 @@ export default class HubAuth implements IHubAuth {
   async authenticate(contractOptions?: ContractOptions): Promise<string> {
     let ownerAddress = contractOptions?.from ?? (await this.layer2Web3.eth.getAccounts())[0];
     let { nonce, version } = await this.getNonce();
-    let name = await networkName(this.layer2Web3);
-    let chainId = networkIds[name];
+
+    const netName = await networkName(this.layer2Web3);
+    const chainId = networkIds[netName];
+
+    const hubUrl = await this.getHubUrl(netName);
+
     const typedData = {
       types: {
         EIP712Domain: [
@@ -51,7 +55,7 @@ export default class HubAuth implements IHubAuth {
         ],
       },
       domain: {
-        name: this.hubRootUrl.replace(/https?:\/\//, ''),
+        name: hubUrl.replace(/https?:\/\//, ''),
         version,
         chainId,
       },
@@ -70,7 +74,7 @@ export default class HubAuth implements IHubAuth {
         },
       },
     });
-    let response = await global.fetch(`${this.hubRootUrl}/api/session`, {
+    let response = await global.fetch(`${hubUrl}/api/session`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/vnd.api+json',
@@ -89,7 +93,9 @@ export default class HubAuth implements IHubAuth {
   }
 
   private async httpGetSession(authToken?: string): Promise<Response> {
-    let url = `${this.hubRootUrl}/api/session`;
+    const hubUrl = await this.getHubUrl();
+
+    let url = `${hubUrl}/api/session`;
     let headers = {
       'Content-Type': 'application/vnd.api+json',
     } as Record<string, string>;
@@ -97,5 +103,11 @@ export default class HubAuth implements IHubAuth {
       headers['Authorization'] = `Bearer ${authToken}`;
     }
     return global.fetch(url, { headers });
+  }
+
+  private async getHubUrl(network?: string): Promise<string> {
+    const netName = network || (await networkName(this.layer2Web3));
+
+    return this.hubRootUrl || getConstantByNetwork('hubUrl', netName);
   }
 }

--- a/packages/cardpay-sdk/sdk/utils/signing-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/signing-utils.ts
@@ -274,12 +274,13 @@ export async function signTypedData(web3OrSigner: Web3 | Signer, account: string
     }
     if (Signer.isSigner(web3OrSigner)) {
       let signer = web3OrSigner;
-      let {
-        types: { SafeTx },
-        domain,
-        message,
-      } = data;
-      let types = { SafeTx };
+      let { domain, message } = data;
+
+      // Ethers signer errors when types fields are mismatched with message fields,
+      // Which is the case for EIP712Domain, so it needs to be removed before signing
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { EIP712Domain: removed, ...types } = data.types;
+
       //@ts-ignore the _signTypedData method is unfortunately not typed
       signature = await signer._signTypedData(domain, types, message);
     } else {


### PR DESCRIPTION
This PR adds the option to use ethers signer for hub authentication, it also makes the hubUrl optional, since it already has the network value, in other to use ethers signer for other tx, that are not safeTx, the `signTypedData` was  modified to filter out `EIP712Domain` which fields are not applied on the message.