### PR TITLE
No misused promises

### DIFF
--- a/packages/eslint-config/-ts.js
+++ b/packages/eslint-config/-ts.js
@@ -22,6 +22,12 @@ module.exports = {
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md
     // '@typescript-eslint/naming-convention': 'error',
     indent: 'off',
+    '@typescript-eslint/no-misused-promises': [
+      'error',
+      {
+        checksVoidReturn: false,
+      },
+    ],
     '@typescript-eslint/indent': 'off',
     '@typescript-eslint/member-delimiter-style': 'error',
     '@typescript-eslint/consistent-type-assertions': 'error',

--- a/packages/hub/services/serializers/prepaid-card-pattern-serializer.ts
+++ b/packages/hub/services/serializers/prepaid-card-pattern-serializer.ts
@@ -27,14 +27,13 @@ export default class PrepaidCardPatternSerializer {
 
   async loadPrepaidCardPattern(id: string): Promise<PrepaidCardPattern> {
     let prisma = await this.prismaManager.getClient();
-    let pattern = prisma.prepaidCardPattern.findUnique({ where: { id } });
+    let pattern = await prisma.prepaidCardPattern.findUnique({ where: { id } });
 
     if (!pattern) {
       return Promise.reject(new Error(`No prepaid_card_pattern record found with id ${id}`));
     }
 
-    // TODO why? If it’s already known to not be null. CS-4255
-    return pattern as unknown as PrepaidCardPattern;
+    return pattern;
   }
 }
 


### PR DESCRIPTION
Prevents promises from being used in inappropriate comparisons because an `await` was omitted - see #3094 for example. Currently just testing out the rule to see what it affects.

web-client, ssr-web, and boxel will need separate config updates since they don't extend the base eslint config in our monorepo