### PR TITLE
hub: Add data integrity checks for scheduled payments

### DIFF
--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -97,6 +97,7 @@ import ScheduledPaymentSerializer from './services/serializers/scheduled-payment
 import ScheduledPaymentValidator from './services/validators/scheduled-payment';
 import ScheduledPaymentsRoute from './routes/scheduled-payments';
 import ScheduledPaymentsExecutorService from './services/scheduled-payments/executor';
+import DataIntegrityChecksScheduledPayments from './services/data-integrity-checks/scheduled-payments';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -181,6 +182,7 @@ export function createRegistry(): Registry {
   registry.register('scheduled-payment-serializer', ScheduledPaymentSerializer);
   registry.register('scheduled-payment-validator', ScheduledPaymentValidator);
   registry.register('scheduled-payments-route', ScheduledPaymentsRoute);
+  registry.register('data-integrity-checks-scheduled-payments', DataIntegrityChecksScheduledPayments);
 
   if (process.env.COMPILER) {
     registry.register(

--- a/packages/hub/node-tests/services/data-integrity-checks-test.ts
+++ b/packages/hub/node-tests/services/data-integrity-checks-test.ts
@@ -1,0 +1,259 @@
+import { setupHub } from '../helpers/server';
+import { nowUtc } from '../../utils/dates';
+import { ExtendedPrismaClient } from '../../services/prisma-manager';
+import { subMinutes } from 'date-fns';
+import DataIntegrityChecksScheduledPayments, {
+  CREATION_UNMINED_ALLOWED_MINUTES,
+  CREATION_WITHOUT_TX_HASH_ALLOWED_MINUTES,
+  CANCELATION_WITHOUT_TX_HASH_ALLOWED_MINUTES,
+  CANCELATION_UNMINED_ALLOWED_MINUTES,
+} from '../../services/data-integrity-checks/scheduled-payments';
+import shortUuid from 'short-uuid';
+
+describe('data integrity checks', function () {
+  let prisma: ExtendedPrismaClient;
+
+  let { getPrisma, getContainer } = setupHub(this);
+
+  this.beforeEach(async function () {
+    prisma = await getPrisma();
+  });
+
+  describe('scheduled payments', function () {
+    let service: DataIntegrityChecksScheduledPayments;
+
+    this.beforeEach(async function () {
+      service = await getContainer().lookup('data-integrity-checks-scheduled-payments');
+    });
+
+    it('returns a degraded check when there are scheduled payments that should have a creation transaction hash or should be mined by now', async function () {
+      let sp1 = await prisma.scheduledPayment.create({
+        data: {
+          id: shortUuid.uuid(),
+          senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+          moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+          tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+          gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+          amount: '100',
+          payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+          executionGasEstimation: 100000,
+          maxGasPrice: '1000000000',
+          feeFixedUsd: '0',
+          feePercentage: '0',
+          salt: '54lt',
+          payAt: nowUtc(),
+          spHash: '0x123',
+          chainId: 1,
+          userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+          creationTransactionHash: null,
+          createdAt: subMinutes(nowUtc(), CREATION_WITHOUT_TX_HASH_ALLOWED_MINUTES + 1),
+        },
+      });
+
+      let sp2 = await prisma.scheduledPayment.create({
+        data: {
+          id: shortUuid.uuid(),
+          senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+          moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+          tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+          gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+          amount: '100',
+          payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+          executionGasEstimation: 100000,
+          maxGasPrice: '1000000000',
+          feeFixedUsd: '0',
+          feePercentage: '0',
+          salt: '54lt',
+          payAt: nowUtc(),
+          spHash: '0x1234',
+          chainId: 1,
+          userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+          creationTransactionHash: '0x123',
+          createdAt: subMinutes(nowUtc(), CREATION_UNMINED_ALLOWED_MINUTES + 1),
+        },
+      });
+
+      let result = await service.check();
+
+      expect(result).to.deep.equal({
+        status: 'degraded',
+        name: 'scheduled-payments',
+        message: `scheduled payments without creationTransactionHash: ${sp1.id}; scheduled payment creations that should be mined by now: ${sp2.id}`,
+      });
+    });
+
+    it('returns a degraded check when there are scheduled payments that should have a deletion transaction hash or should be mined by now', async function () {
+      let sp1 = await prisma.scheduledPayment.create({
+        data: {
+          id: shortUuid.uuid(),
+          senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+          moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+          tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+          gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+          amount: '100',
+          payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+          executionGasEstimation: 100000,
+          maxGasPrice: '1000000000',
+          feeFixedUsd: '0',
+          feePercentage: '0',
+          salt: '54lt',
+          payAt: nowUtc(),
+          spHash: '0x123',
+          chainId: 1,
+          userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+          cancelationTransactionHash: null,
+          canceledAt: subMinutes(nowUtc(), CANCELATION_WITHOUT_TX_HASH_ALLOWED_MINUTES + 1),
+        },
+      });
+
+      let sp2 = await prisma.scheduledPayment.create({
+        data: {
+          id: shortUuid.uuid(),
+          senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+          moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+          tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+          gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+          amount: '100',
+          payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+          executionGasEstimation: 100000,
+          maxGasPrice: '1000000000',
+          feeFixedUsd: '0',
+          feePercentage: '0',
+          salt: '54lt',
+          payAt: nowUtc(),
+          spHash: '0x1234',
+          chainId: 1,
+          userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+          cancelationTransactionHash: '0x123',
+          canceledAt: subMinutes(nowUtc(), CANCELATION_UNMINED_ALLOWED_MINUTES + 1),
+        },
+      });
+
+      let result = await service.check();
+
+      expect(result).to.deep.equal({
+        status: 'degraded',
+        name: 'scheduled-payments',
+        message: `scheduled payments without cancelationTransactionHash: ${sp1.id}; scheduled payment cancelations that should be mined by now: ${sp2.id}`,
+      });
+    });
+
+    it('returns a degraded check when there are unattempted scheduled payments', async function () {
+      let sp1 = await prisma.scheduledPayment.create({
+        data: {
+          id: shortUuid.uuid(),
+          senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+          moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+          tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+          gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+          amount: '100',
+          payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+          executionGasEstimation: 100000,
+          maxGasPrice: '1000000000',
+          feeFixedUsd: '0',
+          feePercentage: '0',
+          salt: '54lt',
+          payAt: subMinutes(nowUtc(), 61),
+          spHash: '0x123',
+          chainId: 1,
+          userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+          creationTransactionHash: '0x123',
+        },
+      });
+
+      let result = await service.check();
+
+      expect(result).to.deep.equal({
+        status: 'degraded',
+        name: 'scheduled-payments',
+        message: `scheduled payments that should have been attempted by now: ${sp1.id}`,
+      });
+    });
+
+    it('returns a degraded check when there are stuck payment attempts', async function () {
+      let sp = await prisma.scheduledPayment.create({
+        data: {
+          id: shortUuid.uuid(),
+          senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+          moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+          tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+          gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+          amount: '100',
+          payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+          executionGasEstimation: 100000,
+          maxGasPrice: '1000000000',
+          feeFixedUsd: '0',
+          feePercentage: '0',
+          salt: '54lt',
+          payAt: subMinutes(nowUtc(), 60 * 24),
+          spHash: '0x123',
+          chainId: 1,
+          userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+          creationTransactionHash: '0x123',
+        },
+      });
+
+      let spa = await prisma.scheduledPaymentAttempt.create({
+        data: {
+          id: shortUuid.uuid(),
+          startedAt: subMinutes(nowUtc(), 60 * 24),
+          endedAt: null,
+          status: 'inProgress',
+          scheduledPaymentId: sp.id,
+          transactionHash: '0x123',
+        },
+      });
+
+      let result = await service.check();
+
+      expect(result).to.deep.equal({
+        status: 'degraded',
+        name: 'scheduled-payments',
+        message: `stuck scheduled payment attempts: ${spa.id}`,
+      });
+    });
+
+    it('returns a degraded check when there are payment attempts without transaction hash', async function () {
+      let sp = await prisma.scheduledPayment.create({
+        data: {
+          id: shortUuid.uuid(),
+          senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+          moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+          tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+          gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+          amount: '100',
+          payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+          executionGasEstimation: 100000,
+          maxGasPrice: '1000000000',
+          feeFixedUsd: '0',
+          feePercentage: '0',
+          salt: '54lt',
+          payAt: subMinutes(nowUtc(), 60 * 24),
+          spHash: '0x123',
+          chainId: 1,
+          userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+          creationTransactionHash: '0x123',
+        },
+      });
+
+      let spa = await prisma.scheduledPaymentAttempt.create({
+        data: {
+          id: shortUuid.uuid(),
+          startedAt: subMinutes(nowUtc(), 60),
+          endedAt: null,
+          status: 'inProgress',
+          scheduledPaymentId: sp.id,
+          transactionHash: null,
+        },
+      });
+
+      let result = await service.check();
+
+      expect(result).to.deep.equal({
+        status: 'degraded',
+        name: 'scheduled-payments',
+        message: `scheduled payment attempts without transaction hash: ${spa.id}`,
+      });
+    });
+  });
+});

--- a/packages/hub/services/data-integrity-checks/scheduled-payments.ts
+++ b/packages/hub/services/data-integrity-checks/scheduled-payments.ts
@@ -1,0 +1,167 @@
+import { inject } from '@cardstack/di';
+import { subMinutes } from 'date-fns';
+import { nowUtc } from '../../utils/dates';
+
+export const CREATION_WITHOUT_TX_HASH_ALLOWED_MINUTES = 2;
+export const CREATION_UNMINED_ALLOWED_MINUTES = 3 * 60;
+export const CANCELATION_WITHOUT_TX_HASH_ALLOWED_MINUTES = CREATION_WITHOUT_TX_HASH_ALLOWED_MINUTES;
+export const CANCELATION_UNMINED_ALLOWED_MINUTES = CREATION_UNMINED_ALLOWED_MINUTES;
+export const UNATTEMPTED_ALLOWED_MINUTES = 24 * 60;
+export const ATTEMPTS_WITHOUT_TX_HASH_ALLOWED_MINUTES = 60;
+export const UNFINISHED_ATTEMPT_DURATION_ALLOWED_MINUTES = 24 * 60;
+
+function addToMessages(collection: any, message: string, messages: string[]) {
+  if (collection.length == 0) return;
+
+  messages.push(`${message}: ${collection.map((item: any) => item.id).join(', ')}`);
+}
+
+interface IntegrityCheckResult {
+  name: string;
+  status: 'degraded' | 'operational';
+  message: string | null;
+}
+
+export default class DataIntegrityChecksScheduledPayments {
+  prismaManager = inject('prisma-manager', { as: 'prismaManager' });
+
+  async check(): Promise<IntegrityCheckResult> {
+    let prisma = await this.prismaManager.getClient();
+
+    // This can happen if the SDK call to create a scheduled payment fails somewhere in the middle of the process (i.e. the new
+    // scheduled payment is created in the DB but something went wrong when submitting the transaction to the blockchain)
+    let scheduledPaymentsWithoutCreationTxHash = await prisma.scheduledPayment.findMany({
+      where: {
+        creationTransactionHash: null,
+        createdAt: {
+          lt: subMinutes(nowUtc(), CREATION_WITHOUT_TX_HASH_ALLOWED_MINUTES),
+        },
+      },
+    });
+
+    // Blockchain transaction to register a scheduled payment was submitted but it's still unmined after a while.
+    // Unsure why this would happen but it needs to be investigated if it happens (gas price too low to compete?)
+    let unminedScheduledPaymentCreations = await prisma.scheduledPayment.findMany({
+      where: {
+        creationBlockNumber: null,
+        createdAt: {
+          lt: subMinutes(nowUtc(), CREATION_UNMINED_ALLOWED_MINUTES),
+        },
+        creationTransactionError: null,
+      },
+    });
+
+    // Similarly as above, but for the cancelation transaction.
+    let scheduledPaymentsWithoutCancelationTxHash = await prisma.scheduledPayment.findMany({
+      where: {
+        cancelationTransactionHash: null,
+        canceledAt: {
+          lt: subMinutes(nowUtc(), CANCELATION_WITHOUT_TX_HASH_ALLOWED_MINUTES),
+        },
+      },
+    });
+
+    // Similarly as above, but for the cancelation transaction.
+    let unminedScheduledPaymentCancelations = await prisma.scheduledPayment.findMany({
+      where: {
+        cancelationBlockNumber: null,
+        canceledAt: {
+          lt: subMinutes(nowUtc(), CANCELATION_UNMINED_ALLOWED_MINUTES),
+        },
+        creationTransactionError: null,
+      },
+    });
+
+    // Scheduled payment was due to be executed but it wasn't attempted on time
+    // This can happen if the scheduler worker is not running or if the scheduled payment fetcher is not working properly.
+    let unattemptedScheduledPayments = await prisma.scheduledPayment.findMany({
+      where: {
+        payAt: {
+          lt: subMinutes(nowUtc(), 60),
+          gt: subMinutes(nowUtc(), UNATTEMPTED_ALLOWED_MINUTES),
+        },
+        scheduledPaymentAttempts: {
+          none: {
+            startedAt: {
+              gt: subMinutes(nowUtc(), UNATTEMPTED_ALLOWED_MINUTES),
+            },
+          },
+        },
+      },
+    });
+
+    // Scheduled payment was attempted but the transaction hash was not recorded. It can indicate a problem in the executePayment
+    // where we submit the transaction to the blockchain.
+    let scheduledPaymentAttemptsWithoutTxHash = await prisma.scheduledPaymentAttempt.findMany({
+      where: {
+        startedAt: {
+          lte: subMinutes(nowUtc(), ATTEMPTS_WITHOUT_TX_HASH_ALLOWED_MINUTES),
+        },
+        transactionHash: null,
+        status: 'inProgress',
+      },
+    });
+
+    // Scheduled payment was attempted but the attempt is taking too long to finish. This can happen if the transaction is stuck
+    // for some reason (i.e. gas price too low to compete). Needs to be investigated if this happens.
+    let stuckScheduledPaymentAttempts = await prisma.scheduledPaymentAttempt.findMany({
+      where: {
+        startedAt: {
+          lte: subMinutes(nowUtc(), UNFINISHED_ATTEMPT_DURATION_ALLOWED_MINUTES),
+        },
+        endedAt: null,
+      },
+    });
+
+    let errorMessages: string[] = [];
+
+    addToMessages(
+      scheduledPaymentsWithoutCreationTxHash,
+      'scheduled payments without creationTransactionHash',
+      errorMessages
+    );
+    addToMessages(
+      unminedScheduledPaymentCreations,
+      'scheduled payment creations that should be mined by now',
+      errorMessages
+    );
+
+    addToMessages(
+      scheduledPaymentsWithoutCancelationTxHash,
+      'scheduled payments without cancelationTransactionHash',
+      errorMessages
+    );
+
+    addToMessages(
+      unminedScheduledPaymentCancelations,
+      'scheduled payment cancelations that should be mined by now',
+      errorMessages
+    );
+
+    addToMessages(
+      unattemptedScheduledPayments,
+      'scheduled payments that should have been attempted by now',
+      errorMessages
+    );
+
+    addToMessages(stuckScheduledPaymentAttempts, 'stuck scheduled payment attempts', errorMessages);
+
+    addToMessages(
+      scheduledPaymentAttemptsWithoutTxHash,
+      'scheduled payment attempts without transaction hash',
+      errorMessages
+    );
+
+    return {
+      name: 'scheduled-payments',
+      status: errorMessages.length > 0 ? 'degraded' : 'operational',
+      message: errorMessages.length > 0 ? errorMessages.join('; ') : null,
+    };
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'data-integrity-checks-scheduled-payments': DataIntegrityChecksScheduledPayments;
+  }
+}


### PR DESCRIPTION
Ticket: CS-4383

This PR introduces the first batch of checks that will be run periodically (by Checkly, which will send alerts to our Discord) and will tell us if there are problematic scheduled payments that need manual inspection or troubleshooting. 

Here are 7 checks that tell us:

1. Are there scheduled payments without creation transaction hash? It means something went wrong with the SDK call to create a scheduled payment.
2. Are there scheduled payments without creation block number? It means the worker that waits for the mined creation transaction isn't functioning or the transaction is stuck 
3. Same as (1) but for cancelation
4. Same as (2) but for cancelation
5. Are there scheduled payments that should be attempted but they weren't? It could indicate the executor is not picking them up
6. Are there scheduled payments without tx hash? It means something went wrong when trying to submit the transaction
7. Are there attempts that are stuck? It could mean the gas is too low to compete or something else went wrong with it - needs inspection.

The next task which will come in a separate PR will be to introduce a data integrity checks route which will respond with a result of these checks. Then we can configure Checkly to periodically query `data-integrity-checks/scheduled-payments` and send an alert if the status is degraded. 