### PR TITLE
boxel: Add TabBar

### DIFF
--- a/packages/boxel/addon/components/boxel/tab-bar/index.css
+++ b/packages/boxel/addon/components/boxel/tab-bar/index.css
@@ -1,0 +1,48 @@
+.boxel-tab-bar {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  border-bottom: 1px solid var(--boxel-light-500);
+}
+
+.boxel-tab-bar__item:hover {
+  cursor: pointer;
+}
+
+.boxel-tab-bar__item--is-active {
+  font-weight: 600;
+  border-bottom: 2px solid var(--boxel-cyan);
+}
+
+/*
+  Column flex and ::after with data-text allow bold-on-hover without layout shift:
+  https://css-tricks.com/bold-on-hover-without-the-layout-shift/
+*/
+
+.boxel-tab-bar__item > a {
+  display: inline-flex;
+  flex-direction: column;
+  padding: var(--boxel-sp-xs) var(--boxel-sp-lg);
+}
+
+.boxel-tab-bar__item > a::after {
+  content: attr(data-text);
+  content: attr(data-text) / "";
+  height: 0;
+  visibility: hidden;
+  overflow: hidden;
+  user-select: hidden;
+  pointer-events: none;
+  font-weight: 600;
+}
+
+@media speech {
+  .boxel-tab-bar__item > a::after {
+    display: none;
+  }
+}
+
+.boxel-tab-bar__item > a:hover {
+  font-weight: 600;
+  color: inherit;
+}

--- a/packages/boxel/addon/components/boxel/tab-bar/index.hbs
+++ b/packages/boxel/addon/components/boxel/tab-bar/index.hbs
@@ -1,6 +1,6 @@
 <nav role="tablist" class={{cn "boxel-tab-bar" @class}} ...attributes>
-  {{#if @items}}
-    {{#each (compact @items) as |tab|}}
+  {{#if this.linkItems}}
+    {{#each this.linkItems as |tab|}}
       <div
         role="none"
         class={{cn
@@ -9,14 +9,14 @@
         }}
       >
         {{!-- template-lint-disable require-context-role --}}
-        <a
+        <LinkTo
+          @route={{tab.action.routeName}}
+          @query={{or tab.action.queryParams (hash)}}
           role="tab"
-          href={{tab.action.url}}
           data-text={{tab.text}}
-          {{on "click" (fn this.invokeMenuItemAction tab.action)}}
         >
           {{tab.text}}
-        </a>
+        </LinkTo>
       </div>
     {{/each}}
   {{/if}}

--- a/packages/boxel/addon/components/boxel/tab-bar/index.hbs
+++ b/packages/boxel/addon/components/boxel/tab-bar/index.hbs
@@ -1,0 +1,23 @@
+<nav role="tablist" class={{cn "boxel-tab-bar" @class}} ...attributes>
+  {{#if @items}}
+    {{#each (compact @items) as |tab|}}
+      <div
+        role="none"
+        class={{cn
+          "boxel-tab-bar__item"
+          boxel-tab-bar__item--is-active=tab.action.isActive
+        }}
+      >
+        {{!-- template-lint-disable require-context-role --}}
+        <a
+          role="tab"
+          href="#"
+          data-text={{tab.text}}
+          {{on "click" (fn this.invokeMenuItemAction tab.action)}}
+        >
+          {{tab.text}}
+        </a>
+      </div>
+    {{/each}}
+  {{/if}}
+</nav>

--- a/packages/boxel/addon/components/boxel/tab-bar/index.hbs
+++ b/packages/boxel/addon/components/boxel/tab-bar/index.hbs
@@ -11,7 +11,7 @@
         {{!-- template-lint-disable require-context-role --}}
         <a
           role="tab"
-          href="#"
+          href={{tab.action.url}}
           data-text={{tab.text}}
           {{on "click" (fn this.invokeMenuItemAction tab.action)}}
         >

--- a/packages/boxel/addon/components/boxel/tab-bar/index.ts
+++ b/packages/boxel/addon/components/boxel/tab-bar/index.ts
@@ -1,16 +1,15 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
 import { Link } from 'ember-link';
+import { MenuItem } from '@cardstack/boxel/helpers/menu-item';
 import '@cardstack/boxel/styles/global.css';
 import './index.css';
 
-export default class TabBar extends Component {
-  invokeMenuItemAction(actionOrLink: () => never, e: Event): void;
-  invokeMenuItemAction(actionOrLink: Link, e: Event): void;
-  @action invokeMenuItemAction(actionOrLink: unknown, e: Event): void {
-    if (!(actionOrLink instanceof Link)) {
-      e.preventDefault();
-      (actionOrLink as () => never)();
-    }
+interface TabBarArgs {
+  items: MenuItem[];
+}
+
+export default class TabBar extends Component<TabBarArgs> {
+  get linkItems() {
+    return this.args.items.filter((item) => item.action instanceof Link);
   }
 }

--- a/packages/boxel/addon/components/boxel/tab-bar/index.ts
+++ b/packages/boxel/addon/components/boxel/tab-bar/index.ts
@@ -8,10 +8,8 @@ export default class TabBar extends Component {
   invokeMenuItemAction(actionOrLink: () => never, e: Event): void;
   invokeMenuItemAction(actionOrLink: Link, e: Event): void;
   @action invokeMenuItemAction(actionOrLink: unknown, e: Event): void {
-    e.preventDefault();
-    if (actionOrLink instanceof Link && actionOrLink.transitionTo) {
-      actionOrLink.transitionTo();
-    } else {
+    if (!(actionOrLink instanceof Link)) {
+      e.preventDefault();
       (actionOrLink as () => never)();
     }
   }

--- a/packages/boxel/addon/components/boxel/tab-bar/index.ts
+++ b/packages/boxel/addon/components/boxel/tab-bar/index.ts
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { Link } from 'ember-link';
+import '@cardstack/boxel/styles/global.css';
+import './index.css';
+
+export default class TabBar extends Component {
+  invokeMenuItemAction(actionOrLink: () => never, e: Event): void;
+  invokeMenuItemAction(actionOrLink: Link, e: Event): void;
+  @action invokeMenuItemAction(actionOrLink: unknown, e: Event): void {
+    e.preventDefault();
+    if (actionOrLink instanceof Link && actionOrLink.transitionTo) {
+      actionOrLink.transitionTo();
+    } else {
+      (actionOrLink as () => never)();
+    }
+  }
+}

--- a/packages/boxel/addon/components/boxel/tab-bar/usage.hbs
+++ b/packages/boxel/addon/components/boxel/tab-bar/usage.hbs
@@ -1,0 +1,17 @@
+<Freestyle::Usage @name="TabBar">
+  <:example>
+    <Boxel::TabBar
+      @items={{array
+        (menu-item "Docs" (link route="docs" query=(hash s="Components" ss="<Boxel::TabBar>")))
+        (menu-item "About" (link route="about"))
+        (menu-item "Log" (fn this.log "Log menu item clicked"))
+      }}
+    />
+  </:example>
+  <:api as |Args|>
+    <Args.Object
+      @name="items"
+      @description="An array of MenuItems, created using the `menu-item` helper. The menu-item helper accepts the menu item text as its first argument, and an action or link (as created using ember-link) as the second argument."
+    />
+  </:api>
+</Freestyle::Usage>

--- a/packages/boxel/addon/components/boxel/tab-bar/usage.hbs
+++ b/packages/boxel/addon/components/boxel/tab-bar/usage.hbs
@@ -2,16 +2,16 @@
   <:example>
     <Boxel::TabBar
       @items={{array
+        (menu-item "Home" (link route="index"))
         (menu-item "Docs" (link route="docs" query=(hash s="Components" ss="<Boxel::TabBar>")))
         (menu-item "About" (link route="about"))
-        (menu-item "Log" (fn this.log "Log menu item clicked"))
       }}
     />
   </:example>
   <:api as |Args|>
     <Args.Object
       @name="items"
-      @description="An array of MenuItems, created using the `menu-item` helper. The menu-item helper accepts the menu item text as its first argument, and an action or link (as created using ember-link) as the second argument."
+      @description="An array of link MenuItems, created using the `menu-item` helper. The menu-item helper accepts the menu item text as its first argument, and a link (as created using ember-link) as the second argument."
     />
   </:api>
 </Freestyle::Usage>

--- a/packages/boxel/addon/components/boxel/tab-bar/usage.ts
+++ b/packages/boxel/addon/components/boxel/tab-bar/usage.ts
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class TabBarComponent extends Component {
+  @action log(message: string): void {
+    // eslint-disable-next-line no-console
+    console.log(message);
+  }
+}

--- a/packages/boxel/addon/helpers/menu-item.ts
+++ b/packages/boxel/addon/helpers/menu-item.ts
@@ -15,7 +15,7 @@ interface MenuItemOptions {
   header: boolean;
   icon: string;
 }
-class MenuItem {
+export class MenuItem {
   text: string;
   type: string;
   dangerous: boolean;


### PR DESCRIPTION
The issue called for the interface to include `@selectedItem` and `@onClickItem` but since this is so menu-like I chose to follow the pattern of `Boxel::Menu`, which takes a list of `(menu-item)` as `@items`. Then the items have their actions specified alongside them, or can use `(link)`, which is likely the most common usage. `ember-link` supplies the `isActive` property for `(link)`, which is used for CSS styling.

Though the design didn’t specify any hover behaviour, it seemed sensible to me to make the text bold. This includes an [approach from CSS-Tricks](https://css-tricks.com/bold-on-hover-without-the-layout-shift/) that lets the bolding not cause the following items to shift; without it, it would look like this:

![bold-on-hover-shift](https://user-images.githubusercontent.com/43280/187977403-28f055b4-fa11-4abc-8696-1cebe68ca336.gif)

One possible avenue for improvement is that the links are currently `href="#"`, which means they can’t be copied or opened in a new tab. The current implementation supports arbitrary actions in the items, but if they were all `(link)`, they would act as expected. Is this the way to go? 🤔

