### PR TITLE
hub: Change Docker setup for Prisma

### DIFF
--- a/packages/hub/Dockerfile
+++ b/packages/hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-slim
+FROM node:14-alpine3.16
 ARG hub_command
 ENV stored_hub_command=$hub_command
 WORKDIR /workspace

--- a/packages/hub/Dockerfile
+++ b/packages/hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:14-slim
 ARG hub_command
 ENV stored_hub_command=$hub_command
 WORKDIR /workspace

--- a/packages/hub/Dockerfile
+++ b/packages/hub/Dockerfile
@@ -1,7 +1,8 @@
-FROM node:14-alpine3.16
+FROM node:14-alpine
 ARG hub_command
 ENV stored_hub_command=$hub_command
 WORKDIR /workspace
+RUN apk add --no-cache libc6-compat openssl1.1-compat
 COPY dist packages/hub/dist
 COPY config packages/hub/config
 COPY dist/sql node_modules/graphile-worker/sql

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -55,7 +55,7 @@
     "@koa/router": "^10.0.0",
     "@mailchimp/mailchimp_marketing": "^3.0.75",
     "@pagerduty/pdjs": "^2.2.4",
-    "@prisma/client": "^4.1.0",
+    "@prisma/client": "^4.7.1",
     "@sentry/integrations": "^7.10.0",
     "@sentry/node": "^7.8.0",
     "assert-never": "^1.2.1",

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -1,7 +1,7 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["interactiveTransactions"]
-  binaryTargets   = ["native", "linux-musl"]
+  binaryTargets   = ["native", "debian-openssl-1.1.x", "linux-musl"]
 }
 
 datasource db {

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -1,7 +1,7 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["interactiveTransactions"]
-  binaryTargets   = ["native", "debian-openssl-1.1.x", "linux-musl"]
+  binaryTargets   = ["native", "linux-musl"]
 }
 
 datasource db {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5887,17 +5887,17 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.2.tgz#830beaec4b4091a9e9398ac50f865ddea52186b9"
   integrity sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==
 
-"@prisma/client@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-4.1.0.tgz#7c5341b2276c083821e432536ff97d8cc8f8b936"
-  integrity sha512-MvfPGAd42vHTiCYxwS6N+2U3F+ukoJ48D2QRnX1zSPJHBkh1CBtshl75daKzvVfgQwSouzSQeugKDej5di+E/g==
+"@prisma/client@^4.7.1":
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-4.7.1.tgz#66fe84aca25de17cb3d9141dec003f34714914b9"
+  integrity sha512-/GbnOwIPtjiveZNUzGXOdp7RxTEkHL4DZP3vBaFNadfr6Sf0RshU5EULFzVaSi9i9PIK9PYd+1Rn7z2B2npb9w==
   dependencies:
-    "@prisma/engines-version" "4.1.0-48.8d8414deb360336e4698a65aa45a1fbaf1ce13d8"
+    "@prisma/engines-version" "4.7.1-1.272861e07ab64f234d3ffc4094e32bd61775599c"
 
-"@prisma/engines-version@4.1.0-48.8d8414deb360336e4698a65aa45a1fbaf1ce13d8":
-  version "4.1.0-48.8d8414deb360336e4698a65aa45a1fbaf1ce13d8"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-4.1.0-48.8d8414deb360336e4698a65aa45a1fbaf1ce13d8.tgz#ce00e6377126e491a8b1e0e2039c97e2924bd6d9"
-  integrity sha512-cRRJwpHFGFJZvtHbY3GZjMffNBEjjZk68ztn+S2hDgPCGB4H66IK26roK94GJxBodSehwRJ0wGyebC2GoIH1JQ==
+"@prisma/engines-version@4.7.1-1.272861e07ab64f234d3ffc4094e32bd61775599c":
+  version "4.7.1-1.272861e07ab64f234d3ffc4094e32bd61775599c"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-4.7.1-1.272861e07ab64f234d3ffc4094e32bd61775599c.tgz#43ff7d85478e64a1d790e4d53e78768a2acfacfe"
+  integrity sha512-Bd4LZ+WAnUHOq31e9X/ihi5zPlr4SzTRwUZZYxvWOxlerIZ7HJlVa9zXpuKTKLpI9O1l8Ec4OYCKsivWCs5a3Q==
 
 "@prisma/engines@4.7.1":
   version "4.7.1"


### PR DESCRIPTION
Prisma queries were failing with errors like this:

```
Error: 
Invalid `prisma.$queryRaw()` invocation:


Unable to load Node-API Library from /workspace/node_modules/.prisma/client/libquery_engine-linux-musl.so.node, Library may be corrupt
```

The culprit was that the `node:14-alpine` Docker image that Hub runs on was [updated](https://github.com/yobasystems/alpine/blob/935827272dfe303a11b870e61a00b25f1a6d938e/CHANGELOG#L21) and OpenSSL 3.0 became the default. This adapts a fix mentioned [here](https://github.com/t3-oss/create-t3-app/issues/975#issuecomment-1351548930), but we wanted to be able to stay on `node:14-alpine` (latest) vs having to pin to an older version (3.16 was the working one).

This also updates `@prisma/client` to match the `prisma` version to bypass [this error](https://github.com/cardstack/cardstack/actions/runs/3704795929/jobs/6278311091#step:6:20).