### PR TITLE
Fix deposit modal display of safe info

### DIFF
--- a/packages/safe-tools-client/app/templates/schedule.hbs
+++ b/packages/safe-tools-client/app/templates/schedule.hbs
@@ -58,7 +58,7 @@
 <DepositModal
   @isOpen={{this.isDepositModalOpen}}
   @onClose={{set this 'isDepositModalOpen' false}}
-  @safeAddress={{this.safes.curentSafe.address}}
-  @networkName={{this.network}}
+  @safeAddress={{this.safes.currentSafe.address}}
+  @networkName={{this.network.name}}
   @tokensToCover={{this.scheduledPaymentsTokensToCover}}
 />


### PR DESCRIPTION
- Glint should have caught this -- need to figure out why it isn't. Answer: it is because of our "include" glint config. Let's merge #3467 and then opt this template into glint checks