### PR TITLE
Add date and status filter

### DIFF
--- a/packages/boxel/addon/components/boxel/input/filter-select/index.css
+++ b/packages/boxel/addon/components/boxel/input/filter-select/index.css
@@ -1,0 +1,42 @@
+.boxel-input-filter-select {
+  --boxel-input-filter-select-border-color: var(--boxel-form-control-border-color);
+  --boxel-input-filter-select-border-radius: var(--boxel-border-radius-lg);
+
+  align-items: center;
+  border-radius: var(--boxel-input-filter-select-border-radius);
+  border: 1px solid var(--boxel-input-filter-select-border-color);
+  display: flex;
+  font-family: var(--boxel-font-family);
+  font-size: var(--boxel-font-size);
+  height: var(--boxel-form-control-height);
+  position: relative;
+  transition: border-color var(--boxel-transition);
+  width: 100%;
+  padding: var(--boxel-sp-xxs) var(--boxel-sp-sm);
+
+  cursor: pointer;
+}
+
+.boxel-input-filter-select--disabled {
+  opacity: 0.5;
+}
+
+.boxel-input-filter-select__dropdown {
+  flex-grow: 1;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.boxel-input-filter-select__dropdown .ember-power-select-status-icon {
+  background: url("/@cardstack/boxel/images/icons/caret-down.svg") no-repeat;
+  width: 11px;
+  height: 9px;
+  display: inline-block;
+  margin-right: var(--boxel-sp);
+}
+
+.boxel-input-filter-select__dropdown-item {
+  padding: var(--boxel-sp-xxs) var(--boxel-sp-sm);
+}

--- a/packages/boxel/addon/components/boxel/input/filter-select/index.gts
+++ b/packages/boxel/addon/components/boxel/input/filter-select/index.gts
@@ -1,0 +1,66 @@
+import Component from '@glimmer/component';
+import BoxelSelect from '../../select';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { guidFor } from '@ember/object/internals';
+import cn from '@cardstack/boxel/helpers/cn';
+import '@cardstack/boxel/styles/global.css';
+import './index.css';
+
+interface Signature {
+  Element: HTMLDivElement;
+  Args: {
+    disabled?: boolean;
+    errorMessage?: string;
+    invalid?: boolean;
+    label: string;
+    options: any[];
+    value?: any;
+    onChooseFilter: (selected: any) => void;
+    onBlur?: (ev: FocusEvent) => void;
+  };
+}
+
+export default class FilterSelect extends Component<Signature> {
+  helperId = guidFor(this);
+  @action onBlur(_select: any, ev: FocusEvent): void {
+    this.args.onBlur?.(ev);
+  }
+  @tracked selectedItem: any = this.args.value ?? this.args.options[0];
+  @action onSelectItem(_selected: any) {
+    this.selectedItem = _selected;
+    this.args.onChooseFilter(_selected);
+  }
+  <template>
+    <div class={{cn
+          "boxel-input-filter-select"
+          boxel-input-filter-select--disabled=@disabled
+        }}>
+      <div class="boxel-input-filter-select__label">
+        {{@label}} :
+      </div>
+      <BoxelSelect
+        @options={{@options}}
+        @selected={{this.selectedItem}}
+        @disabled={{@disabled}}
+        @onChange={{this.onSelectItem}}
+        @onBlur={{this.onBlur}}
+        @verticalPosition="below"
+        aria-invalid={{if @invalid "true"}}
+        class="boxel-input-filter-select__dropdown"
+        ...attributes
+        as |item|
+      >
+        <div class="boxel-input-filter-select__dropdown-item">
+          {{item}}
+        </div>
+      </BoxelSelect>
+    </div>
+  </template>
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Boxel::Input::FilterSelect': typeof FilterSelect;
+  }
+}

--- a/packages/boxel/addon/components/boxel/input/filter-select/usage.gts
+++ b/packages/boxel/addon/components/boxel/input/filter-select/usage.gts
@@ -1,0 +1,80 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import BoxelInputFilterSelect from './index';
+import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
+import { fn } from '@ember/helper';
+
+export default class BoxelInputFilterSelectUsage extends Component {
+  filterOptions: string[] = ["Last 30 Days", "Last 90 Days", "Last 120 Days"];
+
+  @tracked disabled = false;
+  @tracked label: string = "Date";
+  @tracked value: string | undefined;
+
+  cssClassName = 'boxel-input-filter-select';
+
+
+  @action onChooseFilter(selected: string) {
+    this.value = selected;
+  }
+
+  <template>
+    <FreestyleUsage @name="Input::FilterSelect">
+      <:example>
+        <BoxelInputFilterSelect
+          @disabled={{this.disabled}}
+          @value={{this.value}}
+          @label={{this.label}}
+          @options={{this.filterOptions}}
+          @onChooseFilter={{this.onChooseFilter}}
+        />
+      </:example>
+      <:api as |Args|>
+        <Args.Array
+          @name="options"
+          @description="An array of items, to be listed on dropdown"         
+          @required={{true}}
+          @items={{this.filterOptions}}
+          @onChange={{fn (mut this.filterOptions)}}
+        />
+        <Args.String
+          @name="label"
+          @description="Label of the filter"
+          @required={{true}}
+          @onInput={{fn (mut this.label)}}
+          @value={{this.label}}
+        />
+        <Args.Bool
+          @name="disabled"
+          @description="Whether the input is disabled"
+          @defaultValue={{false}}
+          @onInput={{fn (mut this.disabled)}}
+          @value={{this.disabled}}
+        />
+        <Args.Action
+          @name="onChooseFilter"
+          @description="Action called when an item is chosen from the dropdown"
+        />
+        <Args.Object
+          @name="value"
+          @description="The selected value"
+          @value={{this.value}}
+          @onInput={{fn (mut this.value)}}
+        />
+      </:api>
+    </FreestyleUsage>
+    <FreestyleUsage @name="Input::FilterSelect">
+      <:example>
+        <BoxelInputFilterSelect
+          @disabled={{this.disabled}}
+          @value={{this.value}}
+          @label={{this.label}}
+          @options={{this.filterOptions}}
+          @onChooseFilter={{this.onChooseFilter}}
+        />
+      </:example>
+    </FreestyleUsage>
+
+  </template>
+}

--- a/packages/safe-tools-client/app/components/payment-transactions-list/index.css
+++ b/packages/safe-tools-client/app/components/payment-transactions-list/index.css
@@ -29,3 +29,12 @@
 .transactions-table-item-payee {
   font-size: var(--boxel-font-size-sm);
 }
+
+.payment-transactions-list__filter_wrapper {
+  display: flex;
+}
+
+.payment-transactions-list__filter_wrapper > * {
+  flex: 0 1 300px;
+  margin-right: 1.5rem;
+}

--- a/packages/safe-tools-client/app/components/payment-transactions-list/index.gts
+++ b/packages/safe-tools-client/app/components/payment-transactions-list/index.gts
@@ -6,13 +6,17 @@ import { use, resource } from 'ember-resources';
 import WalletService from '@cardstack/safe-tools-client/services/wallet';
 import NetworkService from '@cardstack/safe-tools-client/services/network';
 import HubAuthenticationService from '@cardstack/safe-tools-client/services/hub-authentication';
-import ScheduledPaymentsService, { ScheduledPaymentAttempt, ScheduledPaymentResponse } from '@cardstack/safe-tools-client/services/scheduled-payments';
+import ScheduledPaymentsService, { ScheduledPaymentAttempt } from '@cardstack/safe-tools-client/services/scheduled-payments';
 import { inject as service } from '@ember/service';
 import { TrackedObject } from 'tracked-built-ins';
 import eq from 'ember-truth-helpers/helpers/eq';
 import formatDate from '@cardstack/safe-tools-client/helpers/format-date';
 import { taskFor } from 'ember-concurrency-ts';
 import { task, TaskGenerator } from 'ember-concurrency';
+import BoxelInputFilterSelect from '@cardstack/boxel/components/boxel/input/filter-select';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { array } from '@ember/helper';
 
 class PaymentTransactionsList extends Component {
   @service declare wallet: WalletService;
@@ -55,7 +59,31 @@ class PaymentTransactionsList extends Component {
     return state;
   });
 
+  @tracked dateFilter: string | undefined;
+  @action onSelectDateFilter(selectedDateFilter: string) {
+    this.dateFilter = selectedDateFilter;
+  }
+
+  @tracked statusFilter: string | undefined;
+  @action onSelectStatusFilter(selectedStatusFilter: string) {
+    this.statusFilter = selectedStatusFilter;
+  }
+
   <template>
+    <div class="payment-transactions-list__filter_wrapper">
+      <BoxelInputFilterSelect
+        @value={{this.dateFilter}}
+        @label="Date"
+        @options={{array "Last 30 Days" "Last 90 Days" "Last 120 Days"}}
+        @onChooseFilter={{this.onSelectDateFilter}}
+      />
+      <BoxelInputFilterSelect
+        @value={{this.statusFilter}}
+        @label="Status"
+        @options={{array "All" "Pending" "Failed" "Confirmed"}}
+        @onChooseFilter={{this.onSelectStatusFilter}}
+      />
+    </div>
     <table class="table" data-test-scheduled-payment-attempts>
       <thead class="table__header">
         <tr class="table__row">


### PR DESCRIPTION
The goal of this PR is to make the date and status filter like this:

![Screen Shot 2022-12-15 at 15 27 35](https://user-images.githubusercontent.com/12637010/207810049-fad62c26-bc13-421f-979c-b8a7711ea6aa.png)

So I added `Boxel::Input::FilterSelect` component and implemented it in the `payment-transactions-list`.


https://user-images.githubusercontent.com/12637010/207810597-a6bc7047-6e3c-40f6-bb2c-6d7b38f3eefe.mov


https://user-images.githubusercontent.com/12637010/207811032-e234e811-b151-47a2-b3f5-d582d147d299.mov

