### PR TITLE
tools: Fix deployment name in Discord message

### DIFF
--- a/.github/actions/deploy-safe-tools-client/action.yml
+++ b/.github/actions/deploy-safe-tools-client/action.yml
@@ -51,7 +51,7 @@ runs:
       if: ${{ always() }}
       uses: ./.github/actions/discord-notification-deploy
       with:
-        app: web-client
+        app: safe-tools-client
         status: ${{ github.action_status }}
         environment: ${{ inputs.environment }}
         webhook: ${{ inputs.discord_webhook }}


### PR DESCRIPTION
When I deployed from this branch:

<img width="649" alt="#releases-internal | Cardstack - Discord 2022-10-21 15-33-31" src="https://user-images.githubusercontent.com/43280/197284002-086923b1-528e-4242-bceb-6b6a8b0b388c.png">
