### PR TITLE
[CS-4824]: Adds support to different chains

### DIFF
--- a/packages/cardpay-sdk/package.json
+++ b/packages/cardpay-sdk/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.3.3",
+    "@types/ember__owner": "^4.0.1",
     "@types/mocha": "^10.0.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -19,6 +19,8 @@ export const supportedChains = {
   polygon: ['polygon', 'mumbai'],
 };
 
+export const supportedChainsArray = Object.values(supportedChains).flat();
+
 const testHubUrl = {
   hubUrl: 'https://hub-staging.stack.cards',
 };

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -138,7 +138,7 @@ const networksConstants = {
 
 type NetworksType = typeof networksConstants;
 
-export type Networks = keyof NetworksType | 'xdai';
+export type Network = keyof NetworksType | 'xdai';
 
 type ConstantKeys = NestedKeyOf<NetworksType>;
 
@@ -163,7 +163,7 @@ interface RequiredNetworkConstants {
 type NetworkContants = OptionalNetworkContants & RequiredNetworkConstants;
 
 // Order matters, if both have same chainId the last one is used.
-const constants: Record<Networks, NetworkContants> = {
+const constants: Record<Network, NetworkContants> = {
   xdai: networksConstants['gnosis'],
   ...networksConstants,
 } as const;
@@ -174,7 +174,7 @@ export const networkIds: Record<string, number> = Object.freeze(
   networkNames.reduce(
     (netIds, networkName) => ({
       ...netIds,
-      [networkName]: constants[networkName as Networks].chainId,
+      [networkName]: constants[networkName as Network].chainId,
     }),
     {}
   )
@@ -183,8 +183,8 @@ export const networkIds: Record<string, number> = Object.freeze(
 // invert the networkIds object, so { mainnet: 1, ... } becomes { '1': 'mainnet', ... }
 export const networks = invert(networkIds);
 
-export function getConstantByNetwork<K extends ConstantKeys>(name: K, network: Networks | string) {
-  let value = constants[network as Networks][name];
+export function getConstantByNetwork<K extends ConstantKeys>(name: K, network: Network | string) {
+  let value = constants[network as Network][name];
   if (!value) {
     throw new Error(`Don't know about the constant '${name}' for network ${network}`);
   }
@@ -202,7 +202,7 @@ export async function getConstant<K extends ConstantKeys>(
     network = await networkName(web3OrNetworkOrEthersProvider);
   }
 
-  let value = constants[network as Networks][name];
+  let value = constants[network as Network][name];
   if (!value) {
     throw new Error(`Don't know about the constant '${name}' for network ${network}`);
   }

--- a/packages/cardpay-sdk/sdk/network-config-utils.ts
+++ b/packages/cardpay-sdk/sdk/network-config-utils.ts
@@ -1,7 +1,7 @@
-import { supportedChains, Networks, networks, supportedChainsArray } from './constants';
+import { supportedChains, Network, networks, supportedChainsArray } from './constants';
 import { HubConfigResponse } from './hub-config';
 
-type Networkish = string | number | Networks;
+type Networkish = string | number | Network;
 
 const convertChainIdToName = (network: Networkish) => (typeof network === 'number' ? networks[network] : network);
 

--- a/packages/cardpay-sdk/sdk/network-config-utils.ts
+++ b/packages/cardpay-sdk/sdk/network-config-utils.ts
@@ -1,4 +1,4 @@
-import { supportedChains, Networks, networks } from './constants';
+import { supportedChains, Networks, networks, supportedChainsArray } from './constants';
 import { HubConfigResponse } from './hub-config';
 
 type Networkish = string | number | Networks;
@@ -15,5 +15,4 @@ export const getWeb3ConfigByNetwork = (config: HubConfigResponse, network: Netwo
   throw new Error(`Unsupported network: ${network}`);
 };
 
-export const isSupportedChain = (network: Networkish) =>
-  Object.values(supportedChains).flat().includes(convertChainIdToName(network));
+export const isSupportedChain = (network: Networkish) => supportedChainsArray.includes(convertChainIdToName(network));

--- a/packages/safe-tools-client/app/controllers/schedule.ts
+++ b/packages/safe-tools-client/app/controllers/schedule.ts
@@ -5,19 +5,18 @@ import { action } from '@ember/object';
 
 import ApplicationController from '@cardstack/safe-tools-client/controllers/application';
 import WalletService from '@cardstack/safe-tools-client/services/wallet';
+import NetworkService from '@cardstack/safe-tools-client/services/network';
 
 import '../css/schedule.css';
 
 export default class Schedule extends Controller {
   @controller declare application: ApplicationController;
   @service declare wallet: WalletService;
+  @service declare network: NetworkService;
 
   // modified with set helper
   @tracked isSetupSafeModalOpen = false;
   @tracked isDepositModalOpen = false;
-
-  // TODO: replace with network service
-  @tracked network = 'ETH Mainnet';
 
   get safe() {
     //TODO: get safe info from sdk and format it,
@@ -59,22 +58,6 @@ export default class Schedule extends Controller {
     } else {
       this.isSetupSafeModalOpen = true;
     }
-  }
-
-  // TODO: get available networks from sdk, and maybe share network info ?
-  get availableNetworks() {
-    const networks = ['ETH Mainnet', 'Gnosis Chain', 'Polygon'];
-
-    const networkstWithoutSelectedOne = networks.filter(
-      (network) => network !== this.network
-    );
-
-    return networkstWithoutSelectedOne;
-  }
-
-  @action onSelectNetwork(network: string) {
-    // TODO: trigger selection on service;
-    this.network = network;
   }
 
   get scheduledPaymentsTokensToCover() {

--- a/packages/safe-tools-client/app/services/network.ts
+++ b/packages/safe-tools-client/app/services/network.ts
@@ -1,0 +1,48 @@
+import Service from '@ember/service';
+
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+import {
+  getConstantByNetwork,
+  Networks,
+  networks,
+  supportedChainsArray,
+} from '@cardstack/cardpay-sdk';
+
+const DEFAULT_NETWORK = 'mainnet' as const; // TODO: add default based on env
+
+export default class Network extends Service {
+  @tracked chainId = getConstantByNetwork('chainId', DEFAULT_NETWORK);
+  @tracked name = getConstantByNetwork('name', DEFAULT_NETWORK);
+  @tracked symbol: Networks = DEFAULT_NETWORK;
+
+  get supportedList() {
+    return supportedChainsArray
+      .map((networkSymbol) => ({
+        name: getConstantByNetwork('name', networkSymbol),
+        chainId: getConstantByNetwork('chainId', networkSymbol),
+        symbol: networkSymbol,
+      }))
+      .filter(({ name }) => name !== this.name);
+  }
+
+  @action onSelect({ chainId, symbol, name }: Network) {
+    this.name = name;
+    this.symbol = symbol;
+    this.chainId = chainId;
+  }
+
+  @action onChainChanged(chainId: number) {
+    const symbol = networks[chainId];
+    const name = getConstantByNetwork('name', symbol);
+
+    this.onSelect({ chainId, symbol, name } as Network);
+  }
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    network: Network;
+  }
+}

--- a/packages/safe-tools-client/app/services/network.ts
+++ b/packages/safe-tools-client/app/services/network.ts
@@ -5,7 +5,7 @@ import { tracked } from '@glimmer/tracking';
 
 import {
   getConstantByNetwork,
-  Networks,
+  Network,
   networks,
   supportedChainsArray,
 } from '@cardstack/cardpay-sdk';
@@ -13,7 +13,7 @@ import {
 interface NetworkInfo {
   chainId: number;
   name: string;
-  symbol: Networks;
+  symbol: Network;
 }
 const DEFAULT_NETWORK = 'mainnet' as const; // TODO: add default based on env
 

--- a/packages/safe-tools-client/app/services/network.ts
+++ b/packages/safe-tools-client/app/services/network.ts
@@ -10,12 +10,19 @@ import {
   supportedChainsArray,
 } from '@cardstack/cardpay-sdk';
 
+interface NetworkInfo {
+  chainId: number;
+  name: string;
+  symbol: Networks;
+}
 const DEFAULT_NETWORK = 'mainnet' as const; // TODO: add default based on env
 
-export default class Network extends Service {
-  @tracked chainId = getConstantByNetwork('chainId', DEFAULT_NETWORK);
-  @tracked name = getConstantByNetwork('name', DEFAULT_NETWORK);
-  @tracked symbol: Networks = DEFAULT_NETWORK;
+export default class NetworkService extends Service {
+  @tracked networkInfo: NetworkInfo = {
+    chainId: getConstantByNetwork('chainId', DEFAULT_NETWORK),
+    name: getConstantByNetwork('name', DEFAULT_NETWORK),
+    symbol: DEFAULT_NETWORK,
+  };
 
   get supportedList() {
     return supportedChainsArray
@@ -27,22 +34,30 @@ export default class Network extends Service {
       .filter(({ name }) => name !== this.name);
   }
 
-  @action onSelect({ chainId, symbol, name }: Network) {
-    this.name = name;
-    this.symbol = symbol;
-    this.chainId = chainId;
+  @action onSelect(networkInfo: NetworkInfo) {
+    this.networkInfo = networkInfo;
   }
 
   @action onChainChanged(chainId: number) {
     const symbol = networks[chainId];
     const name = getConstantByNetwork('name', symbol);
 
-    this.onSelect({ chainId, symbol, name } as Network);
+    this.onSelect({ chainId, symbol, name } as NetworkInfo);
+  }
+
+  get chainId() {
+    return this.networkInfo.chainId;
+  }
+  get name() {
+    return this.networkInfo.name;
+  }
+  get symbol() {
+    return this.networkInfo.symbol;
   }
 }
 
 declare module '@ember/service' {
   interface Registry {
-    network: Network;
+    network: NetworkService;
   }
 }

--- a/packages/safe-tools-client/app/services/wallet.ts
+++ b/packages/safe-tools-client/app/services/wallet.ts
@@ -1,28 +1,30 @@
-import Service from '@ember/service';
+import Web3 from 'web3';
 
+import Service, { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency-decorators';
 import { taskFor } from 'ember-concurrency-ts';
+import type { default as Owner } from '@ember/owner';
+import { timeout } from 'ember-concurrency';
 
+import { isSupportedChain } from '@cardstack/cardpay-sdk';
 import { ChainConnectionManager } from '@cardstack/safe-tools-client/utils/chain-connection-manager';
+import NetworkService from '@cardstack/safe-tools-client/services/network';
 import walletProviders, {
   WalletProviderId,
 } from '@cardstack/safe-tools-client/utils/wallet-providers';
-import Web3 from 'web3';
-import { timeout } from 'ember-concurrency';
-
-const CHAIN_NAME_FIXME = 'mainnet';
-const CHAIN_ID_FIXME = 1;
 
 export default class Wallet extends Service {
+  @service declare network: NetworkService;
+
   @tracked isConnected = false;
   @tracked providerId: WalletProviderId | undefined;
   @tracked address: string | undefined;
   @tracked isConnecting = false;
 
   web3 = new Web3();
-  chainConnectionManager = new ChainConnectionManager(CHAIN_NAME_FIXME);
+  chainConnectionManager: ChainConnectionManager;
 
   walletProviders = walletProviders.map((w) =>
     w.id === 'metamask'
@@ -36,8 +38,13 @@ export default class Wallet extends Service {
       : { ...w, enabled: true, explanation: '' }
   );
 
-  constructor() {
-    super();
+  constructor(owner?: Owner) {
+    super(owner);
+
+    this.chainConnectionManager = new ChainConnectionManager(
+      this.network.symbol,
+      this.network.chainId
+    );
 
     this.chainConnectionManager.on('connected', (accounts: string[]) => {
       this.isConnected = true;
@@ -48,8 +55,19 @@ export default class Wallet extends Service {
       this.isConnected = false;
     });
 
-    const providerId =
-      ChainConnectionManager.getProviderIdForChain(CHAIN_ID_FIXME);
+    this.chainConnectionManager.on('chain-changed', (chainId: number) => {
+      if (!isSupportedChain(chainId)) {
+        // TODO: improve unsupported net handling
+        alert('Unsupported network! Choose a supported one and reconnect');
+        this.disconnect();
+        return;
+      }
+      this.network.onChainChanged(chainId);
+    });
+
+    const providerId = ChainConnectionManager.getProviderIdForChain(
+      this.network.chainId
+    );
     if (providerId !== 'wallet-connect' && providerId !== 'metamask') {
       return;
     }

--- a/packages/safe-tools-client/app/templates/schedule.hbs
+++ b/packages/safe-tools-client/app/templates/schedule.hbs
@@ -27,11 +27,11 @@
         <Boxel::Select
             class="safe-tools__dashboard-network-selector"
             @selected={{this.network}}
-            @onChange={{this.onSelectNetwork}}
-            @options={{this.availableNetworks}}
+            @onChange={{this.network.onSelect}}
+            @options={{this.network.supportedList}}
             as |network itemCssClass|
           >
-          <div class={{itemCssClass}}>{{network}}</div>
+          <div class={{itemCssClass}}>{{network.name}}</div>
         </Boxel::Select>
     </cp.Item>
     <cp.Item @title='Safe' @icon='safe'>

--- a/packages/safe-tools-client/app/utils/chain-connection-manager.ts
+++ b/packages/safe-tools-client/app/utils/chain-connection-manager.ts
@@ -13,7 +13,7 @@ import { action } from '@ember/object';
 import {
   HubConfig,
   getWeb3ConfigByNetwork,
-  Networks,
+  Network,
 } from '@cardstack/cardpay-sdk';
 import Web3 from 'web3';
 import { TypedChannel } from './typed-channel';
@@ -25,7 +25,7 @@ const WALLET_CONNECT_BRIDGE = 'https://bridge.walletconnect.org';
 
 interface ConnectionManagerOptions {
   chainId: number;
-  networkSymbol: Networks;
+  networkSymbol: Network;
 }
 
 type ConnectionManagerWalletEvent =
@@ -59,7 +59,7 @@ type ConnectionEvent = ConnectEvent | DisconnectEvent;
 export interface ConnectionManagerStrategyFactory {
   createStrategy(
     chainId: number,
-    networkSymbol: Networks,
+    networkSymbol: Network,
     providerId: WalletProviderId
   ): ConnectionStrategy;
 }
@@ -90,11 +90,11 @@ export class ChainConnectionManager {
   broadcastChannel: TypedChannel<ConnectionEvent>;
   strategy: ConnectionStrategy | undefined;
   chainId: number;
-  networkSymbol: Networks;
+  networkSymbol: Network;
   simpleEmitter = new SimpleEmitter();
 
   constructor(
-    networkSymbol: Networks,
+    networkSymbol: Network,
     chainId: number,
     readonly strategyFactory = new ConcreteStrategyFactory()
   ) {
@@ -234,7 +234,7 @@ export class ChainConnectionManager {
 class ConcreteStrategyFactory implements ConnectionManagerStrategyFactory {
   createStrategy(
     chainId: number,
-    networkSymbol: Networks,
+    networkSymbol: Network,
     providerId: WalletProviderId
   ) {
     if (providerId === 'metamask') {
@@ -273,7 +273,7 @@ export abstract class ConnectionStrategy
   abstract destroy(): void;
 
   // networkSymbol and chainId are initialized in the constructor
-  networkSymbol: Networks;
+  networkSymbol: Network;
   chainId: number;
 
   // this is initialized in the `setup` method of concrete classes

--- a/packages/safe-tools-client/app/utils/chain-connection-manager.ts
+++ b/packages/safe-tools-client/app/utils/chain-connection-manager.ts
@@ -10,15 +10,14 @@ import CustomStorageWalletConnect, {
 import { Emitter, SimpleEmitter } from './events';
 import { WalletProviderId } from './wallet-providers';
 import { action } from '@ember/object';
-import { networkIds, HubConfig } from '@cardstack/cardpay-sdk';
+import {
+  HubConfig,
+  getWeb3ConfigByNetwork,
+  Networks,
+} from '@cardstack/cardpay-sdk';
 import Web3 from 'web3';
 import { TypedChannel } from './typed-channel';
 import { MockLocalStorage } from './browser-mocks';
-
-type ProductionChainName = 'mainnet' | 'gnosis' | 'polygon';
-type StagingChainName = 'goerli' | 'sokol' | 'mumbai';
-
-export type ChainName = ProductionChainName | StagingChainName;
 
 const GET_PROVIDER_STORAGE_KEY = (chainId: number) =>
   `cardstack-chain-${chainId}-provider`;
@@ -26,7 +25,7 @@ const WALLET_CONNECT_BRIDGE = 'https://bridge.walletconnect.org';
 
 interface ConnectionManagerOptions {
   chainId: number;
-  networkSymbol: ChainName;
+  networkSymbol: Networks;
 }
 
 type ConnectionManagerWalletEvent =
@@ -60,7 +59,7 @@ type ConnectionEvent = ConnectEvent | DisconnectEvent;
 export interface ConnectionManagerStrategyFactory {
   createStrategy(
     chainId: number,
-    networkSymbol: ChainName,
+    networkSymbol: Networks,
     providerId: WalletProviderId
   ): ConnectionStrategy;
 }
@@ -91,15 +90,16 @@ export class ChainConnectionManager {
   broadcastChannel: TypedChannel<ConnectionEvent>;
   strategy: ConnectionStrategy | undefined;
   chainId: number;
-  networkSymbol: ChainName;
+  networkSymbol: Networks;
   simpleEmitter = new SimpleEmitter();
 
   constructor(
-    networkSymbol: ChainName,
+    networkSymbol: Networks,
+    chainId: number,
     readonly strategyFactory = new ConcreteStrategyFactory()
   ) {
     this.networkSymbol = networkSymbol;
-    this.chainId = networkIds[networkSymbol];
+    this.chainId = chainId;
 
     // we want to ensure that users don't get confused by different tabs having
     // different wallets connected so we communicate connections and disconnections across tabs
@@ -234,7 +234,7 @@ export class ChainConnectionManager {
 class ConcreteStrategyFactory implements ConnectionManagerStrategyFactory {
   createStrategy(
     chainId: number,
-    networkSymbol: ChainName,
+    networkSymbol: Networks,
     providerId: WalletProviderId
   ) {
     if (providerId === 'metamask') {
@@ -273,7 +273,7 @@ export abstract class ConnectionStrategy
   abstract destroy(): void;
 
   // networkSymbol and chainId are initialized in the constructor
-  networkSymbol: ChainName;
+  networkSymbol: Networks;
   chainId: number;
 
   // this is initialized in the `setup` method of concrete classes
@@ -301,7 +301,15 @@ export abstract class ConnectionStrategy
     this.emit('connected', accounts);
   }
 
-  onChainChanged(chainId: number) {
+  async emitChainIdChange(id?: number) {
+    const chainId =
+      id ||
+      parseInt(
+        await this.provider.request({
+          method: 'eth_chainId',
+        })
+      );
+
     this.emit('chain-changed', chainId);
   }
 }
@@ -334,7 +342,7 @@ class MetaMaskConnectionStrategy extends ConnectionStrategy {
 
     // Subscribe to chainId change
     provider.on('chainChanged', (changedChainId: string) => {
-      this.onChainChanged(parseInt(changedChainId));
+      this.emitChainIdChange(parseInt(changedChainId));
     });
 
     // Note that this is, following EIP-1193, about connection of the wallet to the
@@ -378,13 +386,7 @@ class MetaMaskConnectionStrategy extends ConnectionStrategy {
       }
     }
 
-    const chainId = parseInt(
-      await this.provider.request({
-        method: 'eth_chainId',
-      })
-    );
-
-    this.onChainChanged(chainId);
+    this.emitChainIdChange();
 
     return true;
   }
@@ -404,13 +406,7 @@ class MetaMaskConnectionStrategy extends ConnectionStrategy {
       // it is connected to the account so it will not fire the connection/account change events
       this.onConnect(accounts);
 
-      const chainId = parseInt(
-        await this.provider.request({
-          method: 'eth_chainId',
-        })
-      );
-
-      this.onChainChanged(chainId);
+      this.emitChainIdChange();
     } else {
       // if we didn't find accounts, then the stored provider key is not useful, delete it
       ChainConnectionManager.removeProviderFromStorage(this.chainId);
@@ -464,16 +460,19 @@ class WalletConnectConnectionStrategy extends ConnectionStrategy {
     const hubConfigApi = new HubConfig(config.hubUrl);
     const hubConfigResponse = await hubConfigApi.getConfig();
 
+    const { rpcNodeHttpsUrl, rpcNodeWssUrl } = getWeb3ConfigByNetwork(
+      hubConfigResponse,
+      this.networkSymbol
+    );
+
     const provider = new WalletConnectProvider({
       chainId,
       infuraId: config.infuraId,
       rpc: {
-        [networkIds[this.networkSymbol]]:
-          hubConfigResponse.web3.ethereum.rpcNodeHttpsUrl, // FIXME don’t hardcode ethereum
+        [chainId]: rpcNodeHttpsUrl,
       },
       rpcWss: {
-        [networkIds[this.networkSymbol]]:
-          hubConfigResponse.web3.ethereum.rpcNodeWssUrl,
+        [chainId]: rpcNodeWssUrl,
       },
       // based on https://github.com/WalletConnect/walletconnect-monorepo/blob/7aa9a7213e15489fa939e2e020c7102c63efd9c4/packages/providers/web3-provider/src/index.ts#L47-L52
       connector: new CustomStorageWalletConnect(connectorOptions, chainId),
@@ -486,7 +485,7 @@ class WalletConnectConnectionStrategy extends ConnectionStrategy {
 
     // Subscribe to chainId change
     provider.on('chainChanged', (changedChainId: number) => {
-      this.onChainChanged(changedChainId);
+      this.emitChainIdChange(changedChainId);
     });
 
     // Subscribe to session disconnection
@@ -510,6 +509,9 @@ class WalletConnectConnectionStrategy extends ConnectionStrategy {
   async connect() {
     try {
       await this.provider.enable();
+
+      // we need to trigger the event manually to update dapp with wallet network
+      this.emitChainIdChange();
       return true;
     } catch (e) {
       // check modal_closed event in WalletConnectProvider for message to match

--- a/yarn.lock
+++ b/yarn.lock
@@ -6963,6 +6963,11 @@
   resolved "https://registry.yarnpkg.com/@types/ember__owner/-/ember__owner-4.0.0.tgz#2058a8fbf9636774dc79430abd355b07538c51d7"
   integrity sha512-7ZotJNCkZUvJpcGHYswQlQsHyRITQ3aNOoFPi86NFxmOXEIVAGVKPHB87w8ZlMmhssG2vitCuNzuQCeDwPaokQ==
 
+"@types/ember__owner@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/ember__owner/-/ember__owner-4.0.1.tgz#e7d3eebea11887c86ac1dc62c9a2fae840d945f1"
+  integrity sha512-m9a292TdRrG2iu4UgBq0Mf6YnOD2WcpieVtqM0DSFhqqDYlIvMVAfjkmSoJJaIjBtWerTcgV+dO06Av47Nkshg==
+
 "@types/ember__polyfills@*", "@types/ember__polyfills@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/ember__polyfills/-/ember__polyfills-4.0.0.tgz#d83ae94ff2890ad47798315426d9916f39ff4ae6"


### PR DESCRIPTION
This PR removes the hardcoded ethereum setup and networks.

- Adds a list of supported network from sdk
- Adds alert in case wallet's user is  on unsupported network and disconnects wallet
- Updates the UI to reflect wallet's network

This PR DOES NOT cover: 
- Switching the network from the dapp.
- Conditional rendering networks by environment (right now all supported nets are in the dropdown)


The network selector starts with gnosis chain, and once a ethereum wallet connects, the value is updated:

https://user-images.githubusercontent.com/20520102/199979877-757505df-5efb-481a-9638-8b970312ce26.mov



