### PR TITLE
hub: Add data integrity checks route

### DIFF
--- a/packages/hub/config/test.cjs
+++ b/packages/hub/config/test.cjs
@@ -47,6 +47,7 @@ fNnC/5IGBxBkFQIgGC1mdtwPDSBMQY0XpAzPw6dXE8z0LaoV5qXeB8LV8CECIGmi
   emailHashSalt: 'P91APjz3Ef6q3KAdOCfKa5hOcEmOyrPeRPG6+g380LY=',
   checkly: {
     handleWebhookRequests: true,
+    webhookSecret: '123',
   },
   web3: {
     ethereum: {

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -98,6 +98,7 @@ import ScheduledPaymentValidator from './services/validators/scheduled-payment';
 import ScheduledPaymentsRoute from './routes/scheduled-payments';
 import ScheduledPaymentsExecutorService from './services/scheduled-payments/executor';
 import DataIntegrityChecksScheduledPayments from './services/data-integrity-checks/scheduled-payments';
+import DataIntegrityChecksRoute from './routes/data-integrity-checks';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -183,6 +184,7 @@ export function createRegistry(): Registry {
   registry.register('scheduled-payment-validator', ScheduledPaymentValidator);
   registry.register('scheduled-payments-route', ScheduledPaymentsRoute);
   registry.register('data-integrity-checks-scheduled-payments', DataIntegrityChecksScheduledPayments);
+  registry.register('data-integrity-checks-route', DataIntegrityChecksRoute);
 
   if (process.env.COMPILER) {
     registry.register(

--- a/packages/hub/node-tests/routes/data-integrity-checks-test.ts
+++ b/packages/hub/node-tests/routes/data-integrity-checks-test.ts
@@ -15,7 +15,8 @@ describe('GET /api/data-integrity-checks/scheduled-payments', async function () 
 
   it('returns operational status for provided check', async function () {
     await request()
-      .get('/api/data-integrity-checks/scheduled-payments?secret=123')
+      .get('/api/data-integrity-checks/scheduled-payments')
+      .set('X-Data-Integrity-Checks-Authorization', '123')
       .set('Accept', 'application/vnd.api+json')
       .set('Content-Type', 'application/vnd.api+json')
       .expect(200)
@@ -58,7 +59,8 @@ describe('GET /api/data-integrity-checks/scheduled-payments', async function () 
     });
 
     await request()
-      .get('/api/data-integrity-checks/scheduled-payments?secret=123')
+      .get('/api/data-integrity-checks/scheduled-payments')
+      .set('X-Data-Integrity-Checks-Authorization', '123')
       .set('Accept', 'application/vnd.api+json')
       .set('Content-Type', 'application/vnd.api+json')
       .expect(200)
@@ -78,15 +80,17 @@ describe('GET /api/data-integrity-checks/scheduled-payments', async function () 
 
   it('returns not found for unknown check name', async function () {
     await request()
-      .get('/api/data-integrity-checks/unknown-check?secret=123')
+      .get('/api/data-integrity-checks/unknown-check')
+      .set('X-Data-Integrity-Checks-Authorization', '123')
       .set('Accept', 'application/vnd.api+json')
       .set('Content-Type', 'application/vnd.api+json')
       .expect(404);
   });
 
-  it('returns not allowed for wrong or missing secret', async function () {
+  it('returns not allowed for wrong or missing route authorization', async function () {
     await request()
-      .get('/api/data-integrity-checks/scheduled-payments?secret=asd')
+      .get('/api/data-integrity-checks/scheduled-payments')
+      .set('X-Data-Integrity-Checks-Authorization', 'wrongauth')
       .set('Accept', 'application/vnd.api+json')
       .set('Content-Type', 'application/vnd.api+json')
       .expect(403);

--- a/packages/hub/node-tests/routes/data-integrity-checks-test.ts
+++ b/packages/hub/node-tests/routes/data-integrity-checks-test.ts
@@ -1,0 +1,100 @@
+import { subMinutes } from 'date-fns';
+import shortUuid from 'short-uuid';
+import { CREATION_WITHOUT_TX_HASH_ALLOWED_MINUTES } from '../../services/data-integrity-checks/scheduled-payments';
+import { ExtendedPrismaClient } from '../../services/prisma-manager';
+import { nowUtc } from '../../utils/dates';
+import { setupHub } from '../helpers/server';
+
+describe('GET /api/data-integrity-checks/scheduled-payments', async function () {
+  let prisma: ExtendedPrismaClient;
+  let { getPrisma, request } = setupHub(this);
+
+  this.beforeEach(async function () {
+    prisma = await getPrisma();
+  });
+
+  it('returns operational status for provided check', async function () {
+    await request()
+      .get('/api/data-integrity-checks/scheduled-payments?secret=123')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(200)
+      .expect({
+        data: {
+          type: 'data-integrity-check',
+          attributes: {
+            'scheduled-payments': {
+              message: null,
+              status: 'operational',
+            },
+          },
+        },
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('returns degraded status for provided check', async function () {
+    let sp = await prisma.scheduledPayment.create({
+      data: {
+        id: shortUuid.uuid(),
+        senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+        moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+        tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+        gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+        amount: '100',
+        payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+        executionGasEstimation: 100000,
+        maxGasPrice: '1000000000',
+        feeFixedUsd: '0',
+        feePercentage: '0',
+        salt: '54lt',
+        payAt: nowUtc(),
+        spHash: '0x123',
+        chainId: 1,
+        userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+        creationTransactionHash: null,
+        createdAt: subMinutes(nowUtc(), CREATION_WITHOUT_TX_HASH_ALLOWED_MINUTES + 1),
+      },
+    });
+
+    await request()
+      .get('/api/data-integrity-checks/scheduled-payments?secret=123')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(200)
+      .expect({
+        data: {
+          type: 'data-integrity-check',
+          attributes: {
+            'scheduled-payments': {
+              message: `scheduled payments without creationTransactionHash: ${sp.id}`,
+              status: 'degraded',
+            },
+          },
+        },
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+  });
+
+  it('returns not found for unknown check name', async function () {
+    await request()
+      .get('/api/data-integrity-checks/unknown-check?secret=123')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(404);
+  });
+
+  it('returns not allowed for wrong or missing secret', async function () {
+    await request()
+      .get('/api/data-integrity-checks/scheduled-payments?secret=asd')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(403);
+
+    await request()
+      .get('/api/data-integrity-checks/scheduled-payments')
+      .set('Accept', 'application/vnd.api+json')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(403);
+  });
+});

--- a/packages/hub/routes/data-integrity-checks.ts
+++ b/packages/hub/routes/data-integrity-checks.ts
@@ -19,7 +19,14 @@ export default class DataIntegrityChecksRoute {
   }
 
   async get(ctx: Koa.Context) {
-    if (ctx.query.secret !== config.get('checkly.webhookSecret')) {
+    // The middleware converts header names to lower case
+    let authorization = ctx.headers['x-data-integrity-checks-authorization'] as string;
+
+    // Checkly's webhookSecret is used in checkly-webhook.ts for authorizing
+    // requests to create incidents in statuspage. For convenience, since Checkly will
+    // consume this route as well, we use the same secret here to authorize requests to this private route.
+
+    if (authorization !== config.get('checkly.webhookSecret')) {
       ctx.status = 403;
       return;
     }

--- a/packages/hub/routes/data-integrity-checks.ts
+++ b/packages/hub/routes/data-integrity-checks.ts
@@ -1,0 +1,59 @@
+import Koa from 'koa';
+import autoBind from 'auto-bind';
+import { inject } from '@cardstack/di';
+import DataIntegrityChecksScheduledPayments, {
+  IntegrityCheckResult,
+} from '../services/data-integrity-checks/scheduled-payments';
+import config from 'config';
+
+export default class DataIntegrityChecksRoute {
+  dataIntegrityCheckScheduledPayments: DataIntegrityChecksScheduledPayments = inject(
+    'data-integrity-checks-scheduled-payments',
+    {
+      as: 'dataIntegrityCheckScheduledPayments',
+    }
+  );
+
+  constructor() {
+    autoBind(this);
+  }
+
+  async get(ctx: Koa.Context) {
+    if (ctx.query.secret !== config.get('checkly.webhookSecret')) {
+      ctx.status = 403;
+      return;
+    }
+
+    let checkName = ctx.params.check_name;
+    let checkResult: IntegrityCheckResult | null = null;
+
+    if (checkName === 'scheduled-payments') {
+      checkResult = await this.dataIntegrityCheckScheduledPayments.check();
+    }
+
+    if (!checkResult) {
+      ctx.status = 404;
+      return;
+    } else {
+      ctx.status = 200;
+      ctx.body = {
+        data: {
+          type: 'data-integrity-check',
+          attributes: {
+            [checkResult.name]: {
+              status: checkResult.status,
+              message: checkResult.message,
+            },
+          },
+        },
+      };
+      ctx.type = 'application/vnd.api+json';
+    }
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'data-integrity-checks-route': DataIntegrityChecksRoute;
+  }
+}

--- a/packages/hub/services/api-router.ts
+++ b/packages/hub/services/api-router.ts
@@ -46,6 +46,9 @@ export default class APIRouter {
   inventoryRoute = inject('inventory-route', { as: 'inventoryRoute' });
   wyrePricesRoute = inject('wyre-prices-route', { as: 'wyrePricesRoute' });
   scheduledPaymentsRoute = inject('scheduled-payments-route', { as: 'scheduledPaymentsRoute' });
+  dataIntegrityChecksRoute = inject('data-integrity-checks-route', {
+    as: 'dataIntegrityChecksRoute',
+  });
 
   routes() {
     let {
@@ -69,6 +72,7 @@ export default class APIRouter {
       pushNotificationRegistrationsRoute,
       notificationPreferencesRoute,
       scheduledPaymentsRoute,
+      dataIntegrityChecksRoute,
     } = this;
     let apiSubrouter = new Router();
     apiSubrouter.get('/boom', boomRoute.get);
@@ -141,6 +145,7 @@ export default class APIRouter {
     apiSubrouter.patch('/scheduled-payments/:scheduled_payment_id', parseBody, scheduledPaymentsRoute.patch);
     apiSubrouter.delete('/scheduled-payments/:scheduled_payment_id', parseBody, scheduledPaymentsRoute.delete);
     apiSubrouter.get('/wyre-prices', parseBody, wyrePricesRoute.get);
+    apiSubrouter.get('/data-integrity-checks/:check_name', parseBody, dataIntegrityChecksRoute.get);
     apiSubrouter.all('/(.*)', notFound);
 
     let apiRouter = new Router();

--- a/packages/hub/services/data-integrity-checks/scheduled-payments.ts
+++ b/packages/hub/services/data-integrity-checks/scheduled-payments.ts
@@ -16,7 +16,7 @@ function addToMessages(collection: any, message: string, messages: string[]) {
   messages.push(`${message}: ${collection.map((item: any) => item.id).join(', ')}`);
 }
 
-interface IntegrityCheckResult {
+export interface IntegrityCheckResult {
   name: string;
   status: 'degraded' | 'operational';
   message: string | null;


### PR DESCRIPTION
Ticket: CS-4671

This PR adds a route which responds with the provided data integrity check (currently we only have the scheduled-payments check).

This route has to be protected and since Checkly will consume it, I thought it would be a good idea to repurpose the `checkly.webhookSecret` config which we already have configured for Checkly webhooks. That way when we'll configure Checkly checks in the infra, we can include this query parameter to the call and authorize it. 