### PR TITLE
Update action environments to Node 16

### DIFF
--- a/.github/actions/discord-message/action.yml
+++ b/.github/actions/discord-message/action.yml
@@ -13,5 +13,5 @@ inputs:
     required: true
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'

--- a/.github/actions/fetch-stopped-ecs-task/action.yml
+++ b/.github/actions/fetch-stopped-ecs-task/action.yml
@@ -9,5 +9,5 @@ inputs:
     required: false
     default: ./waypoint.hcl
 runs:
-  using: node12
+  using: node16
   main: index.js

--- a/.github/actions/find-pr-number/action.yml
+++ b/.github/actions/find-pr-number/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: 'Branch associated with PR'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'

--- a/.github/actions/waypoint-ecs-failsafe/action.yml
+++ b/.github/actions/waypoint-ecs-failsafe/action.yml
@@ -9,5 +9,5 @@ inputs:
     required: false
     default: ./waypoint.hcl
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"

--- a/.github/actions/waypoint-prune-dangling-resources/action.yml
+++ b/.github/actions/waypoint-prune-dangling-resources/action.yml
@@ -13,5 +13,5 @@ inputs:
     required: false
     default: "0"
 runs:
-  using: "node12"
+  using: "node16"
   main: "index.js"


### PR DESCRIPTION
🚨 Node 12 has an end of life on April 30, 2022.

The GitHub Actions workflow gives the following warning while running the action:

> Node.js 12 actions are deprecated. For more information see: github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12.

This PR updates the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/), rather then node12.

You can see more here: https://github.com/actions/setup-node/compare/v2.5.1...v3.0.0

This is supported on all Actions Runners v2.285.0 or later.

Signed-off-by: Enes <ahmedenesturan@gmail.com>