### PR TITLE
hub: Add mapping for enum fields when transforming

### DIFF
--- a/packages/hub/cli/db/transform-prisma-schema.ts
+++ b/packages/hub/cli/db/transform-prisma-schema.ts
@@ -121,7 +121,8 @@ async function fixPrismaFile() {
 
       // Add map if we needed to convert the field name and the field is not a relational type
       // If it's relational, the field type will be a non-primitive, hence the isPrimitiveType check
-      if (currentFieldName.includes('_') && isPrimitiveType(currentFieldType)) {
+      // If it’s an enum, it’s not a true relation and needs mapping
+      if (currentFieldName.includes('_') && (isPrimitiveType(currentFieldType) || currentFieldType.endsWith('enum'))) {
         fixedLine = `${fixedLine} @map("${currentFieldName}")`;
       }
     }

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -155,7 +155,7 @@ model NotificationPreference {
 model NotificationType {
   id                      String                      @id @db.Uuid
   notificationType        String                      @map("notification_type")
-  defaultStatus           NotificationTypesStatusEnum @default(enabled)
+  defaultStatus           NotificationTypesStatusEnum @default(enabled) @map("default_status")
   createdAt               DateTime                    @default(now()) @map("created_at") @db.Timestamp(6)
   notificationPreferences NotificationPreference[]
 


### PR DESCRIPTION
This fixes an oversight in #3082. It only applied to one column name because the other enum references are single-word.

To see this working:
```
yarn build
git checkout 76d66f1 prisma/schema.prisma
HUB_DATABASE_URL=postgres://postgres:postgres@localhost:5432/hub_development yarn db:update-prisma
```

The only diff in `prisma.schema` should be the one shown here and the removal of [this line](https://github.com/cardstack/cardstack/blob/5f8823629d66d8f9c6d3097f408c729f2af62f81/packages/hub/prisma/schema.prisma#L4) added since 76d66f1.