### PR TITLE
[CS-4656][safe-tools]: Add network switcher UI

### DIFF
--- a/packages/boxel/public/images/icons/caret-down-cyan.svg
+++ b/packages/boxel/public/images/icons/caret-down-cyan.svg
@@ -1,0 +1,1 @@
+<svg height="6.414" viewBox="0 0 10.828 6.414" width="10.828" xmlns="http://www.w3.org/2000/svg"><path d="m9 14 4-4-4-4" fill="none" stroke="var(--icon-color,#00ebe5)" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" transform="matrix(0 1 -1 0 15.414 -7.586)"/></svg>

--- a/packages/safe-tools-client/app/controllers/schedule.ts
+++ b/packages/safe-tools-client/app/controllers/schedule.ts
@@ -16,6 +16,9 @@ export default class Schedule extends Controller {
   @tracked isSetupSafeModalOpen = false;
   @tracked isDepositModalOpen = false;
 
+  // TODO: replace with network service
+  @tracked network = 'ETH Mainnet';
+
   get safe() {
     //TODO: get safe info from sdk and format it,
     return {
@@ -58,9 +61,20 @@ export default class Schedule extends Controller {
     }
   }
 
-  // TODO: add selected network
-  get network() {
-    return 'Ethereum';
+  // TODO: get available networks from sdk, and maybe share network info ?
+  get availableNetworks() {
+    const networks = ['ETH Mainnet', 'Gnosis Chain', 'Polygon'];
+
+    const networkstWithoutSelectedOne = networks.filter(
+      (network) => network !== this.network
+    );
+
+    return networkstWithoutSelectedOne;
+  }
+
+  @action onSelectNetwork(network: string) {
+    // TODO: trigger selection on service;
+    this.network = network;
   }
 
   get scheduledPaymentsTokensToCover() {

--- a/packages/safe-tools-client/app/css/schedule.css
+++ b/packages/safe-tools-client/app/css/schedule.css
@@ -59,7 +59,26 @@
 }
 
 .temporary-form-container {
-  display:flex;
-  justify-content:center;
-  margin-top:var(--boxel-sp-xl);
+  display: flex;
+  justify-content: center;
+  margin-top: var(--boxel-sp-xl);
+}
+
+.safe-tools__dashboard-network-selector {
+  display: inline-flex;
+  align-items: center;
+}
+
+.safe-tools__dashboard-network-selector.boxel-select .boxel-select__item {
+  font-weight: 600;
+  font-size: var(--boxel-font-size-sm);
+}
+
+.safe-tools__dashboard-network-selector .ember-power-select-status-icon {
+  background: url('/@cardstack/boxel/images/icons/caret-down-cyan.svg')
+    no-repeat;
+  width: 11px;
+  height: 9px;
+  margin-top: 5px;
+  display: inline-block;
 }

--- a/packages/safe-tools-client/app/templates/schedule.hbs
+++ b/packages/safe-tools-client/app/templates/schedule.hbs
@@ -1,6 +1,6 @@
 <section class='safe-tools__dashboard-schedule'>
   <Boxel::ControlPanel as |cp|>
-    <cp.Item @title='Wallet' @icon='wallet' @isActive={{true}}>
+    <cp.Item @title='Wallet' @icon='wallet' @isActive={{not this.wallet.isConnected}}>
       {{#if this.wallet.isConnected}}
         <div
           class='safe-tools__dashboard-schedule-control-panel-wallet-address'
@@ -23,7 +23,17 @@
         @onConnect={{set this.application 'isShowingConnectModal' true}}
       />
     </cp.Item>
-    <cp.Item @title='Network' @icon='network' />
+    <cp.Item @title='Network' @icon='network'>
+        <Boxel::Select
+            class="safe-tools__dashboard-network-selector"
+            @selected={{this.network}}
+            @onChange={{this.onSelectNetwork}}
+            @options={{this.availableNetworks}}
+            as |network itemCssClass|
+          >
+          <div class={{itemCssClass}}>{{network}}</div>
+        </Boxel::Select>
+    </cp.Item>
     <cp.Item @title='Safe' @icon='safe'>
       {{#if this.safe}}
         {{#each this.safe.tokens as |token|}}


### PR DESCRIPTION
This PR adds the network switcher on the control-panel, it uses mocked network info that should be replaced with sdk info.
I've added a new caret icon, because the css approaches to change the svg color while using it as a background image, doesn't seemed to work for this icon, I think it's because its color comes from stroke property and not fill one. 

https://user-images.githubusercontent.com/20520102/198088483-7e6afee9-b3a5-4235-aa4c-0d3b526f8dda.mov

