### PR TITLE
[CS-4626]: Refactor PowerSelect components to use BoxelSelect

### DIFF
--- a/packages/boxel/addon/components/boxel/card-picker/index.css
+++ b/packages/boxel/addon/components/boxel/card-picker/index.css
@@ -1,4 +1,3 @@
-/* stylelint-disable max-line-length */
 .boxel-card-picker {
   --boxel-card-picker-width: 24rem;
   --boxel-card-picker-dropdown-menu-height: 33rem;
@@ -9,34 +8,45 @@
 
 .boxel-card-picker--change-card {
   display: flex;
-  flex-wrap: wrap;
   justify-content: space-between;
 }
 
-.boxel-card-picker__dropdown {
+.boxel-card-picker__select {
   position: static;
-  width: var(--boxel-card-picker-width);
   max-width: 100%;
   color: var(--boxel-dark);
   font: var(--boxel-font);
   letter-spacing: var(--boxel-lsp-sm);
-  z-index: 1;
-  padding: var(--boxel-sp-xs) var(--boxel-sp-xxxl) var(--boxel-sp-xs) var(--boxel-sp);
-  background: url("/@cardstack/boxel/images/icons/caret-down.svg") right var(--boxel-sp) center/auto 0.5rem no-repeat;
+  padding: var(--boxel-sp-xs) var(--boxel-sp-xxxl) var(--boxel-sp-xs)
+    var(--boxel-sp);
+  background: url('/@cardstack/boxel/images/icons/caret-down.svg') right
+    var(--boxel-sp) center/auto 0.5rem no-repeat;
   background-color: var(--boxel-light);
   border: 1px solid var(--boxel-purple-300);
   border-radius: var(--boxel-border-radius);
   transition: border-color var(--boxel-transition);
 }
 
-.boxel-card-picker__dropdown + .ember-basic-dropdown-content-wormhole-origin {
+.boxel-card-picker__dropdown {
+  --boxel-select-current-color: var(--boxel-purple-100);
+  --boxel-select-selected-color: transparent;
+
+  background-color: var(--boxel-light);
+  border: 1px solid rgb(0 0 0 / 15%);
+  border-radius: var(--boxel-border-radius);
+  box-shadow: 0 15px 30px rgb(0 0 0 / 25%);
+  width: var(--boxel-card-picker-width);
   position: absolute;
-  width: 100%;
   top: 0;
   left: 0;
 }
 
-.boxel-card-picker__dropdown--selected {
+.boxel-card-picker--change-card .boxel-card-picker__dropdown {
+  top: -0.15rem;
+  left: -17rem;
+}
+
+.boxel-card-picker__select--selected {
   padding: var(--boxel-sp-xxxs) var(--boxel-sp);
   background-image: none;
   border-radius: 100px;
@@ -44,74 +54,62 @@
   letter-spacing: var(--boxel-lsp-lg);
 }
 
-.boxel-card-picker__dropdown:hover {
-  border-color: var(--boxel-dark);
-  cursor: pointer;
-}
-
-.boxel-card-picker__dropdown + .ember-basic-dropdown-content-wormhole-origin .ember-basic-dropdown-content {
-  position: relative;
-  width: 100%;
-  background-color: var(--boxel-light);
-  border: 1px solid rgb(0 0 0 / 15%);
-  border-radius: var(--boxel-border-radius);
-  box-shadow: 0 15px 30px rgb(0 0 0 / 25%);
-  z-index: 1;
-}
-
-.boxel-card-picker__dropdown + .ember-basic-dropdown-content-wormhole-origin .ember-basic-dropdown-content.ember-basic-dropdown--transitioning-in {
+.boxel-card-picker__dropdown.ember-basic-dropdown--transitioning-in {
   animation: drop-fade-below var(--boxel-transition);
 }
 
-.boxel-card-picker__dropdown + .ember-basic-dropdown-content-wormhole-origin .ember-basic-dropdown-content.ember-basic-dropdown--transitioning-out {
+.boxel-card-picker__dropdown.ember-basic-dropdown--transitioning-out {
   animation: drop-fade-below var(--boxel-transition) reverse;
 }
 
-.boxel-card-picker__dropdown + .ember-basic-dropdown-content-wormhole-origin .ember-power-select-options {
-  list-style: none;
+.boxel-card-picker__dropdown .ember-power-select-options {
   margin: 0;
   padding: 0;
-  height: 100%;
   border-radius: inherit;
   max-height: var(--boxel-card-picker-dropdown-menu-height);
   overflow-y: auto;
 }
 
-.boxel-card-picker__dropdown + .ember-basic-dropdown-content-wormhole-origin .ember-power-select-option {
+.boxel-card-picker__dropdown .ember-power-select-option {
   padding: var(--boxel-sp) var(--boxel-sp-xxxl);
-  background-image: url("/@cardstack/boxel/images/icons/icon-circle-light.svg");
+  background-image: url('/@cardstack/boxel/images/icons/icon-circle-light.svg');
   background-repeat: no-repeat;
   background-position: left var(--boxel-sp) center;
   background-size: var(--boxel-icon-sm) var(--boxel-icon-sm);
 }
 
-.boxel-card-picker__dropdown + .ember-basic-dropdown-content-wormhole-origin .ember-power-select-option + .ember-power-select-option {
+.boxel-card-picker__dropdown
+  .ember-power-select-option
+  + .ember-power-select-option {
   border-top: 1px solid var(--boxel-light-400);
 }
 
-.boxel-card-picker__dropdown + .ember-basic-dropdown-content-wormhole-origin .ember-power-select-option[aria-selected="true"] {
-  background-image: url("/@cardstack/boxel/images/icons/success-bordered.svg");
+.boxel-card-picker__dropdown .ember-power-select-option[aria-selected='true'] {
+  background-image: url('/@cardstack/boxel/images/icons/success-bordered.svg');
 }
 
-.boxel-card-picker__dropdown + .ember-basic-dropdown-content-wormhole-origin .ember-power-select-option:hover:not([aria-disabled="true"]):not(.ember-power-select-option--no-matches-message) {
+.boxel-card-picker__dropdown
+  .ember-power-select-option:hover:not([aria-disabled='true']):not(.ember-power-select-option--no-matches-message) {
+  background-color: var(--boxel-purple-100);
   cursor: pointer;
 }
 
-.boxel-card-picker__dropdown + .ember-basic-dropdown-content-wormhole-origin .ember-power-select-option[aria-current="true"] {
-  background-color: var(--boxel-purple-100);
-}
-
-.boxel-card-picker__dropdown + .ember-basic-dropdown-content-wormhole-origin .ember-power-select-option[aria-disabled="true"] {
+.boxel-card-picker__dropdown .ember-power-select-option[aria-disabled='true'] {
   opacity: 0.45;
   cursor: not-allowed;
 }
 
-.boxel-card-picker__dropdown + .ember-basic-dropdown-content-wormhole-origin .ember-power-select-option--no-matches-message {
+.boxel-card-picker__dropdown .ember-power-select-option--no-matches-message {
   background-image: none;
 }
 
+.boxel-card-picker .ember-basic-dropdown .boxel-card-picker__select--selected {
+  display: inline;
+}
+
 .boxel-card-picker__selected-card {
-  width: var(--boxel-xxs-container);
+  margin-right: var(--boxel-sp-xxs);
+  flex: 1;
 }
 
 @keyframes drop-fade-below {

--- a/packages/boxel/addon/components/boxel/card-picker/index.gts
+++ b/packages/boxel/addon/components/boxel/card-picker/index.gts
@@ -1,7 +1,10 @@
 import Component from '@glimmer/component';
-import PowerSelect from 'ember-power-select/components/power-select';
+
+import BoxelSelect from '@cardstack/boxel/components/boxel/select';
+
 import cn from '@cardstack/boxel/helpers/cn';
 import SelectedItemComponent from './selected-item';
+
 import '@cardstack/boxel/styles/global.css';
 import './index.css';
 
@@ -41,6 +44,7 @@ export default class BoxelCardPicker extends Component<Signature> {
   get isSelected() {
     return !!this.args.selectedItem;
   }
+
   <template>
     <div class={{cn "boxel-card-picker" boxel-card-picker--change-card=this.isSelected}} data-test-boxel-card-picker ...attributes>
       {{#if this.selectedOption}}
@@ -48,20 +52,20 @@ export default class BoxelCardPicker extends Component<Signature> {
           {{yield this.selectedOption}}
         </div>
       {{/if}}
-      <PowerSelect
-        class={{cn "boxel-card-picker__dropdown" boxel-card-picker__dropdown--selected=this.isSelected}}
+      <BoxelSelect
+        class={{cn "boxel-card-picker__select" boxel-card-picker__select--selected=this.isSelected}}
         @options={{@items}}
         @selected={{this.selectedOption}}
         @selectedItemComponent={{component SelectedItemComponent}}
         @placeholder="Select Card"
         @onChange={{@chooseItem}}
+        @dropdownClass="boxel-card-picker__dropdown"
         @renderInPlace={{true}}
-        @eventType="click"
         @verticalPosition="below"
         data-test-boxel-card-picker-dropdown
       as |item|>
         {{yield item}}
-      </PowerSelect>
+      </BoxelSelect>
     </div>
   </template>
 }

--- a/packages/boxel/addon/components/boxel/input/ranged-number-picker/index.css
+++ b/packages/boxel/addon/components/boxel/input/ranged-number-picker/index.css
@@ -15,36 +15,15 @@
   position: absolute;
 }
 
-.boxel-ranged-number-picker__dropdown {
-  box-shadow: var(--boxel-box-shadow);
-  border-radius: var(--boxel-border-radius);
-}
-
 .boxel-ranged-number-picker__dropdown ul {
-  list-style: none;
-  padding: 0;
   text-align: center;
-  overflow: auto;
   max-height: var(--boxel-xs-container);
-}
-
-.ember-power-select-option[aria-current='true']
-  .boxel-ranged-number-picker__item,
-.ember-power-select-option[aria-selected='true']
-  .boxel-ranged-number-picker__item {
-  background-color: var(--boxel-light-100);
 }
 
 .boxel-ranged-number-picker__item {
   display: inherit;
-  font-weight: 600;
-  font-size: var(--boxel-font-size-sm);
-  padding: var(--boxel-sp-xxs) var(--boxel-sp-sm);
 }
 
-.boxel-ranged-number-picker .ember-power-select-placeholder,
 .boxel-ranged-number-picker--selected .boxel-ranged-number-picker__item {
-  font-weight: bold;
-  font-size: var(--boxel-font-size);
   padding: 0;
 }

--- a/packages/boxel/addon/components/boxel/input/ranged-number-picker/index.gts
+++ b/packages/boxel/addon/components/boxel/input/ranged-number-picker/index.gts
@@ -2,7 +2,7 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { type EmptyObject } from '@ember/component/helper';
-import PowerSelect from 'ember-power-select/components/power-select';
+import BoxelSelect from '@cardstack/boxel/components/boxel/select';
 import cn from '@cardstack/boxel/helpers/cn';
 import or from 'ember-truth-helpers/helpers/or';
 import './index.css';
@@ -41,7 +41,7 @@ export default class BoxelInputRangedNumberPicker extends Component<Signature> {
   }
 
   <template>
-    <PowerSelect
+    <BoxelSelect
       class={{cn
         "boxel-ranged-number-picker"
         boxel-ranged-number-picker--selected=this.selectedNumber
@@ -54,10 +54,12 @@ export default class BoxelInputRangedNumberPicker extends Component<Signature> {
       @renderInPlace={{true}}
       @dropdownClass="boxel-ranged-number-picker__dropdown"
       @triggerComponent={{@triggerComponent}}
-      as |item|
+      as |item itemCssClass|
     >
-      <div class="boxel-ranged-number-picker__item">{{item}}</div>
-    </PowerSelect>
+      <div class={{cn itemCssClass "boxel-ranged-number-picker__item"}}>
+        {{item}}
+      </div>
+    </BoxelSelect>
   </template>
 }
 

--- a/packages/boxel/tests/dummy/app/components/boxel/field-renderer/index.hbs
+++ b/packages/boxel/tests/dummy/app/components/boxel/field-renderer/index.hbs
@@ -74,7 +74,7 @@
     >
       {{#if (eq @field.type "dropdown")}}
         <div class="field-renderer__dropdown">
-          <PowerSelect
+          <Boxel::Select
             @options={{@field.options}}
             @selected={{@field.value}}
             @onChange={{fn (mut @field.value)}}
@@ -82,7 +82,7 @@
             @verticalPosition="below"
           as |option|>
             {{option}}
-          </PowerSelect>
+          </Boxel::Select>
         </div>
       {{else if (eq @field.type "textarea")}}
         <Textarea @type={{@field.type}} class="field-renderer__input field-renderer__textarea" @value={{@field.value}} />

--- a/packages/boxel/tests/dummy/app/components/queue.hbs
+++ b/packages/boxel/tests/dummy/app/components/queue.hbs
@@ -13,7 +13,7 @@
 
     <div class="queue__filter-group">
       <div class="queue__filter-dropdown">
-        <PowerSelect
+        <Boxel::Select
           @options={{this.viewOptions}}
           @selected={{this.displayQueue}}
           @onChange={{this.filterQueue}}
@@ -21,7 +21,7 @@
           @verticalPosition="below"
         as |option|>
           {{option.name}}
-        </PowerSelect>
+        </Boxel::Select>
       </div>
       <Boxel::IconButton
         class="queue__search-btn"

--- a/packages/boxel/tests/dummy/app/css/components/queue.css
+++ b/packages/boxel/tests/dummy/app/css/components/queue.css
@@ -82,6 +82,9 @@
 
 .queue__filter-dropdown .ember-power-select-trigger,
 .queue__filter-dropdown .ember-power-select-dropdown {
+  --boxel-select-current-color: transparent;
+  --boxel-select-selected-color: transparent;
+  
   width: 100%;
   min-height: 40px;
   padding: 10px 40px 10px 18px;

--- a/packages/cardhost/app/templates/playground.hbs
+++ b/packages/cardhost/app/templates/playground.hbs
@@ -3,7 +3,7 @@
 <button {{on 'click' (perform this.queryUsersTask)}}>Query Users</button>
 
 {{#if this.queryUsersTask.isRunning}}
-  {{!-- template-lint-disable no-obsolete-elements --}}
+  {{! template-lint-disable no-obsolete-elements }}
   <blink>Loading...</blink>
 {{/if}}
 
@@ -12,19 +12,3 @@
 {{else}}
   No Users....yet
 {{/each}}
-
-{{!--
-# NEEDS:
-- List to iterator over
-- If one is currently selected
-- onChange
-- Embeded card view
-
- --}}
-{{!-- <PowerSelect
-  @options={{this.countries}}
-  @selected={{this.destination}}
-  @onChange={{this.foo}} as |country|>
-  <img src={{country.flagUrl}} class="icon-flag" alt="Flag of {{country.name}}">
-  <strong>{{country.name}}</strong>
-</PowerSelect> --}}


### PR DESCRIPTION
This PR replaces PowerSelect with BoxelSelect on components used in boxel, the webclient migration to BoxelSelect will happen on a diff PR. It also fixes the CardPicker "Change Card" layout.