### PR TITLE
boxel: Add CancelButton to default ActionChin

### DIFF
--- a/packages/boxel/addon/components/boxel/action-chin/index.hbs
+++ b/packages/boxel/addon/components/boxel/action-chin/index.hbs
@@ -73,6 +73,12 @@
           kind="primary"
           disabled=@disabled
         )
+        CancelButton=(component
+          "boxel/button"
+          kind="secondary-dark"
+          disabled=@disabled
+          class="boxel-action-chin__cancel-button"
+        )
         ActionStatusArea=(component
           "boxel/action-chin/action-status-area"
         )

--- a/packages/boxel/addon/components/boxel/action-chin/usage.hbs
+++ b/packages/boxel/addon/components/boxel/action-chin/usage.hbs
@@ -73,10 +73,11 @@
                 CancelButton
               </td>
               <td>
-                Button to cancel the main action. It should only appear in the 'in-progress' state.
+                Button to cancel the main action.
               </td>
               <td>
                 <ul>
+                  <li>default</li>
                   <li>in-progress</li>
                 </ul>
               </td>
@@ -112,6 +113,9 @@
         <a.ActionButton>
           Default CTA
         </a.ActionButton>
+        <a.CancelButton>
+          Cancel
+        </a.CancelButton>
         <a.InfoArea>
           Custom info area
         </a.InfoArea>

--- a/packages/boxel/tests/integration/components/boxel/action-chin-test.js
+++ b/packages/boxel/tests/integration/components/boxel/action-chin-test.js
@@ -27,10 +27,11 @@ module('Integration | Component | ActionChin', function (hooks) {
   const infoAreaText = 'infoAreaText';
   const mainActionAreaText = 'mainActionAreaText';
 
-  test('it accepts and renders the default block with the ActionButton, ActionStatusArea, and InfoArea components', async function (assert) {
+  test('it accepts and renders the default block with the ActionButton, CancelButton, ActionStatusArea, and InfoArea components', async function (assert) {
     this.setProperties({
       state: 'default',
       mainActionButtonText,
+      cancelActionButtonText,
       mainActionAreaText,
       infoAreaText,
     });
@@ -42,12 +43,18 @@ module('Integration | Component | ActionChin', function (hooks) {
         <a.ActionButton>
           {{this.mainActionButtonText}}
         </a.ActionButton>
+
+        <a.CancelButton>
+          {{this.cancelActionButtonText}}
+        </a.CancelButton>
+
         <a.InfoArea>
           {{this.infoAreaText}}
         </a.InfoArea>
       </Boxel::ActionChin>
     `);
     assert.dom(MAIN_ACTION_BUTTON_SELECTOR).containsText(mainActionButtonText);
+    assert.dom(CANCEL_CTA).containsText(cancelActionButtonText);
     assert.dom(INFO_AREA_SELECTOR).containsText(infoAreaText);
     assert.dom(MAIN_ACTION_AREA_SELECTOR).doesNotExist();
 


### PR DESCRIPTION
Some ERP designs include a `CancelButton` in the `ActionChin` when the state is not `in-progress`, so this enables that. It can be seen [here](https://boxel.stack.cards/boxel/action-chin-cancel-4466/#/docs?s=Components&ss=%3CBoxel%3A%3AActionChin%3E) when the preview deployment is complete.