### PR TITLE
boxel: Update button element type to be as-dependent

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build:subgraph": "yarn --cwd packages/cardpay-subgraph build",
     "check:waypoint-secrets": "ts-node scripts/verify-waypoint-secrets.ts",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*",
-    "lint:boxel": "yarn --cwd packages/boxel",
+    "lint:boxel": "yarn --cwd packages/boxel lint",
     "lint:cardhost": "yarn --cwd packages/cardhost lint",
     "lint:ssr-web": "yarn --cwd packages/ssr-web lint",
     "lint:web-client": "yarn --cwd packages/web-client lint",

--- a/packages/boxel/addon/components/boxel/button/usage.gts
+++ b/packages/boxel/addon/components/boxel/button/usage.gts
@@ -11,6 +11,25 @@ import eq from 'ember-truth-helpers/helpers/eq';
 import { on } from '@ember/modifier';
 import './usage.css';
 
+
+interface ButtonContainerSignature {
+  Element: HTMLButtonElement;
+  Args: {
+  }
+}
+
+class ButtonContainer extends Component<ButtonContainerSignature> {
+  <template>
+    <BoxelButton
+      @as="button"
+      @kind="secondary-dark"
+      ...attributes
+    >
+      Do Something
+    </BoxelButton>
+  </template>
+}
+
 export default class ButtonUsage extends Component {
   sizeVariants = ['extra-small', 'small', 'base', 'tall', 'touch'];
   kindVariants = {
@@ -218,6 +237,8 @@ export default class ButtonUsage extends Component {
             Button Text
           </BoxelButton>
         </div>
+
+        <ButtonContainer class="an-appended-class" />
       </:example>
     </FreestyleUsage>
   </template>


### PR DESCRIPTION
Having the `Boxel::Button` signature element be `HTMLAnchorElement | HTMLButtonElement` means `...attributes` cannot be used on something that consumes it. `@as` should control the button’s element type.

[`ConnectButton` from `safe-tools`](https://github.com/cardstack/cardstack/blob/641d4ac5cf2fdd981cc1f2dcc745a557568f2cda/packages/safe-tools-client/app/components/connect-button/index.gts) renders different buttons based on whether the wallet is connected. It should work to invoke it like this:

```
<ConnectButton class='a-class' />
```

But using `...attributes` in the template for `ConnectButton` produces a type error because `HTMLButtonElement` accepts various attributes that `HTMLAnchorElement` does not.