### PR TITLE
Returns the range of gas prices in USD

### DIFF
--- a/packages/cardpay-cli/scheduled-payment/estimate-gas.ts
+++ b/packages/cardpay-cli/scheduled-payment/estimate-gas.ts
@@ -43,8 +43,11 @@ export default {
     );
 
     console.log(`Required gas: ${result.gas}`);
-    console.log(`Required gas in eth (slow): ${fromWei(result.gasRangeInWei.slow.toString(), 'ether')}`);
-    console.log(`Required gas in eth (standard): ${fromWei(result.gasRangeInWei.standard.toString(), 'ether')}`);
-    console.log(`Required gas in eth (fast): ${fromWei(result.gasRangeInWei.fast.toString(), 'ether')}`);
+    console.log(`Required gas in ETH (slow): ${fromWei(result.gasRangeInWei.slow.toString(), 'ether')}`);
+    console.log(`Required gas in ETH (standard): ${fromWei(result.gasRangeInWei.standard.toString(), 'ether')}`);
+    console.log(`Required gas in ETH (fast): ${fromWei(result.gasRangeInWei.fast.toString(), 'ether')}`);
+    console.log(`Required gas in USDT (slow): ${fromWei(result.gasRangeInUSD.slow.toString(), 'ether')}`);
+    console.log(`Required gas in USDT (standard): ${fromWei(result.gasRangeInUSD.standard.toString(), 'ether')}`);
+    console.log(`Required gas in USDT (fast): ${fromWei(result.gasRangeInUSD.fast.toString(), 'ether')}`);
   },
 } as CommandModule;

--- a/packages/cardpay-cli/scheduled-payment/estimate-gas.ts
+++ b/packages/cardpay-cli/scheduled-payment/estimate-gas.ts
@@ -46,8 +46,8 @@ export default {
     console.log(`Required gas in ETH (slow): ${fromWei(result.gasRangeInWei.slow.toString(), 'ether')}`);
     console.log(`Required gas in ETH (standard): ${fromWei(result.gasRangeInWei.standard.toString(), 'ether')}`);
     console.log(`Required gas in ETH (fast): ${fromWei(result.gasRangeInWei.fast.toString(), 'ether')}`);
-    console.log(`Required gas in USDT (slow): ${fromWei(result.gasRangeInUSD.slow.toString(), 'ether')}`);
-    console.log(`Required gas in USDT (standard): ${fromWei(result.gasRangeInUSD.standard.toString(), 'ether')}`);
-    console.log(`Required gas in USDT (fast): ${fromWei(result.gasRangeInUSD.fast.toString(), 'ether')}`);
+    console.log(`Required gas in USD (slow): ${fromWei(result.gasRangeInUSD.slow.toString(), 'ether')}`);
+    console.log(`Required gas in USD (standard): ${fromWei(result.gasRangeInUSD.standard.toString(), 'ether')}`);
+    console.log(`Required gas in USD (fast): ${fromWei(result.gasRangeInUSD.fast.toString(), 'ether')}`);
   },
 } as CommandModule;

--- a/packages/cardpay-sdk/contracts/addresses.ts
+++ b/packages/cardpay-sdk/contracts/addresses.ts
@@ -101,7 +101,7 @@ const GOERLI = {
   moduleProxyFactory: '0x00000000000DC7F163742Eb4aBEf650037b1f588',
   metaGuard: '0xe2847462a574bfd43014d1c7BB6De5769C294691',
   wrappedNativeToken: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6', // WETH
-  usdcToken: '0x07865c6E87B9F70255377e024ace6630C1Eaa37F'
+  usdcToken: '0x07865c6E87B9F70255377e024ace6630C1Eaa37F',
 };
 const MUMBAI = {
   gnosisSafeMasterCopy: '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552',
@@ -115,7 +115,7 @@ const MUMBAI = {
   moduleProxyFactory: '0x00000000000DC7F163742Eb4aBEf650037b1f588',
   metaGuard: '0xe2847462a574bfd43014d1c7BB6De5769C294691',
   wrappedNativeToken: '0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889', // WMATIC
-  usdcToken: '0xe6b8a5CF854791412c1f6EFC7CAf629f5Df1c747'
+  usdcToken: '0xe6b8a5CF854791412c1f6EFC7CAf629f5Df1c747',
 };
 
 const MAINNET = {
@@ -128,7 +128,7 @@ const MAINNET = {
   scheduledPaymentExchange: '',
   scheduledPaymentModule: '',
   wrappedNativeToken: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
-  usdcToken: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+  usdcToken: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
 };
 const GNOSIS = {
   gnosisProxyFactory_v1_2: '0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B',

--- a/packages/cardpay-sdk/contracts/addresses.ts
+++ b/packages/cardpay-sdk/contracts/addresses.ts
@@ -101,6 +101,7 @@ const GOERLI = {
   moduleProxyFactory: '0x00000000000DC7F163742Eb4aBEf650037b1f588',
   metaGuard: '0xe2847462a574bfd43014d1c7BB6De5769C294691',
   wrappedNativeToken: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6', // WETH
+  usdcToken: '0x07865c6E87B9F70255377e024ace6630C1Eaa37F'
 };
 const MUMBAI = {
   gnosisSafeMasterCopy: '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552',
@@ -114,6 +115,7 @@ const MUMBAI = {
   moduleProxyFactory: '0x00000000000DC7F163742Eb4aBEf650037b1f588',
   metaGuard: '0xe2847462a574bfd43014d1c7BB6De5769C294691',
   wrappedNativeToken: '0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889', // WMATIC
+  usdcToken: '0xe6b8a5CF854791412c1f6EFC7CAf629f5Df1c747'
 };
 
 const MAINNET = {
@@ -126,6 +128,7 @@ const MAINNET = {
   scheduledPaymentExchange: '',
   scheduledPaymentModule: '',
   wrappedNativeToken: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
+  usdcToken: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
 };
 const GNOSIS = {
   gnosisProxyFactory_v1_2: '0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B',

--- a/packages/cardpay-sdk/index.ts
+++ b/packages/cardpay-sdk/index.ts
@@ -52,6 +52,6 @@ export { default as JsonRpcProvider } from './providers/json-rpc-provider';
 export { default as Web3Provider } from './providers/web3-provider';
 export { MIN_PAYMENT_AMOUNT_IN_SPEND as MIN_PAYMENT_AMOUNT_IN_SPEND__PREFER_ON_CHAIN_WHEN_POSSIBLE } from './sdk/do-not-use-on-chain-constants';
 export { protocolVersions } from './contracts/addresses';
-export { gasPriceInToken, getCurrentGasPrice } from './sdk/utils/conversions';
+export { gasPriceInToken, getGasPricesInNativeWei } from './sdk/utils/conversions';
 export * from './sdk/network-config-utils';
 export * from './sdk/scheduled-payment/utils';

--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -46,7 +46,7 @@ import {
 import BN from 'bn.js';
 import { Interface } from 'ethers/lib/utils';
 import JsonRpcProvider from '../providers/json-rpc-provider';
-import { getConstant, getConstantByNetwork, SchedulerCapableNetworks } from './constants';
+import { getConstant, getConstantByNetwork } from './constants';
 import { getGasPricesInNativeWei, getNativeWeiInToken } from './utils/conversions';
 
 export interface EnableModuleAndGuardResult {
@@ -1296,10 +1296,9 @@ export default class ScheduledPaymentModule {
       fast: gas.mul(String(gasStationResponse.fast)),
     };
 
-    let tokenList = getConstantByNetwork('tokenList', network as SchedulerCapableNetworks)?.tokens;
-    let tokenUSD = tokenList.find((t) => t.symbol === 'USDT');
-    if (!tokenUSD) throw Error('USD token not found');
-    let priceWeiInUSD = String(await getNativeWeiInToken(this.ethersProvider, tokenUSD?.address));
+    let usdcToken = await getAddress('usdcToken', this.ethersProvider);
+    if (!usdcToken) throw Error('USDC token not found');
+    let priceWeiInUSD = String(await getNativeWeiInToken(this.ethersProvider, usdcToken));
     let gasRangeInUSD = {
       slow: gasRangeInWei.slow.mul(priceWeiInUSD),
       standard: gasRangeInWei.standard.mul(priceWeiInUSD),

--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -47,7 +47,7 @@ import BN from 'bn.js';
 import { Interface } from 'ethers/lib/utils';
 import JsonRpcProvider from '../providers/json-rpc-provider';
 import { getConstant, getConstantByNetwork, SchedulerCapableNetworks } from './constants';
-import { getCurrentGasPrice, getNativeWeiInToken } from './utils/conversions';
+import { getGasPricesInNativeWei, getNativeWeiInToken } from './utils/conversions';
 
 export interface EnableModuleAndGuardResult {
   scheduledPaymentModuleAddress: string;
@@ -1288,28 +1288,28 @@ export default class ScheduledPaymentModule {
       },
       body: JSON.stringify(body),
     });
-    let gasStationResponse = await getCurrentGasPrice(chainId);
+    let gasStationResponse = await getGasPricesInNativeWei(chainId);
     let gas = BigNumber.from((await gasEstimationResponse.json()).data?.attributes?.gas);
+    let gasRangeInWei = {
+      slow: gas.mul(String(gasStationResponse.slow)),
+      standard: gas.mul(String(gasStationResponse.standard)),
+      fast: gas.mul(String(gasStationResponse.fast)),
+    };
 
     let tokenList = getConstantByNetwork('tokenList', network as SchedulerCapableNetworks)?.tokens;
     let tokenUSD = tokenList.find((t) => t.symbol === 'USDT');
-    let priceWeiInUSD = BigNumber.from(0);
-    if (tokenUSD) {
-      priceWeiInUSD = await getNativeWeiInToken(this.ethersProvider, tokenUSD?.address);
-    }
+    if (!tokenUSD) throw Error('USD token not found');
+    let priceWeiInUSD = String(await getNativeWeiInToken(this.ethersProvider, tokenUSD?.address));
+    let gasRangeInUSD = {
+      slow: gasRangeInWei.slow.mul(priceWeiInUSD),
+      standard: gasRangeInWei.standard.mul(priceWeiInUSD),
+      fast: gasRangeInWei.fast.mul(priceWeiInUSD),
+    };
 
     return {
       gas,
-      gasRangeInWei: {
-        slow: gas.mul(gasStationResponse.slow),
-        standard: gas.mul(gasStationResponse.standard),
-        fast: gas.mul(gasStationResponse.fast),
-      },
-      gasRangeInUSD: {
-        slow: gas.mul(gasStationResponse.slow).mul(priceWeiInUSD),
-        standard: gas.mul(gasStationResponse.standard).mul(priceWeiInUSD),
-        fast: gas.mul(gasStationResponse.fast).mul(priceWeiInUSD),
-      },
+      gasRangeInWei,
+      gasRangeInUSD,
     };
   }
 }

--- a/packages/cardpay-sdk/sdk/utils/conversions.ts
+++ b/packages/cardpay-sdk/sdk/utils/conversions.ts
@@ -5,11 +5,11 @@ import { getAddressByNetwork } from '../../contracts/addresses';
 import { getConstantByNetwork } from '../constants';
 import JsonRpcProvider from '../../providers/json-rpc-provider';
 import { networkName } from './general-utils';
+import BN from 'bn.js';
 import { BaseProvider } from '@ethersproject/providers';
-import { BigNumber } from 'ethers';
 import { convertChainIdToName } from '../network-config-utils';
 
-type GasPrice = Record<'slow' | 'standard' | 'fast', BigNumber>;
+type GasPrice = Record<'slow' | 'standard' | 'fast', BN>;
 
 async function tokenPairRate(provider: JsonRpcProvider, token1Address: string, token2Address: string): Promise<Price> {
   let network = await provider.getNetwork();
@@ -23,18 +23,12 @@ async function tokenPairRate(provider: JsonRpcProvider, token1Address: string, t
   return route.midPrice; // How many "token 1" we can get for one "token 2" in Uniswap
 }
 
-export async function gasPriceInToken(
-  provider: JsonRpcProvider,
-  tokenAddress: string,
-  gasPriceInNativeTokenInWei?: BigNumber
-): Promise<BigNumber> {
+export async function gasPriceInToken(provider: JsonRpcProvider, tokenAddress: string): Promise<BN> {
   let network = await networkName(provider);
   let chainId = (await provider.getNetwork()).chainId;
 
-  if (!gasPriceInNativeTokenInWei) {
-    // Gas station will return current gas price in native token in wei.
-    gasPriceInNativeTokenInWei = (await getCurrentGasPrice(chainId)).standard;
-  }
+  // Gas station will return current gas price in native token in wei.
+  let gasPriceInNativeTokenInWei = new BN((await getGasPricesInNativeWei(chainId)).standard.toString());
 
   // We use the wrapped native token address because the native token doesn't have an address in Uniswap.
   // The price of the wrapped native token, such as WETH, is the same as the price of the native token.
@@ -46,11 +40,11 @@ export async function gasPriceInToken(
 
   // Convert the current gas price which is in native token to the token we want to pay the gas with.
   return gasPriceInNativeTokenInWei
-    .mul(BigNumber.from(rate.adjusted.numerator.toString())) // rate.adjusted is an adjustment of the difference in coin decimals, for example WETH has 18 decimals, USDT and USDC have 6.
-    .div(BigNumber.from(rate.adjusted.denominator.toString()));
+    .mul(new BN(rate.adjusted.numerator.toString())) // rate.adjusted is an adjustment of the difference in coin decimals, for example WETH has 18 decimals, USDT and USDC have 6.
+    .div(new BN(rate.adjusted.denominator.toString()));
 }
 
-export async function getCurrentGasPrice(chainId: number): Promise<GasPrice> {
+export async function getGasPricesInNativeWei(chainId: number): Promise<GasPrice> {
   const network = convertChainIdToName(chainId);
 
   let gasStationResponse = await fetch(`${getConstantByNetwork('hubUrl', network)}/api/gas-station/${chainId}`, {
@@ -63,19 +57,20 @@ export async function getCurrentGasPrice(chainId: number): Promise<GasPrice> {
   let gasPriceJson = await gasStationResponse.json();
 
   return {
-    slow: BigNumber.from(gasPriceJson.slow),
-    standard: BigNumber.from(gasPriceJson.standard),
-    fast: BigNumber.from(gasPriceJson.fast),
+    slow: new BN(gasPriceJson.slow),
+    standard: new BN(gasPriceJson.standard),
+    fast: new BN(gasPriceJson.fast),
   };
 }
 
-export async function getNativeWeiInToken(provider: JsonRpcProvider, tokenAddress: string): Promise<BigNumber> {
-  let naticeWeiInUSD;
-  try {
-    naticeWeiInUSD = await gasPriceInToken(provider, tokenAddress, BigNumber.from(1));
-  } catch (e) {
-    naticeWeiInUSD = BigNumber.from(0);
+export async function getNativeWeiInToken(provider: JsonRpcProvider, tokenAddress: string): Promise<BN> {
+  let network = await networkName(provider);
+  let wrappedNativeToken = getAddressByNetwork('wrappedNativeToken', network);
+  if (tokenAddress === wrappedNativeToken) {
+    return new BN(1);
   }
 
-  return naticeWeiInUSD;
+  let rate = await tokenPairRate(provider, tokenAddress, wrappedNativeToken);
+  return new BN(rate.adjusted.numerator.toString()) // rate.adjusted is an adjustment of the difference in coin decimals, for example WETH has 18 decimals, USDT and USDC have 6.
+    .div(new BN(rate.adjusted.denominator.toString()));
 }

--- a/packages/cardpay-sdk/sdk/utils/conversions.ts
+++ b/packages/cardpay-sdk/sdk/utils/conversions.ts
@@ -5,7 +5,6 @@ import { getAddressByNetwork } from '../../contracts/addresses';
 import { getConstantByNetwork } from '../constants';
 import JsonRpcProvider from '../../providers/json-rpc-provider';
 import { networkName } from './general-utils';
-import BN from 'bn.js';
 import { BaseProvider } from '@ethersproject/providers';
 import { BigNumber } from 'ethers';
 import { convertChainIdToName } from '../network-config-utils';
@@ -24,12 +23,18 @@ async function tokenPairRate(provider: JsonRpcProvider, token1Address: string, t
   return route.midPrice; // How many "token 1" we can get for one "token 2" in Uniswap
 }
 
-export async function gasPriceInToken(provider: JsonRpcProvider, tokenAddress: string): Promise<BN> {
+export async function gasPriceInToken(
+  provider: JsonRpcProvider,
+  tokenAddress: string,
+  gasPriceInNativeTokenInWei?: BigNumber
+): Promise<BigNumber> {
   let network = await networkName(provider);
   let chainId = (await provider.getNetwork()).chainId;
 
-  // Gas station will return current gas price in native token in wei.
-  let gasPriceInNativeTokenInWei = new BN((await getCurrentGasPrice(chainId)).standard.toString());
+  if (!gasPriceInNativeTokenInWei) {
+    // Gas station will return current gas price in native token in wei.
+    gasPriceInNativeTokenInWei = (await getCurrentGasPrice(chainId)).standard;
+  }
 
   // We use the wrapped native token address because the native token doesn't have an address in Uniswap.
   // The price of the wrapped native token, such as WETH, is the same as the price of the native token.
@@ -41,8 +46,8 @@ export async function gasPriceInToken(provider: JsonRpcProvider, tokenAddress: s
 
   // Convert the current gas price which is in native token to the token we want to pay the gas with.
   return gasPriceInNativeTokenInWei
-    .mul(new BN(rate.adjusted.numerator.toString())) // rate.adjusted is an adjustment of the difference in coin decimals, for example WETH has 18 decimals, USDT and USDC have 6.
-    .div(new BN(rate.adjusted.denominator.toString()));
+    .mul(BigNumber.from(rate.adjusted.numerator.toString())) // rate.adjusted is an adjustment of the difference in coin decimals, for example WETH has 18 decimals, USDT and USDC have 6.
+    .div(BigNumber.from(rate.adjusted.denominator.toString()));
 }
 
 export async function getCurrentGasPrice(chainId: number): Promise<GasPrice> {
@@ -62,4 +67,15 @@ export async function getCurrentGasPrice(chainId: number): Promise<GasPrice> {
     standard: BigNumber.from(gasPriceJson.standard),
     fast: BigNumber.from(gasPriceJson.fast),
   };
+}
+
+export async function getNativeWeiInToken(provider: JsonRpcProvider, tokenAddress: string): Promise<BigNumber> {
+  let naticeWeiInUSD;
+  try {
+    naticeWeiInUSD = await gasPriceInToken(provider, tokenAddress, BigNumber.from(1));
+  } catch (e) {
+    naticeWeiInUSD = BigNumber.from(0);
+  }
+
+  return naticeWeiInUSD;
 }

--- a/packages/hub/node-tests/services/scheduled-payments/executor-test.ts
+++ b/packages/hub/node-tests/services/scheduled-payments/executor-test.ts
@@ -5,6 +5,7 @@ import ScheduledPaymentsExecutorService from '../../../services/scheduled-paymen
 import { setupStubWorkerClient } from '../../helpers/stub-worker-client';
 import BN from 'bn.js';
 import CrankNonceLock from '../../../services/crank-nonce-lock';
+import { BigNumber } from 'ethers';
 
 let sdkError: Error | null = null;
 
@@ -57,7 +58,7 @@ describe('executing scheduled payments', function () {
 
   this.beforeEach(async function () {
     subject = (await getContainer().lookup('scheduled-payment-executor')) as ScheduledPaymentsExecutorService;
-    subject.getCurrentGasPrice = async () => new BN('1000000000');
+    subject.getCurrentGasPrice = async () => BigNumber.from('1000000000');
     prisma = await getPrisma();
     crankNonceLock = (await getContainer().lookup('crank-nonce-lock')) as CrankNonceLock;
     crankNonceLock.withNonce = async (chainId: number, cb: (nonce: BN) => Promise<any>) => {

--- a/packages/hub/node-tests/services/scheduled-payments/executor-test.ts
+++ b/packages/hub/node-tests/services/scheduled-payments/executor-test.ts
@@ -5,7 +5,6 @@ import ScheduledPaymentsExecutorService from '../../../services/scheduled-paymen
 import { setupStubWorkerClient } from '../../helpers/stub-worker-client';
 import BN from 'bn.js';
 import CrankNonceLock from '../../../services/crank-nonce-lock';
-import { BigNumber } from 'ethers';
 
 let sdkError: Error | null = null;
 
@@ -58,7 +57,7 @@ describe('executing scheduled payments', function () {
 
   this.beforeEach(async function () {
     subject = (await getContainer().lookup('scheduled-payment-executor')) as ScheduledPaymentsExecutorService;
-    subject.getCurrentGasPrice = async () => BigNumber.from('1000000000');
+    subject.getCurrentGasPrice = async () => new BN('1000000000');
     prisma = await getPrisma();
     crankNonceLock = (await getContainer().lookup('crank-nonce-lock')) as CrankNonceLock;
     crankNonceLock.withNonce = async (chainId: number, cb: (nonce: BN) => Promise<any>) => {


### PR DESCRIPTION
In the payment scheduling form, we need to show the gas prices range in USD. I updated the `estimateGas` function in the scheduled payment module SDK to include the gas prices in USD by converting gas prices in Wei to USD.