### PR TITLE
Add cron to lambda

### DIFF
--- a/packages/cardpay-reward-programs/scripts/check_missing_roots.py
+++ b/packages/cardpay-reward-programs/scripts/check_missing_roots.py
@@ -1,5 +1,6 @@
 import json
 import re
+from typing import Any, Callable, Dict, TypedDict
 
 import boto3
 import pandas as pd
@@ -9,35 +10,46 @@ from cardpay_reward_programs.config import config
 from scripts.utils import Environment
 
 
-def query(skip: int):
-    return """
-    {
+class SubgraphQuery(TypedDict):
+    name: str
+    query: str
+
+
+def merkle_root_submissions_query(
+    skip: int, blockNumber_gt=0, **filters
+) -> SubgraphQuery:
+    query = """{{
         merkleRootSubmissions(
-            skip: %s,
-            orderBy: id,
+            skip: {skip},
+            orderBy: blockNumber,
+            where: {{ blockNumber_gt: {blockNumber_gt} }}
         )
-        {
-            rewardProgram {
+        {{
+            rewardProgram {{
                 id
-            }
+            }}
             paymentCycle
-        }
-    }""" % (
-        skip
+        }}
+    }}""".format(
+        **{"skip": skip, "blockNumber_gt": blockNumber_gt, **filters}
     )
+    return {"name": "merkleRootSubmissions", "query": query}
 
 
-def call(env: str, skip: int):
+def query_subgraph(
+    env: str, skip: int, query: Callable[[int, int, Dict[str, Any]], SubgraphQuery]
+):
     print(f"Skipping {skip}")
     subgraph_url = config[env]["subgraph_url"]
+    subgraph_query = query(skip)
     r = requests.post(
         subgraph_url,
-        json={"query": query(skip)},
+        json={"query": subgraph_query["query"]},
     )
     if r.ok:
         json_data = json.loads(r.text)
         data = json_data["data"]
-        return data["merkleRootSubmissions"]
+        return data[subgraph_query["name"]]
 
 
 def transform(subgraph_o):
@@ -52,10 +64,18 @@ def get_all_merkle_root_submissions(env: Environment):
     res = []
 
     i = 0
-    while c := call(env, i * paginate_size):
+    while c := query_subgraph(env, i * paginate_size, merkle_root_submissions_query):
         if len(c) == 0:
             break
-        transformed_c = list(map(transform, c))
+        transformed_c = list(
+            map(
+                lambda o: {
+                    "reward_program_id": o["rewardProgram"]["id"],
+                    "payment_cycle": o["paymentCycle"],
+                },
+                c,
+            )
+        )
 
         res = res + transformed_c
         i = i + 1
@@ -72,21 +92,6 @@ def safe_regex_group_search(regex, string, group):
         return match.group(group)
     else:
         return None
-
-
-def query_subgraph(subgraph_url, query):
-    try:
-        r = requests.post(
-            subgraph_url,
-            json={"query": query},
-        )
-        if r.ok:
-            json_data = r.json()
-            return json_data["data"]
-        else:
-            raise (r.raise_for_status())
-    except Exception as e:
-        raise (e)
 
 
 def check_missing_roots(

--- a/packages/cardpay-reward-programs/scripts/check_missing_roots.py
+++ b/packages/cardpay-reward-programs/scripts/check_missing_roots.py
@@ -103,14 +103,13 @@ def check_missing_roots(
             r"rewardProgramID=([^/]*)", str(o.key), 1
         )
         payment_cycle = safe_regex_group_search(r"paymentCycle=([^/]*)", str(o.key), 1)
-        roots.append(
-            {"reward_program_id": reward_program_id, "payment_cycle": payment_cycle}
-        )
+        if o.key.endswith("results.parquet"):
+            roots.append(
+                {"reward_program_id": reward_program_id, "payment_cycle": payment_cycle}
+            )
     col_keys = ["reward_program_id", "payment_cycle"]
     subgraph_df = get_all_merkle_root_submissions(env)
-    s3_df = pd.DataFrame(roots).drop_duplicates(subset=col_keys)
-    # have to drop duplicates because there are two files in each bucket. there is no great way to list directories in s3 because it doesn't support glob-like pattern
-    # TODO: it would be nice to fix this because it is very error-prone -- https://stackoverflow.com/questions/35442383/filter-a-glob-like-regex-pattern-in-boto3
+    s3_df = pd.DataFrame(roots)
     left_join_df = s3_df.merge(
         subgraph_df, how="left", on=col_keys, indicator=True
     ).copy()

--- a/packages/cardpay-reward-programs/scripts/check_missing_roots.py
+++ b/packages/cardpay-reward-programs/scripts/check_missing_roots.py
@@ -52,13 +52,6 @@ def query_subgraph(
         return data[subgraph_query["name"]]
 
 
-def transform(subgraph_o):
-    return {
-        "reward_program_id": subgraph_o["rewardProgram"]["id"],
-        "payment_cycle": subgraph_o["paymentCycle"],
-    }
-
-
 def get_all_merkle_root_submissions(env: Environment):
     paginate_size = 100
     res = []

--- a/packages/reward-root-submitter/.vscode/launch.json
+++ b/packages/reward-root-submitter/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run manual",
+      "type": "python",
+      "request": "launch",
+      "module": "reward_root_submitter.manual",
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/packages/reward-root-submitter/README.md
+++ b/packages/reward-root-submitter/README.md
@@ -38,7 +38,7 @@ And
 
 A submission can be triggered by pointing to a file either local or on S3
 
-    ENVIRONMENT=staging EVM_FULL_NODE_URL=http://127.0.0.1:8545 python -m reward_root_submitter.manual file_path_goes_here
+    python -m reward_root_submitter.manual file_path_goes_here
 
 All required config can be overridden by setting an environment variable, otherwise they will be taken from the secrets manager
 

--- a/packages/reward-root-submitter/pdm.lock
+++ b/packages/reward-root-submitter/pdm.lock
@@ -406,6 +406,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pandas"
+version = "1.5.0"
+requires_python = ">=3.8"
+summary = "Powerful data structures for data analysis, time series, and statistics"
+dependencies = [
+    "numpy>=1.20.3; python_version < \"3.10\"",
+    "numpy>=1.21.0; python_version >= \"3.10\"",
+    "python-dateutil>=2.8.1",
+    "pytz>=2020.1",
+]
+
+[[package]]
 name = "parsimonious"
 version = "0.8.1"
 summary = "(Soon to be) the fastest pure-Python PEG parser I could muster"
@@ -583,6 +595,11 @@ requires_python = ">=3.5"
 summary = "Read key-value pairs from a .env file and set them as environment variables"
 
 [[package]]
+name = "pytz"
+version = "2022.2.1"
+summary = "World timezone definitions, modern and historical"
+
+[[package]]
 name = "pywin32"
 version = "304"
 summary = "Python for Window Extensions"
@@ -743,7 +760,7 @@ dependencies = [
 
 [metadata]
 lock_version = "4.0"
-content_hash = "sha256:206309781fdfe0ad4f3b17326a5c0a2a00ec619edec3d91186bdda4fdc016446"
+content_hash = "sha256:c064e9dffc9ab933d3fa5b63edd7a6291870d891148e3279043dd22a0ea4eb99"
 
 [metadata.files]
 "aiohttp 3.8.1" = [
@@ -1344,6 +1361,35 @@ content_hash = "sha256:206309781fdfe0ad4f3b17326a5c0a2a00ec619edec3d91186bdda4fd
     {url = "https://files.pythonhosted.org/packages/05/8e/8de486cbd03baba4deef4142bd643a3e7bbe954a784dc1bb17142572d127/packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {url = "https://files.pythonhosted.org/packages/df/9e/d1a7217f69310c1db8fdf8ab396229f55a699ce34a203691794c5d1cad0c/packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
+"pandas 1.5.0" = [
+    {url = "https://files.pythonhosted.org/packages/05/4b/cade88002bce6a808c44199617160bd9d78c23d4bb91950f4397aebf063f/pandas-1.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1b82ccc7b093e0a93f8dffd97a542646a3e026817140e2c01266aaef5fdde11b"},
+    {url = "https://files.pythonhosted.org/packages/0f/dc/9e6655b5403b2d29e96e950e6fcecb4dc57826325ef5fc9fd777abe666c1/pandas-1.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:207d63ac851e60ec57458814613ef4b3b6a5e9f0b33c57623ba2bf8126c311f8"},
+    {url = "https://files.pythonhosted.org/packages/10/ee/11b87cb8c1f7528f49c3eae401461759f7481eaf6b3f76f690d400a89410/pandas-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:171cef540bfcec52257077816a4dbbac152acdb8236ba11d3196ae02bf0959d8"},
+    {url = "https://files.pythonhosted.org/packages/13/94/ffc33b085128c3c67f29b5bee296a7761aa53147439710a01affe0695066/pandas-1.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:85a516a7f6723ca1528f03f7851fa8d0360d1d6121cf15128b290cf79b8a7f6a"},
+    {url = "https://files.pythonhosted.org/packages/1d/4c/59163e34135e72eda5f083aa89183f582d7a24415132f4bfc8ecc486125a/pandas-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:86d87279ebc5bc20848b4ceb619073490037323f80f515e0ec891c80abad958a"},
+    {url = "https://files.pythonhosted.org/packages/28/92/d8ede5d604e7970172e23e3bed9e9a19b841baed95e2fd6d87ac90f87026/pandas-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:1642fc6138b4e45d57a12c1b464a01a6d868c0148996af23f72dde8d12486bbc"},
+    {url = "https://files.pythonhosted.org/packages/2a/24/f5042daa59b91e94e6ea41edbb28d2b7e3712d0cf54a76f9ffde394efbe7/pandas-1.5.0.tar.gz", hash = "sha256:3ee61b881d2f64dd90c356eb4a4a4de75376586cd3c9341c6c0fcaae18d52977"},
+    {url = "https://files.pythonhosted.org/packages/2b/a9/f5e78b7dea7ab35e713425eb571d72002cfdac2e5c9113ce40176c8dcc9e/pandas-1.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:8a4fc04838615bf0a8d3a03ed68197f358054f0df61f390bcc64fbe39e3d71ec"},
+    {url = "https://files.pythonhosted.org/packages/4a/ad/50a7329fcd1d23cca74dcd1eae4dfb429d5fb28963f5822649fda8320bf2/pandas-1.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e9c5049333c5bebf993033f4bf807d163e30e8fada06e1da7fa9db86e2392009"},
+    {url = "https://files.pythonhosted.org/packages/4c/cc/e4670163011b9ac92f728b871c617d8e9421461df5c30ececb65dce52ba6/pandas-1.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62e61003411382e20d7c2aec1ee8d7c86c8b9cf46290993dd8a0a3be44daeb38"},
+    {url = "https://files.pythonhosted.org/packages/60/91/dd83dd2222b6c8f707a39b0d8da91158c42e4827d6962229553a31199548/pandas-1.5.0-cp38-cp38-win32.whl", hash = "sha256:e178ce2d7e3b934cf8d01dc2d48d04d67cb0abfaffdcc8aa6271fd5a436f39c8"},
+    {url = "https://files.pythonhosted.org/packages/80/79/f59ad6186a5271c7b1ddeb261738f667a997e782ecd9a5ae55c6b4c15d73/pandas-1.5.0-cp39-cp39-win32.whl", hash = "sha256:2504c032f221ef9e4a289f5e46a42b76f5e087ecb67d62e342ccbba95a32a488"},
+    {url = "https://files.pythonhosted.org/packages/82/6c/c35ea6ed019829714a8432da14690f442f96ffeb050343278fe0733fb768/pandas-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0d8d7433d19bfa33f11c92ad9997f15a902bda4f5ad3a4814a21d2e910894484"},
+    {url = "https://files.pythonhosted.org/packages/85/74/1aafd4d480ee3c22c6b30c2449939e129f3a75bbb042ff6cc3bdcc99295c/pandas-1.5.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:73844e247a7b7dac2daa9df7339ecf1fcf1dfb8cbfd11e3ffe9819ae6c31c515"},
+    {url = "https://files.pythonhosted.org/packages/86/56/1166f3d36fda4e16f4d7296207fae1fa5c01352b32e9c480e1ed360b180e/pandas-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a68a9b9754efff364b0c5ee5b0f18e15ca640c01afe605d12ba8b239ca304d6b"},
+    {url = "https://files.pythonhosted.org/packages/8c/00/e247f93bd07133c47b1b6e7df5a5d5d1a3525d9ba790d38057e1e8ca66a0/pandas-1.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e8e5edf97d8793f51d258c07c629bd49d271d536ce15d66ac00ceda5c150eb3"},
+    {url = "https://files.pythonhosted.org/packages/91/e2/61f674f92e4a13a9c4b24260d2ca8c964e4affccfa3cb9fc2284996618a3/pandas-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:de34636e2dc04e8ac2136a8d3c2051fd56ebe9fd6cd185581259330649e73ca9"},
+    {url = "https://files.pythonhosted.org/packages/a2/bb/33c637f9d284a8b314aee0a6fc2c2ef243d9145e9480f910f4eca54e6887/pandas-1.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c76f1d104844c5360c21d2ef0e1a8b2ccf8b8ebb40788475e255b9462e32b2be"},
+    {url = "https://files.pythonhosted.org/packages/a9/28/b22dee58c431006f84cc6336c44be980ba3ff90ce81e95f007e14f2c484d/pandas-1.5.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:1d34b1f43d9e3f4aea056ba251f6e9b143055ebe101ed04c847b41bb0bb4a989"},
+    {url = "https://files.pythonhosted.org/packages/aa/42/0933b9430425286d2ee3059e067ece3590b63542d9d7a9bb66d3a300ca85/pandas-1.5.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4e30a31039574d96f3d683df34ccb50bb435426ad65793e42a613786901f6761"},
+    {url = "https://files.pythonhosted.org/packages/ba/51/5d6a6e360a69ce88b1170db0897d7c497f02fdbbf77281a9d01aa8eaa064/pandas-1.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:947ed9f896ee61adbe61829a7ae1ade493c5a28c66366ec1de85c0642009faac"},
+    {url = "https://files.pythonhosted.org/packages/d0/83/944ebe877e40b1ac9c47b4ea827f9358f10640ec0523e0b54cebf3d39d84/pandas-1.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7f38d91f21937fe2bec9449570d7bf36ad7136227ef43b321194ec249e2149d"},
+    {url = "https://files.pythonhosted.org/packages/da/4a/a0c8d3ba8d875a25578bcb3032b6ac9b2db3d016b0a762ab41e1a13f3b52/pandas-1.5.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc987f7717e53d372f586323fff441263204128a1ead053c1b98d7288f836ac9"},
+    {url = "https://files.pythonhosted.org/packages/f6/5d/4020469c1f7df76644b8575b160e9ccafdf1eeb5af7d0b5627e0f565fd18/pandas-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5cc47f2ebaa20ef96ae72ee082f9e101b3dfbf74f0e62c7a12c0b075a683f03c"},
+    {url = "https://files.pythonhosted.org/packages/fa/9d/c9820dbe371c1d6297f59ef76a17e032df2659addadfc76bb87106ca35db/pandas-1.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41aec9f87455306496d4486df07c1b98c15569c714be2dd552a6124cd9fda88f"},
+    {url = "https://files.pythonhosted.org/packages/fa/d2/554c10c71f983040d513eca07c2661c6f4fff386652943561a948d55e13a/pandas-1.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:33a9d9e21ab2d91e2ab6e83598419ea6a664efd4c639606b299aae8097c1c94f"},
+    {url = "https://files.pythonhosted.org/packages/fa/fe/c81ad3991f2c6aeacf01973f1d37b1dc76c0682f312f104741602a9557f1/pandas-1.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e252a9e49b233ff96e2815c67c29702ac3a062098d80a170c506dff3470fd060"},
+]
 "parsimonious 0.8.1" = [
     {url = "https://files.pythonhosted.org/packages/02/fc/067a3f89869a41009e1a7cdfb14725f8ddd246f30f63c645e8ef8a1c56f4/parsimonious-0.8.1.tar.gz", hash = "sha256:3add338892d580e0cb3b1a39e4a1b427ff9f687858fdd61097053742391a9f6b"},
 ]
@@ -1574,6 +1620,10 @@ content_hash = "sha256:206309781fdfe0ad4f3b17326a5c0a2a00ec619edec3d91186bdda4fd
 "python-dotenv 0.20.0" = [
     {url = "https://files.pythonhosted.org/packages/02/ee/43e1c862a3e7259a1f264958eaea144f0a2fac9f175c1659c674c34ea506/python-dotenv-0.20.0.tar.gz", hash = "sha256:b7e3b04a59693c42c36f9ab1cc2acc46fa5df8c78e178fc33a8d4cd05c8d498f"},
     {url = "https://files.pythonhosted.org/packages/30/5f/2e5c564bd86349fe6b82ca840f46acf6f4bb76d79ba9057fce3d3e008864/python_dotenv-0.20.0-py3-none-any.whl", hash = "sha256:d92a187be61fe482e4fd675b6d52200e7be63a12b724abbf931a40ce4fa92938"},
+]
+"pytz 2022.2.1" = [
+    {url = "https://files.pythonhosted.org/packages/24/0c/401283bb1499768e33ddd2e1a35817c775405c1f047a9dc088a29ce2ea5d/pytz-2022.2.1.tar.gz", hash = "sha256:cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5"},
+    {url = "https://files.pythonhosted.org/packages/d5/50/54451e88e3da4616286029a3a17fc377de817f66a0f50e1faaee90161724/pytz-2022.2.1-py2.py3-none-any.whl", hash = "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197"},
 ]
 "pywin32 304" = [
     {url = "https://files.pythonhosted.org/packages/05/6b/9f8421a9a2ab5f33cbb9fd2f282ac971e584f6a83d44f6672bd17f1d68b2/pywin32-304-cp310-cp310-win32.whl", hash = "sha256:3c7bacf5e24298c86314f03fa20e16558a4e4138fc34615d7de4070c23e65af3"},

--- a/packages/reward-root-submitter/pyproject.toml
+++ b/packages/reward-root-submitter/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "schedule>=1.1.0",
     "sentry-sdk>=1.5.12",
     "pydantic[dotenv]>=1.9.1",
+    "pandas>=1.5.0",
 ]
 requires-python = ">=3.9"
 license = {text = "MIT"}

--- a/packages/reward-root-submitter/reward_root_submitter/config.py
+++ b/packages/reward-root-submitter/reward_root_submitter/config.py
@@ -26,7 +26,7 @@ class Config(BaseSettings):
     reward_program_output: str
     subgraph_url: str
     log_level: str = Field("INFO")
-    aws_region = str = Field("us-east-1")
+    aws_region: str = Field("us-east-1")
 
     @root_validator(pre=True)
     def load_secrets(cls, values):

--- a/packages/reward-root-submitter/reward_root_submitter/config.py
+++ b/packages/reward-root-submitter/reward_root_submitter/config.py
@@ -26,7 +26,6 @@ class Config(BaseSettings):
     reward_program_output: str
     subgraph_url: str
     log_level: str = Field("INFO")
-    aws_region: str = Field("us-east-1")
 
     @root_validator(pre=True)
     def load_secrets(cls, values):

--- a/packages/reward-root-submitter/reward_root_submitter/config.py
+++ b/packages/reward-root-submitter/reward_root_submitter/config.py
@@ -26,6 +26,7 @@ class Config(BaseSettings):
     reward_program_output: str
     subgraph_url: str
     log_level: str = Field("INFO")
+    aws_region = str = Field("us-east-1")
 
     @root_validator(pre=True)
     def load_secrets(cls, values):

--- a/packages/reward-root-submitter/reward_root_submitter/config.py
+++ b/packages/reward-root-submitter/reward_root_submitter/config.py
@@ -23,6 +23,8 @@ class Config(BaseSettings):
     reward_root_submitter_address: str
     reward_root_submitter_private_key: str
     reward_root_submitter_sentry_dsn: str
+    reward_program_output: str
+    subgraph_url: str
     log_level: str = Field("INFO")
 
     @root_validator(pre=True)

--- a/packages/reward-root-submitter/reward_root_submitter/lambda.py
+++ b/packages/reward-root-submitter/reward_root_submitter/lambda.py
@@ -22,7 +22,7 @@ sentry_sdk.init(
 
 
 def handler(event, _context):
-    if event["source"] == "aws.events":
+    if event.get("source") == "aws.events":
         logging.info("Cron event triggered")
         unsubmitted_roots = get_all_unsubmitted_roots(config)
         for index, row in unsubmitted_roots.iterrows():

--- a/packages/reward-root-submitter/reward_root_submitter/lambda.py
+++ b/packages/reward-root-submitter/reward_root_submitter/lambda.py
@@ -1,3 +1,4 @@
+import logging
 import urllib
 
 import sentry_sdk
@@ -21,8 +22,11 @@ sentry_sdk.init(
 
 
 def handler(event, _context):
-    bucket = event["Records"][0]["s3"]["bucket"]["name"]
-    key = urllib.parse.unquote_plus(
-        event["Records"][0]["s3"]["object"]["key"], encoding="utf-8"
-    )
-    process_file(AnyPath(f"s3://{bucket}/{key}"), Config())
+    if event["source"] == "aws.events":
+        logging.info("event triggered")
+    elif event["Records"]["eventSource"] == "aws.s3":
+        bucket = event["Records"][0]["s3"]["bucket"]["name"]
+        key = urllib.parse.unquote_plus(
+            event["Records"][0]["s3"]["object"]["key"], encoding="utf-8"
+        )
+        process_file(AnyPath(f"s3://{bucket}/{key}"), Config())

--- a/packages/reward-root-submitter/reward_root_submitter/lambda.py
+++ b/packages/reward-root-submitter/reward_root_submitter/lambda.py
@@ -27,7 +27,7 @@ def handler(event, _context):
         unsubmitted_roots = get_all_unsubmitted_roots(config)
         for index, row in unsubmitted_roots.iterrows():
             process_file(row["file"], config)
-    elif event["Records"]["eventSource"] == "aws.s3":
+    elif event["Records"][0]["eventSource"] == "aws.s3":
         bucket = event["Records"][0]["s3"]["bucket"]["name"]
         key = urllib.parse.unquote_plus(
             event["Records"][0]["s3"]["object"]["key"], encoding="utf-8"

--- a/packages/reward-root-submitter/reward_root_submitter/lambda.py
+++ b/packages/reward-root-submitter/reward_root_submitter/lambda.py
@@ -24,6 +24,7 @@ sentry_sdk.init(
 def handler(event, _context):
     if event["source"] == "aws.events":
         logging.info("event triggered")
+        # TODO: get_all_unsubmitted_roots & write to blockchain
     elif event["Records"]["eventSource"] == "aws.s3":
         bucket = event["Records"][0]["s3"]["bucket"]["name"]
         key = urllib.parse.unquote_plus(

--- a/packages/reward-root-submitter/reward_root_submitter/lambda.py
+++ b/packages/reward-root-submitter/reward_root_submitter/lambda.py
@@ -23,10 +23,10 @@ sentry_sdk.init(
 
 def handler(event, _context):
     if event["source"] == "aws.events":
-        logging.info("event triggered")
-        # TODO: get_all_unsubmitted_roots & write to blockchain
-        o = get_all_unsubmitted_roots(config)
-        logging.info(o)
+        logging.info("Cron event triggered")
+        unsubmitted_roots = get_all_unsubmitted_roots(config)
+        for index, row in unsubmitted_roots.iterrows():
+            process_file(row["file"], config)
     elif event["Records"]["eventSource"] == "aws.s3":
         bucket = event["Records"][0]["s3"]["bucket"]["name"]
         key = urllib.parse.unquote_plus(

--- a/packages/reward-root-submitter/reward_root_submitter/lambda.py
+++ b/packages/reward-root-submitter/reward_root_submitter/lambda.py
@@ -6,7 +6,7 @@ from cloudpathlib import AnyPath
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
 from .config import Config
-from .main import process_file, setup_logging
+from .main import get_all_unsubmitted_roots, process_file, setup_logging
 
 config = Config()
 setup_logging(config)
@@ -25,6 +25,8 @@ def handler(event, _context):
     if event["source"] == "aws.events":
         logging.info("event triggered")
         # TODO: get_all_unsubmitted_roots & write to blockchain
+        o = get_all_unsubmitted_roots(config)
+        logging.info(o)
     elif event["Records"]["eventSource"] == "aws.s3":
         bucket = event["Records"][0]["s3"]["bucket"]["name"]
         key = urllib.parse.unquote_plus(

--- a/packages/reward-root-submitter/reward_root_submitter/main.py
+++ b/packages/reward-root-submitter/reward_root_submitter/main.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from dataclasses import dataclass
 
 import pyarrow.parquet as pq

--- a/packages/reward-root-submitter/reward_root_submitter/main.py
+++ b/packages/reward-root-submitter/reward_root_submitter/main.py
@@ -8,7 +8,7 @@ from web3 import Web3
 
 from .config import Config
 from .contracts import RewardPool
-from .utils import get_roots_s3, get_roots_subgraph
+from .utils import get_roots_s3, get_roots_subgraph, safe_regex_group_search
 
 NULL_HEX = HexBytes(
     "0x0000000000000000000000000000000000000000000000000000000000000000"
@@ -30,17 +30,6 @@ class MerkleRoot:
 
 def setup_logging(config):
     logging.getLogger().setLevel(level=config.log_level.upper())
-
-
-def safe_regex_group_search(regex, string, group):
-    """
-    Returns None in the case of a missing group
-    """
-    match = re.search(regex, string)
-    if match:
-        return match.group(group)
-    else:
-        return None
 
 
 def get_merkle_root_details(reward_output_filename):

--- a/packages/reward-root-submitter/reward_root_submitter/main.py
+++ b/packages/reward-root-submitter/reward_root_submitter/main.py
@@ -89,11 +89,15 @@ def process_file(reward_output_filename, config):
     )
 
 
-def get_all_unsubmitted_roots(config: Config):
+def get_all_unsubmitted_roots(config: Config, min_scan_block: int = None):
     evm_node = config.evm_full_node_url
     w3 = Web3(Web3.HTTPProvider(evm_node))
     current_block = w3.eth.get_block("latest")["number"]
-    min_scan_block = current_block - DEFAULT_MAX_PAST_BLOCKS
+    min_scan_block = (
+        current_block - DEFAULT_MAX_PAST_BLOCKS
+        if min_scan_block is None
+        else min_scan_block
+    )
 
     s3_df = get_roots_s3(config, min_scan_block)
     subgraph_df = get_roots_subgraph(config, min_scan_block)
@@ -109,3 +113,4 @@ def get_all_unsubmitted_roots(config: Config):
     logging.info(
         f"Total of {len(missing_roots_df)} out of {len(s3_df)} roots are missing "
     )
+    return missing_roots_df

--- a/packages/reward-root-submitter/reward_root_submitter/manual.py
+++ b/packages/reward-root-submitter/reward_root_submitter/manual.py
@@ -3,12 +3,10 @@ import sys
 from cloudpathlib import AnyPath
 
 from .config import Config
-from .main import process_file, setup_logging
+from .main import get_all_unsubmitted_roots, process_file, setup_logging
 
 config = Config()
 setup_logging(config)
 
 if __name__ == "__main__":
-    file_path = sys.argv[1]
-    print(file_path)
-    process_file(AnyPath(file_path), Config())
+    get_all_unsubmitted_roots(config)

--- a/packages/reward-root-submitter/reward_root_submitter/manual.py
+++ b/packages/reward-root-submitter/reward_root_submitter/manual.py
@@ -3,10 +3,12 @@ import sys
 from cloudpathlib import AnyPath
 
 from .config import Config
-from .main import get_all_unsubmitted_roots, process_file, setup_logging
+from .main import process_file, setup_logging
 
 config = Config()
 setup_logging(config)
 
 if __name__ == "__main__":
-    get_all_unsubmitted_roots(config)
+    file_path = sys.argv[1]
+    print(file_path)
+    process_file(AnyPath(file_path), Config())

--- a/packages/reward-root-submitter/reward_root_submitter/utils.py
+++ b/packages/reward-root-submitter/reward_root_submitter/utils.py
@@ -1,0 +1,168 @@
+import json
+import logging
+import re
+from typing import Any, Callable, Dict, TypedDict
+
+import pandas as pd
+import requests
+from cloudpathlib import AnyPath
+from web3 import Web3
+
+from .config import Config
+
+DEFAULT_MAX_PAST_BLOCKS = 34560  # 2 days (1 block every 5s)
+DEFAULT_SUBGRAPH_PAGINATE_SIZE = 100
+
+
+class SubgraphQuery(TypedDict):
+    name: str
+    query: str
+
+
+def merkle_root_submissions_query(
+    skip: int, blockNumber_gt=0, **filters
+) -> SubgraphQuery:
+    query = """{{
+        merkleRootSubmissions(
+            skip: {skip},
+            orderBy: blockNumber,
+            where: {{ blockNumber_gt: {blockNumber_gt} }}
+        )
+        {{
+            rewardProgram {{
+                id
+            }}
+            paymentCycle
+        }}
+    }}""".format(
+        **{"skip": skip, "blockNumber_gt": blockNumber_gt, **filters}
+    )
+    return {"name": "merkleRootSubmissions", "query": query}
+
+
+def query_subgraph(
+    config: Config,
+    skip: int,
+    blockNumber_gt: int,
+    query: Callable[[int, int, Dict[str, Any]], SubgraphQuery],
+):
+    print(f"Skipping {skip}")
+    subgraph_url = config.subgraph_url
+    subgraph_query = query(skip, blockNumber_gt)
+    r = requests.post(
+        subgraph_url,
+        json={"query": subgraph_query["query"]},
+    )
+    if r.ok:
+        json_data = json.loads(r.text)
+        data = json_data["data"]
+        return data[subgraph_query["name"]]
+
+
+def get_roots_subgraph(config: Config, min_scan_block=0):
+    paginate_size = 100
+    res = []
+
+    i = 0
+    while c := query_subgraph(
+        config, i * paginate_size, min_scan_block, merkle_root_submissions_query
+    ):
+        if len(c) == 0:
+            break
+        transformed_c = list(
+            map(
+                lambda o: {
+                    "reward_program_id": o["rewardProgram"]["id"],
+                    "payment_cycle": int(o["paymentCycle"]),
+                },
+                c,
+            )
+        )
+
+        res = res + transformed_c
+        i = i + 1
+    df = pd.DataFrame(res)
+    return df
+
+
+def safe_regex_group_search(regex, string, group):
+    """
+    Returns None in the case of a missing group
+    """
+    match = re.search(regex, string)
+    if match:
+        return match.group(group)
+    else:
+        return None
+
+
+def _get_potential_reward_output_locations(reward_program_bucket: AnyPath):
+    """
+    This is a generator that yields the locations
+    of reward programs _if_ all results are well formed.
+    """
+    for i in reward_program_bucket.glob("rewardProgramID=*/paymentCycle=*/*.parquet"):
+        yield i
+
+
+def get_all_reward_outputs(reward_program_bucket: AnyPath, min_scan_block: int = 0):
+    # This does not need to be initialised with an address
+    # we just need the utility functions attached
+    web3 = Web3()
+    for result_file in _get_potential_reward_output_locations(reward_program_bucket):
+        reward_program_id = safe_regex_group_search(
+            r"rewardProgramID=([^/]*)", str(result_file), 1
+        )
+        payment_cycle = safe_regex_group_search(
+            r"paymentCycle=(\d*)", str(result_file), 1
+        )
+        if int(payment_cycle) < min_scan_block:
+            continue
+        if (
+            web3.isChecksumAddress(reward_program_id)
+            and result_file.is_file()  # checks existence & is not a folder
+            and (payment_cycle or "").isdigit()
+        ):
+            yield {
+                "file": result_file,
+                "reward_program_id": reward_program_id,
+                "payment_cycle": int(payment_cycle),
+            }
+
+
+def get_roots_s3(config: Config, min_scan_block=0):
+
+    outputs = get_all_reward_outputs(
+        AnyPath(config.reward_program_output), min_scan_block
+    )
+    roots = []
+    for output in outputs:
+        roots.append(output)
+
+    return (
+        pd.DataFrame(roots)
+        .drop("file", axis=1)
+        .drop_duplicates(subset=["reward_program_id", "payment_cycle"])
+    )
+
+
+def get_all_unsubmitted_roots(config: Config):
+    evm_node = config.evm_full_node_url
+    w3 = Web3(Web3.HTTPProvider(evm_node))
+    current_block = w3.eth.get_block("latest")["number"]
+    min_scan_block = current_block - DEFAULT_MAX_PAST_BLOCKS
+
+    s3_df = get_roots_s3(config, min_scan_block)
+    subgraph_df = get_roots_subgraph(config, min_scan_block)
+    left_exclude_join_df = s3_df.merge(
+        subgraph_df,
+        how="left",
+        on=["reward_program_id", "payment_cycle"],
+        indicator=True,
+    ).copy()
+    missing_roots_df = left_exclude_join_df[
+        left_exclude_join_df["_merge"] == "left_only"
+    ].drop("_merge", axis=1)
+    logging.info(
+        f"Total of {len(missing_roots_df)} out of {len(s3_df)} roots are missing "
+    )

--- a/packages/reward-root-submitter/reward_root_submitter/utils.py
+++ b/packages/reward-root-submitter/reward_root_submitter/utils.py
@@ -80,17 +80,13 @@ def get_roots_subgraph(config: Config, min_scan_block=0):
     ):
         if len(c) == 0:
             break
-        transformed_c = list(
-            map(
-                lambda o: {
-                    "reward_program_id": o["rewardProgram"]["id"],
-                    "payment_cycle": int(o["paymentCycle"]),
-                },
-                c,
-            )
+        res.extend(
+            {
+                "reward_program_id": root_submission["rewardProgram"]["id"],
+                "payment_cycle": int(root_submission["paymentCycle"]),
+            }
+            for root_submission in c
         )
-
-        res = res + transformed_c
         i = i + 1
     df = pd.DataFrame(res)
     return df

--- a/packages/reward-root-submitter/reward_root_submitter/utils.py
+++ b/packages/reward-root-submitter/reward_root_submitter/utils.py
@@ -63,7 +63,7 @@ def query_subgraph(
         json={"query": subgraph_query["query"]},
     )
     if r.ok:
-        json_data = json.loads(r.text)
+        json_data = r.json()
         data = json_data["data"]
         return data[subgraph_query["name"]]
 

--- a/packages/reward-root-submitter/reward_root_submitter/utils.py
+++ b/packages/reward-root-submitter/reward_root_submitter/utils.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import re
 from typing import Any, Callable, Dict, TypedDict

--- a/packages/reward-root-submitter/reward_root_submitter/utils.py
+++ b/packages/reward-root-submitter/reward_root_submitter/utils.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import re
 from typing import Any, Callable, Dict, TypedDict
 
@@ -10,7 +9,6 @@ from web3 import Web3
 
 from .config import Config
 
-DEFAULT_MAX_PAST_BLOCKS = 34560  # 2 days (1 block every 5s)
 DEFAULT_SUBGRAPH_PAGINATE_SIZE = 100
 
 
@@ -143,26 +141,4 @@ def get_roots_s3(config: Config, min_scan_block=0):
         pd.DataFrame(roots)
         .drop("file", axis=1)
         .drop_duplicates(subset=["reward_program_id", "payment_cycle"])
-    )
-
-
-def get_all_unsubmitted_roots(config: Config):
-    evm_node = config.evm_full_node_url
-    w3 = Web3(Web3.HTTPProvider(evm_node))
-    current_block = w3.eth.get_block("latest")["number"]
-    min_scan_block = current_block - DEFAULT_MAX_PAST_BLOCKS
-
-    s3_df = get_roots_s3(config, min_scan_block)
-    subgraph_df = get_roots_subgraph(config, min_scan_block)
-    left_exclude_join_df = s3_df.merge(
-        subgraph_df,
-        how="left",
-        on=["reward_program_id", "payment_cycle"],
-        indicator=True,
-    ).copy()
-    missing_roots_df = left_exclude_join_df[
-        left_exclude_join_df["_merge"] == "left_only"
-    ].drop("_merge", axis=1)
-    logging.info(
-        f"Total of {len(missing_roots_df)} out of {len(s3_df)} roots are missing "
     )

--- a/packages/reward-root-submitter/reward_root_submitter/utils.py
+++ b/packages/reward-root-submitter/reward_root_submitter/utils.py
@@ -12,6 +12,17 @@ from .config import Config
 DEFAULT_SUBGRAPH_PAGINATE_SIZE = 100
 
 
+def safe_regex_group_search(regex, string, group):
+    """
+    Returns None in the case of a missing group
+    """
+    match = re.search(regex, string)
+    if match:
+        return match.group(group)
+    else:
+        return None
+
+
 class SubgraphQuery(TypedDict):
     name: str
     query: str
@@ -81,17 +92,6 @@ def get_roots_subgraph(config: Config, min_scan_block=0):
         i = i + 1
     df = pd.DataFrame(res)
     return df
-
-
-def safe_regex_group_search(regex, string, group):
-    """
-    Returns None in the case of a missing group
-    """
-    match = re.search(regex, string)
-    if match:
-        return match.group(group)
-    else:
-        return None
 
 
 def _get_potential_reward_output_locations(reward_program_bucket: AnyPath):

--- a/packages/reward-root-submitter/reward_root_submitter/utils.py
+++ b/packages/reward-root-submitter/reward_root_submitter/utils.py
@@ -116,18 +116,17 @@ def get_all_reward_outputs(reward_program_bucket: AnyPath, min_scan_block: int =
         payment_cycle = safe_regex_group_search(
             r"paymentCycle=(\d*)", str(result_file), 1
         )
-        if int(payment_cycle) < min_scan_block:
-            continue
-        if (
-            web3.isChecksumAddress(reward_program_id)
-            and result_file.is_file()  # checks existence & is not a folder
-            and (payment_cycle or "").isdigit()
-        ):
-            yield {
-                "file": result_file,
-                "reward_program_id": reward_program_id,
-                "payment_cycle": int(payment_cycle),
-            }
+        if int(payment_cycle) >= min_scan_block:
+            if (
+                web3.isChecksumAddress(reward_program_id)
+                and result_file.is_file()  # checks existence & is not a folder
+                and (payment_cycle or "").isdigit()
+            ):
+                yield {
+                    "file": result_file,
+                    "reward_program_id": reward_program_id,
+                    "payment_cycle": int(payment_cycle),
+                }
 
 
 def get_roots_s3(config: Config, min_scan_block=0):
@@ -139,8 +138,6 @@ def get_roots_s3(config: Config, min_scan_block=0):
     for output in outputs:
         roots.append(output)
 
-    return (
-        pd.DataFrame(roots)
-        .drop("file", axis=1)
-        .drop_duplicates(subset=["reward_program_id", "payment_cycle"])
+    return pd.DataFrame(roots).drop_duplicates(
+        subset=["reward_program_id", "payment_cycle"]
     )

--- a/packages/reward-root-submitter/reward_root_submitter/utils.py
+++ b/packages/reward-root-submitter/reward_root_submitter/utils.py
@@ -35,6 +35,7 @@ def merkle_root_submissions_query(
         merkleRootSubmissions(
             skip: {skip},
             orderBy: blockNumber,
+            orderDirection: asc,
             where: {{ blockNumber_gt: {blockNumber_gt} }}
         )
         {{

--- a/packages/reward-root-submitter/reward_root_submitter/utils.py
+++ b/packages/reward-root-submitter/reward_root_submitter/utils.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 from typing import Any, Callable, Dict, TypedDict
 
@@ -56,7 +57,7 @@ def query_subgraph(
     blockNumber_gt: int,
     query: Callable[[int, int, Dict[str, Any]], SubgraphQuery],
 ):
-    print(f"Skipping {skip}")
+    logging.info(f"Skipping {skip}")
     subgraph_url = config.subgraph_url
     subgraph_query = query(skip, blockNumber_gt)
     r = requests.post(

--- a/packages/reward-root-submitter/reward_root_submitter/utils.py
+++ b/packages/reward-root-submitter/reward_root_submitter/utils.py
@@ -98,9 +98,11 @@ def _get_potential_reward_output_locations(reward_program_bucket: AnyPath):
     """
     This is a generator that yields the locations
     of reward programs _if_ all results are well formed.
+    NOTE: Please do not use .glob(). It is too slow
     """
-    for i in reward_program_bucket.glob("rewardProgramID=*/paymentCycle=*/*.parquet"):
-        yield i
+    for reward_program_folder in reward_program_bucket.iterdir():
+        for payment_cycle_folder in reward_program_folder.iterdir():
+            yield payment_cycle_folder / "results.parquet"
 
 
 def get_all_reward_outputs(reward_program_bucket: AnyPath, min_scan_block: int = 0):

--- a/packages/reward-root-submitter/tests/test_submitter.py
+++ b/packages/reward-root-submitter/tests/test_submitter.py
@@ -144,6 +144,8 @@ def config(deploy_address, deploy_key):
         reward_root_submitter_address=deploy_address,
         reward_root_submitter_private_key=deploy_key,
         reward_root_submitter_sentry_dsn="test",
+        reward_program_output="tests/resources/reward_output/",
+        subgraph_url="https://graph-staging.stack.cards/subgraphs/name/habdelra/cardpay-sokol",
     )
 
 


### PR DESCRIPTION
This adds an additional code path to the lambda to listen to a cron event (cloudwatch event) that is triggered every 1 day. 
- it looks at s3 and subgraph and figures out the unsubmitted roots 
- submits the unsubmitted roots
- theres `min_scan_block` of ~2 days back to avoid lambda timeouts

infra pr: [here](https://github.com/cardstack/infra/pull/258)