### PR TITLE
hub: DB migrate improvements

### DIFF
--- a/packages/hub/cli/db/migrate.ts
+++ b/packages/hub/cli/db/migrate.ts
@@ -15,6 +15,11 @@ export async function handler(_argv: Argv & { _: string[]; checkOrder?: boolean 
     _: [, , direction],
     checkOrder = true,
   } = _argv;
+
+  if (direction == null) {
+    direction = 'up';
+  }
+
   if (direction! !== 'up' && direction! !== 'down') {
     console.error(`Invalid migration direction: '${direction}'. Must be 'up' or 'down'`);
     process.exit(1);
@@ -30,7 +35,7 @@ export async function handler(_argv: Argv & { _: string[]; checkOrder?: boolean 
       direction,
       dir,
       migrationsTable: 'pgmigrations',
-      count: Infinity,
+      count: direction === 'up' ? Infinity : 1,
       dbClient,
       checkOrder,
       verbose: true,

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -21,6 +21,7 @@
     "start:bot": "node --no-deprecation -r source-map-support/register dist/hub.js bot",
     "start:event-listener": "node --no-deprecation -r source-map-support/register dist/hub.js event-listener",
     "console": "yarn build_if_missing && node --no-deprecation --experimental-repl-await ./dist/hub.js console",
+    "migrate": "node-pg-migrate",
     "db:test-init": "yarn build_if_missing && NODE_ENV=test node --no-deprecation -r source-map-support/register ./dist/hub.js db init",
     "db:migrate": "node --no-deprecation -r source-map-support/register dist/hub.js db migrate --no-check-order",
     "db:update-prisma": "prisma db pull && node dist/hub.js db transform-prisma-schema && prisma format && prisma generate",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -22,7 +22,7 @@
     "start:event-listener": "node --no-deprecation -r source-map-support/register dist/hub.js event-listener",
     "console": "yarn build_if_missing && node --no-deprecation --experimental-repl-await ./dist/hub.js console",
     "db:test-init": "yarn build_if_missing && NODE_ENV=test node --no-deprecation -r source-map-support/register ./dist/hub.js db init",
-    "db:migrate": "node --no-deprecation -r source-map-support/register dist/hub.js db migrate up --no-check-order",
+    "db:migrate": "node --no-deprecation -r source-map-support/register dist/hub.js db migrate --no-check-order",
     "db:update-prisma": "prisma db pull && node dist/hub.js db transform-prisma-schema && prisma format && prisma generate",
     "test": "yarn build_if_missing && npm-run-all test:*",
     "test:node": "NODE_ENV=test mocha --no-deprecation -r source-map-support/register dist/tests.js --timeout 60000",


### PR DESCRIPTION
This PR is a suggestion to change the behaviour of the `yarn db:migrate` command to be more Rails-like, where `rails db:migrate` will migrate all pending migrations, and `rails db:rollback` will revert the latest migration only. I find this a good default practice and wish to apply it here as well. 

So this translates to: `yarn db:migrate` (will migrate all pending) and `yarn db:migrate down` (will only rollback the last one). 

Also, `migrate` was added to the scripts so we can use it to generate migrations, for example `yarn migrate create add user address to scheduled payments`