### PR TITLE
Add boxel-component blueprint

### DIFF
--- a/packages/boxel/.eslintrc.js
+++ b/packages/boxel/.eslintrc.js
@@ -42,6 +42,7 @@ module.exports = {
         './tests/dummy/config/**/*.js',
         './generate-thumbs.js',
         './lib/**/*.js',
+        './blueprints/*/index.js',
       ],
       parserOptions: {
         sourceType: 'script',
@@ -56,7 +57,7 @@ module.exports = {
         {},
         require('eslint-plugin-node').configs.recommended.rules,
         {
-          // add your custom rules and overrides for node files here
+          'node/no-unpublished-require': 'off',
         }
       ),
     },

--- a/packages/boxel/.stylelintrc.js
+++ b/packages/boxel/.stylelintrc.js
@@ -1,6 +1,10 @@
 module.exports = {
   extends: 'stylelint-config-standard',
-  ignoreFiles: ['dist/**/*.css', 'node_modules/**/*.css'],
+  ignoreFiles: [
+    'dist/**/*.css',
+    'node_modules/**/*.css',
+    'blueprints/**/*.css',
+  ],
   rules: {
     'property-no-vendor-prefix': null,
     'selector-class-pattern':

--- a/packages/boxel/README.md
+++ b/packages/boxel/README.md
@@ -58,6 +58,12 @@ yarn test
 
 Check `package.json` file for other testing and linting scripts.
 
+
+## Generator
+
+In addition to the normal suite of ember generators, Boxel has a 'boxel-component` blueprint allowing you to generate a new boxel component (index.gts), a
+CSS file, a usage.gts, and an intergration test. Run it using `ember generate boxel-component your-component-name`.
+
 #### Thumbnails
 
 Generating multiple image sizes / thumbs from

--- a/packages/boxel/blueprints/boxel-component-addon/.gitkeep
+++ b/packages/boxel/blueprints/boxel-component-addon/.gitkeep
@@ -1,0 +1,1 @@
+This prevents ember CLI's generator from trying to reexport the boxel component created by the boxel-component blueprint

--- a/packages/boxel/blueprints/boxel-component-test/files/tests/integration/components/boxel/__name__-test.gts
+++ b/packages/boxel/blueprints/boxel-component-test/files/tests/integration/components/boxel/__name__-test.gts
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import Boxel<%= classifiedModuleName %> from '@cardstack/boxel/components/boxel/<%= dasherizedModuleName %>';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+
+const COMPONENT_SELECTOR = '[data-test-<%= cssClassName %>]';
+
+module('Integration | Component | <%= classifiedModuleName %>', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('Accessibility Check', async function (assert) {
+    await render(<template>
+      <Boxel<%= classifiedModuleName %>>Hello world</Boxel<%= classifiedModuleName %>>
+    </template>);
+    assert.dom(COMPONENT_SELECTOR).hasText('Hello world');
+
+    await a11yAudit();
+    assert.ok(true, 'no a11y errors found!');
+  });
+});

--- a/packages/boxel/blueprints/boxel-component-test/index.js
+++ b/packages/boxel/blueprints/boxel-component-test/index.js
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+'use strict';
+const kebabCase = require('lodash/kebabCase');
+
+module.exports = {
+  description: 'Generate a boxel component',
+
+  locals(options) {
+    let { name } = options.entity;
+    return {
+      cssClassName: `boxel-${kebabCase(name).replace(/\//g, '-')}`,
+    };
+  },
+};

--- a/packages/boxel/blueprints/boxel-component/files/__root__/components/boxel/__name__/index.css
+++ b/packages/boxel/blueprints/boxel-component/files/__root__/components/boxel/__name__/index.css
@@ -1,0 +1,4 @@
+.<%= cssClassName %> {
+  --<%= cssClassName %>-background-color: pink;
+  background-color: var(--<%= cssClassName %>-background-color);
+}

--- a/packages/boxel/blueprints/boxel-component/files/__root__/components/boxel/__name__/index.gts
+++ b/packages/boxel/blueprints/boxel-component/files/__root__/components/boxel/__name__/index.gts
@@ -1,0 +1,31 @@
+import Component from '@glimmer/component';
+import '@cardstack/boxel/styles/global.css';
+import './index.css';
+
+interface Signature {
+  Element: HTMLDivElement;
+  Args: {
+    // example?: string;
+  };
+  Blocks: {
+    'default': []
+  }
+}
+
+export default class Boxel<%= classifiedModuleName %> extends Component<Signature> {
+  <template>
+    <div
+      class="<%= cssClassName %>"
+      data-test-<%= cssClassName %>
+      ...attributes
+    >
+      {{yield}}
+    </div>
+  </template>
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    '<%= classComponentName %>': typeof Boxel<%= classifiedModuleName %>;
+  }
+}

--- a/packages/boxel/blueprints/boxel-component/files/__root__/components/boxel/__name__/usage.gts
+++ b/packages/boxel/blueprints/boxel-component/files/__root__/components/boxel/__name__/usage.gts
@@ -1,0 +1,49 @@
+import Component from '@glimmer/component';
+import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
+import Boxel<%= classifiedModuleName %> from './index';
+import { tracked } from '@glimmer/tracking';
+import { cssVariable, CSSVariableInfo } from 'ember-freestyle/decorators/css-variable';
+import cssVar from '@cardstack/boxel/helpers/css-var';
+import { fn } from '@ember/helper';
+
+export default class Boxel<%= classifiedModuleName %>Usage extends Component {
+  cssClassName = '<%= cssClassName %>';
+
+  @cssVariable declare boxel<%= classifiedModuleName %>BackgroundColor: CSSVariableInfo; // TODO: replace or remove
+  @tracked someProp = 'someValue'; // TODO: replace or remove
+
+  <template>
+    <FreestyleUsage @name="<%= classifiedModuleName %>">
+      <:description>
+        A brief description of <%= classifiedModuleName %>.
+      </:description>
+      <:example>
+        <Boxel<%= classifiedModuleName %>
+          @someProp={{this.someProp}}
+          style={{cssVar
+            <%= cssClassName %>-background-color=this.boxel<%= classifiedModuleName %>BackgroundColor.value
+          }}
+        >
+          Hello, world.
+        </Boxel<%= classifiedModuleName %>>
+      </:example>
+      <:api as |Args|>
+        <Args.Object
+          @name="someProp"
+          @description="A decription of the someProp property"
+          @value={{this.someProp}}
+          @onInput={{fn (mut this.someProp)}}
+        />
+      </:api>
+      <:cssVars as |Css|>
+        <Css.Basic
+          @name="<%= cssClassName %>-background-color"
+          @type="color"
+          @defaultValue={{this.boxel<%= classifiedModuleName %>BackgroundColor.defaults}}
+          @value={{this.boxel<%= classifiedModuleName %>BackgroundColor.value}}
+          @onInput={{this.boxel<%= classifiedModuleName %>BackgroundColor.update}}
+        />
+      </:cssVars>
+    </FreestyleUsage>
+  </template>
+}

--- a/packages/boxel/blueprints/boxel-component/index.js
+++ b/packages/boxel/blueprints/boxel-component/index.js
@@ -1,0 +1,20 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+'use strict';
+const kebabCase = require('lodash/kebabCase');
+const camelCase = require('lodash/camelCase');
+const startCase = require('lodash/startCase');
+
+module.exports = {
+  description: 'Generate a boxel component',
+
+  locals(options) {
+    let { name } = options.entity;
+    return {
+      cssClassName: `boxel-${kebabCase(name).replace(/\//g, '-')}`,
+      classComponentName: `Boxel::${startCase(camelCase(name)).replace(
+        / /g,
+        '::'
+      )}`,
+    };
+  },
+};

--- a/packages/boxel/package.json
+++ b/packages/boxel/package.json
@@ -148,6 +148,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-qunit": "^7.3.1",
     "loader.js": "^4.7.0",
+    "lodash": "^4.17.21",
     "node-sass": "^7.0.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",

--- a/packages/boxel/tsconfig.json
+++ b/packages/boxel/tsconfig.json
@@ -56,6 +56,7 @@
     "transform": {
       "exclude": [
         "app/components/**/*",
+        "blueprints/**/*",
         "tests/dummy/app/components/apply-changes-toggle/**/*",
         "tests/dummy/app/components/boxel/**/*",
         "tests/dummy/app/components/card-select/**/*",


### PR DESCRIPTION
This blueprint allows a developer to generate a new boxel component (index.gts), a
CSS file, a usage.gts file, and an integration test. Run it using
`ember generate boxel-component your-component-name`.