### PR TITLE
[CS-4658]: Add safe info to control panel

### DIFF
--- a/packages/safe-tools-client/app/controllers/schedule.ts
+++ b/packages/safe-tools-client/app/controllers/schedule.ts
@@ -9,6 +9,37 @@ export default class Schedule extends Controller {
 
   // modified with set helper
   @tracked isSetupSafeModalOpen = false;
+  @tracked isDepositModalOpen = false;
+
+  get safe() {
+    // Should we grab the network nativeToken info here, or expect the sdk method to return it within safeInfo?
+
+    //TODO: get safe info from sdk and format it
+    return {
+      address: '0xABCD...EFFF',
+      token: {
+        address: 'eth',
+        name: 'Ethereum',
+        symbol: 'ETH',
+        decimals: 18,
+        balance: 0,
+      },
+    };
+  }
+
+  get safeButton() {
+    if (!this.safe) {
+      return {
+        label: 'Create Safe',
+        modalFlag: 'isSetupSafeModalOpen',
+      };
+    }
+
+    return {
+      label: 'Add Funds',
+      modalFlag: 'isDepositModalOpen',
+    };
+  }
 }
 
 declare module '@ember/controller' {

--- a/packages/safe-tools-client/app/controllers/schedule.ts
+++ b/packages/safe-tools-client/app/controllers/schedule.ts
@@ -1,6 +1,8 @@
 import Controller, { inject as controller } from '@ember/controller';
-import ApplicationController from '@cardstack/safe-tools-client/controllers/application';
 import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+import ApplicationController from '@cardstack/safe-tools-client/controllers/application';
 
 import '../css/schedule.css';
 
@@ -27,18 +29,16 @@ export default class Schedule extends Controller {
     };
   }
 
-  get safeButton() {
-    if (!this.safe) {
-      return {
-        label: 'Create Safe',
-        modalFlag: 'isSetupSafeModalOpen',
-      };
-    }
+  get safeButtonLabel() {
+    return this.safe ? 'Add Funds' : 'Create Safe';
+  }
 
-    return {
-      label: 'Add Funds',
-      modalFlag: 'isDepositModalOpen',
-    };
+  @action onSafeButtonClick() {
+    if (this.safe) {
+      this.isDepositModalOpen = true;
+    } else {
+      this.isSetupSafeModalOpen = true;
+    }
   }
 }
 

--- a/packages/safe-tools-client/app/css/schedule.css
+++ b/packages/safe-tools-client/app/css/schedule.css
@@ -8,10 +8,27 @@
   padding: var(--boxel-sp-xxl) var(--boxel-sp-lg) 0;
 }
 
-.safe-tools__dashboard-schedule-control-panel-safe-info {
-  margin-top: calc(var(--boxel-sp-xxs) * -1);
+.safe-tools__dashboard-schedule-control-panel-safe-info-address,
+.safe-tools__dashboard-schedule-control-panel-safe-info-balance,
+.safe-tools__dashboard-schedule-control-panel-safe-info-create {
   inline-size: 200px;
+  display: block;
   text-align: left;
   font-weight: normal;
   font-size: var(--boxel-font-size-sm);
+}
+
+.safe-tools__dashboard-schedule-control-panel-safe-info-create {
+  margin-top: calc(var(--boxel-sp-xxs) * -1);
+}
+
+.safe-tools__dashboard-schedule-control-panel-safe-info-address {
+  color: var(--boxel-purple-300);
+  margin-bottom: 2px;
+}
+
+.safe-tools__dashboard-schedule-control-panel-safe-info-balance {
+  font-weight: bold;
+  color: var(--boxel-highlight);
+  margin-bottom: var(--boxel-sp-sm);
 }

--- a/packages/safe-tools-client/app/templates/schedule.hbs
+++ b/packages/safe-tools-client/app/templates/schedule.hbs
@@ -22,9 +22,9 @@
       {{/if}}
       <Boxel::Button
         @kind='primary'
-        {{on 'click' (set this this.safeButton.modalFlag true)}}
+        {{on 'click' this.onSafeButtonClick}}
       >
-        {{this.safeButton.label}}
+        {{this.safeButtonLabel}}
       </Boxel::Button>
     </cp.Item>
   </Boxel::ControlPanel>

--- a/packages/safe-tools-client/app/templates/schedule.hbs
+++ b/packages/safe-tools-client/app/templates/schedule.hbs
@@ -7,15 +7,24 @@
     </cp.Item>
     <cp.Item @title='Network' @icon='network' />
     <cp.Item @title='Safe' @icon='safe'>
-      <p class='safe-tools__dashboard-schedule-control-panel-safe-info'>
-        You need to have a safe which contains funds that would be deducted
-        automatically when schedule payments are due.
-      </p>
+      {{#if this.safe}}
+        <span class='safe-tools__dashboard-schedule-control-panel-safe-info-address'>
+          {{this.safe.token.address}}:{{this.safe.address}}
+        </span>
+        <span class='safe-tools__dashboard-schedule-control-panel-safe-info-balance'>
+          {{this.safe.token.balance}} {{this.safe.token.symbol}}
+        </span>
+      {{else}}
+        <p class='safe-tools__dashboard-schedule-control-panel-safe-info-create'>
+          You need to have a safe which contains funds that would be deducted
+          automatically when schedule payments are due.
+        </p>
+      {{/if}}
       <Boxel::Button
         @kind='primary'
-        {{on 'click' (set this 'isSetupSafeModalOpen' true)}}
+        {{on 'click' (set this this.safeButton.modalFlag true)}}
       >
-        Create Safe
+        {{this.safeButton.label}}
       </Boxel::Button>
     </cp.Item>
   </Boxel::ControlPanel>

--- a/packages/safe-tools-client/package.json
+++ b/packages/safe-tools-client/package.json
@@ -88,7 +88,6 @@
     "ember-svg-jar": "^2.3.3",
     "ember-template-imports": "^3.1.2",
     "ember-template-lint": "^4.10.1",
-    "ember-set-helper": "^2.0.1",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-ember": "^11.0.2",


### PR DESCRIPTION
This PR adds the mocked UI for when a user has a safe. I've created a data structure to show the safe info, but that's flexible if we need to change it, also, I'm not sure about ember patterns to split concerns etc, but it felt cleaner to have the get safeButton function in order to render what we need, lmk if there's a diff pattern you'd like me to follow. It adds a flag for the deposit modal, which I'll be working on next.

PS: address truncation will be added once we have the full address and/or helper


<img width="313" alt="image" src="https://user-images.githubusercontent.com/20520102/196812786-d8ebbad3-3735-431f-ad00-fff29ed36205.png">
