### PR TITLE
[Chore]: Override boxel js prettier to match template

### DIFF
--- a/packages/boxel/.prettierrc.js
+++ b/packages/boxel/.prettierrc.js
@@ -2,4 +2,12 @@
 
 module.exports = {
   singleQuote: true,
+  overrides: [
+    {
+      files: '*.hbs',
+      options: {
+        singleQuote: false,
+      },
+    },
+  ],
 };


### PR DESCRIPTION
using VsCode, if we had format on save enabled it was actually adding singles quotes to templates. In order to correctly auto format we need to override the rule. There's this [great article ](https://dev.to/jelhan/format-glimmer-templates-with-prettier-ipa)with more info.

https://user-images.githubusercontent.com/20520102/190681693-9e8e8bdd-b29c-42d9-bcef-4f565124aa6c.mov


