### PR TITLE
boxel: Fix ControlPanel contextual yield

### DIFF
--- a/packages/boxel/addon/components/boxel/control-panel/index.gts
+++ b/packages/boxel/addon/components/boxel/control-panel/index.gts
@@ -56,7 +56,7 @@ export default class ControlPanel extends Component<Signature> {
 
   <template>
     <div class="boxel-control-panel">
-      {{yield (hash Item=(component Item))}}
+      {{yield (hash Item=Item)}}
     </div>
   </template>
 }


### PR DESCRIPTION
This fixes [a lint failure](https://github.com/cardstack/cardstack/actions/runs/3128935827/jobs/5077520166). I don’t know why it didn’t show up in #3254.

I also don’t understand the SSR Percy diff, how could that be related? 🧐