### PR TITLE
Cs 4234 subgraph extraction parquet metadata

### DIFF
--- a/packages/cardpay-subgraph-extraction/requirements.txt
+++ b/packages/cardpay-subgraph-extraction/requirements.txt
@@ -1,4 +1,4 @@
-subgraph_extractor>=0.2.0
+subgraph_extractor>=0.2.1
 click
 cloudpathlib[s3]
 schedule

--- a/packages/cardpay-subgraph-extraction/requirements.txt
+++ b/packages/cardpay-subgraph-extraction/requirements.txt
@@ -1,4 +1,4 @@
-subgraph_extractor>=0.1.1
+subgraph_extractor>=0.2.0
 click
 cloudpathlib[s3]
 schedule

--- a/packages/cardpay-subgraph-extraction/requirements.txt
+++ b/packages/cardpay-subgraph-extraction/requirements.txt
@@ -1,4 +1,4 @@
-subgraph_extractor>=0.2.1
+subgraph_extractor>=0.2.2
 click
 cloudpathlib[s3]
 schedule


### PR DESCRIPTION
This uses the more recent version of the extractor package that's already been merged.

Deployed to staging, seems to be working fine there. When we deploy to production I may need to regenerate a few partitions but I can do that while putting a heads up in the on-call.