### PR TITLE
boxel: Add multiline option for Input

### DIFF
--- a/packages/boxel/addon/components/boxel/input/index.hbs
+++ b/packages/boxel/addon/components/boxel/input/index.hbs
@@ -3,26 +3,28 @@
 {{/if}}
 {{#let (and @invalid @errorMessage) as |shouldShowErrorMessage|}}
   {{#let (unique-id) as |helperId|}}
-    <input
-      class={{cn "boxel-input" boxel-input--invalid=@invalid}}
-      id={{@id}}
-      value={{@value}}
-      required={{@required}}
-      disabled={{@disabled}}
-      aria-describedby={{if @helperText (concat "helper-text-" helperId) false}}
-      aria-invalid={{if @invalid "true"}}
-      aria-errormessage={{if shouldShowErrorMessage (concat "error-message-" helperId) false}}
-      data-test-boxel-input
-      data-test-boxel-input-id={{@id}}
-      {{on "input" (pick "target.value" (optional @onInput))}}
-      {{on "blur" (optional @onBlur)}}
-      ...attributes
-    />
-    {{#if shouldShowErrorMessage}}
-      <div id={{concat "error-message-" helperId}} class="boxel-input__error-message" aria-live="polite" data-test-boxel-input-error-message>{{@errorMessage}}</div>
-    {{/if}}
-    {{#if @helperText}}
-      <div id={{concat "helper-text-" helperId}} class="boxel-input__helper-text" data-test-boxel-input-helper-text>{{@helperText}}</div>
-    {{/if}}
+    {{#let (element (if @multiline "textarea" "input")) as |InputTag|}}
+      <InputTag
+        class={{cn "boxel-input" boxel-input--invalid=@invalid}}
+        id={{@id}}
+        value={{@value}}
+        required={{@required}}
+        disabled={{@disabled}}
+        aria-describedby={{if @helperText (concat "helper-text-" helperId) false}}
+        aria-invalid={{if @invalid "true"}}
+        aria-errormessage={{if shouldShowErrorMessage (concat "error-message-" helperId) false}}
+        data-test-boxel-input
+        data-test-boxel-input-id={{@id}}
+        {{on "input" (pick "target.value" (optional @onInput))}}
+        {{on "blur" (optional @onBlur)}}
+        ...attributes
+      />
+      {{#if shouldShowErrorMessage}}
+        <div id={{concat "error-message-" helperId}} class="boxel-input__error-message" aria-live="polite" data-test-boxel-input-error-message>{{@errorMessage}}</div>
+      {{/if}}
+      {{#if @helperText}}
+        <div id={{concat "helper-text-" helperId}} class="boxel-input__helper-text" data-test-boxel-input-helper-text>{{@helperText}}</div>
+      {{/if}}
+    {{/let}}
   {{/let}}
 {{/let}}

--- a/packages/boxel/addon/components/boxel/input/usage.hbs
+++ b/packages/boxel/addon/components/boxel/input/usage.hbs
@@ -9,6 +9,7 @@
       @required={{this.required}}
       @optional={{this.optional}}
       @invalid={{this.invalid}}
+      @multiline={{this.multiline}}
       @errorMessage={{this.errorMessage}}
       @helperText={{this.helperText}}
       {{on "blur" this.validate}}
@@ -47,6 +48,11 @@
       @value={{this.invalid}}
       @onInput={{fn (mut this.invalid)}}
     />
+    <Args.Bool
+      @name="multiline"
+      @value={{this.multiline}}
+      @onInput={{fn (mut this.multiline)}}
+    />
     <Args.String
       @name="errorMessage"
       @value={{this.errorMessage}}
@@ -63,6 +69,18 @@
       @description="Function to update the passed in value. This receives the changed value as a string."
     />
   </:api>
+</Freestyle::Usage>
+
+<Freestyle::Usage class="remove-in-percy" @name="Configure a multiline input using textarea attributes">
+  <:example>
+    <Boxel::Input
+      @id="multilineExample"
+      @value=""
+      @multiline="true"
+      rows="10"
+      cols="20"
+    />
+  </:example>
 </Freestyle::Usage>
 
 <Freestyle::Usage class="remove-in-percy" @name="Use the @onInput argument to access the input's value in the callback directly.">

--- a/packages/boxel/addon/components/boxel/input/usage.hbs
+++ b/packages/boxel/addon/components/boxel/input/usage.hbs
@@ -73,6 +73,7 @@
 
 <Freestyle::Usage class="remove-in-percy" @name="Configure a multiline input using textarea attributes">
   <:example>
+    <label for="multilineExample" class="boxel-sr-only">event example input</label>
     <Boxel::Input
       @id="multilineExample"
       @value=""


### PR DESCRIPTION
`textarea`-specific attributes don’t need special handling thanks to `…attributes`. The change is rendered [here](https://boxel.stack.cards/boxel/input-multiline-cs-4467/#/docs?s=Components&ss=%3CBoxel%3A%3AInput%3E).