### PR TITLE
hub: Remove bot from Action and Waypoint

### DIFF
--- a/.github/actions/deploy-hub/action.yml
+++ b/.github/actions/deploy-hub/action.yml
@@ -56,15 +56,6 @@ runs:
       with:
         app: "hub-worker"
 
-    - name: Deploy bot
-      run: waypoint up --app=hub-bot -prune-retain=0 -plain
-      shell: bash
-
-    - name: Prune dangling resources [hub-bot]
-      uses: ./.github/actions/waypoint-prune-dangling-resources
-      with:
-        app: "hub-bot"
-
     - name: Deploy event handler
       run: waypoint up --app=hub-event-listener -prune-retain=0 -plain
       shell: bash


### PR DESCRIPTION
This doesn’t remove any code related to the Discord bot, nor does it remove its infrastructure or Waypoint setup. But the bot is not being used, so there’s no need to slow down deployments for it.

I deployed this to staging and it took 14:45. Other deployments have taken between 15 and 18 minutes so it seems likely to be a time-saver on average!

Is there a possibility of running `waypoint up` in parallel for each application? And then running the cleanup tasks afterward 🤔