### PR TITLE
Add API in the Hub to get gas prices

### DIFF
--- a/packages/cardpay-sdk/sdk/network-config-utils.ts
+++ b/packages/cardpay-sdk/sdk/network-config-utils.ts
@@ -5,7 +5,8 @@ import { HubConfigResponse, RpcNodeUrl } from './hub-config';
 
 type Networkish = string | number | Network;
 
-const convertChainIdToName = (network: Networkish) => (typeof network === 'number' ? networks[network] : network);
+export const convertChainIdToName = (network: Networkish) =>
+  typeof network === 'number' ? networks[network] : network;
 
 export const getWeb3ConfigByNetwork = (config: HubConfigResponse, network: Networkish): RpcNodeUrl => {
   const networkName = convertChainIdToName(network);

--- a/packages/hub/config/custom-environment-variables.json
+++ b/packages/hub/config/custom-environment-variables.json
@@ -110,5 +110,10 @@
   },
   "authSecret": "HUB_AUTH_SECRET",
   "emailHashSalt": "HUB_EMAIL_HASH_SALT",
-  "hubPrivateKey": "HUB_PRIVATE_KEY"
+  "hubPrivateKey": "HUB_PRIVATE_KEY",
+  "gasStationUrls": {
+    "gnosis": "GNOSIS_GAS_STATION_URL",
+    "ethereum": "ETHEREUM_GAS_STATION_URL",
+    "polygon": "POLYGON_GAS_STATION_URL"
+  }
 }

--- a/packages/hub/config/default.cjs
+++ b/packages/hub/config/default.cjs
@@ -143,4 +143,9 @@ module.exports = {
   pagerDuty: {
     token: null,
   },
+  gasStationUrls: {
+    gnosis: "https://blockscout.com/poa/sokol/api/v1/gas-price-oracle",
+    ethereum: "https://api.etherscan.io/api?module=gastracker&action=gasoracle",
+    polygon: "https://gasstation-mumbai.matic.today/v2"
+  }
 };

--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -949,6 +949,23 @@ CREATE TABLE public.exchange_rates (
 ALTER TABLE public.exchange_rates OWNER TO postgres;
 
 --
+-- Name: gas_prices; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.gas_prices (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    chain_id integer NOT NULL,
+    slow text NOT NULL,
+    standard text NOT NULL,
+    fast text NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+ALTER TABLE public.gas_prices OWNER TO postgres;
+
+--
 -- Name: job_tickets; Type: TABLE; Schema: public; Owner: postgres
 --
 
@@ -1408,6 +1425,22 @@ ALTER TABLE ONLY public.exchange_rates
 
 
 --
+-- Name: gas_prices gas_prices_chain_id_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.gas_prices
+    ADD CONSTRAINT gas_prices_chain_id_key UNIQUE (chain_id);
+
+
+--
+-- Name: gas_prices gas_prices_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.gas_prices
+    ADD CONSTRAINT gas_prices_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: job_tickets job_tickets_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
@@ -1832,14 +1865,14 @@ SET row_security = off;
 --
 
 COPY graphile_worker.migrations (id, ts) FROM stdin;
-1	2022-11-03 04:55:42.3105+00
-2	2022-11-03 04:55:42.3105+00
-3	2022-11-03 04:55:42.3105+00
-4	2022-11-03 04:55:42.3105+00
-5	2022-11-03 04:55:42.3105+00
-6	2022-11-03 04:55:42.3105+00
-7	2022-11-03 04:55:42.3105+00
-8	2022-11-03 04:55:42.3105+00
+1	2022-11-15 16:29:27.957943+00
+2	2022-11-15 16:29:27.957943+00
+3	2022-11-15 16:29:27.957943+00
+4	2022-11-15 16:29:27.957943+00
+5	2022-11-15 16:29:27.957943+00
+6	2022-11-15 16:29:27.957943+00
+7	2022-11-15 16:29:27.957943+00
+8	2022-11-15 16:29:27.957943+00
 \.
 
 
@@ -1848,51 +1881,52 @@ COPY graphile_worker.migrations (id, ts) FROM stdin;
 --
 
 COPY public.pgmigrations (id, name, run_on) FROM stdin;
-1	20210527151505645_create-prepaid-card-tables	2022-11-03 04:55:42.153647
-2	20210614080132698_create-prepaid-card-customizations-table	2022-11-03 04:55:42.232315
-3	20210623052200757_create-graphile-worker-schema	2022-11-03 04:55:42.3105
-4	20210809113449561_merchant-infos	2022-11-03 04:55:42.644116
-5	20210817184105100_wallet-orders	2022-11-03 04:55:42.68879
-6	20210920142313915_prepaid-card-reservations	2022-11-03 04:55:42.753122
-7	20210924200122612_order-indicies	2022-11-03 04:55:42.859764
-8	20211006090701108_create-card-spaces	2022-11-03 04:55:42.889529
-9	20211013155536724_card-index	2022-11-03 04:55:42.939978
-10	20211013173917696_beta-testers	2022-11-03 04:55:42.980407
-11	20211014131843187_add-fields-to-card-spaces	2022-11-03 04:55:43.040687
-12	20211020231214235_discord-bots	2022-11-03 04:55:43.050099
-13	20211105180905492_wyre-price-service	2022-11-03 04:55:43.10777
-14	20211110210324178_card-index-part-duex	2022-11-03 04:55:43.150202
-15	20211118084217151_create-uploads	2022-11-03 04:55:43.155241
-16	20211129083801382_create-push-notification-registrations	2022-11-03 04:55:43.19327
-17	20211129123635817_create-notification-types	2022-11-03 04:55:43.249934
-18	20211129130425303_create-notification-preferences	2022-11-03 04:55:43.296327
-19	20211206195559187_card-index-generations	2022-11-03 04:55:43.400578
-20	20211207151150639_sent-push-notifications	2022-11-03 04:55:43.411015
-21	20211207190527999_create-latest-event-block	2022-11-03 04:55:43.453819
-22	20211214163123421_card-index-errors	2022-11-03 04:55:43.48377
-23	20220103201128435_invalidation-ordering	2022-11-03 04:55:43.523717
-24	20220107151914576_rename-beta-testers-table	2022-11-03 04:55:43.588086
-25	20220111204952452_index-optimizations	2022-11-03 04:55:43.593667
-26	20220119232151260_space-belongs-to-merchant	2022-11-03 04:55:43.598148
-27	20220216104259120_allow-nulls-in-card-spaces	2022-11-03 04:55:43.624849
-28	20220301101637933_create-card-space-profiles-for-existing-merchants	2022-11-03 04:55:43.643266
-29	20220413090421591_card-space-unused-data-cleanup	2022-11-03 04:55:43.646849
-30	20220413215720902_create-email-card-drop-requests	2022-11-03 04:55:43.657785
-31	20220502174343477_create-email-card-drop-state	2022-11-03 04:55:43.694125
-32	20220527204632100_create-exchange-rates	2022-11-03 04:55:43.716762
-33	20220610203119883_create-job-tickets	2022-11-03 04:55:43.751905
-34	20220622235635327_add-job-ticket-spec	2022-11-03 04:55:43.797978
-35	20220629173134216_add-job-ticket-source-arguments	2022-11-03 04:55:43.804098
-36	20220728144935996_add-profiles	2022-11-03 04:55:43.810448
-37	20220802184224370_populate-profiles	2022-11-03 04:55:43.859838
-38	20220802184244353_delete-profile-components	2022-11-03 04:55:43.925383
-39	20220810123016866_create-scheduled-payments	2022-11-03 04:55:43.932086
-40	20220810123029047_create-scheduled-payment-attempts	2022-11-03 04:55:43.987948
-41	20220831081406596_alter-scheduled-payment-fields	2022-11-03 04:55:44.036842
-42	20220921073021534_alter-scheduled-payment-fields-2	2022-11-03 04:55:44.074182
-43	20221003121041200_change_bigint-add-gas-token-address-to-scheduled-payments	2022-11-03 04:55:44.340343
-44	20221014121655874_rename-cancellation-transaction-error	2022-11-03 04:55:44.962981
-45	20221025140643069_create-crank-nonces	2022-11-03 04:55:44.96969
+1	20210527151505645_create-prepaid-card-tables	2022-11-15 16:29:27.829759
+2	20210614080132698_create-prepaid-card-customizations-table	2022-11-15 16:29:27.90183
+3	20210623052200757_create-graphile-worker-schema	2022-11-15 16:29:27.957943
+4	20210809113449561_merchant-infos	2022-11-15 16:29:28.290577
+5	20210817184105100_wallet-orders	2022-11-15 16:29:28.333055
+6	20210920142313915_prepaid-card-reservations	2022-11-15 16:29:28.394257
+7	20210924200122612_order-indicies	2022-11-15 16:29:28.470021
+8	20211006090701108_create-card-spaces	2022-11-15 16:29:28.49584
+9	20211013155536724_card-index	2022-11-15 16:29:28.539908
+10	20211013173917696_beta-testers	2022-11-15 16:29:28.600063
+11	20211014131843187_add-fields-to-card-spaces	2022-11-15 16:29:28.65967
+12	20211020231214235_discord-bots	2022-11-15 16:29:28.666642
+13	20211105180905492_wyre-price-service	2022-11-15 16:29:28.723803
+14	20211110210324178_card-index-part-duex	2022-11-15 16:29:28.767695
+15	20211118084217151_create-uploads	2022-11-15 16:29:28.772532
+16	20211129083801382_create-push-notification-registrations	2022-11-15 16:29:28.805225
+17	20211129123635817_create-notification-types	2022-11-15 16:29:28.847782
+18	20211129130425303_create-notification-preferences	2022-11-15 16:29:28.885329
+19	20211206195559187_card-index-generations	2022-11-15 16:29:28.94833
+20	20211207151150639_sent-push-notifications	2022-11-15 16:29:28.957633
+21	20211207190527999_create-latest-event-block	2022-11-15 16:29:28.998868
+22	20211214163123421_card-index-errors	2022-11-15 16:29:29.023268
+23	20220103201128435_invalidation-ordering	2022-11-15 16:29:29.063997
+24	20220107151914576_rename-beta-testers-table	2022-11-15 16:29:29.121945
+25	20220111204952452_index-optimizations	2022-11-15 16:29:29.127029
+26	20220119232151260_space-belongs-to-merchant	2022-11-15 16:29:29.132367
+27	20220216104259120_allow-nulls-in-card-spaces	2022-11-15 16:29:29.154419
+28	20220301101637933_create-card-space-profiles-for-existing-merchants	2022-11-15 16:29:29.175344
+29	20220413090421591_card-space-unused-data-cleanup	2022-11-15 16:29:29.179434
+30	20220413215720902_create-email-card-drop-requests	2022-11-15 16:29:29.191511
+31	20220502174343477_create-email-card-drop-state	2022-11-15 16:29:29.228035
+32	20220527204632100_create-exchange-rates	2022-11-15 16:29:29.249582
+33	20220610203119883_create-job-tickets	2022-11-15 16:29:29.285322
+34	20220622235635327_add-job-ticket-spec	2022-11-15 16:29:29.32846
+35	20220629173134216_add-job-ticket-source-arguments	2022-11-15 16:29:29.333588
+36	20220728144935996_add-profiles	2022-11-15 16:29:29.338293
+37	20220802184224370_populate-profiles	2022-11-15 16:29:29.383677
+38	20220802184244353_delete-profile-components	2022-11-15 16:29:29.432561
+39	20220810123016866_create-scheduled-payments	2022-11-15 16:29:29.437409
+40	20220810123029047_create-scheduled-payment-attempts	2022-11-15 16:29:29.490247
+41	20220831081406596_alter-scheduled-payment-fields	2022-11-15 16:29:29.540087
+42	20220921073021534_alter-scheduled-payment-fields-2	2022-11-15 16:29:29.580293
+43	20221003121041200_change_bigint-add-gas-token-address-to-scheduled-payments	2022-11-15 16:29:29.865977
+44	20221014121655874_rename-cancellation-transaction-error	2022-11-15 16:29:30.501616
+45	20221025140643069_create-crank-nonces	2022-11-15 16:29:30.507468
+46	20221115065506357_create-gas-prices	2022-11-15 16:29:30.539621
 \.
 
 
@@ -1900,7 +1934,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 -- Name: pgmigrations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.pgmigrations_id_seq', 45, true);
+SELECT pg_catalog.setval('public.pgmigrations_id_seq', 46, true);
 
 
 --

--- a/packages/hub/db/migrations/20221115065506357_create-gas-prices.ts
+++ b/packages/hub/db/migrations/20221115065506357_create-gas-prices.ts
@@ -1,0 +1,19 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+const TABLE = 'gas_prices';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable(TABLE, {
+    id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    chain_id: { type: 'integer', notNull: true, unique: true },
+    slow: { type: 'string', notNull: true },
+    standard: { type: 'string', notNull: true },
+    fast: { type: 'string', notNull: true },
+    created_at: { type: 'timestamp', notNull: true, default: pgm.func('current_timestamp') },
+    updated_at: { type: 'timestamp', notNull: true, default: pgm.func('current_timestamp') },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable(TABLE);
+}

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -101,6 +101,8 @@ import EthersProvider from './services/ethers-provider';
 import CrankNonceLock from './services/crank-nonce-lock';
 import DataIntegrityChecksScheduledPayments from './services/data-integrity-checks/scheduled-payments';
 import DataIntegrityChecksRoute from './routes/data-integrity-checks';
+import GasStationService from './services/gas-station';
+import GasStationRoute from './routes/gas-station';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -189,6 +191,8 @@ export function createRegistry(): Registry {
   registry.register('ethers-provider', EthersProvider);
   registry.register('data-integrity-checks-scheduled-payments', DataIntegrityChecksScheduledPayments);
   registry.register('data-integrity-checks-route', DataIntegrityChecksRoute);
+  registry.register('gas-station-service', GasStationService);
+  registry.register('gas-station-route', GasStationRoute);
 
   if (process.env.COMPILER) {
     registry.register(

--- a/packages/hub/node-tests/services/gas-station-test.ts
+++ b/packages/hub/node-tests/services/gas-station-test.ts
@@ -1,0 +1,132 @@
+import { rest } from 'msw';
+import { setupServer, SetupServerApi } from 'msw/node';
+import GasStationService from '../../services/gas-station';
+import { setupHub } from '../helpers/server';
+import config from 'config';
+import { ethers } from 'ethers';
+
+const ethereumGasPrice = {
+  status: '1',
+  message: 'OK',
+  result: {
+    LastBlock: '15975904',
+    SafeGasPrice: '16',
+    ProposeGasPrice: '18',
+    FastGasPrice: '20',
+    suggestBaseFee: '15.660586612',
+    gasUsedRatio: '0.206799033333333,0.849954066666667,0.670711266666667,0.480958133333333,0.427384866666667',
+  },
+};
+
+const polygonGasPrice = {
+  safeLow: {
+    maxPriorityFee: 1.39333,
+    maxFee: 1.39333,
+  },
+  standard: {
+    maxPriorityFee: 1.473333,
+    maxFee: 1.4733396,
+  },
+  fast: {
+    maxPriorityFee: 1.69998,
+    maxFee: 1.7,
+  },
+  estimatedBaseFee: 0.000006497,
+  blockTime: 5,
+  blockNumber: 29161250,
+};
+
+const gnosisGasPrice = {
+  average: 1.51,
+  fast: 1.52,
+  slow: 1.51,
+};
+
+describe('GasStationService', function () {
+  let subject: GasStationService;
+  let mockServer: SetupServerApi;
+
+  let { getPrisma, getContainer } = setupHub(this);
+
+  this.beforeEach(async function () {
+    subject = (await getContainer().lookup('gas-station-service')) as GasStationService;
+  });
+
+  this.beforeEach(async function () {
+    mockServer = setupServer(
+      rest.get(config.get('gasStationUrls.ethereum'), (_req, res, ctx) => {
+        return res(ctx.status(200), ctx.json(ethereumGasPrice));
+      }),
+      rest.get(config.get('gasStationUrls.polygon'), (_req, res, ctx) => {
+        return res(ctx.status(200), ctx.json(polygonGasPrice));
+      }),
+      rest.get(config.get('gasStationUrls.gnosis'), (_req, res, ctx) => {
+        return res(ctx.status(200), ctx.json(gnosisGasPrice));
+      })
+    );
+
+    mockServer.listen();
+  });
+
+  this.afterEach(async function () {
+    mockServer.close();
+  });
+
+  it('returns gas price for ethereum', async function () {
+    let chainId = 1;
+    let prisma = await getPrisma();
+    let gasPrice = await subject.getGasPriceByChainId(chainId);
+    let gasPriceFromDB = await prisma.gasPrice.findFirst({
+      where: { chainId },
+    });
+
+    expect(gasPrice).not.null;
+    expect(gasPrice?.slow).equal(ethers.utils.parseUnits(ethereumGasPrice.result.SafeGasPrice, 'gwei').toString());
+    expect(gasPrice?.standard).equal(
+      ethers.utils.parseUnits(ethereumGasPrice.result.ProposeGasPrice, 'gwei').toString()
+    );
+    expect(gasPrice?.fast).equal(ethers.utils.parseUnits(ethereumGasPrice.result.FastGasPrice, 'gwei').toString());
+    expect(gasPrice?.chainId).equal(gasPriceFromDB?.chainId);
+    expect(gasPrice?.slow).equal(gasPriceFromDB?.slow);
+    expect(gasPrice?.standard).equal(gasPriceFromDB?.standard);
+    expect(gasPrice?.fast).equal(gasPriceFromDB?.fast);
+  });
+
+  it('returns gas price for polygon', async function () {
+    let chainId = 137;
+    let prisma = await getPrisma();
+    let gasPrice = await subject.getGasPriceByChainId(chainId);
+    let gasPriceFromDB = await prisma.gasPrice.findFirst({
+      where: { chainId },
+    });
+
+    expect(gasPrice).not.null;
+    expect(gasPrice?.slow).equal(ethers.utils.parseUnits(String(polygonGasPrice.safeLow.maxFee), 'gwei').toString());
+    expect(gasPrice?.standard).equal(
+      ethers.utils.parseUnits(String(polygonGasPrice.standard.maxFee), 'gwei').toString()
+    );
+    expect(gasPrice?.fast).equal(ethers.utils.parseUnits(String(polygonGasPrice.fast.maxFee), 'gwei').toString());
+    expect(gasPrice?.chainId).equal(gasPriceFromDB?.chainId);
+    expect(gasPrice?.slow).equal(gasPriceFromDB?.slow);
+    expect(gasPrice?.standard).equal(gasPriceFromDB?.standard);
+    expect(gasPrice?.fast).equal(gasPriceFromDB?.fast);
+  });
+
+  it('returns gas price for gnosis', async function () {
+    let chainId = 100;
+    let prisma = await getPrisma();
+    let gasPrice = await subject.getGasPriceByChainId(chainId);
+    let gasPriceFromDB = await prisma.gasPrice.findFirst({
+      where: { chainId },
+    });
+
+    expect(gasPrice).not.null;
+    expect(gasPrice?.slow).equal(ethers.utils.parseUnits(String(gnosisGasPrice.slow), 'gwei').toString());
+    expect(gasPrice?.standard).equal(ethers.utils.parseUnits(String(gnosisGasPrice.average), 'gwei').toString());
+    expect(gasPrice?.fast).equal(ethers.utils.parseUnits(String(gnosisGasPrice.fast), 'gwei').toString());
+    expect(gasPrice?.chainId).equal(gasPriceFromDB?.chainId);
+    expect(gasPrice?.slow).equal(gasPriceFromDB?.slow);
+    expect(gasPrice?.standard).equal(gasPriceFromDB?.standard);
+    expect(gasPrice?.fast).equal(gasPriceFromDB?.fast);
+  });
+});

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -340,6 +340,18 @@ model CrankNonce {
   @@map("crank_nonces")
 }
 
+model GasPrice {
+  id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  chainId   Int      @unique @map("chain_id")
+  slow      String
+  standard  String
+  fast      String
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamp(6)
+  updatedAt DateTime @default(now()) @map("updated_at") @db.Timestamp(6)
+
+  @@map("gas_prices")
+}
+
 enum DiscordBotsStatusEnum {
   connecting
   connected

--- a/packages/hub/routes/gas-station.ts
+++ b/packages/hub/routes/gas-station.ts
@@ -1,0 +1,32 @@
+import Koa from 'koa';
+import autoBind from 'auto-bind';
+import { inject } from '@cardstack/di';
+
+export default class GasStationRoute {
+  gasStationService = inject('gas-station-service');
+
+  constructor() {
+    autoBind(this);
+  }
+
+  async get(ctx: Koa.Context) {
+    let chainId: number = ctx.params.chainId;
+    let gasPrice = await this.gasStationService.getGasPriceByChainId(chainId);
+    if (!gasPrice) {
+      ctx.status = 404;
+      return;
+    }
+
+    ctx.status = 200;
+    ctx.body = {
+      gasPrice,
+    };
+    ctx.type = 'application/vnd.api+json';
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'gas-station-route': GasStationRoute;
+  }
+}

--- a/packages/hub/services/gas-station.ts
+++ b/packages/hub/services/gas-station.ts
@@ -1,0 +1,95 @@
+/*global fetch */
+
+import { supportedChains, convertChainIdToName } from '@cardstack/cardpay-sdk';
+import { inject } from '@cardstack/di';
+import { addMilliseconds } from 'date-fns';
+import { nowUtc } from '../utils/dates';
+import config from 'config';
+import { ethers } from 'ethers';
+
+export default class GasStationService {
+  prismaManager = inject('prisma-manager', { as: 'prismaManager' });
+  readonly gasPriceTTL = 60000; //1 minutes
+
+  async getGasPriceByChainId(chainId: number) {
+    let prisma = await this.prismaManager.getClient();
+    let gasPrice = await prisma.gasPrice.findFirst({
+      where: { chainId },
+    });
+
+    if (!gasPrice || addMilliseconds(gasPrice.updatedAt, this.gasPriceTTL) <= nowUtc()) {
+      let url = this.getGasStatioUrl(chainId);
+      let response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+      });
+      if (!response.ok) {
+        throw new Error(`Cannot retrieve gas price from gas station: ${url}`);
+      }
+
+      let gasPriceResponse = this.extractGasPriceResponse(chainId, await response.json());
+      gasPrice = await prisma.gasPrice.upsert({
+        where: { chainId },
+        create: {
+          chainId,
+          slow: gasPriceResponse.slow.toString(),
+          standard: gasPriceResponse.standard.toString(),
+          fast: gasPriceResponse.fast.toString(),
+        },
+        update: {
+          slow: gasPriceResponse.slow.toString(),
+          standard: gasPriceResponse.standard.toString(),
+          fast: gasPriceResponse.fast.toString(),
+        },
+      });
+    }
+
+    return gasPrice;
+  }
+
+  private getGasStatioUrl(chainId: number) {
+    const networkName = convertChainIdToName(chainId);
+    const gasStationUrls: { ethereum: string; gnosis: string; polygon: string } = config.get('gasStationUrls');
+    if (supportedChains.ethereum.includes(networkName)) return gasStationUrls.ethereum;
+    if (supportedChains.gnosis.includes(networkName)) return gasStationUrls.gnosis;
+    if (supportedChains.polygon.includes(networkName)) return gasStationUrls.polygon;
+
+    throw new Error(`Cannot get gas station url, unsupported network: ${chainId}`);
+  }
+
+  private extractGasPriceResponse(chainId: number, response: any) {
+    const networkName = convertChainIdToName(chainId);
+    if (supportedChains.ethereum.includes(networkName)) {
+      return {
+        slow: ethers.utils.parseUnits(String(response.result?.SafeGasPrice), 'gwei'),
+        standard: ethers.utils.parseUnits(String(response.result?.ProposeGasPrice), 'gwei'),
+        fast: ethers.utils.parseUnits(String(response.result?.FastGasPrice), 'gwei'),
+      };
+    }
+    if (supportedChains.gnosis.includes(networkName)) {
+      return {
+        slow: ethers.utils.parseUnits(String(response.slow), 'gwei'),
+        standard: ethers.utils.parseUnits(String(response.average), 'gwei'),
+        fast: ethers.utils.parseUnits(String(response.fast), 'gwei'),
+      };
+    }
+    if (supportedChains.polygon.includes(networkName)) {
+      return {
+        slow: ethers.utils.parseUnits(String(response.safeLow?.maxFee), 'gwei'),
+        standard: ethers.utils.parseUnits(String(response.standard?.maxFee), 'gwei'),
+        fast: ethers.utils.parseUnits(String(response.fast?.maxFee), 'gwei'),
+      };
+    }
+
+    throw new Error(`Cannot extract gas price, unsupported network: ${chainId}`);
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'gas-station-service': GasStationService;
+  }
+}


### PR DESCRIPTION
Tickets: CS-4859

As a result of our discussion, we decided to add API in the Hub to get gas prices of supported chains. This way, we don't need to rely on a relay server to get this data since we prefer not to update any codes on the relay server.

*Current test cases are only for normal flow. I will add the exception flow and the test cases for the route.