### PR TITLE
Add setup account cli command 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,53 +7,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Run server",
-      "program": "${workspaceRoot}/packages/hub/dist/hub.js",
-      "cwd": "${workspaceRoot}/packages/hub",
-      "console": "integratedTerminal",
-      "args": ["serve"]
-    },
-    {
-      "name": "Ember test browser",
-      "type": "chrome",
-      "request": "launch",
-      "url": "http://localhost:7357",
-      "webRoot": "${workspaceFolder}/packages/data/tests/dummy"
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Hub Node tests",
-      "program": "${workspaceRoot}/node_modules/.bin/_mocha",
-      "cwd": "${workspaceRoot}/packages/hub",
-      "console": "integratedTerminal",
-      "env": {
-        "NODE_ENV": "test"
-      },
-      "args": ["-r", "@cardstack/test-support/prepare-node-tests", "node-tests/**/*-test.js", "--timeout", "600000"]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Run cardpay bot",
-      "program": "${workspaceRoot}/packages/hub/dist/hub.js",
-      "cwd": "${workspaceRoot}/packages/hub",
-      "console": "integratedTerminal",
-      "args": ["bot"]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Bot tests",
-      "program": "${workspaceRoot}/packages/hub/bin/corde",
-      "cwd": "${workspaceRoot}/packages/hub",
-      "console": "integratedTerminal",
-      "args": ["--files", "./bot-tests/services/discord-bots/hub-bot/**/*.ts"]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Build web-client",
+      "name": "Web Client: Build web-client",
       "program": "${workspaceFolder}/node_modules/.bin/ember",
       "cwd": "${workspaceRoot}/packages/web-client",
       "args": ["b"],
@@ -65,7 +19,46 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Hub Auth",
+      "name": "Hub: Run server",
+      "program": "${workspaceRoot}/packages/hub/dist/hub.js",
+      "cwd": "${workspaceRoot}/packages/hub",
+      "console": "integratedTerminal",
+      "args": ["serve"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Hub: Hub Node tests",
+      "program": "${workspaceRoot}/node_modules/.bin/_mocha",
+      "cwd": "${workspaceRoot}/packages/hub",
+      "console": "integratedTerminal",
+      "env": {
+        "NODE_ENV": "test"
+      },
+      "args": ["-r", "@cardstack/test-support/prepare-node-tests", "node-tests/**/*-test.js", "--timeout", "600000"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Hub: Run cardpay bot",
+      "program": "${workspaceRoot}/packages/hub/dist/hub.js",
+      "cwd": "${workspaceRoot}/packages/hub",
+      "console": "integratedTerminal",
+      "args": ["bot"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Hub: Bot tests",
+      "program": "${workspaceRoot}/packages/hub/bin/corde",
+      "cwd": "${workspaceRoot}/packages/hub",
+      "console": "integratedTerminal",
+      "args": ["--files", "./bot-tests/services/discord-bots/hub-bot/**/*.ts"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Hub: Hub Auth",
       "program": "${workspaceFolder}/packages/cardpay-cli/cardpay.js",
       "console": "integratedTerminal",
       "env": {},
@@ -83,7 +76,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Bridge to Layer 1",
+      "name": "Bridge: Bridge to Layer 1",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
       "console": "integratedTerminal",
@@ -105,7 +98,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Bridge to Layer 2",
+      "name": "Bridge: Bridge to Layer 2",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
       "console": "integratedTerminal",
@@ -126,7 +119,7 @@
         "index.ts",
         "bridge",
         "to-l2",
-        "5000",
+        "100",
         "${config:cardCli.network.l1.daiToken}", // Kovan DAI
         "--network",
         "${config:cardCli.network.l1.name}",
@@ -137,7 +130,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Wait for Bridge to Layer 2",
+      "name": "Bridge: Wait for Bridge to Layer 2",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
       "console": "integratedTerminal",
@@ -157,7 +150,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Wait for Bridge Validators",
+      "name": "Bridge: Wait for Bridge Validators",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
       "console": "integratedTerminal",
@@ -177,7 +170,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Get Withdrawal Limits",
+      "name": "Bridge: Get Withdrawal Limits",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
       "console": "integratedTerminal",
@@ -196,7 +189,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Claim Layer 1 Tokens",
+      "name": "Bridge: Claim Layer 1 Tokens",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
       "console": "integratedTerminal",
@@ -219,7 +212,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: View Safes",
+      "name": "Safe: View Safes",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
       "cwd": "${workspaceRoot}/packages/cardpay-cli",
@@ -237,7 +230,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: View Safe",
+      "name": "Safe: View Safe",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -256,7 +249,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Transfer Tokens from Safe",
+      "name": "Safe: Transfer Tokens from Safe",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -279,7 +272,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Gas Estimate for Transfer Tokens from Safe",
+      "name": "Safe: Gas Estimate for Transfer Tokens from Safe",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -301,18 +294,36 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Create Prepaid Card",
+      "name": "Price: USD Price",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
       "env": {},
       "args": [
         "index.ts",
-        "prepaid-card",
-        "create",
-        "0x00F0FBDEEa1cDEc029Ba6025ca726Fdcf43E9025", // Hassan's depot safe feel free to use your own
-        "${config:cardCli.network.l2.daiToken}",
-        "",
+        "price",
+        "usd",
+        "DAI",
+        "5",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Price: ETH Price",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "price",
+        "eth",
+        "DAI",
         "100",
         "--network",
         "${config:cardCli.network.l2.name}",
@@ -323,7 +334,48 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Split Prepaid Card Equally",
+      "name": "Price: Oracle Update Time",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "price",
+        "updated-at",
+        "DAI",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Prepaid Card: Create Prepaid Card",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "prepaid-card",
+        "create",
+        "0xF69508b8fb878EAad06923314BD655Cc0Fe9E8E3",
+        "${config:cardCli.network.l2.daiToken}",
+        "",
+        "10000",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Prepaid Card: Split Prepaid Card Equally",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -344,7 +396,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Split Prepaid Card",
+      "name": "Prepaid Card: Split Prepaid Card",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -366,7 +418,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Transfer Prepaid Card",
+      "name": "Prepaid Card: Transfer Prepaid Card",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -386,7 +438,85 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Provision Prepaid Card",
+      "name": "Prepaid Card: Payment Limits",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "prepaid-card",
+        "payment-limits",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Prepaid Card: Pay Merchant",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "prepaid-card",
+        "pay-merchant",
+        "0x08a4F4fB9938940FA49A4F7dC43B2fb2cd5B3b87", // safe for Hassan's merchant (whose address the correlates with the mnemenoic 0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13)
+        "0x22d0ea6Ba8842Ae1355F842a9fAc32F035F18Ca6", // Hassan's prepaid card --feel free to use your own
+        "50",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Prepaid Card: Price for face value",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "prepaid-card",
+        "price-for-face-value",
+        "${config:cardCli.network.l2.daiToken}", // DAI.CPXD
+        "10000",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Prepaid Card: New prepaid card gas fee",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "prepaid-card",
+        "creation-gas-fee",
+        "${config:cardCli.network.l2.daiToken}", // DAI.CPXD
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Market V1: Provision Prepaid Card",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -408,66 +538,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Register New Merchant",
-      "cwd": "${workspaceFolder}/packages/cardpay-cli",
-      "console": "integratedTerminal",
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
-      "env": {},
-      "args": [
-        "index.ts",
-        "merchant",
-        "register",
-        "0xb51C321b30a173Fd160Ddc21DEa46f91a75E24a4", // Hassan's prepaid card --feel free to use your own
-        "test-did",
-        "--network",
-        "${config:cardCli.network.l2.name}",
-        "--mnemonic",
-        "${config:cardCli.mnemonic}"
-      ]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Cardpay testnet: Payment Limits",
-      "cwd": "${workspaceFolder}/packages/cardpay-cli",
-      "console": "integratedTerminal",
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
-      "env": {},
-      "args": [
-        "index.ts",
-        "prepaid-card",
-        "payment-limits",
-        "--network",
-        "${config:cardCli.network.l2.name}",
-        "--mnemonic",
-        "${config:cardCli.mnemonic}"
-      ]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Cardpay testnet: Pay Merchant",
-      "cwd": "${workspaceFolder}/packages/cardpay-cli",
-      "console": "integratedTerminal",
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
-      "env": {},
-      "args": [
-        "index.ts",
-        "prepaid-card",
-        "pay-merchant",
-        "0x08a4F4fB9938940FA49A4F7dC43B2fb2cd5B3b87", // safe for Hassan's merchant (whose address the correlates with the mnemenoic 0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13)
-        "0x22d0ea6Ba8842Ae1355F842a9fAc32F035F18Ca6", // Hassan's prepaid card --feel free to use your own
-        "50",
-        "--network",
-        "${config:cardCli.network.l2.name}",
-        "--mnemonic",
-        "${config:cardCli.mnemonic}"
-      ]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Cardpay testnet: SKU Info",
+      "name": "Market V1: SKU Info",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -476,7 +547,7 @@
         "index.ts",
         "prepaid-card-market",
         "sku-info",
-        "0x7ac394019c3259d7164796fadfcdca28d48cff380444e581c593d6b15f5f148e", // sku
+        "0x1ddfc20c2c74282ddc8dcaf60d5fecf60f15588bb697e99c7bb1e8acf3560d71",
         "--network",
         "${config:cardCli.network.l2.name}",
         "--mnemonic",
@@ -486,7 +557,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Prepaid Card Inventory",
+      "name": "Market V1: Prepaid Card Inventory",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -505,7 +576,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Prepaid Card Inventories",
+      "name": "Market V1: Prepaid Card Inventories",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -524,7 +595,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Add Prepaid Card Inventory",
+      "name": "Market V1: Add Prepaid Card Inventory",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -544,7 +615,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Remove Prepaid Card Inventory",
+      "name": "Market V1: Remove Prepaid Card Inventory",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -564,7 +635,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Set Prepaid Card Ask",
+      "name": "Market V1: Set Prepaid Card Ask",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -585,7 +656,139 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: View Merchant Revenue",
+      "name": "Market V2: Add Tokens",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "prepaid-card-market-v-2",
+        "add-tokens",
+        "0xF69508b8fb878EAad06923314BD655Cc0Fe9E8E3",
+        "0x159ADe032073d930E85f95AbBAB9995110c43C71",
+        "${config:cardCli.network.l2.daiToken}",
+        "100",
+        "did:cardstack:1p114hzxLcyL3aoScNE45FJC8ae64884286d7df6",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Market V2: Recover Tokens",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "prepaid-card-market-v-2",
+        "add-tokens",
+        "0xF69508b8fb878EAad06923314BD655Cc0Fe9E8E3",
+        "0x159ADe032073d930E85f95AbBAB9995110c43C71",
+        "${config:cardCli.network.l2.daiToken}",
+        "100",
+        "did:cardstack:1p114hzxLcyL3aoScNE45FJC8ae64884286d7df6",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Market V2: Add SKU",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "prepaid-card-market-v-2",
+        "add-sku",
+        "0x41866a4eDcb4Ce2108C36a2c29a3b4Ab9fCe86e1",
+        "0xF69508b8fb878EAad06923314BD655Cc0Fe9E8E3",
+        "1000",
+        "did:cardstack:1p114hzxLcyL3aoScNE45FJC8ae64884286d7df6",
+        "${config:cardCli.network.l2.daiToken}",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Market V2: Get SKU",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "prepaid-card-market-v-2",
+        "get-sku",
+        "0x159ade032073d930e85f95abbab9995110c43c71",
+        "${config:cardCli.network.l2.daiToken}",
+        "1000",
+        "did:cardstack:1p114hzxLcyL3aoScNE45FJC8ae64884286d7df6",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Market V2: Set Ask",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "prepaid-card-market-v-2",
+        "set-ask",
+        "0x41866a4eDcb4Ce2108C36a2c29a3b4Ab9fCe86e1",
+        "0xbdd9b9de628f3c2ddf330021facbb43aeef0c8926c068f22800b2dd26c8eb377",
+        "1",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Merchant: Register New Merchant",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "merchant",
+        "register",
+        "0xb51C321b30a173Fd160Ddc21DEa46f91a75E24a4", // Hassan's prepaid card --feel free to use your own
+        "test-did",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Merchant: View Revenue Balances",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -604,7 +807,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Claim Merchant Revenue",
+      "name": "Merchant: Claim Revenue",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -625,7 +828,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Claim Merchant Revenue Gas Estimate",
+      "name": "Merchant: Claim Revenue Gas Estimate",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -646,105 +849,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Price for face value",
-      "cwd": "${workspaceFolder}/packages/cardpay-cli",
-      "console": "integratedTerminal",
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
-      "env": {},
-      "args": [
-        "index.ts",
-        "prepaid-card",
-        "price-for-face-value",
-        "${config:cardCli.network.l2.daiToken}", // DAI.CPXD
-        "10000",
-        "--network",
-        "${config:cardCli.network.l2.name}",
-        "--mnemonic",
-        "${config:cardCli.mnemonic}"
-      ]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Cardpay testnet: New prepaid card gas fee",
-      "cwd": "${workspaceFolder}/packages/cardpay-cli",
-      "console": "integratedTerminal",
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
-      "env": {},
-      "args": [
-        "index.ts",
-        "prepaid-card",
-        "creation-gas-fee",
-        "${config:cardCli.network.l2.daiToken}", // DAI.CPXD
-        "--network",
-        "${config:cardCli.network.l2.name}",
-        "--mnemonic",
-        "${config:cardCli.mnemonic}"
-      ]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Cardpay testnet: USD Price",
-      "cwd": "${workspaceFolder}/packages/cardpay-cli",
-      "console": "integratedTerminal",
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
-      "env": {},
-      "args": [
-        "index.ts",
-        "price",
-        "usd",
-        "DAI",
-        "5",
-        "--network",
-        "${config:cardCli.network.l2.name}",
-        "--mnemonic",
-        "${config:cardCli.mnemonic}"
-      ]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Cardpay testnet: ETH Price",
-      "cwd": "${workspaceFolder}/packages/cardpay-cli",
-      "console": "integratedTerminal",
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
-      "env": {},
-      "args": [
-        "index.ts",
-        "price",
-        "eth",
-        "DAI",
-        "100",
-        "--network",
-        "${config:cardCli.network.l2.name}",
-        "--mnemonic",
-        "${config:cardCli.mnemonic}"
-      ]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Cardpay testnet: Oracle Update Time",
-      "cwd": "${workspaceFolder}/packages/cardpay-cli",
-      "console": "integratedTerminal",
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
-      "env": {},
-      "args": [
-        "index.ts",
-        "price",
-        "updated-at",
-        "DAI",
-        "--network",
-        "${config:cardCli.network.l2.name}",
-        "--mnemonic",
-        "${config:cardCli.mnemonic}"
-      ]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Cardpay testnet: View Reward Balances",
+      "name": "Rewards: View Reward Balances",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -765,7 +870,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Register Reward Program",
+      "name": "Rewards: Register Reward Program",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -786,7 +891,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Register Rewardee",
+      "name": "Rewards: Register Rewardee",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -806,7 +911,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Register Rewardee Gas Estimate",
+      "name": "Rewards: Register Rewardee Gas Estimate",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -826,7 +931,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Add Reward Tokens",
+      "name": "Rewards: Add Reward Tokens",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -849,7 +954,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Get Reward Pool Balance",
+      "name": "Rewards: Get Reward Pool Balance",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -868,7 +973,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Claim Reward",
+      "name": "Rewards: Claim Reward",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -889,7 +994,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Claim Rewards Gas Estimate",
+      "name": "Rewards: Claim Rewards Gas Estimate",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -910,7 +1015,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Claim ALL Rewards",
+      "name": "Rewards: Claim ALL Rewards",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -929,7 +1034,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Claim ALL Rewards Gas Estimate",
+      "name": "Rewards: Claim ALL Rewards Gas Estimate",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -949,7 +1054,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Check Rewards Claim Params",
+      "name": "Rewards: Check Rewards Claim Params",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -970,7 +1075,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Get Claimable Reward Proofs",
+      "name": "Rewards: Get Claimable Reward Proofs",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
       "cwd": "${workspaceRoot}/packages/cardpay-cli",
@@ -989,7 +1094,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Lock Reward Program",
+      "name": "Rewards: Lock Reward Program",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -1010,7 +1115,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Set Reward Program Admin",
+      "name": "Rewards: Set Reward Program Admin",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -1032,7 +1137,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Withdraw From Reward Safe",
+      "name": "Rewards: Withdraw From Reward Safe",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -1055,7 +1160,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Withdraw From Reward Safe Gas Estimate",
+      "name": "Rewards: Withdraw From Reward Safe Gas Estimate",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -1077,7 +1182,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Transfer Reward Safe",
+      "name": "Rewards: Transfer Reward Safe",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -1097,7 +1202,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Recover Reward Tokens",
+      "name": "Rewards: Recover Reward Tokens",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -1121,7 +1226,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: View Reward Program",
+      "name": "Rewards: View Reward Program",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -1140,7 +1245,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: View Reward Programs",
+      "name": "Rewards: View Reward Programs",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -1150,7 +1255,8 @@
         "rewards",
         "list",
         "--network",
-        "${config:cardCli.network.l2.name}",
+        "gnosis",
+        // "${config:cardCli.network.l2.name}",
         "--mnemonic",
         "${config:cardCli.mnemonic}"
       ]
@@ -1158,7 +1264,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Add Reward Rule",
+      "name": "Rewards: Add Reward Rule",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -1179,7 +1285,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Resolve DID",
+      "name": "DID Resolver: Resolve DID",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -1198,7 +1304,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Resolve DID alsoKnownAs",
+      "name": "DID Resolver: Resolve DID alsoKnownAs",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -1217,7 +1323,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Encode DID",
+      "name": "DID Resolver: Encode DID",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
@@ -1238,119 +1344,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Cardpay testnet: Add Tokens",
-      "cwd": "${workspaceFolder}/packages/cardpay-cli",
-      "console": "integratedTerminal",
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
-      "env": {},
-      "args": [
-        "index.ts",
-        "prepaid-card-market-v-2",
-        "add-tokens",
-        "0xF69508b8fb878EAad06923314BD655Cc0Fe9E8E3",
-        "0x159ADe032073d930E85f95AbBAB9995110c43C71",
-        "${config:cardCli.network.l2.daiToken}",
-        "100",
-        "did:cardstack:1p114hzxLcyL3aoScNE45FJC8ae64884286d7df6",
-        "--network",
-        "${config:cardCli.network.l2.name}",
-        "--mnemonic",
-        "${config:cardCli.mnemonic}"
-      ]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Cardpay testnet: Recover Tokens",
-      "cwd": "${workspaceFolder}/packages/cardpay-cli",
-      "console": "integratedTerminal",
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
-      "env": {},
-      "args": [
-        "index.ts",
-        "prepaid-card-market-v-2",
-        "add-tokens",
-        "0xF69508b8fb878EAad06923314BD655Cc0Fe9E8E3",
-        "0x159ADe032073d930E85f95AbBAB9995110c43C71",
-        "${config:cardCli.network.l2.daiToken}",
-        "100",
-        "did:cardstack:1p114hzxLcyL3aoScNE45FJC8ae64884286d7df6",
-        "--network",
-        "${config:cardCli.network.l2.name}",
-        "--mnemonic",
-        "${config:cardCli.mnemonic}"
-      ]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Cardpay testnet: Add SKU",
-      "cwd": "${workspaceFolder}/packages/cardpay-cli",
-      "console": "integratedTerminal",
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
-      "env": {},
-      "args": [
-        "index.ts",
-        "prepaid-card-market-v-2",
-        "add-sku",
-        "0x41866a4eDcb4Ce2108C36a2c29a3b4Ab9fCe86e1",
-        "0xF69508b8fb878EAad06923314BD655Cc0Fe9E8E3",
-        "1000",
-        "did:cardstack:1p114hzxLcyL3aoScNE45FJC8ae64884286d7df6",
-        "${config:cardCli.network.l2.daiToken}",
-        "--network",
-        "${config:cardCli.network.l2.name}",
-        "--mnemonic",
-        "${config:cardCli.mnemonic}"
-      ]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Cardpay testnet: Get SKU",
-      "cwd": "${workspaceFolder}/packages/cardpay-cli",
-      "console": "integratedTerminal",
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
-      "env": {},
-      "args": [
-        "index.ts",
-        "prepaid-card-market-v-2",
-        "get-sku",
-        "0x159ade032073d930e85f95abbab9995110c43c71",
-        "${config:cardCli.network.l2.daiToken}",
-        "1000",
-        "did:cardstack:1p114hzxLcyL3aoScNE45FJC8ae64884286d7df6",
-        "--network",
-        "${config:cardCli.network.l2.name}",
-        "--mnemonic",
-        "${config:cardCli.mnemonic}"
-      ]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Cardpay testnet: Set Ask",
-      "cwd": "${workspaceFolder}/packages/cardpay-cli",
-      "console": "integratedTerminal",
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
-      "env": {},
-      "args": [
-        "index.ts",
-        "prepaid-card-market-v-2",
-        "set-ask",
-        "0x41866a4eDcb4Ce2108C36a2c29a3b4Ab9fCe86e1",
-        "0xbdd9b9de628f3c2ddf330021facbb43aeef0c8926c068f22800b2dd26c8eb377",
-        "1",
-        "--network",
-        "${config:cardCli.network.l2.name}",
-        "--mnemonic",
-        "${config:cardCli.mnemonic}"
-      ]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Cardpay testnet: Create account",
+      "name": "Testing: Create account",
       "cwd": "${workspaceFolder}/packages/cardpay-cli",
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1355,18 +1355,17 @@
       "console": "integratedTerminal",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
       "env": {
-        "PROVISIONER_SECRET": "xxxx"
-
       },
       "args": [
         "index.ts",
         "testing",
         "create-account",
-        "true", //create prepaid card
-        "true", //create merchant, profile
-        "true", //create reward safe
+        "false", //create prepaid card
+        "false", //create merchant, profile
+        "false", //create reward safe
+        "true", //create depot safe 
         "--network",
-        "${config:cardCli.network.l2.name}",
+        "${config:cardCli.network.l1.name}",
         "--mnemonic",
         "${config:cardCli.mnemonic}"
       ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1234,6 +1234,142 @@
         "--mnemonic",
         "${config:cardCli.mnemonic}"
       ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Cardpay testnet: Add Tokens",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "prepaid-card-market-v-2",
+        "add-tokens",
+        "0xF69508b8fb878EAad06923314BD655Cc0Fe9E8E3",
+        "0x159ADe032073d930E85f95AbBAB9995110c43C71",
+        "${config:cardCli.network.l2.daiToken}",
+        "100",
+        "did:cardstack:1p114hzxLcyL3aoScNE45FJC8ae64884286d7df6",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Cardpay testnet: Recover Tokens",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "prepaid-card-market-v-2",
+        "add-tokens",
+        "0xF69508b8fb878EAad06923314BD655Cc0Fe9E8E3",
+        "0x159ADe032073d930E85f95AbBAB9995110c43C71",
+        "${config:cardCli.network.l2.daiToken}",
+        "100",
+        "did:cardstack:1p114hzxLcyL3aoScNE45FJC8ae64884286d7df6",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Cardpay testnet: Add SKU",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "prepaid-card-market-v-2",
+        "add-sku",
+        "0x41866a4eDcb4Ce2108C36a2c29a3b4Ab9fCe86e1",
+        "0xF69508b8fb878EAad06923314BD655Cc0Fe9E8E3",
+        "1000",
+        "did:cardstack:1p114hzxLcyL3aoScNE45FJC8ae64884286d7df6",
+        "${config:cardCli.network.l2.daiToken}",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Cardpay testnet: Get SKU",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "prepaid-card-market-v-2",
+        "get-sku",
+        "0x159ade032073d930e85f95abbab9995110c43c71",
+        "${config:cardCli.network.l2.daiToken}",
+        "1000",
+        "did:cardstack:1p114hzxLcyL3aoScNE45FJC8ae64884286d7df6",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Cardpay testnet: Set Ask",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {},
+      "args": [
+        "index.ts",
+        "prepaid-card-market-v-2",
+        "set-ask",
+        "0x41866a4eDcb4Ce2108C36a2c29a3b4Ab9fCe86e1",
+        "0xbdd9b9de628f3c2ddf330021facbb43aeef0c8926c068f22800b2dd26c8eb377",
+        "1",
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Cardpay testnet: Create account",
+      "cwd": "${workspaceFolder}/packages/cardpay-cli",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "env": {
+        "PROVISIONER_SECRET": "xxxx"
+
+      },
+      "args": [
+        "index.ts",
+        "testing",
+        "create-account",
+        "true", //create prepaid card
+        "true", //create merchant, profile
+        "true", //create reward safe
+        "--network",
+        "${config:cardCli.network.l2.name}",
+        "--mnemonic",
+        "${config:cardCli.mnemonic}"
+      ]
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1354,10 +1354,12 @@
         "index.ts",
         "testing",
         "create-account",
-        "false", //create prepaid card
-        "false", //create merchant, profile
-        "false", //create reward safe
+        "true", //create prepaid card
+        "true", //create merchant, profile
+        "true", //create reward safe
         "true", //create depot safe 
+        "--bridgeTokenAddress",
+        "${config:cardCli.network.l1.cardToken}",
         "--network",
         "${config:cardCli.network.l1.name}",
         "--mnemonic",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
 // Justin's testing mnemonic for address 0x388CFef0AB326AEEB4167bab20c189ECab686370
 // "merge husband can canyon custom excite glide aerobic absorb stereo fancy anger",
   "cardCli": {
-    "mnemonic": "fortune reduce accuse famous fetch waste debate alcohol notice salmon wish okay",
+    "mnemonic": "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream",
     "network": {
       "l1": {
         "name": "kovan",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,12 +7,10 @@
 // "ribbon nerve ordinary they relief device flame resemble faculty car alarm caught"
 // Justin's testing mnemonic for address 0x159ADe032073d930E85f95AbBAB9995110c43C71
 // "fortune reduce accuse famous fetch waste debate alcohol notice salmon wish okay",
-// Justin's testing mnemonic for address 0x159ADe032073d930E85f95AbBAB9995110c43C71
-// "fortune reduce accuse famous fetch waste debate alcohol notice salmon wish okay",
 // Justin's testing mnemonic for address 0x388CFef0AB326AEEB4167bab20c189ECab686370
 // "merge husband can canyon custom excite glide aerobic absorb stereo fancy anger",
   "cardCli": {
-    "mnemonic": "pizza monitor radio able holiday boil beyond kingdom throw evil limb dream",
+    "mnemonic": "fortune reduce accuse famous fetch waste debate alcohol notice salmon wish okay",
     "network": {
       "l1": {
         "name": "kovan",

--- a/packages/cardpay-cli/README.md
+++ b/packages/cardpay-cli/README.md
@@ -93,7 +93,7 @@ yarn cardpay safe list --walletConnect
  - [`cardpay rewards list`](#cardpay-rewards-list)
  - [`cardpay rewards pool-balances <rewardProgramId>`](#cardpay-rewards-pool-balances-rewardprogramid)
  - [`cardpay rewards register <prepaidCard> <rewardProgramId>`](#cardpay-rewards-register-prepaidcard-rewardprogramid)
- - [`cardpay rewards reward-balances <address>`](#cardpay-rewards-reward-balances-address)
+ - [`cardpay rewards reward-balances <address> [safeAddress] [rewardProgramId]`](#cardpay-rewards-reward-balances-address-safeaddress-rewardprogramid)
  - [`cardpay rewards transfer-safe <rewardSafe> <newOwner>`](#cardpay-rewards-transfer-safe-rewardsafe-newowner)
  - [`cardpay rewards withdraw-from-safe <rewardSafe> <recipient> <tokenAddress> [amount]`](#cardpay-rewards-withdraw-from-safe-rewardsafe-recipient-tokenaddress-amount)
  - [`cardpay rewards view <rewardProgramId>`](#cardpay-rewards-view-rewardprogramid)
@@ -101,13 +101,15 @@ yarn cardpay safe list --walletConnect
  - [`cardpay rewards claim-reward-gas-estimate <rewardSafe> <leaf> <proof> [acceptPartialClaim]`](#cardpay-rewards-claim-reward-gas-estimate-rewardsafe-leaf-proof-acceptpartialclaim)
  - [`cardpay rewards withdraw-gas-estimate <rewardSafe> <recipient> <tokenAddress> <amount>`](#cardpay-rewards-withdraw-gas-estimate-rewardsafe-recipient-tokenaddress-amount)
  - [`cardpay rewards check-claim-params <rewardSafe> <leaf> <proof> [acceptPartialClaim]`](#cardpay-rewards-check-claim-params-rewardsafe-leaf-proof-acceptpartialclaim)
- - [`cardpay rewards claim-all <address> <rewardSafe> <rewardProgramId> <tokenAddress>`](#cardpay-rewards-claim-all-address-rewardsafe-rewardprogramid-tokenaddress)
- - [`cardpay rewards claim-all-rewards-gas-estimate <address> <rewardSafe> <rewardProgramId> <tokenAddress>`](#cardpay-rewards-claim-all-rewards-gas-estimate-address-rewardsafe-rewardprogramid-tokenaddress)
+ - [`cardpay rewards claim-all <rewardSafe> [rewardProgramId] [tokenAddress]`](#cardpay-rewards-claim-all-rewardsafe-rewardprogramid-tokenaddress)
+ - [`cardpay rewards claim-all-rewards-gas-estimate <rewardSafe> <tokenAddress> [rewardProgramId]`](#cardpay-rewards-claim-all-rewards-gas-estimate-rewardsafe-tokenaddress-rewardprogramid)
  - [`cardpay safe list [address] [safeType]`](#cardpay-safe-list-address-safetype)
  - [`cardpay safe transfer-tokens [safeAddress] [token] [recipient] [amount]`](#cardpay-safe-transfer-tokens-safeaddress-token-recipient-amount)
  - [`cardpay safe transfer-tokens-gas-estimate [safeAddress] [token] [recipient] [amount]`](#cardpay-safe-transfer-tokens-gas-estimate-safeaddress-token-recipient-amount)
  - [`cardpay safe view [safeAddress]`](#cardpay-safe-view-safeaddress)
  - [`cardpay safe debug-sign-typed-data [data] [address]`](#cardpay-safe-debug-sign-typed-data-data-address)
+ - [`cardpay testing create-account <createPrepaidCardSafe> <createMerchantSafe> <createRewardSafe> <createDepotSafe>`](#cardpay-testing-create-account-createprepaidcardsafe-createmerchantsafe-createrewardsafe-createdepotsafe)
+ - [`cardpay scheduled-payment enable-module <safeAddress> <gasTokenAddress>`](#cardpay-scheduled-payment-enable-module-safeaddress-gastokenaddress)
 
 
 ## `cardpay assets token-balance [tokenAddress]`
@@ -898,7 +900,7 @@ Options:
 
 ## `cardpay rewards claim <rewardSafe> <leaf> <proof> [acceptPartialClaim]`
 
-Claim rewards using proof
+Claim reward using proof
 
 ```
 Positionals:
@@ -982,7 +984,7 @@ Options:
   -n, --network         The Layer 2 network to run this script on  [string] [required] [choices: "sokol", "gnosis", "xdai"]
 ```
 
-## `cardpay rewards reward-balances <address>`
+## `cardpay rewards reward-balances <address> [safeAddress] [rewardProgramId]`
 
 View token balances of unclaimed rewards in the reward pool
 
@@ -995,6 +997,7 @@ Options:
   -t, --trezor           A flag to indicate that trezor should be used for the wallet  [boolean]
   -m, --mnemonic         Phrase for mnemonic wallet  [string]
   -e, --ethersMnemonic   Phrase for mnemonic wallet using ethers.js signer  [string]
+      --safeAddress      safe address. Specify if you want gas estimates for each claim  [string]
       --rewardProgramId  The reward program id.  [string]
   -n, --network          The Layer 2 network to run this script on  [string] [required] [choices: "sokol", "gnosis", "xdai"]
 ```
@@ -1126,32 +1129,12 @@ Options:
   -n, --network             The Layer 2 network to run this script on  [string] [required] [choices: "sokol", "gnosis", "xdai"]
 ```
 
-## `cardpay rewards claim-all <address> <rewardSafe> <rewardProgramId> <tokenAddress>`
+## `cardpay rewards claim-all <rewardSafe> [rewardProgramId] [tokenAddress]`
 
-claim all token rewards from a reward program
-
-```
-Positionals:
-  address          The address that tally rewarded -- The owner of prepaid card.  [string] [required]
-  rewardSafe       The address of the rewardSafe which will receive the rewards  [string] [required]
-  rewardProgramId  The reward program id.  [string] [required]
-  tokenAddress     The address of the tokens that are being claimed as rewards  [string] [required]
-
-Options:
-  -w, --walletConnect   A flag to indicate that wallet connect should be used for the wallet  [boolean]
-  -t, --trezor          A flag to indicate that trezor should be used for the wallet  [boolean]
-  -m, --mnemonic        Phrase for mnemonic wallet  [string]
-  -e, --ethersMnemonic  Phrase for mnemonic wallet using ethers.js signer  [string]
-  -n, --network         The Layer 2 network to run this script on  [string] [required] [choices: "sokol", "gnosis", "xdai"]
-```
-
-## `cardpay rewards claim-all-rewards-gas-estimate <address> <rewardSafe> <rewardProgramId> <tokenAddress>`
-
-Obtain a gas estimate to claim all rewards corresponding to a rewardProgrmaId and tokenAddress
+claim all token of rewardee
 
 ```
 Positionals:
-  address     The address that tally rewarded -- The owner of prepaid card.  [string] [required]
   rewardSafe  The address of the rewardSafe which will receive the rewards  [string] [required]
 
 Options:
@@ -1161,6 +1144,24 @@ Options:
   -e, --ethersMnemonic   Phrase for mnemonic wallet using ethers.js signer  [string]
       --rewardProgramId  The reward program id.  [string]
       --tokenAddress     The address of the tokens that are being claimed as rewards  [string]
+  -n, --network          The Layer 2 network to run this script on  [string] [required] [choices: "sokol", "gnosis", "xdai"]
+```
+
+## `cardpay rewards claim-all-rewards-gas-estimate <rewardSafe> <tokenAddress> [rewardProgramId]`
+
+Obtain a gas estimate to claim all rewards corresponding to a rewardProgrmaId and tokenAddress
+
+```
+Positionals:
+  rewardSafe    The address of the rewardSafe which will receive the rewards  [string] [required]
+  tokenAddress  The address of the tokens that are being claimed as rewards  [string] [required]
+
+Options:
+  -w, --walletConnect    A flag to indicate that wallet connect should be used for the wallet  [boolean]
+  -t, --trezor           A flag to indicate that trezor should be used for the wallet  [boolean]
+  -m, --mnemonic         Phrase for mnemonic wallet  [string]
+  -e, --ethersMnemonic   Phrase for mnemonic wallet using ethers.js signer  [string]
+      --rewardProgramId  The reward program id.  [string]
   -n, --network          The Layer 2 network to run this script on  [string] [required] [choices: "sokol", "gnosis", "xdai"]
 ```
 
@@ -1250,6 +1251,44 @@ Options:
   -m, --mnemonic        Phrase for mnemonic wallet  [string]
   -e, --ethersMnemonic  Phrase for mnemonic wallet using ethers.js signer  [string]
   -n, --network         The Layer 2 network to run this script on  [string] [required] [choices: "sokol", "gnosis", "xdai"]
+```
+
+## `cardpay testing create-account <createPrepaidCardSafe> <createMerchantSafe> <createRewardSafe> <createDepotSafe>`
+
+Create an account from scratch and sets up safes based of card pay protocol
+
+```
+Positionals:
+  createPrepaidCardSafe  create a prepaid card  [boolean] [required]
+  createMerchantSafe     create a merchant safe  [boolean] [required]
+  createRewardSafe       create a reward safe  [boolean] [required]
+  createDepotSafe        create a depot safe  [boolean] [required]
+
+Options:
+  -w, --walletConnect       A flag to indicate that wallet connect should be used for the wallet  [boolean]
+  -t, --trezor              A flag to indicate that trezor should be used for the wallet  [boolean]
+  -m, --mnemonic            Phrase for mnemonic wallet  [string]
+  -e, --ethersMnemonic      Phrase for mnemonic wallet using ethers.js signer  [string]
+      --bridgeTokenAmount   amount to bridge  [string]
+      --bridgeTokenAddress  l1 token address to bridge  [string]
+  -n, --network             The Layer 1 network to run this script on  [string] [required] [choices: "kovan", "mainnet"]
+```
+
+## `cardpay scheduled-payment enable-module <safeAddress> <gasTokenAddress>`
+
+Enable scheduled payment module on the safe
+
+```
+Positionals:
+  safeAddress      The address of the safe whose enables the scheduled payment module  [string] [required]
+  gasTokenAddress  The token address (defaults to Kovan DAI)  [string] [required]
+
+Options:
+  -w, --walletConnect   A flag to indicate that wallet connect should be used for the wallet  [boolean]
+  -t, --trezor          A flag to indicate that trezor should be used for the wallet  [boolean]
+  -m, --mnemonic        Phrase for mnemonic wallet  [string]
+  -e, --ethersMnemonic  Phrase for mnemonic wallet using ethers.js signer  [string]
+  -n, --network         The network to run this script on  [string] [required] [choices: "sokol", "kovan", "gnosis", "xdai", "mainnet"]
 ```
 
 <!-- END CLI DOCS GENERATED BY yarn command-docs -->

--- a/packages/cardpay-cli/commands.ts
+++ b/packages/cardpay-cli/commands.ts
@@ -9,6 +9,7 @@ import * as prepaidCardMarketV2 from './prepaid-card-market-v-2';
 import * as price from './price';
 import * as rewards from './rewards';
 import * as safe from './safe';
+import * as testing from './testing';
 
 export const commands: any = [
   assets,
@@ -22,4 +23,5 @@ export const commands: any = [
   price,
   rewards,
   safe,
+  testing,
 ];

--- a/packages/cardpay-cli/package.json
+++ b/packages/cardpay-cli/package.json
@@ -36,6 +36,7 @@
     "@types/lodash": "^4.14.168",
     "@types/semver": "^7.3.9",
     "@walletconnect/web3-provider": "^1.6.0",
+    "bip39": "^3.0.4",
     "did-resolver": "^3.1.0",
     "ethers": "5.6.4",
     "jsonapi-typescript": "^0.1.3",

--- a/packages/cardpay-cli/testing/create-account.ts
+++ b/packages/cardpay-cli/testing/create-account.ts
@@ -105,8 +105,8 @@ export default {
           web3OptsL1,
           networkL2,
           createdWeb3OptsL2,
-          bridgeTokenAmount,
-          bridgeTokenAddress
+          bridgeTokenAddress,
+          bridgeTokenAmount
         )
       : undefined;
 
@@ -224,8 +224,8 @@ const bridgeToken = async (
   web3OptsL1: Web3Opts,
   networkL2: string,
   web3OptsL2: Web3Opts,
-  amount: string | undefined,
-  bridgeTokenAddress: string | undefined
+  bridgeTokenAddress: string | undefined,
+  amount: string | undefined
 ) => {
   let { web3: web3L1 } = await getEthereumClients(networkL1, web3OptsL1);
   let { web3: web3L2 } = await getEthereumClients(networkL2, web3OptsL2);

--- a/packages/cardpay-cli/testing/create-account.ts
+++ b/packages/cardpay-cli/testing/create-account.ts
@@ -1,3 +1,4 @@
+/*global fetch */
 import { Argv } from 'yargs';
 import { getSDK, getConstant, getConstantByNetwork } from '@cardstack/cardpay-sdk';
 import { waitUntilOneBlockAfterTxnMined } from '@cardstack/cardpay-sdk';

--- a/packages/cardpay-cli/testing/create-account.ts
+++ b/packages/cardpay-cli/testing/create-account.ts
@@ -1,0 +1,176 @@
+import { Argv } from 'yargs';
+import { getSDK, getConstant, getConstantByNetwork } from '@cardstack/cardpay-sdk';
+import { waitUntilOneBlockAfterTxnMined } from '@cardstack/cardpay-sdk';
+import { NETWORK_OPTION_LAYER_2, getEthereumClients, getConnectionType, Web3Opts, Web3OptsMnemonic } from '../utils';
+import { Arguments, CommandModule } from 'yargs';
+import { encodeDID } from '@cardstack/did-resolver';
+import Web3 from 'web3';
+const { toChecksumAddress } = Web3.utils;
+import { generateMnemonic } from 'bip39';
+
+export default {
+  command: 'create-account <createPrepaidCardSafe> <createMerchantSafe> <createRewardSafe>',
+  describe: 'Create an account from scratch',
+  builder(yargs: Argv) {
+    return yargs
+      .positional('createPrepaidCardSafe', {
+        type: 'boolean',
+        description: '',
+      })
+      .positional('createMerchantSafe', {
+        type: 'boolean',
+        description: '',
+      })
+      .positional('createRewardSafe', {
+        type: 'boolean',
+        description: '',
+      })
+      .options({
+        network: NETWORK_OPTION_LAYER_2,
+      });
+  },
+  async handler(args: Arguments) {
+    let { network, createPrepaidCardSafe, createMerchantSafe, createRewardSafe } = args as unknown as {
+      network: string;
+      createPrepaidCardSafe: boolean;
+      createMerchantSafe: boolean;
+      createRewardSafe: boolean;
+    };
+
+    if (createRewardSafe && !createPrepaidCardSafe) {
+      throw new Error('Cannot register rewardee without prepaid card');
+    }
+    if (createMerchantSafe && !createPrepaidCardSafe) {
+      throw new Error('Cannot register merchant without prepaid card');
+    }
+
+    const createdMnemonic = generateMnemonic();
+
+    const web3Opts = getConnectionType(args);
+    const createdWeb3Opts: Web3OptsMnemonic = {
+      connectionType: 'mnemonic',
+      mnemonic: createdMnemonic,
+    };
+    const { web3: createdWeb3 } = await getEthereumClients(network, createdWeb3Opts);
+
+    const createdOwner = (await createdWeb3.eth.getAccounts())[0];
+
+    const prepaidCardAddress = createPrepaidCardSafe
+      ? await provisionPrepaidCard(createdOwner, network, web3Opts)
+      : undefined;
+    const merchantSafeAddress =
+      prepaidCardAddress && createMerchantSafe
+        ? await registerMerchant(prepaidCardAddress, network, createdWeb3Opts)
+        : undefined;
+    const rewardSafeAddress =
+      prepaidCardAddress && createRewardSafe
+        ? await registerRewardee(prepaidCardAddress, network, createdWeb3Opts)
+        : undefined;
+
+    console.log(` 
+      Mnemonic: ${createdMnemonic} (WARNING: This is not a secure mnemonic. Only intended for testing!)
+      Address: ${createdOwner}
+      Prepaid card: ${prepaidCardAddress ?? 'No prepaid card created'}
+      Merchant safe: ${merchantSafeAddress ?? 'No merchant safe created'}
+      Reward safe: ${rewardSafeAddress ?? 'No reward safe created'}
+    `);
+  },
+} as CommandModule;
+
+const provisionPrepaidCard = async (createdOwner: string, network: string, web3Opts: Web3Opts): Promise<string> => {
+  console.log('Creating prepaid card');
+  const { web3 } = await getEthereumClients(network, web3Opts);
+  const provisionerSecret = process.env.PROVISIONER_SECRET;
+  if (!provisionerSecret) {
+    throw new Error('Provisioner secret not provided');
+  }
+  let environment: string;
+  let sku: string;
+  switch (network) {
+    case 'gnosis':
+      environment = 'production';
+      sku = '';
+      break;
+    case 'sokol':
+      environment = 'staging';
+      sku = '0xbdd9b9de628f3c2ddf330021facbb43aeef0c8926c068f22800b2dd26c8eb377';
+      break;
+
+    default:
+      throw new Error('Unrecognized network');
+  }
+  let prepaidCardMarketV2 = await getSDK('PrepaidCardMarketV2', web3);
+  const prepaidCardMgr = await getSDK('PrepaidCard', web3);
+  let blockExplorer = await getConstant('blockExplorer', web3);
+
+  console.log(
+    `Provisioning a prepaid card from the SKU ${sku} to the EOA ${createdOwner} in the ${environment} environment...`
+  );
+
+  let quantity = await prepaidCardMarketV2.getQuantity(sku);
+
+  if (quantity === 0) {
+    throw new Error(`There is not enough balance in the issuer safe to provision a card of SKU ${sku}`);
+  }
+
+  let relayUrl = getConstantByNetwork('relayServiceURL', network);
+  let response = await fetch(`${relayUrl}/v2/prepaid-card/provision/${sku}/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: provisionerSecret,
+    },
+    body: JSON.stringify({
+      owner: toChecksumAddress(createdOwner),
+    }),
+  });
+
+  let body = await response.json();
+  if (!response.ok) {
+    console.log(
+      `Could not provision prepaid card for customer ${createdOwner}, sku ${sku}, received ${
+        response.status
+      } from relay server: ${JSON.stringify(body)}`
+    );
+    throw new Error('');
+  }
+  let { txHash } = body;
+  console.log(`Transaction hash: ${blockExplorer}/tx/${txHash}/token-transfers`);
+  await waitUntilOneBlockAfterTxnMined(web3, txHash);
+
+  let [prepaidCard] = await prepaidCardMgr.getPrepaidCardsFromTxn(txHash);
+  console.log(`Provisioned the EOA ${createdOwner} the prepaid card ${prepaidCard}`);
+  return prepaidCard;
+};
+
+const registerMerchant = async (prepaidCard: string, network: string, web3Opts: Web3Opts) => {
+  console.log('Registering merchant account');
+  const { web3, signer } = await getEthereumClients(network, web3Opts);
+  let revenuePool = await getSDK('RevenuePool', web3, signer);
+  let blockExplorer = await getConstant('blockExplorer', web3);
+  let merchantDID = encodeDID({ type: 'MerchantInfo' });
+  let { merchantSafe } =
+    (await revenuePool.registerMerchant(prepaidCard, merchantDID, {
+      onTxnHash: (txnHash) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),
+    })) ?? {};
+  console.log(`Created merchant safe: ${merchantSafe.address}`);
+  return merchantSafe.address;
+};
+
+const registerRewardee = async (prepaidCard: string, network: string, web3Opts: Web3Opts) => {
+  const rewardProgramId = '0x0885ce31D73b63b0Fcb1158bf37eCeaD8Ff0fC72';
+  let { web3 } = await getEthereumClients(network, web3Opts);
+  const prepaidCardMgr = await getSDK('PrepaidCard', web3);
+  const owner = await prepaidCardMgr.getPrepaidCardOwner(prepaidCard);
+  let rewardManagerAPI = await getSDK('RewardManager', web3);
+  let blockExplorer = await getConstant('blockExplorer', web3);
+  let { rewardSafe } = await rewardManagerAPI.registerRewardee(
+    prepaidCard,
+    rewardProgramId,
+    {
+      onTxnHash: (txnHash: string) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}/token-transfers`),
+    },
+    { from: owner }
+  );
+  return rewardSafe;
+};

--- a/packages/cardpay-cli/testing/create-account.ts
+++ b/packages/cardpay-cli/testing/create-account.ts
@@ -11,7 +11,7 @@ import { generateMnemonic } from 'bip39';
 
 export default {
   command: 'create-account <createPrepaidCardSafe> <createMerchantSafe> <createRewardSafe> <createDepotSafe>',
-  describe: 'Create an account from scratch',
+  describe: 'Create an account from scratch and sets up safes based of card pay protocol',
   builder(yargs: Argv) {
     return yargs
       .positional('createPrepaidCardSafe', {

--- a/packages/cardpay-cli/testing/create-account.ts
+++ b/packages/cardpay-cli/testing/create-account.ts
@@ -2,7 +2,7 @@
 import { Argv } from 'yargs';
 import { getSDK, getConstant, getConstantByNetwork, getAddress } from '@cardstack/cardpay-sdk';
 import { waitUntilOneBlockAfterTxnMined } from '@cardstack/cardpay-sdk';
-import { NETWORK_OPTION_LAYER_1, getEthereumClients, getConnectionType, Web3Opts, Web3OptsMnemonic } from '../utils';
+import { NETWORK_OPTION_LAYER_1, getEthereumClients, getConnectionType, Web3Opts } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { encodeDID } from '@cardstack/did-resolver';
 import Web3 from 'web3';

--- a/packages/cardpay-cli/testing/create-account.ts
+++ b/packages/cardpay-cli/testing/create-account.ts
@@ -2,7 +2,7 @@
 import { Argv } from 'yargs';
 import { getSDK, getConstant, getConstantByNetwork, getAddress } from '@cardstack/cardpay-sdk';
 import { waitUntilOneBlockAfterTxnMined } from '@cardstack/cardpay-sdk';
-import { NETWORK_OPTION_LAYER_1, getEthereumClients, getConnectionType, Web3Opts } from '../utils';
+import { NETWORK_OPTION_LAYER_1, getEthereumClients, getConnectionType, Web3Opts, Web3OptsMnemonic } from '../utils';
 import { Arguments, CommandModule } from 'yargs';
 import { encodeDID } from '@cardstack/did-resolver';
 import Web3 from 'web3';

--- a/packages/cardpay-cli/testing/create-account.ts
+++ b/packages/cardpay-cli/testing/create-account.ts
@@ -172,7 +172,7 @@ const provisionPrepaidCard = async (createdOwner: string, network: string, web3O
         response.status
       } from relay server: ${JSON.stringify(body)}`
     );
-    throw new Error('');
+    throw new Error('Provisioning of prepaid card failed');
   }
   let { txHash } = body;
   console.log(`Transaction hash: ${blockExplorer}/tx/${txHash}/token-transfers`);
@@ -198,6 +198,7 @@ const registerMerchant = async (prepaidCard: string, network: string, web3Opts: 
 };
 
 const registerRewardee = async (prepaidCard: string, network: string, web3Opts: Web3Opts) => {
+  console.log('Registering rewardee');
   const rewardProgramId: string = (L2_NETWORK_CONFIG as any)[network].rewardProgramId;
   if (!rewardProgramId) {
     throw new Error(`No reward program id recognised for network ${network}`);
@@ -215,6 +216,7 @@ const registerRewardee = async (prepaidCard: string, network: string, web3Opts: 
     },
     { from: owner }
   );
+  console.log(`Registered rewardee: ${owner} with reward safe ${rewardSafe}`);
   return rewardSafe;
 };
 

--- a/packages/cardpay-cli/testing/create-account.ts
+++ b/packages/cardpay-cli/testing/create-account.ts
@@ -149,7 +149,7 @@ const provisionPrepaidCard = async (createdOwner: string, network: string, web3O
 
   let quantity = await prepaidCardMarketV2.getQuantity(sku);
 
-  if (quantity === 0) {
+  if (quantity.toString() === '0') {
     throw new Error(`There is not enough balance in the issuer safe to provision a card of SKU ${sku}`);
   }
 

--- a/packages/cardpay-cli/testing/create-account.ts
+++ b/packages/cardpay-cli/testing/create-account.ts
@@ -84,7 +84,7 @@ export default {
         : undefined;
 
     const depotAddress = createDepotSafe
-      ? await bridgeToken(createdOwner, undefined, networkL1, web3OptsL1, createdWeb3L2)
+      ? await bridgeToken(createdOwner, undefined, networkL1, web3OptsL1, networkL2, createdWeb3OptsL2)
       : undefined;
 
     console.log(`
@@ -176,6 +176,9 @@ const registerMerchant = async (prepaidCard: string, network: string, web3Opts: 
 
 const registerRewardee = async (prepaidCard: string, network: string, web3Opts: Web3Opts) => {
   const rewardProgramId: string = (L2_NETWORK_CONFIG as any)[network].rewardProgramId;
+  if (!rewardProgramId) {
+    throw new Error(`No reward program id recognised for network ${network}`);
+  }
   let { web3 } = await getEthereumClients(network, web3Opts);
   const prepaidCardMgr = await getSDK('PrepaidCard', web3);
   const owner = await prepaidCardMgr.getPrepaidCardOwner(prepaidCard);
@@ -197,9 +200,11 @@ const bridgeToken = async (
   amountInEth = '10',
   networkL1: string,
   web3OptsL1: Web3Opts,
-  web3L2: Web3
+  networkL2: string,
+  web3OptsL2: Web3Opts
 ) => {
   let { web3: web3L1 } = await getEthereumClients(networkL1, web3OptsL1);
+  let { web3: web3L2 } = await getEthereumClients(networkL2, web3OptsL2);
   let blockExplorer = await getConstant('blockExplorer', web3L1);
   let tokenBridgeForeginSide = await getSDK('TokenBridgeForeignSide', web3L1);
   let tokenBridgeHomeSide = await getSDK('TokenBridgeHomeSide', web3L2);

--- a/packages/cardpay-cli/testing/index.ts
+++ b/packages/cardpay-cli/testing/index.ts
@@ -1,0 +1,14 @@
+import type { Argv } from 'yargs';
+export const command = 'testing <command>';
+export const desc = 'Commands to interact with testing';
+import createAccount from './create-account';
+
+export const builder = function (yargs: Argv) {
+  return yargs
+    .command([createAccount] as any) // cast to work around missing override in types
+    .demandCommand(1, 'You must specify a valid subcommand');
+};
+
+export function handler(/* argv: Argv */) {
+  throw new Error('You must specify a valid subcommand');
+}

--- a/packages/cardpay-cli/utils.ts
+++ b/packages/cardpay-cli/utils.ts
@@ -12,7 +12,7 @@ const BRIDGE = 'https://safe-walletconnect.gnosis.io/';
 
 export type ConnectionType = 'mnemonic' | 'ethers-mnemonic' | 'trezor' | 'wallet-connect';
 
-interface Web3OptsMnemonic {
+export interface Web3OptsMnemonic {
   connectionType: 'mnemonic';
   mnemonic: string;
 }

--- a/packages/cardpay-sdk/index.ts
+++ b/packages/cardpay-sdk/index.ts
@@ -41,6 +41,7 @@ export {
   waitUntilBlock,
   waitUntilTransactionMined,
   waitForSubgraphIndex,
+  waitUntilOneBlockAfterTxnMined,
 } from './sdk/utils/general-utils';
 export { signTypedData } from './sdk/utils/signing-utils';
 export * from './sdk/currency-utils';

--- a/packages/cardpay-sdk/sdk/prepaid-card-market-v-2/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card-market-v-2/base.ts
@@ -180,6 +180,11 @@ export default class PrepaidCardMarketV2 {
     marketAddress = marketAddress ?? (await getAddress('prepaidCardMarketV2', this.layer2Web3));
     let { nonce, onNonce, onTxnHash } = txnOptions ?? {};
     let from = contractOptions?.from ?? (await this.layer2Web3.eth.getAccounts())[0];
+    let contract = new this.layer2Web3.eth.Contract(PrepaidCardMarketV2ABI as AbiItem[], marketAddress);
+    const issuerEOA = await contract.methods.issuers(issuerSafe).call();
+    if (issuerEOA == ZERO_ADDRESS) {
+      throw new Error('Issuer does not exists on prepaid card market v2 contract. Consider adding tokens first.');
+    }
 
     let gnosisResult = await executeSendWithRateLock(this.layer2Web3, prepaidCardAddress, async (rateLock) => {
       let payload = await this.getAddSKUPayload(

--- a/packages/cardpay-sdk/sdk/prepaid-card/base.ts
+++ b/packages/cardpay-sdk/sdk/prepaid-card/base.ts
@@ -566,6 +566,11 @@ export default class PrepaidCard {
     return prepaidCards;
   }
 
+  async getPrepaidCardOwner(prepaidCard: string): Promise<string> {
+    let prepaidCardMgr = await this.getPrepaidCardMgr();
+    return prepaidCardMgr.methods.getPrepaidCardOwner(prepaidCard).call();
+  }
+
   async getPrepaidCardMgr() {
     if (this.prepaidCardManager) {
       return this.prepaidCardManager;
@@ -612,7 +617,7 @@ export default class PrepaidCard {
       .encodeABI();
   }
 
-  private async getPrepaidCardsFromTxn(txnHash: string): Promise<string[]> {
+  async getPrepaidCardsFromTxn(txnHash: string): Promise<string[]> {
     let prepaidCardMgrAddress = await getAddress('prepaidCardManager', this.layer2Web3);
     let txnReceipt = await waitForTransactionConsistency(this.layer2Web3, txnHash);
     return getParamsFromEvent(this.layer2Web3, txnReceipt, this.createPrepaidCardEventABI(), prepaidCardMgrAddress).map(

--- a/packages/cardpay-sdk/sdk/utils/general-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/general-utils.ts
@@ -115,6 +115,12 @@ export function waitUntilBlock(web3: Web3, blockNumber: number, duration = 60 * 
   });
 }
 
+export async function waitUntilOneBlockAfterTxnMined(web3: Web3, txnHash: string) {
+  let receipt = await waitUntilTransactionMined(web3, txnHash);
+  await waitUntilBlock(web3, receipt.blockNumber + 1);
+  return receipt;
+}
+
 export function waitForEvent(contract: Contract, eventName: string, opts: PastEventOptions): Promise<EventData> {
   let eventDataAsync = async function (
     resolve: (value: EventData | Promise<EventData>) => void,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9963,6 +9963,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.12.tgz#ac7fb693ac587ee182c3780c26eb65546a1a3c10"
   integrity sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==
 
+"@types/node@11.11.6":
+  version "11.11.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
+  integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
+
 "@types/node@14.14.35":
   version "14.14.35"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
@@ -11738,7 +11743,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@4.1.4, axe-core@^4.1.4:
+axe-core@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.4.tgz#f19cd99a84ee32a318b9c5b5bb8ed373ad94f143"
   integrity sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==
@@ -12598,6 +12603,16 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
+bip39@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.0.4.tgz#5b11fed966840b5e1b8539f0f54ab6392969b2a0"
+  integrity sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==
+  dependencies:
+    "@types/node" "11.11.6"
+    create-hash "^1.1.0"
+    pbkdf2 "^3.0.9"
+    randombytes "^2.0.1"
+
 bip66@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/bip66/-/bip66-1.1.5.tgz#01fa8748785ca70955d5011217d1b3139969ca22"
@@ -13025,6 +13040,14 @@ broccoli-debug@^0.6.1, broccoli-debug@^0.6.4, broccoli-debug@^0.6.5:
     heimdalljs-logger "^0.1.7"
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
+
+broccoli-file-creator@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-1.2.0.tgz#27f1b25b1b00e7bb7bf3d5d7abed5f4d5388df4d"
+  integrity sha512-l9zthHg6bAtnOfRr/ieZ1srRQEsufMZID7xGYRW3aBDv3u/3Eux+Iawl10tAGYE5pL9YB4n5X4vxkp6iNOoZ9g==
+  dependencies:
+    broccoli-plugin "^1.1.0"
+    mkdirp "^0.5.1"
 
 broccoli-file-creator@^2.1.1:
   version "2.1.1"
@@ -16435,7 +16458,7 @@ elliptic@6.5.4, elliptic@^6.0.0, elliptic@^6.4.0, elliptic@^6.5.2:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-ember-a11y-testing@4.0.3, ember-a11y-testing@^4.0.3:
+ember-a11y-testing@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-4.0.3.tgz#1f5c91266d39ea5b20614b0d294a562079887ac7"
   integrity sha512-Q7nq2crC9+bT+sZi/BORAM4FUhI080edEhnpsvB6vdkD9Ro2Rg4DksQs5Be65/DM108VNDMtbHZtrPS060Mzcw==
@@ -17659,10 +17682,18 @@ ember-freestyle@^0.14.0:
     macro-decorators "^0.1.2"
     strip-indent "^3.0.0"
 
-ember-get-config@2.1.0, "ember-get-config@^0.2.4 || ^0.3.0", ember-get-config@^1.0.2:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-2.1.0.tgz#57c052b742718e8f3eb795cffc635c16d55625f9"
-  integrity sha512-0OJ2Y4zI5+kgVqh7mD/8t1N+LoYrAO847j9sa970swW14IeU0EiiMZ1zwJ7zEhAB7scf7wJyWEHO1ESXgY508Q==
+"ember-get-config@^0.2.4 || ^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.3.0.tgz#a73a1a87b48d9dde4c66a0e52ed5260b8a48cfbd"
+  integrity sha512-0e2pKzwW5lBZ4oJnvu9qHOht4sP1MWz/m3hyz8kpSoMdrlZVf62LDKZ6qfKgy8drcv5YhCMYE6QV7MhnqlrzEQ==
+  dependencies:
+    broccoli-file-creator "^1.1.1"
+    ember-cli-babel "^7.0.0"
+
+ember-get-config@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-1.1.0.tgz#731e192f1fe8022e06c0dbcbe5622fb8c4c78b87"
+  integrity sha512-diD+HwwY8QqpEk5DnDYfH7onYwl6NOgr1qv1ENbXih+/iiWYUVS/e0S/PlM7A4gdorD9spn1bnisnTLTf49Wpw==
   dependencies:
     "@embroider/macros" "^0.50.0 || ^1.0.0"
     ember-cli-babel "^7.26.6"
@@ -28369,6 +28400,17 @@ pbkdf2@^3.0.17, pbkdf2@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.1.tgz#cb8724b0fada984596856d1a6ebafd3584654b94"
   integrity sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==
+  dependencies:
+    create-hash "^1.1.2"
+    create-hmac "^1.1.4"
+    ripemd160 "^2.0.1"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
+
+pbkdf2@^3.0.9:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
+  integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"


### PR DESCRIPTION
This is a devX change that sets up safes based on our card pay protocol. 

When a tester wants to debug a particular state of an account (particularly for UI), 

A dev will execute this command
```
cardpay testing create-account true false false true --network kovan --mnemonic <ur mnemonic>
```

And share the following information with a tester

```
  WARNING: NOT A SECURE MNEMONIC. ONLY INTENDED FOR TESTING!

      Mnemonic: tornado reduce emotion palm asthma rural solid family million coral laptop grant 
      Address: 0x79212DA5173b4e42c1e05C0eF0c98D065497D11b
      Prepaid card: No prepaid card created 
      Merchant safe: No merchant safe created
      Reward safe: No reward safe created
      Depot safe: 0x63f4B6C796E2b74e9DB49FABeB17D785ff8C248B
```

The tester than includes loads the mnemonic into their wallet account.

**Points**
- the signing of this command occurs from the account specified `-w`, `-t`, or `--mnemonic`. The signing only truly occurs when a `createDepot=true`. Getting a prepaid card occurs just from prepaid card market provisioning. Registering a merchant and reward safe will use the new mnemonic generated to sign the prepaid card action. 
- prepaid cards are provisioned by a hardcoded sku on staging. This is setup by me and has 1000 spend per prepaid card by default. This command requires provisioner rights otherwise, the command will not work. production is not set up.
- As above, this means that the dev can provide funds to this testing account without additional work of funding a new account. A lot of times, in order to recreate an cardpay account a person has to `fund a new account`,`bridge`, `create a prepaid card`; now we don't have to `fund a new account`. 
- One can decide which token to bridge and how much using `bridgeTokenAmount`(the default is 10)  and `bridgeTokenAddress` (the default is dai). 



**Extras**
- added some market v2 commands
- added guard for `add-sku`
- rearrange launch file 

