### PR TITLE
lower default priorities of notification tasks

### DIFF
--- a/packages/hub/node-tests/services/worker-client-test.ts
+++ b/packages/hub/node-tests/services/worker-client-test.ts
@@ -1,5 +1,8 @@
 import { KnownTasks } from '@cardstack/hub/tasks';
 import WorkerClient from '../../services/worker-client';
+
+let FAKE_KNOWN_TASK = 'FAKE_KNOWN_TASK' as keyof KnownTasks;
+
 describe('WorkerClient', function () {
   let subject: WorkerClient;
 
@@ -13,7 +16,7 @@ describe('WorkerClient', function () {
 
   it('cannot add job before ready', async function () {
     try {
-      await subject.addJob('foo' as keyof KnownTasks);
+      await subject.addJob(FAKE_KNOWN_TASK);
       expect.fail('Should not reach here');
     } catch (e) {
       expect(e.message).to.equal('Cannot call addJob before workerUtils is ready');
@@ -22,7 +25,34 @@ describe('WorkerClient', function () {
 
   it('can add a job after ready', async function () {
     await subject.ready();
-    let job = await subject.addJob('foo' as keyof KnownTasks);
-    expect(job.task_identifier).to.equal('foo');
+    let job = await subject.addJob(FAKE_KNOWN_TASK);
+    expect(job.task_identifier).to.equal(FAKE_KNOWN_TASK);
+  });
+
+  it('can apply default priorities to a job', async function () {
+    await subject.ready();
+    subject.defaultPriorities[FAKE_KNOWN_TASK] = 1;
+    let job = await subject.addJob(FAKE_KNOWN_TASK);
+    expect(subject.defaultPriorities[FAKE_KNOWN_TASK]).to.equal(1);
+    expect(job.task_identifier).to.equal(FAKE_KNOWN_TASK);
+    expect(job.priority).to.equal(1);
+  });
+
+  it('can respect priority overrides', async function () {
+    await subject.ready();
+    subject.defaultPriorities[FAKE_KNOWN_TASK] = 1;
+    let job = await subject.addJob(FAKE_KNOWN_TASK, undefined, { priority: 2 });
+    expect(subject.defaultPriorities[FAKE_KNOWN_TASK]).to.equal(1);
+    expect(job.task_identifier).to.equal(FAKE_KNOWN_TASK);
+    expect(job.priority).to.equal(2);
+  });
+
+  it('leaves priority unset if there is no default', async function () {
+    await subject.ready();
+    let job = await subject.addJob(FAKE_KNOWN_TASK);
+    expect(subject.defaultPriorities[FAKE_KNOWN_TASK]).to.equal(undefined);
+    expect(job.task_identifier).to.equal(FAKE_KNOWN_TASK);
+    // here we're expecting we get graphile's default of 0, which is the highest priority
+    expect(job.priority).to.equal(0);
   });
 });


### PR DESCRIPTION
This prevents notifications from ending up blocking higher priority tasks - this can happen when the hub-event-listener is restarted. See [graphile docs](https://github.com/graphile/worker#:~:text=/**%0A%20%20%20*%20Jobs%20are%20executed%20in%20numerically%20ascending%20order%20of%20priority%20(jobs%20with%20a%0A%20%20%20*%20numerically%20smaller%20priority%20are%20run%20first).%20(Default%3A%200)%0A%20%20%20*/%0A%20%20priority%3F%3A%20number%3B) for priority - default is 0, higher number means lower priority.