### PR TITLE
refactor dropdown to use modifier for bindings

### DIFF
--- a/packages/boxel/addon/components/boxel/dropdown-button/index.css
+++ b/packages/boxel/addon/components/boxel/dropdown-button/index.css
@@ -1,20 +1,17 @@
-.boxel-dropdown-button {
+/* Remove all default user-agent styles while keeping specificity low */
+:where(.boxel-dropdown-button__reset) {
+  all: unset;
+}
+
+.boxel-dropdown-button__trigger {
   --dropdown-button-size: 40px;
 
   width: var(--dropdown-button-size);
   height: var(--dropdown-button-size);
 }
 
-.boxel-dropdown-button__trigger {
-  height: 100%;
-}
-
-.boxel-dropdown-button__trigger:hover {
+.boxel-dropdown-button__trigger:hover:not(.boxel-dropdown-button--no-hover) {
   --icon-color: var(--boxel-highlight);
-}
-
-.boxel-dropdown-button--no-hover .boxel-dropdown-button__trigger:hover {
-  --icon-color: inherit;
 }
 
 .boxel-dropdown-button__trigger > svg {

--- a/packages/boxel/addon/components/boxel/dropdown-button/index.gts
+++ b/packages/boxel/addon/components/boxel/dropdown-button/index.gts
@@ -14,7 +14,7 @@ import '@cardstack/boxel/styles/global.css';
 import './index.css';
 
 interface Signature {
-  Element: HTMLDivElement;
+  Element: HTMLButtonElement;
   Args: {
     button?: string;
     class?: string;
@@ -34,28 +34,29 @@ interface Signature {
 }
 
 const DropdownButton: TemplateOnlyComponent<Signature> = <template>
-  <div
-    class={{cn
-      "boxel-dropdown-button"
-      @class
-      boxel-dropdown-button--no-hover=@noHoverStyle
-    }}
-    style={{cssVar dropdown-button-size=(concat (or @size 40) "px")}}
-    data-test-boxel-dropdown-button
-    ...attributes
-  >
-    <BoxelDropdown
-      class="boxel-dropdown-button__trigger {{@button}}"
-      aria-label={{or @icon @button}}
-    >
-      <:trigger>
-        {{#if (or @icon @button)}}
-          {{svgJar
-            (or @icon @button)
-            width=(or @iconSize 16)
-            height=(or @iconSize 16)
+    <BoxelDropdown>
+      <:trigger as |bindings|>
+        <button
+          {{bindings}}
+          class={{cn
+            "boxel-dropdown-button"
+            "boxel-dropdown-button__reset"
+            "boxel-dropdown-button__trigger"
+            @class
           }}
-        {{/if}}
+          style={{cssVar dropdown-button-size=(concat (or @size 40) "px")}}
+          aria-label={{or @icon @button}}
+          data-test-boxel-dropdown-button
+          ...attributes
+        >
+          {{#if (or @icon @button)}}
+            {{svgJar
+              (or @icon @button)
+              width=(or @iconSize 16)
+              height=(or @iconSize 16)
+            }}
+          {{/if}}
+        </button>
       </:trigger>
       <:content as |dd|>
         {{yield
@@ -63,8 +64,6 @@ const DropdownButton: TemplateOnlyComponent<Signature> = <template>
         }}
       </:content>
     </BoxelDropdown>
-
-  </div>
 </template>
 
 export default DropdownButton;

--- a/packages/boxel/addon/components/boxel/dropdown/usage.gts
+++ b/packages/boxel/addon/components/boxel/dropdown/usage.gts
@@ -17,13 +17,13 @@ export default class BoxelDropdownUsage extends Component {
    @action log(string: string): void {
     console.log(string);
   }
-  
+
   <template>
     <FreestyleUsage @name="Dropdown">
       <:example>
         <BoxelDropdown>
-          <:trigger>
-            <BoxelButton>
+          <:trigger as |bindings|>
+            <BoxelButton {{bindings}}>
               Trigger
             </BoxelButton>
           </:trigger>
@@ -44,7 +44,7 @@ export default class BoxelDropdownUsage extends Component {
       <:api as |Args|>
         <Args.Yield
           @name="trigger"
-          @description="Content to be used as trigger for basic dropdown"
+          @description="Content to be used as trigger for basic dropdown. Yields a bindings modifier which applies aria- attributes and event handling."
         />
         <Args.Yield
           @name="content"

--- a/packages/boxel/tests/integration/components/boxel/dropdown-test.ts
+++ b/packages/boxel/tests/integration/components/boxel/dropdown-test.ts
@@ -42,6 +42,8 @@ module('Integration | Component | Dropdown', function (hooks) {
 
   // This test is important because event handlers are assigned assuming default HTML button behaviour
   // In particular this includes "free" click events generated from spacebar and enter keys and also touch events
+  // Click events from enter and space are not tested because synthetic keydown events don't generate a click event
+  // https://github.com/emberjs/ember-test-helpers/issues/1054
   test('it errors if it receives a non-button element', async function (assert) {
     let lastError: Error;
     Ember.onerror = (e: Error) => {
@@ -81,30 +83,6 @@ module('Integration | Component | Dropdown', function (hooks) {
 
     assert.dom(DROPDOWN_CONTENT).doesNotExist();
   });
-
-  // https://github.com/emberjs/ember-test-helpers/issues/1054
-  // no click event is generated with synthetic keydown
-  // eslint-disable-next-line qunit/no-commented-tests
-  // test('it can open and close on space', async function (assert) {
-  //   await focus(TRIGGER);
-  //   // https://w3c.github.io/uievents/#fixed-virtual-key-codes
-  //   await triggerKeyEvent(TRIGGER, 'keydown', 32);
-  //   assert.dom(DROPDOWN_CONTENT).isVisible();
-  //   await triggerKeyEvent(TRIGGER, 'keydown', 32);
-  //   assert.dom(DROPDOWN_CONTENT).doesNotExist();
-  // });
-
-  // https://github.com/emberjs/ember-test-helpers/issues/1054
-  // no click event is generated with synthetic keydown
-  // eslint-disable-next-line qunit/no-commented-tests
-  // test('it can open and close on enter', async function (assert) {
-  //   await focus(TRIGGER);
-  //   // https://w3c.github.io/uievents/#fixed-virtual-key-codes
-  //   await triggerKeyEvent(TRIGGER, 'keydown', 13);
-  //   assert.dom(DROPDOWN_CONTENT).isVisible();
-  //   await triggerKeyEvent(TRIGGER, 'keydown', 13);
-  //   assert.dom(DROPDOWN_CONTENT).doesNotExist();
-  // });
 
   test('it assigns focus to the trigger when opened', async function (assert) {
     await click(TRIGGER);

--- a/packages/boxel/tests/integration/components/boxel/dropdown-test.ts
+++ b/packages/boxel/tests/integration/components/boxel/dropdown-test.ts
@@ -47,7 +47,7 @@ module('Integration | Component | Dropdown', function (hooks) {
     // In particular this includes "free" click events generated from spacebar and enter keys and also touch events
     // Click events from enter and space are not tested because synthetic keydown events don't generate a click event
     // https://github.com/emberjs/ember-test-helpers/issues/1054
-    test('it errors if it receives a non-button element', async function (assert) {
+    test('it errors if bindings modifier receives a non-button element', async function (assert) {
       let lastError: Error;
       setupOnerror((e: Error) => {
         lastError = e;

--- a/packages/boxel/types/ember-basic-dropdown/components/basic-dropdown/index.d.ts
+++ b/packages/boxel/types/ember-basic-dropdown/components/basic-dropdown/index.d.ts
@@ -6,6 +6,7 @@ import EmberBasicDropdown, {
   DropdownActions,
   Dropdown,
 } from 'ember-basic-dropdown/addon/components/basic-dropdown';
+export type { Dropdown } from 'ember-basic-dropdown/addon/components/basic-dropdown';
 import BasicDropdownTrigger from 'ember-basic-dropdown/addon/components/basic-dropdown-trigger';
 import BasicDropdownContent from 'ember-basic-dropdown/addon/components/basic-dropdown-content';
 


### PR DESCRIPTION
Refactored dropdown to provide a modifier that attaches appropriate attributes and event listeners via its `<:trigger>` named block - this modifier is meant to be bound to the trigger component. Also refactored it to not render the default dropdown trigger that `ember-basic-dropdown` provides, because the default dropdown trigger is a button in itself and can lead to nested interactives.

This means that we can now do:

```
<BoxelDropdown>
  <:trigger as |bindings|>
    <BoxelButton {{bindings}}>
        Trigger
    </BoxelButton>
  </:trigger>
  <:content as |dd|>
    {{!--Your content here--}}
  </:content>
</BoxelDropdown>
```

Without nested interactives, and we don't need to introduce `@triggerComponent`.