### PR TITLE
safe client: List safe info and token balances in the safe section in the sidebar

### DIFF
--- a/packages/cardpay-sdk/index.ts
+++ b/packages/cardpay-sdk/index.ts
@@ -56,3 +56,4 @@ export { protocolVersions } from './contracts/addresses';
 export { gasPriceInToken, getGasPricesInNativeWei } from './sdk/utils/conversions';
 export * from './sdk/network-config-utils';
 export * from './sdk/scheduled-payment/utils';
+export { convertRawAmountToDecimalFormat } from './sdk/currency-utils';

--- a/packages/cardpay-sdk/index.ts
+++ b/packages/cardpay-sdk/index.ts
@@ -36,6 +36,7 @@ export {
   waitForSubgraphIndex,
   waitUntilOneBlockAfterTxnMined,
 } from './sdk/utils/general-utils';
+export { getTokenBalancesForSafe } from './sdk/utils/safe-utils';
 export { signTypedData } from './sdk/utils/signing-utils';
 export * from './sdk/currency-utils';
 export * from './sdk/currencies';

--- a/packages/cardpay-sdk/sdk/scheduled-payment/safes.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment/safes.ts
@@ -1,3 +1,4 @@
+import { convertChainIdToName } from '../network-config-utils';
 import { query } from '../utils/graphql';
 
 const safesQuery = `
@@ -18,8 +19,9 @@ interface Safe {
   spModuleAddress: string;
 }
 
-export async function getSafesWithSpModuleEnabled(network: string, accountAddress: string): Promise<Safe[]> {
-  let result = await query(network, safesQuery, { account: accountAddress });
+export async function getSafesWithSpModuleEnabled(chainId: number, accountAddress: string): Promise<Safe[]> {
+  let networkName = convertChainIdToName(chainId);
+  let result = await query(networkName, safesQuery, { account: accountAddress });
 
   if (!result.data.account) return [];
 

--- a/packages/safe-tools-client/app/components/create-safe-button/index.gts
+++ b/packages/safe-tools-client/app/components/create-safe-button/index.gts
@@ -11,6 +11,7 @@ import { taskFor } from 'ember-concurrency-ts';
 
 import BoxelButton from '@cardstack/boxel/components/boxel/button';
 import WalletService from '@cardstack/safe-tools-client/services/wallet';
+import SafesService from '@cardstack/safe-tools-client/services/safes';
 import SchedulePaymentSDKService from '@cardstack/safe-tools-client/services/scheduled-payments-sdk';
 
 import SetupSafeModal from '../setup-safe-modal';
@@ -22,6 +23,7 @@ interface Signature {
 
 export default class CreateSafeButton extends Component<Signature> {
   @service declare wallet: WalletService;
+  @service declare safes: SafesService;
   @service declare scheduledPaymentsSdk: SchedulePaymentSDKService;
 
   @tracked isModalOpen = false;
@@ -66,9 +68,8 @@ export default class CreateSafeButton extends Component<Signature> {
 
   @action handleSafeCreation() {
     taskFor(this.scheduledPaymentsSdk.createSafe).perform()
-    .then(async () => { 
-      // Fetch from sdk or add task result manually ??
-      await this.wallet.fetchSafes();
+    .then(async () => {
+      this.safes.safesResource.load();
       this.closeModal();
     }).catch((e) => {
       //TODO: handle error case

--- a/packages/safe-tools-client/app/components/safe-info/index.css
+++ b/packages/safe-tools-client/app/components/safe-info/index.css
@@ -1,0 +1,4 @@
+.safe-tools_safe-info-balance {
+  font-weight: bold;
+  color: var(--boxel-highlight);
+}

--- a/packages/safe-tools-client/app/components/safe-info/index.gts
+++ b/packages/safe-tools-client/app/components/safe-info/index.gts
@@ -1,0 +1,82 @@
+import Component from '@glimmer/component';
+import BoxelSelect from '@cardstack/boxel/components/boxel/select';
+import BoxelButton from '@cardstack/boxel/components/boxel/button';
+import or from 'ember-truth-helpers/helpers/or';
+import gt from 'ember-truth-helpers/helpers/gt';
+import { on } from '@ember/modifier';
+import truncateMiddle from '@cardstack/safe-tools-client/helpers/truncate-middle';
+import weiToDecimal from '@cardstack/safe-tools-client/helpers/wei-to-decimal';
+import CreateSafeButton from '@cardstack/safe-tools-client/components/create-safe-button';
+import { Safe, TokenBalance } from '@cardstack/safe-tools-client/services/safes';
+
+import './index.css';
+
+interface Signature {
+  Element: HTMLDivElement;
+  Args: {
+    currentSafe: Safe | undefined;
+    safes: Safe[];
+    tokenBalances: TokenBalance[];
+    onDepositClick: () => void;
+    onSelectSafe: () => void;
+  }
+}
+
+export default class SafeInfo extends Component<Signature> {
+  get safesHaveLoadedInitially() {
+    return this.args.safes !== undefined;
+  }
+
+  <template>
+    {{#if (gt @safes.length 1)}}
+      <BoxelSelect
+        class='safe-tools__dashboard-dropdown'
+        @selected={{@currentSafe}}
+        @onChange={{@onSelectSafe}}
+        @options={{@safes}}
+        @dropdownClass="boxel-select-usage-dropdown"
+        data-test-safe-dropdown
+        as |safe itemCssClass|>
+        <div class="{{itemCssClass}} blockchain-address">{{truncateMiddle safe.address}}</div>
+      </BoxelSelect>
+    {{else}}
+      <div class='safe-tools__dashboard-schedule-control-panel-address' title={{@currentSafe.address}} data-test-safe-address-label>
+        {{truncateMiddle (or @currentSafe.address '')}}
+      </div>
+    {{/if}}
+
+    {{#if @currentSafe}}
+      <div>
+        {{#each @tokenBalances as |tokenBalance|}}
+          {{#let (weiToDecimal tokenBalance.balance tokenBalance.decimals)
+            as |balanceDecimalValue|
+          }}
+            {{!-- Don't show zero balances and crypto dust --}}
+            {{#if (or tokenBalance.isNativeToken (gt tokenBalance.balance 0.0001))}}
+              <div class='safe-tools_safe-info-balance' data-test-token-balance={{tokenBalance.symbol}}>
+                {{balanceDecimalValue}} {{tokenBalance.symbol}}
+              </div>
+            {{/if}}
+          {{/let}}
+        {{/each}}
+      </div>
+
+      <BoxelButton @kind='primary' {{on 'click' @onDepositClick}}>
+        Add Funds
+      </BoxelButton>
+    {{else if this.safesHaveLoadedInitially}}
+      <p class='info'>
+        To schedule payments, you need to have a safe which contains funds that would be deducted
+        automatically when scheduled payments are due.
+      </p>
+
+      <CreateSafeButton />
+    {{/if}}
+  </template>
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'SafeInfo': typeof SafeInfo;
+  }
+}

--- a/packages/safe-tools-client/app/controllers/schedule.ts
+++ b/packages/safe-tools-client/app/controllers/schedule.ts
@@ -1,10 +1,10 @@
 import ApplicationController from '@cardstack/safe-tools-client/controllers/application';
 import NetworkService from '@cardstack/safe-tools-client/services/network';
 import WalletService from '@cardstack/safe-tools-client/services/wallet';
-
+import TokensService from '@cardstack/safe-tools-client/services/tokens';
+import SafesService from '@cardstack/safe-tools-client/services/safes';
 import Controller, { inject as controller } from '@ember/controller';
-import { action } from '@ember/object';
-import { default as Owner } from '@ember/owner';
+
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
@@ -14,66 +14,11 @@ export default class Schedule extends Controller {
   @controller declare application: ApplicationController;
   @service declare wallet: WalletService;
   @service declare network: NetworkService;
+  @service declare tokens: TokensService;
+  @service declare safes: SafesService;
 
   @tracked isDepositModalOpen = false;
-  @tracked isInitializingSafes = false;
 
-  constructor(owner: Owner) {
-    super(owner);
-    this.initializeSafes();
-  }
-
-  @action async initializeSafes() {
-    try {
-      this.isInitializingSafes = true;
-
-      // TODO: replace with ember resources
-      // Waits a bit to get connection on refresh
-      setTimeout(async () => {
-        if (this.wallet.isConnected) {
-          await this.wallet.fetchSafes();
-        }
-        this.isInitializingSafes = false;
-      }, 500);
-    } catch (e) {
-      console.log('Error initializing safes', e);
-    }
-  }
-
-  // TODO: handle safe info, right now it returns mocked info
-  // even when safes exists
-  get safe() {
-    if (!this.wallet.safes.length) {
-      return undefined;
-    }
-
-    return {
-      address: '0x8a40AFffb53f4F953a204cAE087219A28771df9d',
-      tokens: [
-        {
-          address: 'eth',
-          name: 'Ethereum',
-          symbol: 'ETH',
-          decimals: 18,
-          balance: 1, //in ETH
-        },
-        {
-          address: '0x6B...1d0F', // TODO: check when address is hex, to truncate on template
-          name: 'Dai',
-          symbol: 'DAI',
-          decimals: 18,
-          balance: 1,
-        },
-        {
-          address: 'usdc',
-          name: 'USDC',
-          symbol: 'USDC',
-          decimals: 6,
-          balance: 0,
-        },
-      ],
-    };
-  }
   get scheduledPaymentsTokensToCover() {
     const hasScheduledPayments = false;
     // TODO: Add helper functions to map amounts, use fromWei function

--- a/packages/safe-tools-client/app/controllers/schedule.ts
+++ b/packages/safe-tools-client/app/controllers/schedule.ts
@@ -1,8 +1,8 @@
 import ApplicationController from '@cardstack/safe-tools-client/controllers/application';
 import NetworkService from '@cardstack/safe-tools-client/services/network';
-import WalletService from '@cardstack/safe-tools-client/services/wallet';
-import TokensService from '@cardstack/safe-tools-client/services/tokens';
 import SafesService from '@cardstack/safe-tools-client/services/safes';
+import TokensService from '@cardstack/safe-tools-client/services/tokens';
+import WalletService from '@cardstack/safe-tools-client/services/wallet';
 import Controller, { inject as controller } from '@ember/controller';
 
 import { inject as service } from '@ember/service';

--- a/packages/safe-tools-client/app/css/app.css
+++ b/packages/safe-tools-client/app/css/app.css
@@ -1,0 +1,11 @@
+.boxel-control-panel__item-body {
+  width: 240px;
+}
+
+.blockchain-address {
+  font-family: var(--boxel-monospace-font-family);
+}
+
+.info {
+  font-size: var(--boxel-font-size-sm);
+}

--- a/packages/safe-tools-client/app/css/schedule.css
+++ b/packages/safe-tools-client/app/css/schedule.css
@@ -1,3 +1,11 @@
+.boxel-control-panel__item-body {
+  padding-left: var(--boxel-sp-lg);
+}
+
+.boxel-control-panel__item-body > * + * {
+  margin-top: var(--boxel-sp-sm);
+}
+
 .safe-tools__dashboard-schedule {
   background-color: var(--boxel-dashboard-background-color);
 
@@ -5,7 +13,7 @@
   flex-direction: row;
 }
 
-.safe-tools__dashboard-schedule-control-panel-wallet-address {
+.safe-tools__dashboard-schedule-control-panel-address {
   color: var(--boxel-purple-300);
   font-family: var(--boxel-monospace-font-family);
   font-size: var(--boxel-font-size-sm);
@@ -19,7 +27,6 @@
   gap: var(--boxel-sp-xxxs);
   font-size: var(--boxel-font-size-xs);
   margin-top: var(--boxel-sp-xxxs);
-  margin-bottom: var(--boxel-sp-sm);
 }
 
 .safe-tools__dashboard-schedule-control-panel-connected-status-icon {
@@ -35,29 +42,9 @@
   padding: var(--boxel-sp-xxl) var(--boxel-sp-lg) 0;
 }
 
-.safe-tools__dashboard-schedule-control-panel-safe-info-address,
-.safe-tools__dashboard-schedule-control-panel-safe-info-balance,
-.safe-tools__dashboard-schedule-control-panel-safe-info-create {
-  inline-size: 200px;
-  display: block;
-  text-align: left;
-  font-weight: normal;
-  font-size: var(--boxel-font-size-sm);
-}
-
-.safe-tools__dashboard-schedule-control-panel-safe-info-create {
-  margin-top: calc(var(--boxel-sp-xxs) * -1);
-}
-
 .safe-tools__dashboard-schedule-control-panel-safe-info-address {
   color: var(--boxel-purple-300);
   margin-bottom: 2px;
-}
-
-.safe-tools__dashboard-schedule-control-panel-safe-info-balance {
-  font-weight: bold;
-  color: var(--boxel-highlight);
-  margin-bottom: var(--boxel-sp-sm);
 }
 
 .temporary-form-container {
@@ -66,17 +53,21 @@
   margin-top: var(--boxel-sp-xl);
 }
 
-.safe-tools__dashboard-network-selector {
+.safe-tools__dashboard-dropdown {
   display: inline-flex;
   align-items: center;
 }
 
-.safe-tools__dashboard-network-selector.boxel-select .boxel-select__item {
+.safe-tools__dashboard-dropdown .ember-power-select-selected-item .boxel-select__item {
+  padding-left: 0;
+}
+
+.safe-tools__dashboard-dropdown.boxel-select .boxel-select__item {
   font-weight: 600;
   font-size: var(--boxel-font-size-sm);
 }
 
-.safe-tools__dashboard-network-selector .ember-power-select-status-icon {
+.safe-tools__dashboard-dropdown .ember-power-select-status-icon {
   -webkit-mask: url('/@cardstack/boxel/images/icons/caret-down.svg') no-repeat;
   mask: url('/@cardstack/boxel/images/icons/caret-down.svg') no-repeat;
 

--- a/packages/safe-tools-client/app/helpers/wei-to-decimal.ts
+++ b/packages/safe-tools-client/app/helpers/wei-to-decimal.ts
@@ -1,0 +1,21 @@
+import { convertRawAmountToDecimalFormat } from '@cardstack/cardpay-sdk';
+import { helper } from '@ember/component/helper';
+import { BN } from 'bn.js';
+
+type PositionalArgs = [typeof BN, number];
+
+interface Signature {
+  Args: {
+    Positional: PositionalArgs;
+  };
+  Return: string;
+}
+
+export function weiToDecimal([amount, decimals]: PositionalArgs) {
+  const number = parseFloat(
+    convertRawAmountToDecimalFormat(amount.toString(), decimals)
+  );
+  return String(number % 1 === 0 ? number : number.toFixed(3));
+}
+
+export default helper<Signature>(weiToDecimal);

--- a/packages/safe-tools-client/app/services/safes.ts
+++ b/packages/safe-tools-client/app/services/safes.ts
@@ -1,0 +1,147 @@
+import { SelectableToken } from '@cardstack/boxel/components/boxel/input/selectable-token';
+import {
+  getSafesWithSpModuleEnabled,
+  Web3Provider,
+  getTokenBalancesForSafe,
+  getConstantByNetwork,
+} from '@cardstack/cardpay-sdk';
+import NetworkService from '@cardstack/safe-tools-client/services/network';
+import WalletService from '@cardstack/safe-tools-client/services/wallet';
+import { action } from '@ember/object';
+import Service, { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { BN } from 'bn.js';
+import { use, resource } from 'ember-resources';
+import { TrackedObject } from 'tracked-built-ins';
+
+export interface Safe {
+  address: string;
+  spModuleAddress: string;
+}
+
+export interface TokenBalance {
+  symbol: string;
+  balance: typeof BN;
+  decimals: number;
+  isNativeToken?: boolean;
+}
+
+interface SafeResourceState extends Record<PropertyKey, unknown> {
+  error?: Error;
+  isLoading?: boolean;
+  value?: Safe[];
+  load: () => Promise<void>;
+}
+
+interface TokenBalanceResourceState extends Record<PropertyKey, unknown> {
+  error?: Error;
+  isLoading: boolean;
+  value?: TokenBalance[];
+}
+
+export default class SafesService extends Service {
+  @service declare network: NetworkService;
+  @service declare wallet: WalletService;
+
+  @tracked selectedSafe?: Safe;
+  @tracked _didCreateSafe = false;
+
+  get safes(): Safe[] | undefined {
+    return this.safesResource.value;
+  }
+
+  get tokenBalances(): TokenBalance[] | undefined {
+    return this.tokenBalancesResource.value;
+  }
+
+  get currentSafe(): Safe | undefined {
+    return this.selectedSafe || this.safes?.[0];
+  }
+
+  @action onSelectSafe(safe: Safe) {
+    this.selectedSafe = safe;
+  }
+
+  @use tokenBalancesResource = resource(() => {
+    if (!this.wallet.web3.currentProvider || !this.currentSafe) {
+      return {
+        error: false,
+        isLoading: false,
+        value: [],
+      };
+    }
+
+    const state: TokenBalanceResourceState = new TrackedObject({
+      isLoading: true,
+    });
+
+    //@ts-expect-error currentProvider does not match Web3Provider,
+    //not worth typing as we should replace the web3 one with ethers soon
+    const ethersProvider = new Web3Provider(this.wallet.web3.currentProvider);
+
+    const tokenAddresses = getConstantByNetwork(
+      'tokenList',
+      this.network.symbol
+    ).tokens.map((t: SelectableToken) => t.address);
+
+    (async () => {
+      try {
+        if (!this.currentSafe) return;
+        const nativeTokenBalance = new BN(
+          (await ethersProvider.getBalance(this.currentSafe.address)).toString()
+        );
+
+        const tokenBalances = await getTokenBalancesForSafe(
+          ethersProvider,
+          tokenAddresses,
+          this.currentSafe.address
+        );
+
+        state.value = [
+          {
+            symbol: getConstantByNetwork(
+              'nativeTokenSymbol',
+              this.network.symbol
+            ),
+            balance: nativeTokenBalance as unknown as typeof BN,
+            decimals: 18,
+            isNativeToken: true,
+          },
+          ...tokenBalances,
+        ];
+      } catch (error) {
+        state.error = error;
+      } finally {
+        state.isLoading = false;
+      }
+    })();
+
+    return state;
+  });
+
+  @use safesResource = resource(() => {
+    // because networkInfo is tracked, anytime the network switches,
+    // this resource will re-run
+    const chainId = this.network.networkInfo.chainId;
+    const address = this.wallet.address;
+
+    const state: SafeResourceState = new TrackedObject({
+      load: async () => {
+        if (!address) return;
+
+        state.isLoading = true;
+
+        try {
+          state.value = await getSafesWithSpModuleEnabled(chainId, address);
+        } catch (error) {
+          state.error = error;
+        } finally {
+          state.isLoading = false;
+        }
+      },
+    });
+
+    state.load();
+    return state;
+  });
+}

--- a/packages/safe-tools-client/app/services/safes.ts
+++ b/packages/safe-tools-client/app/services/safes.ts
@@ -44,7 +44,6 @@ export default class SafesService extends Service {
   @service declare wallet: WalletService;
 
   @tracked selectedSafe?: Safe;
-  @tracked _didCreateSafe = false;
 
   get safes(): Safe[] | undefined {
     return this.safesResource.value;

--- a/packages/safe-tools-client/app/services/wallet.ts
+++ b/packages/safe-tools-client/app/services/wallet.ts
@@ -1,7 +1,6 @@
 import {
   getConstantByNetwork,
   getSDK,
-  getSafesWithSpModuleEnabled,
   isSchedulerSupportedChain,
 } from '@cardstack/cardpay-sdk';
 import NetworkService from '@cardstack/safe-tools-client/services/network';
@@ -94,7 +93,6 @@ export default class Wallet extends Service {
         .perform()
         .then(() => {
           if (this.isConnected) {
-            this.fetchSafes();
             onConnectSuccess();
           }
         })
@@ -132,20 +130,6 @@ export default class Wallet extends Service {
     };
 
     return this.nativeTokenBalance;
-  }
-
-  @action async fetchSafes() {
-    try {
-      if (this.address) {
-        // @ts-expect-error we should add correct typing to safe when integrating safesInfo
-        this.safes = await getSafesWithSpModuleEnabled(
-          this.network.symbol,
-          this.address
-        );
-      }
-    } catch (e) {
-      console.log('error fetching safes', e);
-    }
   }
 }
 

--- a/packages/safe-tools-client/app/templates/schedule.hbs
+++ b/packages/safe-tools-client/app/templates/schedule.hbs
@@ -3,7 +3,8 @@
     <cp.Item @title='Wallet' @icon='wallet' @isActive={{not this.wallet.isConnected}}>
       {{#if this.wallet.isConnected}}
         <div
-          class='safe-tools__dashboard-schedule-control-panel-wallet-address'
+          class='safe-tools__dashboard-schedule-control-panel-address'
+          data-test-wallet-address
         >
           {{truncate-middle this.wallet.address}}
         </div>
@@ -25,7 +26,7 @@
     </cp.Item>
     <cp.Item @title='Network' @icon='network'>
         <Boxel::Select
-        class='safe-tools__dashboard-network-selector'
+        class='safe-tools__dashboard-dropdown'
             @selected={{this.network}}
             @onChange={{this.network.onSelect}}
             @options={{this.network.supportedList}}
@@ -34,33 +35,16 @@
           <div class={{itemCssClass}} data-test-selected-network>{{network.name}}</div>
         </Boxel::Select>
     </cp.Item>
-    <cp.Item @title='Safe' @icon='safe' @isActive={{this.wallet.isConnected}}>
+    <cp.Item @title='Safe' @icon='safe'>
       {{#if this.wallet.isConnected}}
-        {{#if this.safe}}
-          {{#each this.safe.tokens as |token|}}
-            {{#if (gt token.balance 0)}}
-              <span class='safe-tools__dashboard-schedule-control-panel-safe-info-address'>
-                {{token.address}}:{{truncate-middle this.safe.address}}
-              </span>
-              <span class='safe-tools__dashboard-schedule-control-panel-safe-info-balance'>
-                {{token.balance}} {{token.symbol}}
-              </span>
-            {{/if}}  
-          {{/each}}
-          <Boxel::Button
-            @kind='primary'
-            {{on 'click' (set this 'isDepositModalOpen' true)}}
-          >
-            Add Funds
-          </Boxel::Button>
-        {{else}}
-          <p class='safe-tools__dashboard-schedule-control-panel-safe-info-create'>
-            You need to have a safe which contains funds that would be deducted
-            automatically when schedule payments are due.
-          </p>
-          <CreateSafeButton />
-        {{/if}}
-      {{/if}}  
+        <SafeInfo
+          @safes={{this.safes.safes}}
+          @currentSafe={{this.safes.currentSafe}}
+          @onSelectSafe={{this.safes.onSelectSafe}}
+          @tokenBalances={{this.safes.tokenBalances}}
+          @onDepositClick={{set this 'isDepositModalOpen' true}}
+        />
+      {{/if}}
     </cp.Item>
   </Boxel::ControlPanel>
   <section class='safe-tools__dashboard-schedule-content'>
@@ -74,7 +58,7 @@
 <DepositModal
   @isOpen={{this.isDepositModalOpen}}
   @onClose={{set this 'isDepositModalOpen' false}}
-  @safeAddress={{this.safe.address}}
+  @safeAddress={{this.safes.curentSafe.address}}
   @networkName={{this.network}}
   @tokensToCover={{this.scheduledPaymentsTokensToCover}}
 />

--- a/packages/safe-tools-client/package.json
+++ b/packages/safe-tools-client/package.json
@@ -74,6 +74,7 @@
     "@walletconnect/utils": "^1.6.0",
     "@walletconnect/web3-provider": "^1.6.0",
     "babel-eslint": "^10.1.0",
+    "bn.js": "^5.2.1",
     "broccoli-asset-rev": "^3.0.0",
     "ember-a11y-testing": "^4.0.3",
     "ember-auto-import": "^2.4.2",

--- a/packages/safe-tools-client/tests/acceptance/wallet-connection-test.ts
+++ b/packages/safe-tools-client/tests/acceptance/wallet-connection-test.ts
@@ -25,7 +25,7 @@ module('Acceptance | wallet connection', function (hooks) {
       await click('[data-test-mainnet-connect-button]');
 
       assert
-        .dom('.safe-tools__dashboard-schedule-control-panel-wallet-address')
+        .dom('[data-test-wallet-address]')
         .hasText(truncateMiddle([TEST_ACCOUNT_1]));
 
       await percySnapshot(assert);
@@ -34,17 +34,15 @@ module('Acceptance | wallet connection', function (hooks) {
 
       await settled();
       assert
-        .dom('.safe-tools__dashboard-schedule-control-panel-wallet-address')
+        .dom('[data-test-wallet-address]')
         .hasText(truncateMiddle([TEST_ACCOUNT_2]));
       assert
-        .dom('.safe-tools__dashboard-schedule-control-panel-wallet-address')
+        .dom('[data-test-wallet-address]')
         .doesNotContainText(truncateMiddle([TEST_ACCOUNT_1]));
 
       await click('[data-test-disconnect-button]');
 
-      assert
-        .dom('.safe-tools__dashboard-schedule-control-panel-wallet-address')
-        .doesNotExist();
+      assert.dom('[data-test-wallet-address]').doesNotExist();
 
       assert.dom('[data-test-connect-button]').exists();
       assert.dom('[data-test-disconnect-button]').doesNotExist();
@@ -69,7 +67,7 @@ module('Acceptance | wallet connection', function (hooks) {
 
       await click('.network-connect-modal__close-button'); // FIXME: I don't think this click should be necessary
       assert
-        .dom('.safe-tools__dashboard-schedule-control-panel-wallet-address')
+        .dom('[data-test-wallet-address]')
         .hasText(truncateMiddle([TEST_ACCOUNT_2]));
     });
   });

--- a/packages/safe-tools-client/tests/integration/safe-info-test.ts
+++ b/packages/safe-tools-client/tests/integration/safe-info-test.ts
@@ -1,0 +1,91 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { render } from '@ember/test-helpers';
+import BN from 'bn.js';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+
+module('Integration | Component | safe-info', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('It renders a single safe when there is only one safe', async function (assert) {
+    assert.expect(2);
+
+    this.set('onSelectSafe', () => {});
+    this.set('onDepositClick', () => {});
+
+    await render(hbs`
+        <SafeInfo
+          @safes={{array (hash address="0x5f62B165B2414C3917487297a42253dF18a55478")}}
+          @currentSafe={{(hash address="0x5f62B165B2414C3917487297a42253dF18a55478")}}
+          @onSelectSafe={{this.onSelectSafe}}
+          @onDepositClick={{this.onDepositClick}}
+        />
+      `);
+
+    assert.dom('[data-test-safe-address-label]').hasText('0x5f62...5478');
+    assert.dom('[data-test-safe-dropdown]').doesNotExist();
+  });
+
+  test('It renders safe info dropdown when there are multiple safes', async function (assert) {
+    assert.expect(3);
+
+    this.set('onSelectSafe', () => {});
+    this.set('onDepositClick', () => {});
+
+    await render(hbs`
+        <SafeInfo
+          @safes={{array (hash address="0x5f62B165B2414C3917487297a42253dF18a55478") (hash address="0x7bc2B165B2414C3917487297a42253dF18a55123")}}
+          @currentSafe={{(hash address="0x5f62B165B2414C3917487297a42253dF18a55478")}}
+          @onSelectSafe={{this.onSelectSafe}}
+          @onDepositClick={{this.onDepositClick}}
+        />
+      `);
+
+    assert.dom('[data-test-safe-address-label]').doesNotExist();
+    assert.dom('[data-test-safe-dropdown]').exists();
+    assert.dom('.ember-power-select-selected-item').hasText('0x5f62...5478');
+  });
+
+  test('It renders token balances without zero or dust amounts', async function (assert) {
+    assert.expect(2);
+
+    this.set('onSelectSafe', () => {});
+    this.set('onDepositClick', () => {});
+    this.set('tokenBalances', [
+      {
+        symbol: 'ETH',
+        decimals: 18,
+        balance: new BN('1000000000000000000'),
+      },
+      {
+        symbol: 'USDC',
+        decimals: 6,
+        balance: new BN('100000000'),
+      },
+      {
+        symbol: 'DAI',
+        decimals: 18,
+        balance: new BN('100000000000'), // crypto dust (0.00001 DAI)
+      },
+      {
+        symbol: 'WMATIC',
+        decimals: 18,
+        balance: new BN('0'),
+      },
+    ]);
+
+    await render(hbs`
+        <SafeInfo
+          @safes={{array (hash address="0x5f62B165B2414C3917487297a42253dF18a55478") (hash address="0x7bc2B165B2414C3917487297a42253dF18a55123")}}
+          @currentSafe={{(hash address="0x5f62B165B2414C3917487297a42253dF18a55478")}}
+          @tokenBalances={{this.tokenBalances}}
+          @onSelectSafe={{this.onSelectSafe}}
+          @onDepositClick={{this.onDepositClick}}
+        />
+      `);
+
+    assert.dom('[data-test-token-balance="ETH"]').hasText('1 ETH');
+    assert.dom('[data-test-token-balance="USDC"]').hasText('100 USDC');
+  });
+});


### PR DESCRIPTION
Ticket: CS-4770

This adds displaying the safe address and a list of token balances in the sidebar. They show up if the user has at least one safe with scheduled payment module enabled. Normally, users will have one safe with sp module if they go through the setup process, but they can also have multiple if they do it manually using the CLI (and eventually in the Gnosis safe dApp).

**This is how it looks when the user has one safe:**

<img width="261" alt="image" src="https://user-images.githubusercontent.com/273660/204823254-27ac1c58-23ee-4002-a7ce-65c5c541f9e2.png">

**Multiple safes:**

<img width="257" alt="image" src="https://user-images.githubusercontent.com/273660/204823393-50fbd582-6886-477a-995e-0f644296daa1.png">

<img width="278" alt="image" src="https://user-images.githubusercontent.com/273660/204823434-80d38dfa-92d0-49ed-9543-ace8a4eb3408.png">


**No safes:** 

<img width="305" alt="image" src="https://user-images.githubusercontent.com/273660/204267214-e8a25ac6-d984-416e-9d7e-89795bf0958e.png">


## To discuss:

### Balances of which tokens should we list?

1. Currently, we list tokens intended for transferring. Should we also list gas tokens?

Answer: We will list all supported tokens (they are stored as `tokenList` in the SDK)

### CSS

I feel that the classes that we use are sometimes uncomfortably long and confusing.

For example: `safe-tools__dashboard-schedule-control-panel-connect-button`

1. The name implies there exists a `safe-tools` block but there isn't one. Maybe we can drop this prefix?
2. `dashboard` and `control-panel` in the same class are confusing since they mean a very similar thing. Also, I'm wondering what is the dashboard supposed to be - only the side panel? If yes, I think we could reduce the class to something like `side-panel-connect-button`


