### PR TITLE
Add endpoint for fetching a list of scheduled payments

### DIFF
--- a/packages/hub/routes/scheduled-payments.ts
+++ b/packages/hub/routes/scheduled-payments.ts
@@ -51,6 +51,29 @@ export default class ScheduledPaymentsRoute {
     ctx.type = 'application/vnd.api+json';
   }
 
+  async list(ctx: Koa.Context) {
+    if (!ensureLoggedIn(ctx)) {
+      return;
+    }
+
+    let prisma = await this.prismaManager.getClient();
+
+    let minPayAt = new Date((ctx.query['filter[payAt][gt]'] as string) || 0);
+
+    let scheduledPayments = await prisma.scheduledPayment.findMany({
+      where: {
+        userAddress: ctx.state.userAddress,
+        payAt: {
+          gt: minPayAt,
+        },
+      },
+    });
+
+    ctx.body = this.scheduledPaymentSerializer.serialize(scheduledPayments);
+    ctx.status = 200;
+    ctx.type = 'application/vnd.api+json';
+  }
+
   async post(ctx: Koa.Context) {
     if (!ensureLoggedIn(ctx)) {
       return;

--- a/packages/hub/services/api-router.ts
+++ b/packages/hub/services/api-router.ts
@@ -142,6 +142,7 @@ export default class APIRouter {
     apiSubrouter.put('/notification-preferences/:push_client_id', parseBody, notificationPreferencesRoute.put);
     apiSubrouter.post('/scheduled-payments', parseBody, scheduledPaymentsRoute.post);
     apiSubrouter.get('/scheduled-payments/:scheduled_payment_id', parseBody, scheduledPaymentsRoute.get);
+    apiSubrouter.get('/scheduled-payments', parseBody, scheduledPaymentsRoute.list);
     apiSubrouter.patch('/scheduled-payments/:scheduled_payment_id', parseBody, scheduledPaymentsRoute.patch);
     apiSubrouter.delete('/scheduled-payments/:scheduled_payment_id', parseBody, scheduledPaymentsRoute.delete);
     apiSubrouter.get('/wyre-prices', parseBody, wyrePricesRoute.get);

--- a/packages/hub/services/serializers/scheduled-payment-serializer.ts
+++ b/packages/hub/services/serializers/scheduled-payment-serializer.ts
@@ -2,39 +2,43 @@ import { ScheduledPayment } from '@prisma/client';
 import { JSONAPIDocument } from '../../utils/jsonapi-document';
 
 export default class ScheduledPaymentSerializer {
-  serialize(model: ScheduledPayment): JSONAPIDocument {
-    const result = {
-      data: {
-        id: model.id,
-        type: 'scheduled-payment',
-        attributes: {
-          'user-address': model.userAddress,
-          'sender-safe-address': model.senderSafeAddress,
-          'module-address': model.moduleAddress,
-          'token-address': model.tokenAddress,
-          'gas-token-address': model.gasTokenAddress,
-          amount: model.amount,
-          'payee-address': model.payeeAddress,
-          'execution-gas-estimation': model.executionGasEstimation,
-          'max-gas-price': model.maxGasPrice,
-          'fee-fixed-usd': model.feeFixedUsd,
-          'fee-percentage': model.feePercentage,
-          salt: model.salt,
-          'pay-at': model.payAt,
-          'sp-hash': model.spHash,
-          'chain-id': model.chainId,
-          'recurring-day-of-month': model.recurringDayOfMonth,
-          'recurring-until': model.recurringUntil,
-          'creation-transaction-hash': model.creationTransactionHash,
-          'creation-block-number': model.creationBlockNumber,
-          'creation-transaction-error': model.creationTransactionError,
-          'cancelation-transaction-hash': model.cancelationTransactionHash,
-          'cancelation-block-number': model.cancelationBlockNumber,
+  serialize(model: ScheduledPayment | ScheduledPayment[]): JSONAPIDocument {
+    if (Array.isArray(model)) {
+      return {
+        data: model.map((m) => this.serialize(m).data),
+      };
+    } else {
+      return {
+        data: {
+          id: model.id,
+          type: 'scheduled-payment',
+          attributes: {
+            'user-address': model.userAddress,
+            'sender-safe-address': model.senderSafeAddress,
+            'module-address': model.moduleAddress,
+            'token-address': model.tokenAddress,
+            'gas-token-address': model.gasTokenAddress,
+            amount: model.amount,
+            'payee-address': model.payeeAddress,
+            'execution-gas-estimation': model.executionGasEstimation,
+            'max-gas-price': model.maxGasPrice,
+            'fee-fixed-usd': model.feeFixedUsd,
+            'fee-percentage': model.feePercentage,
+            salt: model.salt,
+            'pay-at': model.payAt,
+            'sp-hash': model.spHash,
+            'chain-id': model.chainId,
+            'recurring-day-of-month': model.recurringDayOfMonth,
+            'recurring-until': model.recurringUntil,
+            'creation-transaction-hash': model.creationTransactionHash,
+            'creation-block-number': model.creationBlockNumber,
+            'creation-transaction-error': model.creationTransactionError,
+            'cancelation-transaction-hash': model.cancelationTransactionHash,
+            'cancelation-block-number': model.cancelationBlockNumber,
+          },
         },
-      },
-    };
-
-    return result as JSONAPIDocument;
+      };
+    }
   }
 }
 


### PR DESCRIPTION
Ticket: CS-4374

This PR adds an endpoint to fetch all scheduled payments created by the user. It supports filtering by `payAt` which will allow the client to fetch future payments (to list which ones will be executed and when). 

It lacks pagination but we can add this later when we see the need and the clients supports it. 