### PR TITLE
Update estimation endpoint to avoid decimals error

### DIFF
--- a/packages/hub/node-tests/services/gas-estimation/estimation-test.ts
+++ b/packages/hub/node-tests/services/gas-estimation/estimation-test.ts
@@ -35,6 +35,16 @@ class StubCardpaySDK {
         throw new Error(`unsupported mock cardpay sdk: ${sdk}`);
     }
   }
+  getConstantByNetwork(_name: string, _network: string) {
+    return {
+      tokens: [
+        {
+          address: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
+          decimals: 18,
+        },
+      ],
+    };
+  }
 }
 
 describe('estimate gas', function () {
@@ -54,7 +64,7 @@ describe('estimate gas', function () {
     createSafeGas = 7000000;
     let gasEstimationParams: GasEstimationParams = {
       scenario: GasEstimationResultsScenarioEnum.create_safe_with_module,
-      chainId: 1,
+      chainId: 5,
     };
     let gasEstimationResult = await subject.estimate(gasEstimationParams);
 
@@ -69,9 +79,9 @@ describe('estimate gas', function () {
     executionGas = 1000000;
     let gasEstimationParams: GasEstimationParams = {
       scenario: GasEstimationResultsScenarioEnum.execute_one_time_payment,
-      chainId: 1,
-      tokenAddress: '0x0',
-      gasTokenAddress: '0x0',
+      chainId: 5,
+      tokenAddress: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
+      gasTokenAddress: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
     };
     let gasEstimationResult = await subject.estimate(gasEstimationParams);
 
@@ -86,9 +96,9 @@ describe('estimate gas', function () {
     executionGas = 1000000;
     let gasEstimationParams: GasEstimationParams = {
       scenario: GasEstimationResultsScenarioEnum.execute_recurring_payment,
-      chainId: 1,
-      tokenAddress: '0x0',
-      gasTokenAddress: '0x0',
+      chainId: 5,
+      tokenAddress: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
+      gasTokenAddress: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
     };
     let gasEstimationResult = await subject.estimate(gasEstimationParams);
 
@@ -106,7 +116,7 @@ describe('estimate gas', function () {
 
     let gasEstimationParams: GasEstimationParams = {
       scenario: GasEstimationResultsScenarioEnum.create_safe_with_module,
-      chainId: 1,
+      chainId: 5,
     };
     let prisma = await getPrisma();
     await prisma.gasEstimationResult.create({
@@ -128,7 +138,7 @@ describe('estimate gas', function () {
 
     let gasEstimationParams: GasEstimationParams = {
       scenario: GasEstimationResultsScenarioEnum.execute_one_time_payment,
-      chainId: 1,
+      chainId: 5,
     };
     await expect(subject.estimate(gasEstimationParams)).to.be.rejectedWith(
       'tokenAddress and gasTokenAddress is required in execute_one_time_payment'
@@ -140,7 +150,7 @@ describe('estimate gas', function () {
 
     let gasEstimationParams: GasEstimationParams = {
       scenario: GasEstimationResultsScenarioEnum.execute_recurring_payment,
-      chainId: 1,
+      chainId: 5,
       tokenAddress: '',
       gasTokenAddress: '',
     };
@@ -155,8 +165,8 @@ describe('estimate gas', function () {
     let gasEstimationParams: GasEstimationParams = {
       scenario: GasEstimationResultsScenarioEnum.execute_recurring_payment,
       chainId: 3,
-      tokenAddress: '0x0',
-      gasTokenAddress: '0x0',
+      tokenAddress: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
+      gasTokenAddress: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
     };
     await expect(subject.estimate(gasEstimationParams)).to.be.rejectedWith('Unsupported network: 3');
   });

--- a/packages/hub/node-tests/services/gas-estimation/estimation-test.ts
+++ b/packages/hub/node-tests/services/gas-estimation/estimation-test.ts
@@ -35,16 +35,6 @@ class StubCardpaySDK {
         throw new Error(`unsupported mock cardpay sdk: ${sdk}`);
     }
   }
-  getConstantByNetwork(_name: string, _network: string) {
-    return {
-      tokens: [
-        {
-          address: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
-          decimals: 18,
-        },
-      ],
-    };
-  }
 }
 
 describe('estimate gas', function () {

--- a/packages/hub/services/gas-estimation.ts
+++ b/packages/hub/services/gas-estimation.ts
@@ -90,14 +90,14 @@ export default class GasEstimationService {
     let tokenList = this.cardpay.getConstantByNetwork('tokenList', networkName as SchedulerCapableNetworks);
     let token = tokenList.tokens.find((t) => t.address === params.tokenAddress);
     let gasToken = tokenList.tokens.find((t) => t.address === params.gasTokenAddress);
-    if (!token || !gasToken) {
-      throw Error('unknown token and gas token');
-    }
+    if (!token) throw Error('unknown token');
+    if (!gasToken) throw Error('unknown gas token');
+
     //Check the decimals of tokens
     //to avoid error when converting USD tokens
     //because USD token's decimals is lower than native token's decimals
-    let tokenAmount = ethers.utils.parseUnits('1', token.decimals >= 18 ? 'gwei' : 3);
-    let gasTokenAmount = ethers.utils.parseUnits('0.01', gasToken.decimals >= 18 ? 'gwei' : 3);
+    let tokenAmount = ethers.utils.parseUnits('1', token.decimals >= 18 ? 'gwei' : token.decimals);
+    let gasTokenAmount = ethers.utils.parseUnits('0.01', gasToken.decimals >= 18 ? 'gwei' : token.decimals);
 
     let signer = new Wallet(config.get('hubPrivateKey'));
     let scheduledPaymentModule = await this.cardpay.getSDK('ScheduledPaymentModule', provider, signer);

--- a/packages/hub/services/gas-estimation.ts
+++ b/packages/hub/services/gas-estimation.ts
@@ -88,10 +88,10 @@ export default class GasEstimationService {
     let provider = this.ethersProvider.getInstance(params.chainId);
     let signer = new Wallet(config.get('hubPrivateKey'));
     let scheduledPaymentModule = await this.cardpay.getSDK('ScheduledPaymentModule', provider, signer);
-    
-    // Both transferAmount and gasPrice should be as small as possible 
+
+    // Both transferAmount and gasPrice should be as small as possible
     // (so that we don't have to keep a non-trivial balance of tokens in the crank)
-    // given their token decimal amount. 
+    // given their token decimal amount.
     // For transferAmount we should consider the underflow error,
     // since transferAmount will be calculated with fee percentage.
     // And gasPrice is price per unit of gas, so it will be multiplied by the gas execution.

--- a/packages/hub/services/gas-estimation.ts
+++ b/packages/hub/services/gas-estimation.ts
@@ -88,6 +88,13 @@ export default class GasEstimationService {
     let provider = this.ethersProvider.getInstance(params.chainId);
     let signer = new Wallet(config.get('hubPrivateKey'));
     let scheduledPaymentModule = await this.cardpay.getSDK('ScheduledPaymentModule', provider, signer);
+    
+    // Both transferAmount and gasPrice should be as small as possible 
+    // (so that we don't have to keep a non-trivial balance of tokens in the crank)
+    // given their token decimal amount. 
+    // For transferAmount we should consider the underflow error,
+    // since transferAmount will be calculated with fee percentage.
+    // And gasPrice is price per unit of gas, so it will be multiplied by the gas execution.
     let transferAmount = '1000';
     let gasPrice = '100';
     let gas;


### PR DESCRIPTION
Not all tokens have the same decimal point as the native tokens. For example, the decimal value of a USDC token is 6. Before this update, we expected the crank safe to have a balance of 1 Gwei for all tokens, which makes no sense for a token like USDC as it would be too large. So in this PR, we don't use 1 Gwei for all tokens, we check the decimals value first and after that, decide the amount of transfer token and gas token.