### PR TITLE
[CS-4866]: Fix signing on metamask extension

### DIFF
--- a/packages/cardpay-sdk/sdk/utils/signing-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/signing-utils.ts
@@ -288,7 +288,7 @@ export async function signTypedData(
       signature = await signer._signTypedData(domain, types, message);
     } else if (web3OrSignerOrEthersProvider instanceof JsonRpcProvider) {
       let ethersProvider = web3OrSignerOrEthersProvider;
-      return await ethersProvider.send('eth_signTypedData', [account, JSON.stringify(data)]);
+      return await ethersProvider.send('eth_signTypedData_v4', [account, JSON.stringify(data)]);
     } else {
       signature = await signTypedDataWithWeb3(web3OrSignerOrEthersProvider, account, data);
     }


### PR DESCRIPTION
Using the metamask extension to estimate the gas doesn't work, the message to sign is never delivered to the wallet,  by taking a look [here](https://github.com/MetaMask/test-dapp/blob/main/src/index.js) it seems that In order to use stringified params, we need to use a new version of `eth_signTypedData`. This PR updates ethersProvider to use v4.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/20520102/201401649-a3950ff7-5eca-4d03-9b61-8f1176d9019f.png">

No sure though if this impacts other things, I've also tested using WalletConnect, cli  it works.