### PR TITLE
hub: Add an endpoint to create a scheduled payment

### DIFF
--- a/packages/cardpay-sdk/index.ts
+++ b/packages/cardpay-sdk/index.ts
@@ -43,7 +43,7 @@ export {
   waitForSubgraphIndex,
   waitUntilOneBlockAfterTxnMined,
 } from './sdk/utils/general-utils';
-export { signTypedData } from './sdk/utils/signing-utils';
+export { signTypedData, signatureToVRS, Signature } from './sdk/utils/signing-utils';
 export * from './sdk/currency-utils';
 export * from './sdk/currencies';
 export { query as gqlQuery } from './sdk/utils/graphql';

--- a/packages/cardpay-sdk/sdk/token-bridge-foreign-side.ts
+++ b/packages/cardpay-sdk/sdk/token-bridge-foreign-side.ts
@@ -13,6 +13,7 @@ import {
   waitUntilBlock,
   waitUntilTransactionMined,
 } from './utils/general-utils';
+import { signatureToVRS, strip0x } from './utils/signing-utils';
 import type { SuccessfulTransactionReceipt } from './utils/successful-transaction-receipt';
 const { fromWei } = Web3.utils;
 
@@ -350,23 +351,11 @@ function prepSignaturesForExecution(signatures: string[]) {
   return packSignatures(signatures.map(signatureToVRS));
 }
 
-function signatureToVRS(rawSignature: string) {
-  const signature = strip0x(rawSignature);
-  const v = signature.substr(64 * 2);
-  const r = signature.substr(0, 32 * 2);
-  const s = signature.substr(32 * 2, 32 * 2);
-  return { v, r, s };
-}
-
-function packSignatures(array: { v: string; r: string; s: string }[]) {
+function packSignatures(array: { v: number; r: string; s: string }[]) {
   const length = strip0x(Web3.utils.toHex(array.length));
   const msgLength = length.length === 1 ? `0${length}` : length;
   const [v, r, s] = array.reduce(([vs, rs, ss], { v, r, s }) => [vs + v, rs + r, ss + s], ['', '', '']);
   return `0x${msgLength}${v}${r}${s}`;
-}
-
-function strip0x(s: string) {
-  return Web3.utils.isHexStrict(s) ? s.substr(2) : s;
 }
 
 async function waitUntilOneBlockAfterTxnMined(web3: Web3, txnHash: string) {

--- a/packages/cardpay-sdk/sdk/utils/signing-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/signing-utils.ts
@@ -435,3 +435,15 @@ function sortSignaturesAsBytes(
     return [contractSignature, ownerSignature];
   }
 }
+
+export function signatureToVRS(rawSignature: string) {
+  const signature = strip0x(rawSignature);
+  const v = parseInt(signature.substr(64 * 2));
+  const r = signature.substr(0, 32 * 2);
+  const s = signature.substr(32 * 2, 32 * 2);
+  return { v, r, s };
+}
+
+export function strip0x(s: string) {
+  return Web3.utils.isHexStrict(s) ? s.substr(2) : s;
+}

--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -1184,7 +1184,8 @@ CREATE TABLE public.scheduled_payments (
     cancelation_block_number bigint,
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    canceled_at timestamp without time zone
+    canceled_at timestamp without time zone,
+    signature text
 );
 
 

--- a/packages/hub/db/migrations/20220912092105634_add-signature-to-scheduled-payments.ts
+++ b/packages/hub/db/migrations/20220912092105634_add-signature-to-scheduled-payments.ts
@@ -1,0 +1,12 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+const TABLE = 'scheduled_payments';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumns(TABLE, {
+    signature: { type: 'text' },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn(TABLE, 'signature');
+}

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -93,6 +93,9 @@ import Email from './services/email';
 import Mailchimp from './services/mailchimp';
 import PrismaManager from './services/prisma-manager';
 import ScheduledPaymentsFetcherService from './services/scheduled-payments/fetcher';
+import ScheduledPaymentSerializer from './services/serializers/scheduled-payment-serializer';
+import ScheduledPaymentValidator from './services/validators/scheduled-payment';
+import ScheduledPaymentsRoute from './routes/scheduled-payments';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -173,6 +176,9 @@ export function createRegistry(): Registry {
   registry.register('email-card-drop-router', EmailCardDropRouter);
   registry.register('prisma-manager', PrismaManager);
   registry.register('scheduled-payment-fetcher', ScheduledPaymentsFetcherService);
+  registry.register('scheduled-payment-serializer', ScheduledPaymentSerializer);
+  registry.register('scheduled-payment-validator', ScheduledPaymentValidator);
+  registry.register('scheduled-payments-route', ScheduledPaymentsRoute);
 
   if (process.env.COMPILER) {
     registry.register(

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -172,7 +172,7 @@ export function createRegistry(): Registry {
   registry.register('pagerduty-incidents-webhook-route', PagerdutyIncidentsWebhookRoute);
   registry.register('email-card-drop-router', EmailCardDropRouter);
   registry.register('prisma-manager', PrismaManager);
-  registry.register('scheduled-payments-fetcher', ScheduledPaymentsFetcherService);
+  registry.register('scheduled-payment-fetcher', ScheduledPaymentsFetcherService);
 
   if (process.env.COMPILER) {
     registry.register(

--- a/packages/hub/node-tests/routes/scheduled-payments-test.ts
+++ b/packages/hub/node-tests/routes/scheduled-payments-test.ts
@@ -1,0 +1,307 @@
+import { PrismaClient } from '@prisma/client';
+
+import { registry, setupHub } from '../helpers/server';
+import { setupStubWorkerClient } from '../helpers/stub-worker-client';
+
+class StubAuthenticationUtils {
+  validateAuthToken(encryptedAuthToken: string) {
+    return handleValidateAuthToken(encryptedAuthToken);
+  }
+}
+
+let stubUserAddress = '0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13';
+function handleValidateAuthToken(encryptedString: string) {
+  expect(encryptedString).to.equal('abc123--def456--ghi789');
+  return stubUserAddress;
+}
+
+let prisma: PrismaClient;
+let forceSchedulePaymentOnChainTimeout = false;
+let mockTxnHash = '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162';
+
+class StubCardpaySDK {
+  getSDK(sdk: string) {
+    switch (sdk) {
+      case 'ScheduledPaymentModule':
+        return Promise.resolve({
+          schedulePayment: async (
+            _safeAddress: any,
+            _moduleAddress: any,
+            _tokenAddress: any,
+            _spHash: any,
+            _signature: any,
+            { onTxnHash }: any
+          ) => {
+            if (forceSchedulePaymentOnChainTimeout) {
+              // no-op. txn hash will never be returned
+            } else {
+              await onTxnHash(mockTxnHash);
+            }
+          },
+        });
+      default:
+        throw new Error(`unsupported mock cardpay sdk: ${sdk}`);
+    }
+  }
+}
+
+describe('POST /api/scheduled-payments', async function () {
+  let { getJobIdentifiers, getJobPayloads } = setupStubWorkerClient(this);
+
+  this.beforeEach(async function () {
+    registry(this).register('authentication-utils', StubAuthenticationUtils);
+    registry(this).register('cardpay', StubCardpaySDK);
+  });
+
+  let { getPrisma, request } = setupHub(this);
+
+  this.beforeEach(async function () {
+    prisma = await getPrisma();
+  });
+
+  it('returns a 401 if the auth token is invalid', async function () {
+    await request()
+      .post('/api/scheduled-payments')
+      .send({})
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(401)
+      .expect({
+        errors: [
+          {
+            status: '401',
+            title: 'No valid auth token',
+          },
+        ],
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('responds with errors when attrs are missing', async function () {
+    await request()
+      .post('/api/scheduled-payments')
+      .send({
+        data: {
+          type: 'scheduled-payments',
+          attributes: {},
+        },
+      })
+      .set('Accept', 'application/vnd.api+json')
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(422)
+      .expect({
+        errors: [
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/sender-safe-address',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/module-address',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/token-address',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/amount',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/payee-address',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/execution-gas-estimation',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/max-gas-price',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/fee-fixed-usd',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/fee-percentage',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/salt',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/sp-hash',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/signature',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/chain-id',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+        ],
+      });
+  });
+
+  // TODO add a test for recurring scheduled payment
+
+  it('persists scheduled payment, submits a transaction and transaction waiter task', async function () {
+    let scheduledPaymentId;
+    await request()
+      .post('/api/scheduled-payments')
+      .send({
+        data: {
+          type: 'scheduled-payments',
+          attributes: {
+            'sender-safe-address': '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+            'module-address': '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+            'token-address': '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+            amount: 100,
+            'payee-address': '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+            'execution-gas-estimation': 100000,
+            'max-gas-price': 1000000000,
+            'fee-fixed-usd': 0,
+            'fee-percentage': 0,
+            salt: '54lt',
+            'pay-at': '2021-01-01T00:00:00.000Z',
+            'sp-hash': '0x123',
+            'chain-id': 1,
+            signature: '0x123',
+          },
+        },
+      })
+      .set('Accept', 'application/vnd.api+json')
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(201)
+      .expect(function (res) {
+        scheduledPaymentId = res.body.data.id;
+        res.body.data.id = 'id';
+      })
+      .expect({
+        data: {
+          id: 'id',
+          type: 'scheduled-payment',
+          attributes: {
+            'sender-safe-address': '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+            'module-address': '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+            'token-address': '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+            amount: 100,
+            'payee-address': '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+            'execution-gas-estimation': 100000,
+            'max-gas-price': 1000000000,
+            'fee-fixed-usd': 0,
+            'fee-percentage': 0,
+            salt: '54lt',
+            'pay-at': '2021-01-01T00:00:00.000Z',
+            'sp-hash': '0x123',
+            'chain-id': 1,
+            signature: '0x123',
+            'creation-transaction-hash': mockTxnHash,
+            'creation-block-number': null,
+            'cancelation-transaction-hash': null,
+            'cancelation-block-number': null,
+            'recurring-day-of-month': null,
+            'recurring-until': null,
+          },
+        },
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+
+    expect(getJobIdentifiers()[0]).to.equal('scheduled-payment-on-chain-creation-waiter');
+    expect(getJobPayloads()[0]).to.deep.equal({ scheduledPaymentId });
+  });
+
+  it('does not persist a scheduled payment when something goes wrong with on chain call', async function () {
+    forceSchedulePaymentOnChainTimeout = true;
+
+    await request()
+      .post('/api/scheduled-payments')
+      .send({
+        data: {
+          type: 'scheduled-payments',
+          attributes: {
+            'sender-safe-address': '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+            'module-address': '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+            'token-address': '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+            amount: 100,
+            'payee-address': '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+            'execution-gas-estimation': 100000,
+            'max-gas-price': 1000000000,
+            'fee-fixed-usd': 0,
+            'fee-percentage': 0,
+            salt: '54lt',
+            'pay-at': '2021-01-01T00:00:00.000',
+            'sp-hash': '0x123',
+            'chain-id': 1,
+            signature: '0x123',
+          },
+        },
+      })
+      .set('Accept', 'application/vnd.api+json')
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(422);
+
+    let scheduledPayments = await prisma.scheduledPayment.findMany();
+
+    expect(scheduledPayments).to.be.empty;
+  });
+});

--- a/packages/hub/node-tests/services/scheduled-payments/fetcher-test.ts
+++ b/packages/hub/node-tests/services/scheduled-payments/fetcher-test.ts
@@ -16,7 +16,7 @@ describe('fetching scheduled payments that are due', function () {
   let { getPrisma, getContainer } = setupHub(this);
 
   this.beforeEach(async function () {
-    subject = await getContainer().lookup('scheduled-payments-fetcher');
+    subject = await getContainer().lookup('scheduled-payment-fetcher');
     now = convertDateToUTC(new Date());
     validForDays = subject.validForDays;
     prisma = await getPrisma();
@@ -182,6 +182,6 @@ describe('fetching scheduled payments that are due', function () {
 
 declare module '@cardstack/di' {
   interface KnownServices {
-    'scheduled-payments-fetcher': ScheduledPaymentsFetcherService;
+    'scheduled-payment-fetcher': ScheduledPaymentsFetcherService;
   }
 }

--- a/packages/hub/node-tests/tasks/scheduled-payment-on-chain-creation-waiter-test.ts
+++ b/packages/hub/node-tests/tasks/scheduled-payment-on-chain-creation-waiter-test.ts
@@ -1,0 +1,70 @@
+import { expect } from 'chai';
+import ScheduledPaymentOnChainCreationWaiter from '../../tasks/scheduled-payment-on-chain-creation-waiter';
+import { registry, setupHub } from '../helpers/server';
+
+class StubCardpaySDK {
+  getSDK(sdk: string) {
+    switch (sdk) {
+      case 'ScheduledPaymentModule':
+        return Promise.resolve({
+          schedulePayment: async (
+            _safeAddress: any,
+            _moduleAddress: any,
+            _tokenAddress: any,
+            _spHash: any,
+            _signature: any,
+            _obj: any
+          ) => {
+            return {
+              blockNumber: 123,
+            };
+          },
+        });
+      default:
+        throw new Error(`unsupported mock cardpay sdk: ${sdk}`);
+    }
+  }
+}
+
+describe('ScheduledPaymentOnChainCreationWaiterTask', function () {
+  this.beforeEach(async function () {
+    registry(this).register('cardpay', StubCardpaySDK);
+  });
+
+  let { getPrisma, getContainer } = setupHub(this);
+
+  it('waits for the transaction to be mined and updates block number', async function () {
+    let prisma = await getPrisma();
+    let task = await getContainer().instantiate(ScheduledPaymentOnChainCreationWaiter);
+    let scheduledPayment = await prisma.scheduledPayment.create({
+      data: {
+        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+        moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+        tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+        amount: 100,
+        payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+        executionGasEstimation: 100000,
+        maxGasPrice: 1000000000,
+        feeFixedUsd: 0,
+        feePercentage: 0,
+        salt: '54lt',
+        payAt: new Date(),
+        spHash: '0x123',
+        chainId: 1,
+        signature: '0x123',
+        creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
+      },
+    });
+
+    await task.perform({ scheduledPaymentId: scheduledPayment.id });
+    scheduledPayment = await prisma.scheduledPayment.findUniqueOrThrow({
+      where: {
+        id: scheduledPayment.id,
+      },
+    });
+
+    // creationBlockNumber is BigInt
+    expect(Number(scheduledPayment.creationBlockNumber)).to.eq(123);
+  });
+});

--- a/packages/hub/node-tests/utils/scheduled-payments-test.ts
+++ b/packages/hub/node-tests/utils/scheduled-payments-test.ts
@@ -1,0 +1,30 @@
+import { format } from 'date-fns';
+import { calculateNextPayAt } from '../../utils/scheduled-payments';
+
+describe('ScheduledPaymentUtils', function () {
+  let recurringDay = 5;
+
+  it('calculates next pay at when current day number is lower than recurring day', function () {
+    let fromDate = new Date(Date.parse('2022-02-04'));
+
+    let nextPayAt = calculateNextPayAt(fromDate, recurringDay);
+
+    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-02-05');
+  });
+
+  it('calculates next pay at when current day number is the same as recurring day', function () {
+    let fromDate = new Date(Date.parse('2022-02-05'));
+
+    let nextPayAt = calculateNextPayAt(fromDate, recurringDay);
+
+    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-03-05');
+  });
+
+  it('calculates next pay at when current day number is higher same as recurring day', function () {
+    let fromDate = new Date(Date.parse('2022-02-06'));
+
+    let nextPayAt = calculateNextPayAt(fromDate, recurringDay);
+
+    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-03-05');
+  });
+});

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -316,6 +316,7 @@ model ScheduledPayment {
   createdAt                  DateTime                  @default(now()) @map("created_at") @db.Timestamp(6)
   updatedAt                  DateTime                  @default(now()) @map("updated_at") @db.Timestamp(6)
   canceledAt                 DateTime?                 @map("canceled_at") @db.Timestamp(6)
+  signature                  String?
   scheduledPaymentAttempts   ScheduledPaymentAttempt[]
 
   @@index([senderSafeAddress], map: "scheduled_payments_sender_safe_address_index")

--- a/packages/hub/routes/scheduled-payments.ts
+++ b/packages/hub/routes/scheduled-payments.ts
@@ -1,0 +1,149 @@
+import Koa from 'koa';
+import autoBind from 'auto-bind';
+import { ensureLoggedIn } from './utils/auth';
+import { inject } from '@cardstack/di';
+import * as Sentry from '@sentry/node';
+import shortUUID from 'short-uuid';
+import ScheduledPaymentValidator from '../services/validators/scheduled-payment';
+import { serializeErrors } from './utils/error';
+
+import { signatureToVRS } from '@cardstack/cardpay-sdk';
+import ScheduledPaymentSerializer from '../services/serializers/scheduled-payment-serializer';
+import WorkerClient from '../services/worker-client';
+import { timeoutPromise } from '../utils/misc';
+import { calculateNextPayAt } from '../utils/scheduled-payments';
+
+export default class ScheduledPaymentsRoute {
+  scheduledPaymentValidator: ScheduledPaymentValidator = inject('scheduled-payment-validator', {
+    as: 'scheduledPaymentValidator',
+  });
+  scheduledPaymentSerializer: ScheduledPaymentSerializer = inject('scheduled-payment-serializer', {
+    as: 'scheduledPaymentSerializer',
+  });
+  web3 = inject('web3-http', { as: 'web3' });
+  prismaManager = inject('prisma-manager', { as: 'prismaManager' });
+  workerClient: WorkerClient = inject('worker-client', { as: 'workerClient' });
+  cardpay = inject('cardpay');
+
+  constructor() {
+    autoBind(this);
+  }
+
+  async post(ctx: Koa.Context) {
+    if (!ensureLoggedIn(ctx)) {
+      return;
+    }
+
+    let attrs = ctx.request.body.data.attributes;
+
+    let params = {
+      id: shortUUID.uuid(),
+      senderSafeAddress: attrs['sender-safe-address'],
+      moduleAddress: attrs['module-address'],
+      tokenAddress: attrs['token-address'],
+      amount: attrs.amount,
+      payeeAddress: attrs['payee-address'],
+      executionGasEstimation: attrs['execution-gas-estimation'],
+      maxGasPrice: attrs['max-gas-price'],
+      feeFixedUsd: attrs['fee-fixed-usd'],
+      feePercentage: attrs['fee-percentage'],
+      salt: attrs['salt'],
+      payAt: new Date(attrs['pay-at']),
+      recurringDayOfMonth: attrs['recurring-day-of-month'],
+      recurringUntil: attrs['recurring-until'],
+      validForDays: attrs['valid-for-days'],
+      spHash: attrs['sp-hash'],
+      chainId: attrs['chain-id'],
+      signature: attrs['signature'],
+    };
+
+    if (params.recurringDayOfMonth != null) {
+      params.payAt = calculateNextPayAt(new Date(), params.recurringDayOfMonth);
+    }
+
+    let errors = this.scheduledPaymentValidator.validate(params);
+    let hasErrors = Object.values(errors).flatMap((i) => i).length > 0;
+    if (hasErrors) {
+      ctx.status = 422;
+      ctx.body = {
+        errors: serializeErrors(errors),
+      };
+    } else {
+      // TODO: prevent double save (was there the same scheduled payment (apart from the salt) already saved recently?)
+      let prisma = await this.prismaManager.getClient();
+      let scheduledPaymentModule = await this.cardpay.getSDK('ScheduledPaymentModule', this.web3.getInstance());
+
+      // We create the scheduled payment in the database as a first step, so that we can be sure
+      // that the scheduled payment *is persisted* in the database before we try to map it with the transaction.
+      // We don't want to get into a situation where on chain call is triggered but the scheduled payment
+      // wasn't persisted in the database for some reason.
+      let scheduledPayment = await prisma.scheduledPayment.create({
+        data: params,
+      });
+
+      let getTxnHash = new Promise<void>((resolve) => {
+        scheduledPaymentModule.schedulePayment(
+          params.senderSafeAddress,
+          params.moduleAddress,
+          params.tokenAddress,
+          params.spHash,
+          signatureToVRS(params.signature),
+          {
+            onTxnHash: async (txnHash) => {
+              await prisma.scheduledPayment.update({
+                where: {
+                  id: scheduledPayment.id,
+                },
+                data: {
+                  creationTransactionHash: txnHash,
+                },
+              });
+
+              // It might take several minutes for the transaction to be mined, so we wait for it in the background. The client
+              // can poll the record to see when it's mined (creation_block_number attribute will be set).
+              await this.workerClient.addJob('scheduled-payment-on-chain-creation-waiter', {
+                scheduledPaymentId: scheduledPayment.id,
+              });
+
+              resolve();
+            },
+          }
+        );
+      });
+
+      try {
+        let isTestEnv = process.env.NODE_ENV === 'test';
+        let waitFor = isTestEnv ? 10 : 30 * 1000; // 30 seconds should be enough to get a transaction hash. If not, we'll throw an error.
+        await timeoutPromise(getTxnHash, waitFor);
+      } catch (error) {
+        // If submitting the transaction to the blockchain failed, we don't want to have the scheduled payment in the database.
+        await prisma.scheduledPayment.delete({
+          where: {
+            id: scheduledPayment.id,
+          },
+        });
+
+        ctx.status = 422;
+        ctx.body = 'Error while submitting the scheduled payment creation transaction to the blockchain';
+        Sentry.captureException(error);
+
+        return;
+      }
+
+      ctx.status = 201;
+      // Reload the scheduled payment from the database, so that we have the latest data (the creation transaction hash)
+      scheduledPayment = await prisma.scheduledPayment.findFirstOrThrow({
+        where: { id: scheduledPayment.id },
+      });
+      ctx.body = this.scheduledPaymentSerializer.serialize(scheduledPayment);
+    }
+
+    ctx.type = 'application/vnd.api+json';
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'scheduled-payments-route': ScheduledPaymentsRoute;
+  }
+}

--- a/packages/hub/services/api-router.ts
+++ b/packages/hub/services/api-router.ts
@@ -45,6 +45,7 @@ export default class APIRouter {
   reservationsRoute = inject('reservations-route', { as: 'reservationsRoute' });
   inventoryRoute = inject('inventory-route', { as: 'inventoryRoute' });
   wyrePricesRoute = inject('wyre-prices-route', { as: 'wyrePricesRoute' });
+  scheduledPaymentsRoute = inject('scheduled-payments-route', { as: 'scheduledPaymentsRoute' });
 
   routes() {
     let {
@@ -67,6 +68,7 @@ export default class APIRouter {
       wyrePricesRoute,
       pushNotificationRegistrationsRoute,
       notificationPreferencesRoute,
+      scheduledPaymentsRoute,
     } = this;
     let apiSubrouter = new Router();
     apiSubrouter.get('/boom', boomRoute.get);
@@ -134,6 +136,7 @@ export default class APIRouter {
     );
     apiSubrouter.get('/notification-preferences/:push_client_id', parseBody, notificationPreferencesRoute.get);
     apiSubrouter.put('/notification-preferences/:push_client_id', parseBody, notificationPreferencesRoute.put);
+    apiSubrouter.post('/scheduled-payments', parseBody, scheduledPaymentsRoute.post);
     apiSubrouter.get('/wyre-prices', parseBody, wyrePricesRoute.get);
     apiSubrouter.all('/(.*)', notFound);
 

--- a/packages/hub/services/serializers/scheduled-payment-serializer.ts
+++ b/packages/hub/services/serializers/scheduled-payment-serializer.ts
@@ -1,0 +1,51 @@
+import { ScheduledPayment } from '@prisma/client';
+import { JSONAPIDocument } from '../../utils/jsonapi-document';
+
+function transformBigInt(value: BigInt | null): number | null {
+  if (value == null) {
+    return null;
+  } else {
+    return Number(value);
+  }
+}
+
+export default class ScheduledPaymentSerializer {
+  serialize(model: ScheduledPayment): JSONAPIDocument {
+    const result = {
+      data: {
+        id: model.id,
+        type: 'scheduled-payment',
+        attributes: {
+          'sender-safe-address': model.senderSafeAddress,
+          'module-address': model.moduleAddress,
+          'token-address': model.tokenAddress,
+          amount: transformBigInt(model.amount),
+          'payee-address': model.payeeAddress,
+          'execution-gas-estimation': transformBigInt(model.executionGasEstimation),
+          'max-gas-price': transformBigInt(model.maxGasPrice),
+          'fee-fixed-usd': model.feeFixedUsd,
+          'fee-percentage': model.feePercentage,
+          salt: model.salt,
+          'pay-at': model.payAt,
+          'sp-hash': model.spHash,
+          'chain-id': model.chainId,
+          signature: model.signature,
+          'recurring-day-of-month': model.recurringDayOfMonth,
+          'recurring-until': model.recurringUntil,
+          'creation-transaction-hash': model.creationTransactionHash,
+          'creation-block-number': transformBigInt(model.creationBlockNumber),
+          'cancelation-transaction-hash': model.cancelationTransactionHash,
+          'cancelation-block-number': transformBigInt(model.cancelationBlockNumber),
+        },
+      },
+    };
+
+    return result as JSONAPIDocument;
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'scheduled-payment-serializer': ScheduledPaymentSerializer;
+  }
+}

--- a/packages/hub/services/validators/scheduled-payment.ts
+++ b/packages/hub/services/validators/scheduled-payment.ts
@@ -1,0 +1,91 @@
+import { ScheduledPayment } from '@prisma/client';
+import { isAddress } from 'web3-utils';
+
+type ScheduledPaymentAttribute =
+  | 'senderSafeAddress'
+  | 'moduleAddress'
+  | 'tokenAddress'
+  | 'amount'
+  | 'payeeAddress'
+  | 'executionGasEstimation'
+  | 'maxGasPrice'
+  | 'feeFixedUsd'
+  | 'feePercentage'
+  | 'salt'
+  | 'payAt'
+  | 'recurringDayOfMonth'
+  | 'recurringUntil'
+  | 'validForDays'
+  | 'spHash'
+  | 'chainId'
+  | 'signature';
+
+type ScheduledPaymentErrors = Record<ScheduledPaymentAttribute, string[]>;
+
+export default class ScheduledPaymentValidator {
+  validate(scheduledPayment: Partial<ScheduledPayment>): ScheduledPaymentErrors {
+    let errors: ScheduledPaymentErrors = {
+      senderSafeAddress: [],
+      moduleAddress: [],
+      tokenAddress: [],
+      amount: [],
+      payeeAddress: [],
+      executionGasEstimation: [],
+      maxGasPrice: [],
+      feeFixedUsd: [],
+      feePercentage: [],
+      salt: [],
+      payAt: [],
+      recurringDayOfMonth: [],
+      recurringUntil: [],
+      validForDays: [],
+      spHash: [],
+      signature: [],
+      chainId: [],
+    };
+
+    let mandatoryAttributes: ScheduledPaymentAttribute[] = [
+      'senderSafeAddress',
+      'moduleAddress',
+      'tokenAddress',
+      'amount',
+      'payeeAddress',
+      'executionGasEstimation',
+      'maxGasPrice',
+      'feeFixedUsd',
+      'payAt',
+      'feePercentage',
+      'salt',
+      'spHash',
+      'chainId',
+      'signature',
+    ];
+
+    for (let attribute of mandatoryAttributes) {
+      if (scheduledPayment[attribute] == null) {
+        errors[attribute].push('is required');
+      }
+    }
+
+    let addressAttributes: ScheduledPaymentAttribute[] = [
+      'senderSafeAddress',
+      'moduleAddress',
+      'tokenAddress',
+      'payeeAddress',
+    ];
+
+    for (let attribute of addressAttributes) {
+      if (scheduledPayment[attribute] && !isAddress(scheduledPayment[attribute] as string)) {
+        errors[attribute].push('is not a valid address');
+      }
+    }
+
+    return errors;
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'scheduled-payment-validator': ScheduledPaymentValidator;
+  }
+}

--- a/packages/hub/tasks/index.ts
+++ b/packages/hub/tasks/index.ts
@@ -19,6 +19,7 @@ const ALL_KNOWN_TASKS: Record<keyof KnownTasks, true> = {
   'print-queued-jobs': true,
   'persist-off-chain-prepaid-card-customization': true,
   'persist-off-chain-profile': true,
+  'scheduled-payment-on-chain-creation-waiter': true,
   boom: true,
 };
 

--- a/packages/hub/tasks/scheduled-payment-on-chain-creation-waiter.ts
+++ b/packages/hub/tasks/scheduled-payment-on-chain-creation-waiter.ts
@@ -1,0 +1,49 @@
+import { inject } from '@cardstack/di';
+import * as Sentry from '@sentry/node';
+
+export default class ScheduledPaymentOnChainCreationWaiter {
+  prismaManager = inject('prisma-manager', { as: 'prismaManager' });
+  web3 = inject('web3-http', { as: 'web3' });
+  cardpay = inject('cardpay');
+
+  async perform(payload: { scheduledPaymentId: string }) {
+    let prisma = await this.prismaManager.getClient();
+
+    let scheduledPaymentModule = await this.cardpay.getSDK('ScheduledPaymentModule', this.web3.getInstance());
+    let scheduledPayment = await prisma.scheduledPayment.findFirstOrThrow({
+      where: { id: payload.scheduledPaymentId },
+    });
+
+    if (scheduledPayment.creationBlockNumber) {
+      return;
+    }
+
+    if (!scheduledPayment.creationTransactionHash) {
+      Sentry.captureException(
+        new Error('No transaction hash while trying to wait for on chain creation of a scheduled payment'),
+        {
+          tags: {
+            action: 'scheduled-payment-task',
+            scheduledPaymentId: scheduledPayment.id,
+          },
+        }
+      );
+    } else {
+      let receipt = await scheduledPaymentModule.schedulePayment(scheduledPayment.creationTransactionHash);
+      await prisma.scheduledPayment.update({
+        data: {
+          creationBlockNumber: receipt.blockNumber, // To let us know that the scheduled payment has been created on chain and that the process of scheduling payment was completed
+        },
+        where: {
+          id: scheduledPayment.id,
+        },
+      });
+    }
+  }
+}
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    'scheduled-payment-on-chain-creation-waiter': ScheduledPaymentOnChainCreationWaiter;
+  }
+}

--- a/packages/hub/utils/misc.ts
+++ b/packages/hub/utils/misc.ts
@@ -1,0 +1,8 @@
+export function timeoutPromise(promise: Promise<void>, ms: number) {
+  return new Promise(function (resolve, reject) {
+    setTimeout(function () {
+      reject(new Error('timeout'));
+    }, ms);
+    promise.then(resolve, reject);
+  });
+}

--- a/packages/hub/utils/scheduled-payments.ts
+++ b/packages/hub/utils/scheduled-payments.ts
@@ -1,0 +1,15 @@
+import { addMonths, isBefore } from 'date-fns';
+import { convertDateToUTC } from './dates';
+
+export function calculateNextPayAt(fromDate: Date, recurringDay: number) {
+  let nowUtc = convertDateToUTC(fromDate);
+  let nextPayAtUtc = convertDateToUTC(fromDate); // We want a fresh date object, so that we don't mutate the original one (setDate mutates the original date object))
+
+  nextPayAtUtc.setDate(recurringDay);
+
+  if (nextPayAtUtc.getTime() === nowUtc.getTime() || isBefore(nextPayAtUtc, nowUtc)) {
+    nextPayAtUtc = addMonths(nextPayAtUtc, 1);
+  }
+
+  return nextPayAtUtc;
+}


### PR DESCRIPTION
Ticket: CS-4373

It goes like this:

1. Client will generate the signature for creating the transaction to add a scheduled payment on the blockchain
2. Client will send the scheduled payment params to the endpoint, along with the signature
3. Endpoint will save the scheduled payment row in the db, and submit a blockchain transaction. The request will wait until we are able to get the transaction hash. If there are problems submitting the transaction, the request will fail, and the scheduled payment row will be discarded
4. At this point, the transaction is not mined yet. This could take many minutes to finish, so we do it async in a background worker which will update the scheduled payment row once done (it will write the `creation_block_number`). This way the client can poll the scheduled payment and when `creation_block_number` gets written by the background job, it means the scheduled payment has been added in both blockchain and the crank - the client can then show it as "added successfully", otherwise it will be "pending".

TODO:
- [ ] Test using a real chain 
- [ ] More thorough validator checks + validator tests
- [ ] Add a route test for a recurring scheduled payment (important: see if `payAt` gets set correctly)
- [ ] Prevent double save (at the beginning of the request, check if there was a very similar scheduled payment created very recently)