### PR TITLE
claimable proofs must only be valid 

### DIFF
--- a/packages/cardpay-cli/rewards/claim-all-rewards-gas-estimate.ts
+++ b/packages/cardpay-cli/rewards/claim-all-rewards-gas-estimate.ts
@@ -6,7 +6,7 @@ import Web3 from 'web3';
 const { fromWei } = Web3.utils;
 
 export default {
-  command: 'claim-all-rewards-gas-estimate <rewardSafe> [tokenAddress] [rewardProgramId]',
+  command: 'claim-all-rewards-gas-estimate <rewardSafe> <tokenAddress> [rewardProgramId]',
   describe: 'Obtain a gas estimate to claim all rewards corresponding to a rewardProgrmaId and tokenAddress',
   builder(yargs: Argv) {
     return yargs

--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -175,15 +175,18 @@ export default class RewardPool {
     const proofs = await this.addTokenSymbol(res);
     if (safeAddress) {
       // if safeAddress is provided, we need to estimate gas of each proof claim
+      // when gas estimation is performed, we filter out proofs that are not valid
       const proofsWithGasFees = await Promise.all(
-        proofs.map(async (proof) => {
-          const gasEstimate = await this.claimGasEstimate(safeAddress, proof.leaf, proof.proofArray, false);
-          return {
-            ...proof,
-            gasEstimate,
-            safeAddress,
-          };
-        })
+        proofs
+          .filter((o) => o.isValid)
+          .map(async (proof) => {
+            const gasEstimate = await this.claimGasEstimate(safeAddress, proof.leaf, proof.proofArray, false);
+            return {
+              ...proof,
+              gasEstimate,
+              safeAddress,
+            };
+          })
       );
       return proofsWithGasFees;
     } else {


### PR DESCRIPTION
since I estimated the gas high up in data chain (during `getProofs` call), that means non valid proofs were being estimated too. This is a wrong state, if a proof is non valid it cannot be estimated (`eth_call` would give error). This adds the filter to `getProofs` 
