### PR TITLE
hub: Fix Prisma in deployed environments

### DIFF
--- a/.github/actions/deploy-hub/action.yml
+++ b/.github/actions/deploy-hub/action.yml
@@ -51,10 +51,10 @@ runs:
       shell: bash
       working-directory: packages/hub
 
-    - name: Setup upterm session
-      uses: lhotari/action-upterm@v1
-      with:
-        limit-access-to-users: backspace
+    # - name: Setup upterm session
+    #   uses: lhotari/action-upterm@v1
+    #   with:
+    #     limit-access-to-users: backspace
 
     - name: Deploy server
       run: waypoint up --app=hub -plain

--- a/.github/actions/deploy-hub/action.yml
+++ b/.github/actions/deploy-hub/action.yml
@@ -51,7 +51,6 @@ runs:
       shell: bash
       working-directory: packages/hub
 
-    - uses: actions/checkout@v2
     - name: Setup upterm session
       uses: lhotari/action-upterm@v1
       with:

--- a/.github/actions/deploy-hub/action.yml
+++ b/.github/actions/deploy-hub/action.yml
@@ -45,9 +45,13 @@ runs:
         limit-access-to-users: backspace
 
     - run: tree ./node_modules/.prisma
+      shell: bash
     - run: tree ./node_modules/@prisma
+      shell: bash
     - run: tree ../../node_modules/.prisma
+      shell: bash
     - run: tree ../../node_modules/@prisma
+      shell: bash
 
     - name: Deploy server
       run: waypoint up --app=hub -plain

--- a/.github/actions/deploy-hub/action.yml
+++ b/.github/actions/deploy-hub/action.yml
@@ -38,6 +38,11 @@ runs:
       shell: bash
       working-directory: packages/hub
 
+    - run: tree ./node_modules/.prisma
+    - run: tree ./node_modules/@prisma
+    - run: tree ../../node_modules/.prisma
+    - run: tree ../../node_modules/@prisma
+
     - name: Deploy server
       run: waypoint up --app=hub -plain
       shell: bash

--- a/.github/actions/deploy-hub/action.yml
+++ b/.github/actions/deploy-hub/action.yml
@@ -33,6 +33,11 @@ runs:
       shell: bash
       working-directory: packages/hub
 
+    - name: Build Prisma client
+      run: yarn run prisma generate
+      shell: bash
+      working-directory: packages/hub
+
     - name: Deploy server
       run: waypoint up --app=hub -plain
       shell: bash

--- a/.github/actions/deploy-hub/action.yml
+++ b/.github/actions/deploy-hub/action.yml
@@ -38,24 +38,6 @@ runs:
       shell: bash
       working-directory: packages/hub
 
-    - run: tree ./node_modules/.prisma
-      shell: bash
-      working-directory: packages/hub
-    - run: tree ./node_modules/@prisma
-      shell: bash
-      working-directory: packages/hub
-    - run: tree ../../node_modules/.prisma
-      shell: bash
-      working-directory: packages/hub
-    - run: tree ../../node_modules/@prisma
-      shell: bash
-      working-directory: packages/hub
-
-    # - name: Setup upterm session
-    #   uses: lhotari/action-upterm@v1
-    #   with:
-    #     limit-access-to-users: backspace
-
     - name: Deploy server
       run: waypoint up --app=hub -plain
       shell: bash

--- a/.github/actions/deploy-hub/action.yml
+++ b/.github/actions/deploy-hub/action.yml
@@ -38,6 +38,12 @@ runs:
       shell: bash
       working-directory: packages/hub
 
+    - uses: actions/checkout@v2
+    - name: Setup upterm session
+      uses: lhotari/action-upterm@v1
+      with:
+        limit-access-to-users: backspace
+
     - run: tree ./node_modules/.prisma
     - run: tree ./node_modules/@prisma
     - run: tree ../../node_modules/.prisma

--- a/.github/actions/deploy-hub/action.yml
+++ b/.github/actions/deploy-hub/action.yml
@@ -38,20 +38,24 @@ runs:
       shell: bash
       working-directory: packages/hub
 
+    - run: tree ./node_modules/.prisma
+      shell: bash
+      working-directory: packages/hub
+    - run: tree ./node_modules/@prisma
+      shell: bash
+      working-directory: packages/hub
+    - run: tree ../../node_modules/.prisma
+      shell: bash
+      working-directory: packages/hub
+    - run: tree ../../node_modules/@prisma
+      shell: bash
+      working-directory: packages/hub
+
     - uses: actions/checkout@v2
     - name: Setup upterm session
       uses: lhotari/action-upterm@v1
       with:
         limit-access-to-users: backspace
-
-    - run: tree ./node_modules/.prisma
-      shell: bash
-    - run: tree ./node_modules/@prisma
-      shell: bash
-    - run: tree ../../node_modules/.prisma
-      shell: bash
-    - run: tree ../../node_modules/@prisma
-      shell: bash
 
     - name: Deploy server
       run: waypoint up --app=hub -plain

--- a/.github/actions/deploy-hub/action.yml
+++ b/.github/actions/deploy-hub/action.yml
@@ -28,13 +28,13 @@ runs:
         sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
         sudo apt-get install awscli waypoint=${{ inputs.waypoint_version }}
 
-    - name: Webpack build
-      run: yarn build
+    - name: Build Prisma client
+      run: yarn run prisma generate
       shell: bash
       working-directory: packages/hub
 
-    - name: Build Prisma client
-      run: yarn run prisma generate
+    - name: Webpack build
+      run: yarn build
       shell: bash
       working-directory: packages/hub
 

--- a/packages/hub/Dockerfile
+++ b/packages/hub/Dockerfile
@@ -9,11 +9,10 @@ COPY dist/sql node_modules/graphile-worker/sql
 COPY dist/services packages/hub/services
 
 # Copy Prisma necessities
-COPY dist/@prisma/client node_modules/.prisma/client
 COPY dist/@prisma/client node_modules/@prisma/client
 COPY prisma/schema.prisma node_modules/.prisma/client/schema.prisma
 COPY prisma/schema.prisma node_modules/@prisma/client/schema.prisma
-COPY dist/.prisma/client/ node_modules/@prisma/client/
+COPY dist/.prisma/client/ node_modules/.prisma/client/
 
 # Replicate enough of the node_modules structure to support node-pg-migrate
 COPY dist/node-pg-migrate node_modules/node-pg-migrate

--- a/packages/hub/Dockerfile
+++ b/packages/hub/Dockerfile
@@ -8,6 +8,8 @@ COPY dist/sql node_modules/graphile-worker/sql
 # This includes the discord bot image assets that are hosted by the hub
 COPY dist/services packages/hub/services
 
+COPY prisma/schema.prisma packages/hub/prisma/prisma.schema
+
 # Replicate enough of the node_modules structure to support node-pg-migrate
 COPY dist/node-pg-migrate node_modules/node-pg-migrate
 COPY dist/pg node_modules/pg

--- a/packages/hub/Dockerfile
+++ b/packages/hub/Dockerfile
@@ -13,7 +13,7 @@ COPY dist/@prisma/client node_modules/.prisma/client
 COPY dist/@prisma/client node_modules/@prisma/client
 COPY prisma/schema.prisma node_modules/.prisma/client/schema.prisma
 COPY prisma/schema.prisma node_modules/@prisma/client/schema.prisma
-COPY dist/.prisma/client/*.node node_modules/@prisma/client/
+COPY dist/.prisma/client/ node_modules/@prisma/client/
 
 # Replicate enough of the node_modules structure to support node-pg-migrate
 COPY dist/node-pg-migrate node_modules/node-pg-migrate

--- a/packages/hub/Dockerfile
+++ b/packages/hub/Dockerfile
@@ -13,6 +13,7 @@ COPY dist/@prisma/client node_modules/.prisma/client
 COPY dist/@prisma/client node_modules/@prisma/client
 COPY prisma/schema.prisma node_modules/.prisma/client/schema.prisma
 COPY prisma/schema.prisma node_modules/@prisma/client/schema.prisma
+COPY dist/.prisma/client/*.node node_modules/@prisma/client
 
 # Replicate enough of the node_modules structure to support node-pg-migrate
 COPY dist/node-pg-migrate node_modules/node-pg-migrate

--- a/packages/hub/Dockerfile
+++ b/packages/hub/Dockerfile
@@ -13,7 +13,7 @@ COPY dist/@prisma/client node_modules/.prisma/client
 COPY dist/@prisma/client node_modules/@prisma/client
 COPY prisma/schema.prisma node_modules/.prisma/client/schema.prisma
 COPY prisma/schema.prisma node_modules/@prisma/client/schema.prisma
-COPY dist/.prisma/client/*.node node_modules/@prisma/client
+COPY dist/.prisma/client/*.node node_modules/@prisma/client/
 
 # Replicate enough of the node_modules structure to support node-pg-migrate
 COPY dist/node-pg-migrate node_modules/node-pg-migrate

--- a/packages/hub/Dockerfile
+++ b/packages/hub/Dockerfile
@@ -10,7 +10,9 @@ COPY dist/services packages/hub/services
 
 # Copy Prisma necessities
 COPY dist/@prisma/client node_modules/.prisma/client
+COPY dist/@prisma/client node_modules/@prisma/client
 COPY prisma/schema.prisma node_modules/.prisma/client/schema.prisma
+COPY prisma/schema.prisma node_modules/@prisma/client/schema.prisma
 
 # Replicate enough of the node_modules structure to support node-pg-migrate
 COPY dist/node-pg-migrate node_modules/node-pg-migrate

--- a/packages/hub/Dockerfile
+++ b/packages/hub/Dockerfile
@@ -11,7 +11,6 @@ COPY dist/services packages/hub/services
 # Copy Prisma necessities
 COPY dist/@prisma/client node_modules/@prisma/client
 COPY prisma/schema.prisma node_modules/.prisma/client/schema.prisma
-COPY prisma/schema.prisma node_modules/@prisma/client/schema.prisma
 COPY dist/.prisma/client/ node_modules/.prisma/client/
 
 # Replicate enough of the node_modules structure to support node-pg-migrate

--- a/packages/hub/Dockerfile
+++ b/packages/hub/Dockerfile
@@ -8,7 +8,7 @@ COPY dist/sql node_modules/graphile-worker/sql
 # This includes the discord bot image assets that are hosted by the hub
 COPY dist/services packages/hub/services
 
-COPY prisma/schema.prisma packages/hub/prisma/prisma.schema
+COPY prisma/schema.prisma packages/hub/prisma/schema.prisma
 
 # Replicate enough of the node_modules structure to support node-pg-migrate
 COPY dist/node-pg-migrate node_modules/node-pg-migrate

--- a/packages/hub/Dockerfile
+++ b/packages/hub/Dockerfile
@@ -8,7 +8,9 @@ COPY dist/sql node_modules/graphile-worker/sql
 # This includes the discord bot image assets that are hosted by the hub
 COPY dist/services packages/hub/services
 
-COPY prisma/schema.prisma packages/hub/prisma/schema.prisma
+# Copy Prisma necessities
+COPY dist/@prisma/client node_modules/.prisma/client
+COPY prisma/schema.prisma node_modules/.prisma/client/schema.prisma
 
 # Replicate enough of the node_modules structure to support node-pg-migrate
 COPY dist/node-pg-migrate node_modules/node-pg-migrate

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -1,6 +1,7 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["interactiveTransactions"]
+  binaryTargets   = ["native", "linux-musl"]
 }
 
 datasource db {

--- a/packages/hub/webpack.config.ts
+++ b/packages/hub/webpack.config.ts
@@ -58,7 +58,7 @@ module.exports = {
       ],
     }),
 
-    // Prisma?????
+    // copy Prisma client code and libraries
     new CopyPlugin({
       patterns: [
         {

--- a/packages/hub/webpack.config.ts
+++ b/packages/hub/webpack.config.ts
@@ -58,6 +58,16 @@ module.exports = {
       ],
     }),
 
+    // Prisma?????
+    new CopyPlugin({
+      patterns: [
+        {
+          from: path.join('..', '..', 'node_modules', '.prisma', 'client'),
+          to: path.join('.prisma', 'client'),
+        },
+      ],
+    }),
+
     // copy image assets that the hub hosts into dist
     new CopyPlugin({
       patterns: [

--- a/packages/hub/webpack.config.ts
+++ b/packages/hub/webpack.config.ts
@@ -87,7 +87,7 @@ module.exports = {
       ],
     }),
 
-    // copy over pkgs necessary for node-pg-migrate to work. these will be added
+    // copy over pkgs necessary for node-pg-migrate and Prisma to work. these will be added
     // to the docker image's file system
     ...[
       'node-pg-migrate',
@@ -116,7 +116,7 @@ module.exports = {
       'graceful-fs',
       'jsonfile',
       'universalify',
-      '@prisma/client', // FIXME Prisma-related, move elsewhere?
+      '@prisma/client',
     ].map(
       (pkg) =>
         new CopyPlugin({

--- a/packages/hub/webpack.config.ts
+++ b/packages/hub/webpack.config.ts
@@ -106,6 +106,7 @@ module.exports = {
       'graceful-fs',
       'jsonfile',
       'universalify',
+      '@prisma/client', // FIXME Prisma-related, move elsewhere?
     ].map(
       (pkg) =>
         new CopyPlugin({


### PR DESCRIPTION
This updates the Webpack and Docker builds to include the files needed to use Prisma.

With this deployed, Prisma works as expected:

```
curl \
 -s -S -H "Accept: application/vnd.api+json" \
 -H "Accept-Encoding: gzip" \
 -H "Content-Type: application/vnd.api+json" \
 "https://hub-staging.stack.cards/api/prepaid-card-patterns"
{"data":[{"id":"3b8b436b-a99e-4346-ab20-3ba5f9963321","type":"prepaid-card-patterns","attributes":{"pattern- …
```