### PR TITLE
boxel: Add ControlPanel

### DIFF
--- a/packages/boxel/addon/components/boxel/control-panel/index.css
+++ b/packages/boxel/addon/components/boxel/control-panel/index.css
@@ -1,0 +1,32 @@
+.boxel-control-panel {
+  background-color: var(--boxel-purple-600);
+  color: var(--boxel-light);
+}
+
+.boxel-control-panel__item {
+  border-bottom: 1px solid var(--boxel-purple-500);
+  padding: var(--boxel-sp-sm) var(--boxel-sp-sm) var(--boxel-sp-xl) var(--boxel-sp-sm);
+}
+
+.boxel-control-panel__item:last-child {
+  border-bottom-width: 0;
+}
+
+.boxel-control-panel__item-heading {
+  display: grid;
+  grid-template-columns: var(--boxel-sp-xl) 1fr;
+  align-items: center;
+  padding: var(--boxel-sp-sm) 0;
+  color: var(--boxel-light);
+  font: 600 var(--boxel-font-xs);
+  letter-spacing: var(--boxel-lsp-xl);
+  text-transform: uppercase;
+}
+
+.boxel-control-panel__item-icon {
+  --icon-color: var(--boxel-cyan);
+}
+
+.boxel-control-panel__item-body {
+  margin-left: var(--boxel-sp-xl);
+}

--- a/packages/boxel/addon/components/boxel/control-panel/index.css
+++ b/packages/boxel/addon/components/boxel/control-panel/index.css
@@ -16,7 +16,7 @@
 .boxel-control-panel__item-heading {
   position: relative;
   display: grid;
-  grid-template-columns: var(--boxel-sp-xl) 1fr;
+  grid-template-columns: var(--boxel-sp-lg) 1fr;
   align-items: center;
   padding: var(--boxel-sp-sm) 0 var(--boxel-sp) 0;
   color: var(--boxel-light);

--- a/packages/boxel/addon/components/boxel/control-panel/index.css
+++ b/packages/boxel/addon/components/boxel/control-panel/index.css
@@ -40,7 +40,3 @@
 .boxel-control-panel__item-icon {
   --icon-color: var(--boxel-cyan);
 }
-
-.boxel-control-panel__item-body {
-  margin-left: var(--boxel-sp-xl);
-}

--- a/packages/boxel/addon/components/boxel/control-panel/index.css
+++ b/packages/boxel/addon/components/boxel/control-panel/index.css
@@ -5,7 +5,7 @@
 
 .boxel-control-panel__item {
   border-bottom: 1px solid var(--boxel-purple-500);
-  padding: var(--boxel-sp-sm) var(--boxel-sp-sm) var(--boxel-sp-xl) var(--boxel-sp-sm);
+  padding: var(--boxel-sp-sm) var(--boxel-sp-sm) var(--boxel-sp-xxl) var(--boxel-sp-sm);
 }
 
 .boxel-control-panel__item:last-child {

--- a/packages/boxel/addon/components/boxel/control-panel/index.css
+++ b/packages/boxel/addon/components/boxel/control-panel/index.css
@@ -1,6 +1,7 @@
 .boxel-control-panel {
   background-color: var(--boxel-purple-600);
   color: var(--boxel-light);
+  padding: var(--boxel-sp-xl);
 }
 
 .boxel-control-panel__item {
@@ -13,6 +14,7 @@
 }
 
 .boxel-control-panel__item-heading {
+  position: relative;
   display: grid;
   grid-template-columns: var(--boxel-sp-xl) 1fr;
   align-items: center;
@@ -21,6 +23,18 @@
   font: 600 var(--boxel-font-xs);
   letter-spacing: var(--boxel-lsp-xl);
   text-transform: uppercase;
+}
+
+.boxel-control-panel__item-heading--is-active::before {
+  content: "";
+  position: absolute;
+  background-image: url('/@cardstack/boxel/images/icons/active-item.svg');
+  background-repeat: no-repeat;
+  background-position: center left;
+  top: 0;
+  height: 100%;
+  width: 25px;
+  right: 100%;
 }
 
 .boxel-control-panel__item-icon {

--- a/packages/boxel/addon/components/boxel/control-panel/index.css
+++ b/packages/boxel/addon/components/boxel/control-panel/index.css
@@ -18,7 +18,7 @@
   display: grid;
   grid-template-columns: var(--boxel-sp-xl) 1fr;
   align-items: center;
-  padding: var(--boxel-sp-sm) 0;
+  padding: var(--boxel-sp-sm) 0 var(--boxel-sp) 0;
   color: var(--boxel-light);
   font: 600 var(--boxel-font-xs);
   letter-spacing: var(--boxel-lsp-xl);
@@ -30,8 +30,8 @@
   position: absolute;
   background-image: url('/@cardstack/boxel/images/icons/active-item.svg');
   background-repeat: no-repeat;
-  background-position: center left;
-  top: 0;
+  background-position: top left;
+  top: var(--boxel-sp-sm);
   height: 100%;
   width: 25px;
   right: 100%;

--- a/packages/boxel/addon/components/boxel/control-panel/index.gts
+++ b/packages/boxel/addon/components/boxel/control-panel/index.gts
@@ -53,9 +53,6 @@ const Item: TemplateOnlyComponent<ItemSignature> =
 </template>;
 
 export default class ControlPanel extends Component<Signature> {
-  get jortle(): number {
-    return 3;
-  }
 
   <template>
     <nav class="boxel-control-panel">

--- a/packages/boxel/addon/components/boxel/control-panel/index.gts
+++ b/packages/boxel/addon/components/boxel/control-panel/index.gts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 //@ts-expect-error glint does not think this is consumed-but it is consumed in the template https://github.com/typed-ember/glint/issues/374
 import { hash } from '@ember/helper';
+import cn from '@cardstack/boxel/helpers/cn';
 import { svgJar } from '@cardstack/boxel/utils/svg-jar';
 
 import '@cardstack/boxel/styles/global.css';
@@ -20,6 +21,7 @@ interface ItemSignature {
   Element: HTMLElement
   Args: {
     icon: string;
+    isActive: boolean;
     title: string;
   },
   Blocks: {
@@ -30,7 +32,12 @@ interface ItemSignature {
 const Item: TemplateOnlyComponent<ItemSignature> =
 <template>
   <section class="boxel-control-panel__item">
-    <heading class="boxel-control-panel__item-heading">
+    <heading
+      class={{
+        cn
+        "boxel-control-panel__item-heading"
+        boxel-control-panel__item-heading--is-active=@isActive
+      }}>
       {{svgJar
         @icon
         width="18px"

--- a/packages/boxel/addon/components/boxel/control-panel/index.gts
+++ b/packages/boxel/addon/components/boxel/control-panel/index.gts
@@ -55,9 +55,9 @@ const Item: TemplateOnlyComponent<ItemSignature> =
 export default class ControlPanel extends Component<Signature> {
 
   <template>
-    <nav class="boxel-control-panel">
+    <div class="boxel-control-panel">
       {{yield (hash Item=(component Item))}}
-    </nav>
+    </div>
   </template>
 }
 

--- a/packages/boxel/addon/components/boxel/control-panel/index.gts
+++ b/packages/boxel/addon/components/boxel/control-panel/index.gts
@@ -1,0 +1,64 @@
+import Component from '@glimmer/component';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
+//@ts-expect-error glint does not think this is consumed-but it is consumed in the template https://github.com/typed-ember/glint/issues/374
+import { hash } from '@ember/helper';
+import { svgJar } from '@cardstack/boxel/utils/svg-jar';
+
+import '@cardstack/boxel/styles/global.css';
+import './index.css';
+
+interface Signature {
+  Element: HTMLElement;
+  Args: {
+  };
+  Blocks: {
+    default: [{ Item: typeof Item }],
+  };
+}
+
+interface ItemSignature {
+  Element: HTMLElement
+  Args: {
+    icon: string;
+    title: string;
+  },
+  Blocks: {
+    default: [],
+  }
+}
+
+const Item: TemplateOnlyComponent<ItemSignature> =
+<template>
+  <section class="boxel-control-panel__item">
+    <heading class="boxel-control-panel__item-heading">
+      {{svgJar
+        @icon
+        width="18px"
+        height="18px"
+        class="boxel-control-panel__item-icon"
+      }}
+      {{@title}}
+    </heading>
+    <div class="boxel-control-panel__item-body">
+      {{yield}}
+    </div>
+  </section>
+</template>;
+
+export default class ControlPanel extends Component<Signature> {
+  get jortle(): number {
+    return 3;
+  }
+
+  <template>
+    <nav class="boxel-control-panel">
+      {{yield (hash Item=(component Item))}}
+    </nav>
+  </template>
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Boxel::ControlPanel': typeof ControlPanel;
+  }
+}

--- a/packages/boxel/addon/components/boxel/control-panel/usage.gts
+++ b/packages/boxel/addon/components/boxel/control-panel/usage.gts
@@ -1,9 +1,13 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import BoxelControlPanel from './index';
 import BoxelButton from '../button';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 
 export default class extends Component {
+  // Maybe this will be template-only? Removing this causes a build failure
+  @tracked value = 'placeholder;';
+
   <template>
     <FreestyleUsage @name="ControlPanel">
       <:description>

--- a/packages/boxel/addon/components/boxel/control-panel/usage.gts
+++ b/packages/boxel/addon/components/boxel/control-panel/usage.gts
@@ -10,9 +10,6 @@ export default class extends Component {
 
   <template>
     <FreestyleUsage @name="ControlPanel">
-      <:description>
-        xyz
-      </:description>
       <:example>
         <BoxelControlPanel
           as |cp|

--- a/packages/boxel/addon/components/boxel/control-panel/usage.gts
+++ b/packages/boxel/addon/components/boxel/control-panel/usage.gts
@@ -13,10 +13,10 @@ export default class extends Component {
         <BoxelControlPanel
           as |cp|
         >
-        <cp.Item @title="Gear" @icon="gear">
-          <BoxelButton @kind="secondary-dark">Gear something</BoxelButton>
-        </cp.Item>
-        <cp.Item @title="Pin" @icon="pin">two</cp.Item>
+          <cp.Item @title="Gear" @icon="gear">
+            <BoxelButton @kind="secondary-dark">Gear something</BoxelButton>
+          </cp.Item>
+          <cp.Item @title="Pin" @icon="pin">two</cp.Item>
         </BoxelControlPanel>
       </:example>
     </FreestyleUsage>

--- a/packages/boxel/addon/components/boxel/control-panel/usage.gts
+++ b/packages/boxel/addon/components/boxel/control-panel/usage.gts
@@ -1,0 +1,24 @@
+import Component from '@glimmer/component';
+import BoxelControlPanel from './index';
+import BoxelButton from '../button';
+import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
+
+export default class extends Component {
+  <template>
+    <FreestyleUsage @name="ControlPanel">
+      <:description>
+        xyz
+      </:description>
+      <:example>
+        <BoxelControlPanel
+          as |cp|
+        >
+        <cp.Item @title="Gear" @icon="gear">
+          <BoxelButton @kind="secondary-dark">Gear something</BoxelButton>
+        </cp.Item>
+        <cp.Item @title="Pin" @icon="pin">two</cp.Item>
+        </BoxelControlPanel>
+      </:example>
+    </FreestyleUsage>
+  </template>
+}

--- a/packages/boxel/addon/components/boxel/control-panel/usage.gts
+++ b/packages/boxel/addon/components/boxel/control-panel/usage.gts
@@ -26,6 +26,11 @@ export default class extends Component {
           </cp.Item>
         </BoxelControlPanel>
       </:example>
+      <:api as |Args|>
+        <Args.Yield
+          @description="Yields { Item } which must be invoked with @title and @icon. @isActive adds an icon."
+        />
+      </:api>
     </FreestyleUsage>
   </template>
 }

--- a/packages/boxel/addon/components/boxel/control-panel/usage.gts
+++ b/packages/boxel/addon/components/boxel/control-panel/usage.gts
@@ -17,11 +17,11 @@ export default class extends Component {
         <BoxelControlPanel
           as |cp|
         >
-          <cp.Item @title="Gear" @icon="gear">
+          <cp.Item @title="Gear" @icon="gear" @isActive={{false}}>
             <BoxelButton @kind="secondary-dark">Gear Something</BoxelButton>
           </cp.Item>
-          <cp.Item @title="Pin" @icon="pin">two</cp.Item>
-          <cp.Item @title="Lock" @icon="lock">
+          <cp.Item @title="Pin" @icon="pin" @isActive={{true}}>two</cp.Item>
+          <cp.Item @title="Lock" @icon="lock" @isActive={{true}}>
             <BoxelButton @kind="primary">Do Lock Something</BoxelButton>
           </cp.Item>
         </BoxelControlPanel>

--- a/packages/boxel/addon/components/boxel/control-panel/usage.gts
+++ b/packages/boxel/addon/components/boxel/control-panel/usage.gts
@@ -18,9 +18,12 @@ export default class extends Component {
           as |cp|
         >
           <cp.Item @title="Gear" @icon="gear">
-            <BoxelButton @kind="secondary-dark">Gear something</BoxelButton>
+            <BoxelButton @kind="secondary-dark">Gear Something</BoxelButton>
           </cp.Item>
           <cp.Item @title="Pin" @icon="pin">two</cp.Item>
+          <cp.Item @title="Lock" @icon="lock">
+            <BoxelButton @kind="primary">Do Lock Something</BoxelButton>
+          </cp.Item>
         </BoxelControlPanel>
       </:example>
     </FreestyleUsage>

--- a/packages/boxel/public/images/icons/active-item.svg
+++ b/packages/boxel/public/images/icons/active-item.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16.042" height="18.198" viewBox="0 0 16.042 18.198"><path d="M5005.606-3063.5v18.2h9.307l6.735-9.13-6.735-9.068Z" transform="translate(-5005.606 3063.5)" fill="#00ebe5"/></svg>


### PR DESCRIPTION
This is a component meant to support the functionality seen here:

<img width="335" alt="Network Default to ETH then Create Safe - MVP - Zeplin 2022-09-23 12-48-58" src="https://user-images.githubusercontent.com/43280/192027340-13305721-bf80-4af6-9d85-3728ca4182af.png">

Since the indentation there is inconsistent, I chose to align the body with the icon:

<img width="280" alt="Boxel Components 2022-09-23 12-50-02" src="https://user-images.githubusercontent.com/43280/192027458-409842f2-53be-4a32-af2c-8b9111c150c6.png">

This is easily changed if it should be otherwise.

You can see it [here](https://boxel.stack.cards/boxel/control-panel-cs-4565/#/docs?s=Components&ss=%3CBoxel%3A%3AControlPanel%3E).