### PR TITLE
[CS-4751]: Integrate create safe modal with sdk

### DIFF
--- a/packages/safe-tools-client/app/components/create-safe-button/index.gts
+++ b/packages/safe-tools-client/app/components/create-safe-button/index.gts
@@ -66,7 +66,9 @@ export default class CreateSafeButton extends Component<Signature> {
 
   @action handleSafeCreation() {
     taskFor(this.scheduledPaymentsSdk.createSafe).perform()
-    .then(() => { 
+    .then(async () => { 
+      // Fetch from sdk or add task result manually ??
+      await this.wallet.fetchSafes();
       this.closeModal();
     }).catch((e) => {
       //TODO: handle error case

--- a/packages/safe-tools-client/app/components/setup-safe-modal/index.gts
+++ b/packages/safe-tools-client/app/components/setup-safe-modal/index.gts
@@ -1,12 +1,12 @@
 import Component from '@glimmer/component';
 import { on } from '@ember/modifier';
-import not from 'ember-truth-helpers/helpers/not';
 import or from 'ember-truth-helpers/helpers/or';
 
 import { svgJar } from '@cardstack/boxel/utils/svg-jar';
 import cssVar from '@cardstack/boxel/helpers/css-var';
 import BoxelModal from '@cardstack/boxel/components/boxel/modal';
 import BoxelActionContainer from '@cardstack/boxel/components/boxel/action-container'
+import { type ActionChinState }from '@cardstack/boxel/components/boxel/action-chin/state'
 import BoxelLoadingIndicator from '@cardstack/boxel/components/boxel/loading-indicator'
 
 import './index.css';
@@ -19,8 +19,7 @@ interface Signature {
     hasEnoughBalance: boolean;
     gasCostDisplay: string;
     onProvisionClick: () => void;
-    // TODO: provisioning will be status instead of boolean
-    provisioning: boolean;
+    isProvisioning: boolean;
     isLoadingGasInfo: boolean;
   };
 }
@@ -30,12 +29,16 @@ export default class SetupSafeModal extends Component<Signature> {
     return !this.args.hasEnoughBalance;
   }
 
+  get state(): ActionChinState { 
+    return this.args.isProvisioning ? 'in-progress' : 'default'
+  }
+  
   <template>
     <BoxelModal 
       @size='medium'
       @isOpen={{@isOpen}} 
       @onClose={{@onClose}}
-      @isOverlayDismissalDisabled={{@provisioning}}>
+      @isOverlayDismissalDisabled={{@isProvisioning}}>
       <BoxelActionContainer as |Section ActionChin|>
         <Section @title='Set up a Payment Safe' class='setup-safe-modal__section'>
           <p>In this step, you create a safe equipped with a module to schedule
@@ -81,21 +84,23 @@ export default class SetupSafeModal extends Component<Signature> {
             </div>
           {{/if}}
         </Section>
-        <ActionChin @state='default'>
+        <ActionChin @state={{this.state}}>
           <:default as |ac|>
             <ac.ActionButton
-              @loading={{@provisioning}}
               disabled={{or this.notEnoughBalance @isLoadingGasInfo}}
               {{on 'click' @onProvisionClick}}
             >
-              Provision{{if @provisioning 'ing'}}
+              Provision
             </ac.ActionButton>
-            {{#if (not @provisioning)}}
-              <ac.CancelButton {{on 'click' @onClose}}>
-                Cancel
-              </ac.CancelButton>
-            {{/if}}
+            <ac.CancelButton {{on 'click' @onClose}}>
+              Cancel
+            </ac.CancelButton>
           </:default>
+          <:inProgress as |ip|>
+            <ip.ActionButton>
+              Provisioning
+            </ip.ActionButton>
+          </:inProgress>
         </ActionChin>
       </BoxelActionContainer>
     </BoxelModal>


### PR DESCRIPTION
This PR adds the ability to create a safe within the setup-safe-modal. Also updates the modal to use  inProgress btn and states.
It partially adds the fetchSafes function, i'm not 100% certain it's in the right place, I've just added it to make sure we only allow one safe to be created and once we have that, the UI is updated with the mocked information for now, until we properly handle the safe info, the same goes for the`initializeSafes` function, which should be replace with a ember-resources and it was added to handle first render and page refresh. Anyways the goal for this PR is to have a safe provisioned which we can check its existence against the subgraph.
it also converts the address toChecksumAddress, to avoid failing queries.
