### PR TITLE
[CS-4654]: Hide banner when wallet connects

### DIFF
--- a/packages/safe-tools-client/app/controllers/schedule.ts
+++ b/packages/safe-tools-client/app/controllers/schedule.ts
@@ -9,6 +9,8 @@ import '../css/schedule.css';
 export default class Schedule extends Controller {
   @controller declare application: ApplicationController;
 
+  // TODO: replace with walletService
+  wallet = { isConnected: true };
   // modified with set helper
   @tracked isSetupSafeModalOpen = false;
   @tracked isDepositModalOpen = false;

--- a/packages/safe-tools-client/app/templates/schedule.hbs
+++ b/packages/safe-tools-client/app/templates/schedule.hbs
@@ -29,7 +29,7 @@
     </cp.Item>
   </Boxel::ControlPanel>
   <section class='safe-tools__dashboard-schedule-content'>
-    <ScheduleCollapsePanel @open={{true}} />
+    <ScheduleCollapsePanel @open={{not this.wallet.isConnected}} />
     <div class="temporary-form-container">
       <SchedulePaymentFormActionCard />
     </div>


### PR DESCRIPTION
This PR wraps the last item of `CS-4654`. The banner is expanded until the user connects the wallet. The real value can be added after #3341 

