### PR TITLE
Set @matchTriggerWidth to false for Boxel::Select

### DIFF
--- a/packages/boxel/addon/components/boxel/select/index.gts
+++ b/packages/boxel/addon/components/boxel/select/index.gts
@@ -44,6 +44,7 @@ const BoxelSelect: TemplateOnlyComponent<Signature> =
     @dropdownClass={{cn "boxel-select__dropdown" @dropdownClass}}
     @triggerComponent={{@triggerComponent}}
     @disabled={{@disabled}}
+    @matchTriggerWidth={{false}}
     @eventType="click"
     ...attributes
     as |item|


### PR DESCRIPTION
This avoids situations where longer options are cut off or wrap awkwardly.
See discussion here for more info on tradeoffs: https://github.com/cibernox/ember-power-select/issues/301