### PR TITLE
[Feat]: Calculate gas estimate and balance on `Create Safe` click

### DIFF
--- a/packages/safe-tools-client/app/components/create-safe-button/index.gts
+++ b/packages/safe-tools-client/app/components/create-safe-button/index.gts
@@ -1,21 +1,19 @@
+import { BigNumber } from 'ethers';
+import Web3 from 'web3';
+
 import Component from '@glimmer/component';
 import { on } from '@ember/modifier';
-// import not from 'ember-truth-helpers/helpers/not';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-// import { inject as service} from '@ember/service';
+import { inject as service } from '@ember/service';
 import set from 'ember-set-helper/helpers/set';
-
 import { type EmptyObject } from '@ember/component/helper';
+
 import BoxelButton from '@cardstack/boxel/components/boxel/button';
+import WalletService from '@cardstack/safe-tools-client/services/wallet';
+import SchedulePaymentSDKService from '@cardstack/safe-tools-client/services/scheduled-payments-sdk';
 
-// import WalletService from '@cardstack/safe-tools-client/services/wallet';
-// import { svgJar } from '@cardstack/boxel/utils/svg-jar';
-// import cssVar from '@cardstack/boxel/helpers/css-var';
-// import BoxelModal from '@cardstack/boxel/components/boxel/modal';
-// import BoxelActionContainer from '@cardstack/boxel/components/boxel/action-container'
 import SetupSafeModal from '../setup-safe-modal';
-
 
 interface Signature {
   Element: HTMLElement;
@@ -23,10 +21,48 @@ interface Signature {
 }
 
 export default class CreateSafeButton extends Component<Signature> {
+  @service declare wallet: WalletService;
+  @service declare scheduledPaymentsSdk: SchedulePaymentSDKService;
+
   @tracked isModalOpen = false;
 
-  @action onClick() {
-    this.isModalOpen = true
+  @tracked gasInfo = {
+    isLoading: false,
+    hasEnoughBalance:  false,
+    costDisplay: `Couldn't estimate gas`
+  }
+
+  @action async onClick() {
+    this.gasInfo.isLoading = true;
+    this.isModalOpen = true;
+
+    try {
+      const [gasEstimate, nativeTokenBalance] = await Promise.all([
+        this.scheduledPaymentsSdk.getCreateSafeGasEstimation(),
+        this.wallet.fetchNativeTokenBalance(),
+      ]);
+
+      const balance = BigNumber.from(nativeTokenBalance?.amount);
+
+      this.gasInfo.hasEnoughBalance = !!gasEstimate?.lt(balance);
+
+      const tokenSymbol = nativeTokenBalance?.symbol || '';
+      const gasEstimateString = Web3.utils.fromWei(
+        gasEstimate?.toString() || ''
+      )
+
+      this.gasInfo.costDisplay = `${gasEstimateString} ${tokenSymbol}`
+
+    } catch (e) {
+      // TODO: handle error 
+      console.log('gasEstimate', e);
+    } finally {
+      this.gasInfo.isLoading = false;
+    }
+  }
+
+  @action async handleSafeCreation() {
+    //TODO: implement safe creating and handle status
   }
 
   <template>
@@ -37,12 +73,17 @@ export default class CreateSafeButton extends Component<Signature> {
     <SetupSafeModal
       @isOpen={{this.isModalOpen}}
       @onClose={{set this 'isModalOpen' false}}
+      @isLoadingGasInfo={{this.gasInfo.isLoading}}
+      @provisioning={{false}}
+      @onProvisionClick={{this.handleSafeCreation}}
+      @hasEnoughBalance={{this.gasInfo.hasEnoughBalance}}
+      @gasCostDisplay={{this.gasInfo.costDisplay}}
     />
   </template>
 }
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {
-    'CreateSafeButton': typeof CreateSafeButton;
+    CreateSafeButton: typeof CreateSafeButton;
   }
 }

--- a/packages/safe-tools-client/app/components/create-safe-button/index.gts
+++ b/packages/safe-tools-client/app/components/create-safe-button/index.gts
@@ -26,14 +26,13 @@ export default class CreateSafeButton extends Component<Signature> {
 
   @tracked isModalOpen = false;
 
-  @tracked gasInfo = {
-    isLoading: false,
-    hasEnoughBalance:  false,
-    costDisplay: `Couldn't estimate gas`
-  }
+  @tracked isLoadingGasInfo = false;
+  @tracked hasEnoughBalance = false;
+  @tracked gasCostDisplay =  `Couldn't estimate gas`
+
 
   @action async onClick() {
-    this.gasInfo.isLoading = true;
+    this.isLoadingGasInfo = true;
     this.isModalOpen = true;
 
     try {
@@ -44,20 +43,20 @@ export default class CreateSafeButton extends Component<Signature> {
 
       const balance = BigNumber.from(nativeTokenBalance?.amount);
 
-      this.gasInfo.hasEnoughBalance = !!gasEstimate?.lt(balance);
+      this.hasEnoughBalance = !!gasEstimate?.lt(balance);
 
       const tokenSymbol = nativeTokenBalance?.symbol || '';
       const gasEstimateString = Web3.utils.fromWei(
         gasEstimate?.toString() || ''
       )
 
-      this.gasInfo.costDisplay = `${gasEstimateString} ${tokenSymbol}`
+      this.gasCostDisplay = `${gasEstimateString} ${tokenSymbol}`
 
     } catch (e) {
       // TODO: handle error 
       console.log('gasEstimate', e);
     } finally {
-      this.gasInfo.isLoading = false;
+      this.isLoadingGasInfo = false;
     }
   }
 
@@ -73,11 +72,11 @@ export default class CreateSafeButton extends Component<Signature> {
     <SetupSafeModal
       @isOpen={{this.isModalOpen}}
       @onClose={{set this 'isModalOpen' false}}
-      @isLoadingGasInfo={{this.gasInfo.isLoading}}
+      @isLoadingGasInfo={{this.isLoadingGasInfo}}
       @provisioning={{false}}
       @onProvisionClick={{this.handleSafeCreation}}
-      @hasEnoughBalance={{this.gasInfo.hasEnoughBalance}}
-      @gasCostDisplay={{this.gasInfo.costDisplay}}
+      @hasEnoughBalance={{this.hasEnoughBalance}}
+      @gasCostDisplay={{this.gasCostDisplay}}
     />
   </template>
 }

--- a/packages/safe-tools-client/app/components/create-safe-button/index.gts
+++ b/packages/safe-tools-client/app/components/create-safe-button/index.gts
@@ -1,0 +1,48 @@
+import Component from '@glimmer/component';
+import { on } from '@ember/modifier';
+// import not from 'ember-truth-helpers/helpers/not';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+// import { inject as service} from '@ember/service';
+import set from 'ember-set-helper/helpers/set';
+
+import { type EmptyObject } from '@ember/component/helper';
+import BoxelButton from '@cardstack/boxel/components/boxel/button';
+
+// import WalletService from '@cardstack/safe-tools-client/services/wallet';
+// import { svgJar } from '@cardstack/boxel/utils/svg-jar';
+// import cssVar from '@cardstack/boxel/helpers/css-var';
+// import BoxelModal from '@cardstack/boxel/components/boxel/modal';
+// import BoxelActionContainer from '@cardstack/boxel/components/boxel/action-container'
+import SetupSafeModal from '../setup-safe-modal';
+
+
+interface Signature {
+  Element: HTMLElement;
+  Args: EmptyObject;
+}
+
+export default class CreateSafeButton extends Component<Signature> {
+  @tracked isModalOpen = false;
+
+  @action onClick() {
+    this.isModalOpen = true
+  }
+
+  <template>
+    <BoxelButton @kind='primary' {{on 'click' this.onClick}}>
+      Create Safe
+    </BoxelButton>
+
+    <SetupSafeModal
+      @isOpen={{this.isModalOpen}}
+      @onClose={{set this 'isModalOpen' false}}
+    />
+  </template>
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'CreateSafeButton': typeof CreateSafeButton;
+  }
+}

--- a/packages/safe-tools-client/app/components/setup-safe-modal/index.css
+++ b/packages/safe-tools-client/app/components/setup-safe-modal/index.css
@@ -16,7 +16,8 @@
   margin: var(--boxel-sp-xxs) 0;
 }
 
-.safe-setup-modal__section-wallet-info {
+.safe-setup-modal__section-wallet-info,
+.safe-setup-modal__section__section-gas-loading {
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/packages/safe-tools-client/app/controllers/schedule.ts
+++ b/packages/safe-tools-client/app/controllers/schedule.ts
@@ -16,6 +16,7 @@ export default class Schedule extends Controller {
   @tracked isDepositModalOpen = false;
 
   get safe() {
+    return undefined;
     //TODO: get safe info from sdk and format it,
     return {
       address: '0x8a40AFffb53f4F953a204cAE087219A28771df9d',

--- a/packages/safe-tools-client/app/controllers/schedule.ts
+++ b/packages/safe-tools-client/app/controllers/schedule.ts
@@ -1,8 +1,8 @@
 import ApplicationController from '@cardstack/safe-tools-client/controllers/application';
 import NetworkService from '@cardstack/safe-tools-client/services/network';
 import WalletService from '@cardstack/safe-tools-client/services/wallet';
+
 import Controller, { inject as controller } from '@ember/controller';
-import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
@@ -13,8 +13,6 @@ export default class Schedule extends Controller {
   @service declare wallet: WalletService;
   @service declare network: NetworkService;
 
-  // modified with set helper
-  @tracked isSetupSafeModalOpen = false;
   @tracked isDepositModalOpen = false;
 
   get safe() {
@@ -45,18 +43,6 @@ export default class Schedule extends Controller {
         },
       ],
     };
-  }
-
-  get safeButtonLabel() {
-    return this.safe ? 'Add Funds' : 'Create Safe';
-  }
-
-  @action onSafeButtonClick() {
-    if (this.safe) {
-      this.isDepositModalOpen = true;
-    } else {
-      this.isSetupSafeModalOpen = true;
-    }
   }
 
   get scheduledPaymentsTokensToCover() {

--- a/packages/safe-tools-client/app/services/scheduled-payments-sdk.ts
+++ b/packages/safe-tools-client/app/services/scheduled-payments-sdk.ts
@@ -20,31 +20,27 @@ export default class SchedulePaymentSDKService extends Service {
   }
 
   @action async getCreateSafeGasEstimation(): Promise<BigNumber | undefined> {
-    try {
-      const scheduledPayments = await this.getSchedulePaymentsModule();
+    // TODO: Remove once sdk starts working with dapp
+    // return new Promise((resolve) => {
+    //   setTimeout(() => {
+    //     console.log('Create safe');
+    //     resolve(BigNumber.from('100000000000000000'));
+    //   }, 2000);
+    // });
 
-      const estimatedSafeCreationGas =
-        await scheduledPayments.createSafeWithModuleAndGuardEstimation();
+    const scheduledPayments = await this.getSchedulePaymentsModule();
 
-      return estimatedSafeCreationGas;
-    } catch (e) {
-      // TODO: handle error
-      console.log(e);
-    }
-    return;
+    const estimatedSafeCreationGas =
+      await scheduledPayments.createSafeWithModuleAndGuardEstimation();
+
+    return estimatedSafeCreationGas;
   }
 
-  // TODO convert it to task
+  // TODO: convert it to task
   @action async createSafe() {
-    try {
-      const scheduledPayments = await this.getSchedulePaymentsModule();
+    const scheduledPayments = await this.getSchedulePaymentsModule();
 
-      const result = await scheduledPayments.createSafeWithModuleAndGuard();
-      console.log({ result });
-    } catch (e) {
-      // TODO: handle error
-      console.log(e);
-    }
+    await scheduledPayments.createSafeWithModuleAndGuard();
   }
 }
 

--- a/packages/safe-tools-client/app/services/scheduled-payments-sdk.ts
+++ b/packages/safe-tools-client/app/services/scheduled-payments-sdk.ts
@@ -33,7 +33,9 @@ export default class SchedulePaymentSDKService extends Service {
     const scheduledPayments = await this.getSchedulePaymentsModule();
 
     const estimatedSafeCreationGas =
-      await scheduledPayments.createSafeWithModuleAndGuardEstimation();
+      await scheduledPayments.createSafeWithModuleAndGuardEstimation({
+        from: this.wallet.address,
+      });
 
     return estimatedSafeCreationGas;
   }

--- a/packages/safe-tools-client/app/services/scheduled-payments-sdk.ts
+++ b/packages/safe-tools-client/app/services/scheduled-payments-sdk.ts
@@ -12,7 +12,9 @@ export default class SchedulePaymentSDKService extends Service {
   estimatedSafeCreationGas: undefined | BigNumber;
 
   private async getSchedulePaymentsModule() {
-    const ethersProvider = new Web3Provider(this.wallet.web3.givenProvider);
+    //@ts-expect-error currentProvider does not match Web3Provider,
+    //not worth typing as we should replace the web3 one with ethers soon
+    const ethersProvider = new Web3Provider(this.wallet.web3.currentProvider);
 
     const module = await getSDK('ScheduledPaymentModule', ethersProvider);
 

--- a/packages/safe-tools-client/app/services/scheduled-payments-sdk.ts
+++ b/packages/safe-tools-client/app/services/scheduled-payments-sdk.ts
@@ -1,0 +1,55 @@
+import { getSDK, Web3Provider } from '@cardstack/cardpay-sdk';
+import WalletService from '@cardstack/safe-tools-client/services/wallet';
+
+import { action } from '@ember/object';
+import Service, { inject as service } from '@ember/service';
+
+import { BigNumber } from 'ethers';
+
+export default class SchedulePaymentSDKService extends Service {
+  @service declare wallet: WalletService;
+
+  estimatedSafeCreationGas: undefined | BigNumber;
+
+  private async getSchedulePaymentsModule() {
+    const ethersProvider = new Web3Provider(this.wallet.web3.givenProvider);
+
+    const module = await getSDK('ScheduledPaymentModule', ethersProvider);
+
+    return module;
+  }
+
+  @action async getCreateSafeGasEstimation(): Promise<BigNumber | undefined> {
+    try {
+      const scheduledPayments = await this.getSchedulePaymentsModule();
+
+      const estimatedSafeCreationGas =
+        await scheduledPayments.createSafeWithModuleAndGuardEstimation();
+
+      return estimatedSafeCreationGas;
+    } catch (e) {
+      // TODO: handle error
+      console.log(e);
+    }
+    return;
+  }
+
+  // TODO convert it to task
+  @action async createSafe() {
+    try {
+      const scheduledPayments = await this.getSchedulePaymentsModule();
+
+      const result = await scheduledPayments.createSafeWithModuleAndGuard();
+      console.log({ result });
+    } catch (e) {
+      // TODO: handle error
+      console.log(e);
+    }
+  }
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    scheduledPaymentsSdk: SchedulePaymentSDKService;
+  }
+}

--- a/packages/safe-tools-client/app/services/wallet.ts
+++ b/packages/safe-tools-client/app/services/wallet.ts
@@ -29,6 +29,7 @@ export default class Wallet extends Service {
 
   @tracked nativeTokenBalance: Record<'symbol' | 'amount', string> | undefined;
 
+  // TODO: replace with ethers
   web3 = new Web3();
   chainConnectionManager: ChainConnectionManager;
 

--- a/packages/safe-tools-client/app/services/wallet.ts
+++ b/packages/safe-tools-client/app/services/wallet.ts
@@ -126,6 +126,8 @@ export default class Wallet extends Service {
       symbol: getConstantByNetwork('nativeTokenSymbol', this.network.symbol),
       amount: balance || '0',
     };
+
+    return this.nativeTokenBalance;
   }
 }
 

--- a/packages/safe-tools-client/app/services/wallet.ts
+++ b/packages/safe-tools-client/app/services/wallet.ts
@@ -1,9 +1,14 @@
-import { isSupportedChain } from '@cardstack/cardpay-sdk';
+import {
+  isSupportedChain,
+  getConstantByNetwork,
+  getSDK,
+} from '@cardstack/cardpay-sdk';
 import NetworkService from '@cardstack/safe-tools-client/services/network';
 import { ChainConnectionManager } from '@cardstack/safe-tools-client/utils/chain-connection-manager';
 import walletProviders, {
   WalletProviderId,
 } from '@cardstack/safe-tools-client/utils/wallet-providers';
+
 import { action } from '@ember/object';
 import type { default as Owner } from '@ember/owner';
 import Service, { inject as service } from '@ember/service';
@@ -11,6 +16,7 @@ import { tracked } from '@glimmer/tracking';
 import { timeout } from 'ember-concurrency';
 import { task } from 'ember-concurrency-decorators';
 import { taskFor } from 'ember-concurrency-ts';
+
 import Web3 from 'web3';
 
 export default class Wallet extends Service {
@@ -20,6 +26,8 @@ export default class Wallet extends Service {
   @tracked providerId: WalletProviderId | undefined;
   @tracked address: string | undefined;
   @tracked isConnecting = false;
+
+  @tracked nativeTokenBalance: Record<'symbol' | 'amount', string> | undefined;
 
   web3 = new Web3();
   chainConnectionManager: ChainConnectionManager;
@@ -109,6 +117,15 @@ export default class Wallet extends Service {
 
   @action disconnect() {
     this.chainConnectionManager.disconnect();
+  }
+
+  @action async fetchNativeTokenBalance() {
+    const assets = await getSDK('Assets', this.web3);
+    const balance = await assets.getNativeTokenBalance(this.address);
+    this.nativeTokenBalance = {
+      symbol: getConstantByNetwork('nativeTokenSymbol', this.network.symbol),
+      amount: balance || '0',
+    };
   }
 }
 

--- a/packages/safe-tools-client/app/templates/schedule.hbs
+++ b/packages/safe-tools-client/app/templates/schedule.hbs
@@ -25,7 +25,7 @@
     </cp.Item>
     <cp.Item @title='Network' @icon='network'>
         <Boxel::Select
-            class="safe-tools__dashboard-network-selector"
+        class='safe-tools__dashboard-network-selector'
             @selected={{this.network}}
             @onChange={{this.network.onSelect}}
             @options={{this.network.supportedList}}
@@ -46,32 +46,28 @@
             </span>
           {{/if}}  
         {{/each}}
+        <Boxel::Button
+          @kind='primary'
+          {{on 'click' (set this 'isDepositModalOpen' true)}}
+        >
+          Add Funds
+        </Boxel::Button>
       {{else}}
         <p class='safe-tools__dashboard-schedule-control-panel-safe-info-create'>
           You need to have a safe which contains funds that would be deducted
           automatically when schedule payments are due.
         </p>
+        <CreateSafeButton />
       {{/if}}
-      <Boxel::Button
-        @kind='primary'
-        {{on 'click' this.onSafeButtonClick}}
-      >
-        {{this.safeButtonLabel}}
-      </Boxel::Button>
     </cp.Item>
   </Boxel::ControlPanel>
   <section class='safe-tools__dashboard-schedule-content'>
     <ScheduleCollapsePanel @open={{not this.wallet.isConnected}} />
-    <div class="temporary-form-container">
+    <div class='temporary-form-container'>
       <SchedulePaymentFormActionCard />
     </div>
   </section>
 </section>
-
-<SetupSafeModal
-  @isOpen={{this.isSetupSafeModalOpen}}
-  @onClose={{set this 'isSetupSafeModalOpen' false}}
-/>
 
 <DepositModal
   @isOpen={{this.isDepositModalOpen}}

--- a/packages/safe-tools-client/app/templates/schedule.hbs
+++ b/packages/safe-tools-client/app/templates/schedule.hbs
@@ -34,31 +34,33 @@
           <div class={{itemCssClass}}>{{network.name}}</div>
         </Boxel::Select>
     </cp.Item>
-    <cp.Item @title='Safe' @icon='safe'>
-      {{#if this.safe}}
-        {{#each this.safe.tokens as |token|}}
-          {{#if (gt token.balance 0)}}
-            <span class='safe-tools__dashboard-schedule-control-panel-safe-info-address'>
-              {{token.address}}:{{truncate-middle this.safe.address}}
-            </span>
-            <span class='safe-tools__dashboard-schedule-control-panel-safe-info-balance'>
-              {{token.balance}} {{token.symbol}}
-            </span>
-          {{/if}}  
-        {{/each}}
-        <Boxel::Button
-          @kind='primary'
-          {{on 'click' (set this 'isDepositModalOpen' true)}}
-        >
-          Add Funds
-        </Boxel::Button>
-      {{else}}
-        <p class='safe-tools__dashboard-schedule-control-panel-safe-info-create'>
-          You need to have a safe which contains funds that would be deducted
-          automatically when schedule payments are due.
-        </p>
-        <CreateSafeButton />
-      {{/if}}
+    <cp.Item @title='Safe' @icon='safe' @isActive={{this.wallet.isConnected}}>
+      {{#if this.wallet.isConnected}}
+        {{#if this.safe}}
+          {{#each this.safe.tokens as |token|}}
+            {{#if (gt token.balance 0)}}
+              <span class='safe-tools__dashboard-schedule-control-panel-safe-info-address'>
+                {{token.address}}:{{truncate-middle this.safe.address}}
+              </span>
+              <span class='safe-tools__dashboard-schedule-control-panel-safe-info-balance'>
+                {{token.balance}} {{token.symbol}}
+              </span>
+            {{/if}}  
+          {{/each}}
+          <Boxel::Button
+            @kind='primary'
+            {{on 'click' (set this 'isDepositModalOpen' true)}}
+          >
+            Add Funds
+          </Boxel::Button>
+        {{else}}
+          <p class='safe-tools__dashboard-schedule-control-panel-safe-info-create'>
+            You need to have a safe which contains funds that would be deducted
+            automatically when schedule payments are due.
+          </p>
+          <CreateSafeButton />
+        {{/if}}
+      {{/if}}  
     </cp.Item>
   </Boxel::ControlPanel>
   <section class='safe-tools__dashboard-schedule-content'>

--- a/packages/safe-tools-client/app/utils/chain-connection-manager.ts
+++ b/packages/safe-tools-client/app/utils/chain-connection-manager.ts
@@ -294,25 +294,26 @@ export abstract class ConnectionStrategy
   }
 
   async emitChainIdChange(id?: number) {
-    let intChainId: number;
-
     if (id) {
-      intChainId = id;
-    } else {
-      if (!this.provider) {
-        throw new Error('No provider present');
-      }
-      const chainId = await this.provider.request({
-        method: 'eth_chainId',
-      });
-
-      if (typeof chainId !== 'string') {
-        throw new Error('Could not determine chainId');
-      }
-      intChainId = parseInt(chainId);
+      this.emit('chain-changed', id);
+      return;
     }
 
-    this.emit('chain-changed', intChainId);
+    if (!this.provider) {
+      throw new Error('No provider present');
+    }
+
+    const chainId = parseInt(
+      (await this.provider.request({
+        method: 'eth_chainId',
+      })) as string // even though we cast it to string some providers might return it as a number
+    );
+
+    if (isNaN(chainId)) {
+      throw new Error(`Couldn't determine chainId`);
+    }
+
+    this.emit('chain-changed', chainId);
   }
 }
 

--- a/packages/safe-tools-client/package.json
+++ b/packages/safe-tools-client/package.json
@@ -113,6 +113,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-qunit": "^7.3.1",
     "eth-testing": "^1.9.0",
+    "ethers": "^5.7.2",
     "file-loader": "^6.2.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17548,7 +17548,7 @@ ethers@5.6.4:
     "@ethersproject/web" "5.6.0"
     "@ethersproject/wordlists" "5.6.0"
 
-ethers@^5.5.4:
+ethers@^5.5.4, ethers@^5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==


### PR DESCRIPTION
This PR refactor somethings and adds sdk integration to handle gas estimate.

- Moves setupSafe modal to `CreateSafeButton`, so it handles the presentation logic and information.
- Adds a fix to emit the chainChanged for either number/string
- Adds function to get wallet balance 
- Calculates balance vs gasCost and reflects on the UI.

PS. the sdk error fix has not been merged yet, so it's expect to have an error while trying to  fetch the gasCost

This is an example of a mocked successful balance/gasCost:

https://user-images.githubusercontent.com/20520102/201115899-600f93da-7a1c-43a7-b52e-0dacbc2fc82d.mov


