### PR TITLE
Cs 4872 process reward root job

### DIFF
--- a/packages/hub/config/default.cjs
+++ b/packages/hub/config/default.cjs
@@ -14,6 +14,9 @@ module.exports = {
       roleChain: ['prod:storage-bucket-writer-role'],
       invalidationRoleChain: ['prod:cloudfront-distribution-invalidator-role'],
     },
+    rewards: {
+      bucketName: 'cardpay-staging-reward-programs',
+    },
     ses: {
       supportEmail: 'no-reply@stack.cards',
       region: 'us-east-1',

--- a/packages/hub/config/development.json
+++ b/packages/hub/config/development.json
@@ -3,6 +3,9 @@
     "offchainStorage": {
       "roleChain": ["hub-local-dev", "prod:storage-bucket-writer-role"],
       "invalidationRoleChain": ["hub-local-dev", "prod:cloudfront-distribution-invalidator-role"]
+    },
+    "rewards": {
+      "bucketName": "cardpay-staging-reward-programs"
     }
   },
   "cardDrop": {

--- a/packages/hub/config/production.json
+++ b/packages/hub/config/production.json
@@ -4,6 +4,9 @@
     "ses": {
       "supportEmail": "support@cardstack.com",
       "region": "eu-west-1"
+    },
+    "rewards": {
+      "bucketName": "cardpay-production-reward-programs"
     }
   },
   "sentry": {

--- a/packages/hub/tasks/index.ts
+++ b/packages/hub/tasks/index.ts
@@ -23,6 +23,7 @@ const ALL_KNOWN_TASKS: Record<keyof KnownTasks, true> = {
   'scheduled-payment-on-chain-cancelation-waiter': true,
   'scheduled-payment-on-chain-execution-waiter': true,
   'execute-scheduled-payments': true,
+  'process-reward-root': true,
   boom: true,
 };
 

--- a/packages/hub/tasks/process-reward-root.ts
+++ b/packages/hub/tasks/process-reward-root.ts
@@ -88,6 +88,7 @@ export default class ProcessRewardRoot {
       }
     } catch (e: any) {
       if (e.code == '23505') {
+        // do not scream errors when indexing
         log.info(`rewardProgramId: ${file.rewardProgramId}, paymentCycle: ${file.paymentCycle} is already indexed`);
         return;
       }

--- a/packages/hub/tasks/process-reward-root.ts
+++ b/packages/hub/tasks/process-reward-root.ts
@@ -105,7 +105,7 @@ declare module '@cardstack/hub/tasks' {
 }
 
 const FIELDS_EXCEPT_EXPLANATION_DATA =
-  'rewardProgramID,paymentCycle,validFrom,validTo,tokenType,payee,root,leaf,proof_bytes,explanationId';
+  'rewardProgramID,paymentCycle,validFrom,validTo,tokenType,payee,root,leaf,proof,explanationId';
 
 const queryParquet = async (
   s3Client: S3Client,

--- a/packages/hub/tasks/process-reward-root.ts
+++ b/packages/hub/tasks/process-reward-root.ts
@@ -150,6 +150,11 @@ const queryParquet = async (
   } catch (err: any) {
     if (err.name == 'UnsupportedParquetType') {
       return await queryParquet(s3Client, file, `SELECT ${FIELDS_EXCEPT_EXPLANATION_DATA} FROM s3object`);
+    } else if (err.name == 'NoSuchKey') {
+      log.info(
+        `Key rewardProgramID=${file.rewardProgramId}/paymentCycle=${file.paymentCycle}/results.parquet does not exist`
+      );
+      return [];
     } else {
       log.error('error fetching data: ', err);
       throw err;

--- a/packages/hub/tasks/process-reward-root.ts
+++ b/packages/hub/tasks/process-reward-root.ts
@@ -73,7 +73,7 @@ export default class ProcessRewardRoot {
       if (rows.length > 0) {
         const proofsQuery = `
       INSERT INTO reward_proofs(
-        reward_program_id, payee, leaf, payment_cycle, proof, token_type,  valid_from, valid_to, explanation_id, explanation_data
+        reward_program_id, payee, leaf, payment_cycle, proof_bytes, token_type,  valid_from, valid_to, explanation_id, explanation_data
       ) VALUES %s;
     `;
         const proofsSql = pgFormat(proofsQuery, rows.join());
@@ -105,7 +105,7 @@ declare module '@cardstack/hub/tasks' {
 }
 
 const FIELDS_EXCEPT_EXPLANATION_DATA =
-  'rewardProgramID,paymentCycle,validFrom,validTo,tokenType,payee,root,leaf,proof,explanationId';
+  'rewardProgramID,paymentCycle,validFrom,validTo,tokenType,payee,root,leaf,proof_bytes,explanationId';
 
 const queryParquet = async (
   s3Client: S3Client,

--- a/packages/hub/tasks/process-reward-root.ts
+++ b/packages/hub/tasks/process-reward-root.ts
@@ -1,0 +1,157 @@
+import {
+  S3Client,
+  SelectObjectContentCommand,
+  SelectObjectContentEventStream,
+  SelectObjectContentCommandInput,
+} from '@aws-sdk/client-s3';
+import { inject } from '@cardstack/di';
+import pgFormat from 'pg-format';
+import awsConfig from '../utils/aws-config';
+import Logger from '@cardstack/logger';
+interface S3FileInfo {
+  rewardProgramId: string;
+  paymentCycle: string;
+}
+
+//this is proof returned by parquet in json format
+interface Proof {
+  rewardProgramID: string;
+  payee: string;
+  leaf: string;
+  paymentCycle: number;
+  proof: string; // this will be converted to proof array
+  tokenType: string;
+  validFrom: number;
+  validTo: number;
+  explanationId: string[];
+  explanationData: string;
+}
+
+let log = Logger('task:process-reward-root');
+export default class ProcessRewardRoot {
+  private databaseManager = inject('database-manager', { as: 'databaseManager' });
+  async perform(file: S3FileInfo) {
+    const s3Config = await awsConfig({ roleChain: [] });
+    const s3Client = new S3Client(s3Config);
+    const db = await this.databaseManager.getClient();
+    const proofs = await queryParquet(s3Client, file);
+    if (proofs.length > 0) {
+      const rows = proofs.map((o) => {
+        return (
+          '(' +
+          pgFormat(
+            '%L, %L, %L, %L, ARRAY[%L], %L, %L, %L, %L, %L',
+            o.rewardProgramID,
+            o.payee,
+            o.leaf,
+            o.paymentCycle,
+            o.proof,
+            o.tokenType,
+            o.validFrom,
+            o.validTo,
+            o.explanationId,
+            o.explanationData
+          ) +
+          ')'
+        );
+      });
+      const proofsQuery = `
+      INSERT INTO reward_proofs(
+        reward_program_id, payee, leaf, payment_cycle, proof, token_type,  valid_from, valid_to, explanation_id, explanation_data
+      ) VALUES %s;
+    `;
+      const indexQuery = 'INSERT INTO reward_root_index( reward_program_id, payment_cycle ) VALUES (%L, %L);';
+      const proofsSql = pgFormat(proofsQuery, rows.join());
+      const indexSql = pgFormat(indexQuery, file.rewardProgramId, file.paymentCycle);
+      await this.databaseManager.performTransaction(db, async () => {
+        await db.query(indexSql);
+        const r = await db.query(proofsSql);
+        log.info(`Insert ${r.rowCount} notification_types rows`);
+      });
+    }
+  }
+}
+
+declare module '@cardstack/hub/tasks' {
+  interface KnownTasks {
+    'process-reward-root': ProcessRewardRoot;
+  }
+}
+
+const FIELDS_EXCEPT_EXPLANATION_DATA =
+  'rewardProgramID,paymentCycle,validFrom,validTo,tokenType,payee,root,leaf,proof,explanationId';
+
+const queryParquet = async (
+  s3Client: S3Client,
+  file: S3FileInfo,
+  expression?: SelectObjectContentCommandInput['Expression']
+): Promise<Proof[]> => {
+  let records: Proof[] = [];
+  const params: SelectObjectContentCommandInput = {
+    Bucket: 'cardpay-staging-reward-programs',
+    Key: `rewardProgramID=${file.rewardProgramId}/paymentCycle=${file.paymentCycle}/results.parquet`,
+    ExpressionType: 'SQL',
+    Expression: expression ?? 'SELECT * FROM S3Object',
+    InputSerialization: {
+      Parquet: {}, //no parameters needed here
+    },
+    OutputSerialization: {
+      JSON: {
+        RecordDelimiter: '\n', //each row can be separated by splitting \n
+      },
+    },
+  };
+  try {
+    const command = new SelectObjectContentCommand(params);
+    const s3Data = await s3Client.send(command);
+
+    if (!s3Data.Payload) {
+      throw new Error('payload undefined');
+    }
+    const events: AsyncIterable<SelectObjectContentEventStream> = s3Data.Payload;
+    for await (const event of events) {
+      if (event?.Records) {
+        if (event?.Records?.Payload) {
+          const record = Buffer.from(event.Records.Payload).toString('utf8');
+          const os = record.split('\n');
+          os.map((o) => {
+            if (o != '') {
+              const b: any = JSON.parse(o);
+              if (!('explanationData' in b)) {
+                b.explanationData = '{}';
+              }
+              // when proof array serialize to json, it becomes [{item:... }. {item: ...}]
+              // need to transform to array of hex strings
+              b.proof = b.proof.length > 0 ? b.proof.map((o: any) => '0x' + o.item) : ['0x'];
+              b.leaf = '0x' + b.leaf;
+              records.push(b);
+            }
+          });
+        } else {
+          log.info('skipped event, payload: ', event?.Records?.Payload);
+        }
+      } else if (event.Stats) {
+        log.info(`Processed ${event.Stats.Details?.BytesProcessed} bytes`);
+      } else if (event.End) {
+        log.info('SelectObjectContent completed');
+      }
+    }
+  } catch (err: any) {
+    if (err.name == 'UnsupportedParquetType') {
+      return await queryParquet(s3Client, file, `SELECT ${FIELDS_EXCEPT_EXPLANATION_DATA} FROM s3object`);
+    } else {
+      log.error('error fetching data: ', err);
+      throw err;
+    }
+  }
+  return records;
+};
+
+export const scanParquet = async (s3Client: S3Client, files: S3FileInfo[]) => {
+  const promises: Promise<Proof[]>[] = [];
+  files.forEach((file) => {
+    promises.push(queryParquet(s3Client, file));
+  });
+  const r = (await Promise.all(promises)).flat();
+  return r;
+};

--- a/packages/hub/tasks/process-reward-root.ts
+++ b/packages/hub/tasks/process-reward-root.ts
@@ -44,7 +44,7 @@ export default class ProcessRewardRoot {
     const proofs = await queryParquet(s3Client, file);
     const rows = proofs
       .filter(({ validTo }) => {
-        return currentBlockNumber > validTo;
+        return validTo > currentBlockNumber;
       }) //only index non expired proofs
       .map((o) => {
         return (

--- a/packages/hub/tasks/process-reward-root.ts
+++ b/packages/hub/tasks/process-reward-root.ts
@@ -19,7 +19,7 @@ interface Proof {
   payee: string;
   leaf: string;
   paymentCycle: number;
-  proof: string; // this will be converted to proof array
+  proofBytes: string[];
   tokenType: string;
   validFrom: number;
   validTo: number;
@@ -55,7 +55,7 @@ export default class ProcessRewardRoot {
             o.payee,
             o.leaf,
             o.paymentCycle,
-            o.proof,
+            o.proofBytes,
             o.tokenType,
             o.validFrom,
             o.validTo,
@@ -146,7 +146,9 @@ const queryParquet = async (
               }
               // when proof array serialize to json, it becomes [{item:... }. {item: ...}]
               // need to transform to array of hex strings
-              b.proof = b.proof.length > 0 ? b.proof.map((o: any) => '0x' + o.item) : ['0x'];
+              // - parquet file names column as proof
+              // - database and process names column as proofBytes
+              b.proofBytes = b.proof.length > 0 ? b.proof.map((o: any) => '0x' + o.item) : ['0x'];
               b.leaf = '0x' + b.leaf;
               records.push(b);
             }

--- a/packages/hub/utils/aws-config.ts
+++ b/packages/hub/utils/aws-config.ts
@@ -3,7 +3,7 @@ import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts';
 import Logger from '@cardstack/logger';
 let log = Logger('utils:aws-config');
 
-interface AwsConfigResult {
+export interface AwsConfigResult {
   credentials: any;
   region: string | undefined;
 }


### PR DESCRIPTION
This pr creates the job to process a reward root
- the purpose is to index a single parquet file (rewardProgramId=xxx/paymentCycle=xxx) in s3. This corresponds to a single merkle root but can have multiple rewardees in one process
- the file is queried using s3 select which reads parquet file and serializes to a json format (automatically)
- this job is triggered by a recurring task `check-reward-roots` which you can see here https://github.com/cardstack/cardstack/pull/3459 -- its good place to see how everything ties in together
- the access to s3 bucket `(cardpay-<env>-reward-programs)` should be open and no role assuming is needed
- it also updates `reward_root_index` in a single transaction so the hub knows where indexing has left off
