### PR TITLE
Dropdown button label and icon separation

### DIFF
--- a/packages/boxel/addon/components/boxel/dropdown-button/index.gts
+++ b/packages/boxel/addon/components/boxel/dropdown-button/index.gts
@@ -16,7 +16,7 @@ import './index.css';
 interface Signature {
   Element: HTMLButtonElement;
   Args: {
-    button?: string;
+    label?: string;
     class?: string;
     noHoverStyle?: boolean;
     size?: number;
@@ -45,17 +45,15 @@ const DropdownButton: TemplateOnlyComponent<Signature> = <template>
             @class
           }}
           style={{cssVar dropdown-button-size=(concat (or @size 40) "px")}}
-          aria-label={{or @icon @button}}
+          aria-label={{@label}}
           data-test-boxel-dropdown-button
           ...attributes
         >
-          {{#if (or @icon @button)}}
-            {{svgJar
-              (or @icon @button)
-              width=(or @iconSize 16)
-              height=(or @iconSize 16)
-            }}
-          {{/if}}
+          {{svgJar
+            @icon
+            width=(or @iconSize 16)
+            height=(or @iconSize 16)
+          }}
         </button>
       </:trigger>
       <:content as |dd|>

--- a/packages/boxel/addon/components/boxel/dropdown-button/usage.gts
+++ b/packages/boxel/addon/components/boxel/dropdown-button/usage.gts
@@ -9,8 +9,8 @@ import menuItem from '@cardstack/boxel/helpers/menu-item'
 import menuDivider from '@cardstack/boxel/helpers/menu-divider'
 
 export default class DropdownButtonUsageComponent extends Component {
-  @tracked button = 'gear';
-  @tracked icon: string | undefined;
+  @tracked label = 'Label';
+  @tracked icon: string = 'gear';
   @tracked size = 30;
   @tracked iconSize = 16;
 
@@ -23,7 +23,8 @@ export default class DropdownButtonUsageComponent extends Component {
     <FreestyleUsage @name="DropdownButton">
       <:example>
         <BoxelDropdownButton
-          @button={{this.button}}
+          @label={{this.label}}
+          @icon={{this.icon}}
           @size={{this.size}}
           @iconSize={{this.iconSize}}
           as |ddb|
@@ -44,15 +45,15 @@ export default class DropdownButtonUsageComponent extends Component {
         <Args.String
           @name="button"
           @description="the name to use as the aria-label and added on the trigger element as a css class. If @icon is not specified, this value is also used to specify an svg to use."
-          @value={{this.button}}
+          @value={{this.label}}
           @required={{true}}
-          @onInput={{fn (mut this.button)}}
+          @onInput={{fn (mut this.label)}}
         />
         <Args.String
           @name="icon"
           @description="the name of the svg to show"
           @value={{this.icon}}
-          @defaultValue="falls back to the value of @button"
+          @required={{true}}
           @onInput={{fn (mut this.icon)}}
         />
         <Args.Number
@@ -77,6 +78,6 @@ export default class DropdownButtonUsageComponent extends Component {
           @description="The provided block is rendered when the button is triggered. Yields a 'Menu' component (instance of Boxel::Menu that is preconfigured with @closeMenu defined) and the 'dropdown' object documented in Boxel::Dropdown"
         />
       </:api>
-    </FreestyleUsage>    
+    </FreestyleUsage>
   </template>
 }

--- a/packages/boxel/addon/components/boxel/selection-control-group/index.gts
+++ b/packages/boxel/addon/components/boxel/selection-control-group/index.gts
@@ -60,7 +60,7 @@ export default class SelectionControlGroup extends Component<Signature> {
           selected
           {{#if @menuComponent}}
             <BoxelDropdownButton
-              @button="more-actions"
+              @label="more actions"
               @icon="more-actions"
               class="boxel-selection-control-group__menu-trigger"
               as |ddb|

--- a/packages/boxel/tests/dummy/app/components/boxel-actions.hbs
+++ b/packages/boxel/tests/dummy/app/components/boxel-actions.hbs
@@ -8,7 +8,7 @@
 {{else if @displayHighlightActions}}
   <div class="boxel-actions {{@class}}" data-test-boxel-actions ...attributes>
     {{#if (eq @btnLeft "more-actions")}}
-      <Boxel::DropdownButton @button={{@btnLeft}} @icon={{@btnLeftIcon}} @noHoverStyle={{true}} as |ddb|>
+      <Boxel::DropdownButton @label={{@btnLeft}} @icon={{@btnLeftIcon}} @noHoverStyle={{true}} as |ddb|>
         <ddb.Menu
           @items={{array
             (menu-item "Duplicate" (noop))
@@ -21,7 +21,7 @@
     {{/if}}
 
     {{#if (eq @btnRight "settings")}}
-      <Boxel::DropdownButton @button="gear" @icon="gear" @noHoverStyle={{true}} as |ddb|>
+      <Boxel::DropdownButton @label="gear" @icon="gear" @noHoverStyle={{true}} as |ddb|>
         <ddb.Menu
           @items={{array
             (menu-item "Duplicate" (noop))

--- a/packages/boxel/tests/dummy/app/components/isolated-collection.hbs
+++ b/packages/boxel/tests/dummy/app/components/isolated-collection.hbs
@@ -49,7 +49,7 @@
       <div class="media-collection__btn-group">
         <div class="media-collection__btn-trio media-collection__filters">
           {{#if this.sortColumns.length}}
-            <Boxel::DropdownButton class="media-collection__btn" @button="sort" @icon="sort" @size={{30}}>
+            <Boxel::DropdownButton class="media-collection__btn" @label="sort" @icon="sort" @size={{30}}>
               <Boxel::SortMenu
                 @sortableColumns={{this.sortColumns}}
                 @sortedColumn={{this.sortColumn}}
@@ -58,11 +58,11 @@
               />
             </Boxel::DropdownButton>
           {{/if}}
-          <Boxel::DropdownButton class="media-collection__btn media-collection__filter" @button="filter" @icon="filter" @size={{30}}>
+          <Boxel::DropdownButton class="media-collection__btn media-collection__filter" @label="filter" @icon="filter" @size={{30}}>
           </Boxel::DropdownButton>
 
           {{#if @search}}
-            <Boxel::DropdownButton class="media-collection__btn media-collection__search" @button="search" @icon="search" @size={{30}}>
+            <Boxel::DropdownButton class="media-collection__btn media-collection__search" @label="search" @icon="search" @size={{30}}>
               <Boxel::Input type="search" class="field-renderer__input media-collection__search-input"
                 {{on "input" this.search}}
               />


### PR DESCRIPTION
To merge after #3300 - replace `@button` with `@label`, separate `@label` and `@icon` so that screenreaders are more likely to get a descriptive message.