### PR TITLE
hub: add endpoints for scheduled payments 

### DIFF
--- a/.github/actions/check-secrets/action.yml
+++ b/.github/actions/check-secrets/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Install apt packages
       shell: bash
       run: |
-        sudo apt-get install awscli jq
+        sudo apt-get update && sudo apt-get install awscli jq --fix-missing
 
     - uses: volta-cli/action@v1
 

--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -735,8 +735,8 @@ export default class ScheduledPaymentModule {
     recurringUntil?: number | null,
     onScheduledPaymentCreate?: (scheduledPaymentId: string) => unknown
   ) {
-    let hubAuth = await getSDK('HubAuth', this.web3);
-    let hubRootUrl = await hubAuth.getHubUrl();
+    let hubAuth = await getSDK('HubAuth', this.web3, 'http://localhost:3000');
+    let hubRootUrl = 'http://localhost:3000'; //await hubAuth.getHubUrl();
     let authToken = await hubAuth.authenticate();
 
     let safeAddress: string;

--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -735,8 +735,8 @@ export default class ScheduledPaymentModule {
     recurringUntil?: number | null,
     onScheduledPaymentCreate?: (scheduledPaymentId: string) => unknown
   ) {
-    let hubAuth = await getSDK('HubAuth', this.web3, 'http://localhost:3000');
-    let hubRootUrl = 'http://localhost:3000'; //await hubAuth.getHubUrl();
+    let hubAuth = await getSDK('HubAuth', this.web3);
+    let hubRootUrl = await hubAuth.getHubUrl();
     let authToken = await hubAuth.authenticate();
 
     let safeAddress: string;

--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -1185,8 +1185,10 @@ CREATE TABLE public.scheduled_payments (
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     canceled_at timestamp without time zone,
+    cancelation_transaction_error text,
     user_address text NOT NULL,
-    creation_transaction_error text
+    creation_transaction_error text,
+    cancellation_transaction_error text
 );
 
 

--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -1169,8 +1169,8 @@ CREATE TABLE public.scheduled_payments (
     payee_address text NOT NULL,
     execution_gas_estimation bigint NOT NULL,
     max_gas_price bigint NOT NULL,
-    fee_fixed_usd integer NOT NULL,
-    fee_percentage integer NOT NULL,
+    fee_fixed_usd numeric NOT NULL,
+    fee_percentage numeric NOT NULL,
     salt text NOT NULL,
     pay_at timestamp without time zone,
     recurring_day_of_month integer,
@@ -1184,7 +1184,9 @@ CREATE TABLE public.scheduled_payments (
     cancelation_block_number bigint,
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    canceled_at timestamp without time zone
+    canceled_at timestamp without time zone,
+    user_address text NOT NULL,
+    creation_transaction_error text
 );
 
 
@@ -1626,6 +1628,13 @@ CREATE INDEX scheduled_payments_recurring_until_index ON public.scheduled_paymen
 --
 
 CREATE INDEX scheduled_payments_sender_safe_address_index ON public.scheduled_payments USING btree (sender_safe_address);
+
+
+--
+-- Name: scheduled_payments_user_address_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX scheduled_payments_user_address_index ON public.scheduled_payments USING btree (user_address);
 
 
 --

--- a/packages/hub/db/migrations/20220921073021534_alter-scheduled-payment-fields-2.ts
+++ b/packages/hub/db/migrations/20220921073021534_alter-scheduled-payment-fields-2.ts
@@ -1,0 +1,24 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+const TABLE = 'scheduled_payments';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumns(TABLE, {
+    user_address: { type: 'text', notNull: true },
+    creation_transaction_error: { type: 'text' },
+    cancellation_transaction_error: { type: 'text' },
+  });
+
+  pgm.createIndex(TABLE, 'user_address');
+
+  pgm.alterColumn(TABLE, 'fee_fixed_usd', { type: 'numeric', notNull: true });
+  pgm.alterColumn(TABLE, 'fee_percentage', { type: 'numeric', notNull: true });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn(TABLE, 'user_address');
+  pgm.dropColumn(TABLE, 'creation_transaction_error');
+  pgm.dropColumn(TABLE, 'cancellation_transaction_error');
+
+  pgm.alterColumn(TABLE, 'fee_fixed_usd', { type: 'integer', notNull: true });
+  pgm.alterColumn(TABLE, 'fee_percentage', { type: 'integer', notNull: true });
+}

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -93,6 +93,9 @@ import Email from './services/email';
 import Mailchimp from './services/mailchimp';
 import PrismaManager from './services/prisma-manager';
 import ScheduledPaymentsFetcherService from './services/scheduled-payments/fetcher';
+import ScheduledPaymentSerializer from './services/serializers/scheduled-payment-serializer';
+import ScheduledPaymentValidator from './services/validators/scheduled-payment';
+import ScheduledPaymentsRoute from './routes/scheduled-payments';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -172,7 +175,10 @@ export function createRegistry(): Registry {
   registry.register('pagerduty-incidents-webhook-route', PagerdutyIncidentsWebhookRoute);
   registry.register('email-card-drop-router', EmailCardDropRouter);
   registry.register('prisma-manager', PrismaManager);
-  registry.register('scheduled-payments-fetcher', ScheduledPaymentsFetcherService);
+  registry.register('scheduled-payment-fetcher', ScheduledPaymentsFetcherService);
+  registry.register('scheduled-payment-serializer', ScheduledPaymentSerializer);
+  registry.register('scheduled-payment-validator', ScheduledPaymentValidator);
+  registry.register('scheduled-payments-route', ScheduledPaymentsRoute);
 
   if (process.env.COMPILER) {
     registry.register(

--- a/packages/hub/node-tests/routes/scheduled-payments-test.ts
+++ b/packages/hub/node-tests/routes/scheduled-payments-test.ts
@@ -1,0 +1,561 @@
+import { PrismaClient } from '@prisma/client';
+import { calculateNextPayAt } from '../../utils/scheduled-payments';
+import { registry, setupHub } from '../helpers/server';
+import { setupStubWorkerClient } from '../helpers/stub-worker-client';
+
+class StubAuthenticationUtils {
+  validateAuthToken(encryptedAuthToken: string) {
+    return handleValidateAuthToken(encryptedAuthToken);
+  }
+}
+
+let stubUserAddress = '0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13';
+function handleValidateAuthToken(encryptedString: string) {
+  expect(encryptedString).to.equal('abc123--def456--ghi789');
+  return stubUserAddress;
+}
+
+describe('POST /api/scheduled-payments', async function () {
+  this.beforeEach(async function () {
+    registry(this).register('authentication-utils', StubAuthenticationUtils);
+  });
+
+  let { request } = setupHub(this);
+
+  it('returns a 401 if the auth token is invalid', async function () {
+    await request()
+      .post('/api/scheduled-payments')
+      .send({})
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(401)
+      .expect({
+        errors: [
+          {
+            status: '401',
+            title: 'No valid auth token',
+          },
+        ],
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('responds with errors when attrs are missing', async function () {
+    await request()
+      .post('/api/scheduled-payments')
+      .send({
+        data: {
+          type: 'scheduled-payments',
+          attributes: {},
+        },
+      })
+      .set('Accept', 'application/vnd.api+json')
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(422)
+      .expect({
+        errors: [
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/sender-safe-address',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/module-address',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/token-address',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/amount',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/payee-address',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/execution-gas-estimation',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/max-gas-price',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/fee-fixed-usd',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/fee-percentage',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/salt',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/pay-at',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/sp-hash',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: 'is required',
+            source: {
+              pointer: '/data/attributes/chain-id',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+        ],
+      });
+  });
+
+  it('persists a one time scheduled payment', async function () {
+    await request()
+      .post('/api/scheduled-payments')
+      .send({
+        data: {
+          type: 'scheduled-payments',
+          attributes: {
+            'sender-safe-address': '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+            'module-address': '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+            'token-address': '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+            amount: '100',
+            'payee-address': '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+            'execution-gas-estimation': 100000,
+            'max-gas-price': 1000000000,
+            'fee-fixed-usd': 0,
+            'fee-percentage': 0,
+            salt: '54lt',
+            'pay-at': '2021-01-01T00:00:00.000Z',
+            'sp-hash': '0x123',
+            'chain-id': 1,
+            userAddress: stubUserAddress,
+          },
+        },
+      })
+      .set('Accept', 'application/vnd.api+json')
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(201)
+      .expect(function (res) {
+        res.body.data.id = 'id';
+      })
+      .expect({
+        data: {
+          id: 'id',
+          type: 'scheduled-payment',
+          attributes: {
+            'sender-safe-address': '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+            'module-address': '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+            'token-address': '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+            amount: '100',
+            'payee-address': '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+            'execution-gas-estimation': '100000',
+            'max-gas-price': '1000000000',
+            'fee-fixed-usd': '0',
+            'fee-percentage': '0',
+            salt: '54lt',
+            'pay-at': '2021-01-01T00:00:00.000Z',
+            'sp-hash': '0x123',
+            'chain-id': 1,
+            'user-address': stubUserAddress,
+            'creation-transaction-hash': null,
+            'creation-block-number': null,
+            'creation-transaction-error': null,
+            'cancelation-transaction-hash': null,
+            'cancelation-block-number': null,
+            'recurring-day-of-month': null,
+            'recurring-until': null,
+          },
+        },
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('persists a recurring scheduled payment', async function () {
+    let calculatedPayAt = calculateNextPayAt(new Date(), 1);
+    await request()
+      .post('/api/scheduled-payments')
+      .send({
+        data: {
+          type: 'scheduled-payments',
+          attributes: {
+            'sender-safe-address': '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+            'module-address': '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+            'token-address': '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+            amount: '100',
+            'payee-address': '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+            'execution-gas-estimation': 100000,
+            'max-gas-price': 1000000000,
+            'fee-fixed-usd': 0,
+            'fee-percentage': 0,
+            salt: '54lt',
+            'pay-at': '2021-01-01T00:00:00.000Z',
+            'recurring-day-of-month': 1,
+            'recurring-until': '2022-12-31T00:00:00.000Z',
+            'sp-hash': '0x123',
+            'chain-id': 1,
+            userAddress: stubUserAddress,
+          },
+        },
+      })
+      .set('Accept', 'application/vnd.api+json')
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(201)
+      .expect(function (res) {
+        res.body.data.id = 'id';
+      })
+      .expect({
+        data: {
+          id: 'id',
+          type: 'scheduled-payment',
+          attributes: {
+            'sender-safe-address': '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+            'module-address': '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+            'token-address': '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+            amount: '100',
+            'payee-address': '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+            'execution-gas-estimation': '100000',
+            'max-gas-price': '1000000000',
+            'fee-fixed-usd': '0',
+            'fee-percentage': '0',
+            salt: '54lt',
+            'pay-at': calculatedPayAt.toISOString(),
+            'sp-hash': '0x123',
+            'chain-id': 1,
+            'user-address': stubUserAddress,
+            'creation-transaction-hash': null,
+            'creation-block-number': null,
+            'creation-transaction-error': null,
+            'cancelation-transaction-hash': null,
+            'cancelation-block-number': null,
+            'recurring-day-of-month': 1,
+            'recurring-until': '2022-12-31T00:00:00.000Z',
+          },
+        },
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+});
+
+describe('GET /api/scheduled-payments/:id', async function () {
+  let prisma: PrismaClient;
+
+  this.beforeEach(async function () {
+    registry(this).register('authentication-utils', StubAuthenticationUtils);
+  });
+
+  let { request, getContainer } = setupHub(this);
+
+  this.beforeEach(async function () {
+    let container = getContainer();
+    prisma = await (await container.lookup('prisma-manager')).getClient();
+  });
+
+  it('returns a 401 if the auth token is invalid', async function () {
+    await request()
+      .get('/api/scheduled-payments/id')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(401)
+      .expect({
+        errors: [
+          {
+            status: '401',
+            title: 'No valid auth token',
+          },
+        ],
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('returns a scheduled payment', async function () {
+    let scheduledPayment = await prisma.scheduledPayment.create({
+      data: {
+        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+        moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+        tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+        amount: 100,
+        payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+        executionGasEstimation: 100000,
+        maxGasPrice: 1000000000,
+        feeFixedUsd: '0',
+        feePercentage: '0',
+        salt: '54lt',
+        payAt: '2021-01-01T00:00:00.000Z',
+        spHash: '0x123',
+        chainId: 1,
+        userAddress: stubUserAddress,
+        creationTransactionHash: null,
+      },
+    });
+
+    await request()
+      .get(`/api/scheduled-payments/${scheduledPayment.id}`)
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(200)
+      .expect({
+        data: {
+          id: scheduledPayment.id,
+          type: 'scheduled-payment',
+          attributes: {
+            'sender-safe-address': '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+            'module-address': '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+            'token-address': '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+            amount: '100',
+            'payee-address': '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+            'execution-gas-estimation': '100000',
+            'max-gas-price': '1000000000',
+            'fee-fixed-usd': '0',
+            'fee-percentage': '0',
+            salt: '54lt',
+            'pay-at': '2021-01-01T00:00:00.000Z',
+            'sp-hash': '0x123',
+            'chain-id': 1,
+            'user-address': stubUserAddress,
+            'creation-transaction-hash': null,
+            'creation-block-number': null,
+            'creation-transaction-error': null,
+            'cancelation-transaction-hash': null,
+            'cancelation-block-number': null,
+            'recurring-day-of-month': null,
+            'recurring-until': null,
+          },
+        },
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+});
+
+describe('PATCH /api/scheduled-payments/:id', async function () {
+  let { getJobIdentifiers, getJobPayloads } = setupStubWorkerClient(this);
+  let prisma: PrismaClient;
+
+  this.beforeEach(async function () {
+    registry(this).register('authentication-utils', StubAuthenticationUtils);
+  });
+
+  let { request, getContainer } = setupHub(this);
+
+  this.beforeEach(async function () {
+    let container = getContainer();
+    prisma = await (await container.lookup('prisma-manager')).getClient();
+  });
+
+  it('returns a 401 if the auth token is invalid', async function () {
+    await request()
+      .patch('/api/scheduled-payments/id')
+      .send({})
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(401)
+      .expect({
+        errors: [
+          {
+            status: '401',
+            title: 'No valid auth token',
+          },
+        ],
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('updates a scheduled payment', async function () {
+    let scheduledPayment = await prisma.scheduledPayment.create({
+      data: {
+        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+        moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+        tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+        amount: 100,
+        payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+        executionGasEstimation: 100000,
+        maxGasPrice: 1000000000,
+        feeFixedUsd: 0,
+        feePercentage: 0,
+        salt: '54lt',
+        payAt: '2021-01-01T00:00:00.000Z',
+        spHash: '0x123',
+        chainId: 1,
+        userAddress: stubUserAddress,
+        creationTransactionHash: null,
+      },
+    });
+
+    await request()
+      .patch(`/api/scheduled-payments/${scheduledPayment.id}`)
+      .send({
+        data: {
+          attributes: {
+            'creation-transaction-hash': '0x123',
+          },
+        },
+      })
+      .set('Accept', 'application/vnd.api+json')
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(200)
+      .expect({
+        data: {
+          id: scheduledPayment.id,
+          type: 'scheduled-payment',
+          attributes: {
+            'sender-safe-address': '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+            'module-address': '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+            'token-address': '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+            amount: '100',
+            'payee-address': '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+            'execution-gas-estimation': '100000',
+            'max-gas-price': '1000000000',
+            'fee-fixed-usd': '0',
+            'fee-percentage': '0',
+            salt: '54lt',
+            'pay-at': '2021-01-01T00:00:00.000Z',
+            'sp-hash': '0x123',
+            'chain-id': 1,
+            'user-address': stubUserAddress,
+            'creation-transaction-hash': '0x123',
+            'creation-block-number': null,
+            'creation-transaction-error': null,
+            'cancelation-transaction-hash': null,
+            'cancelation-block-number': null,
+            'recurring-day-of-month': null,
+            'recurring-until': null,
+          },
+        },
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+
+    expect(getJobIdentifiers()[0]).to.equal('scheduled-payment-on-chain-creation-waiter');
+    expect(getJobPayloads()[0]).to.deep.equal({ scheduledPaymentId: scheduledPayment.id });
+  });
+});
+
+describe('DELETE /api/scheduled-payments/:id', async function () {
+  let prisma: PrismaClient;
+
+  this.beforeEach(async function () {
+    registry(this).register('authentication-utils', StubAuthenticationUtils);
+  });
+
+  let { request, getContainer } = setupHub(this);
+
+  this.beforeEach(async function () {
+    let container = getContainer();
+    prisma = await (await container.lookup('prisma-manager')).getClient();
+  });
+
+  it('returns a 401 if the auth token is invalid', async function () {
+    await request()
+      .delete('/api/scheduled-payments/id')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(401)
+      .expect({
+        errors: [
+          {
+            status: '401',
+            title: 'No valid auth token',
+          },
+        ],
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('deletes a scheduled payment', async function () {
+    let scheduledPayment = await prisma.scheduledPayment.create({
+      data: {
+        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+        moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+        tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+        amount: 100,
+        payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+        executionGasEstimation: 100000,
+        maxGasPrice: 1000000000,
+        feeFixedUsd: 0,
+        feePercentage: 0,
+        salt: '54lt',
+        payAt: '2021-01-01T00:00:00.000Z',
+        spHash: '0x123',
+        chainId: 1,
+        userAddress: stubUserAddress,
+        creationTransactionHash: null,
+      },
+    });
+
+    await request()
+      .delete(`/api/scheduled-payments/${scheduledPayment.id}`)
+
+      .set('Accept', 'application/vnd.api+json')
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(200);
+
+    expect(
+      await prisma.scheduledPayment.findFirst({
+        where: {
+          id: scheduledPayment.id,
+        },
+      })
+    ).to.be.null;
+  });
+});

--- a/packages/hub/node-tests/routes/scheduled-payments-test.ts
+++ b/packages/hub/node-tests/routes/scheduled-payments-test.ts
@@ -56,7 +56,7 @@ describe('POST /api/scheduled-payments', async function () {
       .expect({
         errors: [
           {
-            detail: 'is required',
+            detail: 'sender safe address is required',
             source: {
               pointer: '/data/attributes/sender-safe-address',
             },
@@ -64,7 +64,7 @@ describe('POST /api/scheduled-payments', async function () {
             title: 'Invalid attribute',
           },
           {
-            detail: 'is required',
+            detail: 'module address is required',
             source: {
               pointer: '/data/attributes/module-address',
             },
@@ -72,7 +72,7 @@ describe('POST /api/scheduled-payments', async function () {
             title: 'Invalid attribute',
           },
           {
-            detail: 'is required',
+            detail: 'token address is required',
             source: {
               pointer: '/data/attributes/token-address',
             },
@@ -80,7 +80,7 @@ describe('POST /api/scheduled-payments', async function () {
             title: 'Invalid attribute',
           },
           {
-            detail: 'is required',
+            detail: 'amount is required',
             source: {
               pointer: '/data/attributes/amount',
             },
@@ -88,7 +88,7 @@ describe('POST /api/scheduled-payments', async function () {
             title: 'Invalid attribute',
           },
           {
-            detail: 'is required',
+            detail: 'payee address is required',
             source: {
               pointer: '/data/attributes/payee-address',
             },
@@ -96,7 +96,7 @@ describe('POST /api/scheduled-payments', async function () {
             title: 'Invalid attribute',
           },
           {
-            detail: 'is required',
+            detail: 'execution gas estimation is required',
             source: {
               pointer: '/data/attributes/execution-gas-estimation',
             },
@@ -104,7 +104,7 @@ describe('POST /api/scheduled-payments', async function () {
             title: 'Invalid attribute',
           },
           {
-            detail: 'is required',
+            detail: 'max gas price is required',
             source: {
               pointer: '/data/attributes/max-gas-price',
             },
@@ -112,7 +112,7 @@ describe('POST /api/scheduled-payments', async function () {
             title: 'Invalid attribute',
           },
           {
-            detail: 'is required',
+            detail: 'fee fixed usd is required',
             source: {
               pointer: '/data/attributes/fee-fixed-usd',
             },
@@ -120,7 +120,7 @@ describe('POST /api/scheduled-payments', async function () {
             title: 'Invalid attribute',
           },
           {
-            detail: 'is required',
+            detail: 'fee percentage is required',
             source: {
               pointer: '/data/attributes/fee-percentage',
             },
@@ -128,7 +128,7 @@ describe('POST /api/scheduled-payments', async function () {
             title: 'Invalid attribute',
           },
           {
-            detail: 'is required',
+            detail: 'salt is required',
             source: {
               pointer: '/data/attributes/salt',
             },
@@ -136,7 +136,7 @@ describe('POST /api/scheduled-payments', async function () {
             title: 'Invalid attribute',
           },
           {
-            detail: 'is required',
+            detail: 'pay at is required',
             source: {
               pointer: '/data/attributes/pay-at',
             },
@@ -144,7 +144,7 @@ describe('POST /api/scheduled-payments', async function () {
             title: 'Invalid attribute',
           },
           {
-            detail: 'is required',
+            detail: 'sp hash is required',
             source: {
               pointer: '/data/attributes/sp-hash',
             },
@@ -152,7 +152,7 @@ describe('POST /api/scheduled-payments', async function () {
             title: 'Invalid attribute',
           },
           {
-            detail: 'is required',
+            detail: 'chain id is required',
             source: {
               pointer: '/data/attributes/chain-id',
             },

--- a/packages/hub/node-tests/services/scheduled-payments/fetcher-test.ts
+++ b/packages/hub/node-tests/services/scheduled-payments/fetcher-test.ts
@@ -44,6 +44,7 @@ describe('fetching scheduled payments that are due', function () {
         canceledAt: params.canceledAt,
         creationBlockNumber: 'creationBlockNumber' in params ? params.creationBlockNumber : 1,
         chainId: 1,
+        userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
       },
     });
   };

--- a/packages/hub/node-tests/services/scheduled-payments/fetcher-test.ts
+++ b/packages/hub/node-tests/services/scheduled-payments/fetcher-test.ts
@@ -16,7 +16,7 @@ describe('fetching scheduled payments that are due', function () {
   let { getPrisma, getContainer } = setupHub(this);
 
   this.beforeEach(async function () {
-    subject = await getContainer().lookup('scheduled-payments-fetcher');
+    subject = await getContainer().lookup('scheduled-payment-fetcher');
     now = convertDateToUTC(new Date());
     validForDays = subject.validForDays;
     prisma = await getPrisma();
@@ -183,6 +183,6 @@ describe('fetching scheduled payments that are due', function () {
 
 declare module '@cardstack/di' {
   interface KnownServices {
-    'scheduled-payments-fetcher': ScheduledPaymentsFetcherService;
+    'scheduled-payment-fetcher': ScheduledPaymentsFetcherService;
   }
 }

--- a/packages/hub/node-tests/services/scheduled-payments/validator-test.ts
+++ b/packages/hub/node-tests/services/scheduled-payments/validator-test.ts
@@ -11,20 +11,20 @@ describe('ScheduledPaymentValidator', function () {
 
     let errors = await subject.validate(scheduledPayment);
     expect(errors).deep.equal({
-      senderSafeAddress: ['is required'],
-      tokenAddress: ['is required'],
-      moduleAddress: ['is required'],
-      amount: ['is required'],
-      payeeAddress: ['is required'],
-      executionGasEstimation: ['is required'],
-      maxGasPrice: ['is required'],
-      feeFixedUsd: ['is required'],
-      payAt: ['is required'],
-      feePercentage: ['is required'],
-      salt: ['is required'],
-      spHash: ['is required'],
-      chainId: ['is required'],
-      userAddress: ['is required'],
+      senderSafeAddress: ['sender safe address is required'],
+      tokenAddress: ['token address is required'],
+      moduleAddress: ['module address is required'],
+      amount: ['amount is required'],
+      payeeAddress: ['payee address is required'],
+      executionGasEstimation: ['execution gas estimation is required'],
+      maxGasPrice: ['max gas price is required'],
+      feeFixedUsd: ['fee fixed usd is required'],
+      payAt: ['pay at is required'],
+      feePercentage: ['fee percentage is required'],
+      salt: ['salt is required'],
+      spHash: ['sp hash is required'],
+      chainId: ['chain id is required'],
+      userAddress: ['user address is required'],
       recurringDayOfMonth: [],
       recurringUntil: [],
       validForDays: [],
@@ -43,9 +43,9 @@ describe('ScheduledPaymentValidator', function () {
 
     let errors = await subject.validate(scheduledPayment);
 
-    expect(errors.senderSafeAddress).deep.equal(['is not a valid address']);
-    expect(errors.moduleAddress).deep.equal(['is not a valid address']);
-    expect(errors.tokenAddress).deep.equal(['is not a valid address']);
-    expect(errors.payeeAddress).deep.equal(['is not a valid address']);
+    expect(errors.senderSafeAddress).deep.equal(['sender safe address is not a valid address']);
+    expect(errors.moduleAddress).deep.equal(['module address is not a valid address']);
+    expect(errors.tokenAddress).deep.equal(['token address is not a valid address']);
+    expect(errors.payeeAddress).deep.equal(['payee address is not a valid address']);
   });
 });

--- a/packages/hub/node-tests/services/scheduled-payments/validator-test.ts
+++ b/packages/hub/node-tests/services/scheduled-payments/validator-test.ts
@@ -1,0 +1,51 @@
+import { ScheduledPayment } from '@prisma/client';
+import { setupHub } from '../../helpers/server';
+
+describe('ScheduledPaymentValidator', function () {
+  let { getContainer } = setupHub(this);
+
+  it('validates scheduled payment with missing attrs', async function () {
+    let subject = await getContainer().lookup('scheduled-payment-validator');
+
+    const scheduledPayment: Partial<ScheduledPayment> = {};
+
+    let errors = await subject.validate(scheduledPayment);
+    expect(errors).deep.equal({
+      senderSafeAddress: ['is required'],
+      tokenAddress: ['is required'],
+      moduleAddress: ['is required'],
+      amount: ['is required'],
+      payeeAddress: ['is required'],
+      executionGasEstimation: ['is required'],
+      maxGasPrice: ['is required'],
+      feeFixedUsd: ['is required'],
+      payAt: ['is required'],
+      feePercentage: ['is required'],
+      salt: ['is required'],
+      spHash: ['is required'],
+      chainId: ['is required'],
+      userAddress: ['is required'],
+      recurringDayOfMonth: [],
+      recurringUntil: [],
+      validForDays: [],
+    });
+  });
+
+  it('validates scheduled payment with invalid addresses', async function () {
+    let subject = await getContainer().lookup('scheduled-payment-validator');
+
+    const scheduledPayment: Partial<ScheduledPayment> = {
+      senderSafeAddress: '0x123',
+      moduleAddress: '0x123',
+      tokenAddress: '0x123',
+      payeeAddress: '0x123',
+    };
+
+    let errors = await subject.validate(scheduledPayment);
+
+    expect(errors.senderSafeAddress).deep.equal(['is not a valid address']);
+    expect(errors.moduleAddress).deep.equal(['is not a valid address']);
+    expect(errors.tokenAddress).deep.equal(['is not a valid address']);
+    expect(errors.payeeAddress).deep.equal(['is not a valid address']);
+  });
+});

--- a/packages/hub/node-tests/tasks/scheduled-payment-on-chain-creation-waiter-test.ts
+++ b/packages/hub/node-tests/tasks/scheduled-payment-on-chain-creation-waiter-test.ts
@@ -1,0 +1,140 @@
+import { expect } from 'chai';
+import ScheduledPaymentOnChainCreationWaiter from '../../tasks/scheduled-payment-on-chain-creation-waiter';
+import { registry, setupHub } from '../helpers/server';
+
+let sdkError: Error | null = null;
+class StubCardpaySDK {
+  getSDK(sdk: string) {
+    switch (sdk) {
+      case 'ScheduledPaymentModule':
+        return Promise.resolve({
+          schedulePaymentOnChain: async (
+            _safeAddress: any,
+            _moduleAddress: any,
+            _tokenAddress: any,
+            _spHash: any,
+            _signature: any,
+            _obj: any
+          ) => {
+            if (sdkError) {
+              throw sdkError;
+            }
+            return {
+              blockNumber: 123,
+            };
+          },
+        });
+      default:
+        throw new Error(`unsupported mock cardpay sdk: ${sdk}`);
+    }
+  }
+}
+
+describe('ScheduledPaymentOnChainCreationWaiterTask', function () {
+  this.beforeEach(async function () {
+    registry(this).register('cardpay', StubCardpaySDK);
+  });
+
+  let { getPrisma, getContainer } = setupHub(this);
+
+  it('waits for the transaction to be mined and updates block number', async function () {
+    let prisma = await getPrisma();
+    let task = await getContainer().instantiate(ScheduledPaymentOnChainCreationWaiter);
+    let scheduledPayment = await prisma.scheduledPayment.create({
+      data: {
+        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+        moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+        tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+        amount: 100,
+        payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+        executionGasEstimation: 100000,
+        maxGasPrice: 1000000000,
+        feeFixedUsd: 0,
+        feePercentage: 0,
+        salt: '54lt',
+        payAt: new Date(),
+        spHash: '0x123',
+        chainId: 1,
+        userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+        creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
+      },
+    });
+
+    await task.perform({ scheduledPaymentId: scheduledPayment.id });
+    scheduledPayment = await prisma.scheduledPayment.findUniqueOrThrow({
+      where: {
+        id: scheduledPayment.id,
+      },
+    });
+
+    // creationBlockNumber is BigInt
+    expect(Number(scheduledPayment.creationBlockNumber)).to.eq(123);
+    expect(scheduledPayment.creationTransactionError).to.be.null;
+  });
+
+  it('updates the error if revert error happens', async function () {
+    sdkError = new Error('Transaction with hash 0x123 was reverted');
+
+    let prisma = await getPrisma();
+    let task = await getContainer().instantiate(ScheduledPaymentOnChainCreationWaiter);
+    let scheduledPayment = await prisma.scheduledPayment.create({
+      data: {
+        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+        moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+        tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+        amount: 100,
+        payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+        executionGasEstimation: 100000,
+        maxGasPrice: 1000000000,
+        feeFixedUsd: 0,
+        feePercentage: 0,
+        salt: '54lt',
+        payAt: new Date(),
+        spHash: '0x123',
+        chainId: 1,
+        userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+        creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
+      },
+    });
+
+    await task.perform({ scheduledPaymentId: scheduledPayment.id });
+    scheduledPayment = await prisma.scheduledPayment.findUniqueOrThrow({
+      where: {
+        id: scheduledPayment.id,
+      },
+    });
+
+    expect(scheduledPayment.creationTransactionError).to.eq('Transaction with hash 0x123 was reverted');
+  });
+
+  it('restarts the worker if there was an error that we do not handle', async function () {
+    sdkError = new Error('unknown error');
+
+    let prisma = await getPrisma();
+    let task = await getContainer().instantiate(ScheduledPaymentOnChainCreationWaiter);
+    let scheduledPayment = await prisma.scheduledPayment.create({
+      data: {
+        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+        moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+        tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+        amount: 100,
+        payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+        executionGasEstimation: 100000,
+        maxGasPrice: 1000000000,
+        feeFixedUsd: 0,
+        feePercentage: 0,
+        salt: '54lt',
+        payAt: new Date(),
+        spHash: '0x123',
+        chainId: 1,
+        userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+        creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
+      },
+    });
+
+    expect(task.perform({ scheduledPaymentId: scheduledPayment.id })).to.be.rejected;
+  });
+});

--- a/packages/hub/node-tests/utils/scheduled-payments-test.ts
+++ b/packages/hub/node-tests/utils/scheduled-payments-test.ts
@@ -1,0 +1,77 @@
+import { format } from 'date-fns';
+import { calculateNextPayAt } from '../../utils/scheduled-payments';
+
+describe('ScheduledPaymentUtils', function () {
+  let recurringDay = 5;
+
+  it('calculates next pay at when current day number is lower than recurring day', function () {
+    let fromDate = new Date(Date.parse('2022-02-04'));
+
+    let nextPayAt = calculateNextPayAt(fromDate, recurringDay);
+
+    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-02-05');
+  });
+
+  it('calculates next pay at when current day number is the same as recurring day', function () {
+    let fromDate = new Date(Date.parse('2022-02-05'));
+
+    let nextPayAt = calculateNextPayAt(fromDate, recurringDay);
+
+    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-03-05');
+  });
+
+  it('calculates next pay at when current day number is higher same as recurring day', function () {
+    let fromDate = new Date(Date.parse('2022-02-06'));
+
+    let nextPayAt = calculateNextPayAt(fromDate, recurringDay);
+
+    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-03-05');
+  });
+
+  it('throws an error when recurring day is not in the range of 1-31', function () {
+    expect(() => calculateNextPayAt(new Date(), 0)).to.throw();
+    expect(() => calculateNextPayAt(new Date(), 32)).to.throw();
+    expect(() => calculateNextPayAt(new Date(), 1)).to.not.throw();
+    expect(() => calculateNextPayAt(new Date(), 31)).to.not.throw();
+  });
+
+  it('sets the last day of month when month has less days than recurringDay case 1', function () {
+    // February 2022 has 28 days. If recurringDay is set to 31th, payAt should be set to 28th.
+    let a = new Date(Date.UTC(2022, 1, 1)); // 2022-02-01 (months are zero-indexed)
+    let nextPayAt = calculateNextPayAt(a, 31);
+
+    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-02-28');
+  });
+
+  it('sets the last day of month when month has less days than recurringDay case 2', function () {
+    // February 2022 has 28 days. If recurringDay is set to 31th, payAt should be set to 28th.
+    let a = new Date(Date.UTC(2022, 1, 27)); // 2022-02-27 (months are zero-indexed)
+    let nextPayAt = calculateNextPayAt(a, 31);
+
+    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-02-28');
+  });
+
+  it('sets the last day of month when month has less days than recurringDay case 3', function () {
+    // February 2022 has 28 days. If recurringDay is set to 31st and we're on 28th, next payAt should be set to March 30st.
+    let a = new Date(Date.UTC(2022, 1, 28)); // 2022-02-28 (months are zero-indexed)
+    let nextPayAt = calculateNextPayAt(a, 31);
+
+    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-03-31');
+  });
+
+  it('sets the last day of month when month has less days than recurringDay case 4', function () {
+    // April has 30 days. If recurringDay is set to 31st, payAt should be set to 30th.
+    let a = new Date(Date.UTC(2022, 3, 1)); // 2022-04-01 (months are zero-indexed)
+    let nextPayAt = calculateNextPayAt(a, 31);
+
+    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-04-30');
+  });
+
+  it('sets the last day of month when month has less days than recurringDay case 5', function () {
+    // April has 30 days. If recurringDay is set to 31st and we're on 30th, next payAt should be set to May 31st.
+    let a = new Date(Date.UTC(2022, 3, 30)); // 2022-04-30 (months are zero-indexed)
+    let nextPayAt = calculateNextPayAt(a, 31);
+
+    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-05-31');
+  });
+});

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -65,7 +65,7 @@
     "crypto": "^1.0.1",
     "crypto-random-string": "^4.0.0",
     "dag-map": "^2.0.2",
-    "date-fns": "^2.22.1",
+    "date-fns": "^2.23.0",
     "did-resolver": "^3.1.0",
     "dotenv": "^10.0.0",
     "eth-sig-util": "^3.0.1",

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -292,33 +292,35 @@ model ScheduledPaymentAttempt {
 }
 
 model ScheduledPayment {
-  id                         String                    @id @db.Uuid
-  senderSafeAddress          String                    @map("sender_safe_address")
-  moduleAddress              String                    @map("module_address")
-  tokenAddress               String                    @map("token_address")
-  amount                     BigInt
-  payeeAddress               String                    @map("payee_address")
-  executionGasEstimation     BigInt                    @map("execution_gas_estimation")
-  maxGasPrice                BigInt                    @map("max_gas_price")
-  feeFixedUsd                Decimal                   @map("fee_fixed_usd") @db.Decimal
-  feePercentage              Decimal                   @map("fee_percentage") @db.Decimal
-  salt                       String
-  payAt                      DateTime?                 @map("pay_at") @db.Timestamp(6)
-  recurringDayOfMonth        Int?                      @map("recurring_day_of_month")
-  recurringUntil             DateTime?                 @map("recurring_until") @db.Timestamp(6)
-  validForDays               Int?                      @default(3) @map("valid_for_days")
-  spHash                     String                    @unique @map("sp_hash")
-  chainId                    Int                       @map("chain_id")
-  creationTransactionHash    String?                   @map("creation_transaction_hash")
-  creationBlockNumber        BigInt?                   @map("creation_block_number")
-  cancelationTransactionHash String?                   @map("cancelation_transaction_hash")
-  cancelationBlockNumber     BigInt?                   @map("cancelation_block_number")
-  createdAt                  DateTime                  @default(now()) @map("created_at") @db.Timestamp(6)
-  updatedAt                  DateTime                  @default(now()) @map("updated_at") @db.Timestamp(6)
-  canceledAt                 DateTime?                 @map("canceled_at") @db.Timestamp(6)
-  userAddress                String                    @map("user_address")
-  creationTransactionError   String?                   @map("creation_transaction_error")
-  scheduledPaymentAttempts   ScheduledPaymentAttempt[]
+  id                           String                    @id @db.Uuid
+  senderSafeAddress            String                    @map("sender_safe_address")
+  moduleAddress                String                    @map("module_address")
+  tokenAddress                 String                    @map("token_address")
+  amount                       BigInt
+  payeeAddress                 String                    @map("payee_address")
+  executionGasEstimation       BigInt                    @map("execution_gas_estimation")
+  maxGasPrice                  BigInt                    @map("max_gas_price")
+  feeFixedUsd                  Decimal                   @map("fee_fixed_usd") @db.Decimal
+  feePercentage                Decimal                   @map("fee_percentage") @db.Decimal
+  salt                         String
+  payAt                        DateTime?                 @map("pay_at") @db.Timestamp(6)
+  recurringDayOfMonth          Int?                      @map("recurring_day_of_month")
+  recurringUntil               DateTime?                 @map("recurring_until") @db.Timestamp(6)
+  validForDays                 Int?                      @default(3) @map("valid_for_days")
+  spHash                       String                    @unique @map("sp_hash")
+  chainId                      Int                       @map("chain_id")
+  creationTransactionHash      String?                   @map("creation_transaction_hash")
+  creationBlockNumber          BigInt?                   @map("creation_block_number")
+  cancelationTransactionHash   String?                   @map("cancelation_transaction_hash")
+  cancelationBlockNumber       BigInt?                   @map("cancelation_block_number")
+  createdAt                    DateTime                  @default(now()) @map("created_at") @db.Timestamp(6)
+  updatedAt                    DateTime                  @default(now()) @map("updated_at") @db.Timestamp(6)
+  canceledAt                   DateTime?                 @map("canceled_at") @db.Timestamp(6)
+  cancelationTransactionError  String?                   @map("cancelation_transaction_error")
+  userAddress                  String                    @map("user_address")
+  creationTransactionError     String?                   @map("creation_transaction_error")
+  cancellationTransactionError String?                   @map("cancellation_transaction_error")
+  scheduledPaymentAttempts     ScheduledPaymentAttempt[]
 
   @@index([senderSafeAddress], map: "scheduled_payments_sender_safe_address_index")
   @@index([canceledAt, payAt, creationBlockNumber], map: "scheduled_payments_canceled_at_pay_at_creation_block_number_ind")

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -300,8 +300,8 @@ model ScheduledPayment {
   payeeAddress               String                    @map("payee_address")
   executionGasEstimation     BigInt                    @map("execution_gas_estimation")
   maxGasPrice                BigInt                    @map("max_gas_price")
-  feeFixedUsd                Int                       @map("fee_fixed_usd")
-  feePercentage              Int                       @map("fee_percentage")
+  feeFixedUsd                Decimal                   @map("fee_fixed_usd") @db.Decimal
+  feePercentage              Decimal                   @map("fee_percentage") @db.Decimal
   salt                       String
   payAt                      DateTime?                 @map("pay_at") @db.Timestamp(6)
   recurringDayOfMonth        Int?                      @map("recurring_day_of_month")
@@ -316,12 +316,15 @@ model ScheduledPayment {
   createdAt                  DateTime                  @default(now()) @map("created_at") @db.Timestamp(6)
   updatedAt                  DateTime                  @default(now()) @map("updated_at") @db.Timestamp(6)
   canceledAt                 DateTime?                 @map("canceled_at") @db.Timestamp(6)
+  userAddress                String                    @map("user_address")
+  creationTransactionError   String?                   @map("creation_transaction_error")
   scheduledPaymentAttempts   ScheduledPaymentAttempt[]
 
   @@index([senderSafeAddress], map: "scheduled_payments_sender_safe_address_index")
   @@index([canceledAt, payAt, creationBlockNumber], map: "scheduled_payments_canceled_at_pay_at_creation_block_number_ind")
   @@index([recurringDayOfMonth], map: "scheduled_payments_recurring_day_of_month_index")
   @@index([recurringUntil], map: "scheduled_payments_recurring_until_index")
+  @@index([userAddress], map: "scheduled_payments_user_address_index")
   @@map("scheduled_payments")
 }
 

--- a/packages/hub/routes/scheduled-payments.ts
+++ b/packages/hub/routes/scheduled-payments.ts
@@ -178,16 +178,14 @@ export default class ScheduledPaymentsRoute {
     let userAddress = ctx.state.userAddress;
     let scheduledPaymentId: string = ctx.params.scheduled_payment_id;
 
-    let scheduledPayment = await prisma.scheduledPayment.findFirstOrThrow({
+    let scheduledPayment = await prisma.scheduledPayment.findFirst({
       where: {
         id: scheduledPaymentId,
         userAddress,
       },
     });
 
-    if (scheduledPayment.userAddress !== userAddress) {
-      ctx.status = 404;
-    } else {
+    if (scheduledPayment) {
       await prisma.scheduledPayment.delete({
         where: {
           id: scheduledPaymentId,
@@ -195,6 +193,8 @@ export default class ScheduledPaymentsRoute {
       });
       ctx.status = 200;
       ctx.body = {};
+    } else {
+      ctx.status = 404;
     }
 
     ctx.type = 'application/vnd.api+json';

--- a/packages/hub/routes/scheduled-payments.ts
+++ b/packages/hub/routes/scheduled-payments.ts
@@ -1,0 +1,208 @@
+import Koa from 'koa';
+import autoBind from 'auto-bind';
+import { ensureLoggedIn } from './utils/auth';
+import { inject } from '@cardstack/di';
+import shortUUID from 'short-uuid';
+import ScheduledPaymentValidator from '../services/validators/scheduled-payment';
+import { serializeErrors } from './utils/error';
+import ScheduledPaymentSerializer from '../services/serializers/scheduled-payment-serializer';
+import WorkerClient from '../services/worker-client';
+import { calculateNextPayAt } from '../utils/scheduled-payments';
+import { ScheduledPayment } from '@prisma/client';
+
+export default class ScheduledPaymentsRoute {
+  scheduledPaymentValidator: ScheduledPaymentValidator = inject('scheduled-payment-validator', {
+    as: 'scheduledPaymentValidator',
+  });
+  scheduledPaymentSerializer: ScheduledPaymentSerializer = inject('scheduled-payment-serializer', {
+    as: 'scheduledPaymentSerializer',
+  });
+  web3 = inject('web3-http', { as: 'web3' });
+  prismaManager = inject('prisma-manager', { as: 'prismaManager' });
+  workerClient: WorkerClient = inject('worker-client', { as: 'workerClient' });
+  cardpay = inject('cardpay');
+
+  constructor() {
+    autoBind(this);
+  }
+
+  async get(ctx: Koa.Context) {
+    if (!ensureLoggedIn(ctx)) {
+      return;
+    }
+
+    let userAddress = ctx.state.userAddress;
+    let scheduledPaymentId: string = ctx.params.scheduled_payment_id;
+
+    let prisma = await this.prismaManager.getClient();
+    let scheduledPayment = await prisma.scheduledPayment.findFirst({
+      where: {
+        id: scheduledPaymentId,
+        userAddress,
+      },
+    });
+
+    if (scheduledPayment) {
+      ctx.body = this.scheduledPaymentSerializer.serialize(scheduledPayment);
+      ctx.status = 200;
+    } else {
+      ctx.status = 404;
+    }
+    ctx.type = 'application/vnd.api+json';
+  }
+
+  async post(ctx: Koa.Context) {
+    if (!ensureLoggedIn(ctx)) {
+      return;
+    }
+
+    let attrs = ctx.request.body.data.attributes;
+
+    let parseDate = (value: string | number) => {
+      if (value) {
+        if (typeof value === 'string') {
+          return new Date(value);
+        }
+
+        let date = new Date(0);
+        date.setUTCSeconds(value);
+        return date;
+      } else {
+        return null;
+      }
+    };
+
+    let parseBigInt = (value: string) => {
+      if (value) {
+        return BigInt(value);
+      } else {
+        return null;
+      }
+    };
+
+    let params = {
+      id: shortUUID.uuid(),
+      userAddress: ctx.state.userAddress,
+      senderSafeAddress: attrs['sender-safe-address'],
+      moduleAddress: attrs['module-address'],
+      tokenAddress: attrs['token-address'],
+      amount: parseBigInt(attrs.amount),
+      payeeAddress: attrs['payee-address'],
+      executionGasEstimation: parseBigInt(attrs['execution-gas-estimation']),
+      maxGasPrice: parseBigInt(attrs['max-gas-price']),
+      feeFixedUsd: attrs['fee-fixed-usd'],
+      feePercentage: attrs['fee-percentage'],
+      salt: attrs['salt'],
+      spHash: attrs['sp-hash'],
+      chainId: attrs['chain-id'],
+      payAt: parseDate(attrs['pay-at']),
+      recurringDayOfMonth: attrs['recurring-day-of-month'],
+      recurringUntil: parseDate(attrs['recurring-until']),
+      validForDays: attrs['valid-for-days'],
+    } as unknown as ScheduledPayment;
+
+    if (params.recurringDayOfMonth != null) {
+      params.payAt = calculateNextPayAt(new Date(), params.recurringDayOfMonth);
+    }
+
+    let errors = this.scheduledPaymentValidator.validate(params);
+    let hasErrors = Object.values(errors).flatMap((i) => i).length > 0;
+    if (hasErrors) {
+      ctx.status = 422;
+      ctx.body = {
+        errors: serializeErrors(errors),
+      };
+    } else {
+      let prisma = await this.prismaManager.getClient();
+
+      let scheduledPayment = await prisma.scheduledPayment.create({
+        data: params,
+      });
+
+      ctx.body = this.scheduledPaymentSerializer.serialize(scheduledPayment);
+      ctx.status = 201;
+      ctx.type = 'application/vnd.api+json';
+    }
+  }
+
+  async patch(ctx: Koa.Context) {
+    if (!ensureLoggedIn(ctx)) {
+      return;
+    }
+
+    let userAddress = ctx.state.userAddress;
+    let scheduledPaymentId: string = ctx.params.scheduled_payment_id;
+
+    let prisma = await this.prismaManager.getClient();
+    let scheduledPayment = await prisma.scheduledPayment.findFirst({
+      where: {
+        id: scheduledPaymentId,
+        userAddress,
+      },
+    });
+
+    if (scheduledPayment) {
+      let creationTransactionHash = ctx.request.body.data.attributes['creation-transaction-hash'];
+
+      if (creationTransactionHash) {
+        scheduledPayment = await prisma.scheduledPayment.update({
+          where: {
+            id: scheduledPayment.id,
+          },
+          data: {
+            creationTransactionHash,
+          },
+        });
+
+        await this.workerClient.addJob('scheduled-payment-on-chain-creation-waiter', {
+          scheduledPaymentId: scheduledPayment.id,
+        });
+
+        ctx.body = this.scheduledPaymentSerializer.serialize(scheduledPayment);
+        ctx.status = 200;
+      }
+    } else {
+      ctx.status = 404;
+    }
+
+    ctx.type = 'application/vnd.api+json';
+  }
+
+  async delete(ctx: Koa.Context) {
+    if (!ensureLoggedIn(ctx)) {
+      return;
+    }
+
+    let prisma = await this.prismaManager.getClient();
+
+    let userAddress = ctx.state.userAddress;
+    let scheduledPaymentId: string = ctx.params.scheduled_payment_id;
+
+    let scheduledPayment = await prisma.scheduledPayment.findFirstOrThrow({
+      where: {
+        id: scheduledPaymentId,
+        userAddress,
+      },
+    });
+
+    if (scheduledPayment.userAddress !== userAddress) {
+      ctx.status = 404;
+    } else {
+      await prisma.scheduledPayment.delete({
+        where: {
+          id: scheduledPaymentId,
+        },
+      });
+      ctx.status = 200;
+      ctx.body = {};
+    }
+
+    ctx.type = 'application/vnd.api+json';
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'scheduled-payments-route': ScheduledPaymentsRoute;
+  }
+}

--- a/packages/hub/services/api-router.ts
+++ b/packages/hub/services/api-router.ts
@@ -45,6 +45,7 @@ export default class APIRouter {
   reservationsRoute = inject('reservations-route', { as: 'reservationsRoute' });
   inventoryRoute = inject('inventory-route', { as: 'inventoryRoute' });
   wyrePricesRoute = inject('wyre-prices-route', { as: 'wyrePricesRoute' });
+  scheduledPaymentsRoute = inject('scheduled-payments-route', { as: 'scheduledPaymentsRoute' });
 
   routes() {
     let {
@@ -67,6 +68,7 @@ export default class APIRouter {
       wyrePricesRoute,
       pushNotificationRegistrationsRoute,
       notificationPreferencesRoute,
+      scheduledPaymentsRoute,
     } = this;
     let apiSubrouter = new Router();
     apiSubrouter.get('/boom', boomRoute.get);
@@ -134,6 +136,10 @@ export default class APIRouter {
     );
     apiSubrouter.get('/notification-preferences/:push_client_id', parseBody, notificationPreferencesRoute.get);
     apiSubrouter.put('/notification-preferences/:push_client_id', parseBody, notificationPreferencesRoute.put);
+    apiSubrouter.post('/scheduled-payments', parseBody, scheduledPaymentsRoute.post);
+    apiSubrouter.get('/scheduled-payments/:scheduled_payment_id', parseBody, scheduledPaymentsRoute.get);
+    apiSubrouter.patch('/scheduled-payments/:scheduled_payment_id', parseBody, scheduledPaymentsRoute.patch);
+    apiSubrouter.delete('/scheduled-payments/:scheduled_payment_id', parseBody, scheduledPaymentsRoute.delete);
     apiSubrouter.get('/wyre-prices', parseBody, wyrePricesRoute.get);
     apiSubrouter.all('/(.*)', notFound);
 

--- a/packages/hub/services/serializers/scheduled-payment-serializer.ts
+++ b/packages/hub/services/serializers/scheduled-payment-serializer.ts
@@ -1,0 +1,52 @@
+import { ScheduledPayment } from '@prisma/client';
+import { JSONAPIDocument } from '../../utils/jsonapi-document';
+
+function transformToString(value: BigInt | null): string | null {
+  if (value == null) {
+    return null;
+  } else {
+    return String(value);
+  }
+}
+
+export default class ScheduledPaymentSerializer {
+  serialize(model: ScheduledPayment): JSONAPIDocument {
+    const result = {
+      data: {
+        id: model.id,
+        type: 'scheduled-payment',
+        attributes: {
+          'user-address': model.userAddress,
+          'sender-safe-address': model.senderSafeAddress,
+          'module-address': model.moduleAddress,
+          'token-address': model.tokenAddress,
+          amount: transformToString(model.amount),
+          'payee-address': model.payeeAddress,
+          'execution-gas-estimation': transformToString(model.executionGasEstimation),
+          'max-gas-price': transformToString(model.maxGasPrice),
+          'fee-fixed-usd': model.feeFixedUsd,
+          'fee-percentage': model.feePercentage,
+          salt: model.salt,
+          'pay-at': model.payAt,
+          'sp-hash': model.spHash,
+          'chain-id': model.chainId,
+          'recurring-day-of-month': model.recurringDayOfMonth,
+          'recurring-until': model.recurringUntil,
+          'creation-transaction-hash': model.creationTransactionHash,
+          'creation-block-number': transformToString(model.creationBlockNumber),
+          'creation-transaction-error': model.creationTransactionError,
+          'cancelation-transaction-hash': model.cancelationTransactionHash,
+          'cancelation-block-number': transformToString(model.cancelationBlockNumber),
+        },
+      },
+    };
+
+    return result as JSONAPIDocument;
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'scheduled-payment-serializer': ScheduledPaymentSerializer;
+  }
+}

--- a/packages/hub/services/validators/scheduled-payment.ts
+++ b/packages/hub/services/validators/scheduled-payment.ts
@@ -1,4 +1,5 @@
 import { ScheduledPayment } from '@prisma/client';
+import { startCase } from 'lodash';
 import { isAddress } from 'web3-utils';
 
 type ScheduledPaymentAttribute =
@@ -63,7 +64,7 @@ export default class ScheduledPaymentValidator {
 
     for (let attribute of mandatoryAttributes) {
       if (scheduledPayment[attribute] == null) {
-        errors[attribute].push('is required');
+        errors[attribute].push(`${startCase(attribute).toLowerCase()} is required`);
       }
     }
 
@@ -76,7 +77,7 @@ export default class ScheduledPaymentValidator {
 
     for (let attribute of addressAttributes) {
       if (scheduledPayment[attribute] && !isAddress(scheduledPayment[attribute] as string)) {
-        errors[attribute].push('is not a valid address');
+        errors[attribute].push(`${startCase(attribute).toLowerCase()} is not a valid address`);
       }
     }
 

--- a/packages/hub/services/validators/scheduled-payment.ts
+++ b/packages/hub/services/validators/scheduled-payment.ts
@@ -1,6 +1,7 @@
+import Web3 from 'web3';
 import { ScheduledPayment } from '@prisma/client';
 import { startCase } from 'lodash';
-import { isAddress } from 'web3-utils';
+const { isAddress } = Web3.utils;
 
 type ScheduledPaymentAttribute =
   | 'senderSafeAddress'

--- a/packages/hub/services/validators/scheduled-payment.ts
+++ b/packages/hub/services/validators/scheduled-payment.ts
@@ -1,0 +1,91 @@
+import { ScheduledPayment } from '@prisma/client';
+import { isAddress } from 'web3-utils';
+
+type ScheduledPaymentAttribute =
+  | 'senderSafeAddress'
+  | 'moduleAddress'
+  | 'tokenAddress'
+  | 'amount'
+  | 'payeeAddress'
+  | 'executionGasEstimation'
+  | 'maxGasPrice'
+  | 'feeFixedUsd'
+  | 'feePercentage'
+  | 'salt'
+  | 'payAt'
+  | 'recurringDayOfMonth'
+  | 'recurringUntil'
+  | 'validForDays'
+  | 'spHash'
+  | 'chainId'
+  | 'userAddress';
+
+type ScheduledPaymentErrors = Record<ScheduledPaymentAttribute, string[]>;
+
+export default class ScheduledPaymentValidator {
+  validate(scheduledPayment: Partial<ScheduledPayment>): ScheduledPaymentErrors {
+    let errors: ScheduledPaymentErrors = {
+      senderSafeAddress: [],
+      moduleAddress: [],
+      tokenAddress: [],
+      amount: [],
+      payeeAddress: [],
+      executionGasEstimation: [],
+      maxGasPrice: [],
+      feeFixedUsd: [],
+      feePercentage: [],
+      salt: [],
+      payAt: [],
+      recurringDayOfMonth: [],
+      recurringUntil: [],
+      validForDays: [],
+      spHash: [],
+      userAddress: [],
+      chainId: [],
+    };
+
+    let mandatoryAttributes: ScheduledPaymentAttribute[] = [
+      'senderSafeAddress',
+      'moduleAddress',
+      'tokenAddress',
+      'amount',
+      'payeeAddress',
+      'executionGasEstimation',
+      'maxGasPrice',
+      'feeFixedUsd',
+      'payAt',
+      'feePercentage',
+      'salt',
+      'spHash',
+      'chainId',
+      'userAddress',
+    ];
+
+    for (let attribute of mandatoryAttributes) {
+      if (scheduledPayment[attribute] == null) {
+        errors[attribute].push('is required');
+      }
+    }
+
+    let addressAttributes: ScheduledPaymentAttribute[] = [
+      'senderSafeAddress',
+      'moduleAddress',
+      'tokenAddress',
+      'payeeAddress',
+    ];
+
+    for (let attribute of addressAttributes) {
+      if (scheduledPayment[attribute] && !isAddress(scheduledPayment[attribute] as string)) {
+        errors[attribute].push('is not a valid address');
+      }
+    }
+
+    return errors;
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'scheduled-payment-validator': ScheduledPaymentValidator;
+  }
+}

--- a/packages/hub/tasks/index.ts
+++ b/packages/hub/tasks/index.ts
@@ -19,6 +19,7 @@ const ALL_KNOWN_TASKS: Record<keyof KnownTasks, true> = {
   'print-queued-jobs': true,
   'persist-off-chain-prepaid-card-customization': true,
   'persist-off-chain-profile': true,
+  'scheduled-payment-on-chain-creation-waiter': true,
   boom: true,
 };
 

--- a/packages/hub/tasks/scheduled-payment-on-chain-creation-waiter.ts
+++ b/packages/hub/tasks/scheduled-payment-on-chain-creation-waiter.ts
@@ -1,0 +1,95 @@
+import { inject } from '@cardstack/di';
+import * as Sentry from '@sentry/node';
+import { isBefore, subDays } from 'date-fns';
+
+export default class ScheduledPaymentOnChainCreationWaiter {
+  prismaManager = inject('prisma-manager', { as: 'prismaManager' });
+  web3 = inject('web3-http', { as: 'web3' });
+  cardpay = inject('cardpay');
+
+  async perform(payload: { scheduledPaymentId: string }) {
+    let prisma = await this.prismaManager.getClient();
+
+    let scheduledPaymentModule = await this.cardpay.getSDK('ScheduledPaymentModule', this.web3.getInstance());
+    let scheduledPayment = await prisma.scheduledPayment.findFirstOrThrow({
+      where: { id: payload.scheduledPaymentId },
+    });
+
+    if (scheduledPayment.creationBlockNumber) {
+      // Did we somehow spawn this task after it already updated creationBlockNumber previously?
+      return Sentry.captureException(
+        new Error('Task run for scheduled payment that already has a creation block number'),
+        {
+          tags: {
+            action: 'scheduled-payment-task',
+            scheduledPaymentId: scheduledPayment.id,
+          },
+        }
+      );
+    }
+
+    if (!scheduledPayment.creationTransactionHash) {
+      // This should never happen because we spawn this task only after updating creationTransactionHash in the route. But just in case...
+      return Sentry.captureException(new Error('Missing transaction hash'), {
+        tags: {
+          action: 'scheduled-payment-task',
+          scheduledPaymentId: scheduledPayment.id,
+        },
+      });
+    }
+
+    if (isBefore(scheduledPayment.createdAt, subDays(new Date(), 1))) {
+      return Sentry.captureException(
+        new Error('Scheduled payment is more than a day old and the creation transaction still has not been mined'),
+        {
+          tags: {
+            action: 'scheduled-payment-task',
+            scheduledPaymentId: scheduledPayment.id,
+          },
+        }
+      );
+    }
+
+    try {
+      let receipt = await scheduledPaymentModule.schedulePaymentOnChain(scheduledPayment.creationTransactionHash);
+      return await prisma.scheduledPayment.update({
+        data: {
+          creationBlockNumber: receipt.blockNumber, // To let us know that the scheduled payment has been created on chain and that the process of scheduling the payment was completed
+        },
+        where: {
+          id: scheduledPayment.id,
+        },
+      });
+    } catch (error: any) {
+      if (error.message.includes('revert')) {
+        // Error message from the waitUntilTransactionMined in the SDK will be: Transaction with hash "${txnHash}" was reverted
+        await prisma.scheduledPayment.update({
+          data: {
+            creationTransactionError: error.message,
+          },
+          where: {
+            id: scheduledPayment.id,
+          },
+        });
+
+        return; // We don't want to throw an error here because we don't want the task to be retried - the transaction was obviously reverted
+      }
+
+      // At this point, we don't know what error to expect. Let's throw the error so that the task will restart
+      Sentry.captureException(error, {
+        tags: {
+          action: 'scheduled-payment-task',
+          scheduledPaymentId: scheduledPayment.id,
+        },
+      });
+
+      throw error;
+    }
+  }
+}
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    'scheduled-payment-on-chain-creation-waiter': ScheduledPaymentOnChainCreationWaiter;
+  }
+}

--- a/packages/hub/utils/scheduled-payments.ts
+++ b/packages/hub/utils/scheduled-payments.ts
@@ -1,0 +1,29 @@
+import { addMonths } from 'date-fns';
+import { convertDateToUTC } from './dates';
+
+// This function will return the next payment date based on the frequency.
+// fromDate will be either the current date when a recurring scheduled is created,
+// or the date of the last payment.
+export function calculateNextPayAt(fromDate: Date, recurringDay: number) {
+  if (recurringDay < 1 || recurringDay > 31) {
+    throw new Error('Recurring day must be in the range of 1-31');
+  }
+
+  let fromDateUtc = convertDateToUTC(fromDate);
+  let nextPayAtUtc = convertDateToUTC(fromDate);
+
+  // We take min() because some months can have less days than the recurring day (e.g. there is no Feb 31)
+  let adjustedRecurringDay = Math.min(recurringDay, daysInMonth(fromDateUtc));
+  if (fromDate.getDate() < adjustedRecurringDay) {
+    nextPayAtUtc.setDate(adjustedRecurringDay); // next pay this month
+  } else {
+    nextPayAtUtc = addMonths(nextPayAtUtc, 1); // next pay next month
+    nextPayAtUtc.setDate(Math.min(recurringDay, daysInMonth(nextPayAtUtc)));
+  }
+
+  return nextPayAtUtc;
+}
+
+function daysInMonth(date: Date) {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
+}

--- a/packages/hub/worker.ts
+++ b/packages/hub/worker.ts
@@ -23,6 +23,7 @@ import SubscribeEmail from './tasks/subscribe-email';
 import RemoveOldSentNotificationsTask from './tasks/remove-old-sent-notifications';
 import WyreTransferTask from './tasks/wyre-transfer';
 import PrintQueuedJobsTask from './tasks/print-queued-jobs';
+import ScheduledPaymentOnChainCreationWaiter from './tasks/scheduled-payment-on-chain-creation-waiter';
 
 let dbConfig = config.get('db') as Record<string, any>;
 const log = logger('hub/worker');
@@ -81,6 +82,7 @@ export class HubWorker {
         'remove-old-sent-notifications': this.instantiateTask(RemoveOldSentNotificationsTask),
         'wyre-transfer': this.instantiateTask(WyreTransferTask),
         's3-put-json': s3PutJson,
+        'scheduled-payment-on-chain-creation-waiter': this.instantiateTask(ScheduledPaymentOnChainCreationWaiter),
       },
       // https://github.com/graphile/worker#recurring-tasks-crontab
       // remove old notifications at midnight every day

--- a/yarn.lock
+++ b/yarn.lock
@@ -12187,6 +12187,11 @@ date-fns@^2.0.1, date-fns@^2.22.1, date-fns@^2.28.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.1.tgz#9667c2615525e552b5135a3116b95b1961456e60"
   integrity sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw==
 
+date-fns@^2.23.0:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"


### PR DESCRIPTION
This PR adds POST/GET/PATCH/DELETE endpoints for scheduled payments, with a specialty in the PATCH endpoint which updates `creation-transaction-hash` and spawns a background worker that will wait until the transaction is done and update `creation-block-number` once the transaction has been mined. 

The consumer of these endpoints is the SDK. Please check PR https://github.com/cardstack/cardstack/pull/3257 for more info on how this flow works. 

One potential problem ➡️ we identified an edge case where the SDK call to schedule a payment could only succeed to the point of successfully calling POST, but no further (due to various system errors that could occur). In that case, we'd end up with a scheduled payment saved in the hub which has no `creation-transaction-hash`. That means we don't know if it has been mined or if was even submitted as a transaction on the blockchain. We need a watchdog process that continuously looks for these cases and tries to update their `creation-transaction-hash` (and spawn the waiter task) by looking at the blockchain event logs for the schedule payment event and filtering by `spHash`. In case no transaction could be found that way, we should remove that record from the hub. 

This edge case will be addressed as an automated process in a separate PR but it seems low priority for now. 

