### PR TITLE
Fix border color of input group select accessory when disabled

### DIFF
--- a/packages/boxel/addon/components/boxel/input-group/index.css
+++ b/packages/boxel/addon/components/boxel/input-group/index.css
@@ -108,7 +108,8 @@
 .boxel-input-group--disabled .boxel-input-group__form-control,
 .boxel-input-group--disabled .boxel-input-group__text-accessory,
 .boxel-input-group--disabled .boxel-input-group__icon-button-accessory,
-.boxel-input-group--disabled .boxel-input-group__button-accessory {
+.boxel-input-group--disabled .boxel-input-group__button-accessory,
+.boxel-input-group--disabled .boxel-input-group__select-accessory {
   border-color: var(--boxel-input-group-border-color);
   color: rgb(0 0 0 / 50%);
   opacity: 0.5;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/353/197540696-140328ea-fe73-4a9f-9aec-9c56d2629fe3.png)
