### PR TITLE
Update params of scheduled payment module setup

### DIFF
--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -181,7 +181,7 @@ export default class ScheduledPaymentModule {
       AddressZero,
       generateSaltNonce('cardstack-sp-create-safe')
     );
-    let enableModuleTxs = await this.generateEnableModuleTxs(expectedSafeAddress);
+    let enableModuleTxs = await this.generateEnableModuleTxs(expectedSafeAddress, [from]);
     let setGuardTxs = await this.generateSetGuardTxs(expectedSafeAddress);
 
     let multiSendTx = await encodeMultiSend(this.ethersProvider, [...enableModuleTxs.txs, ...setGuardTxs.txs]);
@@ -288,7 +288,7 @@ export default class ScheduledPaymentModule {
     };
   }
 
-  async generateEnableModuleTxs(safeAddress: string) {
+  async generateEnableModuleTxs(safeAddress: string, safeOwners: string[] = []) {
     let masterCopy = new Contract(
       await getAddress('scheduledPaymentModule', this.ethersProvider),
       ScheduledPaymentABI,
@@ -297,8 +297,8 @@ export default class ScheduledPaymentModule {
     let configAddress = await getAddress('scheduledPaymentConfig', this.ethersProvider);
     let exchangeAddress = await getAddress('scheduledPaymentExchange', this.ethersProvider);
     let { transaction, expectedModuleAddress } = await deployAndSetUpModule(this.ethersProvider, masterCopy, {
-      types: ['address', 'address', 'address', 'address', 'address'],
-      values: [safeAddress, safeAddress, safeAddress, configAddress, exchangeAddress],
+      types: ['address', 'address', 'address[]', 'address', 'address', 'address'],
+      values: [safeAddress, safeAddress, safeOwners, safeAddress, configAddress, exchangeAddress],
     });
     let safe = new Contract(safeAddress, GnosisSafeABI, this.ethersProvider);
     let enableModuleData = safe.interface.encodeFunctionData('enableModule', [expectedModuleAddress]);


### PR DESCRIPTION
The latest version of the scheduled payment module requires safe owners as a parameter if the safe doesn't exist yet.