### PR TITLE
subgraph: Add missing param in the CreatePrepaidCard handler

### DIFF
--- a/packages/cardpay-subgraph/subgraph-template.yaml
+++ b/packages/cardpay-subgraph/subgraph-template.yaml
@@ -41,7 +41,7 @@ dataSources:
         - name: GnosisSafe
           file: ./abis/GnosisSafe.json
       eventHandlers:
-        - event: CreatePrepaidCard(address,address,address,address,uint256,uint256,uint256,string)
+        - event: CreatePrepaidCard(address,address,address,address,address,uint256,uint256,uint256,string)
           handler: handleCreatePrepaidCard
         - event: TransferredPrepaidCard(address,address,address)
           handler: handleTransferPrepaidCard


### PR DESCRIPTION
Adds a missing parameter in the event signature. The event that gets emitted is here: https://github.com/cardstack/card-pay-protocol/blame/f98e599c005747e8c1311a9af2bb4e278fcc9dc7/contracts/PrepaidCardManager.sol#L55

Will probably need to regenerate the ABI before the deploy. 