### PR TITLE
[Bug]:[safe-tools] Fix background color on resize

### DIFF
--- a/packages/safe-tools-client/app/css/schedule.css
+++ b/packages/safe-tools-client/app/css/schedule.css
@@ -1,4 +1,6 @@
 .safe-tools__dashboard-schedule {
+  background-color: var(--boxel-dashboard-background-color);
+
   display: flex;
   flex-direction: row;
 }


### PR DESCRIPTION
This PR fixes the background color when the window is resized, before the bg was partially white.

Before:
<img width="400" alt="Screen Shot 2022-10-27 at 10 13 42" src="https://user-images.githubusercontent.com/20520102/198295426-5b99738f-bbcd-40e2-af42-8baa16a8730c.png">

Now:
<img width="400" alt="Screen Shot 2022-10-27 at 10 13 54" src="https://user-images.githubusercontent.com/20520102/198295448-273b8704-b231-433d-be2d-931e82aebd14.png">


Open to suggestions if there's a better way, I've tried inherit. but it didn't work. 