### PR TITLE
[CS-4802][safe-tools]: Connect modal features

### DIFF
--- a/packages/safe-tools-client/app/components/network-connect-modal/index.css
+++ b/packages/safe-tools-client/app/components/network-connect-modal/index.css
@@ -49,7 +49,7 @@
 .network-connect-modal .network-connect-modal__cancel-button {
   min-height: 1.25rem;
   min-width: unset;
-  padding: 0 var(--boxel-sp-xxxs);
+  padding: 0;
   border: unset;
   margin: 0;
   display: inline-block;

--- a/packages/safe-tools-client/app/components/network-connect-modal/index.gts
+++ b/packages/safe-tools-client/app/components/network-connect-modal/index.gts
@@ -38,7 +38,7 @@ class NetworkConnectModal extends Component<Signature> {
   @action async cancelConnection(): Promise<void> {
     // TODO
   }
-  
+
   get connectionState(): ActionChinState {
     return this.wallet.isConnecting ? 'in-progress' : 'default';
   }
@@ -140,7 +140,7 @@ class NetworkConnectModal extends Component<Signature> {
 
           <ActionChin @state={{this.connectionState}}>
             <:default as |a|>
-              <a.ActionButton {{on "click" (fn this.wallet.connect this.chosenProviderId)}} data-test-mainnet-connect-button disabled={{not this.chosenProviderId}}>
+              <a.ActionButton {{on "click" (fn this.wallet.connect this.chosenProviderId @onClose)}} data-test-mainnet-connect-button disabled={{not this.chosenProviderId}}>
                 Connect Wallet
               </a.ActionButton>
             </:default>

--- a/packages/safe-tools-client/app/components/network-connect-modal/index.gts
+++ b/packages/safe-tools-client/app/components/network-connect-modal/index.gts
@@ -15,6 +15,7 @@ import BoxelActionContainer from '@cardstack/boxel/components/boxel/action-conta
 import BoxelLoadingIndicator from '@cardstack/boxel/components/boxel/loading-indicator';
 import BoxelModal from '@cardstack/boxel/components/boxel/modal';
 import BoxelRadioInput from '@cardstack/boxel/components/boxel/radio-input';
+import { type ActionChinState } from '@cardstack/boxel/components/boxel/action-chin/state';
 
 import './index.css';
 
@@ -36,6 +37,10 @@ class NetworkConnectModal extends Component<Signature> {
 
   @action async cancelConnection(): Promise<void> {
     // TODO
+  }
+  
+  get connectionState(): ActionChinState {
+    return this.wallet.isConnecting ? 'in-progress' : 'default';
   }
 
   <template>
@@ -133,9 +138,9 @@ class NetworkConnectModal extends Component<Signature> {
             </BoxelRadioInput>
           </Section>
 
-          <ActionChin @state='default'>
+          <ActionChin @state={{this.connectionState}}>
             <:default as |a|>
-              <a.ActionButton {{on "click" (fn this.wallet.connect this.chosenProviderId)}} data-test-mainnet-connect-button>
+              <a.ActionButton {{on "click" (fn this.wallet.connect this.chosenProviderId)}} data-test-mainnet-connect-button disabled={{not this.chosenProviderId}}>
                 Connect Wallet
               </a.ActionButton>
             </:default>

--- a/packages/safe-tools-client/app/components/network-connect-modal/index.gts
+++ b/packages/safe-tools-client/app/components/network-connect-modal/index.gts
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
 import { inject as service} from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 //@ts-expect-error glint does not think this is consumed-but it is consumed in the template https://github.com/typed-ember/glint/issues/374
@@ -34,10 +33,6 @@ class NetworkConnectModal extends Component<Signature> {
   @service declare wallet: WalletService;
 
   @tracked chosenProviderId: string | undefined;
-
-  @action async cancelConnection(): Promise<void> {
-    // TODO
-  }
 
   get connectionState(): ActionChinState {
     return this.wallet.isConnecting ? 'in-progress' : 'default';
@@ -150,7 +145,7 @@ class NetworkConnectModal extends Component<Signature> {
                 <BoxelLoadingIndicator class="network-connect-modal__loading-indicator" @color="var(--boxel-light)" />
                 <div class="network-connect-modal__waiting-status">
                   Waiting for you to connect your {{!-- network-display-info "conversationalName" --}} wallet...
-                  <i.CancelButton class="network-connect-modal__cancel-button" {{on "click" this.cancelConnection}}>
+                  <i.CancelButton class="network-connect-modal__cancel-button" {{on "click" this.wallet.cancelConnection}}>
                     Cancel
                   </i.CancelButton>
                 </div>

--- a/packages/safe-tools-client/app/services/wallet.ts
+++ b/packages/safe-tools-client/app/services/wallet.ts
@@ -57,11 +57,20 @@ export default class Wallet extends Service {
     this.chainConnectionManager.reconnect(this.web3, this.providerId);
   }
 
-  @action connect(providerId: WalletProviderId) {
+  @action connect(providerId: WalletProviderId, onConnectSuccess: () => void) {
     this.providerId = providerId;
 
     if (!this.isConnected) {
-      taskFor(this.connectWalletTask).perform();
+      taskFor(this.connectWalletTask)
+        .perform()
+        .then(() => {
+          if (this.isConnected) {
+            onConnectSuccess();
+          }
+        })
+        .catch((e) => {
+          console.log(e);
+        });
     }
   }
 

--- a/packages/safe-tools-client/app/services/wallet.ts
+++ b/packages/safe-tools-client/app/services/wallet.ts
@@ -19,6 +19,7 @@ export default class Wallet extends Service {
   @tracked isConnected = false;
   @tracked providerId: WalletProviderId | undefined;
   @tracked address: string | undefined;
+  @tracked isConnecting = false;
 
   web3 = new Web3();
   chainConnectionManager = new ChainConnectionManager(CHAIN_NAME_FIXME);
@@ -61,6 +62,7 @@ export default class Wallet extends Service {
     this.providerId = providerId;
 
     if (!this.isConnected) {
+      this.isConnecting = true;
       taskFor(this.connectWalletTask)
         .perform()
         .then(() => {
@@ -81,14 +83,12 @@ export default class Wallet extends Service {
 
     yield this.chainConnectionManager.connect(this.web3, this.providerId);
     yield timeout(500); // allow time for strategy to verify connected chain -- it might not accept the connection
-  }
 
-  get isConnecting() {
-    return taskFor(this.connectWalletTask).isRunning;
+    this.isConnecting = false;
   }
 
   @action cancelConnection() {
-    // TODO
+    this.isConnecting = false;
   }
 
   @action disconnect() {


### PR DESCRIPTION
This PR

Completes CS-4802: Adds state to track progress on modal
Completes CS-4803: Hides the modal on a successful connection
Completes CS-4804: Disables Connect Wallet button if no provider is selected
Completes CS-4809: Handles cancel action. It adds a isConnecting flag, to track the connection instead of using the taskRunner since the task might still be occurring once it's dependent on the user and not on us.
