### PR TITLE
hub: Add text-color as required merchant attribute

### DIFF
--- a/packages/hub/node-tests/routes/profile-purchases-test.ts
+++ b/packages/hub/node-tests/routes/profile-purchases-test.ts
@@ -416,6 +416,11 @@ describe('POST /api/profile-purchases', function () {
             title: 'Missing required attribute: color',
             detail: 'Required field color was not provided',
           },
+          {
+            status: '422',
+            title: 'Missing required attribute: text-color',
+            detail: 'Required field text-color was not provided',
+          },
         ],
       });
   });

--- a/packages/hub/routes/merchant-infos.ts
+++ b/packages/hub/routes/merchant-infos.ts
@@ -60,7 +60,7 @@ export default class MerchantInfosRoute {
       return;
     }
 
-    if (!validateRequiredFields(ctx, { requiredAttributes: ['name', 'slug', 'color'] })) {
+    if (!validateRequiredFields(ctx, { requiredAttributes: ['name', 'slug', 'color', 'text-color'] })) {
       return;
     }
 

--- a/packages/hub/routes/profile-purchases.ts
+++ b/packages/hub/routes/profile-purchases.ts
@@ -101,7 +101,7 @@ export default class ProfilePurchasesRoute {
 
     if (
       !validateRequiredFields(ctx, {
-        requiredAttributes: ['name', 'slug', 'color'],
+        requiredAttributes: ['name', 'slug', 'color', 'text-color'],
         attributesObject: merchantAttributes,
       })
     ) {


### PR DESCRIPTION
This is a required field in the database. There are no `POST /api/merchant-infos` tests exercising this but I added it there anyway since it would cause the same failure.

Without this, a `POST /api/profile-purchases` without `text-color` for the merchant produced a 500, which was only intelligible by looking at Sentry or Hub logs. I think we should consider catching 500s and attaching Postgres errors to the response so the problem is more immediately obvious and doesn’t require looking elsewhere. That way when @oidoug encountered this, it would have been clear that adding `text-color` would allow the exercise to continue.

But is there a danger of exposing information that shouldn’t be known? Maybe it could be staging-only 🤔 thoughts @Aierie?