### PR TITLE
hub: Reject already-used IAP receipts

### DIFF
--- a/packages/hub/node-tests/routes/job-tickets-test.ts
+++ b/packages/hub/node-tests/routes/job-tickets-test.ts
@@ -176,7 +176,7 @@ describe('POST /api/job-tickets/:id/retry', function () {
     expect(getJobPayloads()).to.deep.equal([{ 'a-payload': 'yes' }]);
     expect(getJobSpecs()).to.deep.equal([{ 'a-spec': 'yes' }]);
 
-    let newTicket = await jobTicketsQueries.find(newJobId!);
+    let newTicket = await jobTicketsQueries.find({ id: newJobId! });
 
     expect(newTicket?.ownerAddress).to.equal(stubUserAddress);
     expect(newTicket?.jobType).to.equal('a-job');

--- a/packages/hub/node-tests/routes/profile-purchases-test.ts
+++ b/packages/hub/node-tests/routes/profile-purchases-test.ts
@@ -141,7 +141,7 @@ describe('POST /api/profile-purchases', function () {
     let cardSpaceRecord = (await cardSpacesQueries.query({ merchantId }))[0];
     expect(cardSpaceRecord).to.exist;
 
-    let jobTicketRecord = await jobTicketsQueries.find(jobTicketId!);
+    let jobTicketRecord = await jobTicketsQueries.find({ id: jobTicketId! });
     expect(jobTicketRecord?.state).to.equal('pending');
     expect(jobTicketRecord?.ownerAddress).to.equal(stubUserAddress);
     expect(jobTicketRecord?.payload).to.deep.equal({ 'job-ticket-id': jobTicketId, 'merchant-info-id': merchantId });

--- a/packages/hub/node-tests/tasks/create-profile-test.ts
+++ b/packages/hub/node-tests/tasks/create-profile-test.ts
@@ -106,7 +106,7 @@ describe('CreateProfileTask', function () {
     expect(getJobIdentifiers()[0]).to.equal('persist-off-chain-merchant-info');
     expect(getJobPayloads()[0]).to.deep.equal({ 'merchant-safe-id': merchantInfosId });
 
-    let jobTicket = await jobTicketsQueries.find(jobTicketId);
+    let jobTicket = await jobTicketsQueries.find({ id: jobTicketId });
     expect(jobTicket?.state).to.equal('success');
     expect(jobTicket?.result).to.deep.equal({ 'merchant-safe-id': mockMerchantSafeAddress });
   });
@@ -119,7 +119,7 @@ describe('CreateProfileTask', function () {
       'merchant-info-id': merchantInfosId,
     });
 
-    let jobTicket = await jobTicketsQueries.find(jobTicketId);
+    let jobTicket = await jobTicketsQueries.find({ id: jobTicketId });
     expect(jobTicket?.state).to.equal('failed');
     expect(jobTicket?.result).to.deep.equal({ error: 'Error: registering should error' });
 
@@ -138,7 +138,7 @@ describe('CreateProfileTask', function () {
       'merchant-info-id': merchantInfosId,
     });
 
-    let jobTicket = await jobTicketsQueries.find(jobTicketId);
+    let jobTicket = await jobTicketsQueries.find({ id: jobTicketId });
     expect(jobTicket?.state).to.equal('failed');
     expect(jobTicket?.result).to.deep.equal({
       error: `Error: subgraph query for transaction ${mockTransactionHash} returned no results`,

--- a/packages/hub/queries/job-tickets.ts
+++ b/packages/hub/queries/job-tickets.ts
@@ -3,12 +3,7 @@ import { inject } from '@cardstack/di';
 import { JobTicket } from '../routes/job-tickets';
 import { buildConditions } from '../utils/queries';
 
-export interface JobTicketsQueriesFilter {
-  id?: string;
-  jobType?: string;
-  ownerAddress?: string;
-  sourceArguments?: any;
-}
+export type JobTicketsQueriesFilter = Partial<Pick<JobTicket, 'id' | 'jobType' | 'ownerAddress' | 'sourceArguments'>>;
 
 export default class JobTicketsQueries {
   databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });

--- a/packages/hub/queries/job-tickets.ts
+++ b/packages/hub/queries/job-tickets.ts
@@ -1,30 +1,24 @@
 import DatabaseManager from '@cardstack/db';
 import { inject } from '@cardstack/di';
 import { JobTicket } from '../routes/job-tickets';
+import { buildConditions } from '../utils/queries';
+
+export interface JobTicketsQueriesFilter {
+  id?: string;
+  jobType?: string;
+  ownerAddress?: string;
+  sourceArguments?: string;
+}
 
 export default class JobTicketsQueries {
   databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
 
-  async find(id: string): Promise<JobTicket | null> {
+  async find(filter: JobTicketsQueriesFilter): Promise<JobTicket | null> {
     let db = await this.databaseManager.getClient();
 
-    let query = `SELECT * FROM job_tickets WHERE ID = $1`;
-    let queryResult = await db.query(query, [id]);
-
-    if (queryResult.rows.length) {
-      let row = queryResult.rows[0];
-
-      return mapRowToModel(row);
-    } else {
-      return null;
-    }
-  }
-
-  async findAlreadyCreated(jobType: string, ownerAddress: string, attributes: any): Promise<JobTicket | null> {
-    let db = await this.databaseManager.getClient();
-
-    let query = `SELECT * FROM job_tickets WHERE job_type = $1 AND owner_address = $2 AND source_arguments = $3`;
-    let queryResult = await db.query(query, [jobType, ownerAddress, attributes]);
+    let conditions = buildConditions(filter);
+    let query = `SELECT * FROM job_tickets WHERE ${conditions.where}`;
+    let queryResult = await db.query(query, conditions.values);
 
     if (queryResult.rows.length) {
       let row = queryResult.rows[0];
@@ -43,7 +37,7 @@ export default class JobTicketsQueries {
       [model.id, model.jobType, model.ownerAddress, model.payload, model.spec, model.sourceArguments]
     );
 
-    return this.find(model.id!);
+    return this.find({ id: model.id! });
   }
 
   async update(id: string, result: any, state: string) {

--- a/packages/hub/queries/job-tickets.ts
+++ b/packages/hub/queries/job-tickets.ts
@@ -7,7 +7,7 @@ export interface JobTicketsQueriesFilter {
   id?: string;
   jobType?: string;
   ownerAddress?: string;
-  sourceArguments?: string;
+  sourceArguments?: any;
 }
 
 export default class JobTicketsQueries {

--- a/packages/hub/routes/job-tickets.ts
+++ b/packages/hub/routes/job-tickets.ts
@@ -35,7 +35,7 @@ export default class JobTicketsRoute {
     }
 
     let id = ctx.params.id;
-    let jobTicket = await this.jobTicketsQueries.find(id);
+    let jobTicket = await this.jobTicketsQueries.find({ id });
 
     if (!jobTicket) {
       ctx.body = {
@@ -81,7 +81,7 @@ export default class JobTicketsRoute {
     }
 
     let id = ctx.params.id;
-    let jobTicketToRetry = await this.jobTicketsQueries.find(id);
+    let jobTicketToRetry = await this.jobTicketsQueries.find({ id });
 
     if (!jobTicketToRetry) {
       ctx.body = {

--- a/packages/hub/routes/profile-purchases.ts
+++ b/packages/hub/routes/profile-purchases.ts
@@ -38,10 +38,16 @@ export default class ProfilePurchasesRoute {
       return;
     }
 
+    let { provider, receipt } = ctx.request.body.data.attributes || {};
+    let sourceArguments = {
+      provider,
+      receipt,
+    };
+
     let alreadyCreatedJobTicket = await this.jobTicketsQueries.find({
       jobType: 'create-profile',
       ownerAddress: ctx.state.userAddress,
-      sourceArguments: ctx.request.body.data.attributes,
+      sourceArguments,
     });
 
     if (alreadyCreatedJobTicket) {
@@ -142,7 +148,25 @@ export default class ProfilePurchasesRoute {
       return;
     }
 
-    let { provider, receipt } = ctx.request.body.data.attributes;
+    let alreadyUsedReceipt = await this.jobTicketsQueries.find({
+      jobType: 'create-profile',
+      sourceArguments,
+    });
+
+    if (alreadyUsedReceipt) {
+      ctx.status = 422;
+      ctx.body = {
+        errors: [
+          {
+            status: '422',
+            title: 'Invalid purchase receipt',
+            detail: 'Purchase receipt is not valid',
+          },
+        ],
+      };
+      ctx.type = 'application/vnd.api+json';
+      return;
+    }
 
     let { valid: purchaseValidationResult, response: purchaseValidationResponse } = await this.inAppPurchases.validate(
       provider,
@@ -189,7 +213,7 @@ export default class ProfilePurchasesRoute {
       ownerAddress: ctx.state.userAddress,
       payload: { 'merchant-info-id': merchantInfoId, 'job-ticket-id': jobTicketId },
       spec: { maxAttempts: 1 },
-      sourceArguments: ctx.request.body.data.attributes,
+      sourceArguments,
     };
 
     let insertedJobTicket = await this.jobTicketsQueries.insert(jobTicket as unknown as JobTicket);

--- a/packages/hub/routes/profile-purchases.ts
+++ b/packages/hub/routes/profile-purchases.ts
@@ -38,11 +38,11 @@ export default class ProfilePurchasesRoute {
       return;
     }
 
-    let alreadyCreatedJobTicket = await this.jobTicketsQueries.findAlreadyCreated(
-      'create-profile',
-      ctx.state.userAddress,
-      ctx.request.body.data.attributes
-    );
+    let alreadyCreatedJobTicket = await this.jobTicketsQueries.find({
+      jobType: 'create-profile',
+      ownerAddress: ctx.state.userAddress,
+      sourceArguments: ctx.request.body.data.attributes,
+    });
 
     if (alreadyCreatedJobTicket) {
       ctx.status = 200;


### PR DESCRIPTION
This updates `POST /api/profile-purchases` to reject an attempt to reuse an IAP receipt that has been referenced in any `job_tickets` row, regardless of `owner_address`.

It also includes a [commit based on feedback](https://github.com/cardstack/cardstack/pull/3046/files/d6a01648dbc61eaead20b0db33690def16af8868..faf52e0d87d3ea2c70f42ac05c484b55cc548901#r910703172) that was meant to be in #3046 but I failed to push before merging 😳