### PR TITLE
sdk, cli: Add scheduled payment

### DIFF
--- a/packages/cardpay-sdk/sdk/hub-auth.ts
+++ b/packages/cardpay-sdk/sdk/hub-auth.ts
@@ -105,7 +105,7 @@ export default class HubAuth implements IHubAuth {
     return global.fetch(url, { headers });
   }
 
-  private async getHubUrl(network?: string): Promise<string> {
+  async getHubUrl(network?: string): Promise<string> {
     const netName = network || (await networkName(this.layer2Web3));
 
     return this.hubRootUrl || getConstantByNetwork('hubUrl', netName);

--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -681,9 +681,9 @@ export default class ScheduledPaymentModule {
     safeAddress: string,
     moduleAddress: string,
     gasTokenAddress: string,
-    spHash: string
+    spHash: string,
+    txnParams: TransactionParams
   ) {
-    let txnParams = await this.generateSchedulePaymentTxParams(safeAddress, moduleAddress, gasTokenAddress, spHash);
     return new Promise<void>((resolve, reject) => {
       this.schedulePaymentOnChain(safeAddress, moduleAddress, gasTokenAddress, spHash, txnParams, {
         onTxnHash: async (txHash: string) => {
@@ -792,6 +792,8 @@ export default class ScheduledPaymentModule {
       );
     }
 
+    let txnParams = await this.generateSchedulePaymentTxParams(safeAddress, moduleAddress, gasTokenAddress, spHash);
+
     let account = (await this.web3.eth.getAccounts())[0];
     let scheduledPaymentResponse = await hubRequest(hubRootUrl, 'api/scheduled-payments', authToken, 'POST', {
       data: {
@@ -827,7 +829,8 @@ export default class ScheduledPaymentModule {
         safeAddress,
         moduleAddress,
         gasTokenAddress,
-        spHash
+        spHash,
+        txnParams
       );
     } catch (error) {
       console.log(

--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -708,7 +708,7 @@ export default class ScheduledPaymentModule {
     });
   }
 
-  async schedulePayment(scheduledPaymentId: string): Promise<{ scheduledPaymentId: string; promise: Promise<void> }>;
+  async schedulePayment(scheduledPaymentId: string): Promise<void>;
   async schedulePayment(
     safeAddress: string,
     moduleAddress: string,
@@ -725,7 +725,7 @@ export default class ScheduledPaymentModule {
     recurringDayOfMonth?: number | null,
     recurringUntil?: number | null,
     onScheduledPaymentCreate?: (scheduledPaymentId: string) => unknown
-  ): Promise<{ scheduledPaymentId: string; promise: Promise<void> }>;
+  ): Promise<void>;
   async schedulePayment(
     safeAddressOrScheduledPaymentId: string,
     moduleAddress?: string,

--- a/packages/cardpay-sdk/sdk/scheduled-payment/utils.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment/utils.ts
@@ -1,0 +1,13 @@
+import { hubRequest, poll } from '../utils/general-utils';
+
+export async function waitUntilSchedulePaymentTransactionMined(
+  hubRootUrl: string,
+  scheduledPaymentId: string,
+  authToken: string
+) {
+  return poll(
+    () => hubRequest(hubRootUrl, `api/scheduled-payments/${scheduledPaymentId}`, authToken, 'GET'),
+    (response: any) => response.data.attributes['creation-block-number'] != null,
+    1000
+  );
+}

--- a/packages/cardpay-sdk/sdk/scheduled-payment/utils.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment/utils.ts
@@ -7,7 +7,14 @@ export async function waitUntilSchedulePaymentTransactionMined(
 ) {
   return poll(
     () => hubRequest(hubRootUrl, `api/scheduled-payments/${scheduledPaymentId}`, authToken, 'GET'),
-    (response: any) => response.data.attributes['creation-block-number'] != null,
+    (response: any) => {
+      let attributes = response.data.attributes;
+      let error = attributes['creation-transaction-error'];
+      if (error) {
+        throw new Error(`Transaction reverted: ${error}`);
+      }
+      return attributes['creation-block-number'] != null;
+    },
     1000
   );
 }

--- a/packages/cardpay-sdk/sdk/utils/general-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/general-utils.ts
@@ -317,3 +317,43 @@ export function generateSaltNonce(prefix: string) {
   let result = [...uuid].reduce((result, char) => result + String(char.charCodeAt(0)), '');
   return result.substring(0, 77);
 }
+
+export async function hubRequest(
+  hubUrl: string,
+  path: string,
+  authToken: string,
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
+  body = {}
+) {
+  let url = `${hubUrl}/${path}`;
+  let options = {
+    method,
+    headers: {
+      'Content-Type': 'application/vnd.api+json',
+      Authorization: `Bearer ${authToken}`,
+      Accept: 'application/json',
+    },
+    body: Object.keys(body).length === 0 ? null : JSON.stringify(body),
+  };
+
+  let response = await global.fetch(url, options);
+  if (!response?.ok) {
+    throw new Error(await response.text());
+  }
+  return response.json();
+}
+
+export async function poll(fn: () => Promise<unknown>, fnCondition: (arg: unknown) => boolean, ms: number) {
+  let result = await fn();
+  while (!fnCondition(result)) {
+    await wait(ms);
+    result = await fn();
+  }
+  return result;
+}
+
+export async function wait(ms = 1000) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}


### PR DESCRIPTION
This PR introduces a new approach for scheduling payments (one-time and recurring). Instead of having the client pass a signature to the hub which is responsible for submitting a transaction (previous approach, can be seen in this closed PR: https://github.com/cardstack/cardstack/pull/3231), the implementation changed to a way where `schedulePayment` SDK call orchestrates *the whole flow*, which makes the process easier to reason about:

1. Receiving all the params needed for a scheduled payment
2. Creating the scheduled payment hash by calling the pure function on the module contract
3. Getting the signature and submitting the transaction to add the scheduled payment to the blockchain (i.e. storing the `spHash` in the safe's module contract) 
4. Saving the scheduled payment in the crank (hub), making sure it's persisted before the on-chain flow begins
5. Updating the scheduled payment in the crank once tx hash is known, which triggers the async worker in the hub that waits until transaction is mined
5. Waiting until the transaction is mined by polling the hub and checking if creation block is written
6. Making it available to the client to pass in the `scheduledPaymentId` to resume waiting in case of timeouts or client restarts

The flow is depicted by this diagram (only the SDK part - the hub part will come in a separate PR):
![image](https://user-images.githubusercontent.com/273660/192253323-88616681-499e-427c-a1f6-65dbab61d82e.png)
