### PR TITLE
tools: Add declarations for images

### DIFF
--- a/packages/safe-tools-client/app/declarations.d.ts
+++ b/packages/safe-tools-client/app/declarations.d.ts
@@ -1,0 +1,14 @@
+declare module '*.svg' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.png' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.jpg' {
+  const value: string;
+  export default value;
+}


### PR DESCRIPTION
This prevents type errors when importing images into Typescript files.