### PR TITLE
Upgrade Prisma to get rid of a bug in db transaction error handling

### DIFF
--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -151,7 +151,7 @@
     "msw": "^0.40.0",
     "node-loader": "^2.0.0",
     "npm-run-all": "^4.1.5",
-    "prisma": "^4.1.0",
+    "prisma": "^4.7.1",
     "sentry-testkit": "^4.0.2",
     "supertest": "^6.1.3",
     "ts-loader": "^9.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6138,10 +6138,10 @@
   resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-4.1.0-48.8d8414deb360336e4698a65aa45a1fbaf1ce13d8.tgz#ce00e6377126e491a8b1e0e2039c97e2924bd6d9"
   integrity sha512-cRRJwpHFGFJZvtHbY3GZjMffNBEjjZk68ztn+S2hDgPCGB4H66IK26roK94GJxBodSehwRJ0wGyebC2GoIH1JQ==
 
-"@prisma/engines@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-4.1.0.tgz#da8002d4b75c92e3fd564ba5b0bd04847ffb3c4c"
-  integrity sha512-quqHXD3P83NBLVtRlts4SgKHmqgA8GMiyDTJ7af03Wg0gl6F5t65mBYvIuwmD+52vHm42JtIsp/fAO9YIV0JBA==
+"@prisma/engines@4.7.1":
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-4.7.1.tgz#d657d4d05724158140022fa00614e143643090c2"
+  integrity sha512-zWabHosTdLpXXlMefHmnouhXMoTB1+SCbUU3t4FCmdrtIOZcarPKU3Alto7gm/pZ9vHlGOXHCfVZ1G7OIrSbog==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -27424,12 +27424,12 @@ prism-media@^1.2.9:
   resolved "https://registry.yarnpkg.com/prism-media/-/prism-media-1.3.1.tgz#418acd2b122bedea2e834056d678f9a5ad2943ae"
   integrity sha512-nyYAa3KB4qteJIqdguKmwxTJgy55xxUtkJ3uRnOvO5jO+frci+9zpRXw6QZVcfDeva3S654fU9+26P2OSTzjHw==
 
-prisma@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-4.1.0.tgz#5d43597f0f2603a4a75d9586346c74110d8e221f"
-  integrity sha512-iwqpAT6In1uvMSwQAM3PqmaBdhh2OaQ/2t+n3RjpW4vAKP3R7E1T34FZUU4zGOWtMWm5dt0sPThQkT/h87r6gw==
+prisma@^4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-4.7.1.tgz#0a1beac26abdc4421e496b75eb50413f3ee3b0ba"
+  integrity sha512-CCQP+m+1qZOGIZlvnL6T3ZwaU0LAleIHYFPN9tFSzjs/KL6vH9rlYbGOkTuG9Q1s6Ki5D0LJlYlW18Z9EBUpGg==
   dependencies:
-    "@prisma/engines" "4.1.0"
+    "@prisma/engines" "4.7.1"
 
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"


### PR DESCRIPTION
Ticket: CS-4970

When a smart contract revert happens during executing a scheduled payment, for example `ExceedMaxGasPrice` revert error, it looks like the process fails later in Prisma with an odd error that looks like something is wrong with Prisma code (`Cannot create property 'clientVersion' on string 'ExceedMaxGasPrice 0x55e6314242b42a6e6ffa13d68656503af31e53575b837e4b57e8e2b4b397196f'`) 

Looks like the error was fixed here in a more recent version of Prisma: https://github.com/prisma/prisma/pull/15196. This upgrade fixes the issue. 

