### PR TITLE
[Boxel]: Fix modal positioning and add boxel lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "build:subgraph": "yarn --cwd packages/cardpay-subgraph build",
     "check:waypoint-secrets": "ts-node scripts/verify-waypoint-secrets.ts",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*",
+    "lint:boxel": "yarn --cwd packages/boxel",
     "lint:cardhost": "yarn --cwd packages/cardhost lint",
     "lint:ssr-web": "yarn --cwd packages/ssr-web lint",
     "lint:web-client": "yarn --cwd packages/web-client lint",

--- a/packages/boxel/.stylelintrc.js
+++ b/packages/boxel/.stylelintrc.js
@@ -20,5 +20,6 @@ module.exports = {
         ignoreValues: ['box'],
       },
     ],
+    'length-zero-no-unit': [true, { ignore: ['custom-properties'] }],
   },
 };

--- a/packages/boxel/addon/components/boxel/modal/index.css
+++ b/packages/boxel/addon/components/boxel/modal/index.css
@@ -1,7 +1,8 @@
 .boxel-modal {
-  --boxel-modal-offset-top: 0;
-  --boxel-modal-offset-left: 0;
-  --boxel-modal-offset-right: 0;
+  /* Unit is required to be used on calc */
+  --boxel-modal-offset-top: 0px;
+  --boxel-modal-offset-left: 0px;
+  --boxel-modal-offset-right: 0px;
 
   position: fixed;
   width: 100%;
@@ -41,7 +42,7 @@
 
 .boxel-modal--large {
   --boxel-modal-offset-top: var(--boxel-sp-lg);
-  --boxel-modal-max-width: 65rem;   /* 1040px */
+  --boxel-modal-max-width: 65rem; /* 1040px */
 }
 
 .boxel-modal__inner {


### PR DESCRIPTION
The boxel's offset properties need to have a unit in order to work with `calc`, we also noticed that boxel linter was not running on CI, so this PR adds it to the global package.json.