### PR TITLE
hub: Fix followup payload in create-profile

### DIFF
--- a/packages/hub/node-tests/tasks/create-profile-test.ts
+++ b/packages/hub/node-tests/tasks/create-profile-test.ts
@@ -104,11 +104,11 @@ describe('CreateProfileTask', function () {
     expect(registeredDid).to.equal(encodeDID({ type: 'MerchantInfo', uniqueId: merchantInfosId }));
 
     expect(getJobIdentifiers()[0]).to.equal('persist-off-chain-merchant-info');
-    expect(getJobPayloads()[0]).to.deep.equal({ 'merchant-safe-id': merchantInfosId });
+    expect(getJobPayloads()[0]).to.deep.equal({ id: merchantInfosId });
 
     let jobTicket = await jobTicketsQueries.find({ id: jobTicketId });
     expect(jobTicket?.state).to.equal('success');
-    expect(jobTicket?.result).to.deep.equal({ 'merchant-safe-id': mockMerchantSafeAddress });
+    expect(jobTicket?.result).to.deep.equal({ id: mockMerchantSafeAddress });
   });
 
   it('fails the job ticket and logs to Sentry if the profile provisioning fails', async function () {

--- a/packages/hub/routes/merchant-infos.ts
+++ b/packages/hub/routes/merchant-infos.ts
@@ -99,7 +99,7 @@ export default class MerchantInfosRoute {
     };
 
     let db = await this.databaseManager.getClient();
-    let merchantInfoId;
+    let merchantInfoId!: string;
 
     await this.databaseManager.performTransaction(db, async () => {
       merchantInfoId = (await this.merchantInfoQueries.insert(merchantInfo, db)).id;

--- a/packages/hub/tasks/create-profile.ts
+++ b/packages/hub/tasks/create-profile.ts
@@ -62,11 +62,11 @@ export default class CreateProfile {
 
       await this.jobTickets.update(
         jobTicketId,
-        { 'merchant-safe-id': merchantCreationsSubgraphResult.data.transaction.merchantCreations[0].merchantSafe.id },
+        { id: merchantCreationsSubgraphResult.data.transaction.merchantCreations[0].merchantSafe.id },
         'success'
       );
 
-      this.workerClient.addJob('persist-off-chain-merchant-info', { 'merchant-safe-id': merchantInfoId });
+      this.workerClient.addJob('persist-off-chain-merchant-info', { id: merchantInfoId });
     } catch (error) {
       let errorString = (error as Error).toString();
       Sentry.captureException(error);

--- a/packages/hub/tasks/persist-off-chain-merchant-info.ts
+++ b/packages/hub/tasks/persist-off-chain-merchant-info.ts
@@ -12,7 +12,7 @@ export default class PersistOffChainMerchantInfo {
     as: 'merchantInfoQueries',
   });
 
-  async perform(payload: any, helpers: Helpers) {
+  async perform(payload: { id: string }, helpers: Helpers) {
     const { id } = payload;
 
     let merchantInfo = (await this.merchantInfoQueries.fetch({ id }))[0];


### PR DESCRIPTION
The issue for CreateProfile specified a payload that didn’t
match the payload expected by PersistOffChainMerchantInfo.
It would be nice if Typescript could detect this!