### PR TITLE
[CS-4798]: Add action to disconnect wallet

### DIFF
--- a/packages/safe-tools-client/app/components/connect-button/index.gts
+++ b/packages/safe-tools-client/app/components/connect-button/index.gts
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import { inject as service} from '@ember/service';
-import { action } from '@ember/object';
 import BoxelButton from '@cardstack/boxel/components/boxel/button';
 import cn from '@cardstack/boxel/helpers/cn';
 import or from 'ember-truth-helpers/helpers/or';
@@ -21,15 +20,11 @@ interface Signature {
 export default class ConnectButton extends Component<Signature> {
   @service declare wallet: WalletService;
 
-  @action async disconnect(): Promise<void> {
-    // TODO
-  }
-
   <template>
     {{#if this.wallet.isConnected}}
       <BoxelButton
         @kind="secondary-dark"
-        {{on "click" this.disconnect}}
+        {{on "click" this.wallet.disconnect}}
         data-test-disconnect-button
         {{! @glint-ignore See notes here https://github.com/typed-ember/glint/pull/138#issue-852455350 }}
         ...attributes

--- a/packages/safe-tools-client/app/services/wallet.ts
+++ b/packages/safe-tools-client/app/services/wallet.ts
@@ -43,6 +43,10 @@ export default class Wallet extends Service {
       this.address = accounts[0];
     });
 
+    this.chainConnectionManager.on('disconnected', () => {
+      this.isConnected = false;
+    });
+
     const providerId =
       ChainConnectionManager.getProviderIdForChain(CHAIN_ID_FIXME);
     if (providerId !== 'wallet-connect' && providerId !== 'metamask') {
@@ -76,6 +80,10 @@ export default class Wallet extends Service {
 
   @action cancelConnection() {
     // TODO
+  }
+
+  @action disconnect() {
+    this.chainConnectionManager.disconnect();
   }
 }
 


### PR DESCRIPTION
Adds the action to disconnect a wallet. I thought it made more sense for it to leave in the walletService, but let me know if the pattern is to keep in the component. The UI also reflects in case we disconnect from Metamask.

https://user-images.githubusercontent.com/20520102/198363594-cf9ca406-b464-4fad-a8a9-7af1dbae7a8c.mov

PS. the close action will be added on a diff PR 