### PR TITLE
hub: Replace card_spaces/merchant_infos with profiles

### DIFF
--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -823,22 +823,6 @@ CREATE TABLE public.card_drop_recipients (
 ALTER TABLE public.card_drop_recipients OWNER TO postgres;
 
 --
--- Name: card_spaces; Type: TABLE; Schema: public; Owner: postgres
---
-
-CREATE TABLE public.card_spaces (
-    id uuid NOT NULL,
-    profile_image_url text,
-    profile_description text,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    links json[] DEFAULT '{}'::json[] NOT NULL,
-    merchant_id uuid NOT NULL
-);
-
-
-ALTER TABLE public.card_spaces OWNER TO postgres;
-
---
 -- Name: cards; Type: TABLE; Schema: public; Owner: postgres
 --
 
@@ -971,23 +955,6 @@ CREATE TABLE public.latest_event_block (
 ALTER TABLE public.latest_event_block OWNER TO postgres;
 
 --
--- Name: merchant_infos; Type: TABLE; Schema: public; Owner: postgres
---
-
-CREATE TABLE public.merchant_infos (
-    id uuid NOT NULL,
-    name text NOT NULL,
-    slug text NOT NULL,
-    color text NOT NULL,
-    text_color text NOT NULL,
-    owner_address text NOT NULL,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
-);
-
-
-ALTER TABLE public.merchant_infos OWNER TO postgres;
-
---
 -- Name: notification_preferences; Type: TABLE; Schema: public; Owner: postgres
 --
 
@@ -1094,6 +1061,26 @@ CREATE TABLE public.prepaid_card_patterns (
 
 
 ALTER TABLE public.prepaid_card_patterns OWNER TO postgres;
+
+--
+-- Name: profiles; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.profiles (
+    id uuid NOT NULL,
+    name text NOT NULL,
+    slug text NOT NULL,
+    color text NOT NULL,
+    text_color text NOT NULL,
+    owner_address text NOT NULL,
+    links json[] DEFAULT '{}'::json[] NOT NULL,
+    profile_image_url text,
+    profile_description text,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.profiles OWNER TO postgres;
 
 --
 -- Name: push_notification_registrations; Type: TABLE; Schema: public; Owner: postgres
@@ -1274,14 +1261,6 @@ ALTER TABLE ONLY public.card_drop_recipients
 
 
 --
--- Name: card_spaces card_spaces_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.card_spaces
-    ADD CONSTRAINT card_spaces_pkey PRIMARY KEY (id);
-
-
---
 -- Name: cards cards_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
@@ -1346,14 +1325,6 @@ ALTER TABLE ONLY public.latest_event_block
 
 
 --
--- Name: merchant_infos merchant_infos_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.merchant_infos
-    ADD CONSTRAINT merchant_infos_pkey PRIMARY KEY (id);
-
-
---
 -- Name: notification_types notification_types_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
@@ -1391,6 +1362,14 @@ ALTER TABLE ONLY public.prepaid_card_customizations
 
 ALTER TABLE ONLY public.prepaid_card_patterns
     ADD CONSTRAINT prepaid_card_patterns_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: profiles profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.profiles
+    ADD CONSTRAINT profiles_pkey PRIMARY KEY (id);
 
 
 --
@@ -1457,13 +1436,6 @@ CREATE INDEX jobs_priority_run_at_id_locked_at_without_failures_idx ON graphile_
 
 
 --
--- Name: card_spaces_merchant_id_unique_index; Type: INDEX; Schema: public; Owner: postgres
---
-
-CREATE UNIQUE INDEX card_spaces_merchant_id_unique_index ON public.card_spaces USING btree (merchant_id);
-
-
---
 -- Name: discord_bots_bot_type_status_index; Type: INDEX; Schema: public; Owner: postgres
 --
 
@@ -1475,13 +1447,6 @@ CREATE INDEX discord_bots_bot_type_status_index ON public.discord_bots USING btr
 --
 
 CREATE INDEX job_tickets_job_type_owner_address_state_index ON public.job_tickets USING btree (job_type, owner_address, state);
-
-
---
--- Name: merchant_infos_slug_unique_index; Type: INDEX; Schema: public; Owner: postgres
---
-
-CREATE UNIQUE INDEX merchant_infos_slug_unique_index ON public.merchant_infos USING btree (slug);
 
 
 --
@@ -1608,14 +1573,6 @@ CREATE TRIGGER _900_notify_worker AFTER INSERT ON graphile_worker.jobs FOR EACH 
 --
 
 CREATE TRIGGER discord_bots_updated_trigger AFTER INSERT OR UPDATE ON public.discord_bots FOR EACH ROW EXECUTE FUNCTION public.discord_bots_updated_trigger();
-
-
---
--- Name: card_spaces card_spaces_merchant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.card_spaces
-    ADD CONSTRAINT card_spaces_merchant_id_fkey FOREIGN KEY (merchant_id) REFERENCES public.merchant_infos(id);
 
 
 --
@@ -1747,6 +1704,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 39	20220610203119883_create-job-tickets	2022-06-13 09:56:55.438506
 40	20220622235635327_add-job-ticket-spec	2022-06-22 19:02:28.256468
 41	20220629173134216_add-job-ticket-source-arguments	2022-06-29 16:48:05.380858
+52	20220728144935996_add-profiles	2022-07-28 11:07:31.429076
 \.
 
 
@@ -1754,7 +1712,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 -- Name: pgmigrations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.pgmigrations_id_seq', 41, true);
+SELECT pg_catalog.setval('public.pgmigrations_id_seq', 52, true);
 
 
 --

--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -1464,6 +1464,13 @@ CREATE UNIQUE INDEX notification_preferences_owner_address_notification_type_id_
 
 
 --
+-- Name: profiles_slug_unique_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX profiles_slug_unique_index ON public.profiles USING btree (slug);
+
+
+--
 -- Name: push_notification_registrations_owner_address_push_client_id_un; Type: INDEX; Schema: public; Owner: postgres
 --
 

--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -1076,7 +1076,7 @@ CREATE TABLE public.profiles (
     links json[] DEFAULT '{}'::json[] NOT NULL,
     profile_image_url text,
     profile_description text,
-    created_at timestamp without time zone NOT NULL
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
 

--- a/packages/hub/db/migrations/20220728144935996_add-profiles.ts
+++ b/packages/hub/db/migrations/20220728144935996_add-profiles.ts
@@ -28,6 +28,8 @@ export async function up(pgm: MigrationBuilder, run: () => Promise<void>): Promi
     ...createdAtField,
   });
 
+  pgm.createIndex('profiles', 'slug', { unique: true });
+
   await forceRun(pgm, run);
 
   await pgm.db.query(`
@@ -54,6 +56,8 @@ export async function down(pgm: MigrationBuilder, run: () => any): Promise<void>
     merchant_id: { type: 'uuid', references: 'merchant_infos' },
     ...createdAtField,
   });
+
+  pgm.createIndex('merchant_infos', 'slug', { unique: true });
 
   await forceRun(pgm, run);
 

--- a/packages/hub/db/migrations/20220728144935996_add-profiles.ts
+++ b/packages/hub/db/migrations/20220728144935996_add-profiles.ts
@@ -3,7 +3,6 @@ import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
 export const shorthands: ColumnDefinitions | undefined = undefined;
 
 const idField = { id: { type: 'uuid', primaryKey: true } };
-const createdAtField = { created_at: { type: 'timestamp', notNull: true } };
 
 const merchantInfosFields = {
   name: { type: 'string', notNull: true },
@@ -20,6 +19,8 @@ const cardSpaceFields = {
 };
 
 export async function up(pgm: MigrationBuilder, run: () => Promise<void>): Promise<void> {
+  const createdAtField = { created_at: { type: 'timestamp', notNull: true, default: pgm.func('current_timestamp') } };
+
   pgm.createTable('profiles', {
     ...idField,
     ...merchantInfosFields,
@@ -44,6 +45,8 @@ export async function up(pgm: MigrationBuilder, run: () => Promise<void>): Promi
 }
 
 export async function down(pgm: MigrationBuilder, run: () => any): Promise<void> {
+  const createdAtField = { created_at: { type: 'timestamp', notNull: true, default: pgm.func('current_timestamp') } };
+
   pgm.createTable('merchant_infos', { ...idField, ...merchantInfosFields, ...createdAtField });
   pgm.createTable('card_spaces', {
     ...idField,

--- a/packages/hub/db/migrations/20220728144935996_add-profiles.ts
+++ b/packages/hub/db/migrations/20220728144935996_add-profiles.ts
@@ -1,0 +1,78 @@
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+const idField = { id: { type: 'uuid', primaryKey: true } };
+const createdAtField = { created_at: { type: 'timestamp', notNull: true } };
+
+const merchantInfosFields = {
+  name: { type: 'string', notNull: true },
+  slug: { type: 'string', notNull: true },
+  color: { type: 'string', notNull: true },
+  text_color: { type: 'string', notNull: true },
+  owner_address: { type: 'string', notNull: true },
+};
+
+const cardSpaceFields = {
+  links: { type: 'json[]', notNull: true, default: '{}' },
+  profile_image_url: { type: 'string' },
+  profile_description: { type: 'string' },
+};
+
+export async function up(pgm: MigrationBuilder, run: () => Promise<void>): Promise<void> {
+  pgm.createTable('profiles', {
+    ...idField,
+    ...merchantInfosFields,
+    ...cardSpaceFields,
+    ...createdAtField,
+  });
+
+  await forceRun(pgm, run);
+
+  await pgm.db.query(`
+    INSERT INTO profiles
+    SELECT
+      m.id, m.name, m.slug, m.color, m.text_color, m.owner_address,
+      c.links, c.profile_image_url, c.profile_description,
+      m.created_at
+    FROM merchant_infos as m
+    LEFT JOIN card_spaces AS c ON m.id = c.merchant_id
+  `);
+
+  await pgm.db.query('DROP TABLE card_spaces');
+  await pgm.db.query('DROP TABLE merchant_infos');
+}
+
+export async function down(pgm: MigrationBuilder, run: () => any): Promise<void> {
+  pgm.createTable('merchant_infos', { ...idField, ...merchantInfosFields, ...createdAtField });
+  pgm.createTable('card_spaces', {
+    ...idField,
+    ...cardSpaceFields,
+    merchant_id: { type: 'uuid', references: 'merchant_infos' },
+    ...createdAtField,
+  });
+
+  await forceRun(pgm, run);
+
+  await pgm.db.query(`
+    INSERT INTO merchant_infos
+    SELECT id, name, slug, color, text_color, owner_address, created_at
+    FROM profiles
+  `);
+
+  await forceRun(pgm, run);
+
+  await pgm.db.query(`
+    INSERT INTO card_spaces
+    SELECT id, links, profile_image_url, profile_description, id, created_at
+    FROM profiles
+  `);
+
+  await pgm.db.query('DROP TABLE profiles');
+}
+
+// This empties the query queue so future operations on dependent tables are able to complete
+async function forceRun(pgm: MigrationBuilder, run: () => Promise<void>) {
+  await run();
+  await pgm.db.query('SELECT NOW()');
+}

--- a/packages/hub/node-tests/routes/card-space-test.ts
+++ b/packages/hub/node-tests/routes/card-space-test.ts
@@ -32,11 +32,11 @@ describe('GET /api/card-spaces/:slug', function () {
   let { request, getPrisma } = setupHub(this);
 
   it('fetches a card space', async function () {
-    let merchantId = 'c8e7ceed-d5f2-4f66-be77-d81806e66ad7';
+    let profileId = 'c8e7ceed-d5f2-4f66-be77-d81806e66ad7';
     let prisma = await getPrisma();
     await prisma.profile.create({
       data: {
-        id: merchantId,
+        id: profileId,
         ownerAddress: stubUserAddress,
         name: 'Satoshi?',
         slug: 'satoshi',
@@ -59,7 +59,7 @@ describe('GET /api/card-spaces/:slug', function () {
         },
         data: {
           type: 'card-spaces',
-          id: merchantId,
+          id: profileId,
           attributes: {
             did: 'did:cardstack:1csqNUmMUPV16eUWwjxGZNZ2r68a319e3ae1d2606',
             'profile-description': "Satoshi's place",
@@ -70,7 +70,7 @@ describe('GET /api/card-spaces/:slug', function () {
             'merchant-info': {
               data: {
                 type: 'merchant-infos',
-                id: merchantId,
+                id: profileId,
               },
             },
           },
@@ -78,10 +78,10 @@ describe('GET /api/card-spaces/:slug', function () {
         included: [
           {
             type: 'merchant-infos',
-            id: merchantId,
+            id: profileId,
             attributes: {
               color: 'black',
-              did: encodeDID({ type: 'MerchantInfo', uniqueId: merchantId }),
+              did: encodeDID({ type: 'MerchantInfo', uniqueId: profileId }),
               name: 'Satoshi?',
               'owner-address': stubUserAddress,
               slug: 'satoshi',
@@ -117,11 +117,11 @@ describe('PATCH /api/card-spaces', function () {
   });
 
   it('returns 403 when resource does not belong to wallet', async function () {
-    let merchantId = uuidv4();
+    let profileId = uuidv4();
     let prisma = await getPrisma();
     await prisma.profile.create({
       data: {
-        id: merchantId,
+        id: profileId,
         ownerAddress: '0x1234',
         name: 'Satoshi?',
         slug: 'satoshi',
@@ -133,7 +133,7 @@ describe('PATCH /api/card-spaces', function () {
     });
 
     await request()
-      .patch(`/api/card-spaces/${merchantId}`)
+      .patch(`/api/card-spaces/${profileId}`)
       .send({})
       .set('Authorization', 'Bearer abc123--def456--ghi789')
       .set('Accept', 'application/vnd.api+json')
@@ -160,12 +160,12 @@ describe('PATCH /api/card-spaces', function () {
   });
 
   it('updates the specified fields of the resource', async function () {
-    let merchantId = 'ab70b8d5-95f5-4c20-997c-4db9013b347c';
+    let profileId = 'ab70b8d5-95f5-4c20-997c-4db9013b347c';
 
     let prisma = await getPrisma();
     await prisma.profile.create({
       data: {
-        id: merchantId,
+        id: profileId,
         ownerAddress: stubUserAddress,
         name: 'Satoshi?',
         slug: 'satoshi',
@@ -187,7 +187,7 @@ describe('PATCH /api/card-spaces', function () {
     };
 
     await request()
-      .patch(`/api/card-spaces/${merchantId}`)
+      .patch(`/api/card-spaces/${profileId}`)
       .send(payload)
       .set('Authorization', 'Bearer abc123--def456--ghi789')
       .set('Accept', 'application/vnd.api+json')
@@ -209,7 +209,7 @@ describe('PATCH /api/card-spaces', function () {
           relationships: {
             'merchant-info': {
               data: {
-                id: merchantId,
+                id: profileId,
                 type: 'merchant-infos',
               },
             },
@@ -220,12 +220,12 @@ describe('PATCH /api/card-spaces', function () {
   });
 
   it('returns errors when updating a resource with invalid attributes', async function () {
-    let merchantId = uuidv4();
+    let profileId = uuidv4();
 
     let prisma = await getPrisma();
     await prisma.profile.create({
       data: {
-        id: merchantId,
+        id: profileId,
         ownerAddress: stubUserAddress,
         name: 'Satoshi?',
         slug: 'satoshi',
@@ -254,7 +254,7 @@ describe('PATCH /api/card-spaces', function () {
     };
 
     await request()
-      .patch(`/api/card-spaces/${merchantId}`)
+      .patch(`/api/card-spaces/${profileId}`)
       .send(payload)
       .set('Authorization', 'Bearer abc123--def456--ghi789')
       .set('Accept', 'application/vnd.api+json')

--- a/packages/hub/node-tests/routes/card-space-test.ts
+++ b/packages/hub/node-tests/routes/card-space-test.ts
@@ -44,7 +44,6 @@ describe('GET /api/card-spaces/:slug', function () {
         textColor: 'red',
         profileDescription: "Satoshi's place",
         profileImageUrl: 'https://test.com/test1.png',
-        createdAt: new Date(),
       },
     });
 
@@ -128,7 +127,6 @@ describe('PATCH /api/card-spaces', function () {
         color: 'black',
         textColor: 'red',
         profileDescription: 'Test',
-        createdAt: new Date(),
       },
     });
 
@@ -173,7 +171,6 @@ describe('PATCH /api/card-spaces', function () {
         textColor: 'red',
         profileDescription: "Satoshi's place",
         profileImageUrl: 'https://test.com/profile.jpg',
-        createdAt: new Date(),
       },
     });
 
@@ -232,7 +229,6 @@ describe('PATCH /api/card-spaces', function () {
         color: 'black',
         textColor: 'red',
         profileDescription: 'Test',
-        createdAt: new Date(),
       },
     });
 

--- a/packages/hub/node-tests/routes/card-space-test.ts
+++ b/packages/hub/node-tests/routes/card-space-test.ts
@@ -32,9 +32,9 @@ describe('GET /api/card-spaces/:slug', function () {
   let { request, getPrisma } = setupHub(this);
 
   it('fetches a card space', async function () {
-    let merchantId = uuidv4();
+    let merchantId = 'c8e7ceed-d5f2-4f66-be77-d81806e66ad7';
     let prisma = await getPrisma();
-    await prisma.merchantInfo.create({
+    await prisma.profile.create({
       data: {
         id: merchantId,
         ownerAddress: stubUserAddress,
@@ -42,18 +42,11 @@ describe('GET /api/card-spaces/:slug', function () {
         slug: 'satoshi',
         color: 'black',
         textColor: 'red',
+        profileDescription: "Satoshi's place",
+        profileImageUrl: 'https://test.com/test1.png',
+        createdAt: new Date(),
       },
     });
-
-    const id = 'c8e7ceed-d5f2-4f66-be77-d81806e66ad7';
-    const cardSpace = {
-      id,
-      profileDescription: "Satoshi's place",
-      profileImageUrl: 'https://test.com/test1.png',
-      merchantId,
-    };
-
-    await prisma.cardSpace.create({ data: cardSpace });
 
     await request()
       .get('/api/card-spaces/satoshi')
@@ -66,7 +59,7 @@ describe('GET /api/card-spaces/:slug', function () {
         },
         data: {
           type: 'card-spaces',
-          id,
+          id: merchantId,
           attributes: {
             did: 'did:cardstack:1csqNUmMUPV16eUWwjxGZNZ2r68a319e3ae1d2606',
             'profile-description': "Satoshi's place",
@@ -109,231 +102,6 @@ describe('GET /api/card-spaces/:slug', function () {
   });
 });
 
-describe('POST /api/card-spaces', function () {
-  setupRegistry(this, ['authentication-utils', StubAuthenticationUtils]);
-  let { request, getPrisma } = setupHub(this);
-
-  it('persists card space', async function () {
-    let merchantId = uuidv4();
-    let prisma = await getPrisma();
-    await prisma.merchantInfo.create({
-      data: {
-        id: merchantId,
-        ownerAddress: stubUserAddress,
-        name: 'Satoshi?',
-        slug: 'satoshi',
-        color: 'black',
-        textColor: 'red',
-      },
-    });
-
-    let payload = {
-      data: {
-        type: 'card-spaces',
-        attributes: {
-          'profile-description': "Satoshi's place",
-          'profile-image-url': 'https://test.com/test1.png',
-        },
-        relationships: {
-          'merchant-info': {
-            data: {
-              type: 'merchant-infos',
-              id: merchantId,
-            },
-          },
-        },
-      },
-    };
-
-    await request()
-      .post('/api/card-spaces')
-      .send(payload)
-      .set('Authorization', 'Bearer abc123--def456--ghi789')
-      .set('Accept', 'application/vnd.api+json')
-      .set('Content-Type', 'application/vnd.api+json')
-      .expect(201)
-      .expect(function (res) {
-        res.body.data.id = 'the-id';
-        res.body.data.attributes.did = 'the-did';
-      })
-      .expect({
-        meta: {
-          network: 'sokol',
-        },
-        data: {
-          type: 'card-spaces',
-          id: 'the-id',
-          attributes: {
-            did: 'the-did',
-            'profile-description': "Satoshi's place",
-            'profile-image-url': 'https://test.com/test1.png',
-          },
-          relationships: {
-            'merchant-info': {
-              data: {
-                type: 'merchant-infos',
-                id: merchantId,
-              },
-            },
-          },
-        },
-      })
-      .expect('Content-Type', 'application/vnd.api+json');
-  });
-
-  it('returns 401 without bearer token', async function () {
-    await request()
-      .post('/api/card-spaces')
-      .send({})
-      .set('Accept', 'application/vnd.api+json')
-      .set('Content-Type', 'application/vnd.api+json')
-      .expect(401)
-      .expect({
-        errors: [
-          {
-            status: '401',
-            title: 'No valid auth token',
-          },
-        ],
-      })
-      .expect('Content-Type', 'application/vnd.api+json');
-  });
-
-  it('returns 403 when the related merchant has a different owner', async function () {
-    let merchantId = uuidv4();
-    let prisma = await getPrisma();
-    await prisma.merchantInfo.create({
-      data: {
-        id: merchantId,
-        ownerAddress: '0xmystery',
-        name: 'Satoshi?',
-        slug: 'satoshi',
-        color: 'black',
-        textColor: 'red',
-      },
-    });
-
-    let payload = {
-      data: {
-        type: 'card-spaces',
-        attributes: {
-          'profile-description': "Satoshi's place",
-          'profile-image-url': 'https://test.com/test1.png',
-        },
-        relationships: {
-          'merchant-info': {
-            data: {
-              type: 'merchant-infos',
-              id: merchantId,
-            },
-          },
-        },
-      },
-    };
-
-    await request()
-      .post('/api/card-spaces')
-      .send(payload)
-      .set('Authorization', 'Bearer abc123--def456--ghi789')
-      .set('Accept', 'application/vnd.api+json')
-      .set('Content-Type', 'application/vnd.api+json')
-      .expect(403)
-      .expect({
-        errors: [
-          {
-            detail: `Given merchant-id ${merchantId} is not owned by the user`,
-            source: { pointer: '/data/relationships/merchant-info' },
-            status: '403',
-            title: 'Invalid relationship',
-          },
-        ],
-      })
-      .expect('Content-Type', 'application/vnd.api+json');
-  });
-
-  it('returns 422 when the merchant id is not specified', async function () {
-    let payload = {
-      data: {
-        type: 'card-spaces',
-        attributes: {
-          'profile-description': "Satoshi's place",
-          'profile-image-url': 'https://test.com/test1.png',
-        },
-      },
-    };
-
-    await request()
-      .post('/api/card-spaces')
-      .send(payload)
-      .set('Authorization', 'Bearer abc123--def456--ghi789')
-      .set('Accept', 'application/vnd.api+json')
-      .set('Content-Type', 'application/vnd.api+json')
-      .expect(422)
-      .expect({
-        errors: [
-          {
-            detail: 'Required relationship merchant-info was not provided',
-            status: '422',
-            title: 'Missing required relationship: merchant-info',
-          },
-        ],
-      });
-  });
-
-  it('returns 422 when the merchant doesn’t exist', async function () {
-    let merchantId = uuidv4();
-    let prisma = await getPrisma();
-    await prisma.merchantInfo.create({
-      data: {
-        id: merchantId,
-        ownerAddress: stubUserAddress,
-        name: 'Satoshi?',
-        slug: 'satoshi',
-        color: 'black',
-        textColor: 'red',
-      },
-    });
-
-    let payloadMerchantId = uuidv4();
-
-    let payload = {
-      data: {
-        type: 'card-spaces',
-        attributes: {
-          'profile-description': "Satoshi's place",
-          'profile-image-url': 'https://test.com/test1.png',
-        },
-        relationships: {
-          'merchant-info': {
-            data: {
-              type: 'merchant-infos',
-              id: payloadMerchantId,
-            },
-          },
-        },
-      },
-    };
-
-    await request()
-      .post('/api/card-spaces')
-      .send(payload)
-      .set('Authorization', 'Bearer abc123--def456--ghi789')
-      .set('Accept', 'application/vnd.api+json')
-      .set('Content-Type', 'application/vnd.api+json')
-      .expect(422)
-      .expect({
-        errors: [
-          {
-            detail: `Given merchant-id ${payloadMerchantId} was not found`,
-            source: { pointer: '/data/relationships/merchant-info' },
-            status: '422',
-            title: 'Invalid relationship',
-          },
-        ],
-      });
-  });
-});
-
 describe('PATCH /api/card-spaces', function () {
   setupRegistry(this, ['authentication-utils', StubAuthenticationUtils]);
   let { request, getPrisma } = setupHub(this);
@@ -351,7 +119,7 @@ describe('PATCH /api/card-spaces', function () {
   it('returns 403 when resource does not belong to wallet', async function () {
     let merchantId = uuidv4();
     let prisma = await getPrisma();
-    await prisma.merchantInfo.create({
+    await prisma.profile.create({
       data: {
         id: merchantId,
         ownerAddress: '0x1234',
@@ -359,19 +127,13 @@ describe('PATCH /api/card-spaces', function () {
         slug: 'satoshi',
         color: 'black',
         textColor: 'red',
-      },
-    });
-
-    await prisma.cardSpace.create({
-      data: {
-        id: 'AB70B8D5-95F5-4C20-997C-4DB9013B347C',
         profileDescription: 'Test',
-        merchantId,
+        createdAt: new Date(),
       },
     });
 
     await request()
-      .patch('/api/card-spaces/AB70B8D5-95F5-4C20-997C-4DB9013B347C')
+      .patch(`/api/card-spaces/${merchantId}`)
       .send({})
       .set('Authorization', 'Bearer abc123--def456--ghi789')
       .set('Accept', 'application/vnd.api+json')
@@ -398,10 +160,10 @@ describe('PATCH /api/card-spaces', function () {
   });
 
   it('updates the specified fields of the resource', async function () {
-    let merchantId = uuidv4();
+    let merchantId = 'ab70b8d5-95f5-4c20-997c-4db9013b347c';
 
     let prisma = await getPrisma();
-    await prisma.merchantInfo.create({
+    await prisma.profile.create({
       data: {
         id: merchantId,
         ownerAddress: stubUserAddress,
@@ -409,15 +171,9 @@ describe('PATCH /api/card-spaces', function () {
         slug: 'satoshi',
         color: 'black',
         textColor: 'red',
-      },
-    });
-
-    await prisma.cardSpace.create({
-      data: {
-        id: 'AB70B8D5-95F5-4C20-997C-4DB9013B347C',
         profileDescription: "Satoshi's place",
         profileImageUrl: 'https://test.com/profile.jpg',
-        merchantId,
+        createdAt: new Date(),
       },
     });
 
@@ -431,7 +187,7 @@ describe('PATCH /api/card-spaces', function () {
     };
 
     await request()
-      .patch('/api/card-spaces/AB70B8D5-95F5-4C20-997C-4DB9013B347C')
+      .patch(`/api/card-spaces/${merchantId}`)
       .send(payload)
       .set('Authorization', 'Bearer abc123--def456--ghi789')
       .set('Accept', 'application/vnd.api+json')
@@ -467,7 +223,7 @@ describe('PATCH /api/card-spaces', function () {
     let merchantId = uuidv4();
 
     let prisma = await getPrisma();
-    await prisma.merchantInfo.create({
+    await prisma.profile.create({
       data: {
         id: merchantId,
         ownerAddress: stubUserAddress,
@@ -475,14 +231,8 @@ describe('PATCH /api/card-spaces', function () {
         slug: 'satoshi',
         color: 'black',
         textColor: 'red',
-      },
-    });
-
-    await prisma.cardSpace.create({
-      data: {
-        id: 'AB70B8D5-95F5-4C20-997C-4DB9013B347C',
         profileDescription: 'Test',
-        merchantId,
+        createdAt: new Date(),
       },
     });
 
@@ -504,7 +254,7 @@ describe('PATCH /api/card-spaces', function () {
     };
 
     await request()
-      .patch('/api/card-spaces/AB70B8D5-95F5-4C20-997C-4DB9013B347C')
+      .patch(`/api/card-spaces/${merchantId}`)
       .send(payload)
       .set('Authorization', 'Bearer abc123--def456--ghi789')
       .set('Accept', 'application/vnd.api+json')

--- a/packages/hub/node-tests/routes/merchant-infos-test.ts
+++ b/packages/hub/node-tests/routes/merchant-infos-test.ts
@@ -31,7 +31,7 @@ describe('POST /api/merchant-infos', function () {
     registry(this).register('authentication-utils', StubAuthenticationUtils);
   });
 
-  let { request, getPrisma } = setupHub(this);
+  let { request } = setupHub(this);
 
   it('persists merchant info', async function () {
     const payload = {
@@ -47,8 +47,6 @@ describe('POST /api/merchant-infos', function () {
       },
     };
 
-    let resourceId = null;
-
     await request()
       .post('/api/merchant-infos')
       .send(payload)
@@ -57,7 +55,6 @@ describe('POST /api/merchant-infos', function () {
       .set('Content-Type', 'application/vnd.api+json')
       .expect(201)
       .expect(function (res) {
-        resourceId = res.body.data.id;
         res.body.data.id = 'the-id';
         res.body.data.attributes.did = 'the-did';
       })
@@ -79,11 +76,6 @@ describe('POST /api/merchant-infos', function () {
         },
       })
       .expect('Content-Type', 'application/vnd.api+json');
-
-    let prisma = await getPrisma();
-    let cardSpace = await prisma.cardSpace.findFirst({ where: { merchantId: String(resourceId) } });
-
-    expect(cardSpace?.merchantId).to.exist;
   });
 
   it('returns 401 without bearer token', async function () {
@@ -435,7 +427,7 @@ describe('GET /api/merchant-infos/short-id/:id', function () {
 
   this.beforeEach(async function () {
     let prisma = await getPrisma();
-    await prisma.merchantInfo.create({
+    await prisma.profile.create({
       data: {
         id: fullUuid,
         name: 'Merchie!',
@@ -443,6 +435,7 @@ describe('GET /api/merchant-infos/short-id/:id', function () {
         color: 'red',
         textColor: 'purple',
         ownerAddress: '0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13',
+        createdAt: new Date(),
       },
     });
   });

--- a/packages/hub/node-tests/routes/merchant-infos-test.ts
+++ b/packages/hub/node-tests/routes/merchant-infos-test.ts
@@ -435,7 +435,6 @@ describe('GET /api/merchant-infos/short-id/:id', function () {
         color: 'red',
         textColor: 'purple',
         ownerAddress: '0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13',
-        createdAt: new Date(),
       },
     });
   });

--- a/packages/hub/node-tests/routes/profile-purchases-test.ts
+++ b/packages/hub/node-tests/routes/profile-purchases-test.ts
@@ -654,7 +654,6 @@ describe('POST /api/profile-purchases', function () {
         color: 'pink',
         textColor: 'black',
         ownerAddress: 'me',
-        createdAt: new Date(),
       },
     });
 

--- a/packages/hub/node-tests/routes/profile-purchases-test.ts
+++ b/packages/hub/node-tests/routes/profile-purchases-test.ts
@@ -130,16 +130,13 @@ describe('POST /api/profile-purchases', function () {
       'a-receipt': 'yes',
     });
 
-    let merchantRecord = await prisma.merchantInfo.findUnique({ where: { id: merchantId } });
+    let merchantRecord = await prisma.profile.findUnique({ where: { id: merchantId } });
     assert(!!merchantRecord);
     expect(merchantRecord.name).to.equal('Satoshi Nakamoto');
     expect(merchantRecord.slug).to.equal('satoshi');
     expect(merchantRecord.color).to.equal('ff0000');
     expect(merchantRecord.textColor).to.equal('ffffff');
     expect(merchantRecord.ownerAddress).to.equal(stubUserAddress);
-
-    let cardSpaceRecord = await prisma.cardSpace.findFirst({ where: { merchantId } });
-    expect(cardSpaceRecord).to.exist;
 
     let jobTicketRecord = await prisma.jobTicket.findUnique({ where: { id: jobTicketId! } });
     expect(jobTicketRecord?.state).to.equal('pending');
@@ -649,7 +646,7 @@ describe('POST /api/profile-purchases', function () {
   });
 
   it('rejects a duplicate slug', async function () {
-    await prisma.merchantInfo.create({
+    await prisma.profile.create({
       data: {
         id: shortUUID.uuid(),
         name: 'yes',
@@ -657,6 +654,7 @@ describe('POST /api/profile-purchases', function () {
         color: 'pink',
         textColor: 'black',
         ownerAddress: 'me',
+        createdAt: new Date(),
       },
     });
 

--- a/packages/hub/node-tests/routes/profile-purchases-test.ts
+++ b/packages/hub/node-tests/routes/profile-purchases-test.ts
@@ -53,8 +53,8 @@ describe('POST /api/profile-purchases', function () {
   });
 
   it('validates the purchase, persists merchant information, returns a job ticket, and queues a single-attempt CreateProfile task', async function () {
-    let merchantId,
-      merchantDid,
+    let profileId,
+      profileDid,
       jobTicketId: string | undefined = undefined;
 
     await request()
@@ -95,17 +95,17 @@ describe('POST /api/profile-purchases', function () {
       .expect(201)
       .expect('Content-Type', 'application/vnd.api+json')
       .expect(function (res) {
-        merchantId = res.body.data.id;
-        merchantDid = res.body.data.attributes.did;
+        profileId = res.body.data.id;
+        profileDid = res.body.data.attributes.did;
         jobTicketId = res.body.included.find((included: any) => included.type === 'job-tickets').id;
 
         expect(res.body).to.deep.equal({
           data: {
-            id: merchantId,
+            id: profileId,
             type: 'merchant-infos',
             attributes: {
               name: 'Satoshi Nakamoto',
-              did: merchantDid,
+              did: profileDid,
               slug: 'satoshi',
               color: 'ff0000',
               'text-color': 'ffffff',
@@ -130,22 +130,22 @@ describe('POST /api/profile-purchases', function () {
       'a-receipt': 'yes',
     });
 
-    let merchantRecord = await prisma.profile.findUnique({ where: { id: merchantId } });
-    assert(!!merchantRecord);
-    expect(merchantRecord.name).to.equal('Satoshi Nakamoto');
-    expect(merchantRecord.slug).to.equal('satoshi');
-    expect(merchantRecord.color).to.equal('ff0000');
-    expect(merchantRecord.textColor).to.equal('ffffff');
-    expect(merchantRecord.ownerAddress).to.equal(stubUserAddress);
+    let profileRecord = await prisma.profile.findUnique({ where: { id: profileId } });
+    assert(!!profileRecord);
+    expect(profileRecord.name).to.equal('Satoshi Nakamoto');
+    expect(profileRecord.slug).to.equal('satoshi');
+    expect(profileRecord.color).to.equal('ff0000');
+    expect(profileRecord.textColor).to.equal('ffffff');
+    expect(profileRecord.ownerAddress).to.equal(stubUserAddress);
 
     let jobTicketRecord = await prisma.jobTicket.findUnique({ where: { id: jobTicketId! } });
     expect(jobTicketRecord?.state).to.equal('pending');
     expect(jobTicketRecord?.ownerAddress).to.equal(stubUserAddress);
-    expect(jobTicketRecord?.payload).to.deep.equal({ 'job-ticket-id': jobTicketId, 'merchant-info-id': merchantId });
+    expect(jobTicketRecord?.payload).to.deep.equal({ 'job-ticket-id': jobTicketId, 'merchant-info-id': profileId });
     expect(jobTicketRecord?.spec).to.deep.equal({ maxAttempts: 1 });
 
     expect(getJobIdentifiers()).to.deep.equal(['create-profile']);
-    expect(getJobPayloads()).to.deep.equal([{ 'job-ticket-id': jobTicketId, 'merchant-info-id': merchantId }]);
+    expect(getJobPayloads()).to.deep.equal([{ 'job-ticket-id': jobTicketId, 'merchant-info-id': profileId }]);
     expect(getJobSpecs()).to.deep.equal([{ maxAttempts: 1 }]);
   });
 

--- a/packages/hub/node-tests/services/card-space-validator-test.ts
+++ b/packages/hub/node-tests/services/card-space-validator-test.ts
@@ -1,4 +1,4 @@
-import { CardSpace } from '@prisma/client';
+import { Profile } from '@prisma/client';
 import { setupHub } from '../helpers/server';
 
 describe('CardSpaceValidator', function () {
@@ -7,7 +7,7 @@ describe('CardSpaceValidator', function () {
   it('validates urls', async function () {
     let subject = await getContainer().lookup('card-space-validator');
 
-    const cardSpace: Partial<CardSpace> = {
+    const cardSpace: Partial<Profile> = {
       id: '',
       profileImageUrl: 'invalid',
     };
@@ -19,7 +19,7 @@ describe('CardSpaceValidator', function () {
   it('validates text field attributes', async function () {
     let subject = await getContainer().lookup('card-space-validator');
 
-    const cardSpace: Partial<CardSpace> = {
+    const cardSpace: Partial<Profile> = {
       id: '',
       profileDescription: 'long string'.repeat(100),
     };
@@ -30,7 +30,7 @@ describe('CardSpaceValidator', function () {
 
   it('validates links', async function () {
     let subject = await getContainer().lookup('card-space-validator');
-    const cardSpace: Partial<CardSpace> = {
+    const cardSpace: Partial<Profile> = {
       id: '',
       links: [
         { title: '', url: 'sth' },

--- a/packages/hub/node-tests/tasks/create-profile-test.ts
+++ b/packages/hub/node-tests/tasks/create-profile-test.ts
@@ -100,7 +100,7 @@ describe('CreateProfileTask', function () {
     });
 
     merchantInfosId = shortUUID.uuid();
-    await prisma.merchantInfo.create({
+    await prisma.profile.create({
       data: {
         id: merchantInfosId,
         ownerAddress: exampleEthereumAddress,
@@ -108,6 +108,7 @@ describe('CreateProfileTask', function () {
         slug: '',
         color: '',
         textColor: '',
+        createdAt: new Date(),
       },
     });
 

--- a/packages/hub/node-tests/tasks/create-profile-test.ts
+++ b/packages/hub/node-tests/tasks/create-profile-test.ts
@@ -108,7 +108,6 @@ describe('CreateProfileTask', function () {
         slug: '',
         color: '',
         textColor: '',
-        createdAt: new Date(),
       },
     });
 

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -21,18 +21,6 @@ model CardDropRecipient {
   @@map("card_drop_recipients")
 }
 
-model CardSpace {
-  id                 String       @id @db.Uuid
-  profileImageUrl    String?      @map("profile_image_url")
-  profileDescription String?      @map("profile_description")
-  createdAt          DateTime     @default(now()) @map("created_at") @db.Timestamp(6)
-  links              Json[]       @default([]) @db.Json
-  merchantId         String       @unique(map: "card_spaces_merchant_id_unique_index") @map("merchant_id") @db.Uuid
-  merchantInfo       MerchantInfo @relation(fields: [merchantId], references: [id], onDelete: NoAction, onUpdate: NoAction)
-
-  @@map("card_spaces")
-}
-
 model Card {
   url            String   @id
   data           Json?
@@ -124,19 +112,6 @@ model LatestEventBlock {
   updatedAt   DateTime @default(now()) @map("updated_at") @db.Timestamp(6)
 
   @@map("latest_event_block")
-}
-
-model MerchantInfo {
-  id           String     @id @db.Uuid
-  name         String
-  slug         String     @unique(map: "merchant_infos_slug_unique_index")
-  color        String
-  textColor    String     @map("text_color")
-  ownerAddress String     @map("owner_address")
-  createdAt    DateTime   @default(now()) @map("created_at") @db.Timestamp(6)
-  cardSpace    CardSpace?
-
-  @@map("merchant_infos")
 }
 
 model NotificationPreference {
@@ -285,6 +260,21 @@ model WyrePrice {
 
   @@index([disabled], map: "wyre_prices_disabled_index")
   @@map("wyre_prices")
+}
+
+model Profile {
+  id                 String   @id @db.Uuid
+  name               String
+  slug               String
+  color              String
+  textColor          String   @map("text_color")
+  ownerAddress       String   @map("owner_address")
+  links              Json[]   @default([]) @db.Json
+  profileImageUrl    String?  @map("profile_image_url")
+  profileDescription String?  @map("profile_description")
+  createdAt          DateTime @map("created_at") @db.Timestamp(6)
+
+  @@map("profiles")
 }
 
 enum DiscordBotsStatusEnum {

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -265,7 +265,7 @@ model WyrePrice {
 model Profile {
   id                 String   @id @db.Uuid
   name               String
-  slug               String
+  slug               String   @unique(map: "profiles_slug_unique_index")
   color              String
   textColor          String   @map("text_color")
   ownerAddress       String   @map("owner_address")

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -272,7 +272,7 @@ model Profile {
   links              Json[]   @default([]) @db.Json
   profileImageUrl    String?  @map("profile_image_url")
   profileDescription String?  @map("profile_description")
-  createdAt          DateTime @map("created_at") @db.Timestamp(6)
+  createdAt          DateTime @default(now()) @map("created_at") @db.Timestamp(6)
 
   @@map("profiles")
 }

--- a/packages/hub/routes/merchant-infos.ts
+++ b/packages/hub/routes/merchant-infos.ts
@@ -84,7 +84,7 @@ export default class MerchantInfosRoute {
     };
 
     await prisma.$transaction(async () => {
-      await prisma.profile.create({ data: { ...merchantInfo, createdAt: new Date() } });
+      await prisma.profile.create({ data: { ...merchantInfo } });
     });
 
     await this.workerClient.addJob('persist-off-chain-merchant-info', {

--- a/packages/hub/routes/merchant-infos.ts
+++ b/packages/hub/routes/merchant-infos.ts
@@ -6,7 +6,7 @@ import { ensureLoggedIn } from './utils/auth';
 import { validateMerchantId } from '@cardstack/cardpay-sdk';
 import { validateRequiredFields } from './utils/validation';
 import shortUUID from 'short-uuid';
-import { Profile } from '@prisma/client';
+import { ProfileMerchantSubset } from '../services/merchant-info';
 
 export default class MerchantInfosRoute {
   merchantInfoSerializer = inject('merchant-info-serializer', {
@@ -74,7 +74,7 @@ export default class MerchantInfosRoute {
     }
 
     let prisma = await this.prismaManager.getClient();
-    const merchantInfo: Omit<Profile, 'links' | 'profileImageUrl' | 'profileDescription' | 'createdAt'> = {
+    const merchantInfo: ProfileMerchantSubset = {
       id: shortUuid.uuid(),
       name: ctx.request.body.data.attributes['name'],
       slug,

--- a/packages/hub/routes/merchant-infos.ts
+++ b/packages/hub/routes/merchant-infos.ts
@@ -28,7 +28,7 @@ export default class MerchantInfosRoute {
       return;
     }
     let prisma = await this.prismaManager.getClient();
-    let merchantInfos = await prisma.profile.findMany({
+    let profiles = await prisma.profile.findMany({
       where: {
         ownerAddress: ctx.state.userAddress,
       },
@@ -36,7 +36,7 @@ export default class MerchantInfosRoute {
 
     ctx.type = 'application/vnd.api+json';
     ctx.status = 200;
-    ctx.body = this.merchantInfoSerializer.serializeCollection(merchantInfos);
+    ctx.body = this.merchantInfoSerializer.serializeCollection(profiles);
   }
 
   async post(ctx: Koa.Context) {
@@ -129,10 +129,10 @@ export default class MerchantInfosRoute {
         };
       } else {
         let prisma = await this.prismaManager.getClient();
-        let merchantInfo = await prisma.profile.findFirst({ where: { slug } });
+        let profile = await prisma.profile.findFirst({ where: { slug } });
         return {
-          slugAvailable: merchantInfo ? false : true,
-          detail: merchantInfo ? 'This ID is already taken. Please choose another one' : 'ID is available',
+          slugAvailable: profile ? false : true,
+          detail: profile ? 'This ID is already taken. Please choose another one' : 'ID is available',
         };
       }
     }
@@ -140,19 +140,19 @@ export default class MerchantInfosRoute {
 
   async getFromShortId(ctx: Koa.Context) {
     let prisma = await this.prismaManager.getClient();
-    let merchantInfo = await prisma.profile.findUnique({
+    let profile = await prisma.profile.findUnique({
       where: {
         id: shortUUID().toUUID(ctx.params.id),
       },
     });
 
-    if (!merchantInfo) {
+    if (!profile) {
       ctx.status = 404;
       return;
     }
 
     ctx.status = 200;
-    ctx.body = this.merchantInfoSerializer.serialize(merchantInfo);
+    ctx.body = this.merchantInfoSerializer.serialize(profile);
     ctx.type = 'application/vnd.api+json';
   }
 }

--- a/packages/hub/routes/merchant-infos.ts
+++ b/packages/hub/routes/merchant-infos.ts
@@ -6,7 +6,7 @@ import { ensureLoggedIn } from './utils/auth';
 import { validateMerchantId } from '@cardstack/cardpay-sdk';
 import { validateRequiredFields } from './utils/validation';
 import shortUUID from 'short-uuid';
-import { MerchantInfo } from '@prisma/client';
+import { Profile } from '@prisma/client';
 
 export default class MerchantInfosRoute {
   merchantInfoSerializer = inject('merchant-info-serializer', {
@@ -28,7 +28,7 @@ export default class MerchantInfosRoute {
       return;
     }
     let prisma = await this.prismaManager.getClient();
-    let merchantInfos = await prisma.merchantInfo.findMany({
+    let merchantInfos = await prisma.profile.findMany({
       where: {
         ownerAddress: ctx.state.userAddress,
       },
@@ -74,7 +74,7 @@ export default class MerchantInfosRoute {
     }
 
     let prisma = await this.prismaManager.getClient();
-    const merchantInfo: Omit<MerchantInfo, 'createdAt'> = {
+    const merchantInfo: Omit<Profile, 'links' | 'profileImageUrl' | 'profileDescription' | 'createdAt'> = {
       id: shortUuid.uuid(),
       name: ctx.request.body.data.attributes['name'],
       slug,
@@ -84,13 +84,7 @@ export default class MerchantInfosRoute {
     };
 
     await prisma.$transaction(async () => {
-      await prisma.merchantInfo.create({ data: merchantInfo });
-      await prisma.cardSpace.create({
-        data: {
-          id: shortUuid.uuid(),
-          merchantId: merchantInfo.id,
-        },
-      });
+      await prisma.profile.create({ data: { ...merchantInfo, createdAt: new Date() } });
     });
 
     await this.workerClient.addJob('persist-off-chain-merchant-info', {
@@ -135,7 +129,7 @@ export default class MerchantInfosRoute {
         };
       } else {
         let prisma = await this.prismaManager.getClient();
-        let merchantInfo = await prisma.merchantInfo.findFirst({ where: { slug } });
+        let merchantInfo = await prisma.profile.findFirst({ where: { slug } });
         return {
           slugAvailable: merchantInfo ? false : true,
           detail: merchantInfo ? 'This ID is already taken. Please choose another one' : 'ID is available',
@@ -146,7 +140,7 @@ export default class MerchantInfosRoute {
 
   async getFromShortId(ctx: Koa.Context) {
     let prisma = await this.prismaManager.getClient();
-    let merchantInfo = await prisma.merchantInfo.findUnique({
+    let merchantInfo = await prisma.profile.findUnique({
       where: {
         id: shortUUID().toUUID(ctx.params.id),
       },

--- a/packages/hub/routes/profile-purchases.ts
+++ b/packages/hub/routes/profile-purchases.ts
@@ -211,7 +211,7 @@ export default class ProfilePurchasesRoute {
     let db = await this.databaseManager.getClient();
 
     await this.databaseManager.performTransaction(db, async () => {
-      await prisma.profile.create({ data: { ...merchantInfo, createdAt: new Date() } });
+      await prisma.profile.create({ data: { ...merchantInfo } });
     });
 
     let jobTicketId = shortUuid.uuid();

--- a/packages/hub/routes/profile-purchases.ts
+++ b/packages/hub/routes/profile-purchases.ts
@@ -211,8 +211,7 @@ export default class ProfilePurchasesRoute {
     let db = await this.databaseManager.getClient();
 
     await this.databaseManager.performTransaction(db, async () => {
-      await prisma.merchantInfo.create({ data: merchantInfo });
-      await prisma.cardSpace.create({ data: { id: shortUuid.uuid(), merchantId: merchantInfo.id } });
+      await prisma.profile.create({ data: { ...merchantInfo, createdAt: new Date() } });
     });
 
     let jobTicketId = shortUuid.uuid();

--- a/packages/hub/services/api-router.ts
+++ b/packages/hub/services/api-router.ts
@@ -99,7 +99,6 @@ export default class APIRouter {
 
     apiSubrouter.get('/card-spaces/:slug', cardSpacesRoute.get);
     apiSubrouter.patch('/card-spaces/:id', parseBody, cardSpacesRoute.patch);
-    apiSubrouter.post('/card-spaces', parseBody, cardSpacesRoute.post);
 
     apiSubrouter.post('/push-notification-registrations', parseBody, pushNotificationRegistrationsRoute.post);
     apiSubrouter.delete(

--- a/packages/hub/services/merchant-info.ts
+++ b/packages/hub/services/merchant-info.ts
@@ -2,7 +2,7 @@
 import { inject } from '@cardstack/di';
 
 import { getResolver } from '@cardstack/did-resolver';
-import { MerchantInfo } from '@prisma/client';
+import { Profile } from '@prisma/client';
 import { Resolver } from 'did-resolver';
 import { JSONAPIDocument } from '../utils/jsonapi-document';
 
@@ -13,7 +13,9 @@ export default class MerchantInfoService {
     as: 'merchantInfoSerializer',
   });
 
-  async getMerchantInfo(did?: string): Promise<MerchantInfo | Omit<MerchantInfo, 'createdAt'> | null> {
+  async getMerchantInfo(
+    did?: string
+  ): Promise<Profile | Omit<Profile, 'links' | 'profileImageUrl' | 'profileDescription' | 'createdAt'> | null> {
     if (!did) {
       return null;
     }

--- a/packages/hub/services/merchant-info.ts
+++ b/packages/hub/services/merchant-info.ts
@@ -7,6 +7,7 @@ import { Resolver } from 'did-resolver';
 import { JSONAPIDocument } from '../utils/jsonapi-document';
 
 export type ProfileMerchantSubset = Omit<Profile, 'links' | 'profileImageUrl' | 'profileDescription' | 'createdAt'>;
+
 export default class MerchantInfoService {
   #didResolver = new Resolver(getResolver());
 

--- a/packages/hub/services/merchant-info.ts
+++ b/packages/hub/services/merchant-info.ts
@@ -6,6 +6,7 @@ import { Profile } from '@prisma/client';
 import { Resolver } from 'did-resolver';
 import { JSONAPIDocument } from '../utils/jsonapi-document';
 
+export type ProfileMerchantSubset = Omit<Profile, 'links' | 'profileImageUrl' | 'profileDescription' | 'createdAt'>;
 export default class MerchantInfoService {
   #didResolver = new Resolver(getResolver());
 
@@ -13,9 +14,7 @@ export default class MerchantInfoService {
     as: 'merchantInfoSerializer',
   });
 
-  async getMerchantInfo(
-    did?: string
-  ): Promise<Profile | Omit<Profile, 'links' | 'profileImageUrl' | 'profileDescription' | 'createdAt'> | null> {
+  async getMerchantInfo(did?: string): Promise<Profile | ProfileMerchantSubset | null> {
     if (!did) {
       return null;
     }

--- a/packages/hub/services/serializers/card-space-serializer.ts
+++ b/packages/hub/services/serializers/card-space-serializer.ts
@@ -3,12 +3,12 @@ import { inject } from '@cardstack/di';
 import DatabaseManager from '@cardstack/db';
 import config from 'config';
 import { JSONAPIDocument } from '../../utils/jsonapi-document';
-import { CardSpace } from '@prisma/client';
+import { Profile } from '@prisma/client';
 
 export default class CardSpaceSerializer {
   databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
 
-  async serialize(model: Partial<CardSpace> & Omit<CardSpace, 'createdAt' | 'links'>): Promise<JSONAPIDocument> {
+  async serialize(model: Partial<Profile> & Omit<Profile, 'createdAt' | 'links'>): Promise<JSONAPIDocument> {
     let did = encodeDID({ type: 'CardSpace', uniqueId: model.id });
 
     const result = {
@@ -28,7 +28,7 @@ export default class CardSpaceSerializer {
           'merchant-info': {
             data: {
               type: 'merchant-infos',
-              id: model.merchantId,
+              id: model.id,
             },
           },
         },

--- a/packages/hub/services/serializers/merchant-info-serializer.ts
+++ b/packages/hub/services/serializers/merchant-info-serializer.ts
@@ -3,12 +3,12 @@ import { inject } from '@cardstack/di';
 import DatabaseManager from '@cardstack/db';
 import config from 'config';
 import { JSONAPIDocument } from '../../utils/jsonapi-document';
-import { MerchantInfo } from '@prisma/client';
+import { Profile } from '@prisma/client';
 
-export default class MerchantInfoSerializer {
+export default class ProfileSerializer {
   databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
 
-  serialize(model: Omit<MerchantInfo, 'createdAt'>): JSONAPIDocument {
+  serialize(model: Omit<Profile, 'links' | 'profileImageUrl' | 'profileDescription' | 'createdAt'>): JSONAPIDocument {
     let did = encodeDID({ type: 'MerchantInfo', uniqueId: model.id });
 
     const result = {
@@ -32,7 +32,7 @@ export default class MerchantInfoSerializer {
     return result as JSONAPIDocument;
   }
 
-  serializeCollection(models: MerchantInfo[]): JSONAPIDocument {
+  serializeCollection(models: Profile[]): JSONAPIDocument {
     let result = {
       data: models.map((model) => {
         return this.serialize(model).data;
@@ -42,7 +42,9 @@ export default class MerchantInfoSerializer {
     return result as JSONAPIDocument;
   }
 
-  deserialize(json: JSONAPIDocument): MerchantInfo | Omit<MerchantInfo, 'createdAt'> {
+  deserialize(
+    json: JSONAPIDocument
+  ): Profile | Omit<Profile, 'links' | 'profileImageUrl' | 'profileDescription' | 'createdAt'> {
     return {
       id: json.data.id,
       name: json.data.attributes['name'],
@@ -56,6 +58,6 @@ export default class MerchantInfoSerializer {
 
 declare module '@cardstack/di' {
   interface KnownServices {
-    'merchant-info-serializer': MerchantInfoSerializer;
+    'merchant-info-serializer': ProfileSerializer;
   }
 }

--- a/packages/hub/services/serializers/merchant-info-serializer.ts
+++ b/packages/hub/services/serializers/merchant-info-serializer.ts
@@ -4,11 +4,12 @@ import DatabaseManager from '@cardstack/db';
 import config from 'config';
 import { JSONAPIDocument } from '../../utils/jsonapi-document';
 import { Profile } from '@prisma/client';
+import { ProfileMerchantSubset } from '../merchant-info';
 
 export default class ProfileSerializer {
   databaseManager: DatabaseManager = inject('database-manager', { as: 'databaseManager' });
 
-  serialize(model: Omit<Profile, 'links' | 'profileImageUrl' | 'profileDescription' | 'createdAt'>): JSONAPIDocument {
+  serialize(model: ProfileMerchantSubset): JSONAPIDocument {
     let did = encodeDID({ type: 'MerchantInfo', uniqueId: model.id });
 
     const result = {
@@ -42,9 +43,7 @@ export default class ProfileSerializer {
     return result as JSONAPIDocument;
   }
 
-  deserialize(
-    json: JSONAPIDocument
-  ): Profile | Omit<Profile, 'links' | 'profileImageUrl' | 'profileDescription' | 'createdAt'> {
+  deserialize(json: JSONAPIDocument): Profile | ProfileMerchantSubset {
     return {
       id: json.data.id,
       name: json.data.attributes['name'],

--- a/packages/hub/services/validators/card-space.ts
+++ b/packages/hub/services/validators/card-space.ts
@@ -1,7 +1,7 @@
 import { URL } from 'url';
 import { NestedAttributeError, RelationshipError } from '../../routes/utils/error';
 import { inject } from '@cardstack/di';
-import { CardSpace, MerchantInfo } from '@prisma/client';
+import { Profile } from '@prisma/client';
 
 export type CardSpaceAttribute = 'profileDescription' | 'profileImageUrl' | 'links';
 
@@ -27,7 +27,7 @@ function isValidUrl(url: string): boolean {
 export default class CardSpaceValidator {
   prismaManager = inject('prisma-manager', { as: 'prismaManager' });
 
-  async validate(cardSpace: Partial<CardSpace & { merchantInfo: MerchantInfo }>): Promise<CardSpaceErrors> {
+  async validate(cardSpace: Partial<Profile>): Promise<CardSpaceErrors> {
     let errors: CardSpaceErrors = {
       merchantInfo: [],
       profileDescription: [],

--- a/packages/hub/tasks/create-profile.ts
+++ b/packages/hub/tasks/create-profile.ts
@@ -42,7 +42,7 @@ export default class CreateProfile {
     let prisma = await this.prismaManager.getClient();
 
     try {
-      let merchantInfo = await prisma.merchantInfo.findUnique({ where: { id: merchantInfoId } });
+      let merchantInfo = await prisma.profile.findUnique({ where: { id: merchantInfoId } });
       let did = encodeDID({ type: 'MerchantInfo', uniqueId: merchantInfoId });
 
       let profileRegistrationTxHash = await this.relay.registerProfile(merchantInfo!.ownerAddress, did);

--- a/packages/hub/tasks/create-profile.ts
+++ b/packages/hub/tasks/create-profile.ts
@@ -42,10 +42,10 @@ export default class CreateProfile {
     let prisma = await this.prismaManager.getClient();
 
     try {
-      let merchantInfo = await prisma.profile.findUnique({ where: { id: merchantInfoId } });
+      let profile = await prisma.profile.findUnique({ where: { id: merchantInfoId } });
       let did = encodeDID({ type: 'MerchantInfo', uniqueId: merchantInfoId });
 
-      let profileRegistrationTxHash = await this.relay.registerProfile(merchantInfo!.ownerAddress, did);
+      let profileRegistrationTxHash = await this.relay.registerProfile(profile!.ownerAddress, did);
 
       await this.cardpay.waitForTransactionConsistency(this.web3.getInstance(), profileRegistrationTxHash);
 

--- a/packages/hub/tasks/persist-off-chain-merchant-info.ts
+++ b/packages/hub/tasks/persist-off-chain-merchant-info.ts
@@ -13,7 +13,7 @@ export default class PersistOffChainMerchantInfo {
     const { id } = payload;
     let prisma = await this.prismaManager.getClient();
 
-    let merchantInfo = await prisma.merchantInfo.findUnique({ where: { id } });
+    let merchantInfo = await prisma.profile.findUnique({ where: { id } });
     let jsonAPIDoc = await this.merchantInfoSerializer.serialize(merchantInfo!);
 
     helpers.addJob('s3-put-json', {

--- a/packages/hub/tasks/persist-off-chain-merchant-info.ts
+++ b/packages/hub/tasks/persist-off-chain-merchant-info.ts
@@ -13,8 +13,8 @@ export default class PersistOffChainMerchantInfo {
     const { id } = payload;
     let prisma = await this.prismaManager.getClient();
 
-    let merchantInfo = await prisma.profile.findUnique({ where: { id } });
-    let jsonAPIDoc = await this.merchantInfoSerializer.serialize(merchantInfo!);
+    let profile = await prisma.profile.findUnique({ where: { id } });
+    let jsonAPIDoc = await this.merchantInfoSerializer.serialize(profile!);
 
     helpers.addJob('s3-put-json', {
       bucket: config.get('aws.offchainStorage.bucketName'),


### PR DESCRIPTION
This is mostly a mechanical process of combining the creation of separate models into a single profile. Since the surviving fields on `card_spaces` were all optional and it had a foreign key for merchants, it’s as if it merged into `merchant_infos`.

This preserves the existing endpoints at `/api/card-spaces` and `/api/merchant-infos` so we don’t have to update all clients simultaneously. Then we can add `/api/profiles` and eventually remove those once everything has migrated. I did delete `POST /api/card-spaces` because it’s no longer applicable.