### PR TITLE
ci: Fix security groups ids

### DIFF
--- a/waypoint.hcl
+++ b/waypoint.hcl
@@ -98,7 +98,7 @@ app "hub-worker" {
       subnets             = ["subnet-09af2ce7fb316890b", "subnet-08c7d485ed397ca69"]
       task_role_name      = "hub-worker-ecs-task"
       execution_role_name = "hub-worker-ecs-task-execution"
-      security_group_ids  = ["sg-0977e3c4d1af9f555"]
+      security_group_ids  = ["sg-0cce1f41f369bf838"]
       disable_alb         = true
 
       secrets = {
@@ -154,7 +154,7 @@ app "hub-bot" {
       subnets             = ["subnet-09af2ce7fb316890b", "subnet-08c7d485ed397ca69"]
       task_role_name      = "hub-bot-ecs-task"
       execution_role_name = "hub-bot-ecs-task-execution"
-      security_group_ids  = ["sg-0c2828b424cfb2484"]
+      security_group_ids  = ["sg-06c858d75273b05d6"]
       disable_alb         = true
 
       secrets = {
@@ -209,7 +209,7 @@ app "hub-event-listener" {
       subnets             = ["subnet-09af2ce7fb316890b", "subnet-08c7d485ed397ca69"]
       task_role_name      = "hub-event-listener-ecs-task"
       execution_role_name = "hub-event-listener-ecs-task-execution"
-      security_group_ids  = ["sg-0167a15ab65794aaf"]
+      security_group_ids  = ["sg-02a1b0d7a025fabd0"]
       disable_alb         = true
 
       secrets = {
@@ -317,7 +317,7 @@ app "cardpay-subg-ext" {
       subnets             = ["subnet-081966e0d7a798bc1", "subnet-0544a2e18d66d0040"]
       task_role_name      = "cardpay-subg-ext-ecs-task"
       execution_role_name = "cardpay-subg-ext-ecs-task-execution"
-      security_group_ids  = ["sg-00160f813a48d47c9"]
+      security_group_ids  = ["sg-02c9224910953df81"]
 
       secrets = {
         SE_DATABASE_STRING = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_subg_extract_database_url-kLIcg4"
@@ -533,7 +533,7 @@ app "reward-indexer" {
       subnets             = ["subnet-004c18e7177f0a9a2", "subnet-053fc89a829849140"]
       task_role_name      = "reward-indexer-ecs-task"
       execution_role_name = "reward-indexer-ecs-task-execution"
-      security_group_ids  = ["sg-0df1b0a5714af6fd1"]
+      security_group_ids  = ["sg-0a896e4ebe2606421"]
       disable_alb         = true
 
       secrets = {
@@ -591,7 +591,7 @@ app "reward-scheduler" {
       subnets             = ["subnet-004c18e7177f0a9a2", "subnet-053fc89a829849140"]
       task_role_name      = "reward-scheduler-ecs-task"
       execution_role_name = "reward-scheduler-ecs-task-execution"
-      security_group_ids  = ["sg-0ef2db7a5c985da2d"]
+      security_group_ids  = ["sg-0aeaba4676411bb39"]
       disable_alb         = true
 
       secrets = {


### PR DESCRIPTION
Fix the wrong security groups in `waypoint.hcl` that points to security groups created in the wrong VPC. Updated the security groups with the newly created ones from the fix in https://github.com/cardstack/infra/pull/193