### PR TITLE
sdk: Update the crank when canceling a scheduled payment

### DIFF
--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -36,7 +36,10 @@ import { ERC20ABI, getSDK } from '..';
 import { SuccessfulTransactionReceipt } from './utils/successful-transaction-receipt';
 /* eslint-disable node/no-extraneous-import */
 import { AddressZero } from '@ethersproject/constants';
-import { waitUntilSchedulePaymentTransactionMined } from './scheduled-payment/utils';
+import {
+  waitUntilCancelPaymentTransactionMined,
+  waitUntilSchedulePaymentTransactionMined,
+} from './scheduled-payment/utils';
 import BN from 'bn.js';
 import { Interface } from 'ethers/lib/utils';
 import JsonRpcProvider from '../providers/json-rpc-provider';
@@ -496,8 +499,8 @@ export default class ScheduledPaymentModule {
     return requiredGas + PROXY_GAS + OLD_CALL_GAS;
   }
 
-  async cancelScheduledPayment(txnHash: string): Promise<SuccessfulTransactionReceipt>;
-  async cancelScheduledPayment(
+  async cancelScheduledPaymentOnChain(txnHash: string): Promise<SuccessfulTransactionReceipt>;
+  async cancelScheduledPaymentOnChain(
     safeAddress: string,
     moduleAddress: string,
     spHash: string,
@@ -505,7 +508,7 @@ export default class ScheduledPaymentModule {
     txnOptions?: TransactionOptions,
     contractOptions?: ContractOptions
   ): Promise<void>;
-  async cancelScheduledPayment(
+  async cancelScheduledPaymentOnChain(
     safeAddressOrTxnHash: string,
     moduleAddress?: string,
     spHash?: string,
@@ -707,6 +710,46 @@ export default class ScheduledPaymentModule {
     return { nonce, estimate, payload, signature };
   }
 
+  private async generateCancelPaymentTxParams(
+    safeAddress: string,
+    moduleAddress: string,
+    gasTokenAddress: string,
+    spHash: string
+  ) {
+    let contract = new Contract(moduleAddress, ScheduledPaymentABI, this.ethersProvider);
+    let payload = contract.interface.encodeFunctionData('cancelScheduledPayment', [spHash]);
+
+    let estimate = await gasEstimate(
+      this.ethersProvider,
+      safeAddress,
+      moduleAddress,
+      '0',
+      payload,
+      Operation.CALL,
+      gasTokenAddress
+    );
+
+    let nonce = getNextNonceFromEstimate(estimate);
+    let signer = this.signer ? this.signer : this.ethersProvider.getSigner();
+    let from = await signer.getAddress();
+
+    let signature = (
+      await signSafeTx(
+        this.ethersProvider,
+        safeAddress,
+        moduleAddress,
+        payload,
+        Operation.CALL,
+        estimate,
+        nonce,
+        from,
+        this.signer
+      )
+    )[0];
+
+    return { nonce, estimate, payload, signature };
+  }
+
   private async schedulePaymentOnChainAndUpdateCrank(
     hubRootUrl: string,
     authToken: string,
@@ -731,6 +774,146 @@ export default class ScheduledPaymentModule {
         },
       }).catch(reject);
     });
+  }
+
+  private async cancelPaymentOnChainAndUpdateCrank(
+    hubRootUrl: string,
+    authToken: string,
+    scheduledPaymentId: string,
+    safeAddress: string,
+    moduleAddress: string,
+    gasTokenAddress: string,
+    spHash: string,
+    txnParams: TransactionParams
+  ) {
+    return new Promise<void>((resolve, reject) => {
+      this.cancelPaymentOnChain(safeAddress, moduleAddress, gasTokenAddress, spHash, txnParams, {
+        onTxnHash: async (txHash: string) => {
+          await hubRequest(hubRootUrl, `api/scheduled-payments/${scheduledPaymentId}`, authToken, 'PATCH', {
+            data: {
+              attributes: {
+                'cancelation-transaction-hash': txHash,
+              },
+            },
+          });
+          resolve();
+        },
+      }).catch(reject);
+    });
+  }
+
+  async cancelScheduledPayment(scheduledPaymentId: string) {
+    let hubAuth = await getSDK('HubAuth', this.ethersProvider, undefined, this.signer);
+    let hubRootUrl = await hubAuth.getHubUrl();
+    let authToken = await hubAuth.authenticate();
+
+    let scheduledPaymentResponse = await hubRequest(
+      hubRootUrl,
+      `api/scheduled-payments/${scheduledPaymentId}`,
+      authToken,
+      'GET'
+    );
+
+    let scheduledPayment = scheduledPaymentResponse.data.attributes;
+    let safeAddress = scheduledPayment['sender-safe-address'];
+    let moduleAddress = scheduledPayment['module-address'];
+    let cancelationBlockNumber = scheduledPayment['cancelation-block-number'];
+    let cancelationTransactionHash = scheduledPayment['cancelation-transaction-hash'];
+    let gasTokenAddress = scheduledPayment['gas-token-address'];
+    let spHash = scheduledPayment['sp-hash'];
+
+    if (cancelationBlockNumber) {
+      return true; // Already canceled and transaction mined
+    } else if (cancelationTransactionHash) {
+      return await waitUntilCancelPaymentTransactionMined(hubRootUrl, scheduledPaymentId, authToken);
+    }
+
+    let txnParams = await this.generateCancelPaymentTxParams(safeAddress, moduleAddress, gasTokenAddress, spHash);
+
+    await this.cancelPaymentOnChainAndUpdateCrank(
+      hubRootUrl,
+      authToken,
+      scheduledPaymentId,
+      safeAddress,
+      moduleAddress,
+      gasTokenAddress,
+      spHash,
+      txnParams
+    );
+
+    await waitUntilCancelPaymentTransactionMined(hubRootUrl, scheduledPaymentId, authToken);
+  }
+
+  async schedulePaymentOnChain(txnHash: string): Promise<SuccessfulTransactionReceipt>;
+  async schedulePaymentOnChain(
+    safeAddress: string,
+    moduleAddress: string,
+    gasTokenAddress: string,
+    spHash: string,
+    txnParams?: TransactionParams,
+    txnOptions?: TransactionOptions
+  ): Promise<SuccessfulTransactionReceipt>;
+  async schedulePaymentOnChain(
+    safeAddressOrTxnHash: string,
+    moduleAddress?: string,
+    gasTokenAddress?: string,
+    spHash?: string,
+    txnParams?: TransactionParams,
+    txnOptions?: TransactionOptions
+  ): Promise<SuccessfulTransactionReceipt> {
+    let { onTxnHash } = txnOptions ?? {};
+
+    if (isTransactionHash(safeAddressOrTxnHash)) {
+      let txnHash = safeAddressOrTxnHash;
+      return await waitUntilTransactionMined(this.ethersProvider, txnHash);
+    }
+
+    let safeAddress = safeAddressOrTxnHash;
+
+    if (!safeAddress) {
+      throw new Error('safeAddress must be provided');
+    }
+    if (!moduleAddress) {
+      throw new Error('moduleAddress must be provided');
+    }
+    if (!gasTokenAddress) {
+      throw new Error('gasTokenAddress must be provided');
+    }
+    if (!spHash) {
+      throw new Error('spHash must be provided');
+    }
+
+    let nonce, estimate, payload, signature;
+
+    if (txnParams && Object.keys(txnParams).length > 0) {
+      ({ nonce, estimate, payload, signature } = txnParams);
+    } else {
+      ({ nonce, estimate, payload, signature } = await this.generateSchedulePaymentTxParams(
+        safeAddress,
+        moduleAddress,
+        gasTokenAddress,
+        spHash
+      ));
+    }
+
+    let gnosisTxn = await executeTransaction(
+      this.ethersProvider,
+      safeAddress,
+      moduleAddress,
+      payload,
+      Operation.CALL,
+      estimate,
+      nonce,
+      [signature]
+    );
+
+    let txnHash = gnosisTxn.ethereumTx.txHash;
+
+    if (typeof onTxnHash === 'function') {
+      await onTxnHash(txnHash);
+    }
+
+    return await waitUntilTransactionMined(this.ethersProvider, txnHash);
   }
 
   async schedulePayment(scheduledPaymentId: string): Promise<void>;
@@ -860,8 +1043,8 @@ export default class ScheduledPaymentModule {
     await waitUntilSchedulePaymentTransactionMined(hubRootUrl, scheduledPaymentId, authToken);
   }
 
-  async schedulePaymentOnChain(txnHash: string): Promise<SuccessfulTransactionReceipt>;
-  async schedulePaymentOnChain(
+  async cancelPaymentOnChain(txnHash: string): Promise<SuccessfulTransactionReceipt>;
+  async cancelPaymentOnChain(
     safeAddress: string,
     moduleAddress: string,
     gasTokenAddress: string,
@@ -869,7 +1052,7 @@ export default class ScheduledPaymentModule {
     txnParams?: TransactionParams,
     txnOptions?: TransactionOptions
   ): Promise<SuccessfulTransactionReceipt>;
-  async schedulePaymentOnChain(
+  async cancelPaymentOnChain(
     safeAddressOrTxnHash: string,
     moduleAddress?: string,
     gasTokenAddress?: string,
@@ -904,7 +1087,7 @@ export default class ScheduledPaymentModule {
     if (txnParams && Object.keys(txnParams).length > 0) {
       ({ nonce, estimate, payload, signature } = txnParams);
     } else {
-      ({ nonce, estimate, payload, signature } = await this.generateSchedulePaymentTxParams(
+      ({ nonce, estimate, payload, signature } = await this.generateCancelPaymentTxParams(
         safeAddress,
         moduleAddress,
         gasTokenAddress,

--- a/packages/cardpay-sdk/sdk/scheduled-payment/utils.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment/utils.ts
@@ -18,3 +18,22 @@ export async function waitUntilSchedulePaymentTransactionMined(
     1000
   );
 }
+
+export async function waitUntilCancelPaymentTransactionMined(
+  hubRootUrl: string,
+  scheduledPaymentId: string,
+  authToken: string
+) {
+  return poll(
+    () => hubRequest(hubRootUrl, `api/scheduled-payments/${scheduledPaymentId}`, authToken, 'GET'),
+    (response: any) => {
+      let attributes = response.data.attributes;
+      let error = attributes['cancelation-transaction-error'];
+      if (error) {
+        throw new Error(`Transaction reverted: ${error}`);
+      }
+      return attributes['cancelation-block-number'] != null;
+    },
+    1000
+  );
+}

--- a/packages/hub/node-tests/routes/scheduled-payments-test.ts
+++ b/packages/hub/node-tests/routes/scheduled-payments-test.ts
@@ -659,7 +659,7 @@ describe('PATCH /api/scheduled-payments/:id', async function () {
       .expect('Content-Type', 'application/vnd.api+json');
   });
 
-  it('updates a scheduled payment', async function () {
+  it('updates a scheduled payment when creation transaction hash is provided', async function () {
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
         id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
@@ -728,6 +728,78 @@ describe('PATCH /api/scheduled-payments/:id', async function () {
       .expect('Content-Type', 'application/vnd.api+json');
 
     expect(getJobIdentifiers()[0]).to.equal('scheduled-payment-on-chain-creation-waiter');
+    expect(getJobPayloads()[0]).to.deep.equal({ scheduledPaymentId: scheduledPayment.id });
+  });
+
+  it('updates a scheduled payment when cancelation transaction hash is provided', async function () {
+    let scheduledPayment = await prisma.scheduledPayment.create({
+      data: {
+        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+        moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+        tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+        gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+        amount: '100',
+        payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+        executionGasEstimation: 100000,
+        maxGasPrice: '1000000000',
+        feeFixedUsd: 0,
+        feePercentage: 0,
+        salt: '54lt',
+        payAt: '2021-01-01T00:00:00.000Z',
+        spHash: '0x123',
+        chainId: 1,
+        userAddress: stubUserAddress,
+        creationTransactionHash: null,
+      },
+    });
+
+    await request()
+      .patch(`/api/scheduled-payments/${scheduledPayment.id}`)
+      .send({
+        data: {
+          attributes: {
+            'cancelation-transaction-hash': '0x123',
+          },
+        },
+      })
+      .set('Accept', 'application/vnd.api+json')
+      .set('Authorization', 'Bearer abc123--def456--ghi789')
+      .set('Content-Type', 'application/vnd.api+json')
+      .expect(200)
+      .expect({
+        data: {
+          id: scheduledPayment.id,
+          type: 'scheduled-payment',
+          attributes: {
+            'sender-safe-address': '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+            'module-address': '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+            'token-address': '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+            'gas-token-address': '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+            amount: '100',
+            'payee-address': '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+            'execution-gas-estimation': 100000,
+            'max-gas-price': '1000000000',
+            'fee-fixed-usd': '0',
+            'fee-percentage': '0',
+            salt: '54lt',
+            'pay-at': '2021-01-01T00:00:00.000Z',
+            'sp-hash': '0x123',
+            'chain-id': 1,
+            'user-address': stubUserAddress,
+            'creation-transaction-hash': null,
+            'creation-block-number': null,
+            'creation-transaction-error': null,
+            'cancelation-transaction-hash': '0x123',
+            'cancelation-block-number': null,
+            'recurring-day-of-month': null,
+            'recurring-until': null,
+          },
+        },
+      })
+      .expect('Content-Type', 'application/vnd.api+json');
+
+    expect(getJobIdentifiers()[0]).to.equal('scheduled-payment-on-chain-cancelation-waiter');
     expect(getJobPayloads()[0]).to.deep.equal({ scheduledPaymentId: scheduledPayment.id });
   });
 });

--- a/packages/hub/node-tests/tasks/scheduled-payment-on-chain-cancelation-waiter-test.ts
+++ b/packages/hub/node-tests/tasks/scheduled-payment-on-chain-cancelation-waiter-test.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
+import { subDays } from 'date-fns';
 import ScheduledPaymentOnChainCancelationWaiter from '../../tasks/scheduled-payment-on-chain-cancelation-waiter';
+import { nowUtc } from '../../utils/dates';
 import { registry, setupHub } from '../helpers/server';
 
 let sdkError: Error | null = null;
@@ -36,6 +38,72 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
   });
 
   let { getPrisma, getContainer } = setupHub(this);
+
+  it('returns an error if there is no cancelation tx hash', async function () {
+    let prisma = await getPrisma();
+    await prisma.scheduledPayment.create({
+      data: {
+        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+        moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+        tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+        gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+        amount: '100',
+        payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+        executionGasEstimation: 100000,
+        maxGasPrice: '1000000000',
+        feeFixedUsd: 0,
+        feePercentage: 0,
+        salt: '54lt',
+        payAt: new Date(),
+        spHash: '0x123',
+        chainId: 1,
+        userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+        cancelationTransactionHash: null,
+      },
+    });
+    let task = await getContainer().instantiate(ScheduledPaymentOnChainCancelationWaiter);
+    let result = await task.perform({ scheduledPaymentId: '73994d4b-bb3a-4d73-969f-6fa24da16fb4' });
+
+    expect(result).to.deep.equal({
+      status: 'failure',
+      message: 'Missing transaction hash',
+    });
+  });
+
+  it('returns an error if scheduled payment has been canceled more than a day ago and the cancelation transaction still has not been mined', async function () {
+    let prisma = await getPrisma();
+    await prisma.scheduledPayment.create({
+      data: {
+        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+        moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+        tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+        gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+        amount: '100',
+        payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+        executionGasEstimation: 100000,
+        maxGasPrice: '1000000000',
+        feeFixedUsd: 0,
+        feePercentage: 0,
+        salt: '54lt',
+        payAt: null,
+        canceledAt: subDays(nowUtc(), 2),
+        spHash: '0x123',
+        chainId: 1,
+        userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+        cancelationTransactionHash: '0x123',
+      },
+    });
+    let task = await getContainer().instantiate(ScheduledPaymentOnChainCancelationWaiter);
+    let result = await task.perform({ scheduledPaymentId: '73994d4b-bb3a-4d73-969f-6fa24da16fb4' });
+
+    expect(result).to.deep.equal({
+      status: 'failure',
+      message:
+        'Scheduled payment has been canceled more than a day ago and the cancelation transaction still has not been mined',
+    });
+  });
 
   it('waits for the transaction to be mined and updates block number', async function () {
     let prisma = await getPrisma();

--- a/packages/hub/node-tests/tasks/scheduled-payment-on-chain-cancelation-waiter-test.ts
+++ b/packages/hub/node-tests/tasks/scheduled-payment-on-chain-cancelation-waiter-test.ts
@@ -1,0 +1,143 @@
+import { expect } from 'chai';
+import ScheduledPaymentOnChainCancelationWaiter from '../../tasks/scheduled-payment-on-chain-cancelation-waiter';
+import { registry, setupHub } from '../helpers/server';
+
+let sdkError: Error | null = null;
+class StubCardpaySDK {
+  getSDK(sdk: string) {
+    switch (sdk) {
+      case 'ScheduledPaymentModule':
+        return Promise.resolve({
+          cancelPaymentOnChain: async (
+            _safeAddress: any,
+            _moduleAddress: any,
+            _tokenAddress: any,
+            _spHash: any,
+            _signature: any,
+            _obj: any
+          ) => {
+            if (sdkError) {
+              throw sdkError;
+            }
+            return {
+              blockNumber: 123,
+            };
+          },
+        });
+      default:
+        throw new Error(`unsupported mock cardpay sdk: ${sdk}`);
+    }
+  }
+}
+
+describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
+  this.beforeEach(async function () {
+    registry(this).register('cardpay', StubCardpaySDK);
+  });
+
+  let { getPrisma, getContainer } = setupHub(this);
+
+  it('waits for the transaction to be mined and updates block number', async function () {
+    let prisma = await getPrisma();
+    let task = await getContainer().instantiate(ScheduledPaymentOnChainCancelationWaiter);
+    let scheduledPayment = await prisma.scheduledPayment.create({
+      data: {
+        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+        moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+        tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+        gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+        amount: '100',
+        payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+        executionGasEstimation: 100000,
+        maxGasPrice: '1000000000',
+        feeFixedUsd: 0,
+        feePercentage: 0,
+        salt: '54lt',
+        payAt: new Date(),
+        spHash: '0x123',
+        chainId: 1,
+        userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+        cancelationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
+      },
+    });
+
+    await task.perform({ scheduledPaymentId: scheduledPayment.id });
+    scheduledPayment = await prisma.scheduledPayment.findUniqueOrThrow({
+      where: {
+        id: scheduledPayment.id,
+      },
+    });
+
+    // cancelationBlockNumber is BigInt
+    expect(Number(scheduledPayment.cancelationBlockNumber)).to.eq(123);
+    expect(scheduledPayment.cancelationTransactionError).to.be.null;
+  });
+
+  it('updates the error if revert error happens', async function () {
+    sdkError = new Error('Transaction with hash 0x123 was reverted');
+
+    let prisma = await getPrisma();
+    let task = await getContainer().instantiate(ScheduledPaymentOnChainCancelationWaiter);
+    let scheduledPayment = await prisma.scheduledPayment.create({
+      data: {
+        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+        moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+        tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+        gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+        amount: '100',
+        payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+        executionGasEstimation: 100000,
+        maxGasPrice: '1000000000',
+        feeFixedUsd: 0,
+        feePercentage: 0,
+        salt: '54lt',
+        payAt: new Date(),
+        spHash: '0x123',
+        chainId: 1,
+        userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+        cancelationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
+      },
+    });
+
+    await task.perform({ scheduledPaymentId: scheduledPayment.id });
+    scheduledPayment = await prisma.scheduledPayment.findUniqueOrThrow({
+      where: {
+        id: scheduledPayment.id,
+      },
+    });
+
+    expect(scheduledPayment.cancelationTransactionError).to.eq('Transaction with hash 0x123 was reverted');
+  });
+
+  it('restarts the worker if there was an error that we do not handle', async function () {
+    sdkError = new Error('unknown error');
+
+    let prisma = await getPrisma();
+    let task = await getContainer().instantiate(ScheduledPaymentOnChainCancelationWaiter);
+    let scheduledPayment = await prisma.scheduledPayment.create({
+      data: {
+        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+        moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+        tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+        gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+        amount: '100',
+        payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+        executionGasEstimation: 100000,
+        maxGasPrice: '1000000000',
+        feeFixedUsd: 0,
+        feePercentage: 0,
+        salt: '54lt',
+        payAt: new Date(),
+        spHash: '0x123',
+        chainId: 1,
+        userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+        cancelationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
+      },
+    });
+
+    expect(task.perform({ scheduledPaymentId: scheduledPayment.id })).to.be.rejected;
+  });
+});

--- a/packages/hub/routes/scheduled-payments.ts
+++ b/packages/hub/routes/scheduled-payments.ts
@@ -232,42 +232,6 @@ export default class ScheduledPaymentsRoute {
 
     ctx.type = 'application/vnd.api+json';
   }
-
-  async cancel(ctx: Koa.Context) {
-    if (!ensureLoggedIn(ctx)) {
-      return;
-    }
-
-    let prisma = await this.prismaManager.getClient();
-
-    let userAddress = ctx.state.userAddress;
-    let scheduledPaymentId: string = ctx.params.scheduled_payment_id;
-
-    let scheduledPayment = await prisma.scheduledPayment.findFirst({
-      where: {
-        id: scheduledPaymentId,
-        userAddress,
-      },
-    });
-
-    if (scheduledPayment) {
-      await prisma.scheduledPayment.update({
-        where: {
-          id: scheduledPaymentId,
-        },
-        data: {
-          canceledAt: new Date(),
-          payAt: null,
-        },
-      });
-      ctx.status = 200;
-      ctx.body = {};
-    } else {
-      ctx.status = 404;
-    }
-
-    ctx.type = 'application/vnd.api+json';
-  }
 }
 
 declare module '@cardstack/di' {

--- a/packages/hub/tasks/index.ts
+++ b/packages/hub/tasks/index.ts
@@ -20,6 +20,7 @@ const ALL_KNOWN_TASKS: Record<keyof KnownTasks, true> = {
   'persist-off-chain-prepaid-card-customization': true,
   'persist-off-chain-profile': true,
   'scheduled-payment-on-chain-creation-waiter': true,
+  'scheduled-payment-on-chain-cancelation-waiter': true,
   'scheduled-payment-on-chain-execution-waiter': true,
   'execute-scheduled-payments': true,
   boom: true,

--- a/packages/hub/tasks/scheduled-payment-on-chain-cancelation-waiter.ts
+++ b/packages/hub/tasks/scheduled-payment-on-chain-cancelation-waiter.ts
@@ -1,0 +1,99 @@
+import { inject } from '@cardstack/di';
+import * as Sentry from '@sentry/node';
+import { isBefore, subDays } from 'date-fns';
+import { nowUtc } from '../utils/dates';
+
+export default class ScheduledPaymentOnChainCancelationWaiter {
+  prismaManager = inject('prisma-manager', { as: 'prismaManager' });
+  cardpay = inject('cardpay');
+  ethersProvider = inject('ethers-provider', { as: 'ethersProvider' });
+
+  async perform(payload: { scheduledPaymentId: string }) {
+    let prisma = await this.prismaManager.getClient();
+    let scheduledPayment = await prisma.scheduledPayment.findFirstOrThrow({
+      where: { id: payload.scheduledPaymentId },
+    });
+
+    let provider = this.ethersProvider.getInstance(scheduledPayment.chainId);
+    let scheduledPaymentModule = await this.cardpay.getSDK('ScheduledPaymentModule', provider);
+
+    if (scheduledPayment.cancelationBlockNumber) {
+      // Did we somehow spawn this task after it already updated cancelationBlockNumber previously?
+      return Sentry.captureException(
+        new Error('Task run for scheduled payment that already has a cancelation block number'),
+        {
+          tags: {
+            action: 'scheduled-payment-task',
+            scheduledPaymentId: scheduledPayment.id,
+          },
+        }
+      );
+    }
+
+    if (!scheduledPayment.cancelationTransactionHash) {
+      // This should never happen because we spawn this task only after updating cancelationTransactionHash in the route. But just in case...
+      return Sentry.captureException(new Error('Missing transaction hash'), {
+        tags: {
+          action: 'scheduled-payment-task',
+          scheduledPaymentId: scheduledPayment.id,
+        },
+      });
+    }
+
+    if (isBefore(scheduledPayment.canceledAt!, subDays(nowUtc(), 1))) {
+      return Sentry.captureException(
+        new Error(
+          'Scheduled payment has been canceled more than a day ago and the cancelation transaction still has not been mined'
+        ),
+        {
+          tags: {
+            action: 'scheduled-payment-task',
+            scheduledPaymentId: scheduledPayment.id,
+          },
+        }
+      );
+    }
+
+    try {
+      let receipt = await scheduledPaymentModule.cancelPaymentOnChain(scheduledPayment.cancelationTransactionHash);
+      return await prisma.scheduledPayment.update({
+        data: {
+          cancelationBlockNumber: receipt.blockNumber, // To let us know that the scheduled payment has been created on chain and that the process of scheduling the payment was completed
+        },
+        where: {
+          id: scheduledPayment.id,
+        },
+      });
+    } catch (error: any) {
+      if (error.message.includes('revert')) {
+        // Error message from the waitUntilTransactionMined in the SDK will be: Transaction with hash "${txnHash}" was reverted
+        await prisma.scheduledPayment.update({
+          data: {
+            cancelationTransactionError: error.message,
+          },
+          where: {
+            id: scheduledPayment.id,
+          },
+        });
+
+        return; // We don't want to throw an error here because we don't want the task to be retried - the transaction was obviously reverted
+      }
+
+      // At this point, we don't know what error to expect. Let's throw the error so that the task will restart
+      Sentry.captureException(error, {
+        tags: {
+          action: 'scheduled-payment-task',
+          scheduledPaymentId: scheduledPayment.id,
+        },
+      });
+
+      throw error;
+    }
+  }
+}
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    'scheduled-payment-on-chain-cancelation-waiter': ScheduledPaymentOnChainCancelationWaiter;
+  }
+}

--- a/packages/hub/tasks/scheduled-payment-on-chain-cancelation-waiter.ts
+++ b/packages/hub/tasks/scheduled-payment-on-chain-cancelation-waiter.ts
@@ -3,12 +3,17 @@ import * as Sentry from '@sentry/node';
 import { isBefore, subDays } from 'date-fns';
 import { nowUtc } from '../utils/dates';
 
+interface TaskResult {
+  status: 'success' | 'failure';
+  message: string;
+}
+
 export default class ScheduledPaymentOnChainCancelationWaiter {
   prismaManager = inject('prisma-manager', { as: 'prismaManager' });
   cardpay = inject('cardpay');
   ethersProvider = inject('ethers-provider', { as: 'ethersProvider' });
 
-  async perform(payload: { scheduledPaymentId: string }) {
+  async perform(payload: { scheduledPaymentId: string }): Promise<TaskResult> {
     let prisma = await this.prismaManager.getClient();
     let scheduledPayment = await prisma.scheduledPayment.findFirstOrThrow({
       where: { id: payload.scheduledPaymentId },
@@ -19,44 +24,44 @@ export default class ScheduledPaymentOnChainCancelationWaiter {
 
     if (scheduledPayment.cancelationBlockNumber) {
       // Did we somehow spawn this task after it already updated cancelationBlockNumber previously?
-      return Sentry.captureException(
-        new Error('Task run for scheduled payment that already has a cancelation block number'),
-        {
-          tags: {
-            action: 'scheduled-payment-task',
-            scheduledPaymentId: scheduledPayment.id,
-          },
-        }
-      );
-    }
-
-    if (!scheduledPayment.cancelationTransactionHash) {
-      // This should never happen because we spawn this task only after updating cancelationTransactionHash in the route. But just in case...
-      return Sentry.captureException(new Error('Missing transaction hash'), {
+      let errorMessage = 'Task run for scheduled payment that already has a cancelation block number';
+      Sentry.captureException(new Error(errorMessage), {
         tags: {
           action: 'scheduled-payment-task',
           scheduledPaymentId: scheduledPayment.id,
         },
       });
+
+      return { status: 'failure', message: errorMessage };
+    }
+
+    if (!scheduledPayment.cancelationTransactionHash) {
+      // This should never happen because we spawn this task only after updating cancelationTransactionHash in the route. But just in case...
+      let errorMessage = 'Missing transaction hash';
+      Sentry.captureException(new Error(errorMessage), {
+        tags: {
+          action: 'scheduled-payment-task',
+          scheduledPaymentId: scheduledPayment.id,
+        },
+      });
+      return { status: 'failure', message: errorMessage };
     }
 
     if (isBefore(scheduledPayment.canceledAt!, subDays(nowUtc(), 1))) {
-      return Sentry.captureException(
-        new Error(
-          'Scheduled payment has been canceled more than a day ago and the cancelation transaction still has not been mined'
-        ),
-        {
-          tags: {
-            action: 'scheduled-payment-task',
-            scheduledPaymentId: scheduledPayment.id,
-          },
-        }
-      );
+      let errorMessage =
+        'Scheduled payment has been canceled more than a day ago and the cancelation transaction still has not been mined';
+      Sentry.captureException(new Error(errorMessage), {
+        tags: {
+          action: 'scheduled-payment-task',
+          scheduledPaymentId: scheduledPayment.id,
+        },
+      });
+      return { status: 'failure', message: errorMessage };
     }
 
     try {
       let receipt = await scheduledPaymentModule.cancelPaymentOnChain(scheduledPayment.cancelationTransactionHash);
-      return await prisma.scheduledPayment.update({
+      await prisma.scheduledPayment.update({
         data: {
           cancelationBlockNumber: receipt.blockNumber, // To let us know that the scheduled payment has been created on chain and that the process of scheduling the payment was completed
         },
@@ -64,6 +69,7 @@ export default class ScheduledPaymentOnChainCancelationWaiter {
           id: scheduledPayment.id,
         },
       });
+      return { status: 'success', message: 'Scheduled payment cancelation transaction mined' };
     } catch (error: any) {
       if (error.message.includes('revert')) {
         // Error message from the waitUntilTransactionMined in the SDK will be: Transaction with hash "${txnHash}" was reverted
@@ -76,7 +82,8 @@ export default class ScheduledPaymentOnChainCancelationWaiter {
           },
         });
 
-        return; // We don't want to throw an error here because we don't want the task to be retried - the transaction was obviously reverted
+        // We don't want to throw an error here because we don't want the task to be retried - the transaction was obviously reverted
+        return { status: 'failure', message: error.message };
       }
 
       // At this point, we don't know what error to expect. Let's throw the error so that the task will restart

--- a/packages/hub/worker.ts
+++ b/packages/hub/worker.ts
@@ -24,6 +24,7 @@ import RemoveOldSentNotificationsTask from './tasks/remove-old-sent-notification
 import WyreTransferTask from './tasks/wyre-transfer';
 import PrintQueuedJobsTask from './tasks/print-queued-jobs';
 import ScheduledPaymentOnChainCreationWaiter from './tasks/scheduled-payment-on-chain-creation-waiter';
+import ScheduledPaymentOnChainCancelationWaiter from './tasks/scheduled-payment-on-chain-cancelation-waiter';
 import ScheduledPaymentOnChainExecutionWaiter from './tasks/scheduled-payment-on-chain-execution-waiter';
 import ExecuteScheduledPayments from './tasks/execute-scheduled-payments';
 
@@ -85,6 +86,7 @@ export class HubWorker {
         'wyre-transfer': this.instantiateTask(WyreTransferTask),
         's3-put-json': s3PutJson,
         'scheduled-payment-on-chain-creation-waiter': this.instantiateTask(ScheduledPaymentOnChainCreationWaiter),
+        'scheduled-payment-on-chain-cancelation-waiter': this.instantiateTask(ScheduledPaymentOnChainCancelationWaiter),
         'scheduled-payment-on-chain-execution-waiter': this.instantiateTask(ScheduledPaymentOnChainExecutionWaiter),
         'execute-scheduled-payments': this.instantiateTask(ExecuteScheduledPayments),
       },


### PR DESCRIPTION
Ticket: CS-4377

This PR adjusts the process to cancel a scheduled payment: now it includes communication with the crank too. This is needed so that when the user cancels a scheduled payment, the scheduled payment record in the hub is updated - `canceledAt` gets set, and a worker that waits for the on chain transaction is spawned. The worker then updates `cancelationBlockNumber` which lets us know that the transaction has been mined and that the payment is canceled successfully in both the crank and on chain. 

I tested this on Goerli network using the following command:

`yarn cardpay scheduled-payment cancel-payment <SCHEDULED_PAYMENT_ID> --network goerli --ethersMnemonic '...'`

This SDK functionality can be used in the scheduled payment client like so: `await cancelScheduledPayment(scheduledPaymentId)`. 
