### PR TITLE
hub: Change Sentry.init to only be called once

### DIFF
--- a/packages/hub/node-tests/helpers/sentry.ts
+++ b/packages/hub/node-tests/helpers/sentry.ts
@@ -6,15 +6,22 @@ import { Suite } from 'mocha';
 const { testkit, sentryTransport } = sentryTestkit();
 const DUMMY_DSN = 'https://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001';
 
+let sentryNeedsInit = true;
+
 export function setupSentry(context: Suite) {
-  context.beforeAll(function () {
-    Sentry.init({
-      dsn: DUMMY_DSN,
-      release: 'test',
-      tracesSampleRate: 1,
-      transport: sentryTransport,
+  // Only call Sentry.init once to prevent memory leaks
+  if (sentryNeedsInit) {
+    context.beforeAll(function () {
+      Sentry.init({
+        dsn: DUMMY_DSN,
+        release: 'test',
+        tracesSampleRate: 1,
+        transport: sentryTransport,
+      });
     });
-  });
+
+    sentryNeedsInit = false;
+  }
 
   context.beforeEach(function () {
     testkit.reset();


### PR DESCRIPTION
This fixes a memory leak in tests caused by Sentry.init
being called for every test. There’s no reason to call
it more than once in one process.

See [here](https://github.com/cardstack/cardstack/runs/7547445989?check_suite_focus=true#step:9:808) for a pre-fix example. It doesn’t exist in [this job](https://github.com/cardstack/cardstack/runs/7549271955?check_suite_focus=true).