### PR TITLE
Skip processed jobs

### DIFF
--- a/packages/cardpay-reward-scheduler/reward_scheduler/reward_program.py
+++ b/packages/cardpay-reward-scheduler/reward_scheduler/reward_program.py
@@ -166,7 +166,9 @@ class RewardProgram:
         )
 
         if payment_cycle_output.joinpath("results.parquet").exists():
-            logging.info(f"Already processed: {payment_cycle} for {self.reward_program_id}")
+            logging.info(
+                f"Already processed: {payment_cycle} for {self.reward_program_id}"
+            )
             return None
 
         # We can't pass much data directly in AWS batch, so write the

--- a/packages/cardpay-reward-scheduler/reward_scheduler/reward_program.py
+++ b/packages/cardpay-reward-scheduler/reward_scheduler/reward_program.py
@@ -165,6 +165,10 @@ class RewardProgram:
             f"paymentCycle={payment_cycle}"
         )
 
+        if payment_cycle_output.joinpath("results.parquet").exists():
+            logging.info(f"Already processed: {payment_cycle} for {self.reward_program_id}")
+            return None
+
         # We can't pass much data directly in AWS batch, so write the
         # parameters we want to use to S3 and pass the location into the task
         parameters_location = payment_cycle_output.joinpath("parameters.json")


### PR DESCRIPTION
If the file already exists on S3, triggering a new job is irrelevant.

This doesn't deal with things waiting in the job queue, but does cut down significantly on reprocessed jobs.