### PR TITLE
ssr: Update to not report 404s to Sentry

### DIFF
--- a/packages/ssr-web/app/routes/application.ts
+++ b/packages/ssr-web/app/routes/application.ts
@@ -7,6 +7,7 @@ import { isTesting } from '@embroider/macros';
 import { getSentry } from '../utils/sentry';
 import { action } from '@ember/object';
 import Transition from '@ember/routing/-private/transition';
+import { NotFoundError } from './not-found';
 
 export default class ApplicationRoute extends Route {
   @service('profile') declare profile: ProfileService;
@@ -49,7 +50,9 @@ export default class ApplicationRoute extends Route {
   @action error(error: any, _transition: Transition<unknown>): true {
     // Handle uncaught errors and then bubble them up so they can be handled
     // by the application error route
-    this.sentry.captureException(error);
+    if (error != NotFoundError) {
+      this.sentry.captureException(error);
+    }
     return true;
   }
 }

--- a/packages/ssr-web/app/routes/not-found.ts
+++ b/packages/ssr-web/app/routes/not-found.ts
@@ -3,6 +3,8 @@ import { inject as service } from '@ember/service';
 import ProfileService from '@cardstack/ssr-web/services/profile';
 import RouterService from '@ember/routing/router-service';
 
+export const NotFoundError = new Error('404: Not Found');
+
 export default class NotFoundRoute extends Route {
   @service declare router: RouterService;
   @service('profile') declare profile: ProfileService;
@@ -11,7 +13,7 @@ export default class NotFoundRoute extends Route {
     if (this.profile.isActive) {
       this.router.transitionTo('index');
     } else {
-      throw new Error('404: Not Found');
+      throw NotFoundError;
     }
   }
 }


### PR DESCRIPTION
With this deployed to staging, a 404 like [this](https://sentry.io/organizations/cardstack/issues/3494423291/events/a776cd978cc9408eb1be591eb1c6398c/?project=6223279&query=is%3Aunresolved) is no longer logged to Sentry.