### PR TITLE
tools: Fix deployment detection

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -193,6 +193,7 @@ jobs:
       boxel: ${{ steps.filter.outputs.boxel }}
       cardie: ${{ steps.filter.outputs.cardie }}
       ssr_web: ${{ steps.filter.outputs.ssr_web }}
+      safe-tools-client: ${{ steps.filter.outputs.safe-tools-client }}
     steps:
       - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2


### PR DESCRIPTION
The merge of #3302 [didn’t trigger](https://github.com/cardstack/cardstack/actions/runs/3297950682) a staging deployment.

<img width="473" alt="cardstack@d247dd2 2022-10-21 11-43-47" src="https://user-images.githubusercontent.com/43280/197246950-078fa3d0-d4e5-4ba0-a48a-a2eb3b681532.png">
