### PR TITLE
hub: Add a service to fetch scheduled payments

### DIFF
--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -1183,7 +1183,8 @@ CREATE TABLE public.scheduled_payments (
     cancelation_transaction_hash text,
     cancelation_block_number bigint,
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    canceled_at timestamp without time zone
 );
 
 
@@ -1597,6 +1598,13 @@ CREATE INDEX reservations_user_address_index ON public.reservations USING btree 
 --
 
 CREATE INDEX scheduled_payment_attempts_scheduled_payment_id_index ON public.scheduled_payment_attempts USING btree (scheduled_payment_id);
+
+
+--
+-- Name: scheduled_payments_canceled_at_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX scheduled_payments_canceled_at_index ON public.scheduled_payments USING btree (canceled_at);
 
 
 --

--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -1171,7 +1171,7 @@ CREATE TABLE public.scheduled_payments (
     max_gas_price bigint NOT NULL,
     fee_fixed_usd integer NOT NULL,
     fee_percentage integer NOT NULL,
-    nonce text NOT NULL,
+    salt text NOT NULL,
     pay_at timestamp without time zone,
     recurring_day_of_month integer,
     recurring_until timestamp without time zone,
@@ -1601,10 +1601,24 @@ CREATE INDEX scheduled_payment_attempts_scheduled_payment_id_index ON public.sch
 
 
 --
--- Name: scheduled_payments_canceled_at_index; Type: INDEX; Schema: public; Owner: postgres
+-- Name: scheduled_payments_canceled_at_pay_at_creation_block_number_ind; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX scheduled_payments_canceled_at_index ON public.scheduled_payments USING btree (canceled_at);
+CREATE INDEX scheduled_payments_canceled_at_pay_at_creation_block_number_ind ON public.scheduled_payments USING btree (canceled_at, pay_at, creation_block_number);
+
+
+--
+-- Name: scheduled_payments_recurring_day_of_month_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX scheduled_payments_recurring_day_of_month_index ON public.scheduled_payments USING btree (recurring_day_of_month);
+
+
+--
+-- Name: scheduled_payments_recurring_until_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX scheduled_payments_recurring_until_index ON public.scheduled_payments USING btree (recurring_until);
 
 
 --

--- a/packages/hub/db/migrations/20220826123225267_add-canceled-at-to-scheduled-payments.ts
+++ b/packages/hub/db/migrations/20220826123225267_add-canceled-at-to-scheduled-payments.ts
@@ -1,0 +1,14 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+const TABLE = 'scheduled_payments';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumns(TABLE, {
+    canceled_at: { type: 'timestamp' },
+  });
+  pgm.createIndex(TABLE, 'canceled_at');
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumns(TABLE, ['canceled_at']);
+}

--- a/packages/hub/db/migrations/20220831081406596_alter-scheduled-payment-fields.ts
+++ b/packages/hub/db/migrations/20220831081406596_alter-scheduled-payment-fields.ts
@@ -6,9 +6,15 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.addColumns(TABLE, {
     canceled_at: { type: 'timestamp' },
   });
-  pgm.createIndex(TABLE, 'canceled_at');
+
+  pgm.renameColumn(TABLE, 'nonce', 'salt');
+
+  pgm.createIndex(TABLE, ['canceled_at', 'pay_at', 'creation_block_number']);
+  pgm.createIndex(TABLE, 'recurring_day_of_month');
+  pgm.createIndex(TABLE, 'recurring_until');
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
   pgm.dropColumns(TABLE, ['canceled_at']);
+  pgm.renameColumn(TABLE, 'salt', 'nonce');
 }

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -93,6 +93,7 @@ import ProfileSerializer from './services/serializers/profile-serializer';
 import Email from './services/email';
 import Mailchimp from './services/mailchimp';
 import PrismaManager from './services/prisma-manager';
+import ScheduledPaymentsFetcherService from './services/scheduled-payments/fetcher';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -173,6 +174,7 @@ export function createRegistry(): Registry {
   registry.register('pagerduty-incidents-webhook-route', PagerdutyIncidentsWebhookRoute);
   registry.register('email-card-drop-router', EmailCardDropRouter);
   registry.register('prisma-manager', PrismaManager);
+  registry.register('scheduled-payments-fetcher', ScheduledPaymentsFetcherService);
 
   if (process.env.COMPILER) {
     registry.register(

--- a/packages/hub/node-tests/services/scheduled-payments/fetcher-test.ts
+++ b/packages/hub/node-tests/services/scheduled-payments/fetcher-test.ts
@@ -74,11 +74,7 @@ describe('fetching scheduled payments that are due', function () {
       await createScheduledPayment({ payAt: addDays(now, 1) }); // future payment for tomorrow, not due to execute now
       await createScheduledPayment({ payAt: addDays(now, 2) }); // future payment for day after tomorrow, not due to execute now
 
-      expect((await subject.fetchScheduledPayments()).map((sp: ScheduledPayment) => sp.id)).to.deep.equal([
-        sp1.id,
-        sp2.id,
-        sp3.id,
-      ]);
+      expect((await subject.fetchScheduledPayments()).map((sp) => sp.id)).to.deep.equal([sp1.id, sp2.id, sp3.id]);
     });
 
     it('does not fetch scheduled payments with payment attempts in progress', async function () {
@@ -99,7 +95,7 @@ describe('fetching scheduled payments that are due', function () {
       let sp1 = await createScheduledPayment({ payAt: subDays(now, 1) }); // was due yesterday
       await createScheduledPaymentAttempt(sp1, subDays(now, 1), addMinutes(subDays(now, 1), 2), 'failed'); // it failed yesterday, but it's still valid to retry now
 
-      expect((await subject.fetchScheduledPayments()).map((sp: ScheduledPayment) => sp.id)).to.deep.equal([sp1.id]);
+      expect((await subject.fetchScheduledPayments()).map((sp) => sp.id)).to.deep.equal([sp1.id]);
     });
   });
 
@@ -133,10 +129,7 @@ describe('fetching scheduled payments that are due', function () {
         payAt: addDays(now, 1),
       });
 
-      expect((await subject.fetchScheduledPayments()).map((sp: ScheduledPayment) => sp.id)).to.deep.equal([
-        sp1.id,
-        sp2.id,
-      ]);
+      expect((await subject.fetchScheduledPayments()).map((sp) => sp.id)).to.deep.equal([sp1.id, sp2.id]);
     });
 
     it('does not fetch payments that have recurringUntil in the past', async function () {
@@ -158,7 +151,7 @@ describe('fetching scheduled payments that are due', function () {
 
       await createScheduledPaymentAttempt(sp1, subMonths(now, 1), addMinutes(subMonths(now, 1), 1), 'succeeded');
 
-      expect((await subject.fetchScheduledPayments()).map((sp: ScheduledPayment) => sp.id)).to.deep.equal([sp1.id]);
+      expect((await subject.fetchScheduledPayments()).map((sp) => sp.id)).to.deep.equal([sp1.id]);
     });
   });
 

--- a/packages/hub/node-tests/services/scheduled-payments/fetcher-test.ts
+++ b/packages/hub/node-tests/services/scheduled-payments/fetcher-test.ts
@@ -1,0 +1,114 @@
+import shortUUID from 'short-uuid';
+import ScheduledPaymentsFetcherService from '../../../services/scheduled-payments/fetcher';
+import { setupHub } from '../../helpers/server';
+import crypto from 'crypto';
+import { addDays, addMinutes, subDays, subMinutes } from 'date-fns';
+import { ScheduledPayment, ScheduledPaymentAttemptStatusEnum } from '@prisma/client';
+
+describe('fetching scheduled payments that are due', function () {
+  let subject: ScheduledPaymentsFetcherService;
+  let { getPrisma, getContainer } = setupHub(this);
+
+  this.beforeEach(async function () {
+    subject = await getContainer().lookup('scheduled-payments-fetcher');
+  });
+
+  let createScheduledPayment = async (payAt: Date) => {
+    let prisma = await getPrisma();
+    return prisma.scheduledPayment.create({
+      data: {
+        id: shortUUID.uuid(),
+        senderSafeAddress: '0x123',
+        moduleAddress: '0x456',
+        tokenAddress: '0x789',
+        amount: 1,
+        payeeAddress: '0xabc',
+        executionGasEstimation: 1,
+        maxGasPrice: 1,
+        feeFixedUsd: 1,
+        feePercentage: 1,
+        nonce: 'abc',
+        payAt,
+        spHash: crypto.randomBytes(20).toString('hex'),
+        chainId: 1,
+      },
+    });
+  };
+
+  let createScheduledPaymentAttempt = async (
+    scheduledPayment: ScheduledPayment,
+    startedAt: Date,
+    endedAt: Date | null,
+    status: ScheduledPaymentAttemptStatusEnum
+  ) => {
+    let prisma = await getPrisma();
+    return prisma.scheduledPaymentAttempt.create({
+      data: {
+        id: shortUUID.uuid(),
+        startedAt,
+        endedAt,
+        status,
+        scheduledPaymentId: scheduledPayment.id,
+      },
+    });
+  };
+
+  describe('scheduled payments with no payment attempts', async function () {
+    it('fetches the correct payments that are due to execute now', async function () {
+      let now = new Date();
+      let validForDays = subject.validForDays;
+
+      await createScheduledPayment(addDays(now, -validForDays - 1)); // not valid to retry anymore
+      let sp1 = await createScheduledPayment(addDays(now, -validForDays)); // still valid to retry
+      let sp2 = await createScheduledPayment(addDays(now, -validForDays + 1)); // still valid to retry
+      let sp3 = await createScheduledPayment(now);
+      await createScheduledPayment(addDays(now, 1)); // future payment for tomorrow, not due to execute now
+      await createScheduledPayment(addDays(now, 2)); // future payment for day after tomorrow, not due to execute now
+
+      expect((await subject.fetchScheduledPayments()).map((sp: ScheduledPayment) => sp.id)).to.deep.equal([
+        sp1.id,
+        sp2.id,
+        sp3.id,
+      ]);
+    });
+  });
+
+  describe('scheduled payments with payment attempts in progress', async function () {
+    it('fetches the correct payments that are due to execute now', async function () {
+      let now = new Date();
+
+      let sp1 = await createScheduledPayment(now);
+      await createScheduledPaymentAttempt(sp1, now, null, 'inProgress');
+
+      expect(await subject.fetchScheduledPayments()).to.be.empty;
+    });
+  });
+
+  describe('scheduled payments with payment attempts that succeeded', async function () {
+    it('fetches the correct payments that are due to execute now', async function () {
+      let now = new Date();
+
+      let sp1 = await createScheduledPayment(subDays(now, 1));
+      await createScheduledPaymentAttempt(sp1, subMinutes(now, 2), subMinutes(now, 1), 'succeeded');
+
+      expect(await subject.fetchScheduledPayments()).to.be.empty;
+    });
+  });
+
+  describe('scheduled payments with payment attempts that failed', async function () {
+    it('fetches the correct payments that are due to execute now', async function () {
+      let now = new Date();
+
+      let sp1 = await createScheduledPayment(subDays(now, 1)); // was due yesterday
+      await createScheduledPaymentAttempt(sp1, subDays(now, 1), addMinutes(subDays(now, 1), 2), 'failed'); // it failed yesterday, but it's still valid to retry now
+
+      expect((await subject.fetchScheduledPayments()).map((sp: ScheduledPayment) => sp.id)).to.deep.equal([sp1.id]);
+    });
+  });
+});
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'scheduled-payments-fetcher': ScheduledPaymentsFetcherService;
+  }
+}

--- a/packages/hub/node-tests/services/scheduled-payments/fetcher-test.ts
+++ b/packages/hub/node-tests/services/scheduled-payments/fetcher-test.ts
@@ -35,7 +35,7 @@ describe('fetching scheduled payments that are due', function () {
         maxGasPrice: 1,
         feeFixedUsd: 1,
         feePercentage: 1,
-        nonce: 'abc',
+        salt: 'abc',
         payAt: params.payAt,
         recurringDayOfMonth: params.recurringDayOfMonth,
         recurringUntil: params.recurringUntil,

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -278,14 +278,14 @@ model Profile {
 }
 
 model ScheduledPaymentAttempt {
-  id                 String                             @id @db.Uuid
-  startedAt          DateTime?                          @map("started_at") @db.Timestamp(6)
-  endedAt            DateTime?                          @map("ended_at") @db.Timestamp(6)
-  status             ScheduledPaymentAttemptsStatusEnum @default(in_progress)
-  transactionHash    String?                            @map("transaction_hash")
-  failureReason      String?                            @map("failure_reason")
-  scheduledPaymentId String                             @map("scheduled_payment_id") @db.Uuid
-  scheduledPayment   ScheduledPayment                   @relation(fields: [scheduledPaymentId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  id                 String                            @id @db.Uuid
+  startedAt          DateTime?                         @map("started_at") @db.Timestamp(6)
+  endedAt            DateTime?                         @map("ended_at") @db.Timestamp(6)
+  status             ScheduledPaymentAttemptStatusEnum @default(inProgress)
+  transactionHash    String?                           @map("transaction_hash")
+  failureReason      String?                           @map("failure_reason")
+  scheduledPaymentId String                            @map("scheduled_payment_id") @db.Uuid
+  scheduledPayment   ScheduledPayment                  @relation(fields: [scheduledPaymentId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
   @@index([scheduledPaymentId], map: "scheduled_payment_attempts_scheduled_payment_id_index")
   @@map("scheduled_payment_attempts")
@@ -298,8 +298,8 @@ model ScheduledPayment {
   tokenAddress               String                    @map("token_address")
   amount                     BigInt
   payeeAddress               String                    @map("payee_address")
-  executionGasEstimation     BigInt
-  maxGasPrice                BigInt
+  executionGasEstimation     BigInt                    @map("execution_gas_estimation")
+  maxGasPrice                BigInt                    @map("max_gas_price")
   feeFixedUsd                Int                       @map("fee_fixed_usd")
   feePercentage              Int                       @map("fee_percentage")
   nonce                      String
@@ -310,14 +310,16 @@ model ScheduledPayment {
   spHash                     String                    @unique @map("sp_hash")
   chainId                    Int                       @map("chain_id")
   creationTransactionHash    String?                   @map("creation_transaction_hash")
-  creationBlockNumber        BigInt?
+  creationBlockNumber        BigInt?                   @map("creation_block_number")
   cancelationTransactionHash String?                   @map("cancelation_transaction_hash")
-  cancelationBlockNumber     BigInt?
+  cancelationBlockNumber     BigInt?                   @map("cancelation_block_number")
   createdAt                  DateTime                  @default(now()) @map("created_at") @db.Timestamp(6)
   updatedAt                  DateTime                  @default(now()) @map("updated_at") @db.Timestamp(6)
+  canceledAt                 DateTime?                 @map("canceled_at") @db.Timestamp(6)
   scheduledPaymentAttempts   ScheduledPaymentAttempt[]
 
   @@index([senderSafeAddress], map: "scheduled_payments_sender_safe_address_index")
+  @@index([canceledAt], map: "scheduled_payments_canceled_at_index")
   @@map("scheduled_payments")
 }
 
@@ -356,8 +358,8 @@ enum WalletOrdersStatusEnum {
   @@map("wallet_orders_status_enum")
 }
 
-enum ScheduledPaymentAttemptsStatusEnum {
-  in_progress
+enum ScheduledPaymentAttemptStatusEnum {
+  inProgress @map("in_progress")
   succeeded
   failed
 

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -302,7 +302,7 @@ model ScheduledPayment {
   maxGasPrice                BigInt                    @map("max_gas_price")
   feeFixedUsd                Int                       @map("fee_fixed_usd")
   feePercentage              Int                       @map("fee_percentage")
-  nonce                      String
+  salt                       String
   payAt                      DateTime?                 @map("pay_at") @db.Timestamp(6)
   recurringDayOfMonth        Int?                      @map("recurring_day_of_month")
   recurringUntil             DateTime?                 @map("recurring_until") @db.Timestamp(6)
@@ -319,7 +319,9 @@ model ScheduledPayment {
   scheduledPaymentAttempts   ScheduledPaymentAttempt[]
 
   @@index([senderSafeAddress], map: "scheduled_payments_sender_safe_address_index")
-  @@index([canceledAt], map: "scheduled_payments_canceled_at_index")
+  @@index([canceledAt, payAt, creationBlockNumber], map: "scheduled_payments_canceled_at_pay_at_creation_block_number_ind")
+  @@index([recurringDayOfMonth], map: "scheduled_payments_recurring_day_of_month_index")
+  @@index([recurringUntil], map: "scheduled_payments_recurring_until_index")
   @@map("scheduled_payments")
 }
 

--- a/packages/hub/services/scheduled-payments/fetcher.ts
+++ b/packages/hub/services/scheduled-payments/fetcher.ts
@@ -25,7 +25,7 @@ export default class ScheduledPaymentsFetcherService {
           gt: 0,
         },
         payAt: {
-          gt: startOfDay(subDays(new Date(), this.validForDays)),
+          gt: startOfDay(subDays(nowUtc, this.validForDays)),
           lte: nowUtc,
         },
         OR: [

--- a/packages/hub/services/scheduled-payments/fetcher.ts
+++ b/packages/hub/services/scheduled-payments/fetcher.ts
@@ -1,4 +1,5 @@
 import { inject } from '@cardstack/di';
+import { ScheduledPayment } from '@prisma/client';
 import { startOfDay, subDays } from 'date-fns';
 import { convertDateToUTC } from '../../utils/dates';
 
@@ -14,7 +15,7 @@ export default class ScheduledPaymentsFetcherService {
   // It is also important to note that validForDays tells us for how many days the payment is still valid to retry in
   // case it is failing for some reason.
 
-  async fetchScheduledPayments(): Promise<any> {
+  async fetchScheduledPayments(): Promise<ScheduledPayment[]> {
     let prisma = await this.prismaManager.getClient();
     let nowUtc = convertDateToUTC(new Date());
 

--- a/packages/hub/services/scheduled-payments/fetcher.ts
+++ b/packages/hub/services/scheduled-payments/fetcher.ts
@@ -5,7 +5,7 @@ import { convertDateToUTC } from '../../utils/dates';
 
 export default class ScheduledPaymentsFetcherService {
   prismaManager = inject('prisma-manager', { as: 'prismaManager' });
-  validForDays = 10; // Keep this in sync with the value in the config contract
+  validForDays = 10; // TODO: Keep this in sync with the value in the config contract
 
   // This query fetches scheduled payments that are due to be executed now.
   // Payment scheduler will periodically try to fetch these payments at regular intervals and execute them if they are due.

--- a/packages/hub/services/scheduled-payments/fetcher.ts
+++ b/packages/hub/services/scheduled-payments/fetcher.ts
@@ -1,25 +1,60 @@
 import { inject } from '@cardstack/di';
 import { startOfDay, subDays } from 'date-fns';
+import { convertDateToUTC } from '../../utils/dates';
 
 export default class ScheduledPaymentsFetcherService {
   prismaManager = inject('prisma-manager', { as: 'prismaManager' });
   validForDays = 10; // Keep this in sync with the value in the config contract
 
+  // This query fetches scheduled payments that are due to be executed now.
+  // Payment scheduler will periodically try to fetch these payments at regular intervals and execute them if they are due.
+  // This query mostly relies on the payAt field, which is set to the time when the payment should be executed.
+  // In case of one-time payments, payAt is set only initially, and then never changed.
+  // In case of recurring payments, payAt will update on every successful payment (to 1 month in the future).
+  // It is also important to note that validForDays tells us for how many days the payment is still valid to retry in
+  // case it is failing for some reason.
+
   async fetchScheduledPayments(): Promise<any> {
     let prisma = await this.prismaManager.getClient();
+    let nowUtc = convertDateToUTC(new Date());
 
     return prisma.scheduledPayment.findMany({
       where: {
         canceledAt: null,
+        creationBlockNumber: {
+          gt: 0,
+        },
         payAt: {
-          lte: new Date(),
           gt: startOfDay(subDays(new Date(), this.validForDays)),
+          lte: nowUtc,
         },
-        scheduledPaymentAttempts: {
-          none: {
-            OR: [{ status: 'succeeded' }, { status: 'inProgress' }],
+        OR: [
+          {
+            AND: {
+              recurringDayOfMonth: null,
+              scheduledPaymentAttempts: {
+                none: {
+                  OR: [{ status: 'succeeded' }, { status: 'inProgress' }],
+                },
+              },
+            },
           },
-        },
+          {
+            AND: {
+              recurringDayOfMonth: {
+                gt: 0,
+              },
+              recurringUntil: {
+                gte: nowUtc,
+              },
+              scheduledPaymentAttempts: {
+                none: {
+                  status: 'inProgress',
+                },
+              },
+            },
+          },
+        ],
       },
     });
   }

--- a/packages/hub/services/scheduled-payments/fetcher.ts
+++ b/packages/hub/services/scheduled-payments/fetcher.ts
@@ -1,0 +1,26 @@
+import { inject } from '@cardstack/di';
+import { startOfDay, subDays } from 'date-fns';
+
+export default class ScheduledPaymentsFetcherService {
+  prismaManager = inject('prisma-manager', { as: 'prismaManager' });
+  validForDays = 10; // Keep this in sync with the value in the config contract
+
+  async fetchScheduledPayments(): Promise<any> {
+    let prisma = await this.prismaManager.getClient();
+
+    return prisma.scheduledPayment.findMany({
+      where: {
+        canceledAt: null,
+        payAt: {
+          lte: new Date(),
+          gt: startOfDay(subDays(new Date(), this.validForDays)),
+        },
+        scheduledPaymentAttempts: {
+          none: {
+            OR: [{ status: 'succeeded' }, { status: 'inProgress' }],
+          },
+        },
+      },
+    });
+  }
+}

--- a/packages/hub/utils/dates.ts
+++ b/packages/hub/utils/dates.ts
@@ -1,0 +1,11 @@
+// https://stackoverflow.com/questions/948532/how-to-convert-a-date-to-utc
+export function convertDateToUTC(date: Date) {
+  return new Date(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds()
+  );
+}


### PR DESCRIPTION
Ticket: CS-4379

The idea is that there will be a scheduled payments scheduler that will trigger every 5 minutes and check whether there are any scheduled payments due, and pass them to the scheduled payments executor. This service will return the scheduled payments that are due to be executed at the time of checking.

Since `pay_at` is used to query for both one-time (`pay_at` is set initially only) and recurring payments (`pay_at` is updated on every sucessful payment), we had some discussions whether it would make sense to rename it to `next_pay_at` (or have both `pay_at` and `next_pay_at`). I opted in for keeping the `pay_at` and use it for both types of scheduled payment so that we can keep the fetching query as simple as possible.

TODO: 

- [x] Fetch one time payments
- [x] Fetch recurring payments
