### PR TITLE
ssr/web: Fix token names in Sokol

### DIFF
--- a/packages/ssr-web/app/utils/web3-strategies/network-display-info.ts
+++ b/packages/ssr-web/app/utils/web3-strategies/network-display-info.ts
@@ -27,7 +27,7 @@ let layer2NetworkDisplayInfo: Record<
     shortName: 'Sokol',
     conversationalName: 'Sokol',
     nativeTokenSymbol: 'SPOA',
-    daiToken: 'DAI',
+    daiToken: 'DAI.CPXD',
   },
   'test-layer2': {
     fullName: 'L2 test chain',

--- a/packages/web-client/app/utils/token.ts
+++ b/packages/web-client/app/utils/token.ts
@@ -59,8 +59,8 @@ const contractNames: Record<
     CARD: 'cardToken',
   },
   sokol: {
-    DAI: 'daiCpxd',
-    CARD: 'cardCpxd',
+    'DAI.CPXD': 'daiCpxd',
+    'CARD.CPXD': 'cardCpxd',
   },
   gnosis: {
     'DAI.CPXD': 'daiCpxd',


### PR DESCRIPTION
The names now match those on mainnet.