### PR TITLE
remove handling of hub subgraph status check

### DIFF
--- a/packages/hub/node-tests/routes/checkly-webhook-test.ts
+++ b/packages/hub/node-tests/routes/checkly-webhook-test.ts
@@ -34,7 +34,7 @@ describe('POST /callbacks/checkly', async function () {
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/json')
       .send({
-        check_name: 'hub-prod subgraph / RPC node block number diff within threshold',
+        check_name: 'graph-production status check',
         alert_type: 'ALERT_FAILURE',
       })
       .expect(200);
@@ -53,7 +53,7 @@ describe('POST /callbacks/checkly', async function () {
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/json')
       .send({
-        check_name: 'hub-prod subgraph / RPC node block number diff within threshold',
+        check_name: 'graph-production status check',
         alert_type: 'ALERT_DEGRADED',
       })
       .expect(200);
@@ -72,7 +72,7 @@ describe('POST /callbacks/checkly', async function () {
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/json')
       .send({
-        check_name: 'hub-prod subgraph / RPC node block number diff within threshold',
+        check_name: 'graph-production status check',
         alert_type: 'ALERT_RECOVERY',
       })
       .expect(200);

--- a/packages/hub/routes/checkly-webhook.ts
+++ b/packages/hub/routes/checkly-webhook.ts
@@ -10,7 +10,6 @@ import Logger from '@cardstack/logger';
 let log = Logger('checkly-webhook');
 // Check names and component names should map to the names and components in Checkly
 type CheckName =
-  | 'hub-prod subgraph / RPC node block number diff within threshold'
   | 'graph-production status check'
   | 'xdai archive health check (eth_blockNumber)'
   | 'xdai non-archive health check - late-cold-smoke (eth_blockNumber)'
@@ -34,11 +33,6 @@ export default class ChecklyWebhookRoute {
   statuspageApi: StatuspageApi = inject('statuspage-api', { as: 'statuspageApi' });
 
   checks: Checks = {
-    'hub-prod subgraph / RPC node block number diff within threshold': {
-      componentName: 'Subgraph',
-      incidentName: 'Transactions delayed',
-      incidentMessage: `We are experiencing blockchain indexing delays. The blockchain index is delayed by at least ${degradedSubgraphThreshold} blocks. This will result increased transaction processing times.`,
-    },
     'graph-production status check': {
       componentName: 'Subgraph',
       incidentName: 'Transactions delayed',


### PR DESCRIPTION
replaced by graph-production status. tested that hub can handle the new check in the checkly callback route.