### PR TITLE
ci: Add waypoint hooks to add tags to services and tasks created

### DIFF
--- a/scripts/waypoint-ecs-add-tags.mjs
+++ b/scripts/waypoint-ecs-add-tags.mjs
@@ -1,0 +1,102 @@
+import hcl from 'hcl2-parser';
+import fs from 'fs';
+import { execSync } from 'child_process';
+
+function execute(command, options = {}) {
+  return execSync(command, options).toString().trim();
+}
+
+function getAppConfig(waypointConfigFilePath, appName) {
+  const waypointHcl = fs.readFileSync(waypointConfigFilePath, 'utf8');
+  const waypointConfig = hcl.parseToObject(waypointHcl)[0];
+  const waypointApp = waypointConfig.app[appName][0];
+  const cluster = waypointApp.deploy[0].use['aws-ecs'][0].cluster;
+  const certificate = waypointApp.deploy[0].use['aws-ecs'][0].alb[0].certificate;
+  const disableAlb = Boolean(waypointApp.deploy[0].use['aws-ecs'][0].disable_alb);
+
+  return { cluster, certificate, disableAlb };
+}
+
+function getAppNameFromServiceArn(serviceArn) {
+  const arnPattern = /^.*\/(.*)-[^-]*$/;
+  const matches = serviceArn.match(arnPattern);
+  return matches && matches.length > 1 ? matches[1] : '';
+}
+
+function getServices(cluster, appName) {
+  let serviceArns = [];
+  let nextToken = null;
+  do {
+    const startingTokenArg = nextToken ? `--starting-token ${nextToken}` : '';
+    const responseJson = execute(`aws ecs list-services --cluster ${cluster} ${startingTokenArg}`);
+    const response = JSON.parse(responseJson);
+    const filtered = response.serviceArns.filter((arn) => getAppNameFromServiceArn(arn) === appName);
+    serviceArns = serviceArns.concat(filtered);
+    nextToken = response.nextToken;
+  } while (nextToken);
+
+  let services = [];
+  for (let i = 0; i < serviceArns.length; i += 10) {
+    const slicedServiceNames = serviceArns.slice(i, i + 10 > serviceArns.length ? serviceArns.length : i + 10);
+
+    const responseJson = execute(
+      `aws ecs describe-services --cluster ${cluster} --services ${slicedServiceNames.join(' ')}`
+    );
+    const response = JSON.parse(responseJson);
+    services = services.concat(response.services);
+  }
+
+  services.sort((a, b) => {
+    if (a.createdAt < b.createdAt) {
+      return 1;
+    } else if (a.createdAt > b.createdAt) {
+      return -1;
+    } else {
+      return 0;
+    }
+  });
+
+  return services;
+}
+
+function tagResources(cluster, service, tags) {
+  const tagsArgs = Object.entries(tags)
+    .map(([key, val]) => `key=${key},value=${val}`)
+    .join(' ');
+
+  console.log(`-> Tagging service: ${service.serviceName}`);
+  execute(`aws ecs tag-resource --resource-arn ${service.serviceArn} --tags ${tagsArgs}`);
+
+  console.log(`-> Updating service to propagate tags to tasks: ${service.serviceName}`);
+  execute(
+    `aws ecs update-service` +
+      ` --cluster ${cluster}` +
+      ` --service ${service.serviceArn}` +
+      ` --force-new-deployment` +
+      ` --enable-ecs-managed-tags` +
+      ` --propagate-tags SERVICE`
+  );
+}
+
+function main() {
+  const [appName, ...extraArgs] = process.argv.slice(2);
+  const waypointConfigFilePath = extraArgs.length > 0 ? extraArgs[0] : 'waypoint.hcl';
+
+  const config = getAppConfig(waypointConfigFilePath, appName);
+
+  const tags = {
+    'waypoint-app': appName,
+    'cardstack:application-id': appName,
+  };
+
+  console.log('\n» Tagging resources...');
+  const services = getServices(config.cluster, appName);
+  const latestService = services[0];
+  tagResources(config.cluster, latestService, tags);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err);
+}

--- a/waypoint.hcl
+++ b/waypoint.hcl
@@ -59,6 +59,11 @@ app "hub" {
 
     hook {
       when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "hub"]
+    }
+
+    hook {
+      when    = "after"
       command = ["node", "./scripts/wait-service-stable.mjs", "hub"]
     }
   }
@@ -111,6 +116,11 @@ app "hub-worker" {
         PAGERDUTY_TOKEN                  = "arn:aws:secretsmanager:us-east-1:680542703984:secret:PAGERDUTY_TOKEN-kTxFxL"
         MAILCHIMP_API_KEY                = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_MAILCHIMP_API_KEY-lkxsEk"
       }
+    }
+
+    hook {
+      when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "hub-worker"]
     }
 
     hook {
@@ -170,6 +180,11 @@ app "hub-bot" {
 
     hook {
       when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "hub-bot"]
+    }
+
+    hook {
+      when    = "after"
       command = ["node", "./scripts/wait-service-stable.mjs", "hub-bot"]
     }
   }
@@ -225,6 +240,11 @@ app "hub-event-listener" {
 
     hook {
       when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "hub-event-listener"]
+    }
+
+    hook {
+      when    = "after"
       command = ["node", "./scripts/wait-service-stable.mjs", "hub-event-listener"]
     }
   }
@@ -267,6 +287,11 @@ app "cardie" {
         DISCORD_TOKEN = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_discord_token-g5tbvH"
         GITHUB_TOKEN  = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_github_token-sJaf5H"
       }
+    }
+
+    hook {
+      when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "cardie"]
     }
 
     hook {
@@ -329,6 +354,11 @@ app "cardpay-subg-ext" {
 
     hook {
       when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "cardpay-subg-ext"]
+    }
+
+    hook {
+      when    = "after"
       command = ["node", "./scripts/wait-service-stable.mjs", "cardpay-subg-ext"]
     }
   }
@@ -371,6 +401,11 @@ app "ssr-web" {
         subnets     = ["subnet-09af2ce7fb316890b", "subnet-08c7d485ed397ca69"]
         certificate = "arn:aws:acm:us-east-1:680542703984:certificate/8b232d17-3bb7-41f5-abc0-7b32b0d5190c"
       }
+    }
+
+    hook {
+      when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "ssr-web"]
     }
 
     hook {
@@ -426,6 +461,11 @@ app "reward-submit" {
         OWNER_PRIVATE_KEY = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_reward_root_submitter_private_key-4BFs6t"
         SENTRY_DSN        = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_reward_root_submitter_sentry_dsn-npg871"
       }
+    }
+
+    hook {
+      when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "reward-submit"]
     }
 
     hook {
@@ -490,6 +530,11 @@ app "reward-api" {
 
     hook {
       when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "reward-api"]
+    }
+
+    hook {
+      when    = "after"
       command = ["node", "./scripts/wait-service-stable.mjs", "reward-api"]
     }
   }
@@ -544,7 +589,12 @@ app "reward-indexer" {
 
     hook {
       when    = "after"
-      command = ["node", "./scripts/wait-service-stable.mjs", "reward-api"]
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "reward-indexer"]
+    }
+
+    hook {
+      when    = "after"
+      command = ["node", "./scripts/wait-service-stable.mjs", "reward-indexer"]
     }
   }
 
@@ -598,6 +648,16 @@ app "reward-scheduler" {
         SENTRY_DSN        = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_reward_programs_sentry_dsn-zAMOFo"
         EVM_FULL_NODE_URL = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_evm_full_node_url-NBKUCq"
       }
+    }
+
+    hook {
+      when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "reward-scheduler"]
+    }
+
+    hook {
+      when    = "after"
+      command = ["node", "./scripts/wait-service-stable.mjs", "reward-scheduler"]
     }
   }
 

--- a/waypoint.prod.hcl
+++ b/waypoint.prod.hcl
@@ -59,6 +59,11 @@ app "hub" {
 
     hook {
       when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "hub"]
+    }
+
+    hook {
+      when    = "after"
       command = ["node", "./scripts/wait-service-stable.mjs", "hub"]
     }
   }
@@ -111,6 +116,11 @@ app "hub-worker" {
         PAGERDUTY_TOKEN                  = "arn:aws:secretsmanager:us-east-1:120317779495:secret:PAGERDUTY_TOKEN-1L68JJ"
         MAILCHIMP_API_KEY                = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_MAILCHIMP_API_KEY-XCGDUW"
       }
+    }
+
+    hook {
+      when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "hub-worker"]
     }
 
     hook {
@@ -170,6 +180,11 @@ app "hub-bot" {
 
     hook {
       when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "hub-bot"]
+    }
+
+    hook {
+      when    = "after"
       command = ["node", "./scripts/wait-service-stable.mjs", "hub-bot"]
     }
   }
@@ -221,6 +236,11 @@ app "hub-event-listener" {
         DISCORD_ON_CALL_INTERNAL_WEBHOOK = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_discord_on_call_internal_webhook-n7SCZC"
         PAGERDUTY_TOKEN                  = "arn:aws:secretsmanager:us-east-1:120317779495:secret:PAGERDUTY_TOKEN-1L68JJ"
       }
+    }
+
+    hook {
+      when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "hub-event-listener"]
     }
 
     hook {
@@ -283,6 +303,11 @@ app "cardpay-subg-ext" {
 
     hook {
       when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "cardpay-subg-ext"]
+    }
+
+    hook {
+      when    = "after"
       command = ["node", "./scripts/wait-service-stable.mjs", "cardpay-subg-ext"]
     }
   }
@@ -324,6 +349,11 @@ app "ssr-web" {
         subnets     = ["subnet-0c22641bd41cbdd1e", "subnet-01d36d7bcd0334fc0"]
         certificate = "arn:aws:acm:us-east-1:120317779495:certificate/e1d6a1c7-456e-4058-b90b-9c603a65734d"
       }
+    }
+
+    hook {
+      when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "ssr-web"]
     }
 
     hook {
@@ -379,6 +409,11 @@ app "reward-submit" {
         OWNER_PRIVATE_KEY = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_reward_root_submitter_private_key-Eflz67"
         SENTRY_DSN        = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_reward_root_submitter_sentry_dsn-DjQjLC"
       }
+    }
+
+    hook {
+      when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "reward-submit"]
     }
 
     hook {
@@ -443,6 +478,11 @@ app "reward-api" {
 
     hook {
       when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "reward-api"]
+    }
+
+    hook {
+      when    = "after"
       command = ["node", "./scripts/wait-service-stable.mjs", "reward-api"]
     }
   }
@@ -493,6 +533,11 @@ app "reward-indexer" {
         DB_STRING  = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_reward_api_database_url-EIMQl7"
         SENTRY_DSN = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_reward_api_sentry_dsn-Pwim3k"
       }
+    }
+
+    hook {
+      when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "reward-indexer"]
     }
 
     hook {
@@ -550,6 +595,16 @@ app "reward-scheduler" {
         SENTRY_DSN        = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_reward_programs_sentry_dsn-lsCwEe"
         EVM_FULL_NODE_URL = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_evm_full_node_url-K67DON"
       }
+    }
+
+    hook {
+      when    = "after"
+      command = ["node", "./scripts/waypoint-ecs-add-tags.mjs", "reward-scheduler"]
+    }
+
+    hook {
+      when    = "after"
+      command = ["node", "./scripts/wait-service-stable.mjs", "reward-scheduler"]
     }
   }
 


### PR DESCRIPTION
This PR adds a waypoint hook that will add tags to ECS services and tasks. The current tags that will be added are:
```json
{
  "waypoint-app": "example",
  "cardstack:application-id": "example"
}
```

Tags are added to support Cloudwatch alarms that will be triggered by Cloudwatch events. Example of a Cloudwatch event rule:
```json
{
  "source" : ["aws.ecs"],
  "detail-type" : ["ECS Task State Change"],
  "detail" : {
    "desiredStatus" : ["STOPPED"],
    "lastStatus" : ["STOPPED"],
    "stopCode" : [{ "anything-but" : ["UserInitiated"] }],
    "stoppedReason" : [{ "anything-but" : { "prefix" : "Scaling activity initiated" } }],
    "tags": [{
      "key": "cardstack:application-id",
      "value": "example"
    }]
  }
}
```
The tags will allow us to add alarm for each app, instead of events of different apps getting accumulated to trigger one alarm.