### PR TITLE
tools: Fix deployment

### DIFF
--- a/.github/actions/deploy-safe-tools-client/action.yml
+++ b/.github/actions/deploy-safe-tools-client/action.yml
@@ -21,12 +21,12 @@ runs:
           echo "AWS_REGION=us-east-1" >> $GITHUB_ENV
           echo "AWS_ROLE_ARN=arn:aws:iam::120317779495:role/safe-tools-client" >> $GITHUB_ENV
           echo "AWS_S3_BUCKET=cardstack-safe-tools-client-production" >> $GITHUB_ENV
-          echo "AWS_CLOUDFRONT_DISTRIBUTION=E2DKGK0IA0DNFT" >> $GITHUB_ENV
+          echo "AWS_CLOUDFRONT_DISTRIBUTION=E2HQA2XOPIVJAB" >> $GITHUB_ENV
         elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
           echo "AWS_REGION=us-east-1" >> $GITHUB_ENV
           echo "AWS_ROLE_ARN=arn:aws:iam::680542703984:role/safe-tools-client" >> $GITHUB_ENV
           echo "AWS_S3_BUCKET=cardstack-safe-tools-client-staging" >> $GITHUB_ENV
-          echo "AWS_CLOUDFRONT_DISTRIBUTION=E8OCN7TYF3CBC" >> $GITHUB_ENV
+          echo "AWS_CLOUDFRONT_DISTRIBUTION=E1ISUWH82UQ1XJ" >> $GITHUB_ENV
         else
           echo "unrecognized environment"
           exit 1;

--- a/packages/safe-tools-client/config/deploy.js
+++ b/packages/safe-tools-client/config/deploy.js
@@ -2,6 +2,9 @@
 
 module.exports = function (deployTarget) {
   let ENV = {
+    pipeline: {
+      activateOnDeploy: true,
+    },
     plugins: ['build', 'compress', 's3', 'cloudfront'],
     build: {},
     s3: {


### PR DESCRIPTION
Two changes needed:
* `activateOnDeploy`
* correct Cloudfront distribution ids

The latter makes me think we should use Github secrets for this. It’s unwieldy but better than things breaking (silently even!) because a Cloudfront function changed or the like.