### PR TITLE
[Chore]: Update github actions to node 16 migration

### DIFF
--- a/.github/actions/check-secrets/action.yml
+++ b/.github/actions/check-secrets/action.yml
@@ -15,7 +15,7 @@ runs:
       run: |
         sudo apt-get update && sudo apt-get install awscli jq --fix-missing
 
-    - uses: volta-cli/action@v1
+    - uses: volta-cli/action@v4
 
     - run: yarn --prefer-offline --frozen-lockfile
       shell: bash

--- a/.github/actions/deploy-ember-preview/action.yml
+++ b/.github/actions/deploy-ember-preview/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: volta-cli/action@v4
     - name: Set up node_modules cache
       uses: actions/cache@v3

--- a/.github/actions/deploy-ember-preview/action.yml
+++ b/.github/actions/deploy-ember-preview/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v2
-    - uses: volta-cli/action@v1
+    - uses: volta-cli/action@v4
     - name: Set up node_modules cache
       uses: actions/cache@v3
       with:

--- a/.github/actions/deploy-ssr-web/action.yml
+++ b/.github/actions/deploy-ssr-web/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: volta-cli/action@v1
+    - uses: volta-cli/action@v4
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/deploy-web-client-preview/action.yml
+++ b/.github/actions/deploy-web-client-preview/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v2
-    - uses: volta-cli/action@v1
+    - uses: volta-cli/action@v4
 
     - name: Set up node_modules cache
       uses: actions/cache@v3

--- a/.github/actions/deploy-web-client-preview/action.yml
+++ b/.github/actions/deploy-web-client-preview/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: volta-cli/action@v4
 
     - name: Set up node_modules cache

--- a/.github/actions/deploy-web-client/action.yml
+++ b/.github/actions/deploy-web-client/action.yml
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: volta-cli/action@v1
+    - uses: volta-cli/action@v4
 
     - run: yarn --prefer-offline --frozen-lockfile
       shell: bash

--- a/.github/actions/waypoint-deploy/action.yml
+++ b/.github/actions/waypoint-deploy/action.yml
@@ -23,7 +23,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: volta-cli/action@v1
+    - uses: volta-cli/action@v4
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/manual-cardie.yml
+++ b/.github/workflows/manual-cardie.yml
@@ -16,7 +16,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up env
         env:

--- a/.github/workflows/manual-cardpay-reward-program-rules.yml
+++ b/.github/workflows/manual-cardpay-reward-program-rules.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up env
         env:
           INPUT_ENVIRONMENT: ${{ github.event.inputs.environment }}

--- a/.github/workflows/manual-hub.yml
+++ b/.github/workflows/manual-hub.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache
         uses: actions/cache@v3

--- a/.github/workflows/manual-hub.yml
+++ b/.github/workflows/manual-hub.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache
@@ -59,7 +59,7 @@ jobs:
           - retain: "1"
             app: hub
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up node_modules cache
         uses: actions/cache@v3

--- a/.github/workflows/manual-publish.yaml
+++ b/.github/workflows/manual-publish.yaml
@@ -14,7 +14,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: main
 

--- a/.github/workflows/manual-publish.yaml
+++ b/.github/workflows/manual-publish.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           ref: main
 
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache
         uses: actions/cache@v3

--- a/.github/workflows/manual-reward-api.yml
+++ b/.github/workflows/manual-reward-api.yml
@@ -16,7 +16,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up node_modules cache
         uses: actions/cache@v3

--- a/.github/workflows/manual-reward-indexer.yml
+++ b/.github/workflows/manual-reward-indexer.yml
@@ -16,7 +16,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up node_modules cache
         uses: actions/cache@v3

--- a/.github/workflows/manual-reward-root-submitter.yml
+++ b/.github/workflows/manual-reward-root-submitter.yml
@@ -16,7 +16,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up env
         env:

--- a/.github/workflows/manual-reward-scheduler.yml
+++ b/.github/workflows/manual-reward-scheduler.yml
@@ -16,7 +16,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up node_modules cache
         uses: actions/cache@v3

--- a/.github/workflows/manual-ssr-web.yml
+++ b/.github/workflows/manual-ssr-web.yml
@@ -16,7 +16,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up env
         env:

--- a/.github/workflows/manual-subgraph-extractor.yml
+++ b/.github/workflows/manual-subgraph-extractor.yml
@@ -16,7 +16,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up node_modules cache
         uses: actions/cache@v3

--- a/.github/workflows/manual-web-client.yml
+++ b/.github/workflows/manual-web-client.yml
@@ -16,7 +16,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up env
         env:
           INPUT_ENVIRONMENT: ${{ github.event.inputs.environment }}

--- a/.github/workflows/pr-boxel.yml
+++ b/.github/workflows/pr-boxel.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
         with:
@@ -65,7 +65,7 @@ jobs:
       S3_PREVIEW_REGION: us-east-1
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
         with:
@@ -103,7 +103,7 @@ jobs:
       S3_PREVIEW_WEBSITE_URL: https://boxel.stack.cards
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/pr-boxel.yml
+++ b/.github/workflows/pr-boxel.yml
@@ -20,7 +20,7 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
@@ -43,7 +43,7 @@ jobs:
     outputs:
       boxel-files-changed: ${{ steps.boxel-files-that-changed.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get boxel files that changed
         id: boxel-files-that-changed
         uses: tj-actions/changed-files@v1.1.2
@@ -64,7 +64,7 @@ jobs:
       S3_PREVIEW_ASSET_BUCKET_ENDPOINT: https://s3.us-east-1.amazonaws.com/boxel-preview-assets.cardstack.com
       S3_PREVIEW_REGION: us-east-1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
@@ -102,7 +102,7 @@ jobs:
     env:
       S3_PREVIEW_WEBSITE_URL: https://boxel.stack.cards
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3

--- a/.github/workflows/pr-cardpay-reward-api.yml
+++ b/.github/workflows/pr-cardpay-reward-api.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.9", "3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/pr-cardpay-reward-indexer.yml
+++ b/.github/workflows/pr-cardpay-reward-indexer.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.9", "3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/pr-cardpay-reward-programs.yml
+++ b/.github/workflows/pr-cardpay-reward-programs.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.9", "3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/pr-cardpay-subgraph.yml
+++ b/.github/workflows/pr-cardpay-subgraph.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache
         uses: actions/cache@v3

--- a/.github/workflows/pr-cardpay-subgraph.yml
+++ b/.github/workflows/pr-cardpay-subgraph.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build & Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache

--- a/.github/workflows/pr-did-resolver.yml
+++ b/.github/workflows/pr-did-resolver.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache

--- a/.github/workflows/pr-did-resolver.yml
+++ b/.github/workflows/pr-did-resolver.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache
         uses: actions/cache@v3

--- a/.github/workflows/pr-discord-bot.yml
+++ b/.github/workflows/pr-discord-bot.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache
         uses: actions/cache@v3

--- a/.github/workflows/pr-discord-bot.yml
+++ b/.github/workflows/pr-discord-bot.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache

--- a/.github/workflows/pr-hub.yml
+++ b/.github/workflows/pr-hub.yml
@@ -45,7 +45,7 @@ jobs:
         run: sudo -u postgres createdb hub_test
 
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache
         uses: actions/cache@v3

--- a/.github/workflows/pr-hub.yml
+++ b/.github/workflows/pr-hub.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Create database
         run: sudo -u postgres createdb hub_test
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache

--- a/.github/workflows/pr-linter-check.yml
+++ b/.github/workflows/pr-linter-check.yml
@@ -16,7 +16,7 @@ jobs:
       # increasing the heap size to 8GB
       NODE_OPTIONS: --max-old-space-size=8192
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache

--- a/.github/workflows/pr-linter-check.yml
+++ b/.github/workflows/pr-linter-check.yml
@@ -17,7 +17,7 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=8192
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache
         uses: actions/cache@v3

--- a/.github/workflows/pr-python-did-resolver.yml
+++ b/.github/workflows/pr-python-did-resolver.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ["3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/pr-python-did-resolver.yml
+++ b/.github/workflows/pr-python-did-resolver.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache
         uses: actions/cache@v3

--- a/.github/workflows/pr-python-linter-check.yml
+++ b/.github/workflows/pr-python-linter-check.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build & Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'

--- a/.github/workflows/pr-reward-root-submitter.yml
+++ b/.github/workflows/pr-reward-root-submitter.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.9", "3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/pr-reward-scheduler.yml
+++ b/.github/workflows/pr-reward-scheduler.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.9", "3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/pr-safe-tools-client.yml
+++ b/.github/workflows/pr-safe-tools-client.yml
@@ -23,7 +23,7 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3

--- a/.github/workflows/pr-safe-tools-client.yml
+++ b/.github/workflows/pr-safe-tools-client.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/pr-ssr-web.yml
+++ b/.github/workflows/pr-ssr-web.yml
@@ -25,7 +25,7 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
@@ -61,7 +61,7 @@ jobs:
     outputs:
       ssr-web-files-changed: ${{ steps.ssr-web-files-that-changed.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get ssr-web files that changed
         id: ssr-web-files-that-changed
         uses: tj-actions/changed-files@v1.1.2
@@ -77,7 +77,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref && needs.check-if-requires-preview.outputs.ssr-web-files-changed == 'true'
     needs: check-if-requires-preview
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -104,7 +104,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref && needs.check-if-requires-preview.outputs.ssr-web-files-changed == 'true'
     needs: check-if-requires-preview
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/pr-ssr-web.yml
+++ b/.github/workflows/pr-ssr-web.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/pr-waypoint.yml
+++ b/.github/workflows/pr-waypoint.yml
@@ -18,7 +18,7 @@ jobs:
     name: Check Secret Access
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache

--- a/.github/workflows/pr-waypoint.yml
+++ b/.github/workflows/pr-waypoint.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache
         uses: actions/cache@v3

--- a/.github/workflows/pr-wc-provider.yml
+++ b/.github/workflows/pr-wc-provider.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache
         uses: actions/cache@v3

--- a/.github/workflows/pr-wc-provider.yml
+++ b/.github/workflows/pr-wc-provider.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
 
       - name: Set up node_modules cache

--- a/.github/workflows/pr-web-client.yml
+++ b/.github/workflows/pr-web-client.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/pr-web-client.yml
+++ b/.github/workflows/pr-web-client.yml
@@ -27,7 +27,7 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
@@ -63,7 +63,7 @@ jobs:
     outputs:
       web-client-files-changed: ${{ steps.web-client-files-that-changed.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get web client files that changed
         id: web-client-files-that-changed
         uses: tj-actions/changed-files@v1.1.2
@@ -79,7 +79,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref && needs.check-if-requires-preview.outputs.web-client-files-changed == 'true'
     needs: check-if-requires-preview
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -104,7 +104,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref && needs.check-if-requires-preview.outputs.web-client-files-changed == 'true'
     needs: check-if-requires-preview
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
         with:
@@ -40,7 +40,7 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=8192
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
         with:
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
         with:
@@ -118,7 +118,7 @@ jobs:
       - name: Create database
         run: sudo -u postgres createdb hub_test
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
         with:
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
         with:
@@ -243,7 +243,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
         with:
@@ -350,7 +350,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
         with:
@@ -384,7 +384,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
         with:
@@ -424,7 +424,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -16,7 +16,7 @@ jobs:
     name: Update node_modules cache
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
@@ -39,7 +39,7 @@ jobs:
       # increasing the heap size to 8GB
       NODE_OPTIONS: --max-old-space-size=8192
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
@@ -59,7 +59,7 @@ jobs:
     needs: update-cache
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
@@ -117,7 +117,7 @@ jobs:
     steps:
       - name: Create database
         run: sudo -u postgres createdb hub_test
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
@@ -139,7 +139,7 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
@@ -194,7 +194,7 @@ jobs:
       cardie: ${{ steps.filter.outputs.cardie }}
       ssr_web: ${{ steps.filter.outputs.ssr_web }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -242,7 +242,7 @@ jobs:
     if: ${{ needs.change_check.outputs.hub == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
@@ -279,7 +279,7 @@ jobs:
           - retain: "1"
             app: hub
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up node_modules cache
         uses: actions/cache@v3
         with:
@@ -317,7 +317,7 @@ jobs:
     if: ${{ needs.change_check.outputs.web_client == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up node_modules cache
         uses: actions/cache@v3
         with:
@@ -349,7 +349,7 @@ jobs:
     if: ${{ needs.change_check.outputs.ssr_web == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
@@ -383,7 +383,7 @@ jobs:
     if: ${{ needs.change_check.outputs.boxel == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3
@@ -423,7 +423,7 @@ jobs:
     if: ${{ needs.change_check.outputs.cardie == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - name: Set up node_modules cache
         uses: actions/cache@v3


### PR DESCRIPTION
Github actions only supports node: >16 now, and volta v1 was using node 14, this PR updates the volta actions to use the latest version alongside with checkout actions.