### PR TITLE
replace broken WalletConnect bridge url

### DIFF
--- a/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer-1-connection-manager.ts
@@ -16,7 +16,7 @@ import { MockLocalStorage } from '../browser-mocks';
 
 const GET_PROVIDER_STORAGE_KEY = (chainId: number) =>
   `cardstack-chain-${chainId}-provider`;
-const WALLET_CONNECT_BRIDGE = 'https://safe-walletconnect.gnosis.io/';
+const WALLET_CONNECT_BRIDGE = 'https://bridge.walletconnect.org';
 
 interface ConnectionManagerOptions {
   chainId: number;

--- a/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
+++ b/packages/web-client/app/utils/web3-strategies/layer2-chain.ts
@@ -66,7 +66,7 @@ interface Layer2ConnectEvent {
   session?: any;
 }
 
-const BRIDGE = 'https://safe-walletconnect.gnosis.io/';
+const BRIDGE = 'https://bridge.walletconnect.org';
 
 export default abstract class Layer2ChainWeb3Strategy
   implements Layer2Web3Strategy, Emitter<Layer2ChainEvent>


### PR DESCRIPTION
Use the default public WalletConnect bridge url for now.