### PR TITLE
Bundle Prisma client generation into hub build/rebuild commands

### DIFF
--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -11,10 +11,10 @@
   "license": "MIT",
   "description": "Stock API server for the Cardstack tech stack.",
   "scripts": {
-    "build": "webpack --progress",
+    "build": "prisma generate && webpack --progress",
     "build_if_missing": "[ -d dist ] || yarn build",
     "clean": "rm -rf dist",
-    "rebuild": "webpack --watch --progress",
+    "rebuild": "prisma generate && webpack --watch --progress",
     "start": "yarn build_if_missing && run-p -c start:*",
     "start:server": "node --no-deprecation -r source-map-support/register dist/hub.js server",
     "start:worker": "node --no-deprecation -r source-map-support/register dist/hub.js worker",


### PR DESCRIPTION
If the Prisma schema changes when you git pull, without this change, you might get build errors if you have an older version built locally