### PR TITLE
Add minDate attribute in Boxel::Calendar and Boxel::Input::Date

### DIFF
--- a/packages/boxel/addon/components/boxel/calendar/index.gts
+++ b/packages/boxel/addon/components/boxel/calendar/index.gts
@@ -11,6 +11,7 @@ interface Signature {
     onSelect?: Function;
     center?: Day;
     onCenterChange?: Function;
+    minDate?: Day;
   };
 }
 
@@ -41,7 +42,7 @@ export default class BoxelCalendar extends Component<Signature> {
       as |calendar|
     >
       <calendar.Nav />
-      <calendar.Days @weekdayFormat="min" />
+      <calendar.Days @weekdayFormat="min" @minDate={{@minDate}}/>
     </PowerCalendar>
   </template>
 }

--- a/packages/boxel/addon/components/boxel/calendar/usage.gts
+++ b/packages/boxel/addon/components/boxel/calendar/usage.gts
@@ -16,7 +16,8 @@ export default class BoxelCalendarUsage extends Component {
   @action onCenterChange(val: Day) {
     this.center = val;
   }
-  
+  minDate: Day = new Date(2022,7,4);
+
   <template>
     <FreestyleUsage @name="Calendar">
       <:description>
@@ -28,6 +29,7 @@ export default class BoxelCalendarUsage extends Component {
           @onSelect={{this.onSelect}}
           @center={{this.center}}
           @onCenterChange={{this.onCenterChange}}
+          @minDate={{this.minDate}}
         />
       </:example>
       <:api as |Args|>
@@ -50,6 +52,11 @@ export default class BoxelCalendarUsage extends Component {
         <Args.Action
           @name="onCenterChange"
           @description="Called when a user changes the month shown"
+        />
+        <Args.Object
+          @name="minDate"
+          @description="Dates before this date will be disabled"
+          @value={{this.minDate}}
         />
       </:api>
     </FreestyleUsage>

--- a/packages/boxel/addon/components/boxel/input/date/index.gts
+++ b/packages/boxel/addon/components/boxel/input/date/index.gts
@@ -16,6 +16,7 @@ export { Day };
 interface ComponentArgs {
   value?: Day;
   onChange: (val: Day) => void;
+  minDate?: Day;
 }
 
 interface Signature {
@@ -63,6 +64,7 @@ export default class BoxelInputDate extends Component<Signature> {
             @onSelect={{@onChange}}
             @center={{this.center}}
             @onCenterChange={{fn (mut this.center)}}
+            @minDate={{@minDate}}
           />
         </div>
       </:content>

--- a/packages/boxel/addon/components/boxel/input/date/usage.gts
+++ b/packages/boxel/addon/components/boxel/input/date/usage.gts
@@ -12,6 +12,7 @@ export default class BoxelInputDateUsage extends Component {
   @action onChange(val: Day) {
     this.value = val;
   }
+  minDate = new Date(2022, 7, 4) as Day;
   
   <template>
     <FreestyleUsage @name="InputDate">
@@ -22,6 +23,7 @@ export default class BoxelInputDateUsage extends Component {
         <BoxelInputDate
           @value={{this.value}}
           @onChange={{this.onChange}}
+          @minDate={{this.minDate}}
         />
       </:example>
       <:api as |Args|>
@@ -30,6 +32,11 @@ export default class BoxelInputDateUsage extends Component {
           @description="An object conforming to the Day interface exported from the Boxel::Date component"
           @value={{this.value}}
           @onInput={{fn (mut this.value)}}
+        />
+        <Args.Object
+          @name="minDate"
+          @description="An object conforming to the Day interface exported from the Boxel::Date component"
+          @value={{this.minDate}}
         />
         <Args.Action
           @name="onChange"

--- a/packages/boxel/tests/integration/components/boxel/calendar-test.gts
+++ b/packages/boxel/tests/integration/components/boxel/calendar-test.gts
@@ -78,4 +78,20 @@ module('Integration | Component | Calendar', function (hooks) {
       year: 'numeric',
     }));
   });
+
+  test('the dates before minDate should be disabled', async function (assert) {
+    bindings.selected = new Date(2022, 2, 3, 13, 45);
+    let minDate = new Date(2022, 2, 3, 13, 45);
+
+    await render(<template>
+      <BoxelCalendar
+        @selected={{bindings.selected}}
+        @onSelect={{onSelect}}
+        @minDate={{minDate}}
+      />
+    </template>);
+
+    assert.dom('[data-date="2022-03-02"]').isDisabled();
+    assert.dom('[data-date="2022-03-01"]').isDisabled();
+  });
 });

--- a/packages/boxel/types/ember-power-calendar/components/power-calendar/index.d.ts
+++ b/packages/boxel/types/ember-power-calendar/components/power-calendar/index.d.ts
@@ -6,6 +6,7 @@ import { ComponentLike } from '@glint/template';
 interface DaysComponentSignature {
   Args: {
     weekdayFormat: string;
+    minDate: any;
   };
 }
 


### PR DESCRIPTION
Add `minDate` attribute so the dates before this date will be disabled. With this attribute, we can block the dates in the past.


https://user-images.githubusercontent.com/12637010/206197260-7a601d2d-ed37-42bc-9e20-b25a01b96c06.mov

