### PR TITLE
hub: Add checkly secret so that we can use it to authenticate data integrity checks requests

### DIFF
--- a/waypoint.hcl
+++ b/waypoint.hcl
@@ -64,6 +64,7 @@ app "hub" {
         MAILCHIMP_API_KEY                             = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_MAILCHIMP_API_KEY-lkxsEk"
         CRYPTOCOMPARE_API_KEY                         = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_CRYPTOCOMPARE_API_KEY-3Sk0nr"
         HUB_PRIVATE_KEY                               = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_hub_private_key-fJhPUj"
+        CHECKLY_WEBHOOK_SECRET                        = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_hub_checkly_webhook_secret-etKeUa"
       }
     }
 

--- a/waypoint.prod.hcl
+++ b/waypoint.prod.hcl
@@ -62,6 +62,7 @@ app "hub" {
         PAGERDUTY_TOKEN                               = "arn:aws:secretsmanager:us-east-1:120317779495:secret:PAGERDUTY_TOKEN-1L68JJ"
         MAILCHIMP_API_KEY                             = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_MAILCHIMP_API_KEY-XCGDUW"
         CRYPTOCOMPARE_API_KEY                         = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_CRYPTOCOMPARE_API_KEY-c9yTJ9"
+        CHECKLY_WEBHOOK_SECRET                        = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_hub_checkly_webhook_secret-1VZEgk"
       }
     }
 


### PR DESCRIPTION
Will be used here: https://github.com/cardstack/cardstack/blob/main/packages/hub/routes/data-integrity-checks.ts#L29

Accompanying infra PR: https://github.com/cardstack/infra/pull/318

Currently, `config.get('checkly.webhookSecret')` works in production but throws an error in staging due to unconfigured env var. I suppose this is because the secret was set manually using Waypoint CLI in production but not on staging.