### PR TITLE
[CS-5053] Add Gnosis and Sokol tokenlist files

### DIFF
--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -5,6 +5,8 @@ import JsonRpcProvider from '../providers/json-rpc-provider';
 import ethTokenList from '../token-lists/ethereum-tokenlist.json';
 import goerliTokenList from '../token-lists/goerli-tokenlist.json';
 import polygonTokenList from '../token-lists/polygon-tokenlist.json';
+import sokolTokenList from '../token-lists/sokol-tokenlist.json';
+import gnosisTokenList from '../token-lists/gnosis-tokenlist.json';
 import { type TokenList } from '@uniswap/token-lists';
 import { difference } from 'lodash';
 
@@ -54,6 +56,7 @@ interface SchedulerCapableNetworkConstants {
 }
 
 interface CardPayCapableNetworkConstants {
+  tokenList: TokenList;
   bridgedDaiTokenSymbol: string;
   bridgedCardTokenSymbol: string;
   bridgeExplorer: string;
@@ -128,6 +131,7 @@ const constants: {
     ...testHubUrl,
     ...ethNativeTokens,
     ...bridgedTokens,
+    tokenList: sokolTokenList,
     apiBaseUrl: 'https://blockscout.com/poa/sokol/api',
     blockExplorer: 'https://blockscout.com/poa/sokol',
     bridgeExplorer: 'https://alm-test-amb.herokuapp.com/77',
@@ -144,6 +148,7 @@ const constants: {
   gnosis: {
     ...hubUrl,
     ...bridgedTokens,
+    tokenList: gnosisTokenList,
     apiBaseUrl: 'https://blockscout.com/xdai/mainnet/api',
     blockExplorer: 'https://blockscout.com/xdai/mainnet',
     bridgeExplorer: 'https://alm-xdai.herokuapp.com/100',

--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -181,7 +181,7 @@ const constants: {
   mainnet: {
     ...hubUrl,
     ...ethNativeTokens,
-    tokenList: ethTokenList as unknown as TokenList, // TODO: check json to match type
+    tokenList: ethTokenList,
     apiBaseUrl: 'https://api.etherscan.io/api',
     blockExplorer: 'https://etherscan.io',
     bridgeExplorer: 'https://alm-xdai.herokuapp.com/1',

--- a/packages/cardpay-sdk/token-lists/ethereum-tokenlist.json
+++ b/packages/cardpay-sdk/token-lists/ethereum-tokenlist.json
@@ -6,7 +6,7 @@
     "patch": 0
   },
   "logoURI": "https://wallet-asset.matic.network/img/tokens/eth.svg",
-  "keywords": ["polygon", "mainnet", "default", "tokens"],
+  "keywords": ["ethereum", "mainnet", "default", "tokens"],
   "tags": {
     "stablecoin": {
       "name": "stablecoin",
@@ -21,20 +21,19 @@
       "description": "Tokens that can be used to reimburse gas to the Cardstack relay server on this chain"
     }
   },
+  "timestamp": "2022-12-27T18:44:00.000Z",
   "tokens": [
     {
       "chainId": 1,
-      "asset": "c60_t0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-      "tags": ["erc20", "relayGas"],
-      "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
       "name": "WETH",
+      "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
       "symbol": "WETH",
       "decimals": 18,
+      "tags": ["erc20", "relayGas"],
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x0000000000085d4780B73119b644AE5ecd22b376",
       "tags": ["erc20"],
       "address": "0x0000000000085d4780B73119b644AE5ecd22b376",
       "name": "TrueUSD",
@@ -43,7 +42,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x0000000000085d4780B73119b644AE5ecd22b376/logo.png"
     },
     {
-      "asset": "c60_t0x0000000000095413afC295d19EDeb1Ad7B71c952",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x0000000000095413afC295d19EDeb1Ad7B71c952",
       "name": "Tokenlon",
@@ -52,7 +51,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x0000000000095413afC295d19EDeb1Ad7B71c952/logo.png"
     },
     {
-      "asset": "c60_t0x00a8b738E453fFd858a7edf03bcCfe20412f0Eb0",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x00a8b738E453fFd858a7edf03bcCfe20412f0Eb0",
       "name": "AllianceBlock",
@@ -61,7 +60,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x00a8b738E453fFd858a7edf03bcCfe20412f0Eb0/logo.png"
     },
     {
-      "asset": "c60_t0x00c83aeCC790e8a4453e5dD3B0B4b3680501a7A7",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x00c83aeCC790e8a4453e5dD3B0B4b3680501a7A7",
       "name": "SKALE Network",
@@ -70,7 +69,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x00c83aeCC790e8a4453e5dD3B0B4b3680501a7A7/logo.png"
     },
     {
-      "asset": "c60_t0x0202Be363B8a4820f3F4DE7FaF5224fF05943AB1",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x0202Be363B8a4820f3F4DE7FaF5224fF05943AB1",
       "name": "UniLend",
@@ -79,7 +78,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x0202Be363B8a4820f3F4DE7FaF5224fF05943AB1/logo.png"
     },
     {
-      "asset": "c60_t0x0258F474786DdFd37ABCE6df6BBb1Dd5dfC4434a",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x0258F474786DdFd37ABCE6df6BBb1Dd5dfC4434a",
       "name": "Orion Protocol",
@@ -88,7 +87,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x0258F474786DdFd37ABCE6df6BBb1Dd5dfC4434a/logo.png"
     },
     {
-      "asset": "c60_t0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919",
       "name": "Rai Reflex Index",
@@ -97,7 +96,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919/logo.png"
     },
     {
-      "asset": "c60_t0x0488401c3F535193Fa8Df029d9fFe615A06E74E6",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x0488401c3F535193Fa8Df029d9fFe615A06E74E6",
       "name": "SparkPoint",
@@ -106,7 +105,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x0488401c3F535193Fa8Df029d9fFe615A06E74E6/logo.png"
     },
     {
-      "asset": "c60_t0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828",
       "name": "UMA",
@@ -115,7 +114,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png"
     },
     {
-      "asset": "c60_t0x06A01a4d579479Dd5D884EBf61A31727A3d8D442",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x06A01a4d579479Dd5D884EBf61A31727A3d8D442",
       "name": "SmartKey",
@@ -124,7 +123,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x06A01a4d579479Dd5D884EBf61A31727A3d8D442/logo.png"
     },
     {
-      "asset": "c60_t0x07150e919B4De5fD6a63DE1F9384828396f25fDC",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x07150e919B4De5fD6a63DE1F9384828396f25fDC",
       "name": "Base Protocol",
@@ -133,7 +132,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x07150e919B4De5fD6a63DE1F9384828396f25fDC/logo.png"
     },
     {
-      "asset": "c60_t0x09a3EcAFa817268f77BE1283176B946C4ff2E608",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x09a3EcAFa817268f77BE1283176B946C4ff2E608",
       "name": "Mirror Protocol",
@@ -142,7 +141,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x09a3EcAFa817268f77BE1283176B946C4ff2E608/logo.png"
     },
     {
-      "asset": "c60_t0x09e64c2B61a5f1690Ee6fbeD9baf5D6990F8dFd0",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x09e64c2B61a5f1690Ee6fbeD9baf5D6990F8dFd0",
       "name": "Growth DeFi",
@@ -151,7 +150,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x09e64c2B61a5f1690Ee6fbeD9baf5D6990F8dFd0/logo.png"
     },
     {
-      "asset": "c60_t0x0a50C93c762fDD6E56D86215C24AaAD43aB629aa",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x0a50C93c762fDD6E56D86215C24AaAD43aB629aa",
       "name": "LGO Token",
@@ -161,7 +160,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x0Ae055097C6d159879521C384F1D2123D1f195e6",
       "tags": ["erc20"],
       "address": "0x0Ae055097C6d159879521C384F1D2123D1f195e6",
       "name": "xDai",
@@ -171,7 +169,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
       "tags": ["erc20"],
       "address": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
       "name": "yearn.finance",
@@ -180,7 +177,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e/logo.png"
     },
     {
-      "asset": "c60_t0x0c7D5ae016f806603CB1782bEa29AC69471CAb9c",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x0c7D5ae016f806603CB1782bEa29AC69471CAb9c",
       "name": "Bifrost",
@@ -189,7 +186,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x0c7D5ae016f806603CB1782bEa29AC69471CAb9c/logo.png"
     },
     {
-      "asset": "c60_t0x0CDF9acd87E940837ff21BB40c9fd55F68bba059",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x0CDF9acd87E940837ff21BB40c9fd55F68bba059",
       "name": "Public Mint",
@@ -198,7 +195,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x0CDF9acd87E940837ff21BB40c9fd55F68bba059/logo.png"
     },
     {
-      "asset": "c60_t0x0cEC1A9154Ff802e7934Fc916Ed7Ca50bDE6844e",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x0cEC1A9154Ff802e7934Fc916Ed7Ca50bDE6844e",
       "name": "PoolTogether",
@@ -208,7 +205,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
       "tags": ["erc20"],
       "address": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
       "name": "Basic Attention Token",
@@ -217,7 +213,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x0D8775F648430679A709E98d2b0Cb6250d2887EF/logo.png"
     },
     {
-      "asset": "c60_t0x0f51bb10119727a7e5eA3538074fb341F56B09Ad",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x0f51bb10119727a7e5eA3538074fb341F56B09Ad",
       "name": "DAO Maker",
@@ -227,7 +223,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
       "tags": ["erc20"],
       "address": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
       "name": "Decentraland",
@@ -236,7 +231,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x0F5D2fB29fb7d3CFeE444a200298f468908cC942/logo.png"
     },
     {
-      "asset": "c60_t0x0f7F961648aE6Db43C75663aC7E5414Eb79b5704",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x0f7F961648aE6Db43C75663aC7E5414Eb79b5704",
       "name": "Blockzero Labs",
@@ -245,7 +240,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x0f7F961648aE6Db43C75663aC7E5414Eb79b5704/logo.png"
     },
     {
-      "asset": "c60_t0x0FD10b9899882a6f2fcb5c371E17e70FdEe00C38",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x0FD10b9899882a6f2fcb5c371E17e70FdEe00C38",
       "name": "Pundi X",
@@ -254,7 +249,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x0FD10b9899882a6f2fcb5c371E17e70FdEe00C38/logo.png"
     },
     {
-      "asset": "c60_t0x0fF6ffcFDa92c53F615a4A75D982f399C989366b",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x0fF6ffcFDa92c53F615a4A75D982f399C989366b",
       "name": "Unilayer",
@@ -263,7 +258,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x0fF6ffcFDa92c53F615a4A75D982f399C989366b/logo.png"
     },
     {
-      "asset": "c60_t0x10Be9a8dAe441d276a5027936c3aADEd2d82bC15",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x10Be9a8dAe441d276a5027936c3aADEd2d82bC15",
       "name": "UniMex Network",
@@ -273,7 +268,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x111111111117dC0aa78b770fA6A738034120C302",
       "tags": ["erc20"],
       "address": "0x111111111117dC0aa78b770fA6A738034120C302",
       "name": "1INCH Token",
@@ -282,7 +276,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x111111111117dC0aa78b770fA6A738034120C302/logo.png"
     },
     {
-      "asset": "c60_t0x1337DEF16F9B486fAEd0293eb623Dc8395dFE46a",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x1337DEF16F9B486fAEd0293eb623Dc8395dFE46a",
       "name": "ARMOR",
@@ -291,7 +285,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x1337DEF16F9B486fAEd0293eb623Dc8395dFE46a/logo.png"
     },
     {
-      "asset": "c60_t0x1337DEF18C680aF1f9f45cBcab6309562975b1dD",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x1337DEF18C680aF1f9f45cBcab6309562975b1dD",
       "name": "Armor NXM",
@@ -300,7 +294,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x1337DEF18C680aF1f9f45cBcab6309562975b1dD/logo.png"
     },
     {
-      "asset": "c60_t0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b",
       "name": "DeFi Pulse Index",
@@ -309,7 +303,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b/logo.png"
     },
     {
-      "asset": "c60_t0x152687Bc4A7FCC89049cF119F9ac3e5aCF2eE7ef",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x152687Bc4A7FCC89049cF119F9ac3e5aCF2eE7ef",
       "name": "DeltaHub Community",
@@ -318,7 +312,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x152687Bc4A7FCC89049cF119F9ac3e5aCF2eE7ef/logo.png"
     },
     {
-      "asset": "c60_t0x15874d65e649880c2614e7a480cb7c9A55787FF6",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x15874d65e649880c2614e7a480cb7c9A55787FF6",
       "name": "EthereumMax",
@@ -327,7 +321,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x15874d65e649880c2614e7a480cb7c9A55787FF6/logo.png"
     },
     {
-      "asset": "c60_t0x1614F18Fc94f47967A3Fbe5FfcD46d4e7Da3D787",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x1614F18Fc94f47967A3Fbe5FfcD46d4e7Da3D787",
       "name": "PAID Network",
@@ -336,7 +330,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x1614F18Fc94f47967A3Fbe5FfcD46d4e7Da3D787/logo.png"
     },
     {
-      "asset": "c60_t0x16980b3B4a3f9D89E33311B5aa8f80303E5ca4F8",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x16980b3B4a3f9D89E33311B5aa8f80303E5ca4F8",
       "name": "KIRA Network",
@@ -345,7 +339,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x16980b3B4a3f9D89E33311B5aa8f80303E5ca4F8/logo.png"
     },
     {
-      "asset": "c60_t0x1796ae0b0fa4862485106a0de9b654eFE301D0b2",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x1796ae0b0fa4862485106a0de9b654eFE301D0b2",
       "name": "Polychain Monsters",
@@ -354,7 +348,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x1796ae0b0fa4862485106a0de9b654eFE301D0b2/logo.png"
     },
     {
-      "asset": "c60_t0x17aC188e09A7890a1844E5E65471fE8b0CcFadF3",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x17aC188e09A7890a1844E5E65471fE8b0CcFadF3",
       "name": "Cryptocurrency Top 10 Tokens Index",
@@ -363,7 +357,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x17aC188e09A7890a1844E5E65471fE8b0CcFadF3/logo.png"
     },
     {
-      "asset": "c60_t0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998",
       "name": "Audius",
@@ -373,7 +367,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x1985365e9f78359a9B6AD760e32412f4a445E862",
       "tags": ["erc20"],
       "address": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
       "name": "Augur",
@@ -382,7 +375,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x1985365e9f78359a9B6AD760e32412f4a445E862/logo.png"
     },
     {
-      "asset": "c60_t0x1b40183EFB4Dd766f11bDa7A7c3AD8982e998421",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x1b40183EFB4Dd766f11bDa7A7c3AD8982e998421",
       "name": "Vesper",
@@ -391,7 +384,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x1b40183EFB4Dd766f11bDa7A7c3AD8982e998421/logo.png"
     },
     {
-      "asset": "c60_t0x1C9491865a1DE77C5b6e19d2E6a5F1D7a6F2b25F",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x1C9491865a1DE77C5b6e19d2E6a5F1D7a6F2b25F",
       "name": "Antimatter.Finance Governance Token",
@@ -400,7 +393,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x1C9491865a1DE77C5b6e19d2E6a5F1D7a6F2b25F/logo.png"
     },
     {
-      "asset": "c60_t0x1C9922314ED1415c95b9FD453c3818fd41867d0B",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x1C9922314ED1415c95b9FD453c3818fd41867d0B",
       "name": "TOWER",
@@ -409,7 +402,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x1C9922314ED1415c95b9FD453c3818fd41867d0B/logo.png"
     },
     {
-      "asset": "c60_t0x1cBb83EbcD552D5EBf8131eF8c9CD9d9BAB342bC",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x1cBb83EbcD552D5EBf8131eF8c9CD9d9BAB342bC",
       "name": "Non-Fungible Yearn",
@@ -419,7 +412,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44",
       "tags": ["erc20"],
       "address": "0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44",
       "name": "Keep3rV1",
@@ -428,7 +420,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44/logo.png"
     },
     {
-      "asset": "c60_t0x1dD80016e3d4ae146Ee2EBB484e8edD92dacC4ce",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x1dD80016e3d4ae146Ee2EBB484e8edD92dacC4ce",
       "name": "Lead Wallet",
@@ -438,7 +430,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
       "tags": ["erc20"],
       "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
       "name": "Uniswap",
@@ -447,7 +438,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/logo.png"
     },
     {
-      "asset": "c60_t0x1fE24F25b1Cf609B9c4e7E12D802e3640dFA5e43",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x1fE24F25b1Cf609B9c4e7E12D802e3640dFA5e43",
       "name": "ChainGuardians Governance Token",
@@ -456,7 +447,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x1fE24F25b1Cf609B9c4e7E12D802e3640dFA5e43/logo.png"
     },
     {
-      "asset": "c60_t0x21BfBDa47A0B4B5b1248c767Ee49F7caA9B23697",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x21BfBDa47A0B4B5b1248c767Ee49F7caA9B23697",
       "name": "OVR",
@@ -465,7 +456,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x21BfBDa47A0B4B5b1248c767Ee49F7caA9B23697/logo.png"
     },
     {
-      "asset": "c60_t0x221657776846890989a759BA2973e427DfF5C9bB",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x221657776846890989a759BA2973e427DfF5C9bB",
       "name": "Reputation",
@@ -475,7 +466,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
       "tags": ["erc20"],
       "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
       "name": "Wrapped Bitcoin",
@@ -484,7 +474,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
     },
     {
-      "asset": "c60_t0x226f7b842E0F0120b7E194D05432b3fd14773a9D",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x226f7b842E0F0120b7E194D05432b3fd14773a9D",
       "name": "UNION Protocol Governance Token",
@@ -493,7 +483,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x226f7b842E0F0120b7E194D05432b3fd14773a9D/logo.png"
     },
     {
-      "asset": "c60_t0x23B608675a2B2fB1890d3ABBd85c5775c51691d5",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x23B608675a2B2fB1890d3ABBd85c5775c51691d5",
       "name": "Unisocks Edition 0",
@@ -502,7 +492,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x23B608675a2B2fB1890d3ABBd85c5775c51691d5/logo.png"
     },
     {
-      "asset": "c60_t0x25e1474170c4c0aA64fa98123bdc8dB49D7802fa",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x25e1474170c4c0aA64fa98123bdc8dB49D7802fa",
       "name": "Bidao",
@@ -511,7 +501,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x25e1474170c4c0aA64fa98123bdc8dB49D7802fa/logo.png"
     },
     {
-      "asset": "c60_t0x26c8AFBBFE1EBaca03C2bB082E69D0476Bffe099",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x26c8AFBBFE1EBaca03C2bB082E69D0476Bffe099",
       "name": "Cellframe",
@@ -520,7 +510,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x26c8AFBBFE1EBaca03C2bB082E69D0476Bffe099/logo.png"
     },
     {
-      "asset": "c60_t0x26E43759551333e57F073bb0772F50329A957b30",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x26E43759551333e57F073bb0772F50329A957b30",
       "name": "DegenVC",
@@ -529,7 +519,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x26E43759551333e57F073bb0772F50329A957b30/logo.png"
     },
     {
-      "asset": "c60_t0x27C70Cd1946795B66be9d954418546998b546634",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x27C70Cd1946795B66be9d954418546998b546634",
       "name": "DOGE KILLER",
@@ -538,7 +528,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x27C70Cd1946795B66be9d954418546998b546634/logo.png"
     },
     {
-      "asset": "c60_t0x29502fE4d233EF0b45C3647101Fa1252cE0634BD",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x29502fE4d233EF0b45C3647101Fa1252cE0634BD",
       "name": "Froge Finance",
@@ -548,7 +538,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x2b591e99afE9f32eAA6214f7B7629768c40Eeb39",
       "tags": ["erc20"],
       "address": "0x2b591e99afE9f32eAA6214f7B7629768c40Eeb39",
       "name": "HEX",
@@ -558,7 +547,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x2ba592F78dB6436527729929AAf6c908497cB200",
       "tags": ["erc20"],
       "address": "0x2ba592F78dB6436527729929AAf6c908497cB200",
       "name": "Cream Finance",
@@ -567,7 +555,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2ba592F78dB6436527729929AAf6c908497cB200/logo.png"
     },
     {
-      "asset": "c60_t0x2e1E15C44Ffe4Df6a0cb7371CD00d5028e571d14",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x2e1E15C44Ffe4Df6a0cb7371CD00d5028e571d14",
       "name": "Mettalex",
@@ -576,7 +564,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2e1E15C44Ffe4Df6a0cb7371CD00d5028e571d14/logo.png"
     },
     {
-      "asset": "c60_t0x2e2f3246b6c65CCc4239c9Ee556EC143a7E5DE2c",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x2e2f3246b6c65CCc4239c9Ee556EC143a7E5DE2c",
       "name": "Yfi.mobi",
@@ -585,7 +573,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2e2f3246b6c65CCc4239c9Ee556EC143a7E5DE2c/logo.png"
     },
     {
-      "asset": "c60_t0x2eDf094dB69d6Dcd487f1B3dB9febE2eeC0dd4c5",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x2eDf094dB69d6Dcd487f1B3dB9febE2eeC0dd4c5",
       "name": "ZeroSwap",
@@ -594,7 +582,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2eDf094dB69d6Dcd487f1B3dB9febE2eeC0dd4c5/logo.png"
     },
     {
-      "asset": "c60_t0x30f271C9E86D2B7d00a6376Cd96A1cFBD5F0b9b3",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x30f271C9E86D2B7d00a6376Cd96A1cFBD5F0b9b3",
       "name": "Decentr",
@@ -603,7 +591,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x30f271C9E86D2B7d00a6376Cd96A1cFBD5F0b9b3/logo.png"
     },
     {
-      "asset": "c60_t0x3155BA85D5F96b2d030a4966AF206230e46849cb",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x3155BA85D5F96b2d030a4966AF206230e46849cb",
       "name": "THORChain ETH.RUNE",
@@ -612,7 +600,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x3155BA85D5F96b2d030a4966AF206230e46849cb/logo.png"
     },
     {
-      "asset": "c60_t0x3301Ee63Fb29F863f2333Bd4466acb46CD8323E6",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x3301Ee63Fb29F863f2333Bd4466acb46CD8323E6",
       "name": "Akita Inu",
@@ -621,7 +609,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x3301Ee63Fb29F863f2333Bd4466acb46CD8323E6/logo.png"
     },
     {
-      "asset": "c60_t0x3383c5a8969Dc413bfdDc9656Eb80A1408E4bA20",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x3383c5a8969Dc413bfdDc9656Eb80A1408E4bA20",
       "name": "Anatha",
@@ -630,7 +618,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x3383c5a8969Dc413bfdDc9656Eb80A1408E4bA20/logo.png"
     },
     {
-      "asset": "c60_t0x33D0568941C0C64ff7e0FB4fbA0B11BD37deEd9f",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x33D0568941C0C64ff7e0FB4fbA0B11BD37deEd9f",
       "name": "RAMP DEFI",
@@ -639,7 +627,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x33D0568941C0C64ff7e0FB4fbA0B11BD37deEd9f/logo.png"
     },
     {
-      "asset": "c60_t0x3593D125a4f7849a1B059E64F4517A86Dd60c95d",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x3593D125a4f7849a1B059E64F4517A86Dd60c95d",
       "name": "MANTRA DAO",
@@ -648,7 +636,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x3593D125a4f7849a1B059E64F4517A86Dd60c95d/logo.png"
     },
     {
-      "asset": "c60_t0x362bc847A3a9637d3af6624EeC853618a43ed7D2",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x362bc847A3a9637d3af6624EeC853618a43ed7D2",
       "name": "PARSIQ",
@@ -657,7 +645,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x362bc847A3a9637d3af6624EeC853618a43ed7D2/logo.png"
     },
     {
-      "asset": "c60_t0x3845badAde8e6dFF049820680d1F14bD3903a5d0",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x3845badAde8e6dFF049820680d1F14bD3903a5d0",
       "name": "The Sandbox",
@@ -666,7 +654,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x3845badAde8e6dFF049820680d1F14bD3903a5d0/logo.png"
     },
     {
-      "asset": "c60_t0x389999216860AB8E0175387A0c90E5c52522C945",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x389999216860AB8E0175387A0c90E5c52522C945",
       "name": "FEG Token",
@@ -675,7 +663,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x389999216860AB8E0175387A0c90E5c52522C945/logo.png"
     },
     {
-      "asset": "c60_t0x38e4adB44ef08F22F5B5b76A8f0c2d0dCbE7DcA1",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x38e4adB44ef08F22F5B5b76A8f0c2d0dCbE7DcA1",
       "name": "Concentrated Voting Power",
@@ -684,7 +672,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x38e4adB44ef08F22F5B5b76A8f0c2d0dCbE7DcA1/logo.png"
     },
     {
-      "asset": "c60_t0x3aFfCCa64c2A6f4e3B6Bd9c64CD2C969EFd1ECBe",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x3aFfCCa64c2A6f4e3B6Bd9c64CD2C969EFd1ECBe",
       "name": "DSLA",
@@ -693,7 +681,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x3aFfCCa64c2A6f4e3B6Bd9c64CD2C969EFd1ECBe/logo.png"
     },
     {
-      "asset": "c60_t0x3D3D35bb9bEC23b06Ca00fe472b50E7A4c692C30",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x3D3D35bb9bEC23b06Ca00fe472b50E7A4c692C30",
       "name": "Vidya",
@@ -703,7 +691,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x408e41876cCCDC0F92210600ef50372656052a38",
       "tags": ["erc20"],
       "address": "0x408e41876cCCDC0F92210600ef50372656052a38",
       "name": "Ren",
@@ -713,7 +700,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x40FD72257597aA14C7231A7B1aaa29Fce868F677",
       "tags": ["erc20"],
       "address": "0x40FD72257597aA14C7231A7B1aaa29Fce868F677",
       "name": "SORA",
@@ -722,7 +708,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x40FD72257597aA14C7231A7B1aaa29Fce868F677/logo.png"
     },
     {
-      "asset": "c60_t0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b",
       "name": "FunFair",
@@ -731,7 +717,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b/logo.png"
     },
     {
-      "asset": "c60_t0x41A3Dba3D677E573636BA691a70ff2D606c29666",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x41A3Dba3D677E573636BA691a70ff2D606c29666",
       "name": "GoBlank",
@@ -740,7 +726,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x41A3Dba3D677E573636BA691a70ff2D606c29666/logo.png"
     },
     {
-      "asset": "c60_t0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5",
       "name": "Pickle Finance",
@@ -749,7 +735,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5/logo.png"
     },
     {
-      "asset": "c60_t0x431ad2ff6a9C365805eBaD47Ee021148d6f7DBe0",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x431ad2ff6a9C365805eBaD47Ee021148d6f7DBe0",
       "name": "dForce",
@@ -758,7 +744,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x431ad2ff6a9C365805eBaD47Ee021148d6f7DBe0/logo.png"
     },
     {
-      "asset": "c60_t0xcf0C122c6b73ff809C693DB761e7BaeBe62b6a2E",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xcf0C122c6b73ff809C693DB761e7BaeBe62b6a2E",
       "name": "FLOKI",
@@ -767,7 +753,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xcf0C122c6b73ff809C693DB761e7BaeBe62b6a2E/logo.png"
     },
     {
-      "asset": "c60_t0x4575f41308EC1483f3d399aa9a2826d74Da13Deb",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x4575f41308EC1483f3d399aa9a2826d74Da13Deb",
       "name": "Orchid",
@@ -776,7 +762,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x4575f41308EC1483f3d399aa9a2826d74Da13Deb/logo.png"
     },
     {
-      "asset": "c60_t0x45804880De22913dAFE09f4980848ECE6EcbAf78",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x45804880De22913dAFE09f4980848ECE6EcbAf78",
       "name": "PAX Gold",
@@ -785,7 +771,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x45804880De22913dAFE09f4980848ECE6EcbAf78/logo.png"
     },
     {
-      "asset": "c60_t0x4691937a7508860F876c9c0a2a617E7d9E945D4B",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x4691937a7508860F876c9c0a2a617E7d9E945D4B",
       "name": "WOO Network",
@@ -794,7 +780,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x4691937a7508860F876c9c0a2a617E7d9E945D4B/logo.png"
     },
     {
-      "asset": "c60_t0x4a220E6096B25EADb88358cb44068A3248254675",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x4a220E6096B25EADb88358cb44068A3248254675",
       "name": "Quant",
@@ -803,7 +789,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x4a220E6096B25EADb88358cb44068A3248254675/logo.png"
     },
     {
-      "asset": "c60_t0x4B1E80cAC91e2216EEb63e29B957eB91Ae9C2Be8",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x4B1E80cAC91e2216EEb63e29B957eB91Ae9C2Be8",
       "name": "Jupiter",
@@ -812,7 +798,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x4B1E80cAC91e2216EEb63e29B957eB91Ae9C2Be8/logo.png"
     },
     {
-      "asset": "c60_t0x4c11249814f11b9346808179Cf06e71ac328c1b5",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x4c11249814f11b9346808179Cf06e71ac328c1b5",
       "name": "Oraichain Token",
@@ -821,7 +807,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x4c11249814f11b9346808179Cf06e71ac328c1b5/logo.png"
     },
     {
-      "asset": "c60_t0x4C19596f5aAfF459fA38B0f7eD92F11AE6543784",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x4C19596f5aAfF459fA38B0f7eD92F11AE6543784",
       "name": "TrueFi",
@@ -830,7 +816,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x4C19596f5aAfF459fA38B0f7eD92F11AE6543784/logo.png"
     },
     {
-      "asset": "c60_t0x4e352cF164E64ADCBad318C3a1e222E9EBa4Ce42",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x4e352cF164E64ADCBad318C3a1e222E9EBa4Ce42",
       "name": "MCDEX Token",
@@ -839,7 +825,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x4e352cF164E64ADCBad318C3a1e222E9EBa4Ce42/logo.png"
     },
     {
-      "asset": "c60_t0x4fE83213D56308330EC302a8BD641f1d0113A4Cc",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x4fE83213D56308330EC302a8BD641f1d0113A4Cc",
       "name": "NuCypher",
@@ -848,7 +834,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x4fE83213D56308330EC302a8BD641f1d0113A4Cc/logo.png"
     },
     {
-      "asset": "c60_t0x50DE6856358Cc35f3A9a57eAAA34BD4cB707d2cd",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x50DE6856358Cc35f3A9a57eAAA34BD4cB707d2cd",
       "name": "Razor Network",
@@ -858,7 +844,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x514910771AF9Ca656af840dff83E8264EcF986CA",
       "tags": ["erc20"],
       "address": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
       "name": "Chainlink",
@@ -867,7 +852,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
     },
     {
-      "asset": "c60_t0x5218E472cFCFE0b64A064F055B43b4cdC9EfD3A6",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x5218E472cFCFE0b64A064F055B43b4cdC9EfD3A6",
       "name": "unFederalReserve",
@@ -876,7 +861,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x5218E472cFCFE0b64A064F055B43b4cdC9EfD3A6/logo.png"
     },
     {
-      "asset": "c60_t0x5228a22e72ccC52d415EcFd199F99D0665E7733b",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x5228a22e72ccC52d415EcFd199F99D0665E7733b",
       "name": "pTokens BTC",
@@ -885,7 +870,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x5228a22e72ccC52d415EcFd199F99D0665E7733b/logo.png"
     },
     {
-      "asset": "c60_t0x54C9EA2E9C9E8eD865Db4A4ce6711C2a0d5063Ba",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x54C9EA2E9C9E8eD865Db4A4ce6711C2a0d5063Ba",
       "name": "BarterTrade",
@@ -894,7 +879,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x54C9EA2E9C9E8eD865Db4A4ce6711C2a0d5063Ba/logo.png"
     },
     {
-      "asset": "c60_t0x557B933a7C2c45672B610F8954A3deB39a51A8Ca",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x557B933a7C2c45672B610F8954A3deB39a51A8Ca",
       "name": "REVV",
@@ -904,7 +889,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x57Ab1ec28D129707052df4dF418D58a2D46d5f51",
       "tags": ["erc20"],
       "address": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51",
       "name": "sUSD",
@@ -914,7 +898,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x584bC13c7D411c00c01A62e8019472dE68768430",
       "tags": ["erc20"],
       "address": "0x584bC13c7D411c00c01A62e8019472dE68768430",
       "name": "Hegic",
@@ -923,7 +906,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x584bC13c7D411c00c01A62e8019472dE68768430/logo.png"
     },
     {
-      "asset": "c60_t0x5a666c7d92E5fA7Edcb6390E4efD6d0CDd69cF37",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x5a666c7d92E5fA7Edcb6390E4efD6d0CDd69cF37",
       "name": "UnMarshal",
@@ -932,7 +915,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x5a666c7d92E5fA7Edcb6390E4efD6d0CDd69cF37/logo.png"
     },
     {
-      "asset": "c60_t0x5BEfBB272290dD5b8521D4a938f6c4757742c430",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x5BEfBB272290dD5b8521D4a938f6c4757742c430",
       "name": "Xfinance",
@@ -941,7 +924,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x5BEfBB272290dD5b8521D4a938f6c4757742c430/logo.png"
     },
     {
-      "asset": "c60_t0x5cAf454Ba92e6F2c929DF14667Ee360eD9fD5b26",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x5cAf454Ba92e6F2c929DF14667Ee360eD9fD5b26",
       "name": "Dev",
@@ -950,7 +933,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x5cAf454Ba92e6F2c929DF14667Ee360eD9fD5b26/logo.png"
     },
     {
-      "asset": "c60_t0x5Dc02Ea99285E17656b8350722694c35154DB1E8",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x5Dc02Ea99285E17656b8350722694c35154DB1E8",
       "name": "BOND",
@@ -959,7 +942,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x5Dc02Ea99285E17656b8350722694c35154DB1E8/logo.png"
     },
     {
-      "asset": "c60_t0x5F64Ab1544D28732F0A24F4713c2C8ec0dA089f0",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x5F64Ab1544D28732F0A24F4713c2C8ec0dA089f0",
       "name": "DEXTF Token",
@@ -968,7 +951,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x5F64Ab1544D28732F0A24F4713c2C8ec0dA089f0/logo.png"
     },
     {
-      "asset": "c60_t0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
       "name": "Liquity USD",
@@ -978,7 +961,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x607F4C5BB672230e8672085532f7e901544a7375",
       "tags": ["erc20"],
       "address": "0x607F4C5BB672230e8672085532f7e901544a7375",
       "name": "iExec RLC",
@@ -987,7 +969,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x607F4C5BB672230e8672085532f7e901544a7375/logo.png"
     },
     {
-      "asset": "c60_t0x6149C26Cd2f7b5CCdb32029aF817123F6E37Df5B",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x6149C26Cd2f7b5CCdb32029aF817123F6E37Df5B",
       "name": "Launchpool",
@@ -996,7 +978,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6149C26Cd2f7b5CCdb32029aF817123F6E37Df5B/logo.png"
     },
     {
-      "asset": "c60_t0x62359Ed7505Efc61FF1D56fEF82158CcaffA23D7",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x62359Ed7505Efc61FF1D56fEF82158CcaffA23D7",
       "name": "cVault.finance",
@@ -1005,7 +987,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x62359Ed7505Efc61FF1D56fEF82158CcaffA23D7/logo.png"
     },
     {
-      "asset": "c60_t0x6243d8CEA23066d098a15582d81a598b4e8391F4",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x6243d8CEA23066d098a15582d81a598b4e8391F4",
       "name": "Reflexer Ungovernance Token",
@@ -1014,7 +996,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6243d8CEA23066d098a15582d81a598b4e8391F4/logo.png"
     },
     {
-      "asset": "c60_t0x626E8036dEB333b408Be468F951bdB42433cBF18",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x626E8036dEB333b408Be468F951bdB42433cBF18",
       "name": "AIOZ Network",
@@ -1023,7 +1005,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x626E8036dEB333b408Be468F951bdB42433cBF18/logo.png"
     },
     {
-      "asset": "c60_t0x63b4f3e3fa4e438698CE330e365E831F7cCD1eF4",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x63b4f3e3fa4e438698CE330e365E831F7cCD1eF4",
       "name": "CyberFi Token",
@@ -1032,7 +1014,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x63b4f3e3fa4e438698CE330e365E831F7cCD1eF4/logo.png"
     },
     {
-      "asset": "c60_t0x66a0f676479Cee1d7373f3DC2e2952778BfF5bd6",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x66a0f676479Cee1d7373f3DC2e2952778BfF5bd6",
       "name": "Wise Token",
@@ -1041,7 +1023,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x66a0f676479Cee1d7373f3DC2e2952778BfF5bd6/logo.png"
     },
     {
-      "asset": "c60_t0x67B6D479c7bB412C54e03dCA8E1Bc6740ce6b99C",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x67B6D479c7bB412C54e03dCA8E1Bc6740ce6b99C",
       "name": "Kylin",
@@ -1050,7 +1032,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x67B6D479c7bB412C54e03dCA8E1Bc6740ce6b99C/logo.png"
     },
     {
-      "asset": "c60_t0x67c597624B17b16fb77959217360B7cD18284253",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x67c597624B17b16fb77959217360B7cD18284253",
       "name": "Benchmark Protocol",
@@ -1059,7 +1041,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x67c597624B17b16fb77959217360B7cD18284253/logo.png"
     },
     {
-      "asset": "c60_t0x6810e776880C02933D47DB1b9fc05908e5386b96",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
       "name": "Gnosis",
@@ -1068,7 +1050,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png"
     },
     {
-      "asset": "c60_t0x69692D3345010a207b759a7D1af6fc7F38b35c5E",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x69692D3345010a207b759a7D1af6fc7F38b35c5E",
       "name": "chads.vc",
@@ -1077,7 +1059,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x69692D3345010a207b759a7D1af6fc7F38b35c5E/logo.png"
     },
     {
-      "asset": "c60_t0x69A95185ee2a045CDC4bCd1b1Df10710395e4e23",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x69A95185ee2a045CDC4bCd1b1Df10710395e4e23",
       "name": "Poolz Finance",
@@ -1086,7 +1068,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x69A95185ee2a045CDC4bCd1b1Df10710395e4e23/logo.png"
     },
     {
-      "asset": "c60_t0x69af81e73A73B40adF4f3d4223Cd9b1ECE623074",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x69af81e73A73B40adF4f3d4223Cd9b1ECE623074",
       "name": "Mask Network",
@@ -1096,7 +1078,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x6B175474E89094C44Da98b954EedeAC495271d0F",
       "tags": ["erc20", "stablecoin", "relayGas"],
       "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
       "name": "Dai",
@@ -1106,7 +1087,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
       "tags": ["erc20"],
       "address": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
       "name": "SushiSwap",
@@ -1116,7 +1096,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x6BFf2fE249601ed0Db3a87424a2E923118BB0312",
       "tags": ["erc20"],
       "address": "0x6BFf2fE249601ed0Db3a87424a2E923118BB0312",
       "name": "Fyooz",
@@ -1125,7 +1104,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6BFf2fE249601ed0Db3a87424a2E923118BB0312/logo.png"
     },
     {
-      "asset": "c60_t0x6c6EE5e31d828De241282B9606C8e98Ea48526E2",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x6c6EE5e31d828De241282B9606C8e98Ea48526E2",
       "name": "Holo",
@@ -1134,7 +1113,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6c6EE5e31d828De241282B9606C8e98Ea48526E2/logo.png"
     },
     {
-      "asset": "c60_t0x6e0daDE58D2d89eBBe7aFc384e3E4f15b70b14D8",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x6e0daDE58D2d89eBBe7aFc384e3E4f15b70b14D8",
       "name": "QuiverX",
@@ -1143,7 +1122,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6e0daDE58D2d89eBBe7aFc384e3E4f15b70b14D8/logo.png"
     },
     {
-      "asset": "c60_t0x6F87D756DAf0503d08Eb8993686c7Fc01Dc44fB1",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x6F87D756DAf0503d08Eb8993686c7Fc01Dc44fB1",
       "name": "UniTrade",
@@ -1152,7 +1131,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6F87D756DAf0503d08Eb8993686c7Fc01Dc44fB1/logo.png"
     },
     {
-      "asset": "c60_t0x6fC13EACE26590B80cCCAB1ba5d51890577D83B2",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x6fC13EACE26590B80cCCAB1ba5d51890577D83B2",
       "name": "Umbrella Network",
@@ -1161,7 +1140,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6fC13EACE26590B80cCCAB1ba5d51890577D83B2/logo.png"
     },
     {
-      "asset": "c60_t0x70401dFD142A16dC7031c56E862Fc88Cb9537Ce0",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x70401dFD142A16dC7031c56E862Fc88Cb9537Ce0",
       "name": "Bird.Money",
@@ -1170,7 +1149,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x70401dFD142A16dC7031c56E862Fc88Cb9537Ce0/logo.png"
     },
     {
-      "asset": "c60_t0x71F85B2E46976bD21302B64329868fd15eb0D127",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x71F85B2E46976bD21302B64329868fd15eb0D127",
       "name": "Axion",
@@ -1179,7 +1158,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x71F85B2E46976bD21302B64329868fd15eb0D127/logo.png"
     },
     {
-      "asset": "c60_t0x725C263e32c72dDC3A19bEa12C5a0479a81eE688",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x725C263e32c72dDC3A19bEa12C5a0479a81eE688",
       "name": "Bridge Mutual",
@@ -1188,7 +1167,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x725C263e32c72dDC3A19bEa12C5a0479a81eE688/logo.png"
     },
     {
-      "asset": "c60_t0x72630B1e3B42874bf335020Ba0249e3E9e47Bafc",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x72630B1e3B42874bf335020Ba0249e3E9e47Bafc",
       "name": "Paypolitan Token",
@@ -1197,7 +1176,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x72630B1e3B42874bf335020Ba0249e3E9e47Bafc/logo.png"
     },
     {
-      "asset": "c60_t0x72e364F2ABdC788b7E918bc238B21f109Cd634D7",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x72e364F2ABdC788b7E918bc238B21f109Cd634D7",
       "name": "Metaverse Index",
@@ -1206,7 +1185,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x72e364F2ABdC788b7E918bc238B21f109Cd634D7/logo.png"
     },
     {
-      "asset": "c60_t0x72e9D9038cE484EE986FEa183f8d8Df93f9aDA13",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x72e9D9038cE484EE986FEa183f8d8Df93f9aDA13",
       "name": "SmartCredit Token",
@@ -1215,7 +1194,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x72e9D9038cE484EE986FEa183f8d8Df93f9aDA13/logo.png"
     },
     {
-      "asset": "c60_t0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3",
       "name": "Dogelon",
@@ -1224,7 +1203,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3/logo.png"
     },
     {
-      "asset": "c60_t0x7659CE147D0e714454073a5dd7003544234b6Aa0",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x7659CE147D0e714454073a5dd7003544234b6Aa0",
       "name": "XCAD Network",
@@ -1233,7 +1212,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x7659CE147D0e714454073a5dd7003544234b6Aa0/logo.png"
     },
     {
-      "asset": "c60_t0x7671904eed7f10808B664fc30BB8693FD7237abF",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x7671904eed7f10808B664fc30BB8693FD7237abF",
       "name": "Boolberry",
@@ -1242,7 +1221,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x7671904eed7f10808B664fc30BB8693FD7237abF/logo.png"
     },
     {
-      "asset": "c60_t0x77777FeDdddFfC19Ff86DB637967013e6C6A116C",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x77777FeDdddFfC19Ff86DB637967013e6C6A116C",
       "name": "Tornado Cash",
@@ -1251,7 +1230,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x77777FeDdddFfC19Ff86DB637967013e6C6A116C/logo.png"
     },
     {
-      "asset": "c60_t0x7a2Bc711E19ba6aff6cE8246C546E8c4B4944DFD",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x7a2Bc711E19ba6aff6cE8246C546E8c4B4944DFD",
       "name": "WAXE",
@@ -1260,7 +1239,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x7a2Bc711E19ba6aff6cE8246C546E8c4B4944DFD/logo.png"
     },
     {
-      "asset": "c60_t0x7b123f53421b1bF8533339BFBdc7C98aA94163db",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x7b123f53421b1bF8533339BFBdc7C98aA94163db",
       "name": "DFOhub",
@@ -1269,7 +1248,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x7b123f53421b1bF8533339BFBdc7C98aA94163db/logo.png"
     },
     {
-      "asset": "c60_t0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
       "name": "Polygon",
@@ -1278,7 +1257,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0/logo.png"
     },
     {
-      "asset": "c60_t0x7dE91B204C1C737bcEe6F000AAA6569Cf7061cb7",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x7dE91B204C1C737bcEe6F000AAA6569Cf7061cb7",
       "name": "Robonomics",
@@ -1287,7 +1266,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x7dE91B204C1C737bcEe6F000AAA6569Cf7061cb7/logo.png"
     },
     {
-      "asset": "c60_t0x7F3EDcdD180Dbe4819Bd98FeE8929b5cEdB3AdEB",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x7F3EDcdD180Dbe4819Bd98FeE8929b5cEdB3AdEB",
       "name": "xToken",
@@ -1297,7 +1276,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
       "tags": ["erc20"],
       "address": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
       "name": "Aave",
@@ -1306,7 +1284,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9/logo.png"
     },
     {
-      "asset": "c60_t0x7FF4169a6B5122b664c51c95727d87750eC07c84",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x7FF4169a6B5122b664c51c95727d87750eC07c84",
       "name": "Tenset",
@@ -1315,7 +1293,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x7FF4169a6B5122b664c51c95727d87750eC07c84/logo.png"
     },
     {
-      "asset": "c60_t0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26",
       "name": "Origin Protocol",
@@ -1324,7 +1302,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26/logo.png"
     },
     {
-      "asset": "c60_t0x83e6f1E41cdd28eAcEB20Cb649155049Fac3D5Aa",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x83e6f1E41cdd28eAcEB20Cb649155049Fac3D5Aa",
       "name": "Polkastarter",
@@ -1334,7 +1312,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x8400D94A5cb0fa0D041a3788e395285d61c9ee5e",
       "tags": ["erc20"],
       "address": "0x8400D94A5cb0fa0D041a3788e395285d61c9ee5e",
       "name": "Unibright",
@@ -1344,7 +1321,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419",
       "tags": ["erc20"],
       "address": "0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419",
       "name": "DIA",
@@ -1353,7 +1329,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419/logo.png"
     },
     {
-      "asset": "c60_t0x853d955aCEf822Db058eb8505911ED77F175b99e",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x853d955aCEf822Db058eb8505911ED77F175b99e",
       "name": "Frax",
@@ -1362,7 +1338,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x853d955aCEf822Db058eb8505911ED77F175b99e/logo.png"
     },
     {
-      "asset": "c60_t0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC",
       "name": "KEEP Token",
@@ -1371,7 +1347,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC/logo.png"
     },
     {
-      "asset": "c60_t0x8888801aF4d980682e47f1A9036e589479e835C5",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x8888801aF4d980682e47f1A9036e589479e835C5",
       "name": "88mph.app",
@@ -1380,7 +1356,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x8888801aF4d980682e47f1A9036e589479e835C5/logo.png"
     },
     {
-      "asset": "c60_t0x88ACDd2a6425c3FaAE4Bc9650Fd7E27e0Bebb7aB",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x88ACDd2a6425c3FaAE4Bc9650Fd7E27e0Bebb7aB",
       "name": "Alchemist",
@@ -1389,7 +1365,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x88ACDd2a6425c3FaAE4Bc9650Fd7E27e0Bebb7aB/logo.png"
     },
     {
-      "asset": "c60_t0x88EF27e69108B2633F8E1C184CC37940A075cC02",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x88EF27e69108B2633F8E1C184CC37940A075cC02",
       "name": "Dego Finance",
@@ -1398,7 +1374,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x88EF27e69108B2633F8E1C184CC37940A075cC02/logo.png"
     },
     {
-      "asset": "c60_t0x89Ab32156e46F46D02ade3FEcbe5Fc4243B9AAeD",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x89Ab32156e46F46D02ade3FEcbe5Fc4243B9AAeD",
       "name": "pNetwork",
@@ -1407,7 +1383,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x89Ab32156e46F46D02ade3FEcbe5Fc4243B9AAeD/logo.png"
     },
     {
-      "asset": "c60_t0x8a40c222996f9F3431f63Bf80244C36822060f12",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x8a40c222996f9F3431f63Bf80244C36822060f12",
       "name": "Finxflo",
@@ -1416,7 +1392,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x8a40c222996f9F3431f63Bf80244C36822060f12/logo.png"
     },
     {
-      "asset": "c60_t0x8a854288a5976036A725879164Ca3e91d30c6A1B",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x8a854288a5976036A725879164Ca3e91d30c6A1B",
       "name": "GET",
@@ -1425,7 +1401,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x8a854288a5976036A725879164Ca3e91d30c6A1B/logo.png"
     },
     {
-      "asset": "c60_t0xCE3f08e664693ca792caCE4af1364D5e220827B2",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xCE3f08e664693ca792caCE4af1364D5e220827B2",
       "name": "SAITAMA",
@@ -1434,7 +1410,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xCE3f08e664693ca792caCE4af1364D5e220827B2/logo.png"
     },
     {
-      "asset": "c60_t0x8B39B70E39Aa811b69365398e0aACe9bee238AEb",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x8B39B70E39Aa811b69365398e0aACe9bee238AEb",
       "name": "PolkaFoundry",
@@ -1443,7 +1419,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x8B39B70E39Aa811b69365398e0aACe9bee238AEb/logo.png"
     },
     {
-      "asset": "c60_t0x8c15Ef5b4B21951d50E53E4fbdA8298FFAD25057",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x8c15Ef5b4B21951d50E53E4fbdA8298FFAD25057",
       "name": "Function X",
@@ -1453,7 +1429,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x8CE9137d39326AD0cD6491fb5CC0CbA0e089b6A9",
       "tags": ["erc20"],
       "address": "0x8CE9137d39326AD0cD6491fb5CC0CbA0e089b6A9",
       "name": "Swipe",
@@ -1462,7 +1437,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x8CE9137d39326AD0cD6491fb5CC0CbA0e089b6A9/logo.png"
     },
     {
-      "asset": "c60_t0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa",
       "name": "tBTC",
@@ -1471,7 +1446,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa/logo.png"
     },
     {
-      "asset": "c60_t0x5B7533812759B45C2B44C19e320ba2cD2681b542",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x5B7533812759B45C2B44C19e320ba2cD2681b542",
       "name": "SingularityNET Token",
@@ -1480,7 +1455,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x5B7533812759B45C2B44C19e320ba2cD2681b542/logo.png"
     },
     {
-      "asset": "c60_t0x8f8221aFbB33998d8584A2B05749bA73c37a938a",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x8f8221aFbB33998d8584A2B05749bA73c37a938a",
       "name": "Request Token",
@@ -1489,7 +1464,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x8f8221aFbB33998d8584A2B05749bA73c37a938a/logo.png"
     },
     {
-      "asset": "c60_t0x9355372396e3F6daF13359B7b607a3374cc638e0",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x9355372396e3F6daF13359B7b607a3374cc638e0",
       "name": "WHALE",
@@ -1498,7 +1473,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x9355372396e3F6daF13359B7b607a3374cc638e0/logo.png"
     },
     {
-      "asset": "c60_t0x93ED3FBe21207Ec2E8f2d3c3de6e058Cb73Bc04d",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x93ED3FBe21207Ec2E8f2d3c3de6e058Cb73Bc04d",
       "name": "Pinakion",
@@ -1507,7 +1482,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x93ED3FBe21207Ec2E8f2d3c3de6e058Cb73Bc04d/logo.png"
     },
     {
-      "asset": "c60_t0x9469D013805bFfB7D3DEBe5E7839237e535ec483",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x9469D013805bFfB7D3DEBe5E7839237e535ec483",
       "name": "Evolution Land Global Token",
@@ -1516,7 +1491,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x9469D013805bFfB7D3DEBe5E7839237e535ec483/logo.png"
     },
     {
-      "asset": "c60_t0x954b890704693af242613edEf1B603825afcD708",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x954b890704693af242613edEf1B603825afcD708",
       "name": "Cardstack",
@@ -1525,7 +1500,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x954b890704693af242613edEf1B603825afcD708/logo.png"
     },
     {
-      "asset": "c60_t0x956F47F50A910163D8BF957Cf5846D573E7f87CA",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x956F47F50A910163D8BF957Cf5846D573E7f87CA",
       "name": "Fei USD",
@@ -1534,7 +1509,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x956F47F50A910163D8BF957Cf5846D573E7f87CA/logo.png"
     },
     {
-      "asset": "c60_t0x95a4492F028aa1fd432Ea71146b433E7B4446611",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x95a4492F028aa1fd432Ea71146b433E7B4446611",
       "name": "APY.Finance",
@@ -1543,7 +1518,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x95a4492F028aa1fd432Ea71146b433E7B4446611/logo.png"
     },
     {
-      "asset": "c60_t0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE",
       "name": "SHIBA INU",
@@ -1552,7 +1527,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE/logo.png"
     },
     {
-      "asset": "c60_t0x961C8c0B1aaD0c0b10a51FeF6a867E3091BCef17",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x961C8c0B1aaD0c0b10a51FeF6a867E3091BCef17",
       "name": "DeFi Yield Protocol",
@@ -1562,7 +1537,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x967da4048cD07aB37855c090aAF366e4ce1b9F48",
       "tags": ["erc20"],
       "address": "0x967da4048cD07aB37855c090aAF366e4ce1b9F48",
       "name": "Ocean Protocol",
@@ -1571,7 +1545,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x967da4048cD07aB37855c090aAF366e4ce1b9F48/logo.png"
     },
     {
-      "asset": "c60_t0x990f341946A3fdB507aE7e52d17851B87168017c",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x990f341946A3fdB507aE7e52d17851B87168017c",
       "name": "Strong",
@@ -1580,7 +1554,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x990f341946A3fdB507aE7e52d17851B87168017c/logo.png"
     },
     {
-      "asset": "c60_t0x9B02dD390a603Add5c07f9fd9175b7DABE8D63B7",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x9B02dD390a603Add5c07f9fd9175b7DABE8D63B7",
       "name": "Shopping.io",
@@ -1589,7 +1563,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x9B02dD390a603Add5c07f9fd9175b7DABE8D63B7/logo.png"
     },
     {
-      "asset": "c60_t0x9BE89D2a4cd102D8Fecc6BF9dA793be995C22541",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x9BE89D2a4cd102D8Fecc6BF9dA793be995C22541",
       "name": "Binance Wrapped BTC",
@@ -1598,7 +1572,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x9BE89D2a4cd102D8Fecc6BF9dA793be995C22541/logo.png"
     },
     {
-      "asset": "c60_t0x9cEB84f92A0561fa3Cc4132aB9c0b76A59787544",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x9cEB84f92A0561fa3Cc4132aB9c0b76A59787544",
       "name": "Doki Doki Finance",
@@ -1607,7 +1581,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x9cEB84f92A0561fa3Cc4132aB9c0b76A59787544/logo.png"
     },
     {
-      "asset": "c60_t0x9EA3b5b4EC044b70375236A281986106457b20EF",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x9EA3b5b4EC044b70375236A281986106457b20EF",
       "name": "Delta Financial",
@@ -1616,7 +1590,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x9EA3b5b4EC044b70375236A281986106457b20EF/logo.png"
     },
     {
-      "asset": "c60_t0x9Ed8e7C9604790F7Ec589F99b94361d8AAB64E5E",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x9Ed8e7C9604790F7Ec589F99b94361d8AAB64E5E",
       "name": "Unistake",
@@ -1625,7 +1599,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x9Ed8e7C9604790F7Ec589F99b94361d8AAB64E5E/logo.png"
     },
     {
-      "asset": "c60_t0x9f7229aF0c4b9740e207Ea283b9094983f78ba04",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x9f7229aF0c4b9740e207Ea283b9094983f78ba04",
       "name": "Tadpole",
@@ -1635,7 +1609,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
       "tags": ["erc20"],
       "address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
       "name": "Maker",
@@ -1644,7 +1617,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png"
     },
     {
-      "asset": "c60_t0x9F9c8ec3534c3cE16F928381372BfbFBFb9F4D24",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x9F9c8ec3534c3cE16F928381372BfbFBFb9F4D24",
       "name": "GraphLinq",
@@ -1653,7 +1626,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x9F9c8ec3534c3cE16F928381372BfbFBFb9F4D24/logo.png"
     },
     {
-      "asset": "c60_t0xa0246c9032bC3A600820415aE600c6388619A14D",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xa0246c9032bC3A600820415aE600c6388619A14D",
       "name": "Harvest Finance",
@@ -1662,7 +1635,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xa0246c9032bC3A600820415aE600c6388619A14D/logo.png"
     },
     {
-      "asset": "c60_t0xa0afAA285Ce85974c3C881256cB7F225e3A1178a",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xa0afAA285Ce85974c3C881256cB7F225e3A1178a",
       "name": "Wrapped CrescoFin",
@@ -1672,7 +1645,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
       "tags": ["erc20", "stablecoin", "relayGas"],
       "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
       "name": "USD Coin",
@@ -1681,7 +1653,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
     },
     {
-      "asset": "c60_t0xa117000000f279D81A1D3cc75430fAA017FA5A2e",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xa117000000f279D81A1D3cc75430fAA017FA5A2e",
       "name": "Aragon",
@@ -1690,7 +1662,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xa117000000f279D81A1D3cc75430fAA017FA5A2e/logo.png"
     },
     {
-      "asset": "c60_t0xa1d6Df714F91DeBF4e0802A542E13067f31b8262",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xa1d6Df714F91DeBF4e0802A542E13067f31b8262",
       "name": "RFOX",
@@ -1699,7 +1671,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xa1d6Df714F91DeBF4e0802A542E13067f31b8262/logo.png"
     },
     {
-      "asset": "c60_t0xa393473d64d2F9F026B60b6Df7859A689715d092",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xa393473d64d2F9F026B60b6Df7859A689715d092",
       "name": "Lattice Token",
@@ -1708,7 +1680,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xa393473d64d2F9F026B60b6Df7859A689715d092/logo.png"
     },
     {
-      "asset": "c60_t0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2",
       "name": "Meta",
@@ -1717,7 +1689,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2/logo.png"
     },
     {
-      "asset": "c60_t0xA4EED63db85311E22dF4473f87CcfC3DaDCFA3E3",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xA4EED63db85311E22dF4473f87CcfC3DaDCFA3E3",
       "name": "Rubic",
@@ -1726,7 +1698,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA4EED63db85311E22dF4473f87CcfC3DaDCFA3E3/logo.png"
     },
     {
-      "asset": "c60_t0xA8b919680258d369114910511cc87595aec0be6D",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xA8b919680258d369114910511cc87595aec0be6D",
       "name": "LUKSO",
@@ -1735,7 +1707,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA8b919680258d369114910511cc87595aec0be6D/logo.png"
     },
     {
-      "asset": "c60_t0xa8c8CfB141A3bB59FEA1E2ea6B79b5ECBCD7b6ca",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xa8c8CfB141A3bB59FEA1E2ea6B79b5ECBCD7b6ca",
       "name": "Syntropy",
@@ -1744,7 +1716,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xa8c8CfB141A3bB59FEA1E2ea6B79b5ECBCD7b6ca/logo.png"
     },
     {
-      "asset": "c60_t0xA91ac63D040dEB1b7A5E4d4134aD23eb0ba07e14",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xA91ac63D040dEB1b7A5E4d4134aD23eb0ba07e14",
       "name": "Bella Protocol",
@@ -1753,7 +1725,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA91ac63D040dEB1b7A5E4d4134aD23eb0ba07e14/logo.png"
     },
     {
-      "asset": "c60_t0xAa6E8127831c9DE45ae56bB1b0d4D4Da6e5665BD",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xAa6E8127831c9DE45ae56bB1b0d4D4Da6e5665BD",
       "name": "ETH 2x Flexible Leverage Index",
@@ -1762,7 +1734,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xAa6E8127831c9DE45ae56bB1b0d4D4Da6e5665BD/logo.png"
     },
     {
-      "asset": "c60_t0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F",
       "name": "Trace Token",
@@ -1772,7 +1744,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0xaaAEBE6Fe48E54f431b0C390CfaF0b017d09D42d",
       "tags": ["erc20"],
       "address": "0xaaAEBE6Fe48E54f431b0C390CfaF0b017d09D42d",
       "name": "Celsius",
@@ -1781,7 +1752,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xaaAEBE6Fe48E54f431b0C390CfaF0b017d09D42d/logo.png"
     },
     {
-      "asset": "c60_t0xaAAf91D9b90dF800Df4F55c205fd6989c977E73a",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xaAAf91D9b90dF800Df4F55c205fd6989c977E73a",
       "name": "Monolith TKN",
@@ -1790,7 +1761,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xaAAf91D9b90dF800Df4F55c205fd6989c977E73a/logo.png"
     },
     {
-      "asset": "c60_t0xaC0104Cca91D167873B8601d2e71EB3D4D8c33e0",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xaC0104Cca91D167873B8601d2e71EB3D4D8c33e0",
       "name": "Crowns",
@@ -1799,7 +1770,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xaC0104Cca91D167873B8601d2e71EB3D4D8c33e0/logo.png"
     },
     {
-      "asset": "c60_t0xAd4f86a25bbc20FfB751f2FAC312A0B4d8F88c64",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xAd4f86a25bbc20FfB751f2FAC312A0B4d8F88c64",
       "name": "OptionRoom Token",
@@ -1808,7 +1779,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xAd4f86a25bbc20FfB751f2FAC312A0B4d8F88c64/logo.png"
     },
     {
-      "asset": "c60_t0xaDB2437e6F65682B85F814fBc12FeC0508A7B1D0",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xaDB2437e6F65682B85F814fBc12FeC0508A7B1D0",
       "name": "UniCrypt",
@@ -1817,7 +1788,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xaDB2437e6F65682B85F814fBc12FeC0508A7B1D0/logo.png"
     },
     {
-      "asset": "c60_t0xADE00C28244d5CE17D72E40330B1c318cD12B7c3",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xADE00C28244d5CE17D72E40330B1c318cD12B7c3",
       "name": "Ambire AdEx",
@@ -1826,7 +1797,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xADE00C28244d5CE17D72E40330B1c318cD12B7c3/logo.png"
     },
     {
-      "asset": "c60_t0xAE1eaAE3F627AAca434127644371b67B18444051",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xAE1eaAE3F627AAca434127644371b67B18444051",
       "name": "YOP",
@@ -1835,7 +1806,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xAE1eaAE3F627AAca434127644371b67B18444051/logo.png"
     },
     {
-      "asset": "c60_t0xaE697F994Fc5eBC000F8e22EbFfeE04612f98A0d",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xaE697F994Fc5eBC000F8e22EbFfeE04612f98A0d",
       "name": "LGCY Network",
@@ -1844,7 +1815,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xaE697F994Fc5eBC000F8e22EbFfeE04612f98A0d/logo.png"
     },
     {
-      "asset": "c60_t0xaf9f549774ecEDbD0966C52f250aCc548D3F36E5",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xaf9f549774ecEDbD0966C52f250aCc548D3F36E5",
       "name": "Rio Fuel Token",
@@ -1853,7 +1824,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xaf9f549774ecEDbD0966C52f250aCc548D3F36E5/logo.png"
     },
     {
-      "asset": "c60_t0xB1e9157c2Fdcc5a856C8DA8b2d89b6C32b3c1229",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xB1e9157c2Fdcc5a856C8DA8b2d89b6C32b3c1229",
       "name": "Zenfuse",
@@ -1862,7 +1833,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xB1e9157c2Fdcc5a856C8DA8b2d89b6C32b3c1229/logo.png"
     },
     {
-      "asset": "c60_t0xB26631c6dda06aD89B93C71400D25692de89c068",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xB26631c6dda06aD89B93C71400D25692de89c068",
       "name": "Minds",
@@ -1871,7 +1842,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xB26631c6dda06aD89B93C71400D25692de89c068/logo.png"
     },
     {
-      "asset": "c60_t0xB4d930279552397bbA2ee473229f89Ec245bc365",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xB4d930279552397bbA2ee473229f89Ec245bc365",
       "name": "MahaDAO",
@@ -1880,7 +1851,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xB4d930279552397bbA2ee473229f89Ec245bc365/logo.png"
     },
     {
-      "asset": "c60_t0xB62132e35a6c13ee1EE0f84dC5d40bad8d815206",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xB62132e35a6c13ee1EE0f84dC5d40bad8d815206",
       "name": "Nexo",
@@ -1889,7 +1860,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xB62132e35a6c13ee1EE0f84dC5d40bad8d815206/logo.png"
     },
     {
-      "asset": "c60_t0xB6ff96B8A8d214544Ca0dBc9B33f7AD6503eFD32",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xB6ff96B8A8d214544Ca0dBc9B33f7AD6503eFD32",
       "name": "SYNC",
@@ -1898,7 +1869,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xB6ff96B8A8d214544Ca0dBc9B33f7AD6503eFD32/logo.png"
     },
     {
-      "asset": "c60_t0xb753428af26E81097e7fD17f40c88aaA3E04902c",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xb753428af26E81097e7fD17f40c88aaA3E04902c",
       "name": "saffron.finance",
@@ -1907,7 +1878,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xb753428af26E81097e7fD17f40c88aaA3E04902c/logo.png"
     },
     {
-      "asset": "c60_t0xB987D48Ed8f2C468D52D6405624EADBa5e76d723",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xB987D48Ed8f2C468D52D6405624EADBa5e76d723",
       "name": "Stabilize Token",
@@ -1916,7 +1887,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xB987D48Ed8f2C468D52D6405624EADBa5e76d723/logo.png"
     },
     {
-      "asset": "c60_t0xB9d99C33eA2d86EC5eC6b8A4dD816EBBA64404AF",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xB9d99C33eA2d86EC5eC6b8A4dD816EBBA64404AF",
       "name": "K21",
@@ -1925,7 +1896,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xB9d99C33eA2d86EC5eC6b8A4dD816EBBA64404AF/logo.png"
     },
     {
-      "asset": "c60_t0xb9EF770B6A5e12E45983C5D80545258aA38F3B78",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xb9EF770B6A5e12E45983C5D80545258aA38F3B78",
       "name": "0chain",
@@ -1935,7 +1906,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0xba100000625a3754423978a60c9317c58a424e3D",
       "tags": ["erc20"],
       "address": "0xba100000625a3754423978a60c9317c58a424e3D",
       "name": "Balancer",
@@ -1945,7 +1915,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0xBA11D00c5f74255f56a5E366F4F77f5A186d7f55",
       "tags": ["erc20"],
       "address": "0xBA11D00c5f74255f56a5E366F4F77f5A186d7f55",
       "name": "Band Protocol",
@@ -1954,7 +1923,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xBA11D00c5f74255f56a5E366F4F77f5A186d7f55/logo.png"
     },
     {
-      "asset": "c60_t0xBa21Ef4c9f433Ede00badEFcC2754B8E74bd538A",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xBa21Ef4c9f433Ede00badEFcC2754B8E74bd538A",
       "name": "Swapfolio",
@@ -1963,7 +1932,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xBa21Ef4c9f433Ede00badEFcC2754B8E74bd538A/logo.png"
     },
     {
-      "asset": "c60_t0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
       "name": "Loopring",
@@ -1972,7 +1941,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png"
     },
     {
-      "asset": "c60_t0xBBc2AE13b23d715c30720F079fcd9B4a74093505",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xBBc2AE13b23d715c30720F079fcd9B4a74093505",
       "name": "Ethernity Chain",
@@ -1981,7 +1950,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xBBc2AE13b23d715c30720F079fcd9B4a74093505/logo.png"
     },
     {
-      "asset": "c60_t0xbC396689893D065F41bc2C6EcbeE5e0085233447",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xbC396689893D065F41bc2C6EcbeE5e0085233447",
       "name": "Perpetual",
@@ -1990,7 +1959,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xbC396689893D065F41bc2C6EcbeE5e0085233447/logo.png"
     },
     {
-      "asset": "c60_t0xbE9375C6a420D2eEB258962efB95551A5b722803",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xbE9375C6a420D2eEB258962efB95551A5b722803",
       "name": "StormX",
@@ -1999,7 +1968,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xbE9375C6a420D2eEB258962efB95551A5b722803/logo.png"
     },
     {
-      "asset": "c60_t0xbEa98c05eEAe2f3bC8c3565Db7551Eb738c8CCAb",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xbEa98c05eEAe2f3bC8c3565Db7551Eb738c8CCAb",
       "name": "GYSR",
@@ -2008,7 +1977,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xbEa98c05eEAe2f3bC8c3565Db7551Eb738c8CCAb/logo.png"
     },
     {
-      "asset": "c60_t0xBF494F02EE3FdE1F20BEE6242bCe2d1ED0c15e47",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xBF494F02EE3FdE1F20BEE6242bCe2d1ED0c15e47",
       "name": "World Token",
@@ -2018,7 +1987,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0xc00e94Cb662C3520282E6f5717214004A7f26888",
       "tags": ["erc20"],
       "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
       "name": "Compound",
@@ -2028,7 +1996,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
       "tags": ["erc20"],
       "address": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
       "name": "Synthetix",
@@ -2037,7 +2004,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png"
     },
     {
-      "asset": "c60_t0xC0bA369c8Db6eB3924965e5c4FD0b4C1B91e305F",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xC0bA369c8Db6eB3924965e5c4FD0b4C1B91e305F",
       "name": "DLP Duck Token",
@@ -2046,7 +2013,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xC0bA369c8Db6eB3924965e5c4FD0b4C1B91e305F/logo.png"
     },
     {
-      "asset": "c60_t0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
       "name": "Ethereum Name Service",
@@ -2055,7 +2022,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72/logo.png"
     },
     {
-      "asset": "c60_t0xC4C2614E694cF534D407Ee49F8E44D125E4681c4",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xC4C2614E694cF534D407Ee49F8E44D125E4681c4",
       "name": "Chain Games",
@@ -2064,7 +2031,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xC4C2614E694cF534D407Ee49F8E44D125E4681c4/logo.png"
     },
     {
-      "asset": "c60_t0xC52C326331E9Ce41F04484d3B5E5648158028804",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xC52C326331E9Ce41F04484d3B5E5648158028804",
       "name": "ZEN Exchange Token",
@@ -2073,7 +2040,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xC52C326331E9Ce41F04484d3B5E5648158028804/logo.png"
     },
     {
-      "asset": "c60_t0xC57d533c50bC22247d49a368880fb49a1caA39F7",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xC57d533c50bC22247d49a368880fb49a1caA39F7",
       "name": "PowerTrade Fuel",
@@ -2082,7 +2049,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xC57d533c50bC22247d49a368880fb49a1caA39F7/logo.png"
     },
     {
-      "asset": "c60_t0xc719d010B63E5bbF2C0551872CD5316ED26AcD83",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xc719d010B63E5bbF2C0551872CD5316ED26AcD83",
       "name": "Decentralized Insurance Protocol",
@@ -2091,7 +2058,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xc719d010B63E5bbF2C0551872CD5316ED26AcD83/logo.png"
     },
     {
-      "asset": "c60_t0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B",
       "name": "Tribe",
@@ -2100,7 +2067,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B/logo.png"
     },
     {
-      "asset": "c60_t0xc834Fa996fA3BeC7aAD3693af486ae53D8aA8B50",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xc834Fa996fA3BeC7aAD3693af486ae53D8aA8B50",
       "name": "Convergence",
@@ -2109,7 +2076,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xc834Fa996fA3BeC7aAD3693af486ae53D8aA8B50/logo.png"
     },
     {
-      "asset": "c60_t0xc944E90C64B2c07662A292be6244BDf05Cda44a7",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xc944E90C64B2c07662A292be6244BDf05Cda44a7",
       "name": "The Graph",
@@ -2118,7 +2085,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xc944E90C64B2c07662A292be6244BDf05Cda44a7/logo.png"
     },
     {
-      "asset": "c60_t0xCb5f72d37685C3D5aD0bB5F982443BC8FcdF570E",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xCb5f72d37685C3D5aD0bB5F982443BC8FcdF570E",
       "name": "Rootkit Finance",
@@ -2127,7 +2094,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xCb5f72d37685C3D5aD0bB5F982443BC8FcdF570E/logo.png"
     },
     {
-      "asset": "c60_t0xCbfef8fdd706cde6F208460f2Bf39Aa9c785F05D",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xCbfef8fdd706cde6F208460f2Bf39Aa9c785F05D",
       "name": "Kine Governance Token",
@@ -2136,7 +2103,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xCbfef8fdd706cde6F208460f2Bf39Aa9c785F05D/logo.png"
     },
     {
-      "asset": "c60_t0xCC4304A31d09258b0029eA7FE63d032f52e44EFe",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xCC4304A31d09258b0029eA7FE63d032f52e44EFe",
       "name": "TrustSwap Token",
@@ -2145,7 +2112,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xCC4304A31d09258b0029eA7FE63d032f52e44EFe/logo.png"
     },
     {
-      "asset": "c60_t0xCF3C8Be2e2C42331Da80EF210e9B1b307C03d36A",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xCF3C8Be2e2C42331Da80EF210e9B1b307C03d36A",
       "name": "BEPRO Network",
@@ -2154,7 +2121,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xCF3C8Be2e2C42331Da80EF210e9B1b307C03d36A/logo.png"
     },
     {
-      "asset": "c60_t0xd084B83C305daFD76AE3E1b4E1F1fe2eCcCb3988",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xd084B83C305daFD76AE3E1b4E1F1fe2eCcCb3988",
       "name": "Terra Virtua Kolect",
@@ -2163,7 +2130,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xd084B83C305daFD76AE3E1b4E1F1fe2eCcCb3988/logo.png"
     },
     {
-      "asset": "c60_t0xD23Ac27148aF6A2f339BD82D0e3CFF380b5093de",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xD23Ac27148aF6A2f339BD82D0e3CFF380b5093de",
       "name": "SIREN",
@@ -2172,7 +2139,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xD23Ac27148aF6A2f339BD82D0e3CFF380b5093de/logo.png"
     },
     {
-      "asset": "c60_t0xd2877702675e6cEb975b4A1dFf9fb7BAF4C91ea9",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xd2877702675e6cEb975b4A1dFf9fb7BAF4C91ea9",
       "name": "Terra",
@@ -2181,7 +2148,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xd2877702675e6cEb975b4A1dFf9fb7BAF4C91ea9/logo.png"
     },
     {
-      "asset": "c60_t0xd379700999F4805Ce80aa32DB46A94dF64561108",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xd379700999F4805Ce80aa32DB46A94dF64561108",
       "name": "Dextrust",
@@ -2190,7 +2157,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xd379700999F4805Ce80aa32DB46A94dF64561108/logo.png"
     },
     {
-      "asset": "c60_t0xD478161C952357F05f0292B56012Cd8457F1cfbF",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xD478161C952357F05f0292B56012Cd8457F1cfbF",
       "name": "Polkamarkets",
@@ -2199,7 +2166,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xD478161C952357F05f0292B56012Cd8457F1cfbF/logo.png"
     },
     {
-      "asset": "c60_t0xD533a949740bb3306d119CC777fa900bA034cd52",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
       "name": "Curve DAO Token",
@@ -2208,7 +2175,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png"
     },
     {
-      "asset": "c60_t0xD5525D397898e5502075Ea5E830d8914f6F0affe",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xD5525D397898e5502075Ea5E830d8914f6F0affe",
       "name": "MEME",
@@ -2217,7 +2184,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xD5525D397898e5502075Ea5E830d8914f6F0affe/logo.png"
     },
     {
-      "asset": "c60_t0xD6c67B93a7b248dF608a653d82a100556144c5DA",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xD6c67B93a7b248dF608a653d82a100556144c5DA",
       "name": "ExNetwork Token",
@@ -2227,7 +2194,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0xdAC17F958D2ee523a2206206994597C13D831ec7",
       "tags": ["erc20", "stablecoin", "relayGas"],
       "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
       "name": "Tether",
@@ -2236,7 +2202,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
     },
     {
-      "asset": "c60_t0xdacD69347dE42baBfAEcD09dC88958378780FB62",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xdacD69347dE42baBfAEcD09dC88958378780FB62",
       "name": "Atari Token",
@@ -2245,7 +2211,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xdacD69347dE42baBfAEcD09dC88958378780FB62/logo.png"
     },
     {
-      "asset": "c60_t0xDcB01cc464238396E213a6fDd933E36796eAfF9f",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xDcB01cc464238396E213a6fDd933E36796eAfF9f",
       "name": "Yield",
@@ -2254,7 +2220,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xDcB01cc464238396E213a6fDd933E36796eAfF9f/logo.png"
     },
     {
-      "asset": "c60_t0xDDB3422497E61e13543BeA06989C0789117555c5",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xDDB3422497E61e13543BeA06989C0789117555c5",
       "name": "COTI",
@@ -2263,7 +2229,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xDDB3422497E61e13543BeA06989C0789117555c5/logo.png"
     },
     {
-      "asset": "c60_t0xE1c7E30C42C24582888C758984f6e382096786bd",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xE1c7E30C42C24582888C758984f6e382096786bd",
       "name": "Curate",
@@ -2272,7 +2238,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xE1c7E30C42C24582888C758984f6e382096786bd/logo.png"
     },
     {
-      "asset": "c60_t0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30",
       "name": "Injective",
@@ -2281,7 +2247,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30/logo.png"
     },
     {
-      "asset": "c60_t0xe3818504c1B32bF1557b16C238B2E01Fd3149C17",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xe3818504c1B32bF1557b16C238B2E01Fd3149C17",
       "name": "PILLAR",
@@ -2291,7 +2257,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0xE41d2489571d322189246DaFA5ebDe1F4699F498",
       "tags": ["erc20"],
       "address": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
       "name": "0x",
@@ -2300,7 +2265,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png"
     },
     {
-      "asset": "c60_t0xE452E6Ea2dDeB012e20dB73bf5d3863A3Ac8d77a",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xE452E6Ea2dDeB012e20dB73bf5d3863A3Ac8d77a",
       "name": "WCELO",
@@ -2309,7 +2274,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xE452E6Ea2dDeB012e20dB73bf5d3863A3Ac8d77a/logo.png"
     },
     {
-      "asset": "c60_t0xe53EC727dbDEB9E2d5456c3be40cFF031AB40A55",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xe53EC727dbDEB9E2d5456c3be40cFF031AB40A55",
       "name": "SuperFarm",
@@ -2318,7 +2283,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xe53EC727dbDEB9E2d5456c3be40cFF031AB40A55/logo.png"
     },
     {
-      "asset": "c60_t0xE5CAeF4Af8780E59Df925470b050Fb23C43CA68C",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xE5CAeF4Af8780E59Df925470b050Fb23C43CA68C",
       "name": "Ferrum Network",
@@ -2327,7 +2292,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xE5CAeF4Af8780E59Df925470b050Fb23C43CA68C/logo.png"
     },
     {
-      "asset": "c60_t0xE61fDAF474Fac07063f2234Fb9e60C1163Cfa850",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xE61fDAF474Fac07063f2234Fb9e60C1163Cfa850",
       "name": "COIN",
@@ -2336,7 +2301,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xE61fDAF474Fac07063f2234Fb9e60C1163Cfa850/logo.png"
     },
     {
-      "asset": "c60_t0xE95A203B1a91a908F9B9CE46459d101078c2c3cb",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xE95A203B1a91a908F9B9CE46459d101078c2c3cb",
       "name": "ankrETH",
@@ -2345,7 +2310,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xE95A203B1a91a908F9B9CE46459d101078c2c3cb/logo.png"
     },
     {
-      "asset": "c60_t0xEA1ea0972fa092dd463f2968F9bB51Cc4c981D71",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xEA1ea0972fa092dd463f2968F9bB51Cc4c981D71",
       "name": "Modefi",
@@ -2354,7 +2319,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xEA1ea0972fa092dd463f2968F9bB51Cc4c981D71/logo.png"
     },
     {
-      "asset": "c60_t0xEa319e87Cf06203DAe107Dd8E5672175e3Ee976c",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xEa319e87Cf06203DAe107Dd8E5672175e3Ee976c",
       "name": "SURF Finance",
@@ -2363,7 +2328,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xEa319e87Cf06203DAe107Dd8E5672175e3Ee976c/logo.png"
     },
     {
-      "asset": "c60_t0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D",
       "name": "renBTC",
@@ -2372,7 +2337,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D/logo.png"
     },
     {
-      "asset": "c60_t0xEBd9D99A3982d547C5Bb4DB7E3b1F9F14b67Eb83",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xEBd9D99A3982d547C5Bb4DB7E3b1F9F14b67Eb83",
       "name": "Everest",
@@ -2381,7 +2346,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xEBd9D99A3982d547C5Bb4DB7E3b1F9F14b67Eb83/logo.png"
     },
     {
-      "asset": "c60_t0xEd91879919B71bB6905f23af0A68d231EcF87b14",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xEd91879919B71bB6905f23af0A68d231EcF87b14",
       "name": "DMM: Governance",
@@ -2390,7 +2355,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xEd91879919B71bB6905f23af0A68d231EcF87b14/logo.png"
     },
     {
-      "asset": "c60_t0xee573a945B01B788B9287CE062A0CFC15bE9fd86",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xee573a945B01B788B9287CE062A0CFC15bE9fd86",
       "name": "Exeedme",
@@ -2399,7 +2364,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xee573a945B01B788B9287CE062A0CFC15bE9fd86/logo.png"
     },
     {
-      "asset": "c60_t0xeEAA40B28A2d1b0B08f6f97bB1DD4B75316c6107",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xeEAA40B28A2d1b0B08f6f97bB1DD4B75316c6107",
       "name": "GOVI",
@@ -2408,7 +2373,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xeEAA40B28A2d1b0B08f6f97bB1DD4B75316c6107/logo.png"
     },
     {
-      "asset": "c60_t0xEec2bE5c91ae7f8a338e1e5f3b5DE49d07AfdC81",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xEec2bE5c91ae7f8a338e1e5f3b5DE49d07AfdC81",
       "name": "Dopex Governance Token",
@@ -2417,7 +2382,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xEec2bE5c91ae7f8a338e1e5f3b5DE49d07AfdC81/logo.png"
     },
     {
-      "asset": "c60_t0xEEF9f339514298C6A857EfCfC1A762aF84438dEE",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xEEF9f339514298C6A857EfCfC1A762aF84438dEE",
       "name": "Hermez Network Token",
@@ -2426,7 +2391,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xEEF9f339514298C6A857EfCfC1A762aF84438dEE/logo.png"
     },
     {
-      "asset": "c60_t0xF063fE1aB7a291c5d06a86e14730b00BF24cB589",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xF063fE1aB7a291c5d06a86e14730b00BF24cB589",
       "name": "DxSale Network",
@@ -2435,7 +2400,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xF063fE1aB7a291c5d06a86e14730b00BF24cB589/logo.png"
     },
     {
-      "asset": "c60_t0xf1f955016EcbCd7321c7266BccFB96c68ea5E49b",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xf1f955016EcbCd7321c7266BccFB96c68ea5E49b",
       "name": "Rally",
@@ -2444,7 +2409,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xf1f955016EcbCd7321c7266BccFB96c68ea5E49b/logo.png"
     },
     {
-      "asset": "c60_t0xf21661D0D1d76d3ECb8e1B9F1c923DBfffAe4097",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xf21661D0D1d76d3ECb8e1B9F1c923DBfffAe4097",
       "name": "Realio Network",
@@ -2453,7 +2418,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xf21661D0D1d76d3ECb8e1B9F1c923DBfffAe4097/logo.png"
     },
     {
-      "asset": "c60_t0xF411903cbC70a74d22900a5DE66A2dda66507255",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xF411903cbC70a74d22900a5DE66A2dda66507255",
       "name": "Verasity",
@@ -2462,7 +2427,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xF411903cbC70a74d22900a5DE66A2dda66507255/logo.png"
     },
     {
-      "asset": "c60_t0xf418588522d5dd018b425E472991E52EBBeEEEEE",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xf418588522d5dd018b425E472991E52EBBeEEEEE",
       "name": "PUSH",
@@ -2471,7 +2436,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xf418588522d5dd018b425E472991E52EBBeEEEEE/logo.png"
     },
     {
-      "asset": "c60_t0xf4CD3d3Fda8d7Fd6C5a500203e38640A70Bf9577",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xf4CD3d3Fda8d7Fd6C5a500203e38640A70Bf9577",
       "name": "YfDAI.finance",
@@ -2480,7 +2445,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xf4CD3d3Fda8d7Fd6C5a500203e38640A70Bf9577/logo.png"
     },
     {
-      "asset": "c60_t0xF4d861575ecC9493420A3f5a14F85B13f0b50EB3",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xF4d861575ecC9493420A3f5a14F85B13f0b50EB3",
       "name": "Fractal",
@@ -2490,7 +2455,6 @@
     },
     {
       "chainId": 1,
-      "asset": "c60_t0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c",
       "tags": ["erc20"],
       "address": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c",
       "name": "Enjin Coin",
@@ -2499,7 +2463,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c/logo.png"
     },
     {
-      "asset": "c60_t0xf6537FE0df7F0Cc0985Cf00792CC98249E73EFa0",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xf6537FE0df7F0Cc0985Cf00792CC98249E73EFa0",
       "name": "GIVLY Coin",
@@ -2508,7 +2472,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xf6537FE0df7F0Cc0985Cf00792CC98249E73EFa0/logo.png"
     },
     {
-      "asset": "c60_t0xF938424F7210f31dF2Aee3011291b658f872e91e",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xF938424F7210f31dF2Aee3011291b658f872e91e",
       "name": "Visor.Finance",
@@ -2517,7 +2481,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xF938424F7210f31dF2Aee3011291b658f872e91e/logo.png"
     },
     {
-      "asset": "c60_t0xF94b5C5651c888d928439aB6514B93944eEE6F48",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xF94b5C5651c888d928439aB6514B93944eEE6F48",
       "name": "Yield",
@@ -2526,7 +2490,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xF94b5C5651c888d928439aB6514B93944eEE6F48/logo.png"
     },
     {
-      "asset": "c60_t0xfAd45E47083e4607302aa43c65fB3106F1cd7607",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xfAd45E47083e4607302aa43c65fB3106F1cd7607",
       "name": "Hoge Finance",
@@ -2535,7 +2499,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xfAd45E47083e4607302aa43c65fB3106F1cd7607/logo.png"
     },
     {
-      "asset": "c60_t0xFbEEa1C75E4c4465CB2FCCc9c6d6afe984558E20",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xFbEEa1C75E4c4465CB2FCCc9c6d6afe984558E20",
       "name": "DuckDaoDime",
@@ -2544,7 +2508,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xFbEEa1C75E4c4465CB2FCCc9c6d6afe984558E20/logo.png"
     },
     {
-      "asset": "c60_t0xfC98e825A2264D890F9a1e68ed50E1526abCcacD",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xfC98e825A2264D890F9a1e68ed50E1526abCcacD",
       "name": "Moss Carbon Credit",
@@ -2553,7 +2517,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xfC98e825A2264D890F9a1e68ed50E1526abCcacD/logo.png"
     },
     {
-      "asset": "c60_t0xFca59Cd816aB1eaD66534D82bc21E7515cE441CF",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xFca59Cd816aB1eaD66534D82bc21E7515cE441CF",
       "name": "Rarible",
@@ -2562,7 +2526,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xFca59Cd816aB1eaD66534D82bc21E7515cE441CF/logo.png"
     },
     {
-      "asset": "c60_t0xFE3E6a25e6b192A42a44ecDDCd13796471735ACf",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xFE3E6a25e6b192A42a44ecDDCd13796471735ACf",
       "name": "Reef",
@@ -2571,7 +2535,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xFE3E6a25e6b192A42a44ecDDCd13796471735ACf/logo.png"
     },
     {
-      "asset": "c60_t0xfF20817765cB7f73d4bde2e66e067E58D11095C2",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xfF20817765cB7f73d4bde2e66e067E58D11095C2",
       "name": "Amp",
@@ -2580,7 +2544,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xfF20817765cB7f73d4bde2e66e067E58D11095C2/logo.png"
     },
     {
-      "asset": "c60_t0xfffffffFf15AbF397dA76f1dcc1A1604F45126DB",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xfffffffFf15AbF397dA76f1dcc1A1604F45126DB",
       "name": "FalconSwap Token",
@@ -2589,7 +2553,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xfffffffFf15AbF397dA76f1dcc1A1604F45126DB/logo.png"
     },
     {
-      "asset": "c60_t0x383518188C0C6d7730D91b2c03a03C837814a899",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x383518188C0C6d7730D91b2c03a03C837814a899",
       "name": "OlympusDAO",
@@ -2598,7 +2562,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x383518188C0C6d7730D91b2c03a03C837814a899/logo.png"
     },
     {
-      "asset": "c60_t0x767FE9EDC9E0dF98E07454847909b5E959D7ca0E",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x767FE9EDC9E0dF98E07454847909b5E959D7ca0E",
       "name": "Illuvium",
@@ -2607,7 +2571,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x767FE9EDC9E0dF98E07454847909b5E959D7ca0E/logo.png"
     },
     {
-      "asset": "c60_t0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA",
       "name": "Gala",
@@ -2616,7 +2580,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA/logo.png"
     },
     {
-      "asset": "c60_t0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
       "name": "Convex Token",
@@ -2625,7 +2589,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B/logo.png"
     },
     {
-      "asset": "c60_t0x090185f2135308BaD17527004364eBcC2D37e5F6",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x090185f2135308BaD17527004364eBcC2D37e5F6",
       "name": "Spell Token",
@@ -2634,7 +2598,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x090185f2135308BaD17527004364eBcC2D37e5F6/logo.png"
     },
     {
-      "asset": "c60_t0x3b484b82567a09e2588A13D54D032153f0c0aEe0",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x3b484b82567a09e2588A13D54D032153f0c0aEe0",
       "name": "OpenDAO",
@@ -2643,7 +2607,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x3b484b82567a09e2588A13D54D032153f0c0aEe0/logo.png"
     },
     {
-      "asset": "c60_t0x6Bba316c48b49BD1eAc44573c5c871ff02958469",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x6Bba316c48b49BD1eAc44573c5c871ff02958469",
       "name": "Gas DAO",
@@ -2652,7 +2616,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6Bba316c48b49BD1eAc44573c5c871ff02958469/logo.png"
     },
     {
-      "asset": "c60_t0x4Fabb145d64652a948d72533023f6E7A623C7C53",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x4Fabb145d64652a948d72533023f6E7A623C7C53",
       "name": "Binance USD",
@@ -2661,7 +2625,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x4Fabb145d64652a948d72533023f6E7A623C7C53/logo.png"
     },
     {
-      "asset": "c60_t0x9E32b13ce7f2E80A01932B42553652E053D6ed8e",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x9E32b13ce7f2E80A01932B42553652E053D6ed8e",
       "name": "MetisDAO",
@@ -2670,7 +2634,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x9E32b13ce7f2E80A01932B42553652E053D6ed8e/logo.png"
     },
     {
-      "asset": "c60_t0xf4d2888d29D722226FafA5d9B24F9164c092421E",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xf4d2888d29D722226FafA5d9B24F9164c092421E",
       "name": "LooksRare",
@@ -2679,7 +2643,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xf4d2888d29D722226FafA5d9B24F9164c092421E/logo.png"
     },
     {
-      "asset": "c60_t0x1E4EDE388cbc9F4b5c79681B7f94d36a11ABEBC9",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x1E4EDE388cbc9F4b5c79681B7f94d36a11ABEBC9",
       "name": "X2Y2Token",
@@ -2688,7 +2652,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x1E4EDE388cbc9F4b5c79681B7f94d36a11ABEBC9/logo.png"
     },
     {
-      "asset": "c60_t0x4d224452801ACEd8B2F0aebE155379bb5D594381",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x4d224452801ACEd8B2F0aebE155379bb5D594381",
       "name": "ApeCoin (APE)",
@@ -2697,7 +2661,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x4d224452801ACEd8B2F0aebE155379bb5D594381/logo.png"
     },
     {
-      "asset": "c60_t0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6",
       "name": "StargateToken",
@@ -2706,7 +2670,7 @@
       "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6/logo.png"
     },
     {
-      "asset": "c60_t0x70e8dE73cE538DA2bEEd35d14187F6959a8ecA96",
+      "chainId": 1,
       "tags": ["erc20"],
       "address": "0x70e8dE73cE538DA2bEEd35d14187F6959a8ecA96",
       "name": "XSGD",

--- a/packages/cardpay-sdk/token-lists/gnosis-tokenlist.json
+++ b/packages/cardpay-sdk/token-lists/gnosis-tokenlist.json
@@ -30,7 +30,7 @@
       "symbol": "wxDAI",
       "decimals": 18,
       "logoURI": "https://docs.gnosischain.com/img/tokens/xdai.png",
-      "tags": ["erc20"]
+      "tags": ["erc20", "relayGas"]
     },
     {
       "chainId": 100,
@@ -39,7 +39,7 @@
       "symbol": "CARD.CPXD",
       "decimals": 18,
       "logoURI": "https://raw.githubusercontent.com/cardstack/cardstack/main/packages/web-client/public/images/logos/tokens/card.cpxd.png",
-      "tags": ["erc20"]
+      "tags": ["erc20", "relayGas"]
     },
     {
       "chainId": 100,
@@ -48,7 +48,7 @@
       "symbol": "DAI.CPXD",
       "decimals": 18,
       "logoURI": "https://raw.githubusercontent.com/cardstack/cardstack/main/packages/web-client/public/images/logos/tokens/dai.cpxd.png",
-      "tags": ["erc20"]
+      "tags": ["erc20", "relayGas"]
     }
   ]
 }

--- a/packages/cardpay-sdk/token-lists/gnosis-tokenlist.json
+++ b/packages/cardpay-sdk/token-lists/gnosis-tokenlist.json
@@ -1,0 +1,54 @@
+{
+  "name": "Gnosis Chain Tokens",
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  },
+  "logoURI": "https://docs.gnosischain.com/img/tokens/xdai.png",
+  "keywords": ["gnosis chain", "mainnet", "default", "tokens"],
+  "tags": {
+    "stablecoin": {
+      "name": "stablecoin",
+      "description": "Tokens that are fixed to an external asset, e.g. the US dollar"
+    },
+    "erc20": {
+      "name": "erc20",
+      "description": "Tokens are of ERC20 token type"
+    },
+    "relayGas": {
+      "name": "relayGas",
+      "description": "Tokens that can be used to reimburse gas to the Cardstack relay server on this chain"
+    }
+  },
+  "timestamp": "2022-12-27T18:44:00.000Z",
+  "tokens": [
+    {
+      "chainId": 100,
+      "name": "Wrapped xDAI",
+      "address": "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
+      "symbol": "wxDAI",
+      "decimals": 18,
+      "logoURI": "https://docs.gnosischain.com/img/tokens/xdai.png",
+      "tags": ["erc20"]
+    },
+    {
+      "chainId": 100,
+      "name": "CARD.CPXD",
+      "address": "0x52031d287Bb58E26A379A7Fec2c84acB54f54fe3",
+      "symbol": "CARD.CPXD",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/cardstack/cardstack/main/packages/web-client/public/images/logos/tokens/card.cpxd.png",
+      "tags": ["erc20"]
+    },
+    {
+      "chainId": 100,
+      "name": "DAI.CPXD",
+      "address": "0x26F2319Fbb44772e0ED58fB7c99cf8da59e2b5BE",
+      "symbol": "DAI.CPXD",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/cardstack/cardstack/main/packages/web-client/public/images/logos/tokens/dai.cpxd.png",
+      "tags": ["erc20"]
+    }
+  ]
+}

--- a/packages/cardpay-sdk/token-lists/sokol-tokenlist.json
+++ b/packages/cardpay-sdk/token-lists/sokol-tokenlist.json
@@ -30,7 +30,7 @@
       "symbol": "wxDAI",
       "decimals": 18,
       "logoURI": "https://docs.gnosischain.com/img/tokens/xdai.png",
-      "tags": ["erc20"]
+      "tags": ["erc20", "relayGas"]
     },
     {
       "chainId": 77,
@@ -39,7 +39,7 @@
       "symbol": "CARD.CPXD",
       "decimals": 18,
       "logoURI": "https://raw.githubusercontent.com/cardstack/cardstack/main/packages/web-client/public/images/logos/tokens/card.cpxd.png",
-      "tags": ["erc20"]
+      "tags": ["erc20", "relayGas"]
     },
     {
       "chainId": 77,
@@ -48,7 +48,7 @@
       "symbol": "DAI.CPXD",
       "decimals": 18,
       "logoURI": "https://raw.githubusercontent.com/cardstack/cardstack/main/packages/web-client/public/images/logos/tokens/dai.cpxd.png",
-      "tags": ["erc20"]
+      "tags": ["erc20", "relayGas"]
     }
   ]
 }

--- a/packages/cardpay-sdk/token-lists/sokol-tokenlist.json
+++ b/packages/cardpay-sdk/token-lists/sokol-tokenlist.json
@@ -1,0 +1,54 @@
+{
+  "name": "Sokol Testnet Tokens",
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  },
+  "logoURI": "https://docs.gnosischain.com/img/tokens/chiado-xdai.png",
+  "keywords": ["sokol", "testnet", "cardstack", "tokens"],
+  "tags": {
+    "stablecoin": {
+      "name": "stablecoin",
+      "description": "Tokens that are fixed to an external asset, e.g. the US dollar"
+    },
+    "erc20": {
+      "name": "erc20",
+      "description": "Tokens are of ERC20 token type"
+    },
+    "relayGas": {
+      "name": "relayGas",
+      "description": "Tokens that can be used to reimburse gas to the Cardstack relay server on this chain"
+    }
+  },
+  "timestamp": "2022-12-27T18:44:00.000Z",
+  "tokens": [
+    {
+      "chainId": 77,
+      "name": "Wrapped xDAI",
+      "address": "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
+      "symbol": "wxDAI",
+      "decimals": 18,
+      "logoURI": "https://docs.gnosischain.com/img/tokens/xdai.png",
+      "tags": ["erc20"]
+    },
+    {
+      "chainId": 77,
+      "name": "CARD.CPXD",
+      "address": "0xB0427e9F03Eb448D030bE3EBC96F423857ceEb2f",
+      "symbol": "CARD.CPXD",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/cardstack/cardstack/main/packages/web-client/public/images/logos/tokens/card.cpxd.png",
+      "tags": ["erc20"]
+    },
+    {
+      "chainId": 77,
+      "name": "DAI.CPXD",
+      "address": "0x8F4fdA26e5039eb0bf5dA90c3531AeB91256b56b",
+      "symbol": "DAI.CPXD",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/cardstack/cardstack/main/packages/web-client/public/images/logos/tokens/dai.cpxd.png",
+      "tags": ["erc20"]
+    }
+  ]
+}


### PR DESCRIPTION
This PR handles two things related to the `tokenList` property inside the `constants` file:

1. It adds Gnosis and Sokol tokenlist files. We will be using these tokenlist files in the mobile app to render the token icons via the `getConstantsByNetwork` helper.
2. It updates the Ethereum tokenlist file to match the TokenList type. It was missing `timestamp`, `chainId` to all entries and some of the entries had an `asset` property that's not part of the type. 