### PR TITLE
Add support for remotely hosted icons to Boxel::Input::SelectableToken

### DIFF
--- a/packages/boxel/addon/components/boxel/input/selectable-token-amount/index.css
+++ b/packages/boxel/addon/components/boxel/input/selectable-token-amount/index.css
@@ -21,3 +21,7 @@
 .boxel-input-selectable-token-amount__dropdown-item {
   white-space: nowrap;
 }
+
+.boxel-input-selectable-token-amount__dropdown .ember-power-select-options[role="listbox"] {
+  max-height: 18em;
+}

--- a/packages/boxel/addon/components/boxel/input/selectable-token-amount/index.gts
+++ b/packages/boxel/addon/components/boxel/input/selectable-token-amount/index.gts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import '@cardstack/boxel/styles/global.css';
 import './index.css';
 import BoxelInputGroup from '../../input-group';
-import { svgJar } from '@cardstack/boxel/utils/svg-jar';
+import SelectableTokenItem from './item';
 import { fn } from '@ember/helper';
 import { guidFor } from '@ember/object/internals';
 import cn from '@cardstack/boxel/helpers/cn';
@@ -58,14 +58,10 @@ export default class SelectableTokenAmount extends Component<Signature> {
           @dropdownClass="boxel-input-selectable-token-amount__dropdown"
           @verticalPosition="below" as |item itemCssClass|
         >
-          <div class={{cn itemCssClass "boxel-input-selectable-token-amount__dropdown-item"}}>
-            {{svgJar
-              item.icon
-              class="boxel-input-selectable-token-amount__icon"
-              role="presentation"
-            }}
-            {{item.name}}
-          </div>
+          <SelectableTokenItem
+            @item={{item}}
+            class={{cn itemCssClass "boxel-input-selectable-token-amount__dropdown-item"}}
+          /> 
         </Accessories.Select>
       </:after>
     </BoxelInputGroup>

--- a/packages/boxel/addon/components/boxel/input/selectable-token-amount/item/index.gts
+++ b/packages/boxel/addon/components/boxel/input/selectable-token-amount/item/index.gts
@@ -1,0 +1,40 @@
+import Component from '@glimmer/component';
+import { svgJar } from '@cardstack/boxel/utils/svg-jar';
+import { SelectableToken } from '../../selectable-token';
+import { isPresent } from '@ember/utils';
+
+interface Signature {
+  Element: HTMLDivElement;
+  Args: {
+    item: SelectableToken;
+  };
+}
+
+export default class SelectableTokenAmount extends Component<Signature> {
+  get shouldUseSvgJar() {
+    return /^[a-zA-Z-_]+$/.test(this.args.item.icon);
+  }
+
+  get shouldRenderImage() {
+    return isPresent(this.args.item.icon) && !this.shouldUseSvgJar;
+  }
+
+  <template>
+    <div ...attributes>
+      {{#if this.shouldUseSvgJar}}
+        {{svgJar
+          @item.icon
+          class="boxel-input-selectable-token-amount__icon"
+          role="presentation"
+        }}
+      {{/if}}
+      {{#if this.shouldRenderImage}}
+        <img src={{@item.icon}}
+          class="boxel-input-selectable-token-amount__icon"
+          role="presentation"
+        />
+      {{/if}}
+      {{@item.name}}
+    </div>
+  </template>
+}

--- a/packages/boxel/addon/components/boxel/input/selectable-token-amount/usage.gts
+++ b/packages/boxel/addon/components/boxel/input/selectable-token-amount/usage.gts
@@ -13,6 +13,8 @@ export default class BoxelSelectableInputTokenAmountUsage extends Component {
     { name: 'CARD', icon: 'card' },
     { name: 'HI', icon: 'emoji' },
     { name: 'WORLD', icon: 'world' },
+    { name: 'MASQ', icon: 'https://raw.githubusercontent.com/MASQ-Project/MASQ-contract/master/MASQ%20Logo%20Blue%20Solo%20Transparent.png' },
+    { name: 'ETH', icon: 'https://wallet-asset.matic.network/img/tokens/eth.svg' },
   ];
 
   @tracked id = 'boxel-input-selectable-token-amount-usage';


### PR DESCRIPTION
The token lists we're using include PNG and SVG logo URLs. This change lets us use them rather than requiring a local SVG in all cases.

- Also, add a max height to the token list so that it will scroll.