### PR TITLE
Subgraph: upgrade to 0.27.0

### DIFF
--- a/packages/cardpay-subgraph/lib/get-subgraph-deployment-id.ts
+++ b/packages/cardpay-subgraph/lib/get-subgraph-deployment-id.ts
@@ -1,0 +1,33 @@
+import fetch from 'node-fetch';
+
+// @ts-ignore polyfilling fetch
+global.fetch = fetch;
+
+let subgraphUrl = process.argv[2];
+if (!subgraphUrl) {
+  console.error(`Specify the subgraph url.`);
+  process.exit(1);
+}
+
+(async () => {
+  let response = await fetch(subgraphUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({
+      query: `
+      {
+        _meta {
+          deployment
+        }
+      }`,
+    }),
+  });
+
+  let meta = (await response.json()).data?._meta;
+  let deploymentId = meta?.deployment;
+  console.log(deploymentId);
+  process.exit(0);
+})().catch((err) => console.error(err));

--- a/packages/cardpay-subgraph/package.json
+++ b/packages/cardpay-subgraph/package.json
@@ -49,8 +49,8 @@
   },
   "devDependencies": {
     "@cardstack/cardpay-sdk": "1.0.7",
-    "@graphprotocol/graph-cli": "0.20.0",
-    "@graphprotocol/graph-ts": "graphprotocol/graph-ts#56adb62d9e4233c6fc6c38bc0519a8a566afdd9e",
+    "@graphprotocol/graph-cli": "0.32.0",
+    "@graphprotocol/graph-ts": "0.27.0",
     "@protofire/subgraph-toolkit": "0.1.2",
     "fs-extra": "^10.0.0",
     "node-fetch": "^2.6.1",

--- a/packages/cardpay-subgraph/package.json
+++ b/packages/cardpay-subgraph/package.json
@@ -45,7 +45,8 @@
     "xdai-blue-status": "ts-node ./lib/sync-status.ts xdai-blue",
     "remove-localchain": "graph remove --node http://localhost:8020 localchain",
     "create-localchain": "graph create --node http://localhost:8020 localchain",
-    "deploy-localchain": "graph deploy localchain --ipfs http://localhost:5001 --node http://localhost:8020"
+    "deploy-localchain": "graph deploy localchain --ipfs http://localhost:5001 --node http://localhost:8020",
+    "deploy-local-xdai-fork": "ts-node ./lib/get-subgraph-deployment-id.ts https://graph.cardstack.com/subgraphs/name/habdelra/cardpay-xdai | xargs -o sh -c 'yarn run graph deploy local-subgraph --ipfs http://localhost:5001 --node http://localhost:8020 --debug-fork=\"$0\"'"
   },
   "devDependencies": {
     "@cardstack/cardpay-sdk": "1.0.7",

--- a/packages/cardpay-subgraph/schema.graphql
+++ b/packages/cardpay-subgraph/schema.graphql
@@ -1,22 +1,22 @@
 type Account @entity {
   id: ID!                                          # address
-  safes: [SafeOwner]!                              @derivedFrom(field: "owner")
-  depots: [Depot]!                                 @derivedFrom(field: "supplier")
-  sentBridgedTokens: [BridgeToLayer1Event]!        @derivedFrom(field: "account")
-  receivedBridgedTokens: [BridgeToLayer2Event]!    @derivedFrom(field: "supplier")
-  supplierInfoDIDUpdates: [SupplierInfoDIDUpdate]! @derivedFrom(field: "supplier")
-  createdPrepaidCards: [PrepaidCardCreation]!      @derivedFrom(field: "issuer")
-  splitPrepaidCards: [PrepaidCardSplit]!           @derivedFrom(field: "issuer")
-  createdMerchants: [MerchantCreation]!            @derivedFrom(field: "merchant")
-  createdRewardSafes: [RewardSafe]!                @derivedFrom(field: "rewardee")
-  receivedPrepaidCards: [PrepaidCardTransfer]!     @derivedFrom(field: "to")
-  provisionedPrepaidCards: [PrepaidCardProvisionedEvent]! @derivedFrom(field: "customer")
-  sentPrepaidCards: [PrepaidCardTransfer]!         @derivedFrom(field: "from")
-  tokenSwaps: [TokenSwap]!                         @derivedFrom(field: "to")
-  tokens: [TokenHolder]!                           @derivedFrom(field: "account")
-  transactions: [EOATransaction]!                  @derivedFrom(field: "account")
-  prepaidCardInventory: [SKUInventory]!            @derivedFrom(field: "issuer")
-  skus: [SKU]!                                     @derivedFrom(field: "issuer")
+  safes: [SafeOwner!]                              @derivedFrom(field: "owner")
+  depots: [Depot!]                                 @derivedFrom(field: "supplier")
+  sentBridgedTokens: [BridgeToLayer1Event!]        @derivedFrom(field: "account")
+  receivedBridgedTokens: [BridgeToLayer2Event!]    @derivedFrom(field: "supplier")
+  supplierInfoDIDUpdates: [SupplierInfoDIDUpdate!] @derivedFrom(field: "supplier")
+  createdPrepaidCards: [PrepaidCardCreation!]      @derivedFrom(field: "issuer")
+  splitPrepaidCards: [PrepaidCardSplit!]           @derivedFrom(field: "issuer")
+  createdMerchants: [MerchantCreation!]            @derivedFrom(field: "merchant")
+  createdRewardSafes: [RewardSafe!]                @derivedFrom(field: "rewardee")
+  receivedPrepaidCards: [PrepaidCardTransfer!]     @derivedFrom(field: "to")
+  provisionedPrepaidCards: [PrepaidCardProvisionedEvent!] @derivedFrom(field: "customer")
+  sentPrepaidCards: [PrepaidCardTransfer!]         @derivedFrom(field: "from")
+  tokenSwaps: [TokenSwap!]                         @derivedFrom(field: "to")
+  tokens: [TokenHolder!]                           @derivedFrom(field: "account")
+  transactions: [EOATransaction!]                  @derivedFrom(field: "account")
+  prepaidCardInventory: [SKUInventory!]            @derivedFrom(field: "issuer")
+  skus: [SKU!]                                     @derivedFrom(field: "issuer")
 }
 
 type Depot @entity {
@@ -25,7 +25,7 @@ type Depot @entity {
   createdAt: BigInt!
   supplier: Account!
   infoDid: String
-  receivedBridgedTokens: [BridgeToLayer2Event]!            @derivedFrom(field: "depot")
+  receivedBridgedTokens: [BridgeToLayer2Event!]            @derivedFrom(field: "depot")
 }
 
 type PrepaidCard @entity {
@@ -39,10 +39,10 @@ type PrepaidCard @entity {
   faceValue: BigInt!
   issuingTokenBalance: BigInt!
   creation: PrepaidCardCreation                    @derivedFrom(field: "prepaidCard")
-  payments: [PrepaidCardPayment]!                  @derivedFrom(field: "prepaidCard")
-  splits: [PrepaidCardSplit]!                      @derivedFrom(field: "prepaidCard")
-  transfers: [PrepaidCardTransfer]!                @derivedFrom(field: "prepaidCard")
-  usages: [PrepaidCardSendAction]!                 @derivedFrom(field: "prepaidCard")
+  payments: [PrepaidCardPayment!]                  @derivedFrom(field: "prepaidCard")
+  splits: [PrepaidCardSplit!]                      @derivedFrom(field: "prepaidCard")
+  transfers: [PrepaidCardTransfer!]                @derivedFrom(field: "prepaidCard")
+  usages: [PrepaidCardSendAction!]                 @derivedFrom(field: "prepaidCard")
 }
 
 type MerchantSafe @entity {
@@ -52,10 +52,10 @@ type MerchantSafe @entity {
   spendBalance: BigInt!
   infoDid: String
   creation: MerchantCreation                       @derivedFrom(field: "merchantSafe")
-  spendAccumulations: [SpendAccumulation]!         @derivedFrom(field: "merchantSafe")
-  receivedPayments: [PrepaidCardPayment]!          @derivedFrom(field: "merchantSafe")
-  merchantFees: [MerchantFeePayment]!              @derivedFrom(field: "merchantSafe")
-  merchantRevenue: [MerchantRevenue]!              @derivedFrom(field: "merchantSafe")
+  spendAccumulations: [SpendAccumulation!]         @derivedFrom(field: "merchantSafe")
+  receivedPayments: [PrepaidCardPayment!]          @derivedFrom(field: "merchantSafe")
+  merchantFees: [MerchantFeePayment!]              @derivedFrom(field: "merchantSafe")
+  merchantRevenue: [MerchantRevenue!]              @derivedFrom(field: "merchantSafe")
 }
 
 type BridgeToLayer1Event @entity {
@@ -104,9 +104,9 @@ type PrepaidCardPayment @entity {
   issuingTokenUSDPrice: BigDecimal!
   historicPrepaidCardFaceValue: BigInt!
   historicPrepaidCardIssuingTokenBalance: BigInt!
-  merchantRegistrationPayments: [MerchantRegistrationPayment]! @derivedFrom(field: "prepaidCardPayment")
-  rewardProgramRegistrationPayments: [RewardProgramRegistrationPayment]! @derivedFrom(field: "prepaidCardPayment")
-  rewardeeRegistrationPayments: [RewardeeRegistrationPayment]! @derivedFrom(field: "prepaidCardPayment")
+  merchantRegistrationPayments: [MerchantRegistrationPayment!] @derivedFrom(field: "prepaidCardPayment")
+  rewardProgramRegistrationPayments: [RewardProgramRegistrationPayment!] @derivedFrom(field: "prepaidCardPayment")
+  rewardeeRegistrationPayments: [RewardeeRegistrationPayment!] @derivedFrom(field: "prepaidCardPayment")
 }
 
 type PrepaidCardSplit @entity {
@@ -116,8 +116,8 @@ type PrepaidCardSplit @entity {
   transaction: Transaction!
   prepaidCard: PrepaidCard!
   issuer: Account!
-  faceValues: [BigInt!]!
-  issuingTokenAmounts: [BigInt!]!
+  faceValues: [BigInt!]
+  issuingTokenAmounts: [BigInt!]
   customizationDID: String
 }
 
@@ -159,8 +159,8 @@ type SKUInventory @entity {
   sku: SKU!
   issuer: Account!
   askPrice: BigInt!
-  prepaidCards: [PrepaidCardInventoryItem]!         @derivedFrom(field: "inventory")
-  inventoryEvents: [PrepaidCardInventoryEvent]!     @derivedFrom(field: "inventory")
+  prepaidCards: [PrepaidCardInventoryItem!]         @derivedFrom(field: "inventory")
+  inventoryEvents: [PrepaidCardInventoryEvent!]     @derivedFrom(field: "inventory")
 }
 
 type PrepaidCardInventoryEvent @entity {
@@ -221,8 +221,8 @@ type MerchantRevenue @entity {
   merchantSafe: MerchantSafe!
   lifetimeAccumulation: BigInt!
   unclaimedBalance: BigInt!
-  revenueEvents: [MerchantRevenueEvent]! @derivedFrom(field: "merchantRevenue")
-  earningsByDay: [RevenueEarningsByDay]! @derivedFrom(field: "merchantRevenue")
+  revenueEvents: [MerchantRevenueEvent!] @derivedFrom(field: "merchantRevenue")
+  earningsByDay: [RevenueEarningsByDay!] @derivedFrom(field: "merchantRevenue")
 }
 
 type RevenueEarningsByDay @entity {
@@ -364,15 +364,15 @@ type TokenSwap @entity {
 type Safe @entity {
   id: ID!                                   # safe address
   createdAt: BigInt!                        # unix time
-  owners: [SafeOwner]!                      @derivedFrom(field: "safe")
-  safeTxns: [SafeTransaction]!              @derivedFrom(field: "safe")
+  owners: [SafeOwner!]                      @derivedFrom(field: "safe")
+  safeTxns: [SafeTransaction!]              @derivedFrom(field: "safe")
   depot: Depot                              @derivedFrom(field: "safe")
   merchant: MerchantSafe                    @derivedFrom(field: "safe")
   reward: RewardSafe                      @derivedFrom(field: "safe")
   prepaidCard: PrepaidCard                  @derivedFrom(field: "safe")
-  tokens: [TokenHolder]!                    @derivedFrom(field: "safe")
-  sentBridgedTokens: [BridgeToLayer1Event]! @derivedFrom(field: "safe")
-  ownerChanges: [SafeOwnerChange]!          @derivedFrom(field: "safe")
+  tokens: [TokenHolder!]                    @derivedFrom(field: "safe")
+  sentBridgedTokens: [BridgeToLayer1Event!] @derivedFrom(field: "safe")
+  ownerChanges: [SafeOwnerChange!]          @derivedFrom(field: "safe")
 }
 
 type SafeTransaction @entity {
@@ -438,26 +438,26 @@ type Transaction @entity {
   timestamp: BigInt!
   blockNumber: BigInt!
   gasUsed: BigInt!
-  safeTxns: [SafeTransaction]!                     @derivedFrom(field: "transaction")
-  prepaidCardSendActions: [PrepaidCardSendAction]! @derivedFrom(field: "transaction")
-  bridgeToLayer1Events: [BridgeToLayer1Event]!     @derivedFrom(field: "transaction")
-  bridgeToLayer2Events: [BridgeToLayer2Event]!     @derivedFrom(field: "transaction")
-  supplierInfoDIDUpdates: [SupplierInfoDIDUpdate]! @derivedFrom(field: "transaction")
-  prepaidCardCreations: [PrepaidCardCreation]!     @derivedFrom(field: "transaction")
-  prepaidCardTransfers: [PrepaidCardTransfer]!     @derivedFrom(field: "transaction")
-  tokenTransfers: [TokenTransfer]!                 @derivedFrom(field: "transaction")
-  merchantCreations: [MerchantCreation]!           @derivedFrom(field: "transaction")
-  merchantRegistrationPayments: [MerchantRegistrationPayment]! @derivedFrom(field: "transaction")
-  prepaidCardPayments: [PrepaidCardPayment]!       @derivedFrom(field: "transaction")
-  prepaidCardSplits: [PrepaidCardSplit]!           @derivedFrom(field: "transaction")
-  spendAccumulations: [SpendAccumulation]!         @derivedFrom(field: "transaction")
-  merchantFeePayments: [MerchantFeePayment]!       @derivedFrom(field: "transaction")
-  merchantClaims: [MerchantClaim]!                 @derivedFrom(field: "transaction")
-  rewardClaims: [RewardeeClaim]!                   @derivedFrom(field: "transaction")
-  merchantRevenueEvents: [MerchantRevenueEvent]!   @derivedFrom(field: "transaction")
-  tokenSwaps: [TokenSwap]!                         @derivedFrom(field: "transaction")
-  prepaidCardInventoryEvents: [PrepaidCardInventoryEvent]! @derivedFrom(field: "transaction")
-  PrepaidCardAskSetEvents: [PrepaidCardAskSetEvent]! @derivedFrom(field: "transaction")
+  safeTxns: [SafeTransaction!]                     @derivedFrom(field: "transaction")
+  prepaidCardSendActions: [PrepaidCardSendAction!] @derivedFrom(field: "transaction")
+  bridgeToLayer1Events: [BridgeToLayer1Event!]     @derivedFrom(field: "transaction")
+  bridgeToLayer2Events: [BridgeToLayer2Event!]     @derivedFrom(field: "transaction")
+  supplierInfoDIDUpdates: [SupplierInfoDIDUpdate!] @derivedFrom(field: "transaction")
+  prepaidCardCreations: [PrepaidCardCreation!]     @derivedFrom(field: "transaction")
+  prepaidCardTransfers: [PrepaidCardTransfer!]     @derivedFrom(field: "transaction")
+  tokenTransfers: [TokenTransfer!]                 @derivedFrom(field: "transaction")
+  merchantCreations: [MerchantCreation!]           @derivedFrom(field: "transaction")
+  merchantRegistrationPayments: [MerchantRegistrationPayment!] @derivedFrom(field: "transaction")
+  prepaidCardPayments: [PrepaidCardPayment!]       @derivedFrom(field: "transaction")
+  prepaidCardSplits: [PrepaidCardSplit!]           @derivedFrom(field: "transaction")
+  spendAccumulations: [SpendAccumulation!]         @derivedFrom(field: "transaction")
+  merchantFeePayments: [MerchantFeePayment!]       @derivedFrom(field: "transaction")
+  merchantClaims: [MerchantClaim!]                 @derivedFrom(field: "transaction")
+  rewardClaims: [RewardeeClaim!]                   @derivedFrom(field: "transaction")
+  merchantRevenueEvents: [MerchantRevenueEvent!]   @derivedFrom(field: "transaction")
+  tokenSwaps: [TokenSwap!]                         @derivedFrom(field: "transaction")
+  prepaidCardInventoryEvents: [PrepaidCardInventoryEvent!] @derivedFrom(field: "transaction")
+  PrepaidCardAskSetEvents: [PrepaidCardAskSetEvent!] @derivedFrom(field: "transaction")
 }
 
 # A mapping table is the more performant way to represent many-to-many
@@ -490,7 +490,7 @@ type Token @entity {
   symbol: String
   name: String
   decimals: BigInt
-  transfers: [TokenTransfer]! @derivedFrom(field: "token")
+  transfers: [TokenTransfer!] @derivedFrom(field: "token")
 }
 
 type TokenHolder @entity {
@@ -499,9 +499,9 @@ type TokenHolder @entity {
   account: Account
   safe: Safe
   balance: BigInt!
-  sentTokens: [TokenTransfer]!     @derivedFrom(field: "fromTokenHolder")
-  receivedTokens: [TokenTransfer]! @derivedFrom(field: "toTokenHolder")
-  history: [TokenHistory]!         @derivedFrom(field: "tokenHolder")
+  sentTokens: [TokenTransfer!]     @derivedFrom(field: "fromTokenHolder")
+  receivedTokens: [TokenTransfer!] @derivedFrom(field: "toTokenHolder")
+  history: [TokenHistory!]         @derivedFrom(field: "tokenHolder")
 }
 
 type TokenHistory @entity {
@@ -518,7 +518,7 @@ type TokenPair @entity {
   id: ID!
   token0: Token!
   token1: Token!
-  swaps: [TokenSwap]!             @derivedFrom(field: "tokenPair")
+  swaps: [TokenSwap!]             @derivedFrom(field: "tokenPair")
 }
 
 type RewardProgramRegistrationPayment @entity {
@@ -544,10 +544,10 @@ type RewardeeRegistrationPayment @entity {
 type RewardProgram @entity {
   id: ID!
   admin: Account!
-  rewardSafes: [RewardSafe]! @derivedFrom(field: "rewardProgram")
-  tokenAddEvents: [RewardTokensAdd]! @derivedFrom(field: "rewardProgram")
-  rewardClaimEvents: [RewardeeClaim]! @derivedFrom(field: "rewardProgram")
-  merkleRoots: [MerkleRootSubmission]! @derivedFrom(field: "rewardProgram")
+  rewardSafes: [RewardSafe!] @derivedFrom(field: "rewardProgram")
+  tokenAddEvents: [RewardTokensAdd!] @derivedFrom(field: "rewardProgram")
+  rewardClaimEvents: [RewardeeClaim!] @derivedFrom(field: "rewardProgram")
+  merkleRoots: [MerkleRootSubmission!] @derivedFrom(field: "rewardProgram")
 }
 
 type RewardSafe @entity {
@@ -555,7 +555,7 @@ type RewardSafe @entity {
   rewardProgram: RewardProgram!
   rewardee: Account!
   safe: Safe!
-  claims: [RewardeeClaim]! @derivedFrom(field: "rewardSafe")
+  claims: [RewardeeClaim!] @derivedFrom(field: "rewardSafe")
 }
 
 type RewardeeClaim @entity {

--- a/packages/cardpay-subgraph/src/mappings/gnosis-safe.ts
+++ b/packages/cardpay-subgraph/src/mappings/gnosis-safe.ts
@@ -122,7 +122,7 @@ export function handleExecutionSuccess(event: ExecutionSuccess): void {
         safeTxEntity.safeTxGas.toString(),
         safeTxEntity.baseGas.toString(),
         safeTxEntity.gasPrice.toString(),
-        safeTxEntity.gasToken,
+        safeTxEntity.gasToken as string,
         safeTxEntity.refundReceiver,
         safeTxEntity.signatures.toHex(),
       ]

--- a/packages/cardpay-subgraph/src/utils.ts
+++ b/packages/cardpay-subgraph/src/utils.ts
@@ -41,7 +41,14 @@ export function makeTransaction(event: ethereum.Event): void {
   let txEntity = new Transaction(event.transaction.hash.toHex());
   txEntity.timestamp = event.block.timestamp;
   txEntity.blockNumber = event.block.number;
-  txEntity.gasUsed = event.transaction.gasUsed;
+
+  if (event.receipt === null) {
+    txEntity.gasUsed = new BigInt(0);
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    txEntity.gasUsed = event.receipt!.gasUsed;
+  }
+
   txEntity.save();
 }
 
@@ -157,7 +164,7 @@ export function makePrepaidCardPayment(
   paymentEntity.blockNumber = event.block.number;
   paymentEntity.prepaidCard = prepaidCard;
   paymentEntity.prepaidCardOwner = prepaidCardEntity.owner;
-  if (merchantSafe != null) {
+  if (merchantSafe !== null) {
     let merchantSafeEntity = MerchantSafe.load(merchantSafe);
     if (merchantSafeEntity != null) {
       paymentEntity.merchantSafe = merchantSafe;
@@ -171,7 +178,8 @@ export function makePrepaidCardPayment(
       return;
     }
   }
-  if (spendAmount == null) {
+
+  if (spendAmount === null) {
     spendAmount = convertToSpend(Address.fromString(issuingToken), issuingTokenAmount);
   }
   paymentEntity.issuingToken = issuingToken;
@@ -182,8 +190,8 @@ export function makePrepaidCardPayment(
   paymentEntity.historicPrepaidCardFaceValue = faceValue;
   paymentEntity.save();
 
-  if (merchantSafe != null) {
-    let revenueEntity = makeMerchantRevenue(merchantSafe, issuingToken);
+  if (merchantSafe !== null) {
+    let revenueEntity = makeMerchantRevenue(merchantSafe as string, issuingToken);
 
     let date = dayMonthYearFromEventTimestamp(event);
     let dateStr = date.year.toString() + '-' + date.month.toString() + '-' + date.day.toString();

--- a/packages/cardpay-subgraph/subgraph-template.yaml
+++ b/packages/cardpay-subgraph/subgraph-template.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.4
+specVersion: 0.0.5
 schema:
   file: ./schema.graphql
 
@@ -14,7 +14,7 @@ dataSources:
       startBlock: {CARDPAY_GENESIS_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - PrepaidCard
@@ -43,10 +43,13 @@ dataSources:
       eventHandlers:
         - event: CreatePrepaidCard(address,address,address,address,uint256,uint256,uint256,string)
           handler: handleCreatePrepaidCard
+          receipt: true
         - event: TransferredPrepaidCard(address,address,address)
           handler: handleTransferPrepaidCard
+          receipt: true
         - event: PrepaidCardSend(address,uint256,uint256,uint256,uint256,uint256,string,bytes,bytes)
           handler: handleSendAction
+          receipt: true
       file: ./src/mappings/prepaid-card.ts
 
   - kind: ethereum/contract
@@ -58,7 +61,7 @@ dataSources:
       startBlock: {v0_8_0_START_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Transaction
@@ -89,12 +92,16 @@ dataSources:
       eventHandlers:
         - event: ItemSet(address,address,address,uint256,string,bytes32)
           handler: handleItemSet
+          receipt: true
         - event: ItemRemoved(address,address,bytes32)
           handler: handleItemRemoved
+          receipt: true
         - event: AskSet(address,address,bytes32,uint256)
           handler: handleAskSet
+          receipt: true
         - event: ProvisionedPrepaidCard(address,address,bytes32,uint256)
           handler: handleProvisionedPrepaidCard
+          receipt: true
       file: ./src/mappings/prepaid-card-market.ts
 
   - kind: ethereum/contract
@@ -106,7 +113,7 @@ dataSources:
       startBlock: {v0_7_0_START_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Transaction
@@ -128,6 +135,7 @@ dataSources:
       eventHandlers:
         - event: MerchantCreation(address,address,string)
           handler: handleMerchantCreation
+          receipt: true
       file: ./src/mappings/merchant-manager.ts
 
   - kind: ethereum/contract
@@ -139,7 +147,7 @@ dataSources:
       startBlock: {CARDPAY_GENESIS_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Transaction
@@ -172,7 +180,7 @@ dataSources:
       startBlock: {CARDPAY_GENESIS_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Transaction
@@ -198,6 +206,7 @@ dataSources:
       eventHandlers:
         - event: MerchantRegistrationFee(address,address,uint256,uint256)
           handler: handleMerchantRegistrationFee
+          receipt: true
       file: ./src/mappings/merchant-registration.ts
 
   - kind: ethereum/contract
@@ -209,7 +218,7 @@ dataSources:
       startBlock: {CARDPAY_GENESIS_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Transaction
@@ -239,8 +248,10 @@ dataSources:
       eventHandlers:
         - event: CustomerPayment(address,address,address,uint256,uint256)
           handler: handleMerchantPayment
+          receipt: true
         - event: MerchantFeeCollected(address,address,address,uint256)
           handler: handleMerchantFee
+          receipt: true
       file: ./src/mappings/pay-merchant-handler.ts
 
   - kind: ethereum/contract
@@ -252,7 +263,7 @@ dataSources:
       startBlock: {CARDPAY_GENESIS_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Transaction
@@ -277,6 +288,7 @@ dataSources:
       eventHandlers:
         - event: SplitPrepaidCard(address,uint256[],uint256[],address,address,string)
           handler: handlePrepaidCardSplit
+          receipt: true
       file: ./src/mappings/split-prepaid-card-handler.ts
 
   - kind: ethereum/contract
@@ -288,7 +300,7 @@ dataSources:
       startBlock: {CARDPAY_GENESIS_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Transaction
@@ -322,7 +334,7 @@ dataSources:
       startBlock: {CARDPAY_GENESIS_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Transaction
@@ -343,6 +355,7 @@ dataSources:
       eventHandlers:
         - event: Mint(address,uint256)
           handler: handleMint
+          receipt: true
       file: ./src/mappings/spend.ts
 
   - kind: ethereum/contract
@@ -354,7 +367,7 @@ dataSources:
       startBlock: {CARDPAY_GENESIS_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Safe
@@ -376,8 +389,10 @@ dataSources:
       eventHandlers:
         - event: SupplierSafeCreated(address,address)
           handler: handleCreateDepot
+          receipt: true
         - event: SupplierInfoDIDUpdated(address,string)
           handler: handleSetInfoDID
+          receipt: true
       file: ./src/mappings/depot.ts
 
   - kind: ethereum/contract
@@ -389,7 +404,7 @@ dataSources:
       startBlock: {CARDPAY_GENESIS_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Account
@@ -413,8 +428,10 @@ dataSources:
       eventHandlers:
         - event: TokensBridgedToSafe(indexed address,indexed address,address,uint256,indexed bytes32)
           handler: handleReceivedBridgedTokens
+          receipt: true
         - event: TokensBridgingInitiated(indexed address,indexed address,uint256,indexed bytes32)
           handler: handleSentBridgedTokens
+          receipt: true
       file: ./src/mappings/depot.ts
 
   - kind: ethereum/contract
@@ -426,7 +443,7 @@ dataSources:
       startBlock: {SAFE_GENESIS_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Safe
@@ -457,7 +474,7 @@ dataSources:
       startBlock: {SAFE_GENESIS_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Safe
@@ -488,7 +505,7 @@ dataSources:
       startBlock: {UNISWAP_V2_GENESIS_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mappings/uniswap-factory-{NETWORK}.ts
       entities:
@@ -524,7 +541,7 @@ dataSources:
       startBlock: {TOKEN_START_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Token
@@ -555,6 +572,7 @@ dataSources:
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
+          receipt: true
       file: ./src/mappings/token.ts
 
   - kind: ethereum/contract
@@ -566,7 +584,7 @@ dataSources:
       startBlock: {TOKEN_START_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Token
@@ -597,6 +615,7 @@ dataSources:
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
+          receipt: true
       file: ./src/mappings/token.ts
 
   - kind: ethereum/contract
@@ -608,7 +627,7 @@ dataSources:
       startBlock: {v0_8_7_START_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - RewardSafe
@@ -626,6 +645,7 @@ dataSources:
       eventHandlers:
         - event: RewardeeRegistered(address,address,address)
           handler: handleRewardeeRegistration
+          receipt: true
       file: ./src/mappings/reward-manager.ts
 
   - kind: ethereum/contract
@@ -637,7 +657,7 @@ dataSources:
       startBlock: {v0_8_7_START_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - RewardProgramRegistrationPayment
@@ -670,7 +690,7 @@ dataSources:
       startBlock: {v0_8_7_START_BLOCK}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - RewardeeClaim
@@ -689,8 +709,10 @@ dataSources:
       eventHandlers:
         - event: RewardeeClaim(address,address,address,address,uint256,bytes)
           handler: handleRewardeeClaim
+          receipt: true
         - event: RewardTokensAdded(address,address,address,uint256)
           handler: handleRewardTokensAdded
+          receipt: true
         - event: MerkleRootSubmission(bytes32,address,uint256)
           handler: handleMerkleRootSubmission
       file: ./src/mappings/reward-pool.ts
@@ -703,7 +725,7 @@ templates:
       abi: GnosisSafe
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - SafeTransaction
@@ -722,6 +744,7 @@ templates:
       eventHandlers:
         - event: ExecutionSuccess(bytes32,uint256)
           handler: handleExecutionSuccess
+          receipt: true
         - event: AddedOwner(address)
           handler: handleAddedOwner
         - event: RemovedOwner(address)
@@ -735,7 +758,7 @@ templates:
       abi: UniswapV2Pair
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Swap
@@ -757,4 +780,5 @@ templates:
       eventHandlers:
         - event: Swap(indexed address,uint256,uint256,uint256,uint256,indexed address)
           handler: handleSwap
+          receipt: true
       file: ./src/mappings/token-pair.ts

--- a/yarn.lock
+++ b/yarn.lock
@@ -6769,39 +6769,43 @@
   resolved "https://registry.yarnpkg.com/@graphile/logger/-/logger-0.2.0.tgz#e484ec420162157c6e6f0cfb080fa29ef3a714ba"
   integrity sha512-jjcWBokl9eb1gVJ85QmoaQ73CQ52xAaOCF29ukRbYNl6lY+ts0ErTaDYOBlejcbUs2OpaiqYLO5uDhyLFzWw4w==
 
-"@graphprotocol/graph-cli@0.20.0":
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.20.0.tgz#52d907f906d4845c42ef2d8063fe0f624db95c09"
-  integrity sha512-uUeq54fIdBvj3SVA4U1qArAG0vZuw3Qnw0J7o/kQ712G8YtJ6l2rkmt5IaS35zQHlnNjAmFd1WJ095lSemlHog==
+"@graphprotocol/graph-cli@0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.32.0.tgz#d9e4e1ed65687f0756113fc0c5fc0e2103c2a8cb"
+  integrity sha512-40Kii/Ttype5aNCaQn81AP7utyE6JKB5bI9QtYd6WoaS3oACICqdPA89+5UB1s9t6yXiFbWojK3e7JUokPdYfA==
   dependencies:
-    assemblyscript "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
-    chalk "^3.0.0"
-    chokidar "^3.0.2"
-    debug "^4.1.1"
-    docker-compose "^0.23.2"
-    dockerode "^2.5.8"
-    fs-extra "^9.0.0"
-    glob "^7.1.2"
-    gluegun "^4.3.1"
-    graphql "^15.5.0"
-    immutable "^3.8.2"
-    ipfs-http-client "^34.0.0"
-    jayson "^3.0.2"
-    js-yaml "^3.13.1"
-    node-fetch "^2.3.0"
-    pkginfo "^0.4.1"
-    prettier "^1.13.5"
-    request "^2.88.0"
-    tmp "^0.1.0"
-    yaml "^1.5.1"
-  optionalDependencies:
-    keytar "^7.4.0"
+    assemblyscript "0.19.10"
+    binary-install-raw "0.0.13"
+    chalk "3.0.0"
+    chokidar "3.5.1"
+    debug "4.3.1"
+    docker-compose "0.23.4"
+    dockerode "2.5.8"
+    fs-extra "9.0.0"
+    glob "7.1.6"
+    gluegun "https://github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep"
+    graphql "15.5.0"
+    immutable "3.8.2"
+    ipfs-http-client "34.0.0"
+    jayson "3.6.6"
+    js-yaml "3.13.1"
+    node-fetch "2.6.0"
+    pkginfo "0.4.1"
+    prettier "1.19.1"
+    request "2.88.2"
+    semver "7.3.5"
+    sync-request "6.1.0"
+    tmp-promise "3.0.2"
+    web3-eth-abi "1.7.0"
+    which "2.0.2"
+    yaml "1.9.2"
 
-"@graphprotocol/graph-ts@graphprotocol/graph-ts#56adb62d9e4233c6fc6c38bc0519a8a566afdd9e":
-  version "0.20.0"
-  resolved "https://codeload.github.com/graphprotocol/graph-ts/tar.gz/56adb62d9e4233c6fc6c38bc0519a8a566afdd9e"
+"@graphprotocol/graph-ts@0.27.0":
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.27.0.tgz#948fe1716f6082964a01a63a19bcbf9ac44e06ff"
+  integrity sha512-r1SPDIZVQiGMxcY8rhFSM0y7d/xAbQf5vHMWUf59js1KgoyWpM6P3tczZqmQd7JTmeyNsDGIPzd9FeaxllsU4w==
   dependencies:
-    assemblyscript "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
+    assemblyscript "0.19.10"
 
 "@grpc/grpc-js@~1.4.0":
   version "1.4.4"
@@ -8860,15 +8864,29 @@
   resolved "https://registry.yarnpkg.com/@types/component-emitter/-/component-emitter-1.2.11.tgz#50d47d42b347253817a39709fef03ce66a108506"
   integrity sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ==
 
+"@types/concat-stream@^1.6.0":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@types/concat-stream/-/concat-stream-1.6.1.tgz#24bcfc101ecf68e886aaedce60dfd74b632a1b74"
+  integrity sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/config@^0.0.38":
   version "0.0.38"
   resolved "https://registry.yarnpkg.com/@types/config/-/config-0.0.38.tgz#ca30679b21b5b297299467e3a3f1c8e2e64b9170"
   integrity sha512-z2WizAfIFgSv8SQfQ8c0LlbDAcK47D/o93XW6bxZ9t3bs4fmmfAPjk1nhAIBTG84PBBCHfSPM+8g7vhLdbFokg==
 
-"@types/connect@*", "@types/connect@^3.4.33":
+"@types/connect@*":
   version "3.4.34"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.34.tgz#170a40223a6d666006d93ca128af2beb1d9b1901"
   integrity sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/connect@^3.4.33":
+  version "3.4.35"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
+  integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
   dependencies:
     "@types/node" "*"
 
@@ -9153,7 +9171,7 @@
     "@types/express" "*"
     "@types/express-unless" "*"
 
-"@types/express-serve-static-core@*":
+"@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.9":
   version "4.17.29"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz#2a1795ea8e9e9c91b4a4bbe475034b20c1ec711c"
   integrity sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==
@@ -9162,7 +9180,7 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
-"@types/express-serve-static-core@^4.17.18", "@types/express-serve-static-core@^4.17.9":
+"@types/express-serve-static-core@^4.17.18":
   version "4.17.26"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.26.tgz#5d9a8eeecb9d5f9d7fc1d85f541512a84638ae88"
   integrity sha512-zeu3tpouA043RHxW0gzRxwCHchMgftE8GArRsvYT0ByDMbn19olQHx5jLue0LxWY6iYtXb7rXmuVtSkhy9YZvQ==
@@ -9196,6 +9214,13 @@
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
+
+"@types/form-data@0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-0.0.33.tgz#c9ac85b2a5fd18435b8c85d9ecb50e6d6c893ff8"
+  integrity sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/formidable@^1.0.31":
   version "1.0.32"
@@ -9368,12 +9393,12 @@
     "@types/level-errors" "*"
     "@types/node" "*"
 
-"@types/lodash@^4.14.104":
+"@types/lodash@^4.14.104", "@types/lodash@^4.14.159":
   version "4.14.182"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
   integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
 
-"@types/lodash@^4.14.159", "@types/lodash@^4.14.168", "@types/lodash@^4.14.169":
+"@types/lodash@^4.14.168", "@types/lodash@^4.14.169":
   version "4.14.178"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
   integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
@@ -9453,12 +9478,22 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.16.tgz#e3733f46797b9df9e853ca9f719c8a6f7b84cd26"
   integrity sha512-ydLaGVfQOQ6hI1xK2A5nVh8bl0OGoIfYMxPWHqqYe9bTkWCfqiVvZoh2I/QF2sNSkZzZyROBoTefIEI+PB6iIA==
 
+"@types/node@^10.0.3":
+  version "10.17.60"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
+  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
+
 "@types/node@^11.13.8":
   version "11.13.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.8.tgz#e5d71173c95533be9842b2c798978f095f912aab"
   integrity sha512-szA3x/3miL90ZJxUCzx9haNbK5/zmPieGraZEe4WI+3srN0eGLiT22NXeMHmyhNEopn+IrxqMc7wdVwvPl8meg==
 
-"@types/node@^12.12.54", "@types/node@^12.12.6":
+"@types/node@^12.12.54":
+  version "12.20.55"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
+  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+
+"@types/node@^12.12.6":
   version "12.20.15"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.15.tgz#10ee6a6a3f971966fddfa3f6e89ef7a73ec622df"
   integrity sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==
@@ -9467,6 +9502,11 @@
   version "16.11.45"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.45.tgz#155b13a33c665ef2b136f7f245fa525da419e810"
   integrity sha512-3rKg/L5x0rofKuuUt5zlXzOnKyIHXmIu5R8A0TuNDMF2062/AOIDBciFIjToLEJ/9F9DzkHNot+BpNsMI1OLdQ==
+
+"@types/node@^8.0.0":
+  version "8.10.66"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.66.tgz#dd035d409df322acc83dff62a602f12a5783bbb3"
+  integrity sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==
 
 "@types/node@^9.6.0":
   version "9.6.61"
@@ -9535,7 +9575,7 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.6.tgz#df9c3c8b31a247ec315e6996566be3171df4b3b1"
   integrity sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==
 
-"@types/qs@^6.9.1":
+"@types/qs@^6.2.31", "@types/qs@^6.9.1":
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
@@ -9692,6 +9732,13 @@
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.4.tgz#1dc497280d8049a5450854dd698ee7e6ea9e60b8"
   integrity sha512-qn1LkcFEKK8RPp459jkjzsfpbsx36BBt3oC3pITYtkoBw/aVX+EZFa5j3ThCRTNpLFvIMr5dSTD4RaMdilIOpA==
+  dependencies:
+    "@types/node" "*"
+
+"@types/ws@^7.4.4":
+  version "7.4.7"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.7.tgz#f7c390a36f7a0679aa69de2d501319f4f8d9b702"
+  integrity sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==
   dependencies:
     "@types/node" "*"
 
@@ -10811,12 +10858,12 @@ anymatch@~3.1.1, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-apisauce@^2.0.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/apisauce/-/apisauce-2.1.1.tgz#0b8bc7f2544e6ef710a6fa1d6f49583856940dd2"
-  integrity sha512-P4SsLvmsH8BLLruBn/nsO+65j+ChZlGQ2zC5avCIjbWstYS4PgjxeVWtbeVwFGEWX7dEkLp85OvdapGXy1zS8g==
+apisauce@^1.0.1:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/apisauce/-/apisauce-1.1.5.tgz#31d41a5cf805e401266cec67faf1a50f4aeae234"
+  integrity sha512-gKC8qb/bDJsPsnEXLZnXJ7gVx7dh87CEVNeIwv1dvaffnXoh5GHwac5pWR1P2broLiVj/fqFMQvLDDt/RhjiqA==
   dependencies:
-    axios "^0.21.1"
+    axios "^0.21.2"
     ramda "^0.25.0"
 
 app-module-path@^2.2.0:
@@ -11042,7 +11089,7 @@ as-array@^2.0.0:
   resolved "https://registry.yarnpkg.com/as-array/-/as-array-2.0.0.tgz#4f04805d87f8fce8e511bc2108f8e5e3a287d547"
   integrity sha512-1Sd1LrodN0XYxYeZcN1J4xYZvmvTwD5tDWaPUGPIzH1mFsmzsPnVtd2exWhecMjtZk/wYWjNZJiD3b1SLCeJqg==
 
-asap@^2.0.0:
+asap@^2.0.0, asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
@@ -11076,16 +11123,13 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
-"assemblyscript@https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3":
-  version "0.6.0"
-  resolved "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
+assemblyscript@0.19.10:
+  version "0.19.10"
+  resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.19.10.tgz#7ede6d99c797a219beb4fa4614c3eab9e6343c8e"
+  integrity sha512-HavcUBXB3mBTRGJcpvaQjmnmaqKHBGREjSPNsIvnAk2f9dj78y4BkMaSSdvBQYWcDDzsHQjyUC8stICFkD1Odg==
   dependencies:
-    "@protobufjs/utf8" "^1.1.0"
-    binaryen "77.0.0-nightly.20190407"
-    glob "^7.1.3"
+    binaryen "101.0.0-nightly.20210723"
     long "^4.0.0"
-    opencollective-postinstall "^2.0.0"
-    source-map-support "^0.5.11"
 
 assert-never@^1.1.0, assert-never@^1.2.1:
   version "1.2.1"
@@ -11289,7 +11333,7 @@ axe-core@4.1.4, axe-core@^4.1.4:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.4.tgz#f19cd99a84ee32a318b9c5b5bb8ed373ad94f143"
   integrity sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==
 
-axios@^0.21.1:
+axios@^0.21.1, axios@^0.21.2:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
@@ -12129,6 +12173,15 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
   integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
 
+binary-install-raw@0.0.13:
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/binary-install-raw/-/binary-install-raw-0.0.13.tgz#43a13c6980eb9844e2932eb7a91a56254f55b7dd"
+  integrity sha512-v7ms6N/H7iciuk6QInon3/n2mu7oRX+6knJ9xFPsJ3rQePgAqcR3CRTwUheFd8SLbiq4LL7Z4G/44L9zscdt9A==
+  dependencies:
+    axios "^0.21.1"
+    rimraf "^3.0.2"
+    tar "^6.1.0"
+
 binary@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/binary/-/binary-0.3.0.tgz#9f60553bc5ce8c3386f3b553cff47462adecaa79"
@@ -12137,10 +12190,10 @@ binary@~0.3.0:
     buffers "~0.1.1"
     chainsaw "~0.1.0"
 
-binaryen@77.0.0-nightly.20190407:
-  version "77.0.0-nightly.20190407"
-  resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-77.0.0-nightly.20190407.tgz#fbe4f8ba0d6bd0809a84eb519d2d5b5ddff3a7d1"
-  integrity sha512-1mxYNvQ0xywMe582K7V6Vo2zzhZZxMTeGHH8aE/+/AND8f64D8Q1GThVY3RVRwGY/4p+p95ccw9Xbw2ovFXRIg==
+binaryen@101.0.0-nightly.20210723:
+  version "101.0.0-nightly.20210723"
+  resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-101.0.0-nightly.20210723.tgz#b6bb7f3501341727681a03866c0856500eec3740"
+  integrity sha512-eioJNqhHlkguVSbblHOtLqlhtC882SOEPKmNFZaDuz1hzQjolxZ+eu3/kaS10n3sGPONsIZsO7R9fR00UyhEUA==
 
 "binaryextensions@1 || 2", binaryextensions@^2.1.2:
   version "2.3.0"
@@ -13645,7 +13698,7 @@ cardinal@^2.1.1:
     ansicolors "~0.3.2"
     redeyed "~2.1.0"
 
-caseless@~0.12.0:
+caseless@^0.12.0, caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
@@ -13681,6 +13734,14 @@ chainsaw@~0.1.0:
   dependencies:
     traverse ">=0.3.0 <0.4"
 
+chalk@3.0.0, chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
@@ -13715,14 +13776,6 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
-  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 charcodes@^0.2.0:
   version "0.2.0"
@@ -14213,7 +14266,12 @@ colors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
-colors@1.4.0, colors@^1.1.2, colors@^1.3.3, colors@^1.4.0:
+colors@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
+  integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
+
+colors@1.4.0, colors@^1.1.2, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -14368,7 +14426,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.5.0, concat-stream@~1.6.2:
+concat-stream@^1.5.0, concat-stream@^1.6.0, concat-stream@^1.6.2, concat-stream@~1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
@@ -15432,6 +15490,11 @@ del@^4.1.1:
     pify "^4.0.1"
     rimraf "^2.6.3"
 
+delay@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/delay/-/delay-5.0.0.tgz#137045ef1b96e5071060dd5be60bf9334436bd1d"
+  integrity sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -15651,12 +15714,10 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
-docker-compose@^0.23.2:
-  version "0.23.12"
-  resolved "https://registry.yarnpkg.com/docker-compose/-/docker-compose-0.23.12.tgz#fa883b98be08f6926143d06bf9e522ef7ed3210c"
-  integrity sha512-KFbSMqQBuHjTGZGmYDOCO0L4SaML3BsWTId5oSUyaBa22vALuFHNv+UdDWs3HcMylHWKsxCbLB7hnM/nCosWZw==
-  dependencies:
-    yaml "^1.10.2"
+docker-compose@0.23.4:
+  version "0.23.4"
+  resolved "https://registry.yarnpkg.com/docker-compose/-/docker-compose-0.23.4.tgz#43bcabcde55a6ba2873b52fe0ccd99dd8fdceba8"
+  integrity sha512-yWdXby9uQ8o4syOfvoSJ9ZlTnLipvUmDn59uaYY5VGIUSUAfMPPGqE1DE3pOCnfSg9Tl9UOOFO0PCSAzuIHmuA==
 
 docker-modem@^1.0.8:
   version "1.0.9"
@@ -15668,7 +15729,7 @@ docker-modem@^1.0.8:
     readable-stream "~1.0.26-4"
     split-ca "^1.0.0"
 
-dockerode@^2.5.8:
+dockerode@2.5.8:
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/dockerode/-/dockerode-2.5.8.tgz#1b661e36e1e4f860e25f56e0deabe9f87f1d0acc"
   integrity sha512-+7iOUYBeDTScmOmQqpUYQaE7F4vvIt6+gIZNHWhqAQEI887tiPFB9OvXI/HzQYqfUNvukMK+9myLW63oTJPZpw==
@@ -20099,7 +20160,7 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@^2.3.1:
+form-data@^2.2.0, form-data@^2.3.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
   integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
@@ -20187,6 +20248,16 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
+fs-extra@9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.0.tgz#b6afc31036e247b2466dc99c29ae797d5d4580a3"
+  integrity sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^1.0.0"
+
 fs-extra@^0.24.0:
   version "0.24.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.24.0.tgz#d4e4342a96675cb7846633a6099249332b539952"
@@ -20262,7 +20333,7 @@ fs-extra@^8.0.0, fs-extra@^8.0.1, fs-extra@^8.1, fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.0, fs-extra@^9.0.1, fs-extra@^9.1.0:
+fs-extra@^9.0.1, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -20528,6 +20599,11 @@ get-pkg-repo@^1.0.0:
     normalize-package-data "^2.3.0"
     parse-github-repo-url "^1.3.0"
     through2 "^2.0.0"
+
+get-port@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
+  integrity sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==
 
 get-port@^5.1.1:
   version "5.1.1"
@@ -20935,15 +21011,14 @@ globule@^1.0.0:
     lodash "~4.17.10"
     minimatch "~3.0.2"
 
-gluegun@^4.3.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/gluegun/-/gluegun-4.6.1.tgz#f2a65d20378873de87a2143b8c3939ffc9a9e2b6"
-  integrity sha512-Jd5hV1Uku2rjBg59mYA/bnwLwynK7u9A1zmK/LIb/p5d3pzjDCKRjWFuxZXyPwl9rsvKGhJUQxkFo2HEy8crKQ==
+"gluegun@git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep":
+  version "4.3.1"
+  resolved "git+https://github.com/edgeandnode/gluegun.git#b34b9003d7bf556836da41b57ef36eb21570620a"
   dependencies:
-    apisauce "^2.0.1"
+    apisauce "^1.0.1"
     app-module-path "^2.2.0"
     cli-table3 "~0.5.0"
-    colors "^1.3.3"
+    colors "1.3.3"
     cosmiconfig "6.0.0"
     cross-spawn "^7.0.0"
     ejs "^2.6.1"
@@ -21133,7 +21208,7 @@ graphile-worker@^0.11.3:
     tslib "^2.1.0"
     yargs "^16.2.0"
 
-graphql@^15.5.0:
+graphql@15.5.0:
   version "15.5.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.0.tgz#39d19494dbe69d1ea719915b578bf920344a69d5"
   integrity sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==
@@ -21547,6 +21622,21 @@ http-assert@^1.3.0:
     deep-equal "~1.0.1"
     http-errors "~1.7.2"
 
+http-basic@^8.1.1:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/http-basic/-/http-basic-8.1.3.tgz#a7cabee7526869b9b710136970805b1004261bbf"
+  integrity sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==
+  dependencies:
+    caseless "^0.12.0"
+    concat-stream "^1.6.2"
+    http-response-object "^3.0.1"
+    parse-cache-control "^1.0.1"
+
+http-cache-semantics@3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
+  integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
+
 http-cache-semantics@^4.0.0, http-cache-semantics@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
@@ -21665,6 +21755,13 @@ http-proxy@^1.13.1, http-proxy@^1.17.0, http-proxy@^1.18.1:
     eventemitter3 "^4.0.0"
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
+
+http-response-object@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/http-response-object/-/http-response-object-3.0.2.tgz#7f435bb210454e4360d074ef1f989d5ea8aa9810"
+  integrity sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==
+  dependencies:
+    "@types/node" "^10.0.3"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -21822,10 +21919,10 @@ immediate@~3.2.3:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
   integrity sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=
 
-immutable@^3.8.2:
+immutable@3.8.2:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
-  integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
+  integrity sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==
 
 immutable@^4.0.0-rc.12:
   version "4.0.0"
@@ -22247,7 +22344,7 @@ ipfs-core-utils@^0.10.1:
     timeout-abort-controller "^1.1.1"
     uint8arrays "^3.0.0"
 
-ipfs-http-client@^34.0.0:
+ipfs-http-client@34.0.0:
   version "34.0.0"
   resolved "https://registry.yarnpkg.com/ipfs-http-client/-/ipfs-http-client-34.0.0.tgz#8804d06a11c22306332a8ffa0949b6f672a0c9c8"
   integrity sha512-4RCkk8ix4Dqn6sxqFVwuXWCZ1eLFPsVaj6Ijvu1fs9VYgxgVudsW9PWwarlr4mw1xUCmPWYyXnEbGgzBrfMy0Q==
@@ -23044,6 +23141,11 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+isomorphic-ws@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
+  integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -23167,22 +23269,26 @@ iterable-ndjson@^1.1.0:
   dependencies:
     string_decoder "^1.2.0"
 
-jayson@^3.0.2:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/jayson/-/jayson-3.6.3.tgz#b0bb8d2e37e34e39e68044ab925fd92f103f1bd9"
-  integrity sha512-H/JuWKaJwU8FbwofPHROvtGoMF6R3DB0GGPpYyIaRzXU50Ser/4likFVfo/bpTGe0csB7n/+uybxJpBvX40VOQ==
+jayson@3.6.6:
+  version "3.6.6"
+  resolved "https://registry.yarnpkg.com/jayson/-/jayson-3.6.6.tgz#189984f624e398f831bd2be8e8c80eb3abf764a1"
+  integrity sha512-f71uvrAWTtrwoww6MKcl9phQTC+56AopLyEenWvKVAIMz+q0oVGj6tenLZ7Z6UiPBkJtKLj4kt0tACllFQruGQ==
   dependencies:
     "@types/connect" "^3.4.33"
     "@types/express-serve-static-core" "^4.17.9"
     "@types/lodash" "^4.14.159"
     "@types/node" "^12.12.54"
+    "@types/ws" "^7.4.4"
     JSONStream "^1.3.5"
     commander "^2.20.3"
+    delay "^5.0.0"
     es6-promisify "^5.0.0"
     eyes "^0.1.8"
+    isomorphic-ws "^4.0.1"
     json-stringify-safe "^5.0.1"
     lodash "^4.17.20"
-    uuid "^3.4.0"
+    uuid "^8.3.2"
+    ws "^7.4.5"
 
 jest-diff@^27.0.2:
   version "27.2.5"
@@ -23710,6 +23816,13 @@ keytar@^7.4.0:
   dependencies:
     node-addon-api "^3.0.0"
     prebuild-install "^6.0.0"
+
+keyv@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
+  integrity sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==
+  dependencies:
+    json-buffer "3.0.0"
 
 keyv@^3.0.0:
   version "3.1.0"
@@ -26312,7 +26425,7 @@ noble-secp256k1@^1.2.10:
   resolved "https://registry.yarnpkg.com/noble-secp256k1/-/noble-secp256k1-1.2.14.tgz#39429c941d51211ca40161569cee03e61d72599e"
   integrity sha512-GSCXyoZBUaaPwVWdYncMEmzlSUjF9J/YeEHpklYJCyg8wPuJP3NzDx0BkiwArzINkdX2HJHvUJhL6vVWPOQQcg==
 
-node-abi@^2.21.0, node-abi@^2.7.0:
+node-abi@^2.7.0:
   version "2.30.0"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.30.0.tgz#8be53bf3e7945a34eea10e0fc9a5982776cf550b"
   integrity sha512-g6bZh3YCKQRdwuO/tSZZYJAw622SjsRfJ2X0Iy4sSOHZ34/sPPdVBn8fev2tj7njzLwuqPw9uMtGsGkO5kIQvg==
@@ -26323,11 +26436,6 @@ node-addon-api@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
-
-node-addon-api@^3.0.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
-  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
 
 node-cleanup@^2.1.2:
   version "2.1.2"
@@ -26353,6 +26461,11 @@ node-fetch@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
+
+node-fetch@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-fetch@2.6.7, node-fetch@^2.3.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7, "node-fetch@https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz":
   version "2.6.7"
@@ -27035,11 +27148,6 @@ openapi3-ts@^2.0.1:
   dependencies:
     yaml "^1.10.2"
 
-opencollective-postinstall@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
-  integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
-
 opn@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
@@ -27450,6 +27558,11 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
+
+parse-cache-control@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-cache-control/-/parse-cache-control-1.0.1.tgz#8eeab3e54fa56920fe16ba38f77fa21aacc2d74e"
+  integrity sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==
 
 parse-duration@^1.0.0:
   version "1.0.2"
@@ -27897,10 +28010,10 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
-pkginfo@^0.4.1:
+pkginfo@0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
-  integrity sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=
+  integrity sha512-8xCNE/aT/EXKenuMDZ+xTVwkT8gsoHN2z/Q29l80u0ppGEXVvsKRzNMbtKhg8LS8k1tJLAHHylf6p4VFmP6XUQ==
 
 pluralize@^8.0.0:
   version "8.0.0"
@@ -28103,25 +28216,6 @@ prebuild-install@^5.3.3:
     tunnel-agent "^0.6.0"
     which-pm-runs "^1.0.0"
 
-prebuild-install@^6.0.0:
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-6.1.3.tgz#8ea1f9d7386a0b30f7ef20247e36f8b2b82825a2"
-  integrity sha512-iqqSR84tNYQUQHRXalSKdIaM8Ov1QxOVuBNWI7+BzZWv6Ih9k75wOnH1rGQ9WWTaaLkTpxWKIciOF0KyfM74+Q==
-  dependencies:
-    detect-libc "^1.0.3"
-    expand-template "^2.0.3"
-    github-from-package "0.0.0"
-    minimist "^1.2.3"
-    mkdirp-classic "^0.5.3"
-    napi-build-utils "^1.0.1"
-    node-abi "^2.21.0"
-    npmlog "^4.0.1"
-    pump "^3.0.0"
-    rc "^1.2.7"
-    simple-get "^3.0.3"
-    tar-fs "^2.0.0"
-    tunnel-agent "^0.6.0"
-
 precond@0.2:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/precond/-/precond-0.2.3.tgz#aa9591bcaa24923f1e0f4849d240f47efc1075ac"
@@ -28162,7 +28256,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.13.5:
+prettier@1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
@@ -28296,6 +28390,13 @@ promise.hash.helper@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/promise.hash.helper/-/promise.hash.helper-1.0.7.tgz#2f39d8495df40dcdfbc1d5be9e9e56efeae7f180"
   integrity sha512-0qhWYyCV9TYDMSooYw1fShIb7R6hsWYja7JLqbeb1MvHqDTvP/uy/R1RsyVqDi6GCiHOI4G5p2Hpr3IA+/l/+Q==
+
+promise@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
+  integrity sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==
+  dependencies:
+    asap "~2.0.6"
 
 promise@~1.3.0:
   version "1.3.0"
@@ -29318,7 +29419,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.79.0, request@^2.85.0, request@^2.87.0, request@^2.88.0, request@^2.88.2:
+request@2.88.2, request@^2.79.0, request@^2.85.0, request@^2.87.0, request@^2.88.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -29948,17 +30049,17 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.0.0, semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@7.3.5, semver@^7.0.0, semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@~5.3.0:
   version "5.3.0"
@@ -30620,7 +30721,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.11, source-map-support@^0.5.13, source-map-support@^0.5.17, source-map-support@^0.5.19, source-map-support@^0.5.21, source-map-support@~0.5.12, source-map-support@~0.5.20:
+source-map-support@^0.5.13, source-map-support@^0.5.17, source-map-support@^0.5.19, source-map-support@^0.5.21, source-map-support@~0.5.12, source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -31520,6 +31621,22 @@ tabbable@^5.3.3:
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.3.tgz#aac0ff88c73b22d6c3c5a50b1586310006b47fbf"
   integrity sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==
 
+sync-request@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/sync-request/-/sync-request-6.1.0.tgz#e96217565b5e50bbffe179868ba75532fb597e68"
+  integrity sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==
+  dependencies:
+    http-response-object "^3.0.1"
+    sync-rpc "^1.2.1"
+    then-request "^6.0.0"
+
+sync-rpc@^1.2.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/sync-rpc/-/sync-rpc-1.3.6.tgz#b2e8b2550a12ccbc71df8644810529deb68665a7"
+  integrity sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==
+  dependencies:
+    get-port "^3.1.0"
+
 table@^6.0.9:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/table/-/table-6.7.1.tgz#ee05592b7143831a8c94f3cee6aae4c1ccef33e2"
@@ -31820,6 +31937,23 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-2.6.0.tgz#d7e4ab13fe54e32e08873be40d51b74229b00fc4"
   integrity sha512-49WtAWS+tcsy93dRt6P0P3AMD2m5PvXRhuEA0kaXos5ZLlujtYmpmFsB+QvWUSxE1ZsstmYXfQ7L40+EcQgpAQ==
 
+then-request@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/then-request/-/then-request-6.0.2.tgz#ec18dd8b5ca43aaee5cb92f7e4c1630e950d4f0c"
+  integrity sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==
+  dependencies:
+    "@types/concat-stream" "^1.6.0"
+    "@types/form-data" "0.0.33"
+    "@types/node" "^8.0.0"
+    "@types/qs" "^6.2.31"
+    caseless "~0.12.0"
+    concat-stream "^1.6.0"
+    form-data "^2.2.0"
+    http-basic "^8.1.1"
+    http-response-object "^3.0.1"
+    promise "^8.0.0"
+    qs "^6.4.0"
+
 thenify-all@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
@@ -31958,6 +32092,13 @@ tippy.js@^6.3.7:
   dependencies:
     "@popperjs/core" "^2.9.0"
 
+tmp-promise@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.2.tgz#6e933782abff8b00c3119d63589ca1fb9caaa62a"
+  integrity sha512-OyCLAKU1HzBjL6Ev3gxUeraJNlbNingmi8IrHHEsYH8LTmEuhvYfqvhn2F/je+mjf4N58UmZ96OMEy1JanSCpA==
+  dependencies:
+    tmp "^0.2.0"
+
 tmp@0.0.28:
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.28.tgz#172735b7f614ea7af39664fa84cf0de4e515d120"
@@ -31978,7 +32119,7 @@ tmp@^0.1.0:
   dependencies:
     rimraf "^2.6.3"
 
-tmp@^0.2.1:
+tmp@^0.2.0, tmp@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
   integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
@@ -32641,6 +32782,11 @@ universalify@^0.1.0, universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
+  integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
 
 universalify@^2.0.0:
   version "2.0.0"
@@ -33412,6 +33558,14 @@ web3-eth-abi@1.6.1:
     "@ethersproject/abi" "5.0.7"
     web3-utils "1.6.1"
 
+web3-eth-abi@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.7.0.tgz#4fac9c7d9e5a62b57f8884b37371f515c766f3f4"
+  integrity sha512-heqR0bWxgCJwjWIhq2sGyNj9bwun5+Xox/LdZKe+WMyTSy0cXDXEAgv3XKNkXC4JqdDt/ZlbTEx4TWak4TRMSg==
+  dependencies:
+    "@ethersproject/abi" "5.0.7"
+    web3-utils "1.7.0"
+
 web3-eth-abi@1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.7.1.tgz#6632003220a4defee4de8215dc703e43147382ea"
@@ -33956,6 +34110,19 @@ web3-utils@1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.6.1.tgz#befcb23922b00603ab56d8c5b4158468dc494aca"
   integrity sha512-RidGKv5kOkcerI6jQqDFDoTllQQqV+rPhTzZHhmbqtFObbYpU93uc+yG1LHivRTQhA6llIx67iudc/vzisgO+w==
+  dependencies:
+    bn.js "^4.11.9"
+    ethereum-bloom-filters "^1.0.6"
+    ethereumjs-util "^7.1.0"
+    ethjs-unit "0.1.6"
+    number-to-bn "1.7.0"
+    randombytes "^2.1.0"
+    utf8 "3.0.0"
+
+web3-utils@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.7.0.tgz#c59f0fd43b2449357296eb54541810b99b1c771c"
+  integrity sha512-O8Tl4Ky40Sp6pe89Olk2FsaUkgHyb5QAXuaKo38ms3CxZZ4d3rPGfjP9DNKGm5+IUgAZBNpF1VmlSmNCqfDI1w==
   dependencies:
     bn.js "^4.11.9"
     ethereum-bloom-filters "^1.0.6"
@@ -34771,7 +34938,14 @@ yam@^1.0.0:
     fs-extra "^4.0.2"
     lodash.merge "^4.6.0"
 
-yaml@^1.10.0, yaml@^1.10.2, yaml@^1.5.1, yaml@^1.7.2:
+yaml@1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.9.2.tgz#f0cfa865f003ab707663e4f04b3956957ea564ed"
+  integrity sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
+yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==


### PR DESCRIPTION
EDIT: The problem where issuer and owner were handled incorrectly was addressed and shipped in a separate PR (https://github.com/cardstack/cardstack/pull/3108). This PR now mostly deals with code changes needed to upgrade the graph node to 0.27.0 but is blocked due to issues described in https://github.com/graphprotocol/graph-node/issues/3817.

**Old description below**:

Ticket: [CS-4223](https://linear.app/cardstack/issue/CS-4223)

## Problem 

We're solving the problem where in the case of prepaid cards created with the `PrepaidCardMarketV2` contract, the subgraph is saving the wrong issuer for the prepaid card. There are two reasons why this is happening:

1. The PrepaidCardManager is sending `owner` where it should be sending `issuer`, by event definition: https://github.com/cardstack/card-pay-protocol/blob/main/contracts/PrepaidCardManager.sol#L693
2. The subgraph mapping assigns both `owner` and `issuer` the value of `issuer`: https://github.com/cardstack/cardstack/blob/main/packages/cardpay-subgraph/src/mappings/prepaid-card.ts#L52-L53

This works OK for the prepaid cards created the traditional way (first create with same owner and issuer, then transfer to the new owner), but we forgot to adjust this for the prepaid cards created with the `PrepaidCardMarketV2` contract.

## Solution

The short term solution which we can use in the subgraph to fix this, without doing protocol changes and aligning with the points of its deploy, is reading the issuer and owner from the contract using eth calls and not rely on the (currently wrong) params. This is what this PR is doing. The drawback of using eth calls to get data is that it's now the handler is less performant, and it steers us away a bit from our goal of moving away from eth calls so that we could make use of future next gen subgraph features, such as [Firehose](https://forum.thegraph.com/t/introducing-the-firehose/2329/14).

The long term solution, and a more proper one, would be to get rid of the contract calls in the mapping handler, and use the event params only. However it would take some time to implement mapping versioning in the subgraph (before and after we change params emitted in the contract event), and some effort to align new subgraph deploy with the new protocol deploy. 

We agreed with @habdelra the short term solution described above is alright for now, but we should note and perform this chore later. The fix on the protocol side is already in the works, and after that we can do the block number mapping versioning (i.e use eth calls for events before the protocol deploy, and use params only after the protocol deploy).

## Notable changes

### Upgrade (@graphprotocol/graph-cli and @graphprotocol/graph-ts)

When I was trying to deploy a subgraph locally, I got the following error:

> The current version of graph-cli can't be used with mappings on apiVersion less than '0.0.5'

Then, after I increased the the apiVersion, it wanted me to upgrade the graph libraries. After that, I had to do a couple of post-upgrade code adjustments to appease the upgraded AssemblyScript compiler, especially handling [nullable types in comparisons](https://thegraph.com/docs/en/developer/assemblyscript-migration-guide/#null-comparisons). 

### New way of getting `gasUsed` (loading transaction receipts)

After the upgrades, `gasUsed` was removed from the event transaction. As shown [here](https://github.com/cardstack/cardstack/pull/3080/files#diff-474771ec89547f5ea178293d908e87f8322dc475705401eba6a137ffc18c9d2aL44), the new way is to read it from the transaction receipt. This is a fairly new feature, and to make it work, we need to bump manifest versions and specify `receipt: true` (here's the commit that does it: https://github.com/cardstack/cardstack/pull/3080/commits/ce64f1120a62b9803548dc663fc6c099c765a8ad). 

## Testing

I [forked](https://thegraph.com/docs/en/developer/subgraph-debug-forking/)  our Gnosis chain subgraph locally, and deployed the mapping to my local subgraph. I was able to run a full sync (from the block numbers defined in the subgraph manifest on) on my computer and didn't spot any mapping errors in the log. I poked around a bit in my local database and was able to confirm the subgraph is now saving prepaid card owner and issuer correctly:

<img width="666" alt="image" src="https://user-images.githubusercontent.com/273660/178986744-33996062-5196-4aae-9d11-7afe439ccaa3.png">
(this is the proof the subgraph is now saving the owner and issuer correctly – because they are different, previously they were the same, which was wrong)
~~

