### PR TITLE
hub: Fix timezone issues in calculating next pay at by making sure all logic is in UTC

### DIFF
--- a/packages/hub/node-tests/utils/scheduled-payments-test.ts
+++ b/packages/hub/node-tests/utils/scheduled-payments-test.ts
@@ -1,31 +1,32 @@
-import { format } from 'date-fns';
 import { calculateNextPayAt } from '../../utils/scheduled-payments';
 
 describe('ScheduledPaymentUtils', function () {
   let recurringDay = 5;
 
+  // In below assertions, toISOString is used to compare dates because we want to make sure that
+  // we compare UTC dates. On the other side of the comparison, we use the YYYY-MM-DDT00:00:00.000Z format
+  // for the same reason (Z is at the end to indicate UTC time).
+
   it('calculates next pay at when current day number is lower than recurring day', function () {
-    let fromDate = new Date(Date.parse('2022-02-04'));
+    let prevPayAt = new Date(Date.parse('2022-02-04T00:00:00.000Z'));
 
-    let nextPayAt = calculateNextPayAt(fromDate, recurringDay);
-
-    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-02-05');
+    let nextPayAt = calculateNextPayAt(prevPayAt, recurringDay);
+    expect(nextPayAt.toISOString()).to.equal('2022-02-05T00:00:00.000Z');
   });
 
   it('calculates next pay at when current day number is the same as recurring day', function () {
-    let fromDate = new Date(Date.parse('2022-02-05'));
+    let prevPayAt = new Date(Date.parse('2022-02-05T00:00:00.000Z'));
+    let nextPayAt = calculateNextPayAt(prevPayAt, recurringDay);
 
-    let nextPayAt = calculateNextPayAt(fromDate, recurringDay);
-
-    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-03-05');
+    expect(nextPayAt.toISOString()).to.equal('2022-03-05T00:00:00.000Z');
   });
 
   it('calculates next pay at when current day number is higher same as recurring day', function () {
-    let fromDate = new Date(Date.parse('2022-02-06'));
+    let prevPayAt = new Date(Date.parse('2022-02-06T00:00:00.000Z'));
 
-    let nextPayAt = calculateNextPayAt(fromDate, recurringDay);
+    let nextPayAt = calculateNextPayAt(prevPayAt, recurringDay);
 
-    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-03-05');
+    expect(nextPayAt.toISOString()).to.equal('2022-03-05T00:00:00.000Z');
   });
 
   it('throws an error when recurring day is not in the range of 1-31', function () {
@@ -37,41 +38,41 @@ describe('ScheduledPaymentUtils', function () {
 
   it('sets the last day of month when month has less days than recurringDay case 1', function () {
     // February 2022 has 28 days. If recurringDay is set to 31th, payAt should be set to 28th.
-    let a = new Date(Date.UTC(2022, 1, 1)); // 2022-02-01 (months are zero-indexed)
-    let nextPayAt = calculateNextPayAt(a, 31);
+    let startingDate = new Date(Date.UTC(2022, 1, 1)); // 2022-02-01 (months are zero-indexed)
+    let nextPayAt = calculateNextPayAt(startingDate, 31);
 
-    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-02-28');
+    expect(nextPayAt.toISOString()).to.equal('2022-02-28T00:00:00.000Z');
   });
 
   it('sets the last day of month when month has less days than recurringDay case 2', function () {
     // February 2022 has 28 days. If recurringDay is set to 31th, payAt should be set to 28th.
-    let a = new Date(Date.UTC(2022, 1, 27)); // 2022-02-27 (months are zero-indexed)
-    let nextPayAt = calculateNextPayAt(a, 31);
+    let startingDate = new Date(Date.UTC(2022, 1, 27)); // 2022-02-27 (months are zero-indexed)
+    let nextPayAt = calculateNextPayAt(startingDate, 31);
 
-    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-02-28');
+    expect(nextPayAt.toISOString()).to.equal('2022-02-28T00:00:00.000Z');
   });
 
   it('sets the last day of month when month has less days than recurringDay case 3', function () {
-    // February 2022 has 28 days. If recurringDay is set to 31st and we're on 28th, next payAt should be set to March 30st.
-    let a = new Date(Date.UTC(2022, 1, 28)); // 2022-02-28 (months are zero-indexed)
-    let nextPayAt = calculateNextPayAt(a, 31);
+    // February 2022 has 28 days. If recurringDay is set to 31st and we're on 28th, next payAt should be set to March 31st
+    let startingDate = new Date(Date.UTC(2022, 1, 28)); // 2022-02-28 (months are zero-indexed)
+    let nextPayAt = calculateNextPayAt(startingDate, 31);
 
-    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-03-31');
+    expect(nextPayAt.toISOString()).to.equal('2022-03-31T00:00:00.000Z');
   });
 
   it('sets the last day of month when month has less days than recurringDay case 4', function () {
     // April has 30 days. If recurringDay is set to 31st, payAt should be set to 30th.
-    let a = new Date(Date.UTC(2022, 3, 1)); // 2022-04-01 (months are zero-indexed)
-    let nextPayAt = calculateNextPayAt(a, 31);
+    let startingDate = new Date(Date.UTC(2022, 3, 1)); // 2022-04-01 (months are zero-indexed)
+    let nextPayAt = calculateNextPayAt(startingDate, 31);
 
-    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-04-30');
+    expect(nextPayAt.toISOString()).to.equal('2022-04-30T00:00:00.000Z');
   });
 
   it('sets the last day of month when month has less days than recurringDay case 5', function () {
     // April has 30 days. If recurringDay is set to 31st and we're on 30th, next payAt should be set to May 31st.
-    let a = new Date(Date.UTC(2022, 3, 30)); // 2022-04-30 (months are zero-indexed)
-    let nextPayAt = calculateNextPayAt(a, 31);
+    let startingDate = new Date(Date.UTC(2022, 3, 30)); // 2022-04-30 (months are zero-indexed)
+    let nextPayAt = calculateNextPayAt(startingDate, 31);
 
-    expect(format(nextPayAt, 'yyyy-MM-dd')).to.equal('2022-05-31');
+    expect(nextPayAt.toISOString()).to.equal('2022-05-31T00:00:00.000Z');
   });
 });

--- a/packages/hub/utils/scheduled-payments.ts
+++ b/packages/hub/utils/scheduled-payments.ts
@@ -1,4 +1,3 @@
-import { addMonths } from 'date-fns';
 import { convertDateToUTC } from './dates';
 
 // This function will return the next payment date based on the frequency.
@@ -9,21 +8,20 @@ export function calculateNextPayAt(fromDate: Date, recurringDay: number) {
     throw new Error('Recurring day must be in the range of 1-31');
   }
 
-  let fromDateUtc = convertDateToUTC(fromDate);
   let nextPayAtUtc = convertDateToUTC(fromDate);
 
   // We take min() because some months can have less days than the recurring day (e.g. there is no Feb 31)
-  let adjustedRecurringDay = Math.min(recurringDay, daysInMonth(fromDateUtc));
-  if (fromDate.getDate() < adjustedRecurringDay) {
-    nextPayAtUtc.setDate(adjustedRecurringDay); // next pay this month
+  let adjustedRecurringDay = Math.min(recurringDay, daysInMonth(fromDate));
+  if (fromDate.getUTCDate() < adjustedRecurringDay) {
+    nextPayAtUtc.setUTCDate(adjustedRecurringDay); // next pay this month
   } else {
-    nextPayAtUtc = addMonths(nextPayAtUtc, 1); // next pay next month
-    nextPayAtUtc.setDate(Math.min(recurringDay, daysInMonth(nextPayAtUtc)));
+    nextPayAtUtc.setUTCMonth(nextPayAtUtc.getUTCMonth() + 1);
+    nextPayAtUtc.setUTCDate(Math.min(recurringDay, daysInMonth(nextPayAtUtc)));
   }
 
   return nextPayAtUtc;
 }
 
 function daysInMonth(date: Date) {
-  return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
+  return new Date(date.getUTCFullYear(), date.getUTCMonth() + 1, 0).getDate();
 }


### PR DESCRIPTION
This gets rid of timezone sensitivity in `calculateNextPayAt` (we need to operate on UTC only).

Luckily we discovered this issue by failing tests on  machines running on timezones that are several hours away from UTC. 

It turns out `date-fns` have no support for UTC which caused `format` and `addMonth` to operate on local dates. The implementation was changed to JS's native date UTC methods. I tested this by switching my timezone to eastern and the tests pass. 