### PR TITLE
safe client: switch metamask network 

### DIFF
--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -39,6 +39,7 @@ interface RequiredNetworkConstants {
   nativeTokenCoingeckoId: string;
   nativeTokenName: string;
   nativeTokenSymbol: string;
+  nativeTokenDecimals: number;
   subgraphURL: string;
   relayServiceURL: string;
 }
@@ -99,6 +100,7 @@ const ethNativeTokens = {
   nativeTokenAddress: 'eth',
   nativeTokenSymbol: 'ETH',
   nativeTokenName: 'Ethereum',
+  nativeTokenDecimals: 18,
 };
 
 const bridgedTokens = {
@@ -111,6 +113,7 @@ const polygonNativeTokens = {
   nativeTokenCoingeckoId: 'matic-network',
   nativeTokenSymbol: 'MATIC',
   nativeTokenName: 'Matic',
+  nativeTokenDecimals: 18,
 };
 
 const constants: {
@@ -143,6 +146,7 @@ const constants: {
     nativeTokenCoingeckoId: 'xdai',
     nativeTokenSymbol: 'XDAI',
     nativeTokenName: 'xDai',
+    nativeTokenDecimals: 18,
     name: 'Gnosis Chain',
     relayServiceURL: 'https://relay.cardstack.com/api',
     subgraphURL: 'https://graph.cardstack.com/subgraphs/name/habdelra/cardpay-xdai',

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -49,6 +49,7 @@ interface SchedulerCapableNetworkConstants {
   scheduledPaymentFeeFixedUSD: number;
   scheduledPaymentFeePercentage: number;
   uniswapPairInitCodeHash: string;
+  publicRpcUrls: string[];
 }
 
 interface CardPayCapableNetworkConstants {
@@ -184,6 +185,11 @@ const constants: {
     scheduledPaymentFeePercentage: 0.1, //10%
     subgraphURL: '',
     uniswapPairInitCodeHash: '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f', // Result of keccak256(type(UniswapV2Pair).creationCode) from deployed UniswapV2Factory. We had to deploy our own Uniswap contracts on some networks (for now Mumbai) because they were missing, and add the patches/@uniswap+sdk+3.0.3.patch to support custom token pairs (by providing factory address and token pair code hash)
+    publicRpcUrls: [
+      'https://ethereum.publicnode.com',
+      'https://rpc.ankr.com/eth',
+      'https://eth-mainnet.public.blastapi.io',
+    ],
   },
   goerli: {
     ...testHubUrl,
@@ -198,6 +204,7 @@ const constants: {
     scheduledPaymentFeePercentage: 0,
     subgraphURL: 'https://api.thegraph.com/subgraphs/name/cardstack/safe-tools-goerli',
     uniswapPairInitCodeHash: '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f', //Result of keccak256(type(UniswapV2Pair).creationCode) from deployed UniswapV2Factory
+    publicRpcUrls: ['https://eth-goerli.public.blastapi.io', 'https://rpc.ankr.com/eth_goerli'],
   },
   polygon: {
     ...hubUrl,
@@ -212,6 +219,13 @@ const constants: {
     scheduledPaymentFeeFixedUSD: 0.25,
     scheduledPaymentFeePercentage: 0.1, //10%
     uniswapPairInitCodeHash: '0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303', //Result of keccak256(type(UniswapV2Pair).creationCode) from deployed UniswapV2Factory
+    publicRpcUrls: [
+      'https://polygon-rpc.com/',
+      'https://rpc-mainnet.matic.network',
+      'https://matic-mainnet.chainstacklabs.com',
+      'https://rpc-mainnet.maticvigil.com',
+      'https://rpc-mainnet.matic.quiknode.pro',
+    ],
   },
   mumbai: {
     ...testHubUrl,
@@ -226,6 +240,12 @@ const constants: {
     scheduledPaymentFeePercentage: 0,
     subgraphURL: 'https://api.thegraph.com/subgraphs/name/cardstack/safe-tools-mumbai',
     uniswapPairInitCodeHash: '0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303', //Result of keccak256(type(UniswapV2Pair).creationCode) from deployed UniswapV2Factory
+    publicRpcUrls: [
+      'https://matic-mumbai.chainstacklabs.com',
+      'https://rpc-mumbai.maticvigil.com',
+      'https://matic-testnet-archive-rpc.bwarelabs.com',
+      'https://polygon-testnet.public.blastapi.io',
+    ],
   },
 };
 

--- a/packages/safe-tools-client/app/components/safe-info/index.gts
+++ b/packages/safe-tools-client/app/components/safe-info/index.gts
@@ -75,7 +75,7 @@ export default class SafeInfo extends Component<Signature> {
     {{/if}}
 
     {{#if @safesLoadingError}}
-      <div class="info">{{@safesLoadingError.message}}</div>
+      <div class="info">⚠️ {{@safesLoadingError.message}}</div>
     {{/if}}
   </template>
 }

--- a/packages/safe-tools-client/app/components/safe-info/index.gts
+++ b/packages/safe-tools-client/app/components/safe-info/index.gts
@@ -17,6 +17,7 @@ interface Signature {
     currentSafe: Safe | undefined;
     safes: Safe[];
     tokenBalances: TokenBalance[];
+    safesLoadingError: Error | undefined;
     onDepositClick: () => void;
     onSelectSafe: () => void;
   }
@@ -71,6 +72,10 @@ export default class SafeInfo extends Component<Signature> {
       </p>
 
       <CreateSafeButton />
+    {{/if}}
+
+    {{#if @safesLoadingError}}
+      <div class="info">{{@safesLoadingError.message}}</div>
     {{/if}}
   </template>
 }

--- a/packages/safe-tools-client/app/services/network.ts
+++ b/packages/safe-tools-client/app/services/network.ts
@@ -5,9 +5,11 @@ import {
   schedulerSupportedChainsArray,
   SchedulerCapableNetworks,
 } from '@cardstack/cardpay-sdk';
+import WalletService from '@cardstack/safe-tools-client/services/wallet';
 import { getOwner } from '@ember/application';
 import { action } from '@ember/object';
 import Service from '@ember/service';
+import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 interface NetworkInfo {
@@ -20,11 +22,16 @@ const LOCALSTORAGE_NETWORK_KEY = 'cardstack-cached-network';
 
 export default class NetworkService extends Service {
   storage: Storage;
+
+  // @ts-expect-error "Property 'wallet' has no initializer and is not definitely assigned in the constructor" - ignore this error because Ember will inject the service
+  @service wallet: WalletService;
+
   @tracked networkInfo: NetworkInfo;
 
   constructor(properties?: object | undefined) {
     super(properties);
     const owner = getOwner(this);
+
     this.storage =
       (owner.lookup('storage:local') as Storage) || window.localStorage;
 
@@ -50,7 +57,12 @@ export default class NetworkService extends Service {
       }))
       .filter(({ name }) => name !== this.name);
   }
-  @action onSelect(networkInfo: NetworkInfo) {
+
+  @action async onSelect(networkInfo: NetworkInfo) {
+    await this.wallet.switchNetwork(networkInfo.chainId);
+
+    if (this.networkInfo.chainId === networkInfo.chainId) return;
+
     this.networkInfo = networkInfo;
     this.storage.setItem(LOCALSTORAGE_NETWORK_KEY, networkInfo.symbol);
   }

--- a/packages/safe-tools-client/app/services/safes.ts
+++ b/packages/safe-tools-client/app/services/safes.ts
@@ -86,28 +86,12 @@ export default class SafesService extends Service {
     (async () => {
       try {
         if (!this.currentSafe) return;
-        const nativeTokenBalance = new BN(
-          (await ethersProvider.getBalance(this.currentSafe.address)).toString()
-        );
 
-        const tokenBalances = await getTokenBalancesForSafe(
-          ethersProvider,
+        state.value = await this.fetchTokenBalances(
+          this.currentSafe.address,
           tokenAddresses,
-          this.currentSafe.address
+          ethersProvider
         );
-
-        state.value = [
-          {
-            symbol: getConstantByNetwork(
-              'nativeTokenSymbol',
-              this.network.symbol
-            ),
-            balance: nativeTokenBalance as unknown as typeof BN,
-            decimals: 18,
-            isNativeToken: true,
-          },
-          ...tokenBalances,
-        ];
       } catch (error) {
         console.log(error);
         state.error = error;
@@ -134,7 +118,7 @@ export default class SafesService extends Service {
         state.isLoading = true;
 
         try {
-          state.value = await getSafesWithSpModuleEnabled(chainId, address);
+          state.value = await this.fetchSafes(chainId, address);
         } catch (error) {
           state.error = new Error(
             'There was an error while fetching your safes. Try switching to this network again, or contact support if the problem persists.'
@@ -149,4 +133,35 @@ export default class SafesService extends Service {
     state.load();
     return state;
   });
+
+  async fetchTokenBalances(
+    safeAddress: string,
+    tokenAddresses: string[],
+    provider: Web3Provider
+  ): Promise<TokenBalance[]> {
+    const nativeTokenBalance = new BN(
+      (await provider.getBalance(safeAddress)).toString()
+    );
+
+    const tokenBalances = await getTokenBalancesForSafe(
+      provider,
+      tokenAddresses,
+      safeAddress
+    );
+
+    return [
+      {
+        symbol: getConstantByNetwork('nativeTokenSymbol', this.network.symbol),
+        balance: nativeTokenBalance as unknown as typeof BN,
+        decimals: 18,
+        isNativeToken: true,
+      },
+      ...tokenBalances,
+    ];
+  }
+
+  // Wrapped in a method for stubbing in tests
+  async fetchSafes(chainId: number, address: string) {
+    return getSafesWithSpModuleEnabled(chainId, address);
+  }
 }

--- a/packages/safe-tools-client/app/services/safes.ts
+++ b/packages/safe-tools-client/app/services/safes.ts
@@ -109,6 +109,7 @@ export default class SafesService extends Service {
           ...tokenBalances,
         ];
       } catch (error) {
+        console.log(error);
         state.error = error;
       } finally {
         state.isLoading = false;
@@ -125,6 +126,8 @@ export default class SafesService extends Service {
     const address = this.wallet.address;
 
     const state: SafeResourceState = new TrackedObject({
+      error: undefined,
+
       load: async () => {
         if (!address) return;
 
@@ -133,7 +136,10 @@ export default class SafesService extends Service {
         try {
           state.value = await getSafesWithSpModuleEnabled(chainId, address);
         } catch (error) {
-          state.error = error;
+          state.error = new Error(
+            '⚠️ There was an error while fetching your safes. Try switching to this network again, or contact support if the problem persists.'
+          );
+          throw error;
         } finally {
           state.isLoading = false;
         }

--- a/packages/safe-tools-client/app/services/safes.ts
+++ b/packages/safe-tools-client/app/services/safes.ts
@@ -137,7 +137,7 @@ export default class SafesService extends Service {
           state.value = await getSafesWithSpModuleEnabled(chainId, address);
         } catch (error) {
           state.error = new Error(
-            '⚠️ There was an error while fetching your safes. Try switching to this network again, or contact support if the problem persists.'
+            'There was an error while fetching your safes. Try switching to this network again, or contact support if the problem persists.'
           );
           throw error;
         } finally {

--- a/packages/safe-tools-client/app/services/wallet.ts
+++ b/packages/safe-tools-client/app/services/wallet.ts
@@ -19,6 +19,8 @@ import { task } from 'ember-concurrency-decorators';
 import { taskFor } from 'ember-concurrency-ts';
 import Web3 from 'web3';
 
+const ERR_METAMASK_UNKNOWN_NETWORK = 4902; // The requested chain has not been added by MetaMask
+
 export default class Wallet extends Service {
   @service declare network: NetworkService;
 
@@ -102,7 +104,7 @@ export default class Wallet extends Service {
         params: [{ chainId: chainIdHex }],
       });
     } catch (error) {
-      if (error.code === 4902) {
+      if (error.code === ERR_METAMASK_UNKNOWN_NETWORK) {
         // Network not added in Metamask. We prompt the user to add it.
 
         const networkName = convertChainIdToName(chainId);

--- a/packages/safe-tools-client/app/services/wallet.ts
+++ b/packages/safe-tools-client/app/services/wallet.ts
@@ -131,7 +131,10 @@ export default class Wallet extends Service {
                 blockExplorerUrls: [
                   getConstantByNetwork('blockExplorer', networkName),
                 ],
-                rpcUrls: getConstantByNetwork('publicRpcUrls', networkName),
+                rpcUrls: getConstantByNetwork(
+                  'publicRpcUrls',
+                  networkName as typeof this.network.symbol
+                ),
               },
             ],
           });

--- a/packages/safe-tools-client/app/templates/schedule.hbs
+++ b/packages/safe-tools-client/app/templates/schedule.hbs
@@ -43,6 +43,7 @@
           @onSelectSafe={{this.safes.onSelectSafe}}
           @tokenBalances={{this.safes.tokenBalances}}
           @onDepositClick={{set this 'isDepositModalOpen' true}}
+          @safesLoadingError={{this.safes.safesResource.error}}
         />
       {{/if}}
     </cp.Item>

--- a/packages/safe-tools-client/types/global.d.ts
+++ b/packages/safe-tools-client/types/global.d.ts
@@ -1,7 +1,14 @@
 import '@glint/environment-ember-loose';
 import '@cardstack/boxel/glint';
+import { MetaMaskInpageProvider } from '@metamask/providers';
 
 declare module '@glint/environment-ember-loose/registry' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   export default interface Registry {}
+}
+
+declare global {
+  interface Window {
+    ethereum?: MetaMaskInpageProvider;
+  }
 }


### PR DESCRIPTION
Ticket: CS-4938

This PR assures that when using Metamask, the network selected in the client is also selected in Metamask. Without this, fetching token balances will fail because we use eth calls for that (`balanceOf`). If selected network in the client and in metamask are different, there will be a mismatch between the network and safe/token addresses.

This is how it looks like when the user selects a different network from the dropdown. If user approves, the change is applied and safes / token balances will be refetched from the newly selected network:

<img width="370" alt="image" src="https://user-images.githubusercontent.com/273660/205927254-72e80190-20c4-448b-9729-21fa8de3ad59.png">

And this is how it looks if the user tries to switch to a network that they don't have in Metamask yet:

<img width="365" alt="image" src="https://user-images.githubusercontent.com/273660/206136422-95449fe7-854e-450d-b749-ddd599cb990b.png">

