### PR TITLE
Update response of gas station endpoint in the Hub

### DIFF
--- a/packages/cardpay-sdk/sdk/utils/conversions.ts
+++ b/packages/cardpay-sdk/sdk/utils/conversions.ts
@@ -58,8 +58,8 @@ export async function getCurrentGasPrice(chainId: number): Promise<GasPrice> {
   let gasPriceJson = await gasStationResponse.json();
 
   return {
-    slow: BigNumber.from(gasPriceJson.slow),
-    standard: BigNumber.from(gasPriceJson.standard),
-    fast: BigNumber.from(gasPriceJson.fast),
+    slow: BigNumber.from(gasPriceJson.data.attributes.slow),
+    standard: BigNumber.from(gasPriceJson.data.attributes.standard),
+    fast: BigNumber.from(gasPriceJson.data.attributes.fast),
   };
 }

--- a/packages/hub/main.ts
+++ b/packages/hub/main.ts
@@ -109,6 +109,7 @@ import GasEstimationValidator from './services/validators/gas-estimation';
 import GasEstimationResultSerializer from './services/serializers/gas-estimation-result-serializer';
 import ScheduledPaymentsAttemptsRoute from './routes/scheduled-payment-attempts';
 import ScheduledPaymentAttemptSerializer from './services/serializers/scheduled-payment-attempt-serializer';
+import GasPriceSerializer from './services/serializers/gas-price-serializer';
 
 //@ts-ignore polyfilling fetch
 global.fetch = fetch;
@@ -201,6 +202,7 @@ export function createRegistry(): Registry {
   registry.register('data-integrity-checks-route', DataIntegrityChecksRoute);
   registry.register('gas-station-service', GasStationService);
   registry.register('gas-station-route', GasStationRoute);
+  registry.register('gas-price-serializer', GasPriceSerializer);
   registry.register('gas-estimation-route', GasEstimationRoute);
   registry.register('gas-estimation-service', GasEstimationService);
   registry.register('gas-estimation-validator', GasEstimationValidator);

--- a/packages/hub/node-tests/routes/gas-station-test.ts
+++ b/packages/hub/node-tests/routes/gas-station-test.ts
@@ -43,7 +43,18 @@ describe('GET /api/gas-station', async function () {
       .set('Accept', 'application/vnd.api+json')
       .set('Content-Type', 'application/vnd.api+json')
       .expect(200)
-      .expect(result)
+      .expect({
+        data: {
+          id: result.id,
+          type: 'gas-prices',
+          attributes: {
+            'chain-id': result.chainId,
+            slow: result.slow,
+            standard: result.standard,
+            fast: result.fast,
+          },
+        },
+      })
       .expect('Content-Type', 'application/vnd.api+json');
   });
 

--- a/packages/hub/routes/gas-station.ts
+++ b/packages/hub/routes/gas-station.ts
@@ -5,6 +5,7 @@ import { NotFound } from '@cardstack/core/src/utils/errors';
 
 export default class GasStationRoute {
   gasStationService = inject('gas-station-service', { as: 'gasStationService' });
+  gasPriceSerializer = inject('gas-price-serializer', { as: 'gasPriceSerializer' });
 
   constructor() {
     autoBind(this);
@@ -15,7 +16,7 @@ export default class GasStationRoute {
       let chainId = Number(ctx.params.chain_id);
       let gasPrice = await this.gasStationService.getGasPriceByChainId(chainId);
       ctx.status = 200;
-      ctx.body = gasPrice;
+      ctx.body = this.gasPriceSerializer.serialize(gasPrice);
       ctx.type = 'application/vnd.api+json';
     } catch (error) {
       if (error instanceof NotFound) {

--- a/packages/hub/services/serializers/gas-price-serializer.ts
+++ b/packages/hub/services/serializers/gas-price-serializer.ts
@@ -1,0 +1,31 @@
+import { GasPrice } from '@prisma/client';
+import { JSONAPIDocument } from '../../utils/jsonapi-document';
+
+export default class GasPriceSerializer {
+  serialize(model: GasPrice | GasPrice[]): JSONAPIDocument {
+    if (Array.isArray(model)) {
+      return {
+        data: model.map((m) => this.serialize(m).data),
+      };
+    } else {
+      return {
+        data: {
+          id: model.id,
+          type: 'gas-prices',
+          attributes: {
+            'chain-id': model.chainId,
+            slow: model.slow,
+            standard: model.standard,
+            fast: model.fast,
+          },
+        },
+      };
+    }
+  }
+}
+
+declare module '@cardstack/di' {
+  interface KnownServices {
+    'gas-price-serializer': GasPriceSerializer;
+  }
+}


### PR DESCRIPTION
Updating gas station response to make it has the same response format as other endpoints in the Hub.