### PR TITLE
Fix pdm install. New requirement parser giving trouble

### DIFF
--- a/.github/workflows/pr-cardpay-reward-api.yml
+++ b/.github/workflows/pr-cardpay-reward-api.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pdm
+          python -m pip install --upgrade pdm packaging==21.3
           pdm config python.use_venv false
           pdm install -d
       - name: Test with pytest

--- a/.github/workflows/pr-cardpay-reward-indexer.yml
+++ b/.github/workflows/pr-cardpay-reward-indexer.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pdm
+          python -m pip install --upgrade pdm packaging>=20,!=22.0
           pdm config python.use_venv false
           pdm install -d
       - name: Test with pytest

--- a/.github/workflows/pr-cardpay-reward-indexer.yml
+++ b/.github/workflows/pr-cardpay-reward-indexer.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pdm packaging>=20,!=22.0
+          python -m pip install --upgrade pdm packaging==21.3
           pdm config python.use_venv false
           pdm install -d
       - name: Test with pytest

--- a/.github/workflows/pr-cardpay-reward-programs.yml
+++ b/.github/workflows/pr-cardpay-reward-programs.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pdm
+          python -m pip install --upgrade pdm packaging==21.3
           pdm config python.use_venv false
           pdm install -d
       - name: Test with pytest

--- a/.github/workflows/pr-python-did-resolver.yml
+++ b/.github/workflows/pr-python-did-resolver.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pdm
+          python -m pip install --upgrade pdm packaging==21.3
           pdm config python.use_venv false
           pdm install -d
 

--- a/.github/workflows/pr-reward-root-submitter.yml
+++ b/.github/workflows/pr-reward-root-submitter.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pdm
+          python -m pip install --upgrade pdm packaging==21.3
           pdm config python.use_venv false
           pdm install -d
           pdm add setuptools

--- a/.github/workflows/pr-reward-scheduler.yml
+++ b/.github/workflows/pr-reward-scheduler.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pdm
+          python -m pip install --upgrade pdm packaging==21.3
           pdm config python.use_venv false
           pdm install -d
           pdm add setuptools

--- a/packages/cardpay-reward-api/Dockerfile
+++ b/packages/cardpay-reward-api/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.9
 
 RUN pip install -U pip setuptools wheel
-RUN pip install pdm
+RUN pip install pdm packaging==21.3
 RUN pdm config python.use_venv false
 
 COPY pyproject.toml pdm.lock /project/

--- a/packages/cardpay-reward-indexer/Dockerfile
+++ b/packages/cardpay-reward-indexer/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9
 
 RUN pip install -U pip setuptools wheel
-RUN pip install pdm
+RUN pip install pdm packaging==21.3
 RUN pdm config python.use_venv false
 
 COPY pyproject.toml pdm.lock /project/

--- a/packages/cardpay-reward-indexer/README.md
+++ b/packages/cardpay-reward-indexer/README.md
@@ -52,3 +52,4 @@ You can check if the dbs are synced with s3 by
 ## Deploy 
 
 This application is deployed via a manual dispatch of a github action 
+

--- a/packages/cardpay-reward-programs/Dockerfile
+++ b/packages/cardpay-reward-programs/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.9 AS builder
 
 # install PDM
 RUN pip install -U pip setuptools wheel
-RUN pip install pdm
+RUN pip install pdm packaging==21.3
 RUN pdm config python.use_venv false
 
 # copy files

--- a/packages/cardpay-reward-scheduler/Dockerfile
+++ b/packages/cardpay-reward-scheduler/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.9 AS builder
 
 # install PDM
 RUN pip install -U pip setuptools wheel
-RUN pip install pdm
+RUN pip install pdm packaging==21.3
 RUN pdm config python.use_venv false
 
 # copy files

--- a/packages/reward-root-submitter/Dockerfile
+++ b/packages/reward-root-submitter/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.9 AS builder
 
 # install PDM
 RUN pip install -U pip setuptools wheel
-RUN pip install pdm
+RUN pip install pdm packaging==21.3
 RUN pdm config python.use_venv false
 
 # copy files


### PR DESCRIPTION
Do not upgrade to `packaging=22.0` lib that uses new requirement parser

See here 
- https://github.com/pdm-project/pdm/issues/1558
- https://github.com/pdm-project/pdm/issues/1554 for workaround 

Also remember to downgrade on your local. If you use pipx you can use this https://github.com/pdm-project/pdm/issues/1558#issuecomment-1345444582