### PR TITLE
subgraph: Add polygon and mainnet subgraphs for tracking safes with scheduled payment module

### DIFF
--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -178,7 +178,7 @@ const constants: {
     chainId: 1,
     scheduledPaymentFeeFixedUSD: 0.25,
     scheduledPaymentFeePercentage: 0.1, //10%
-    subgraphURL: '',
+    subgraphURL: 'https://api.thegraph.com/subgraphs/name/cardstack/safe-tools-mainnet',
     uniswapPairInitCodeHash: '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f', // Result of keccak256(type(UniswapV2Pair).creationCode) from deployed UniswapV2Factory. We had to deploy our own Uniswap contracts on some networks (for now Mumbai) because they were missing, and add the patches/@uniswap+sdk+3.0.3.patch to support custom token pairs (by providing factory address and token pair code hash)
   },
   goerli: {
@@ -204,7 +204,7 @@ const constants: {
     name: 'Polygon',
     chainId: 137,
     relayServiceURL: '',
-    subgraphURL: '',
+    subgraphURL: 'https://api.thegraph.com/subgraphs/name/cardstack/safe-tools-polygon',
     scheduledPaymentFeeFixedUSD: 0.25,
     scheduledPaymentFeePercentage: 0.1, //10%
     uniswapPairInitCodeHash: '0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303', //Result of keccak256(type(UniswapV2Pair).creationCode) from deployed UniswapV2Factory

--- a/packages/safe-tools-subgraph/README.md
+++ b/packages/safe-tools-subgraph/README.md
@@ -13,3 +13,10 @@ Currently we are indexing safes that users provision using the safe tools interf
 
 1. `yarn build --network <NETWORK>`
 2. `yarn deploy:<NETWORK> --access-token <TOKEN>`
+
+### ⚠️ Deploying polygon network
+
+Since matic network renamed to polygon, there is an inconsistency with the naming. Please use the following commands to deploy the polygon subgraph:
+
+1. `yarn graph build --network matic`
+2. `yarn deploy:polygon --access-token <TOKEN>`.

--- a/packages/safe-tools-subgraph/networks.json
+++ b/packages/safe-tools-subgraph/networks.json
@@ -17,10 +17,10 @@
   },
   "matic": {
     "ScheduledPaymentModule": {
-      "startBlock": 36537441
+      "startBlock": 36621581
     },
     "GnosisSafe": {
-      "startBlock": 36537441
+      "startBlock": 36621581
     }
   },
   "mainnet": {

--- a/packages/safe-tools-subgraph/networks.json
+++ b/packages/safe-tools-subgraph/networks.json
@@ -14,5 +14,21 @@
     "GnosisSafe": {
       "startBlock": 29044929
     }
+  },
+  "matic": {
+    "ScheduledPaymentModule": {
+      "startBlock": 36537441
+    },
+    "GnosisSafe": {
+      "startBlock": 36537441
+    }
+  },
+  "mainnet": {
+    "ScheduledPaymentModule": {
+      "startBlock": 16119342
+    },
+    "GnosisSafe": {
+      "startBlock": 16119342
+    }
   }
 }

--- a/packages/safe-tools-subgraph/package.json
+++ b/packages/safe-tools-subgraph/package.json
@@ -6,6 +6,8 @@
     "build": "graph build",
     "deploy:goerli": "graph deploy --product hosted-service cardstack/safe-tools-goerli",
     "deploy:mumbai": "graph deploy --product hosted-service cardstack/safe-tools-mumbai",
+    "deploy:polygon": "graph deploy --product hosted-service cardstack/safe-tools-polygon",
+    "deploy:mainnet": "graph deploy --product hosted-service cardstack/safe-tools-mainnet",
     "create-local": "graph create --node http://localhost:8020/ cardstack/safe-tools",
     "remove-local": "graph remove --node http://localhost:8020/ cardstack/safe-tools",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 cardstack/safe-tools"


### PR DESCRIPTION
This PR adds 2 subgraphs that we can use to fetch safes in the payments tool. One for ethereum mainnet, and the other one for polygon (we already have subgraphs for their testnets):

1. https://api.thegraph.com/subgraphs/name/cardstack/safe-tools-mainnet
2. https://api.thegraph.com/subgraphs/name/cardstack/safe-tools-polygon

## TODO
 
Once the scheduled payment module is deployed to Polygon, change the `startBlock` number to be the actual block number of when the scheduled payment module was deployed, and redeploy the polygon subgraph. The current `startBlock`is currently set to one of the yesterday's blocks. 