### PR TITLE
sdk: Add a function for fetching safes with sp module enabled

### DIFF
--- a/packages/cardpay-sdk/index.ts
+++ b/packages/cardpay-sdk/index.ts
@@ -26,6 +26,7 @@ export type { AddressKeys } from './contracts/addresses';
 export type { TransactionOptions } from './sdk/utils/general-utils';
 
 export { viewSafe } from './sdk/safes';
+export { getSafesWithSpModuleEnabled } from './sdk/scheduled-payment/safes';
 export { getAddress, getAddressByNetwork, getOracle, getOracleByNetwork } from './contracts/addresses';
 export * from './sdk/constants';
 export {

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -91,6 +91,7 @@ const networksConstants = {
     chainId: 5,
     scheduledPaymentFeeFixedUSD: 0,
     scheduledPaymentFeePercentage: 0,
+    subgraphURL: 'https://api.thegraph.com/subgraphs/name/cardstack/safe-tools-goerli',
   },
   polygon: {
     ...hubUrl,
@@ -112,6 +113,7 @@ const networksConstants = {
     chainId: 80001,
     scheduledPaymentFeeFixedUSD: 0,
     scheduledPaymentFeePercentage: 0,
+    subgraphURL: 'https://api.thegraph.com/subgraphs/name/cardstack/safe-tools-mumbai',
   },
   mainnet: {
     ...hubUrl,

--- a/packages/cardpay-sdk/sdk/scheduled-payment/safes.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment/safes.ts
@@ -1,0 +1,30 @@
+import { query } from '../utils/graphql';
+
+const safesQuery = `
+  query($account: ID!) {
+    account(id: $account) {
+      safes {
+        safe {
+          id
+          spModule
+        }
+      }
+    }
+  }
+`;
+
+interface Safe {
+  address: string;
+  spModuleAddress: string;
+}
+
+export async function getSafesWithSpModuleEnabled(network: string, accountAddress: string): Promise<Safe[]> {
+  let result = await query(network, safesQuery, { account: accountAddress });
+
+  if (!result.data.account) return [];
+
+  return result.data.account.safes.map((safeData: any) => {
+    let safe = safeData.safe;
+    return { address: safe.id, spModuleAddress: safe.spModule };
+  });
+}


### PR DESCRIPTION
Ticket: CS-4770

I added a minimal implementation to fetch safes that have scheduled payment module enabled, owned by the provided address. This will be used by the safe tools client where we will show the safe info, and use the sp module address to schedule payments.

We're already doing similar things in https://github.com/cardstack/cardstack/blob/main/packages/cardpay-sdk/sdk/safes.ts, but that looks like legacy code because it deals with different safe types (merchant, prepaid card,...). The subgraph data structure is also a bit different - for example in the new one we don't stora `createdAt`, `tokens` for safes. I'm also not sure we need the the `_meta` field. That's why I opted into namespacing the new safes under the /scheduled-payment namespace and added a minimal safe interface to fetch only what is currently needed in the safe tools client. 