### PR TITLE
sdk: Add SDK & CLI command for adding a scheduled payment

### DIFF
--- a/packages/cardpay-cli/scheduled-payment/index.ts
+++ b/packages/cardpay-cli/scheduled-payment/index.ts
@@ -4,9 +4,10 @@ export const command = 'scheduled-payment <command>';
 export const desc = 'Commands to interact with the scheduled payment module';
 import enableModule from './enable-module';
 import estimateExecution from './estimate-execution';
+import schedulePayment from './schedule-payment';
 
 export const builder = function (yargs: Argv) {
-  return yargs.command([createSafe, enableModule, estimateExecution] as any);
+  return yargs.command([createSafe, enableModule, estimateExecution, schedulePayment] as any);
 };
 
 export function handler(/* argv: Argv */) {

--- a/packages/cardpay-cli/scheduled-payment/schedule-payment.ts
+++ b/packages/cardpay-cli/scheduled-payment/schedule-payment.ts
@@ -4,11 +4,11 @@ import { getEthereumClients, getConnectionType, NETWORK_OPTION_ANY } from '../ut
 import { Arguments } from 'yargs';
 
 export default {
-  command: 'schedule-payment <senderSafeAddress> <safeModuleAddress> <tokenAddress> <spHash>',
+  command: 'schedule-payment <safeAddress> <safeModuleAddress> <gasTokenAddress> <spHash>',
   describe: ' ',
   builder(yargs: Argv) {
     return yargs
-      .positional('senderSafeAddress', {
+      .positional('safeAddress', {
         type: 'string',
         description: 'The address of the safe that will fund the scheduled payment',
       })
@@ -16,7 +16,7 @@ export default {
         type: 'string',
         description: 'The address of the scheduled payment safe module',
       })
-      .positional('tokenAddress', {
+      .positional('gasTokenAddress', {
         type: 'string',
         description: 'The address of the gas token',
       })
@@ -27,11 +27,11 @@ export default {
       .option('network', NETWORK_OPTION_ANY);
   },
   async handler(args: Arguments) {
-    let { network, senderSafeAddress, tokenAddress, safeModuleAddress, spHash } = args as unknown as {
+    let { network, safeAddress, gasTokenAddress, safeModuleAddress, spHash } = args as unknown as {
       network: string;
-      senderSafeAddress: string;
+      safeAddress: string;
       safeModuleAddress: string;
-      tokenAddress: string;
+      gasTokenAddress: string;
       spHash: string;
     };
 
@@ -42,7 +42,7 @@ export default {
     let blockExplorer = await getConstant('blockExplorer', web3);
 
     console.log(`Waiting for the transaction to be mined...`);
-    await scheduledPaymentModule.schedulePayment(senderSafeAddress, safeModuleAddress, tokenAddress, spHash, null, {
+    await scheduledPaymentModule.schedulePayment(safeAddress, safeModuleAddress, gasTokenAddress, spHash, null, {
       onTxnHash: (txnHash) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}`),
     });
 

--- a/packages/cardpay-cli/scheduled-payment/schedule-payment.ts
+++ b/packages/cardpay-cli/scheduled-payment/schedule-payment.ts
@@ -42,7 +42,7 @@ export default {
     let blockExplorer = await getConstant('blockExplorer', web3);
 
     console.log(`Waiting for the transaction to be mined...`);
-    await scheduledPaymentModule.schedulePayment(senderSafeAddress, safeModuleAddress, tokenAddress, spHash, {
+    await scheduledPaymentModule.schedulePayment(senderSafeAddress, safeModuleAddress, tokenAddress, spHash, null, {
       onTxnHash: (txnHash) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}`),
     });
 

--- a/packages/cardpay-cli/scheduled-payment/schedule-payment.ts
+++ b/packages/cardpay-cli/scheduled-payment/schedule-payment.ts
@@ -1,0 +1,51 @@
+import { Argv } from 'yargs';
+import { getConstant, getSDK } from '@cardstack/cardpay-sdk';
+import { getEthereumClients, getConnectionType, NETWORK_OPTION_ANY } from '../utils';
+import { Arguments } from 'yargs';
+
+export default {
+  command: 'schedule-payment <senderSafeAddress> <safeModuleAddress> <tokenAddress> <spHash>',
+  describe: ' ',
+  builder(yargs: Argv) {
+    return yargs
+      .positional('senderSafeAddress', {
+        type: 'string',
+        description: 'The address of the safe that will fund the scheduled payment',
+      })
+      .positional('safeModuleAddress', {
+        type: 'string',
+        description: 'The address of the scheduled payment safe module',
+      })
+      .positional('tokenAddress', {
+        type: 'string',
+        description: 'The address of the gas token',
+      })
+      .positional('spHash', {
+        type: 'string',
+        description: 'Keccak hash of the scheduled payment params',
+      })
+      .option('network', NETWORK_OPTION_ANY);
+  },
+  async handler(args: Arguments) {
+    let { network, senderSafeAddress, tokenAddress, safeModuleAddress, spHash } = args as unknown as {
+      network: string;
+      senderSafeAddress: string;
+      safeModuleAddress: string;
+      tokenAddress: string;
+      spHash: string;
+    };
+
+    console.log(`Adding scheduled payment with scheduled payment hash: ${spHash}...`);
+
+    let { web3, signer } = await getEthereumClients(network, getConnectionType(args));
+    let scheduledPaymentModule = await getSDK('ScheduledPaymentModule', web3, signer);
+    let blockExplorer = await getConstant('blockExplorer', web3);
+
+    console.log(`Waiting for the transaction to be mined...`);
+    await scheduledPaymentModule.schedulePayment(senderSafeAddress, safeModuleAddress, tokenAddress, spHash, {
+      onTxnHash: (txnHash) => console.log(`Transaction hash: ${blockExplorer}/tx/${txnHash}`),
+    });
+
+    console.log(`Done`);
+  },
+};

--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -484,11 +484,20 @@ export default class ScheduledPaymentModule {
     return [nonce, estimate, payload];
   }
 
+  async schedulePayment(txnHash: string): Promise<SuccessfulTransactionReceipt>;
   async schedulePayment(
-    senderSafeAddressOrTxnHash: string,
+    senderSafeAddress: string,
     moduleAddress: string,
     tokenAddress: string,
     spHash: string,
+    signature?: Signature | null,
+    txnOptions?: TransactionOptions
+  ): Promise<SuccessfulTransactionReceipt>;
+  async schedulePayment(
+    senderSafeAddressOrTxnHash: string,
+    moduleAddress?: string,
+    tokenAddress?: string,
+    spHash?: string,
     signature?: Signature | null,
     txnOptions?: TransactionOptions
   ): Promise<SuccessfulTransactionReceipt> {

--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -430,13 +430,13 @@ export default class ScheduledPaymentModule {
 
   async generateSchedulePaymentSignature(
     senderSafeAddress: string,
-    spSafeModuleAddress: string,
+    moduleAddress: string,
     tokenAddress: string,
     spHash: string
   ) {
     let [nonce, estimate, payload] = await this.generateSchedulePaymentTxParams(
       senderSafeAddress,
-      spSafeModuleAddress,
+      moduleAddress,
       tokenAddress,
       spHash
     );
@@ -447,7 +447,7 @@ export default class ScheduledPaymentModule {
       await signSafeTx(
         this.layer2Web3,
         senderSafeAddress,
-        spSafeModuleAddress,
+        moduleAddress,
         payload,
         Operation.CALL,
         estimate,
@@ -462,17 +462,17 @@ export default class ScheduledPaymentModule {
 
   private async generateSchedulePaymentTxParams(
     senderSafeAddress: string,
-    spSafeModuleAddress: string,
+    moduleAddress: string,
     tokenAddress: string,
     spHash: string
   ) {
-    let contract = new this.layer2Web3.eth.Contract(ScheduledPaymentABI as AbiItem[], spSafeModuleAddress);
+    let contract = new this.layer2Web3.eth.Contract(ScheduledPaymentABI as AbiItem[], moduleAddress);
     let payload = await contract.methods.schedulePayment(spHash).encodeABI();
 
     let estimate = await gasEstimate(
       this.layer2Web3,
       senderSafeAddress,
-      spSafeModuleAddress,
+      moduleAddress,
       '0',
       payload,
       Operation.CALL,
@@ -486,7 +486,7 @@ export default class ScheduledPaymentModule {
 
   async schedulePayment(
     senderSafeAddressOrTxnHash: string,
-    spSafeModuleAddress: string,
+    moduleAddress: string,
     tokenAddress: string,
     spHash: string,
     signature?: Signature | null,
@@ -504,8 +504,8 @@ export default class ScheduledPaymentModule {
     if (!senderSafeAddress) {
       throw new Error('senderSafeAddress must be provided');
     }
-    if (!spSafeModuleAddress) {
-      throw new Error('spSafeModuleAddress must be provided');
+    if (!moduleAddress) {
+      throw new Error('moduleAddress must be provided');
     }
     if (!tokenAddress) {
       throw new Error('tokenAddress must be provided');
@@ -516,24 +516,19 @@ export default class ScheduledPaymentModule {
 
     let [nonce, estimate, payload] = await this.generateSchedulePaymentTxParams(
       senderSafeAddress,
-      spSafeModuleAddress,
+      moduleAddress,
       tokenAddress,
       spHash
     );
 
     if (!signature) {
-      signature = await this.generateSchedulePaymentSignature(
-        senderSafeAddress,
-        spSafeModuleAddress,
-        tokenAddress,
-        spHash
-      );
+      signature = await this.generateSchedulePaymentSignature(senderSafeAddress, moduleAddress, tokenAddress, spHash);
     }
 
     let gnosisTxn = await executeTransaction(
       this.layer2Web3,
       senderSafeAddress,
-      spSafeModuleAddress,
+      moduleAddress,
       payload,
       Operation.CALL,
       estimate,


### PR DESCRIPTION
Ticket: CS-4512

After enabling the scheduled payment module on my safe using `enable-module` CLI command, 
I was able to add a scheduled payment hash successfully to my scheduled payment safe module on Sokol testnet.

Here's how the command looks like:

```
❯ yarn cardpay scheduled-payment schedule-payment 0x15356cc1C1DeCeDdcdE588937bB245C4f9D64F36 0x93E408e119FA77fF5C246FCFb9B55582897dd698 0x8F4fdA26e5039eb0bf5dA90c3531AeB91256b56b 0x0760979e23e829dd41ab346b0f1112ae5aa911c3fe82d9db6a5767104b3fdafb -n sokol
yarn run v1.22.17
$ ts-node ./index.ts scheduled-payment schedule-payment 0x15356cc1C1DeCeDdcdE588937bB245C4f9D64F36 0x93E408e119FA77fF5C246FCFb9B55582897dd698 0x8F4fdA26e5039eb0bf5dA90c3531AeB91256b56b 0x0760979e23e829dd41ab346b0f1112ae5aa911c3fe82d9db6a5767104b3fdafb -n sokol
Adding scheduled payment with scheduled payment hash: 0x0760979e23e829dd41ab346b0f1112ae5aa911c3fe82d9db6a5767104b3fdafb...
Waiting for the transaction to be mined...
Transaction hash: https://blockscout.com/poa/sokol/tx/0xf0ac6f6fc0c9341c4e16ffa15f20e69f723ecc575c9d9b9d4613164bd227cc4c
Done
✨  Done in 16.89s.
```

I confirmed the spHash is contained in the [safe module contract]:(https://blockscout.com/poa/sokol/address/0x93E408e119FA77fF5C246FCFb9B55582897dd698/read-contract#address-tabs)
<img width="1197" alt="image" src="https://user-images.githubusercontent.com/273660/188646457-74dd6fbd-8071-4fd8-9260-deeaabc6ff66.png">

