### PR TITLE
ci: Add dependabot to bump github actions version

### DIFF
--- a/.github/.dependabot.yml
+++ b/.github/.dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Set update schedule for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
Following the disruption caused by deprecation of node 12 in GitHub Actions (resolved in #3322), this PR adds dependabot to manage our github actions' versions.