### PR TITLE
Task interface registry

### DIFF
--- a/packages/hub/node-tests/routes/job-tickets-test.ts
+++ b/packages/hub/node-tests/routes/job-tickets-test.ts
@@ -2,6 +2,7 @@ import { registry, setupHub } from '../helpers/server';
 import shortUUID from 'short-uuid';
 import JobTicketsQueries from '../../queries/job-tickets';
 import { setupStubWorkerClient } from '../helpers/stub-worker-client';
+import { KnownTasks } from '@cardstack/hub/tasks';
 
 class StubAuthenticationUtils {
   validateAuthToken(encryptedAuthToken: string) {
@@ -27,11 +28,19 @@ describe('GET /api/job-tickets/:id', function () {
     jobTicketsQueries = await getContainer().lookup('job-tickets', { type: 'query' });
 
     jobTicketId = shortUUID.uuid();
-    await jobTicketsQueries.insert({ id: jobTicketId, jobType: 'a-job', ownerAddress: stubUserAddress });
+    await jobTicketsQueries.insert({
+      id: jobTicketId,
+      jobType: 'a-job' as keyof KnownTasks,
+      ownerAddress: stubUserAddress,
+    });
     await jobTicketsQueries.update(jobTicketId, { 'a-result': 'yes' }, 'success');
 
     otherOwnerJobTicketId = shortUUID.uuid();
-    await jobTicketsQueries.insert({ id: otherOwnerJobTicketId, jobType: 'a-job', ownerAddress: '0x111' });
+    await jobTicketsQueries.insert({
+      id: otherOwnerJobTicketId,
+      jobType: 'a-job' as keyof KnownTasks,
+      ownerAddress: '0x111',
+    });
   });
 
   it('returns the job ticket details', async function () {
@@ -123,7 +132,7 @@ describe('POST /api/job-tickets/:id/retry', function () {
     jobTicketId = shortUUID.uuid();
     await jobTicketsQueries.insert({
       id: jobTicketId,
-      jobType: 'a-job',
+      jobType: 'a-job' as keyof KnownTasks,
       ownerAddress: stubUserAddress,
       payload: { 'a-payload': 'yes' },
       spec: { 'a-spec': 'yes' },
@@ -131,10 +140,18 @@ describe('POST /api/job-tickets/:id/retry', function () {
     await jobTicketsQueries.update(jobTicketId, { 'a-result': 'yes' }, 'failed');
 
     otherOwnerJobTicketId = shortUUID.uuid();
-    await jobTicketsQueries.insert({ id: otherOwnerJobTicketId, jobType: 'a-job', ownerAddress: '0x111' });
+    await jobTicketsQueries.insert({
+      id: otherOwnerJobTicketId,
+      jobType: 'a-job' as keyof KnownTasks,
+      ownerAddress: '0x111',
+    });
 
     notFailedJobTicketId = shortUUID.uuid();
-    await jobTicketsQueries.insert({ id: notFailedJobTicketId, jobType: 'a-job', ownerAddress: stubUserAddress });
+    await jobTicketsQueries.insert({
+      id: notFailedJobTicketId,
+      jobType: 'a-job' as keyof KnownTasks,
+      ownerAddress: stubUserAddress,
+    });
   });
 
   it('adds a new job, adds a job ticket for it, and returns its details', async function () {

--- a/packages/hub/node-tests/services/worker-client-test.ts
+++ b/packages/hub/node-tests/services/worker-client-test.ts
@@ -1,3 +1,4 @@
+import { KnownTasks } from '@cardstack/hub/tasks';
 import WorkerClient from '../../services/worker-client';
 describe('WorkerClient', function () {
   let subject: WorkerClient;
@@ -12,7 +13,7 @@ describe('WorkerClient', function () {
 
   it('cannot add job before ready', async function () {
     try {
-      await subject.addJob('foo');
+      await subject.addJob('foo' as keyof KnownTasks);
       expect.fail('Should not reach here');
     } catch (e) {
       expect(e.message).to.equal('Cannot call addJob before workerUtils is ready');
@@ -21,7 +22,7 @@ describe('WorkerClient', function () {
 
   it('can add a job after ready', async function () {
     await subject.ready();
-    let job = await subject.addJob('foo');
+    let job = await subject.addJob('foo' as keyof KnownTasks);
     expect(job.task_identifier).to.equal('foo');
   });
 });

--- a/packages/hub/routes/job-tickets.ts
+++ b/packages/hub/routes/job-tickets.ts
@@ -4,10 +4,11 @@ import { query } from '@cardstack/hub/queries';
 import { ensureLoggedIn } from './utils/auth';
 import { inject } from '@cardstack/di';
 import shortUUID from 'short-uuid';
+import { KnownTasks } from '@cardstack/hub/tasks';
 
 export interface JobTicket {
   id: string;
-  jobType: string;
+  jobType: keyof KnownTasks; // TODO: how do we know that this is true?
   ownerAddress: string;
   payload: any;
   result: any;

--- a/packages/hub/services/contract-subscription-event-handler.ts
+++ b/packages/hub/services/contract-subscription-event-handler.ts
@@ -5,19 +5,22 @@ import { inject } from '@cardstack/di';
 import logger from '@cardstack/logger';
 import { query } from '@cardstack/hub/queries';
 import { EventData } from 'web3-eth-contract';
-import { KnownTasks } from '@cardstack/hub/tasks';
 
 const log = logger('hub/contract-subscription-event-handler');
 
 export const HISTORIC_BLOCKS_AVAILABLE = 10000;
 
-export const CONTRACT_EVENTS: {
+type TasksWhichAcceptEventData = 'notify-merchant-claim' | 'notify-customer-payment' | 'notify-prepaid-card-drop';
+
+interface ContractEventConfig {
   abiName: string;
   contractName: AddressKeys;
   eventName: string;
-  taskName: keyof KnownTasks;
+  taskName: TasksWhichAcceptEventData;
   contractStartVersion?: string;
-}[] = [
+}
+
+export const CONTRACT_EVENTS: readonly ContractEventConfig[] = [
   {
     abiName: 'pay-merchant-handler',
     contractName: 'payMerchantHandler' as AddressKeys,
@@ -37,7 +40,7 @@ export const CONTRACT_EVENTS: {
     taskName: 'notify-prepaid-card-drop',
     contractStartVersion: '0.9.0',
   },
-];
+] as const;
 
 export class ContractSubscriptionEventHandler {
   contracts = inject('contracts', { as: 'contracts' });
@@ -76,7 +79,7 @@ export class ContractSubscriptionEventHandler {
           );
 
           await this.latestEventBlockQueries.update(event.blockNumber);
-          this.workerClient.addJob(contractEvent.taskName, event);
+          this.workerClient.addJob<typeof CONTRACT_EVENTS[number]['taskName']>(contractEvent.taskName, event);
         }
       });
     }

--- a/packages/hub/services/contract-subscription-event-handler.ts
+++ b/packages/hub/services/contract-subscription-event-handler.ts
@@ -5,12 +5,19 @@ import { inject } from '@cardstack/di';
 import logger from '@cardstack/logger';
 import { query } from '@cardstack/hub/queries';
 import { EventData } from 'web3-eth-contract';
+import { KnownTasks } from '@cardstack/hub/tasks';
 
 const log = logger('hub/contract-subscription-event-handler');
 
 export const HISTORIC_BLOCKS_AVAILABLE = 10000;
 
-export const CONTRACT_EVENTS = [
+export const CONTRACT_EVENTS: {
+  abiName: string;
+  contractName: AddressKeys;
+  eventName: string;
+  taskName: keyof KnownTasks;
+  contractStartVersion?: string;
+}[] = [
   {
     abiName: 'pay-merchant-handler',
     contractName: 'payMerchantHandler' as AddressKeys,

--- a/packages/hub/services/worker-client.ts
+++ b/packages/hub/services/worker-client.ts
@@ -9,7 +9,15 @@ export default class WorkerClient {
     return config.get('db') as Record<string, any>;
   }
 
-  async addJob(identifier: keyof KnownTasks, payload?: any, spec?: TaskSpec): Promise<Job> {
+  async addJob<T extends keyof KnownTasks>(
+    identifier: T,
+    payload?: KnownTasks[T] extends { perform(payload: unknown, helpers?: any): any }
+      ? Parameters<KnownTasks[T]['perform']>[0]
+      : KnownTasks[T] extends { (payload: unknown, helpers?: any): any }
+      ? Parameters<KnownTasks[T]>[0]
+      : any,
+    spec?: TaskSpec
+  ): Promise<Job> {
     if (this.workerUtils) {
       console.trace('Adding job', identifier, payload, spec);
       return this.workerUtils.addJob(identifier, payload, spec);

--- a/packages/hub/services/worker-client.ts
+++ b/packages/hub/services/worker-client.ts
@@ -11,11 +11,11 @@ export default class WorkerClient {
 
   async addJob<T extends keyof KnownTasks>(
     identifier: T,
-    payload?: KnownTasks[T] extends { perform(payload: unknown, helpers?: any): any }
+    payload?: KnownTasks[T] extends { perform(payload: any, helpers?: any): any }
       ? Parameters<KnownTasks[T]['perform']>[0]
-      : KnownTasks[T] extends { (payload: unknown, helpers?: any): any }
+      : KnownTasks[T] extends (payload: any, helpers?: any) => any
       ? Parameters<KnownTasks[T]>[0]
-      : any,
+      : never,
     spec?: TaskSpec
   ): Promise<Job> {
     if (this.workerUtils) {

--- a/packages/hub/services/worker-client.ts
+++ b/packages/hub/services/worker-client.ts
@@ -1,3 +1,4 @@
+import { KnownTasks } from '@cardstack/hub/tasks';
 import config from 'config';
 import { Job, TaskSpec, WorkerUtils, makeWorkerUtils } from 'graphile-worker';
 
@@ -8,7 +9,7 @@ export default class WorkerClient {
     return config.get('db') as Record<string, any>;
   }
 
-  async addJob(identifier: string, payload?: any, spec?: TaskSpec): Promise<Job> {
+  async addJob(identifier: keyof KnownTasks, payload?: any, spec?: TaskSpec): Promise<Job> {
     if (this.workerUtils) {
       console.trace('Adding job', identifier, payload, spec);
       return this.workerUtils.addJob(identifier, payload, spec);

--- a/packages/hub/tasks/boom.ts
+++ b/packages/hub/tasks/boom.ts
@@ -1,5 +1,11 @@
 import type { Helpers } from 'graphile-worker';
 
-export default async (_payload: any, _helpers: Helpers) => {
+export default async function boomTask(_payload: any, _helpers: Helpers) {
   throw new Error('Boom! Job with intentional failure has thrown this error.');
-};
+}
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    boom: typeof boomTask;
+  }
+}

--- a/packages/hub/tasks/create-profile.ts
+++ b/packages/hub/tasks/create-profile.ts
@@ -75,3 +75,9 @@ export default class CreateProfile {
     }
   }
 }
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    'create-profile': CreateProfile;
+  }
+}

--- a/packages/hub/tasks/discord-post.ts
+++ b/packages/hub/tasks/discord-post.ts
@@ -21,3 +21,9 @@ export default class DiscordPost {
     }
   }
 }
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    'discord-post': DiscordPost;
+  }
+}

--- a/packages/hub/tasks/index.ts
+++ b/packages/hub/tasks/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface KnownTasks {}

--- a/packages/hub/tasks/notify-customer-payment.ts
+++ b/packages/hub/tasks/notify-customer-payment.ts
@@ -165,3 +165,9 @@ export default class NotifyCustomerPayment {
     }
   }
 }
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    'notify-customer-payment': NotifyCustomerPayment;
+  }
+}

--- a/packages/hub/tasks/notify-merchant-claim.ts
+++ b/packages/hub/tasks/notify-merchant-claim.ts
@@ -139,3 +139,9 @@ export default class NotifyMerchantClaim {
     }
   }
 }
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    'notify-merchant-claim': NotifyMerchantClaim;
+  }
+}

--- a/packages/hub/tasks/notify-prepaid-card-drop.ts
+++ b/packages/hub/tasks/notify-prepaid-card-drop.ts
@@ -50,3 +50,9 @@ export default class NotifyPrepaidCardDrop {
     }
   }
 }
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    'notify-prepaid-card-drop': NotifyPrepaidCardDrop;
+  }
+}

--- a/packages/hub/tasks/persist-off-chain-merchant-info.ts
+++ b/packages/hub/tasks/persist-off-chain-merchant-info.ts
@@ -27,3 +27,9 @@ export default class PersistOffChainMerchantInfo {
     });
   }
 }
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    'persist-off-chain-merchant-info': PersistOffChainMerchantInfo;
+  }
+}

--- a/packages/hub/tasks/persist-off-chain-prepaid-card-customization.ts
+++ b/packages/hub/tasks/persist-off-chain-prepaid-card-customization.ts
@@ -25,3 +25,9 @@ export default class PersistOffChainPrepaidCardCustomization {
     });
   }
 }
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    'persist-off-chain-prepaid-card-customization': PersistOffChainPrepaidCardCustomization;
+  }
+}

--- a/packages/hub/tasks/print-queued-jobs.ts
+++ b/packages/hub/tasks/print-queued-jobs.ts
@@ -29,3 +29,9 @@ export default class PrintQueuedJobs {
     }
   }
 }
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    'print-queued-jobs': PrintQueuedJobs;
+  }
+}

--- a/packages/hub/tasks/remove-old-sent-notifications.ts
+++ b/packages/hub/tasks/remove-old-sent-notifications.ts
@@ -41,3 +41,9 @@ export default class RemoveOldSentNotifications {
     }
   }
 }
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    'remove-old-sent-notifications': RemoveOldSentNotifications;
+  }
+}

--- a/packages/hub/tasks/s3-put-json.ts
+++ b/packages/hub/tasks/s3-put-json.ts
@@ -2,7 +2,7 @@ import { Helpers } from 'graphile-worker';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import awsConfig from '../utils/aws-config';
 
-export default async (payload: any, helpers: Helpers) => {
+export default async function s3PutJson(payload: any, helpers: Helpers) {
   const { bucket, path, json, region, roleChain } = payload;
   let s3Config = await awsConfig({ roleChain });
   if (region) {
@@ -20,4 +20,10 @@ export default async (payload: any, helpers: Helpers) => {
 
   const response = await s3Client.send(command);
   helpers.logger.info(`S3 PUT completed ${bucket}:${path} [${response.$metadata.httpStatusCode}]`);
-};
+}
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    's3-put-json': typeof s3PutJson;
+  }
+}

--- a/packages/hub/tasks/send-email-card-drop-verification.ts
+++ b/packages/hub/tasks/send-email-card-drop-verification.ts
@@ -79,3 +79,9 @@ export default class SendEmailCardDropVerification {
     }
   }
 }
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    'send-email-card-drop-verification': SendEmailCardDropVerification;
+  }
+}

--- a/packages/hub/tasks/send-notifications.ts
+++ b/packages/hub/tasks/send-notifications.ts
@@ -104,3 +104,9 @@ export default class SendNotificationsTask {
     }
   }
 }
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    'send-notifications': SendNotificationsTask;
+  }
+}

--- a/packages/hub/tasks/subscribe-email.ts
+++ b/packages/hub/tasks/subscribe-email.ts
@@ -21,3 +21,9 @@ export default class SubscribeEmail {
     }
   }
 }
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    'subscribe-email': SubscribeEmail;
+  }
+}

--- a/packages/hub/tasks/wyre-transfer.ts
+++ b/packages/hub/tasks/wyre-transfer.ts
@@ -59,3 +59,9 @@ export default class WyreTransferTask {
     }
   }
 }
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    'wyre-transfer': WyreTransferTask;
+  }
+}


### PR DESCRIPTION
Typescript enforcement of task names and types. There's room to make a couple of tasks' payloads stricter.

We might want to modify the type interface of `helpers` in a task definition.... if we can find a way to do it nicely.