### PR TITLE
[CS-4814]: Refactor network constants and setup test suite on sdk

### DIFF
--- a/packages/cardpay-sdk/.eslintrc.cjs
+++ b/packages/cardpay-sdk/.eslintrc.cjs
@@ -21,4 +21,9 @@ module.exports = {
       },
     },
   ],
+  env: {
+    commonjs: true,
+    node: true,
+    mocha: true,
+  },
 };

--- a/packages/cardpay-sdk/package.json
+++ b/packages/cardpay-sdk/package.json
@@ -44,6 +44,11 @@
     "web3-utils": "1.5.2"
   },
   "devDependencies": {
+    "@types/chai": "^4.3.3",
+    "@types/mocha": "^10.0.0",
+    "chai": "^4.3.6",
+    "mocha": "^10.1.0",
+    "ts-node": "^10.9.1",
     "tsup": "^5.11.7",
     "typescript": "^4.7.4"
   },
@@ -54,7 +59,9 @@
     "clean": "rm -rf dist generated",
     "postinstall": "yarn codegen",
     "codegen": "if [ -f ./bin/codegen.js ]; then node bin/codegen.js; fi",
-    "prepack": "rm -rf ./dist && tsup ./index.ts --format esm,cjs --dts --legacy-output"
+    "prepack": "rm -rf ./dist && tsup ./index.ts --format esm,cjs --dts --legacy-output",
+    "test": "mocha -r ts-node/register 'tests/**/*-test.ts' --timeout 60000",
+    "autotest": "mocha -r ts-node/register -w --reporter=min 'tests/**/*-test.ts' --timeout 60000"
   },
   "homepage": "https://github.com/cardstack/cardstack",
   "license": "MIT",

--- a/packages/cardpay-sdk/package.json
+++ b/packages/cardpay-sdk/package.json
@@ -47,6 +47,7 @@
     "@types/chai": "^4.3.3",
     "@types/mocha": "^10.0.0",
     "chai": "^4.3.6",
+    "chai-as-promised": "^7.1.1",
     "mocha": "^10.1.0",
     "ts-node": "^10.9.1",
     "tsup": "^5.11.7",

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -1,6 +1,5 @@
 import Web3 from 'web3';
 import invert from 'lodash/invert';
-import mapValues from 'lodash/mapValues';
 import { networkName } from './utils/general-utils';
 import JsonRpcProvider from '../providers/json-rpc-provider';
 
@@ -10,151 +9,176 @@ export const MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME = 'wallet.cardstack.com';
 export const MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME = 'wallet-staging.stack.cards';
 export const CARDWALLET_SCHEME = 'cardwallet';
 
-const SOKOL = {
-  apiBaseUrl: 'https://blockscout.com/poa/sokol/api/eth-rpc',
-  /** deployed instance of this contract: https://github.com/wbobeirne/eth-balance-checker */
-  balanceCheckerContractAddress: '0xaeDFe60b0732924249866E3FeC71835EFb1fc9fF',
-  blockExplorer: 'https://blockscout.com/poa/sokol',
-  bridgeExplorer: 'https://alm-test-amb.herokuapp.com/77',
+type NestedKeyOf<Obj extends object> = {
+  [K in keyof Obj]: Obj[K] extends object ? NestedKeyOf<Obj[K]> : K;
+}[keyof Obj];
+
+const testHubUrl = {
   hubUrl: 'https://hub-staging.stack.cards',
-  nativeTokenAddress: 'spoa',
+};
+
+const hubUrl = {
+  hubUrl: 'https://hub.cardstack.com',
+};
+
+const ethNativeTokens = {
   nativeTokenCoingeckoId: 'ethereum',
-  nativeTokenSymbol: 'SPOA',
-  nativeTokenName: 'SPOA',
+  nativeTokenAddress: 'eth',
+  nativeTokenSymbol: 'ETH',
+  nativeTokenName: 'Ethereum',
+};
+
+const bridgedTokens = {
   bridgedDaiTokenSymbol: 'DAI.CPXD',
   bridgedCardTokenSymbol: 'CARD.CPXD',
-  name: 'Sokol',
-  relayServiceURL: 'https://relay-staging.stack.cards/api',
-  subgraphURL: 'https://graph-staging.stack.cards/subgraphs/name/habdelra/cardpay-sokol',
-  tallyServiceURL: 'https://reward-api-staging.stack.cards',
-  merchantUniLinkDomain: MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,
 };
-const KOVAN = {
-  apiBaseUrl: 'https://api-kovan.etherscan.io/api',
-  /** deployed instance of this contract: https://github.com/wbobeirne/eth-balance-checker */
-  balanceCheckerContractAddress: '0xf3352813b612a2d198e437691557069316b84ebe',
-  blockExplorer: 'https://kovan.etherscan.io',
-  bridgeExplorer: 'https://alm-test-amb.herokuapp.com/42',
-  hubUrl: 'https://hub-staging.stack.cards',
-  nativeTokenAddress: 'eth',
-  nativeTokenCoingeckoId: 'ethereum',
-  nativeTokenSymbol: 'ETH',
-  nativeTokenName: 'Ethereum',
-  name: 'Kovan',
-  // https://docs.tokenbridge.net/kovan-sokol-amb-bridge/about-the-kovan-sokol-amb shows 1 for finalization rate
-  // but making this the same as mainnet so that the dev experience matches prod
-  ambFinalizationRate: '20',
-  subgraphURL: '',
-};
-const GOERLI = {
-  apiBaseUrl: 'https://api-goerli.etherscan.io/api',
-  blockExplorer: 'https://goerli.etherscan.io',
-  hubUrl: 'https://hub-staging.stack.cards',
-  nativeTokenAddress: 'eth',
-  nativeTokenCoingeckoId: 'ethereum',
-  nativeTokenSymbol: 'ETH',
-  nativeTokenName: 'Ethereum',
-  name: 'Goerli',
-  relayServiceURL: 'https://relay-goerli.staging.stack.cards/api',
-};
-const MUMBAI = {
-  apiBaseUrl: 'https://api-testnet.polygon.io/api',
-  blockExplorer: 'https://mumbai.polygonscan.com',
-  hubUrl: 'https://hub-staging.stack.cards',
+
+const polygonNativeTokens = {
   nativeTokenAddress: 'matic',
-  nativeTokenCoingeckoId: 'MATIC',
+  nativeTokenCoingeckoId: 'polygon',
   nativeTokenSymbol: 'MATIC',
   nativeTokenName: 'Matic',
-  name: 'Mumbai',
-  relayServiceURL: 'https://relay-mumbai.staging.stack.cards/api',
-};
-const MAINNET = {
-  apiBaseUrl: 'https://api.etherscan.io/api',
-  /** deployed instance of this contract: https://github.com/wbobeirne/eth-balance-checker */
-  balanceCheckerContractAddress: '0x4dcf4562268dd384fe814c00fad239f06c2a0c2b',
-  blockExplorer: 'https://etherscan.io',
-  bridgeExplorer: 'https://alm-xdai.herokuapp.com/1',
-  hubUrl: 'https://hub.cardstack.com',
-  nativeTokenAddress: 'eth',
-  nativeTokenCoingeckoId: 'ethereum',
-  nativeTokenSymbol: 'ETH',
-  nativeTokenName: 'Ethereum',
-  name: 'Ethereum Mainnet',
-  // check https://docs.tokenbridge.net/eth-xdai-amb-bridge/about-the-eth-xdai-amb for the finalization rate
-  ambFinalizationRate: '20',
-  relayServiceURL: 'https://relay-ethereum.cardstack.com/api',
-};
-const GNOSIS = {
-  apiBaseUrl: 'https://blockscout.com/xdai/mainnet/api',
-  /** deployed instance of this contract: https://github.com/wbobeirne/eth-balance-checker */
-  balanceCheckerContractAddress: '0x6B78C121bBd10D8ef0dd3623CC1abB077b186F65',
-  blockExplorer: 'https://blockscout.com/xdai/mainnet',
-  bridgeExplorer: 'https://alm-xdai.herokuapp.com/100',
-  hubUrl: 'https://hub.cardstack.com',
-  nativeTokenAddress: 'xdai',
-  nativeTokenCoingeckoId: 'xdai',
-  nativeTokenSymbol: 'XDAI',
-  nativeTokenName: 'xDai',
-  bridgedDaiTokenSymbol: 'DAI.CPXD',
-  bridgedCardTokenSymbol: 'CARD.CPXD',
-  name: 'Gnosis Chain',
-  relayServiceURL: 'https://relay.cardstack.com/api',
-  subgraphURL: 'https://graph.cardstack.com/subgraphs/name/habdelra/cardpay-xdai',
-  merchantUniLinkDomain: MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME,
-  tallyServiceURL: 'https://reward-api.cardstack.com',
 };
 
-type ConstantKeys =
-  | keyof typeof SOKOL
-  | keyof typeof KOVAN
-  | keyof typeof MAINNET
-  | keyof typeof GNOSIS
-  | keyof typeof GOERLI
-  | keyof typeof MUMBAI;
-
-const constants: {
-  [network: string]: {
-    [prop: string]: string;
-  };
-} = Object.freeze({
-  sokol: SOKOL,
-  kovan: KOVAN,
-  goerli: GOERLI,
-  mumbai: MUMBAI,
-  mainnet: MAINNET,
-  gnosis: GNOSIS,
-  xdai: GNOSIS,
-});
-
-export const networks: { [networkId: number]: string } = Object.freeze({
-  1: 'mainnet',
-  42: 'kovan',
-  5: 'goerli',
-  77: 'sokol',
-  100: 'xdai',
-  80001: 'mumbai',
-});
-
-// invert the networks object, so { '1': 'mainnet', ... } becomes { mainnet: '1', ... }
-// then map over the values, so that { mainnet: '1', ... } has its values casted as numbers: { mainnet: 1, ... }
-export const networkIds = mapValues(invert({ ...networks }), Number) as unknown as {
-  [networkName: string]: number;
+const networksConstants = {
+  sokol: {
+    ...testHubUrl,
+    ...ethNativeTokens,
+    ...bridgedTokens,
+    apiBaseUrl: 'https://blockscout.com/poa/sokol/api/eth-rpc',
+    blockExplorer: 'https://blockscout.com/poa/sokol',
+    bridgeExplorer: 'https://alm-test-amb.herokuapp.com/77',
+    nativeTokenAddress: 'spoa',
+    nativeTokenSymbol: 'SPOA',
+    nativeTokenName: 'SPOA',
+    name: 'Sokol',
+    relayServiceURL: 'https://relay-staging.stack.cards/api',
+    subgraphURL: 'https://graph-staging.stack.cards/subgraphs/name/habdelra/cardpay-sokol',
+    merchantUniLinkDomain: MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,
+    tallyServiceURL: 'https://reward-api-staging.stack.cards',
+    chainId: 77,
+  },
+  kovan: {
+    ...testHubUrl,
+    ...ethNativeTokens,
+    apiBaseUrl: 'https://api-kovan.etherscan.io/api',
+    blockExplorer: 'https://kovan.etherscan.io',
+    bridgeExplorer: 'https://alm-test-amb.herokuapp.com/42',
+    name: 'Kovan',
+    // https://docs.tokenbridge.net/kovan-sokol-amb-bridge/about-the-kovan-sokol-amb shows 1 for finalization rate
+    // but making this the same as mainnet so that the dev experience matches prod
+    ambFinalizationRate: '20',
+    subgraphURL: '',
+    chainId: 42,
+  },
+  goerli: {
+    ...testHubUrl,
+    ...ethNativeTokens,
+    apiBaseUrl: 'https://api-goerli.etherscan.io/api',
+    blockExplorer: 'https://goerli.etherscan.io',
+    name: 'Goerli',
+    relayServiceURL: 'https://relay-goerli.staging.stack.cards/api',
+    chainId: 5,
+  },
+  polygon: {
+    ...hubUrl,
+    ...polygonNativeTokens,
+    apiBaseUrl: 'https://api-testnet.polygon.io/api', // TODO: add oficial polygon api
+    blockExplorer: 'https://polygonscan.com',
+    name: 'Polygon',
+    chainId: 137,
+  },
+  mumbai: {
+    ...testHubUrl,
+    apiBaseUrl: 'https://api-testnet.polygon.io/api',
+    blockExplorer: 'https://mumbai.polygonscan.com',
+    nativeTokenAddress: 'matic',
+    nativeTokenCoingeckoId: 'polygon',
+    nativeTokenSymbol: 'MATIC',
+    nativeTokenName: 'Matic',
+    name: 'Polygon',
+    relayServiceURL: 'https://relay-mumbai.staging.stack.cards/api',
+    chainId: 80001,
+  },
+  mainnet: {
+    ...hubUrl,
+    ...ethNativeTokens,
+    apiBaseUrl: 'https://api.etherscan.io/api',
+    blockExplorer: 'https://etherscan.io',
+    bridgeExplorer: 'https://alm-xdai.herokuapp.com/1',
+    name: 'Ethereum Mainnet',
+    // check https://docs.tokenbridge.net/eth-xdai-amb-bridge/about-the-eth-xdai-amb for the finalization rate
+    ambFinalizationRate: '20',
+    relayServiceURL: 'https://relay-ethereum.cardstack.com/api',
+    chainId: 1,
+  },
+  gnosis: {
+    ...hubUrl,
+    ...bridgedTokens,
+    apiBaseUrl: 'https://blockscout.com/xdai/mainnet/api',
+    blockExplorer: 'https://blockscout.com/xdai/mainnet',
+    bridgeExplorer: 'https://alm-xdai.herokuapp.com/100',
+    nativeTokenAddress: 'xdai',
+    nativeTokenCoingeckoId: 'xdai',
+    nativeTokenSymbol: 'XDAI',
+    nativeTokenName: 'xDai',
+    name: 'Gnosis Chain',
+    relayServiceURL: 'https://relay.cardstack.com/api',
+    subgraphURL: 'https://graph.cardstack.com/subgraphs/name/habdelra/cardpay-xdai',
+    merchantUniLinkDomain: MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME,
+    tallyServiceURL: 'https://reward-api.cardstack.com',
+    chainId: 100,
+  },
 };
-networkIds['gnosis'] = networkIds['xdai'];
-Object.freeze(networkIds);
 
-export function getConstantByNetwork(name: ConstantKeys, network: string): string {
-  let value = constants[network][name];
+type NetworksType = typeof networksConstants;
+
+type Networks = keyof NetworksType | 'xdai';
+
+type ConstantKeys = NestedKeyOf<NetworksType>;
+
+// TODO: create types dynamically
+type NetworkConstants = NetworksType['sokol'] &
+  NetworksType['gnosis'] &
+  NetworksType['goerli'] &
+  NetworksType['polygon'] &
+  NetworksType['mainnet'] &
+  NetworksType['kovan'] &
+  NetworksType['mumbai'];
+
+// Order matters, if both have same chainId the last one is used.
+const constants: Record<Networks, Partial<NetworkConstants>> = {
+  xdai: networksConstants['gnosis'],
+  ...networksConstants,
+} as const;
+
+const networkNames = Object.keys(constants);
+
+export const networkIds: Record<string, number> = Object.freeze(
+  networkNames.reduce(
+    (netIds, networkName) => ({
+      ...netIds,
+      [networkName]: constants[networkName as Networks].chainId,
+    }),
+    {}
+  )
+);
+
+// invert the networkIds object, so { mainnet: 1, ... } becomes { '1': 'mainnet', ... }
+export const networks = invert(networkIds);
+
+export function getConstantByNetwork<K extends ConstantKeys>(name: K, network: Networks | string) {
+  let value = constants[network as Networks][name];
   if (!value) {
     throw new Error(`Don't know about the constant '${name}' for network ${network}`);
   }
   return value;
 }
 
-export async function getConstant(
-  name: ConstantKeys,
+export async function getConstant<K extends ConstantKeys>(
+  name: K,
   web3OrNetworkOrEthersProvider: Web3 | string | JsonRpcProvider
-): Promise<string> {
+) {
   let network: string;
   if (typeof web3OrNetworkOrEthersProvider === 'string') {
     network = web3OrNetworkOrEthersProvider;
@@ -162,7 +186,7 @@ export async function getConstant(
     network = await networkName(web3OrNetworkOrEthersProvider);
   }
 
-  let value = constants[network][name];
+  let value = constants[network as Networks][name];
   if (!value) {
     throw new Error(`Don't know about the constant '${name}' for network ${network}`);
   }

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -138,7 +138,7 @@ type Networks = keyof NetworksType | 'xdai';
 type ConstantKeys = NestedKeyOf<NetworksType>;
 
 // TODO: create types dynamically
-type NetworkConstants = NetworksType['sokol'] &
+type RequiredNetworkConstants = NetworksType['sokol'] &
   NetworksType['gnosis'] &
   NetworksType['goerli'] &
   NetworksType['polygon'] &
@@ -146,8 +146,10 @@ type NetworkConstants = NetworksType['sokol'] &
   NetworksType['kovan'] &
   NetworksType['mumbai'];
 
+type OptionalNetworkContants = Partial<RequiredNetworkConstants> & { chainId: number };
+
 // Order matters, if both have same chainId the last one is used.
-const constants: Record<Networks, Partial<NetworkConstants>> = {
+const constants: Record<Networks, OptionalNetworkContants> = {
   xdai: networksConstants['gnosis'],
   ...networksConstants,
 } as const;

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -96,7 +96,7 @@ const networksConstants = {
     nativeTokenCoingeckoId: 'polygon',
     nativeTokenSymbol: 'MATIC',
     nativeTokenName: 'Matic',
-    name: 'Polygon',
+    name: 'Mumbai',
     relayServiceURL: 'https://relay-mumbai.staging.stack.cards/api',
     chainId: 80001,
   },
@@ -138,18 +138,26 @@ type Networks = keyof NetworksType | 'xdai';
 type ConstantKeys = NestedKeyOf<NetworksType>;
 
 // TODO: create types dynamically
-type RequiredNetworkConstants = NetworksType['sokol'] &
-  NetworksType['gnosis'] &
-  NetworksType['goerli'] &
-  NetworksType['polygon'] &
-  NetworksType['mainnet'] &
-  NetworksType['kovan'] &
-  NetworksType['mumbai'];
+type OptionalNetworkContants = Partial<
+  NetworksType['sokol'] &
+    NetworksType['gnosis'] &
+    NetworksType['goerli'] &
+    NetworksType['polygon'] &
+    NetworksType['mainnet'] &
+    NetworksType['kovan'] &
+    NetworksType['mumbai']
+>;
 
-type OptionalNetworkContants = Partial<RequiredNetworkConstants> & { chainId: number };
+interface RequiredNetworkConstants {
+  name: string;
+  chainId: number;
+  hubUrl: string;
+}
+
+type NetworkContants = OptionalNetworkContants & RequiredNetworkConstants;
 
 // Order matters, if both have same chainId the last one is used.
-const constants: Record<Networks, OptionalNetworkContants> = {
+const constants: Record<Networks, NetworkContants> = {
   xdai: networksConstants['gnosis'],
   ...networksConstants,
 } as const;

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -90,12 +90,9 @@ const networksConstants = {
   },
   mumbai: {
     ...testHubUrl,
+    ...polygonNativeTokens,
     apiBaseUrl: 'https://api-testnet.polygon.io/api',
     blockExplorer: 'https://mumbai.polygonscan.com',
-    nativeTokenAddress: 'matic',
-    nativeTokenCoingeckoId: 'polygon',
-    nativeTokenSymbol: 'MATIC',
-    nativeTokenName: 'Matic',
     name: 'Mumbai',
     relayServiceURL: 'https://relay-mumbai.staging.stack.cards/api',
     chainId: 80001,

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -83,7 +83,7 @@ const networksConstants = {
   polygon: {
     ...hubUrl,
     ...polygonNativeTokens,
-    apiBaseUrl: 'https://api-testnet.polygon.io/api', // TODO: add oficial polygon api
+    apiBaseUrl: 'https://api-testnet.polygon.io/api', // TODO: add official polygon api
     blockExplorer: 'https://polygonscan.com',
     name: 'Polygon',
     chainId: 137,

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -149,6 +149,7 @@ interface RequiredNetworkConstants {
   name: string;
   chainId: number;
   hubUrl: string;
+  nativeTokenSymbol: string;
 }
 
 type NetworkContants = OptionalNetworkContants & RequiredNetworkConstants;

--- a/packages/cardpay-sdk/sdk/hub-auth.ts
+++ b/packages/cardpay-sdk/sdk/hub-auth.ts
@@ -10,6 +10,7 @@ export interface IHubAuth {
   getNonce(): Promise<NonceResponse>;
   authenticate(): Promise<string>;
   checkValidAuth(authToken: string): Promise<boolean>;
+  getHubUrl(network?: string): Promise<string>;
 }
 interface NonceResponse {
   nonce: string;
@@ -122,6 +123,6 @@ export default class HubAuth implements IHubAuth {
   async getHubUrl(network?: string): Promise<string> {
     const netName = network || (await networkName(this.web3OrEthersProvider));
 
-    return this.hubRootUrl || getConstantByNetwork('hubUrl', netName);
+    return this.hubRootUrl || getConstantByNetwork('hubUrl', netName) || '';
   }
 }

--- a/packages/cardpay-sdk/sdk/utils/graphql.ts
+++ b/packages/cardpay-sdk/sdk/utils/graphql.ts
@@ -18,12 +18,12 @@ export async function query(
   graphQLQuery: string,
   variables?: { [varName: string]: string | number | null }
 ): Promise<{ data: any }> {
-  let subgraphURL: string;
-  if (typeof networkOrWeb3 === 'string') {
-    subgraphURL = await getConstant('subgraphURL', networkOrWeb3);
-  } else {
-    subgraphURL = await getConstant('subgraphURL', networkOrWeb3);
+  const subgraphURL = await getConstant('subgraphURL', networkOrWeb3);
+
+  if (!subgraphURL) {
+    throw `No subgraphURL for ${networkOrWeb3}`;
   }
+
   let response = await fetch(subgraphURL, {
     method: 'POST',
     headers: {

--- a/packages/cardpay-sdk/tests/constants-test.ts
+++ b/packages/cardpay-sdk/tests/constants-test.ts
@@ -1,9 +1,81 @@
 import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import Web3 from 'web3';
+import JsonRpcProvider from '../providers/json-rpc-provider';
+import { networkIds, networks, getConstantByNetwork, getConstant } from '../sdk/constants';
 
-describe('Array', function () {
-  describe('#indexOf()', function () {
-    it('should return -1 when the value is not present', function () {
-      chai.expect([1, 2, 3].indexOf(4)).to.eq(-1);
+chai.use(chaiAsPromised);
+
+describe('Network constants', () => {
+  it('should return an object with network names as key and chainId as value', () => {
+    chai.expect(networkIds).to.deep.eq({
+      xdai: 100,
+      sokol: 77,
+      kovan: 42,
+      goerli: 5,
+      polygon: 137,
+      mumbai: 80001,
+      mainnet: 1,
+      gnosis: 100,
+    });
+  });
+  it('should return an object with network chainId as keys and network name as value', () => {
+    chai.expect(networks).to.deep.eq({
+      77: 'sokol',
+      42: 'kovan',
+      5: 'goerli',
+      137: 'polygon',
+      80001: 'mumbai',
+      1: 'mainnet',
+      100: 'gnosis',
+    });
+  });
+
+  describe('getConstantByNetwork', () => {
+    it('should return ETH for mainnet`s nativeTokenSymbol', () => {
+      const mainnetNativeTokenSymbol = getConstantByNetwork('nativeTokenSymbol', 'mainnet');
+
+      chai.expect(mainnetNativeTokenSymbol).to.eq('ETH');
+    });
+    it('should throw an error if constant does not exist for network', () => {
+      chai
+        .expect(() => getConstantByNetwork('bridgedDaiTokenSymbol', 'polygon'))
+        .to.throw(`Don't know about the constant 'bridgedDaiTokenSymbol' for network polygon`);
+    });
+  });
+
+  describe('getConstant', () => {
+    it('should return chainId as 1 for mainnet using getConstant with string', async () => {
+      const mainnetChainId = await getConstant('chainId', 'mainnet');
+
+      chai.expect(mainnetChainId).to.eq(1);
+    });
+    it('should return chainId as 1 for mainnet using getConstant with web3Provider', async () => {
+      const mockedWeb3 = {
+        eth: {
+          net: { getId: async () => 1 },
+        },
+      } as Web3;
+
+      const mainnetChainId = await getConstant('chainId', mockedWeb3);
+
+      chai.expect(mainnetChainId).to.eq(1);
+    });
+    it('should return chainId as 1 for mainnet using getConstant with JsonRpcProvider', async () => {
+      const instance = Object.create(JsonRpcProvider.prototype);
+
+      const mockedJsonRpc = Object.assign(instance, {
+        getNetwork: async () => ({ chainId: 1 }),
+      });
+
+      const mainnetChainId = await getConstant('chainId', mockedJsonRpc);
+
+      chai.expect(mainnetChainId).to.eq(1);
+    });
+    it('should throw an error if constant does not exist for network', async () => {
+      await chai
+        .expect(getConstant('bridgedDaiTokenSymbol', 'mainnet'))
+        .to.be.rejectedWith(`Don't know about the constant 'bridgedDaiTokenSymbol' for network mainnet`);
     });
   });
 });

--- a/packages/cardpay-sdk/tests/constants-test.ts
+++ b/packages/cardpay-sdk/tests/constants-test.ts
@@ -1,0 +1,9 @@
+import chai from 'chai';
+
+describe('Array', function () {
+  describe('#indexOf()', function () {
+    it('should return -1 when the value is not present', function () {
+      chai.expect([1, 2, 3].indexOf(4)).to.eq(-1);
+    });
+  });
+});

--- a/packages/cardpay-sdk/tsconfig.json
+++ b/packages/cardpay-sdk/tsconfig.json
@@ -24,15 +24,11 @@
       "web3-provider-engine": ["../../types/web3-provider-engine"]
     }
   },
-  "exclude": [
-    "node_modules",
-    "dist"
-  ],
-  "include": [
-    "generated",
-    "contracts",
-    "providers",
-    "sdk",
-    "index.ts"
-  ]
+  "ts-node": {
+    "compilerOptions": {
+      "module": "commonjs"
+    }
+  },
+  "exclude": ["node_modules", "dist"],
+  "include": ["generated", "contracts", "providers", "sdk", "index.ts", "tests"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6716,6 +6716,11 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.15.tgz#b7a6d263c2cecf44b6de9a051cf496249b154553"
   integrity sha512-rYff6FI+ZTKAPkJUoyz7Udq3GaoDZnxYDEvdEdFZASiA7PoErltHezDishqQiSDWrGxvxmplH304jyzQmjp0AQ==
 
+"@types/chai@^4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.3.tgz#3c90752792660c4b562ad73b3fbd68bf3bc7ae07"
+  integrity sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==
+
 "@types/commonmark@^0.27.5":
   version "0.27.5"
   resolved "https://registry.yarnpkg.com/@types/commonmark/-/commonmark-0.27.5.tgz#008f2e8fb845c906146aa97510d66953d916aed2"
@@ -7337,6 +7342,11 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
+
+"@types/mocha@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.0.tgz#3d9018c575f0e3f7386c1de80ee66cc21fbb7a52"
+  integrity sha512-rADY+HtTOA52l9VZWtgQfn4p+UDVM2eDVkMZT1I6syp0YKxW2F9v+0pbRZLsvskhQv/vMb6ZfCay81GHbz5SHg==
 
 "@types/mocha@^8.2.1":
   version "8.2.1"
@@ -11705,6 +11715,19 @@ chai@^4.3.4:
     pathval "^1.1.1"
     type-detect "^4.0.5"
 
+chai@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.6.tgz#ffe4ba2d9fa9d6680cc0b370adae709ec9011e9c"
+  integrity sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    loupe "^2.3.1"
+    pathval "^1.1.1"
+    type-detect "^4.0.5"
+
 chainsaw@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
@@ -11854,6 +11877,21 @@ chokidar@3.5.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
+chokidar@3.5.3, chokidar@^3.0.2, chokidar@^3.4.0, chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.1:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -11872,21 +11910,6 @@ chokidar@^2.1.8:
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
-
-chokidar@^3.0.2, chokidar@^3.4.0, chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.1:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
-  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
-  dependencies:
-    anymatch "~3.1.2"
-    braces "~3.0.2"
-    glob-parent "~5.1.2"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.6.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
 
 chownr@^1.0.1, chownr@^1.1.1, chownr@^1.1.4:
   version "1.1.4"
@@ -13207,7 +13230,7 @@ debug@3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2:
+debug@4, debug@4.3.4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -23277,6 +23300,13 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
+loupe@^2.3.1:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.4.tgz#7e0b9bffc76f148f9be769cb1321d3dcf3cb25f3"
+  integrity sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==
+  dependencies:
+    get-func-name "^2.0.0"
+
 lower-case@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
@@ -23979,6 +24009,13 @@ minimatch@3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
+  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^5.0.1, minimatch@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
@@ -24207,6 +24244,33 @@ mnemonist@^0.38.0:
   integrity sha512-bZTFT5rrPKtPJxj8KSV0WkPyNxl72vQepqqVUAW2ARUpUSF2qXMB6jZj7hW5/k7C1rtpzqbD/IIbJwLXUjCHeg==
   dependencies:
     obliterator "^2.0.0"
+
+mocha@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.1.0.tgz#dbf1114b7c3f9d0ca5de3133906aea3dfc89ef7a"
+  integrity sha512-vUF7IYxEoN7XhQpFLxQAEMtE4W91acW4B6En9l97MwE9stL1A9gusXfoHZCLVHDUJ/7V5+lbCM6yMqzo5vNymg==
+  dependencies:
+    ansi-colors "4.1.1"
+    browser-stdout "1.3.1"
+    chokidar "3.5.3"
+    debug "4.3.4"
+    diff "5.0.0"
+    escape-string-regexp "4.0.0"
+    find-up "5.0.0"
+    glob "7.2.0"
+    he "1.2.0"
+    js-yaml "4.1.0"
+    log-symbols "4.1.0"
+    minimatch "5.0.1"
+    ms "2.1.3"
+    nanoid "3.3.3"
+    serialize-javascript "6.0.0"
+    strip-json-comments "3.1.1"
+    supports-color "8.1.1"
+    workerpool "6.2.1"
+    yargs "16.2.0"
+    yargs-parser "20.2.4"
+    yargs-unparser "2.0.0"
 
 mocha@^7.1.2:
   version "7.2.0"
@@ -24627,6 +24691,11 @@ nanoid@3.1.25:
   version "3.1.25"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.25.tgz#09ca32747c0e543f0e1814b7d3793477f9c8e152"
   integrity sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==
+
+nanoid@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
+  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
 nanoid@^3.0.2, nanoid@^3.1.20, nanoid@^3.1.23, nanoid@^3.3.1:
   version "3.3.1"
@@ -32604,6 +32673,11 @@ workerpool@6.1.5:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.5.tgz#0f7cf076b6215fd7e1da903ff6f22ddd1886b581"
   integrity sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==
 
+workerpool@6.2.1, workerpool@^6.0.0, workerpool@^6.1.4, workerpool@^6.1.5, workerpool@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
+  integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
+
 workerpool@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-3.1.2.tgz#b34e79243647decb174b7481ab5b351dc565c426"
@@ -32612,11 +32686,6 @@ workerpool@^3.1.1:
     "@babel/core" "^7.3.4"
     object-assign "4.1.1"
     rsvp "^4.8.4"
-
-workerpool@^6.0.0, workerpool@^6.1.4, workerpool@^6.1.5, workerpool@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
-  integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
 workerpool@^6.2.0:
   version "6.3.0"


### PR DESCRIPTION
The network constants had loose typing and to add a new network we needed to create an object then remember to add to the consts types, constants object, networksIds, networks. In summary there were 4-5 places to be updated. This PR refactors the constants structure, so every-time a new network is added, typescript will alert which fields are required. 
Also:

- Move some recurring constants into their own object to be share across the main and test net 
- Makes some fields required for every network
- Adds chainId for every network 
- Updated `getConstant` and `getConstantbyNetwork` to return correct type of constant based on the key value 
- Add helper to create networkIds object
- Setup test suite on cardpay sdk 
- Adds tests for network constants 
- Fixes tsc error on the sdk
- Removes some constants that were not used on any project like `balanceCheckerContractAddress`
- Adds polygon network

There's still room for improvement like identifying testnets, or making required fields based on the network type if it's layer1 or layer2 etc, or adding new properties like `shortName`.

One breaking change though is that networks object, will return `100: gnosis` instead of previous `100: xdai`.  But I've searched the code and all cases seems to be covered already, so we shouldn't have any issues.


Here you can see, typescript warns us that the new network is missing chainId, name and hubUrl
<img width="500" alt="image" src="https://user-images.githubusercontent.com/20520102/199118043-1640cb46-a1d8-4847-9a22-5b4d4ec0bb99.png">
