### PR TITLE
[Refactor]: Replace PowerSelect components w/ Boxel Select on web-client

### DIFF
--- a/packages/web-client/app/components/card-pay/balance-chooser-dropdown/index.css
+++ b/packages/web-client/app/components/card-pay/balance-chooser-dropdown/index.css
@@ -1,5 +1,6 @@
 .balance-chooser-dropdown {
   --field-height: 3.75rem;
+  --boxel-select-selected-color: transparent;
 
   position: relative;
   min-height: var(--field-height);
@@ -28,11 +29,13 @@
   overflow: hidden;
 }
 
-.balance-chooser-dropdown .ember-basic-dropdown-content.ember-basic-dropdown--transitioning-in {
+.balance-chooser-dropdown
+  .ember-basic-dropdown-content.ember-basic-dropdown--transitioning-in {
   animation: drop-fade-below var(--boxel-transition);
 }
 
-.balance-chooser-dropdown .ember-basic-dropdown-content.ember-basic-dropdown--transitioning-out {
+.balance-chooser-dropdown
+  .ember-basic-dropdown-content.ember-basic-dropdown--transitioning-out {
   animation: drop-fade-below var(--boxel-transition) reverse;
 }
 

--- a/packages/web-client/app/components/card-pay/balance-chooser-dropdown/index.hbs
+++ b/packages/web-client/app/components/card-pay/balance-chooser-dropdown/index.hbs
@@ -1,5 +1,5 @@
 <div class="balance-chooser-dropdown">
-  <PowerSelect
+  <Boxel::Select
     @options={{@tokens}}
     @selected={{@selectedToken}}
     @onChange={{@chooseToken}}
@@ -18,5 +18,5 @@
       @balance={{format-wei-amount token.balance}}
       @symbol={{token.symbol}}
     />
-  </PowerSelect>
+  </Boxel::Select>
 </div>

--- a/packages/web-client/app/components/card-pay/safe-chooser-dropdown/index.css
+++ b/packages/web-client/app/components/card-pay/safe-chooser-dropdown/index.css
@@ -19,6 +19,8 @@
 }
 
 .safe-chooser-dropdown .ember-basic-dropdown-content {
+  --boxel-select-selected-color: transparent;
+
   max-height: calc(var(--field-height) * 4.5);
   overflow: auto;
   position: absolute;
@@ -29,17 +31,20 @@
   border-radius: var(--boxel-border-radius-sm);
 }
 
-.safe-chooser-dropdown .ember-basic-dropdown-content.ember-basic-dropdown--transitioning-in {
+.safe-chooser-dropdown
+  .ember-basic-dropdown-content.ember-basic-dropdown--transitioning-in {
   animation: drop-fade-below var(--boxel-transition);
 }
 
-.safe-chooser-dropdown .ember-basic-dropdown-content.ember-basic-dropdown--transitioning-out {
+.safe-chooser-dropdown
+  .ember-basic-dropdown-content.ember-basic-dropdown--transitioning-out {
   animation: drop-fade-below var(--boxel-transition) reverse;
 }
 
 .safe-chooser-dropdown__option {
   min-height: var(--field-height);
-  padding: var(--boxel-sp-xs) var(--boxel-sp-xxl) var(--boxel-sp-xs) var(--boxel-sp-xxxs);
+  padding: var(--boxel-sp-xs) var(--boxel-sp-xxl) var(--boxel-sp-xs)
+    var(--boxel-sp-xxxs);
 }
 
 .safe-chooser-dropdown__option--selected {
@@ -55,6 +60,10 @@
 
 .safe-chooser-dropdown__option:hover {
   cursor: pointer;
+}
+
+.safe-chooser-dropdown__option--selected:hover {
+  background-color: var(--boxel-select-current-color);
 }
 
 .ember-power-select-selected-item .safe-chooser-dropdown__option:hover {

--- a/packages/web-client/app/components/card-pay/safe-chooser-dropdown/index.hbs
+++ b/packages/web-client/app/components/card-pay/safe-chooser-dropdown/index.hbs
@@ -1,22 +1,24 @@
 <div class="safe-chooser-dropdown" ...attributes>
   {{#let (or @selectedSafe @safes.firstObject) as |selectedSafe|}}
-    <PowerSelect
+    <Boxel::Select
       @options={{@safes}}
       @selected={{selectedSafe}}
       @onChange={{@onChooseSafe}}
       @renderInPlace={{true}}
-      @eventType="click" {{!-- to prevent auto-selection of first item, as discussed at https://github.com/cardstack/cardstack/pull/2051 --}}
-      @verticalPosition="below"
+      @verticalPosition='below'
       data-test-safe-chooser-dropdown
-    as |safe|>
+      as |safe|
+    >
       <CardPay::SafeChooserDropdown::SafeOption
           class={{cn
-          "safe-chooser-dropdown__option"
-          safe-chooser-dropdown__option--selected=(eq safe.address selectedSafe.address)
+          'safe-chooser-dropdown__option'
+          safe-chooser-dropdown__option--selected=(eq
+            safe.address selectedSafe.address
+          )
         }}
         @safe={{safe}}
         @showSafeId={{@showSafeId}}
       />
-    </PowerSelect>
+    </Boxel::Select>
   {{/let}}
 </div>


### PR DESCRIPTION
This PR replaces PowerSelect components w/ Boxel Select on web-client for two components, SafeChooser and BalanceChooser, they both have similar behaviors, I thought  they could be a single component and I'm pretty sure we can simplify the styles more, but I guess I need more web experience to do so, I've cracked my head a bit trying it, but some styles were not being overridden, anyways, this approach is the most secure and since it's on the web-client I didn't want to risk it. 