### PR TITLE
Update conversion util

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "clean": "git clean -x -f --exclude=packages/*/.env --exclude=cardstack.code-workspace && lerna run clean",
-    "postinstall": "yarn --cwd packages/cardpay-sdk codegen && yarn --cwd packages/ember-shared/addon build",
+    "postinstall": "yarn --cwd packages/cardpay-sdk codegen && yarn --cwd packages/ember-shared/addon build && yarn patch-package",
     "cardpay": "yarn --cwd packages/cardpay-cli cardpay",
     "codegen:subgraph-sokol": "yarn --cwd packages/cardpay-subgraph codegen-sokol",
     "codegen:subgraph-xdai": "yarn --cwd packages/cardpay-subgraph codegen-xdai",

--- a/packages/cardpay-sdk/contracts/addresses.ts
+++ b/packages/cardpay-sdk/contracts/addresses.ts
@@ -102,6 +102,7 @@ const GOERLI = {
   metaGuard: '0xe2847462a574bfd43014d1c7BB6De5769C294691',
   wrappedNativeToken: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6', // WETH
   usdcToken: '0x07865c6E87B9F70255377e024ace6630C1Eaa37F',
+  uniswapV2Factory: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f',
 };
 const MUMBAI = {
   gnosisSafeMasterCopy: '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552',
@@ -115,7 +116,8 @@ const MUMBAI = {
   moduleProxyFactory: '0x00000000000DC7F163742Eb4aBEf650037b1f588',
   metaGuard: '0xe2847462a574bfd43014d1c7BB6De5769C294691',
   wrappedNativeToken: '0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889', // WMATIC
-  usdcToken: '0xe6b8a5CF854791412c1f6EFC7CAf629f5Df1c747',
+  usdcToken: '0xf9A71cf591fd72224eeE9C825Bc9aa4BAE05C55d',
+  uniswapV2Factory: '0xc35DADB65012eC5796536bD9864eD8773aBc74C4',
 };
 
 const MAINNET = {
@@ -129,6 +131,7 @@ const MAINNET = {
   scheduledPaymentModule: '',
   wrappedNativeToken: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
   usdcToken: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  uniswapV2Factory: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f',
 };
 const GNOSIS = {
   gnosisProxyFactory_v1_2: '0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B',

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -179,7 +179,7 @@ const constants: {
     scheduledPaymentFeeFixedUSD: 0.25,
     scheduledPaymentFeePercentage: 0.1, //10%
     subgraphURL: '',
-    uniswapPairInitCodeHash: '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f',
+    uniswapPairInitCodeHash: '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f', //Result of keccak256(type(UniswapV2Pair).creationCode) from deployed UniswapV2Factory
   },
   goerli: {
     ...testHubUrl,
@@ -193,7 +193,7 @@ const constants: {
     scheduledPaymentFeeFixedUSD: 0,
     scheduledPaymentFeePercentage: 0,
     subgraphURL: 'https://api.thegraph.com/subgraphs/name/cardstack/safe-tools-goerli',
-    uniswapPairInitCodeHash: '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f',
+    uniswapPairInitCodeHash: '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f', //Result of keccak256(type(UniswapV2Pair).creationCode) from deployed UniswapV2Factory
   },
   polygon: {
     ...hubUrl,
@@ -207,7 +207,7 @@ const constants: {
     subgraphURL: '',
     scheduledPaymentFeeFixedUSD: 0.25,
     scheduledPaymentFeePercentage: 0.1, //10%
-    uniswapPairInitCodeHash: '0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303',
+    uniswapPairInitCodeHash: '0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303', //Result of keccak256(type(UniswapV2Pair).creationCode) from deployed UniswapV2Factory
   },
   mumbai: {
     ...testHubUrl,
@@ -221,7 +221,7 @@ const constants: {
     scheduledPaymentFeeFixedUSD: 0,
     scheduledPaymentFeePercentage: 0,
     subgraphURL: 'https://api.thegraph.com/subgraphs/name/cardstack/safe-tools-mumbai',
-    uniswapPairInitCodeHash: '0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303',
+    uniswapPairInitCodeHash: '0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303', //Result of keccak256(type(UniswapV2Pair).creationCode) from deployed UniswapV2Factory
   },
 };
 

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -47,6 +47,7 @@ interface SchedulerCapableNetworkConstants {
   tokenList: TokenList;
   scheduledPaymentFeeFixedUSD: number;
   scheduledPaymentFeePercentage: number;
+  uniswapPairInitCodeHash: string;
 }
 
 interface CardPayCapableNetworkConstants {
@@ -178,6 +179,7 @@ const constants: {
     scheduledPaymentFeeFixedUSD: 0.25,
     scheduledPaymentFeePercentage: 0.1, //10%
     subgraphURL: '',
+    uniswapPairInitCodeHash: '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f',
   },
   goerli: {
     ...testHubUrl,
@@ -191,6 +193,7 @@ const constants: {
     scheduledPaymentFeeFixedUSD: 0,
     scheduledPaymentFeePercentage: 0,
     subgraphURL: 'https://api.thegraph.com/subgraphs/name/cardstack/safe-tools-goerli',
+    uniswapPairInitCodeHash: '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f',
   },
   polygon: {
     ...hubUrl,
@@ -204,6 +207,7 @@ const constants: {
     subgraphURL: '',
     scheduledPaymentFeeFixedUSD: 0.25,
     scheduledPaymentFeePercentage: 0.1, //10%
+    uniswapPairInitCodeHash: '0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303',
   },
   mumbai: {
     ...testHubUrl,
@@ -217,6 +221,7 @@ const constants: {
     scheduledPaymentFeeFixedUSD: 0,
     scheduledPaymentFeePercentage: 0,
     subgraphURL: 'https://api.thegraph.com/subgraphs/name/cardstack/safe-tools-mumbai',
+    uniswapPairInitCodeHash: '0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303',
   },
 };
 

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -179,7 +179,7 @@ const constants: {
     scheduledPaymentFeeFixedUSD: 0.25,
     scheduledPaymentFeePercentage: 0.1, //10%
     subgraphURL: '',
-    uniswapPairInitCodeHash: '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f', //Result of keccak256(type(UniswapV2Pair).creationCode) from deployed UniswapV2Factory
+    uniswapPairInitCodeHash: '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f', // Result of keccak256(type(UniswapV2Pair).creationCode) from deployed UniswapV2Factory. We had to deploy our own Uniswap contracts on some networks (for now Mumbai) because they were missing, and add the patches/@uniswap+sdk+3.0.3.patch to support custom token pairs (by providing factory address and token pair code hash)
   },
   goerli: {
     ...testHubUrl,

--- a/packages/cardpay-sdk/sdk/utils/conversions.ts
+++ b/packages/cardpay-sdk/sdk/utils/conversions.ts
@@ -2,7 +2,7 @@
 
 import { Fetcher, Route, Price } from '@uniswap/sdk';
 import { getAddressByNetwork } from '../../contracts/addresses';
-import { getConstantByNetwork } from '../constants';
+import { getConstantByNetwork, SchedulerCapableNetworks } from '../constants';
 import JsonRpcProvider from '../../providers/json-rpc-provider';
 import { networkName } from './general-utils';
 import BN from 'bn.js';
@@ -16,7 +16,16 @@ async function tokenPairRate(provider: JsonRpcProvider, token1Address: string, t
   let token1 = await Fetcher.fetchTokenData(network.chainId, token1Address, provider as unknown as BaseProvider);
   let token2 = await Fetcher.fetchTokenData(network.chainId, token2Address, provider as unknown as BaseProvider);
 
-  let pair = await Fetcher.fetchPairData(token1, token2, provider as unknown as BaseProvider);
+  let networkName = convertChainIdToName(network.chainId);
+  let uniswapV2Factory = getAddressByNetwork('uniswapV2Factory', networkName);
+  let initCodeHash = getConstantByNetwork('uniswapPairInitCodeHash', networkName as SchedulerCapableNetworks);
+  let pair = await Fetcher.fetchPairData(
+    token1,
+    token2,
+    uniswapV2Factory,
+    initCodeHash,
+    provider as unknown as BaseProvider
+  );
 
   let route = new Route([pair], token2);
 

--- a/packages/cardpay-sdk/token-lists/mumbai-tokenlist.json
+++ b/packages/cardpay-sdk/token-lists/mumbai-tokenlist.json
@@ -46,7 +46,7 @@
       "name": "Mumbai USD Coin",
       "symbol": "USDC",
       "decimals": 6,
-      "address": "0xe6b8a5cf854791412c1f6efc7caf629f5df1c747",
+      "address": "0xf9A71cf591fd72224eeE9C825Bc9aa4BAE05C55d",
       "logoURI": "https://wallet-asset.matic.network/img/tokens/usdc.svg",
       "tags": ["erc20", "relayGas", "stablecoin"]
     },
@@ -64,7 +64,7 @@
       "name": "Mumbai USDT",
       "symbol": "USDT",
       "decimals": 18,
-      "address": "0xe583769738b6dd4e7caf8451050d1948be717679",
+      "address": "0x41240e0CaCB8C80E343cCA0b590327B221e8575a",
       "logoURI": "https://wallet-asset.matic.network/img/tokens/usdt.svg",
       "tags": ["erc20", "gas", "stablecoin"]
     },
@@ -82,7 +82,7 @@
       "name": "Test Token",
       "symbol": "TST",
       "decimals": 18,
-      "address": "0xa0d9f8282cd48d22fd875e43be32793124f8ed47",
+      "address": "0x44D01e5E547A745dc8C0FD97D5F8365F791281A9",
       "logoURI": "https://wallet-asset.matic.network/img/tokens/eth.svg",
       "tags": ["erc20"]
     }

--- a/patches/@uniswap+sdk+3.0.3.patch
+++ b/patches/@uniswap+sdk+3.0.3.patch
@@ -1,0 +1,33 @@
+diff --git a/node_modules/@uniswap/sdk/dist/fetcher.d.ts b/node_modules/@uniswap/sdk/dist/fetcher.d.ts
+index 2667e63..1ed6408 100644
+--- a/node_modules/@uniswap/sdk/dist/fetcher.d.ts
++++ b/node_modules/@uniswap/sdk/dist/fetcher.d.ts
+@@ -24,5 +24,5 @@ export declare abstract class Fetcher {
+      * @param tokenB second token
+      * @param provider the provider to use to fetch the data
+      */
+-    static fetchPairData(tokenA: Token, tokenB: Token, provider?: import("@ethersproject/providers").BaseProvider): Promise<Pair>;
++    static fetchPairData(tokenA: Token, tokenB: Token, factoryAddress: string, initCodeHash: string, provider?: import("@ethersproject/providers").BaseProvider): Promise<Pair>;
+ }
+diff --git a/node_modules/@uniswap/sdk/dist/sdk.cjs.development.js b/node_modules/@uniswap/sdk/dist/sdk.cjs.development.js
+index a4450f3..b740191 100644
+--- a/node_modules/@uniswap/sdk/dist/sdk.cjs.development.js
++++ b/node_modules/@uniswap/sdk/dist/sdk.cjs.development.js
+@@ -765,7 +765,7 @@ var Pair = /*#__PURE__*/function () {
+     this.tokenAmounts = tokenAmounts;
+   }
+ 
+-  Pair.getAddress = function getAddress(tokenA, tokenB) {
++  Pair.getAddress = function getAddress(tokenA, tokenB, factoryAddress = FACTORY_ADDRESS, initCodeHash = INIT_CODE_HASH) {
+     var _PAIR_ADDRESS_CACHE, _PAIR_ADDRESS_CACHE$t;
+ 
+     var tokens = tokenA.sortsBefore(tokenB) ? [tokenA, tokenB] : [tokenB, tokenA]; // does safety checks
+@@ -773,7 +773,7 @@ var Pair = /*#__PURE__*/function () {
+     if (((_PAIR_ADDRESS_CACHE = PAIR_ADDRESS_CACHE) === null || _PAIR_ADDRESS_CACHE === void 0 ? void 0 : (_PAIR_ADDRESS_CACHE$t = _PAIR_ADDRESS_CACHE[tokens[0].address]) === null || _PAIR_ADDRESS_CACHE$t === void 0 ? void 0 : _PAIR_ADDRESS_CACHE$t[tokens[1].address]) === undefined) {
+       var _PAIR_ADDRESS_CACHE2, _extends2, _extends3;
+ 
+-      PAIR_ADDRESS_CACHE = _extends({}, PAIR_ADDRESS_CACHE, (_extends3 = {}, _extends3[tokens[0].address] = _extends({}, (_PAIR_ADDRESS_CACHE2 = PAIR_ADDRESS_CACHE) === null || _PAIR_ADDRESS_CACHE2 === void 0 ? void 0 : _PAIR_ADDRESS_CACHE2[tokens[0].address], (_extends2 = {}, _extends2[tokens[1].address] = address.getCreate2Address(FACTORY_ADDRESS, solidity.keccak256(['bytes'], [solidity.pack(['address', 'address'], [tokens[0].address, tokens[1].address])]), INIT_CODE_HASH), _extends2)), _extends3));
++      PAIR_ADDRESS_CACHE = _extends({}, PAIR_ADDRESS_CACHE, (_extends3 = {}, _extends3[tokens[0].address] = _extends({}, (_PAIR_ADDRESS_CACHE2 = PAIR_ADDRESS_CACHE) === null || _PAIR_ADDRESS_CACHE2 === void 0 ? void 0 : _PAIR_ADDRESS_CACHE2[tokens[0].address], (_extends2 = {}, _extends2[tokens[1].address] = address.getCreate2Address(factoryAddress, solidity.keccak256(['bytes'], [solidity.pack(['address', 'address'], [tokens[0].address, tokens[1].address])]), initCodeHash), _extends2)), _extends3));
+     }
+ 
+     return PAIR_ADDRESS_CACHE[tokens[0].address][tokens[1].address];


### PR DESCRIPTION
### Problem

Conversion util didn't work in polygon networks because Uniswap had not deployed their version 2 contracts, and we used those contracts to do the conversion.

### Solution

We could deploy Uniswap V2 contracts by ourselves, but we would have a different UniswapV2Factory address and a different init code hash than the one already used in `@uniswap/sdk`. So the solution is to make the UniswapV2Factory address and init code hash parameterizable.