### PR TITLE
Update JSONRpcProvider error handling

### DIFF
--- a/packages/cardpay-sdk/sdk/utils/signing-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/signing-utils.ts
@@ -288,7 +288,7 @@ export async function signTypedData(
       signature = await signer._signTypedData(domain, types, message);
     } else if (web3OrSignerOrEthersProvider instanceof JsonRpcProvider) {
       let ethersProvider = web3OrSignerOrEthersProvider;
-      return await ethersProvider.send('eth_signTypedData', [account, data]);
+      return await ethersProvider.send('eth_signTypedData', [account, JSON.stringify(data)]);
     } else {
       signature = await signTypedDataWithWeb3(web3OrSignerOrEthersProvider, account, data);
     }
@@ -305,7 +305,7 @@ async function signTypedDataWithWeb3(web3: Web3, account: string, data: any): Pr
     let payload = {
       jsonrpc: '2.0',
       method: 'eth_signTypedData',
-      params: [account, data],
+      params: [account, JSON.stringify(data)],
       id: new Date().getTime(),
     };
 


### PR DESCRIPTION
Ticket: CS-4846

**Problem**

Error when extracting the calculation result of a new safe address. The problem is that the Metamask throws a different error structure than we expected.

Metamask error structure:
`{
    "code": -32603,
    "message": "Internal JSON-RPC error.",
    "data": {
        "code": 3,
        "data": "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000149bd4b4946eabc8a64d198b2fc95866208d1acce5000000000000000000000000",
        "message": "execution reverted: �Դ�n�ȦM\u0019�/�Xf �\u001a��"
    }
}`

Expected error structure:
`{
     "code": 3,
    "data": "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000149bd4b4946eabc8a64d198b2fc95866208d1acce5000000000000000000000000",
   "message": "execution reverted: �Դ�n�ȦM\u0019�/�Xf �\u001a��"
}`

**Solution**

I updated the way of JSONRpcProvider handles errors. The code will try to find the expected error structure using the `spelunk` function.
