### PR TITLE
Fix two reward tokens 

### DIFF
--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -719,7 +719,7 @@ but the balance is the reward pool is ${fromWei(rewardPoolBalanceForRewardProgra
   }
 
   async rewardProgramBalances(rewardProgramId: string): Promise<WithSymbol<RewardTokenBalance>[]> {
-    const tokensAvailable = await this.get_reward_tokens();
+    const tokensAvailable = await this.getRewardTokens();
     let promises = tokensAvailable.map((tokenAddress) => {
       return this.rewardProgramBalance(rewardProgramId, tokenAddress);
     });
@@ -740,11 +740,6 @@ but the balance is the reward pool is ${fromWei(rewardPoolBalanceForRewardProgra
 
   async address(): Promise<string> {
     return await getAddress('rewardPool', this.layer2Web3);
-  }
-
-  async get_reward_tokens(): Promise<string[]> {
-    let card_token_address = await getAddress('cardCpxd', this.layer2Web3);
-    return [card_token_address];
   }
 
   async addTokenSymbol<T extends HasTokenAddress>(arrWithTokenAddress: T[]): Promise<WithSymbol<T>[]> {


### PR DESCRIPTION
There is a redundant function that only returns rewardTokens for card. `rewardTokenBalances` should be agnostic of reward token address. If you want a single token, u can go ahead and filter it away.