### PR TITLE
Subgraph: Add comands for managing a local subgraph deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ package-lock.json
 
 
 # generated files for the subgraph
+/packages/cardpay-subgraph/localchain-addresses.json
 /packages/cardpay-subgraph/subgraph.yaml
 /packages/cardpay-subgraph/abis/generated/
 /packages/cardpay-subgraph/src/generated/

--- a/packages/cardpay-subgraph/package.json
+++ b/packages/cardpay-subgraph/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.7",
   "license": "MIT",
   "scripts": {
+    "codegen-localchain": "node ./etc/pre-codegen.js localchain && graph codegen && node ./etc/pre-tsc-build.js",
     "codegen-sokol": "node ./etc/pre-codegen.js poa-sokol && graph codegen && node ./etc/pre-tsc-build.js",
     "codegen-xdai": "node ./etc/pre-codegen.js gnosis && graph codegen && node ./etc/pre-tsc-build.js",
     "build": "graph build",
@@ -35,13 +36,16 @@
     "remove-xdai-blue": "graph remove --node https://admin-graph-production-blue.cardstack.com/ habdelra/cardpay-xdai",
     "deploy-xdai-blue": "ts-node ./lib/validate-subgraph-network.ts gnosis && graph deploy --node https://admin-graph-production-blue.cardstack.com/ --ipfs https://ipfs-graph-production-blue.cardstack.com habdelra/cardpay-xdai",
     "codegen-graft-local": "node ./etc/pre-codegen.js gnosis http://localhost:8000/subgraphs/name/habdelra/cardpay-xdai && graph codegen && node ./etc/pre-tsc-build.js",
-    "create-local": "graph create --node http://localhost:8020/ habdelra/cardpay-xdai",
-    "remove-local": "graph remove --node http://localhost:8020/ habdelra/cardpay-xdai",
-    "deploy-local": "ts-node ./lib/validate-subgraph-network.ts gnosis && graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 habdelra/cardpay-xdai",
+    "create-local-xdai": "graph create --node http://localhost:8020/ habdelra/cardpay-xdai",
+    "remove-local-xdai": "graph remove --node http://localhost:8020/ habdelra/cardpay-xdai",
+    "deploy-local-xdai": "ts-node ./lib/validate-subgraph-network.ts gnosis && graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 habdelra/cardpay-xdai",
     "sokol-green-status": "ts-node ./lib/sync-status.ts sokol-green",
     "sokol-blue-status": "ts-node ./lib/sync-status.ts sokol-blue",
     "xdai-green-status": "ts-node ./lib/sync-status.ts xdai-green",
-    "xdai-blue-status": "ts-node ./lib/sync-status.ts xdai-blue"
+    "xdai-blue-status": "ts-node ./lib/sync-status.ts xdai-blue",
+    "remove-localchain": "graph remove --node http://localhost:8020 localchain",
+    "create-localchain": "graph create --node http://localhost:8020 localchain",
+    "deploy-localchain": "graph deploy localchain --ipfs http://localhost:5001 --node http://localhost:8020"
   },
   "devDependencies": {
     "@cardstack/cardpay-sdk": "1.0.7",


### PR DESCRIPTION
This set of commands should help when setting up a local protocol dev environment.

I used these commands to deploy a subgraph to a local graph node, connected to a local ethereum node where our contracts are deployed locally. For lack of a better word  I came up with the name of "localchain".

For gnosis and sokol, the contract addresses are sourced from the SDK, but in this case, a developer should put local node contract addresses in `localchain-addresses.json` in the following form:

```
{
  "gnosisProxyFactory_v1_2": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
  "gnosisProxyFactory_v1_3": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
  "homeBridge": "0xB0f05d25e41FbC2b52013099ED9616f1206Ae21B",
  "homeAMB": "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707",
  "daiCpxd": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
  "cardCpxd": "0xA21DDc1f17dF41589BC6A5209292AED2dF61Cc94",
  "prepaidCardManager": "0xaca81583840B1bf2dDF6CDe824ada250C1936B4D",
  "prepaidCardMarket": "0x26B862f640357268Bd2d9E95bc81553a2Aa81D7E",
  "prepaidCardMarketV2": "0x5D42EBdBBa61412295D7b0302d6F50aC449Ddb4F",
  "revenuePool": "0xB06c856C8eaBd1d8321b687E188204C1018BC4E5",
  "bridgeUtils": "0x56D13Eb21a625EdA8438F55DF2C31dC3632034f5",
  "exchange": "0x2b5A4e5493d4a54E717057B127cf0C000C876f9B",
  "relay": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
  "cardstackIssuer": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
  "wyreIssuer": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
  "payMerchantHandler": "0x1780bCf4103D3F501463AD3414c7f4b654bb7aFd",
  "registerMerchantHandler": "0x71089Ba41e478702e1904692385Be3972B2cBf9e",
  "splitPrepaidCardHandler": "0xC66AB83418C20A65C3f8e83B3d11c8C3a6097b6F",
  "transferPrepaidCardHandler": "0x12Bcb546bC60fF39F1Adfc7cE4605d5Bd6a6A876",
  "supplierManager": "0xccf1769D8713099172642EB55DDFFC0c5A444FE9",
  "merchantManager": "0xe70f935c32dA4dB13e7876795f1e175465e6458e",
  "spend": "0x2A590C461Db46bca129E8dBe5C3998A8fF402e76",
  "actionDispatcher": "0x02df3a3F960393F5B349E40A599FEda91a7cc1A7",
  "uniswapV2Router": "0x2F54D1563963fC04770E85AF819c89Dc807f6a06",
  "uniswapV2Factory": "0x0c626FC4A447b01554518550e30600136864640B",
  "rewardPool": "0xAD523115cd35a8d4E60B3C0953E0E0ac10418309",
  "rewardManager": "0x139e1D41943ee15dDe4DF876f9d0E7F85e26660A",
  "registerRewardProgramHandler": "0x8fC8CFB7f7362E44E472c690A6e025B80E406458",
  "registerRewardeeHandler": "0x359570B3a0437805D0a71457D61AD26a28cAC9A2",
  "versionManager": "0x74Cf9087AD26D541930BaC724B7ab21bA8F00a27",
  "deprecatedMerchantManager_v0_6_7": "0xe70f935c32dA4dB13e7876795f1e175465e6458e",
  "oracles": {
    "DAI.CPXD": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
    "CARD.CPXD": "0xb4Fcc975c2b6A57dd5B3d9a3B6b144499f707c7d",
    "DAI": "0xA21DDc1f17dF41589BC6A5209292AED2dF61Cc94",
    "CARD": "0xA21DDc1f17dF41589BC6A5209292AED2dF61Cc94"
  }
}
```

I'll be documenting this more thoroughly but for now I'd like to get some feedback on the "localchain" commands. 
