### PR TITLE
Fix event source for S3 put events

### DIFF
--- a/packages/reward-root-submitter/reward_root_submitter/lambda.py
+++ b/packages/reward-root-submitter/reward_root_submitter/lambda.py
@@ -27,7 +27,7 @@ def handler(event, _context):
         unsubmitted_roots = get_all_unsubmitted_roots(config)
         for index, row in unsubmitted_roots.iterrows():
             process_file(row["file"], config)
-    elif event["Records"][0]["eventSource"] == "aws.s3":
+    elif event["Records"][0]["eventSource"] == "aws:s3":
         bucket = event["Records"][0]["s3"]["bucket"]["name"]
         key = urllib.parse.unquote_plus(
             event["Records"][0]["s3"]["object"]["key"], encoding="utf-8"


### PR DESCRIPTION
Based on the examples in the UI, s3 events are `aws:s3` rather than `aws.s3`, even though the cron events are `aws.events`