### PR TITLE
ssr: Remove reporting of hostWhitelist errors

### DIFF
--- a/packages/ssr-web/app/services/app-context.ts
+++ b/packages/ssr-web/app/services/app-context.ts
@@ -33,10 +33,16 @@ export default class AppContext extends Service implements AppContextService {
   );
 
   get host() {
-    let host = this.fastboot.isFastBoot
-      ? this.fastboot.request.host
-      : window.location.host;
-    return host;
+    if (this.fastboot.isFastBoot) {
+      try {
+        return this.fastboot.request.host;
+      } catch (e: any) {
+        // Ignore Fastboot error when the host is not on the safelist
+        return '';
+      }
+    } else {
+      return window.location.host;
+    }
   }
 
   get hostIsPreview() {


### PR DESCRIPTION
Sentry has dozens of these errors per day. We have an
explicit safelist for what hosts are valid, we don’t
need to report when other hosts fail.

It’s difficult to prove an absence but visiting [the ELB host directly](https://waypoint-ecs-ssr-web-1525503069.us-east-1.elb.amazonaws.com/) (and ignoring the encryption warning) produced [this Sentry issue](https://sentry.io/organizations/cardstack/issues/3493493974/events/5086fc972aef4dd390b3f240b9e17481/?project=6223279&query=is%3Aunresolved) and after I deployed this branch it did not produce an issue.