### PR TITLE
boxel: Add SelectableTokenAmount

### DIFF
--- a/packages/boxel/addon/components/boxel/input/selectable-token-amount/index.css
+++ b/packages/boxel/addon/components/boxel/input/selectable-token-amount/index.css
@@ -1,0 +1,67 @@
+.boxel-selectable-token-amount-input-group {
+  --input-height: 3.75rem; /* 60px */
+  --input-icon-size: var(--boxel-icon-lg);
+  --input-symbol-width: 7rem;
+  --input-icon-space: var(--boxel-sp-xs);
+  --input-symbol-space: var(--boxel-sp-sm);
+
+  position: relative;
+  width: 100%;
+  font-family: var(--boxel-font-family);
+  font-size: 1.25rem;
+  line-height: calc(27 / 20);
+  letter-spacing: var(--boxel-lsp-xs);
+}
+
+.boxel-selectable-token-amount-input-group__input {
+  height: var(--input-height);
+  padding-left: calc(var(--input-icon-size) + var(--input-icon-space) * 2);
+  padding-right: calc(var(--input-symbol-width) + var(--input-symbol-space) * 2);
+  font: inherit;
+  letter-spacing: inherit;
+}
+
+.boxel-selectable-token-amount-input-groxup__icon {
+  position: absolute;
+  width: var(--input-icon-size);
+  height: var(--input-height);
+  left: var(--input-icon-space);
+  top: 0;
+  user-select: none;
+}
+
+.boxel-selectable-token-amount-input-group .ember-basic-dropdown {
+  display: contents;
+}
+
+.boxel-selectable-token-amount-input__select {
+  position: absolute;
+  max-width: var(--input-symbol-width);
+  height: var(--input-height);
+  display: flex;
+  align-items: center;
+  top: 0;
+  right: var(--input-symbol-space);
+  user-select: none;
+}
+
+.boxel-selectable-token-amount-input-group__dropdown {
+  box-shadow: var(--boxel-box-shadow);
+  border-radius: var(--boxel-border--radius);
+}
+
+.boxel-selectable-token-amount-input-group__dropdown ul {
+  list-style: none;
+  padding: 0;
+}
+
+.ember-power-select-option[aria-current='true']
+  .boxel-selectable-token-amount-input-group__dropdown-item,
+.ember-power-select-option[aria-selected='true']
+  .boxel-selectable-token-amount-input-group__dropdown-item {
+  background-color: var(--boxel-light-100);
+}
+
+.boxel-selectable-token-amount-input-group__input:disabled ~ .boxel-selectable-token-amount-input-group__symbol {
+  opacity: 0.5;
+}

--- a/packages/boxel/addon/components/boxel/input/selectable-token-amount/index.gts
+++ b/packages/boxel/addon/components/boxel/input/selectable-token-amount/index.gts
@@ -1,0 +1,78 @@
+import Component from '@glimmer/component';
+import '@cardstack/boxel/styles/global.css';
+import './index.css';
+import BoxelInput from '../index';
+import PowerSelect from 'ember-power-select/components/power-select';
+import { svgJar } from '@cardstack/boxel/utils/svg-jar';
+import { fn } from '@ember/helper';
+
+interface Signature {
+  Element: HTMLElement;
+  Args: {
+    value?: string;
+    disabled: boolean;
+    helperText?: string;
+    invalid: boolean;
+    errorMessage: string;
+    onBlur: () => {};
+    onInput: () => {};
+    onChooseToken: () => {};
+    token: Token;
+    tokens: Token[];
+  };
+  Blocks: {
+    'default': [],
+  }
+}
+
+interface Token {
+  name: string;
+  icon: string;
+}
+
+export default class SelectableTokenAmount extends Component<Signature> {
+  <template>
+    <div class="boxel-selectable-token-amount-input-group" ...attributes>
+      <BoxelInput
+        class="boxel-selectable-token-amount-input-group__input"
+        @id={{@id}}
+        @value={{@value}}
+        @required={{unless @disabled true}}
+        @onInput={{@onInput}}
+        @onBlur={{fn @onInput @value}}
+        @invalid={{unless @disabled @invalid}}
+        @errorMessage={{@errorMessage}}
+        @helperText={{@helperText}}
+        @disabled={{@disabled}}
+        placeholder="0.00"
+        autocomplete="off"
+        inputmode="decimal"
+      />
+      <PowerSelect
+        class="boxel-selectable-token-amount-input__select"
+        @options={{@tokens}}
+        @selected={{@token}}
+        @disabled={{@disabled}}
+        @onChange={{@onChooseToken}}
+        @dropdownClass="boxel-selectable-token-amount-input-group__dropdown"
+        @verticalPosition="below" as |item|
+      >
+        <div class="boxel-selectable-token-amount-input-group__dropdown-item">
+          {{svgJar
+            item.icon
+            class="boxel-selectable-token-amount-input-group__icon"
+            role="presentation"
+          }}
+
+          {{item.name}}
+        </div>
+      </PowerSelect>
+    </div>
+  </template>
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Boxel::Input::SelectableTokenAmount': typeof SelectableTokenAmount;
+  }
+}

--- a/packages/boxel/addon/components/boxel/input/selectable-token-amount/usage.gts
+++ b/packages/boxel/addon/components/boxel/input/selectable-token-amount/usage.gts
@@ -1,0 +1,95 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import BoxelInputSelectableTokenAmount from './index';
+import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
+import { array, fn } from '@ember/helper';
+
+export default class BoxelSelectableInputTokenAmountUsage extends Component {
+  @tracked id = 'boxel-selectable-token-amount-input-usage';
+  @tracked value = '';
+  @tracked helperText = 'Please enter an amount';
+  @tracked errorMessage = '';
+  @tracked disabled = false;
+  @tracked invalid = false;
+  @tracked icon = 'card';
+  @tracked symbol = 'CARD';
+  @tracked token = this.tokens[0];
+
+  tokens = [
+    { name: 'CARD', icon: 'card' },
+    { name: 'HI', icon: 'emoji' },
+    { name: 'WORLD', icon: 'world' },
+  ];
+
+  @action set(amount: string): void {
+    this.value = amount;
+  }
+
+  @action onChooseToken(token: Token) {
+    this.token = token;
+    console.log(token);
+  }
+
+  <template>
+    <FreestyleUsage @name="Input::SelectableTokenAmount">
+      <:example>
+        <label for={{this.id}} class="boxel-sr-only">
+          Label
+        </label>
+        <BoxelInputSelectableTokenAmount
+          @icon={{this.icon}}
+          @symbol={{this.symbol}}
+          @id={{this.id}}
+          @disabled={{this.disabled}}
+          @value={{this.value}}
+          @onInput={{this.set}}
+          @invalid={{this.invalid}}
+          @errorMessage={{this.errorMessage}}
+          @helperText={{this.helperText}}
+          @token={{this.token}}
+          @tokens={{this.tokens}}
+          @onChooseToken={{this.onChooseToken}}
+        />
+      </:example>
+      <:api as |Args|>
+        <Args.Bool
+          @name="disabled"
+          @description="Whether the input is disabled"
+          @defaultValue={{false}}
+          @onInput={{fn (mut this.disabled)}}
+          @value={{this.disabled}}
+        />
+        <Args.Bool
+          @name="invalid"
+          @description="Whether the input is invalid"
+          @defaultValue={{false}}
+          @onInput={{fn (mut this.invalid)}}
+          @value={{this.invalid}}
+        />
+        <Args.String
+          @name="helperText"
+          @description="Helper message to display below the input"
+          @value={{this.helperText}}
+          @onInput={{fn (mut this.helperText)}}
+        />
+        <Args.String
+          @name="errorMessage"
+          @description="Error message to display when the input is invalid"
+          @value={{this.errorMessage}}
+          @onInput={{fn (mut this.errorMessage)}}
+        />
+        <Args.Action
+          @name="onInput"
+          @description="Action to call when the input value changes"
+        />
+        <Args.String
+          @name="value"
+          @description="The value of the input"
+          @value={{this.value}}
+          @onInput={{fn (mut this.value)}}
+        />
+      </:api>
+    </FreestyleUsage>
+  </template>
+}

--- a/packages/boxel/types/ember-power-select/components/power-select/index.d.ts
+++ b/packages/boxel/types/ember-power-select/components/power-select/index.d.ts
@@ -3,9 +3,11 @@ import Component from '@glimmer/component';
 import { PowerSelectArgs } from 'ember-power-select/addon/components/power-select';
 
 interface PatchedPowerSelectArgs extends PowerSelectArgs {
+  disabled?: boolean;
   dropdownClass?: string;
   placeholder?: string;
   renderInPlace?: boolean;
+  verticalPosition?: string;
 }
 
 export default class PowerSelect extends Component<{


### PR DESCRIPTION
This is meant to work like this design:

![image](https://user-images.githubusercontent.com/43280/192389296-1847419f-6714-45f5-9d63-d686105739bb.png)

It’s adapted from `TokenAmount` but needs a lot of work still.