### PR TITLE
[CS-4918]: Fix supportedChains, tests and cli bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "test:web-client:serve": "cd packages/web-client && ember test --serve --no-launch",
     "test:safe-tools-client": "cd packages/safe-tools-client && ember test",
     "test:safe-tools-client:percy": "cd packages/safe-tools-client && percy exec -- ember test",
+    "test:cardpay-sdk": "yarn --cwd packages/cardpay-sdk test",
     "deploy:boxel": "cd ./packages/boxel && ember deploy production --verbose",
     "deploy:boxel:preview": "cd ./packages/boxel && ember deploy s3-preview --verbose",
     "deploy:ssr-web:preview-staging": "cd ./packages/ssr-web && ember deploy s3-preview-staging --verbose",

--- a/packages/cardpay-cli/utils.ts
+++ b/packages/cardpay-cli/utils.ts
@@ -66,7 +66,7 @@ export async function getEthereumClients(
 ): Promise<{ web3: Web3; ethersProvider: JsonRpcProvider; signer?: Signer }> {
   let rpcNodeHttpsUrl!: string;
   let rpcNodeWssUrl!: string;
-  let bridge!: string;
+
   let hubConfigResponse;
   let hubUrl = process.env.HUB_URL || getConstantByNetwork('hubUrl', network);
   let hubConfig = new HubConfig(hubUrl);
@@ -75,25 +75,21 @@ export async function getEthereumClients(
     case 'kovan':
       rpcNodeHttpsUrl = hubConfigResponse.web3.layer1RpcNodeHttpsUrl as string;
       rpcNodeWssUrl = hubConfigResponse.web3.layer1RpcNodeWssUrl as string;
-      bridge = 'https://bridge.walletconnect.org';
       break;
     case 'goerli':
     case 'mainnet':
       rpcNodeHttpsUrl = hubConfigResponse.web3.ethereum.rpcNodeHttpsUrl as string;
       rpcNodeWssUrl = hubConfigResponse.web3.ethereum.rpcNodeWssUrl as string;
-      bridge = 'https://bridge.walletconnect.org';
       break;
     case 'sokol':
     case 'gnosis':
       rpcNodeHttpsUrl = hubConfigResponse.web3.gnosis.rpcNodeHttpsUrl as string;
       rpcNodeWssUrl = hubConfigResponse.web3.gnosis.rpcNodeWssUrl as string;
-      bridge = 'https://safe-walletconnect.gnosis.io/';
       break;
     case 'mumbai':
     case 'polygon':
       rpcNodeHttpsUrl = hubConfigResponse.web3.polygon.rpcNodeHttpsUrl as string;
       rpcNodeWssUrl = hubConfigResponse.web3.polygon.rpcNodeWssUrl as string;
-      bridge = 'https://bridge.walletconnect.org';
       break;
   }
 
@@ -109,7 +105,7 @@ export async function getEthereumClients(
         chainId: networkIds[network],
         rpc: { [networkIds[network]]: rpcNodeHttpsUrl },
         rpcWss: { [networkIds[network]]: rpcNodeWssUrl },
-        bridge,
+        bridge: 'https://bridge.walletconnect.org',
       });
       await walletConnectProvider.enable();
       return {

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -7,7 +7,7 @@ import goerliTokenList from '../token-lists/goerli-tokenlist.json';
 import mumbaiTokenList from '../token-lists/mumbai-tokenlist.json';
 import polygonTokenList from '../token-lists/polygon-tokenlist.json';
 import { type TokenList } from '@uniswap/token-lists';
-import { pullAll } from 'lodash';
+import { difference } from 'lodash';
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
@@ -22,7 +22,7 @@ export const supportedChains = {
 };
 
 export const supportedChainsArray = Object.values(supportedChains).flat();
-export const schedulerSupportedChainsArray = pullAll(supportedChainsArray, supportedChains.gnosis);
+export const schedulerSupportedChainsArray = difference(supportedChainsArray, supportedChains.gnosis);
 
 export type CardPayCapableNetworks = 'sokol' | 'gnosis';
 export type SchedulerCapableNetworks = 'mainnet' | 'goerli' | 'polygon' | 'mumbai';

--- a/packages/cardpay-sdk/tests/constants-test.ts
+++ b/packages/cardpay-sdk/tests/constants-test.ts
@@ -2,7 +2,14 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import Web3 from 'web3';
 import JsonRpcProvider from '../providers/json-rpc-provider';
-import { networkIds, networks, getConstantByNetwork, getConstant } from '../sdk/constants';
+import {
+  networkIds,
+  networks,
+  getConstantByNetwork,
+  getConstant,
+  supportedChainsArray,
+  schedulerSupportedChainsArray,
+} from '../sdk/constants';
 
 chai.use(chaiAsPromised);
 
@@ -28,6 +35,12 @@ describe('Network constants', () => {
       1: 'mainnet',
       100: 'gnosis',
     });
+  });
+  it('should return all supported networks in an array', () => {
+    chai.expect(supportedChainsArray).to.eql(['mainnet', 'goerli', 'gnosis', 'sokol', 'polygon', 'mumbai']);
+  });
+  it('should return all scheduler supported networks in an array', () => {
+    chai.expect(schedulerSupportedChainsArray).to.eql(['mainnet', 'goerli', 'polygon', 'mumbai']);
   });
 
   describe('getConstantByNetwork', () => {

--- a/packages/cardpay-sdk/tests/json-rpc-provider-test.ts
+++ b/packages/cardpay-sdk/tests/json-rpc-provider-test.ts
@@ -33,7 +33,7 @@ const commonError = {
   message: 'execution reverted: �Դ�n�ȦM\u0019�/�Xf �\u001a��',
 };
 
-const sokolEror = { code: -32015, message: 'Reverted 0xb2416de0dd9fbbcf59843aa426a077e327bb5bda' };
+const sokolEror = { message: 'Reverted 0xb2416de0dd9fbbcf59843aa426a077e327bb5bda' };
 
 const expectedErrorBase = {
   reason: 'cannot estimate gas; transaction may fail or may require manual gas limit',
@@ -65,7 +65,7 @@ const assertErrorStructure = (error: any, expectedError: { data: string; message
   chai.expect(error?.message).to.eq(expectedError?.message);
 };
 
-describe.only('JsonRpcProvider', () => {
+describe('JsonRpcProvider', () => {
   describe('gasEstimate', () => {
     it('should throw error with correct data and message for error object with level 1', async () => {
       const error = await performGasEstimate(commonError);
@@ -91,10 +91,10 @@ describe.only('JsonRpcProvider', () => {
 
       assertErrorStructure(error, { data, message });
     });
-    it.only('should throw error with correct message when data does not exist', async () => {
+    it('should throw error with correct message when data does not exist', async () => {
       const error = (await performGasEstimate(sokolEror)) as any;
 
-      chai.expect(error).to.deep.eq(sokolEror);
+      chai.expect(error).to.deep.eq({ ...sokolEror, data: undefined });
     });
   });
 });


### PR DESCRIPTION
This PR fixes a couple of issues:
- SupportedChains were not returning correctly, `pullAll` method actually mutates the array, so gnosis was being remove, pullAll was replaced with `difference` and tests were added to guarantee.
- Sdk tests were not running on CI check and it turns out there was a couple of `.only` which made it harder to perceive this issue
- WalletConnect was not working on cardpay-cli for gnosis and sokol, since the bridge was outdated, so I've replaced with the public one(it would be better to have this bridge on a constant, but considering we'll be migrating to WC 2.0, not worth it).
