### PR TITLE
Fix naming of explanation data to from_block and to_block & fix values

### DIFF
--- a/packages/cardpay-reward-programs/cardpay_reward_programs/rules/staking.py
+++ b/packages/cardpay-reward-programs/cardpay_reward_programs/rules/staking.py
@@ -143,6 +143,6 @@ class Staking(Rule):
             "token": self.token,
             "rollover_amount": payment.get("rollover_amount"),
             "interest_rate": self.interest_rate_monthly,
-            "from_block": self.start_block,
-            "end_block": self.end_block,
+            "from_block": payment["paymentCycle"] - self.payment_cycle_length,
+            "to_block": payment["paymentCycle"],
         }

--- a/packages/cardpay-reward-programs/tests/rules/test_staking.py
+++ b/packages/cardpay-reward-programs/tests/rules/test_staking.py
@@ -157,6 +157,8 @@ def test_correct_calc_rewards(monkeypatch):
     assert pytest.approx(get_amount(result, "owner1")) == 82.26866088e9
     assert pytest.approx(get_amount(result, "owner2")) == 80.74258498e9
     assert pytest.approx(get_amount(result, "owner3")) == 60e9
+    assert result["explanationData"][0]["from_block"] == 0
+    assert result["explanationData"][0]["to_block"] == 30
 
 
 def test_correctly_manages_first_deposit_in_cycle(monkeypatch):


### PR DESCRIPTION
These were set as the start and end block for when the rule should be calculated. Instead the range should be from the start to the end of the payment cycle, and payment cycle refers to the last block. from/end seemed inconsistent so I've standardised on from/to.