### PR TITLE
[CS-4816]: Add supportedNetworks helpers on sdk

### DIFF
--- a/packages/cardpay-sdk/index.ts
+++ b/packages/cardpay-sdk/index.ts
@@ -52,4 +52,4 @@ export { default as Web3Provider } from './providers/web3-provider';
 export { MIN_PAYMENT_AMOUNT_IN_SPEND as MIN_PAYMENT_AMOUNT_IN_SPEND__PREFER_ON_CHAIN_WHEN_POSSIBLE } from './sdk/do-not-use-on-chain-constants';
 export { protocolVersions } from './contracts/addresses';
 export { gasPriceInToken } from './sdk/utils/conversions';
-export { getConfigByNetwork } from './sdk/network-config-utils';
+export { getWeb3ConfigByNetwork } from './sdk/network-config-utils';

--- a/packages/cardpay-sdk/index.ts
+++ b/packages/cardpay-sdk/index.ts
@@ -52,4 +52,4 @@ export { default as Web3Provider } from './providers/web3-provider';
 export { MIN_PAYMENT_AMOUNT_IN_SPEND as MIN_PAYMENT_AMOUNT_IN_SPEND__PREFER_ON_CHAIN_WHEN_POSSIBLE } from './sdk/do-not-use-on-chain-constants';
 export { protocolVersions } from './contracts/addresses';
 export { gasPriceInToken } from './sdk/utils/conversions';
-export { getWeb3ConfigByNetwork } from './sdk/network-config-utils';
+export * from './sdk/network-config-utils';

--- a/packages/cardpay-sdk/index.ts
+++ b/packages/cardpay-sdk/index.ts
@@ -27,15 +27,7 @@ export type { TransactionOptions } from './sdk/utils/general-utils';
 
 export { viewSafe } from './sdk/safes';
 export { getAddress, getAddressByNetwork, getOracle, getOracleByNetwork } from './contracts/addresses';
-export {
-  getConstant,
-  getConstantByNetwork,
-  networks,
-  networkIds,
-  CARDWALLET_SCHEME,
-  MERCHANT_PAYMENT_UNIVERSAL_LINK_HOSTNAME,
-  MERCHANT_PAYMENT_UNIVERSAL_LINK_STAGING_HOSTNAME,
-} from './sdk/constants';
+export * from './sdk/constants';
 export {
   waitForTransactionConsistency,
   waitUntilBlock,
@@ -60,3 +52,4 @@ export { default as Web3Provider } from './providers/web3-provider';
 export { MIN_PAYMENT_AMOUNT_IN_SPEND as MIN_PAYMENT_AMOUNT_IN_SPEND__PREFER_ON_CHAIN_WHEN_POSSIBLE } from './sdk/do-not-use-on-chain-constants';
 export { protocolVersions } from './contracts/addresses';
 export { gasPriceInToken } from './sdk/utils/conversions';
+export { getConfigByNetwork } from './sdk/network-config-utils';

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -2,6 +2,7 @@ import Web3 from 'web3';
 import invert from 'lodash/invert';
 import { networkName } from './utils/general-utils';
 import JsonRpcProvider from '../providers/json-rpc-provider';
+import { pullAll } from 'lodash';
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
@@ -12,6 +13,12 @@ export const CARDWALLET_SCHEME = 'cardwallet';
 type NestedKeyOf<Obj extends object> = {
   [K in keyof Obj]: Obj[K] extends object ? NestedKeyOf<Obj[K]> : K;
 }[keyof Obj];
+
+export const ethereumNetworks = ['mainnet', 'goerli', 'kovan'];
+export const gnosisNetworks = ['gnosis', 'sokol', 'xdai'];
+export const polygonNetworks = ['polygon', 'mumbai'];
+
+export const deprecatedNetworks = ['kovan', 'xdai'];
 
 const testHubUrl = {
   hubUrl: 'https://hub-staging.stack.cards',
@@ -160,7 +167,7 @@ const constants: Record<Networks, NetworkContants> = {
   ...networksConstants,
 } as const;
 
-const networkNames = Object.keys(constants);
+export const networkNames = Object.keys(constants);
 
 export const networkIds: Record<string, number> = Object.freeze(
   networkNames.reduce(
@@ -174,6 +181,8 @@ export const networkIds: Record<string, number> = Object.freeze(
 
 // invert the networkIds object, so { mainnet: 1, ... } becomes { '1': 'mainnet', ... }
 export const networks = invert(networkIds);
+
+export const supportedChains = pullAll(networkNames, deprecatedNetworks);
 
 export function getConstantByNetwork<K extends ConstantKeys>(name: K, network: Networks | string) {
   let value = constants[network as Networks][name];

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -2,7 +2,6 @@ import Web3 from 'web3';
 import invert from 'lodash/invert';
 import { networkName } from './utils/general-utils';
 import JsonRpcProvider from '../providers/json-rpc-provider';
-import { pullAll } from 'lodash';
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
@@ -14,11 +13,11 @@ type NestedKeyOf<Obj extends object> = {
   [K in keyof Obj]: Obj[K] extends object ? NestedKeyOf<Obj[K]> : K;
 }[keyof Obj];
 
-export const ethereumNetworks = ['mainnet', 'goerli', 'kovan'];
-export const gnosisNetworks = ['gnosis', 'sokol', 'xdai'];
-export const polygonNetworks = ['polygon', 'mumbai'];
-
-export const deprecatedNetworks = ['kovan', 'xdai'];
+export const supportedChains = {
+  ethereum: ['mainnet', 'goerli'],
+  gnosis: ['gnosis', 'sokol'],
+  polygon: ['polygon', 'mumbai'],
+};
 
 const testHubUrl = {
   hubUrl: 'https://hub-staging.stack.cards',
@@ -137,7 +136,7 @@ const networksConstants = {
 
 type NetworksType = typeof networksConstants;
 
-type Networks = keyof NetworksType | 'xdai';
+export type Networks = keyof NetworksType | 'xdai';
 
 type ConstantKeys = NestedKeyOf<NetworksType>;
 
@@ -181,8 +180,6 @@ export const networkIds: Record<string, number> = Object.freeze(
 
 // invert the networkIds object, so { mainnet: 1, ... } becomes { '1': 'mainnet', ... }
 export const networks = invert(networkIds);
-
-export const supportedChains = pullAll(networkNames, deprecatedNetworks);
 
 export function getConstantByNetwork<K extends ConstantKeys>(name: K, network: Networks | string) {
   let value = constants[network as Networks][name];

--- a/packages/cardpay-sdk/sdk/hub-config.ts
+++ b/packages/cardpay-sdk/sdk/hub-config.ts
@@ -1,4 +1,4 @@
-interface HubConfigResponse {
+export interface HubConfigResponse {
   web3: Web3HubConfig;
 }
 interface Web3HubConfig {

--- a/packages/cardpay-sdk/sdk/network-config-utils.ts
+++ b/packages/cardpay-sdk/sdk/network-config-utils.ts
@@ -1,12 +1,19 @@
-import { ethereumNetworks, gnosisNetworks, networkIds, polygonNetworks } from './constants';
+import { supportedChains, Networks, networks } from './constants';
 import { HubConfigResponse } from './hub-config';
 
-export const getWeb3ConfigByNetwork = (config: HubConfigResponse, network: string | number) => {
-  const networkName = (typeof network === 'number' ? networkIds[network] : network) as string;
+type Networkish = string | number | Networks;
 
-  if (ethereumNetworks.includes(networkName)) return config.web3.ethereum;
-  if (gnosisNetworks.includes(networkName)) return config.web3.gnosis;
-  if (polygonNetworks.includes(networkName)) return config.web3.polygon;
+const convertChainIdToName = (network: Networkish) => (typeof network === 'number' ? networks[network] : network);
 
-  return { rpcNodeWssUrl: '', rpcNodeHttpsUrl: '' };
+export const getWeb3ConfigByNetwork = (config: HubConfigResponse, network: Networkish) => {
+  const networkName = convertChainIdToName(network);
+
+  if (supportedChains.ethereum.includes(networkName)) return config.web3.ethereum;
+  if (supportedChains.gnosis.includes(networkName)) return config.web3.gnosis;
+  if (supportedChains.polygon.includes(networkName)) return config.web3.polygon;
+
+  throw new Error(`Unsupported network: ${network}`);
 };
+
+export const isSupportedChain = (network: Networkish) =>
+  Object.values(supportedChains).flat().includes(convertChainIdToName(network));

--- a/packages/cardpay-sdk/sdk/network-config-utils.ts
+++ b/packages/cardpay-sdk/sdk/network-config-utils.ts
@@ -1,0 +1,12 @@
+import { ethereumNetworks, gnosisNetworks, networkIds, polygonNetworks } from './constants';
+import { HubConfigResponse } from './hub-config';
+
+export const getConfigByNetwork = (config: HubConfigResponse, network: string | number) => {
+  const networkName = (typeof network === 'number' ? networkIds[network] : network) as string;
+
+  if (ethereumNetworks.includes(networkName)) return config.web3.ethereum;
+  if (gnosisNetworks.includes(networkName)) return config.web3.gnosis;
+  if (polygonNetworks.includes(networkName)) return config.web3.polygon;
+
+  return { rpcNodeWssUrl: '', rpcNodeHttpsUrl: '' };
+};

--- a/packages/cardpay-sdk/sdk/network-config-utils.ts
+++ b/packages/cardpay-sdk/sdk/network-config-utils.ts
@@ -1,7 +1,7 @@
 import { ethereumNetworks, gnosisNetworks, networkIds, polygonNetworks } from './constants';
 import { HubConfigResponse } from './hub-config';
 
-export const getConfigByNetwork = (config: HubConfigResponse, network: string | number) => {
+export const getWeb3ConfigByNetwork = (config: HubConfigResponse, network: string | number) => {
   const networkName = (typeof network === 'number' ? networkIds[network] : network) as string;
 
   if (ethereumNetworks.includes(networkName)) return config.web3.ethereum;

--- a/packages/cardpay-sdk/tests/network-config-utils-test.ts
+++ b/packages/cardpay-sdk/tests/network-config-utils-test.ts
@@ -1,0 +1,52 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+import { HubConfigResponse } from '../sdk/hub-config';
+import { getWeb3ConfigByNetwork } from '../sdk/network-config-utils';
+
+chai.use(chaiAsPromised);
+
+const mockedConfig = {
+  web3: {
+    gnosis: {
+      rpcNodeHttpsUrl: 'gnosisHttpsRpc',
+      rpcNodeWssUrl: 'gnosisWssRpc',
+    },
+    ethereum: {
+      rpcNodeHttpsUrl: 'ethHttpsRpc',
+      rpcNodeWssUrl: 'ethWssRpc',
+    },
+    polygon: {
+      rpcNodeHttpsUrl: 'polygonHttpsssRpc',
+      rpcNodeWssUrl: 'polygonWssRpc',
+    },
+  },
+} as HubConfigResponse;
+
+describe('getWeb3ConfigByNetwork', () => {
+  it('should return ethereum config for mainnet', () => {
+    const config = getWeb3ConfigByNetwork(mockedConfig, 'mainnet');
+
+    chai.expect(config).to.eq(mockedConfig.web3.ethereum);
+  });
+  it('should return polygon config for mumbai', () => {
+    const config = getWeb3ConfigByNetwork(mockedConfig, 'mumbai');
+
+    chai.expect(config).to.eq(mockedConfig.web3.polygon);
+  });
+  it('should return gnosis config for gnosis', () => {
+    const config = getWeb3ConfigByNetwork(mockedConfig, 'gnosis');
+
+    chai.expect(config).to.eq(mockedConfig.web3.gnosis);
+  });
+  it('should return polygon config for polygon', () => {
+    const config = getWeb3ConfigByNetwork(mockedConfig, 'polygon');
+
+    chai.expect(config).to.eq(mockedConfig.web3.polygon);
+  });
+  it('should return empty for non-supported network', () => {
+    const config = getWeb3ConfigByNetwork(mockedConfig, 'foo');
+
+    chai.expect(config).to.deep.eq({ rpcNodeWssUrl: '', rpcNodeHttpsUrl: '' });
+  });
+});

--- a/packages/hub/services/scheduled-payments/executor.ts
+++ b/packages/hub/services/scheduled-payments/executor.ts
@@ -5,11 +5,11 @@ import shortUUID from 'short-uuid';
 import { nowUtc } from '../../utils/dates';
 import config from 'config';
 import { Wallet } from 'ethers';
-import { JsonRpcProvider, gasPriceInToken, getConfigByNetwork, networks } from '@cardstack/cardpay-sdk';
+import { JsonRpcProvider, gasPriceInToken, getWeb3ConfigByNetwork, networks } from '@cardstack/cardpay-sdk';
 import { supportedChains } from '@cardstack/cardpay-sdk/sdk/constants';
 
 export const getHttpRpcUrlByChain = (chainId: number) =>
-  getConfigByNetwork(config.get('web3'), chainId)?.rpcNodeHttpsUrl;
+  getWeb3ConfigByNetwork(config.get('web3'), chainId)?.rpcNodeHttpsUrl;
 
 export const isSupportedChain = (chainId: number) => supportedChains.includes(networks[chainId]);
 

--- a/packages/hub/services/scheduled-payments/executor.ts
+++ b/packages/hub/services/scheduled-payments/executor.ts
@@ -5,18 +5,10 @@ import shortUUID from 'short-uuid';
 import { nowUtc } from '../../utils/dates';
 import config from 'config';
 import { Wallet } from 'ethers';
-import {
-  JsonRpcProvider,
-  gasPriceInToken,
-  getWeb3ConfigByNetwork,
-  networks,
-  supportedChains,
-} from '@cardstack/cardpay-sdk';
+import { JsonRpcProvider, gasPriceInToken, getWeb3ConfigByNetwork } from '@cardstack/cardpay-sdk';
 
 export const getHttpRpcUrlByChain = (chainId: number) =>
   getWeb3ConfigByNetwork(config.get('web3'), chainId)?.rpcNodeHttpsUrl;
-
-export const isSupportedChain = (chainId: number) => supportedChains.includes(networks[chainId]);
 
 export default class ScheduledPaymentsExecutorService {
   prismaManager = inject('prisma-manager', { as: 'prismaManager' });

--- a/packages/hub/services/scheduled-payments/executor.ts
+++ b/packages/hub/services/scheduled-payments/executor.ts
@@ -5,40 +5,13 @@ import shortUUID from 'short-uuid';
 import { nowUtc } from '../../utils/dates';
 import config from 'config';
 import { Wallet } from 'ethers';
-import { JsonRpcProvider, gasPriceInToken } from '@cardstack/cardpay-sdk';
+import { JsonRpcProvider, gasPriceInToken, getConfigByNetwork, networks } from '@cardstack/cardpay-sdk';
+import { supportedChains } from '@cardstack/cardpay-sdk/sdk/constants';
 
-export let supportedChains = [
-  {
-    id: 1,
-    name: 'ethereum',
-    rpcUrl: config.get('web3.ethereum.rpcNodeHttpsUrl'),
-  },
-  {
-    id: 5,
-    name: 'goerli',
-    rpcUrl: config.get('web3.ethereum.rpcNodeHttpsUrl'),
-  },
-  {
-    id: 100,
-    name: 'gnosis',
-    rpcUrl: config.get('web3.gnosis.rpcNodeHttpsUrl'),
-  },
-  {
-    id: 77,
-    name: 'sokol',
-    rpcUrl: config.get('web3.gnosis.rpcNodeHttpsUrl'),
-  },
-  {
-    id: 137,
-    name: 'polygon',
-    rpcUrl: config.get('web3.polygon.rpcNodeHttpsUrl'),
-  },
-  {
-    id: 80001,
-    name: 'mumbai',
-    rpcUrl: config.get('web3.polygon.rpcNodeHttpsUrl'),
-  },
-];
+export const getHttpRpcUrlByChain = (chainId: number) =>
+  getConfigByNetwork(config.get('web3'), chainId)?.rpcNodeHttpsUrl;
+
+export const isSupportedChain = (chainId: number) => supportedChains.includes(networks[chainId]);
 
 export default class ScheduledPaymentsExecutorService {
   prismaManager = inject('prisma-manager', { as: 'prismaManager' });
@@ -52,7 +25,7 @@ export default class ScheduledPaymentsExecutorService {
   }
 
   async executePayment(scheduledPayment: ScheduledPayment) {
-    let rpcUrl = supportedChains.find((chain) => chain.id === scheduledPayment.chainId)?.rpcUrl as string;
+    let rpcUrl = getHttpRpcUrlByChain(scheduledPayment.chainId);
     let provider = new JsonRpcProvider(rpcUrl, scheduledPayment.chainId);
     let signer = new Wallet(config.get('hubPrivateKey'));
     let scheduledPaymentModule = await this.cardpay.getSDK('ScheduledPaymentModule', provider, signer);

--- a/packages/hub/services/scheduled-payments/executor.ts
+++ b/packages/hub/services/scheduled-payments/executor.ts
@@ -5,8 +5,13 @@ import shortUUID from 'short-uuid';
 import { nowUtc } from '../../utils/dates';
 import config from 'config';
 import { Wallet } from 'ethers';
-import { JsonRpcProvider, gasPriceInToken, getWeb3ConfigByNetwork, networks } from '@cardstack/cardpay-sdk';
-import { supportedChains } from '@cardstack/cardpay-sdk/sdk/constants';
+import {
+  JsonRpcProvider,
+  gasPriceInToken,
+  getWeb3ConfigByNetwork,
+  networks,
+  supportedChains,
+} from '@cardstack/cardpay-sdk';
 
 export const getHttpRpcUrlByChain = (chainId: number) =>
   getWeb3ConfigByNetwork(config.get('web3'), chainId)?.rpcNodeHttpsUrl;

--- a/packages/hub/services/validators/scheduled-payment.ts
+++ b/packages/hub/services/validators/scheduled-payment.ts
@@ -1,7 +1,7 @@
 import Web3 from 'web3';
 import { ScheduledPayment } from '@prisma/client';
 import { startCase } from 'lodash';
-import { isSupportedChain } from '../scheduled-payments/executor';
+import { isSupportedChain } from '@cardstack/cardpay-sdk';
 const { isAddress } = Web3.utils;
 
 type ScheduledPaymentAttribute =

--- a/packages/hub/services/validators/scheduled-payment.ts
+++ b/packages/hub/services/validators/scheduled-payment.ts
@@ -1,7 +1,7 @@
 import Web3 from 'web3';
 import { ScheduledPayment } from '@prisma/client';
 import { startCase } from 'lodash';
-import { supportedChains } from '../scheduled-payments/executor';
+import { isSupportedChain } from '../scheduled-payments/executor';
 const { isAddress } = Web3.utils;
 
 type ScheduledPaymentAttribute =
@@ -86,7 +86,7 @@ export default class ScheduledPaymentValidator {
       }
     }
 
-    if (scheduledPayment.chainId && supportedChains.map((c) => c.id).indexOf(scheduledPayment.chainId) === -1) {
+    if (scheduledPayment.chainId && !isSupportedChain(scheduledPayment.chainId)) {
       errors.chainId.push(`chain is not supported`);
     }
 

--- a/packages/hub/tasks/scheduled-payment-on-chain-creation-waiter.ts
+++ b/packages/hub/tasks/scheduled-payment-on-chain-creation-waiter.ts
@@ -2,7 +2,7 @@ import { JsonRpcProvider } from '@cardstack/cardpay-sdk';
 import { inject } from '@cardstack/di';
 import * as Sentry from '@sentry/node';
 import { isBefore, subDays } from 'date-fns';
-import { supportedChains } from '../services/scheduled-payments/executor';
+import { getHttpRpcUrlByChain } from '../services/scheduled-payments/executor';
 
 export default class ScheduledPaymentOnChainCreationWaiter {
   prismaManager = inject('prisma-manager', { as: 'prismaManager' });
@@ -14,7 +14,7 @@ export default class ScheduledPaymentOnChainCreationWaiter {
       where: { id: payload.scheduledPaymentId },
     });
 
-    let rpcUrl = supportedChains.find((chain) => chain.id === scheduledPayment.chainId)?.rpcUrl as string;
+    let rpcUrl = getHttpRpcUrlByChain(scheduledPayment.chainId);
     let provider = new JsonRpcProvider(rpcUrl, scheduledPayment.chainId);
     let scheduledPaymentModule = await this.cardpay.getSDK('ScheduledPaymentModule', provider);
 

--- a/packages/hub/tasks/scheduled-payment-on-chain-execution-waiter.ts
+++ b/packages/hub/tasks/scheduled-payment-on-chain-execution-waiter.ts
@@ -1,7 +1,7 @@
 import { JsonRpcProvider } from '@cardstack/cardpay-sdk';
 import { inject } from '@cardstack/di';
 import { isBefore, subDays } from 'date-fns';
-import { supportedChains } from '../services/scheduled-payments/executor';
+import { getHttpRpcUrlByChain } from '../services/scheduled-payments/executor';
 
 import { nowUtc } from '../utils/dates';
 
@@ -24,7 +24,7 @@ export default class ScheduledPaymentOnChainExecutionWaiter {
     let scheduledPayment = await prisma.scheduledPayment.findFirstOrThrow({
       where: { id: paymentAttempt.scheduledPaymentId },
     });
-    let rpcUrl = supportedChains.find((chain) => chain.id === scheduledPayment.chainId)?.rpcUrl as string;
+    let rpcUrl = getHttpRpcUrlByChain(scheduledPayment.chainId);
     let provider = new JsonRpcProvider(rpcUrl, scheduledPayment.chainId);
     let scheduledPaymentModule = await this.cardpay.getSDK('ScheduledPaymentModule', provider);
 


### PR DESCRIPTION
This PR adds the supported networks and a helper to get the correct config, it also replaces the schedule payment usage. The same function will be used on the safe-tools to match the networks.