### PR TITLE
Extend ember's Owner type

### DIFF
--- a/packages/web-client/app/utils/owner.ts
+++ b/packages/web-client/app/utils/owner.ts
@@ -1,0 +1,22 @@
+import { Registry } from '@ember/service';
+
+// This file augments Ember's `Owner.lookup` so that it understands services in
+// the same way that service injection does.
+
+// This reexport is here because you cannot augment the type of a default
+// export, but you can augment the type of a named export. So we reexport the
+// type we want to augment to make it augmentable.
+//
+// https://github.com/Microsoft/TypeScript/issues/14080
+export type { default as Owner } from '@ember/owner';
+
+// This is *weird*. We are augmenting "our own module" here, and since we
+// reexport the underlying type from Ember we are therefore augmenting that
+// type.
+declare module './owner' {
+  interface Owner {
+    lookup<Name extends keyof Registry>(
+      fullName: `service:${Name}`
+    ): Registry[Name];
+  }
+}


### PR DESCRIPTION
This makes it so that `owner.lookup("service:whatever")` gets the right type automatically, so long as you have already registered your service's type like we already do: https://github.com/cardstack/cardstack/blob/bd47275d064fdd34cd45e278de353c3bb2791f83/packages/ssr-web/app/services/layer2-network.ts#L101-L105

Out-of-the-box, the types only make that work for the `@service` decorator. This makes it also work with `owner.lookup`.

@lukemelia I targeted the boxel-glint-wip branch here because I think this is relevant to those changes and can be tested that context. 