### PR TITLE
Update ember-template-imports

### DIFF
--- a/packages/boxel/addon/components/boxel/cover-art/index.gts
+++ b/packages/boxel/addon/components/boxel/cover-art/index.gts
@@ -43,6 +43,18 @@ export default class CoverArt extends Component<Signature> {
     return this.args.covers.length;
   }
 
+  get coverArtSpacing(): number {
+    let {
+      maxWidth,
+      args: { covers },
+    } = this;
+    let naturalWidth =
+      this.coverArtSize(covers.length) + this.coverArtLeft(covers.length, 1.0); // approx
+    let spacingRatio = maxWidth / naturalWidth;
+
+    return Math.min(1, spacingRatio);
+  }
+
   <template>
     <div
       class="boxel-cover-art"
@@ -68,16 +80,4 @@ export default class CoverArt extends Component<Signature> {
       {{/each}}
     </div>
   </template>
-
-  get coverArtSpacing(): number {
-    let {
-      maxWidth,
-      args: { covers },
-    } = this;
-    let naturalWidth =
-      this.coverArtSize(covers.length) + this.coverArtLeft(covers.length, 1.0); // approx
-    let spacingRatio = maxWidth / naturalWidth;
-
-    return Math.min(1, spacingRatio);
-  }
 }

--- a/packages/boxel/addon/components/boxel/progress-circle/index.gts
+++ b/packages/boxel/addon/components/boxel/progress-circle/index.gts
@@ -18,44 +18,6 @@ interface Signature {
 }
 
 export default class ProgressCircle extends Component<Signature> {
-
-  <template>
-    <div
-      class="boxel-progress-circle"
-      style={{htmlSafe (concat "width:" this.size "px;height:" this.size "px;")}}
-      ...attributes
-    >
-      <div
-        class="boxel-progress-circle__pie"
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" width={{this.size}} height={{this.size}} viewBox="0 0 {{this.outerCircleDiameter}} {{this.outerCircleDiameter}}">
-          <g stroke-width="{{this.progressArcThickness}}">
-            <circle 
-              cx={{this.outerCircleRadius}} 
-              cy={{this.outerCircleRadius}}  
-              r={{this.strokeCircleRadius}} 
-              class="boxel-progress-circle__background-circle"
-            />
-            <circle 
-              cx={{this.outerCircleRadius}} 
-              cy={{this.outerCircleRadius}}  
-              r={{this.strokeCircleRadius}} 
-              class="boxel-progress-circle__indicator-circle"
-              style={{this.pieStyle}}
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="boxel-progress-circle__pct-label"
-        style={{htmlSafe (concat "font-size:" this.fontSize "px;width:" this.percentLabelDiameter "px; height:" this.percentLabelDiameter "px;")}}
-      >
-        {{this.humanPercentComplete}}%
-      </div>
-    </div>
-
-  </template>
-  
   progressArcThickness = 12;
   outerCircleRadius = 60;
   innerCircleRadius = this.outerCircleRadius - this.progressArcThickness;
@@ -88,6 +50,43 @@ export default class ProgressCircle extends Component<Signature> {
     }
     return 0;
   }
+
+  <template>
+    <div
+      class="boxel-progress-circle"
+      style={{htmlSafe (concat "width:" this.size "px;height:" this.size "px;")}}
+      ...attributes
+    >
+      <div
+        class="boxel-progress-circle__pie"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width={{this.size}} height={{this.size}} viewBox="0 0 {{this.outerCircleDiameter}} {{this.outerCircleDiameter}}">
+          <g stroke-width="{{this.progressArcThickness}}">
+            <circle
+              cx={{this.outerCircleRadius}}
+              cy={{this.outerCircleRadius}}
+              r={{this.strokeCircleRadius}}
+              class="boxel-progress-circle__background-circle"
+            />
+            <circle
+              cx={{this.outerCircleRadius}}
+              cy={{this.outerCircleRadius}}
+              r={{this.strokeCircleRadius}}
+              class="boxel-progress-circle__indicator-circle"
+              style={{this.pieStyle}}
+            />
+          </g>
+        </svg>
+      </div>
+      <div
+        class="boxel-progress-circle__pct-label"
+        style={{htmlSafe (concat "font-size:" this.fontSize "px;width:" this.percentLabelDiameter "px; height:" this.percentLabelDiameter "px;")}}
+      >
+        {{this.humanPercentComplete}}%
+      </div>
+    </div>
+
+  </template>
 }
 
 declare module '@glint/environment-ember-loose/registry' {

--- a/packages/boxel/addon/components/boxel/wave-player/index.gts
+++ b/packages/boxel/addon/components/boxel/wave-player/index.gts
@@ -44,31 +44,6 @@ export default class WavePlayerComponent extends Component<Signature> {
   @tracked isPlaying = false;
   @tracked duration = 0;
 
-  <template>
-    <div class="boxel-wave-player" ...attributes>
-      <BoxelIconButton
-        onclick={{perform this.playPause}}
-        class="boxel-wave-player__play {{if this.isPlaying "boxel-wave-player--is-playing"}}"
-        aria-label={{if this.isPlaying "Pause" "Play"}}
-        @icon={{if this.isPlaying "pause-btn" "play-btn"}}
-        @width="30px"
-        @height="30px"
-      />
-      <canvas
-        {{didInsert this.setupPlayer}}
-        role="button"
-        aria-label="Audio track"
-        width={{this.width}} height={{this.height}} style={{htmlSafe this.style}}
-        {{on 'click' this.canvasClick}}
-      >
-      </canvas>
-
-      <div class="boxel-wave-player__times">
-        {{mediaDuration this.currentTime}} / {{mediaDuration this.duration}}
-      </div>
-    </div>    
-  </template>
-
   get style(): string {
     return `
     width: ${this.width / 2}px;
@@ -190,6 +165,31 @@ export default class WavePlayerComponent extends Component<Signature> {
     assert('audio is present', !!this.audio);
     this.audio.currentTime = clickFraction * this.audio.duration;
   }
+
+  <template>
+    <div class="boxel-wave-player" ...attributes>
+      <BoxelIconButton
+        onclick={{perform this.playPause}}
+        class="boxel-wave-player__play {{if this.isPlaying "boxel-wave-player--is-playing"}}"
+        aria-label={{if this.isPlaying "Pause" "Play"}}
+        @icon={{if this.isPlaying "pause-btn" "play-btn"}}
+        @width="30px"
+        @height="30px"
+      />
+      <canvas
+        {{didInsert this.setupPlayer}}
+        role="button"
+        aria-label="Audio track"
+        width={{this.width}} height={{this.height}} style={{htmlSafe this.style}}
+        {{on 'click' this.canvasClick}}
+      >
+      </canvas>
+
+      <div class="boxel-wave-player__times">
+        {{mediaDuration this.currentTime}} / {{mediaDuration this.duration}}
+      </div>
+    </div>
+  </template>
 }
 
 function range(n: number) {

--- a/packages/boxel/package.json
+++ b/packages/boxel/package.json
@@ -55,7 +55,7 @@
     "ember-qunit": "^5.1.5",
     "ember-set-body-class": "^1.0.2",
     "ember-svg-jar": "^2.3.3",
-    "ember-template-imports": "^3.1.1",
+    "ember-template-imports": "^3.1.2",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.1.1",
     "file-loader": "^6.2.0",

--- a/packages/safe-tools-client/package.json
+++ b/packages/safe-tools-client/package.json
@@ -80,7 +80,7 @@
     "ember-source": "~4.6.0",
     "ember-svg-jar": "^2.3.3",
     "ember-template-lint": "^4.10.1",
-    "ember-template-imports": "^3.1.1",
+    "ember-template-imports": "^3.1.2",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-ember": "^11.0.2",

--- a/packages/ssr-web/package.json
+++ b/packages/ssr-web/package.json
@@ -119,7 +119,7 @@
     "ember-sinon-qunit": "^6.0.0",
     "ember-source": "~4.6.0",
     "ember-svg-jar": "^2.3.3",
-    "ember-template-imports": "^3.1.1",
+    "ember-template-imports": "^3.1.2",
     "ember-template-lint": "^3.16.0",
     "ember-window-mock": "^0.8.1",
     "eslint": "^7.32.0",

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -174,7 +174,7 @@
     "broadcastchannel-polyfill": "^1.0.1",
     "cropperjs": "^1.5.12",
     "ember-elsewhere": "^2.0.0",
-    "ember-template-imports": "^3.1.1",
+    "ember-template-imports": "^3.1.2",
     "ember-test-selectors": "^6.0.0",
     "eth-block-tracker": "^5.0.1",
     "filesize": "^8.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14555,6 +14555,21 @@ ember-template-imports@^3.1.1:
     string.prototype.matchall "^4.0.6"
     validate-peer-dependencies "^1.1.0"
 
+ember-template-imports@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/ember-template-imports/-/ember-template-imports-3.1.2.tgz#c2f5ec824c9873cc8e82843b2f4777178e191c35"
+  integrity sha512-8ocUuIxXeY7S5FQQf9hcLBCyGKNvSxXz9cV/dkUUMvGcnfh8NblrglqPggXmCbBcv4eDAoEzDmOfiGccD5kEJQ==
+  dependencies:
+    babel-import-util "^0.2.0"
+    broccoli-stew "^3.0.0"
+    ember-cli-babel-plugin-helpers "^1.1.1"
+    ember-cli-version-checker "^5.1.2"
+    line-column "^1.0.2"
+    magic-string "^0.25.7"
+    parse-static-imports "^1.1.0"
+    string.prototype.matchall "^4.0.6"
+    validate-peer-dependencies "^1.1.0"
+
 ember-template-lint@^3.16.0:
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/ember-template-lint/-/ember-template-lint-3.16.0.tgz#7af2ec8d4386f4726be08c14c39ba121c56f0896"


### PR DESCRIPTION
3.1.2 includes the fix for backticks and slashes breaking template compilation. This updates the Boxel components that had a workaround for this to put the template beneath the class getters and functions.