### PR TITLE
Remove Mumbai from the supported chains array

### DIFF
--- a/packages/cardpay-sdk/sdk/constants.ts
+++ b/packages/cardpay-sdk/sdk/constants.ts
@@ -8,7 +8,6 @@ import polygonTokenList from '../token-lists/polygon-tokenlist.json';
 import sokolTokenList from '../token-lists/sokol-tokenlist.json';
 import gnosisTokenList from '../token-lists/gnosis-tokenlist.json';
 import { type TokenList } from '@uniswap/token-lists';
-import { difference } from 'lodash';
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
@@ -19,12 +18,10 @@ export const CARDWALLET_SCHEME = 'cardwallet';
 export const supportedChains = {
   ethereum: ['mainnet', 'goerli'],
   gnosis: ['gnosis', 'sokol'],
-  polygon: ['polygon', 'mumbai'],
+  polygon: ['polygon'],
 };
 
 export const supportedChainsArray = Object.values(supportedChains).flat();
-// Mumbai is not supported by gnosis team https://docs.gnosis-safe.io/backend/available-services
-export const schedulerSupportedChainsArray = difference(supportedChainsArray, [...supportedChains.gnosis, 'mumbai']);
 
 export type CardPayCapableNetworks = 'sokol' | 'gnosis';
 export type SchedulerCapableNetworks = 'mainnet' | 'goerli' | 'polygon';

--- a/packages/cardpay-sdk/sdk/network-config-utils.ts
+++ b/packages/cardpay-sdk/sdk/network-config-utils.ts
@@ -1,13 +1,6 @@
 /*global fetch */
 
-import {
-  getConstant,
-  supportedChains,
-  Network,
-  networks,
-  supportedChainsArray,
-  schedulerSupportedChainsArray,
-} from './constants';
+import { getConstant, supportedChains, Network, networks, supportedChainsArray } from './constants';
 import { HubConfigResponse, RpcNodeUrl } from './hub-config';
 
 export type Networkish = string | number | Network;
@@ -26,9 +19,6 @@ export const getWeb3ConfigByNetwork = (config: HubConfigResponse, network: Netwo
 };
 
 export const isSupportedChain = (network: Networkish) => supportedChainsArray.includes(convertChainIdToName(network));
-
-export const isSchedulerSupportedChain = (network: Networkish) =>
-  schedulerSupportedChainsArray.includes(convertChainIdToName(network));
 
 export const isCardPaySupportedNetwork = (network: Network | string) => supportedChains.gnosis.includes(network);
 

--- a/packages/cardpay-sdk/tests/constants-test.ts
+++ b/packages/cardpay-sdk/tests/constants-test.ts
@@ -2,14 +2,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import Web3 from 'web3';
 import JsonRpcProvider from '../providers/json-rpc-provider';
-import {
-  networkIds,
-  networks,
-  getConstantByNetwork,
-  getConstant,
-  supportedChainsArray,
-  schedulerSupportedChainsArray,
-} from '../sdk/constants';
+import { networkIds, networks, getConstantByNetwork, getConstant, supportedChainsArray } from '../sdk/constants';
 
 chai.use(chaiAsPromised);
 
@@ -35,10 +28,7 @@ describe('Network constants', () => {
     });
   });
   it('should return all supported networks in an array', () => {
-    chai.expect(supportedChainsArray).to.eql(['mainnet', 'goerli', 'gnosis', 'sokol', 'polygon', 'mumbai']);
-  });
-  it('should return all scheduler supported networks in an array', () => {
-    chai.expect(schedulerSupportedChainsArray).to.eql(['mainnet', 'goerli', 'polygon']);
+    chai.expect(supportedChainsArray).to.eql(['mainnet', 'goerli', 'gnosis', 'sokol', 'polygon']);
   });
 
   describe('getConstantByNetwork', () => {

--- a/packages/cardpay-sdk/tests/network-config-utils-test.ts
+++ b/packages/cardpay-sdk/tests/network-config-utils-test.ts
@@ -10,12 +10,7 @@ if (!globalThis.fetch) {
 }
 
 import { HubConfigResponse } from '../sdk/hub-config';
-import {
-  getWeb3ConfigByNetwork,
-  isSupportedChain,
-  fetchSupportedGasTokens,
-  isSchedulerSupportedChain,
-} from '../sdk/network-config-utils';
+import { getWeb3ConfigByNetwork, isSupportedChain, fetchSupportedGasTokens } from '../sdk/network-config-utils';
 
 chai.use(chaiAsPromised);
 
@@ -43,11 +38,6 @@ describe('getWeb3ConfigByNetwork', () => {
 
       chai.expect(config).to.eq(mockedConfig.web3.ethereum);
     });
-    it('should return polygon config for mumbai', () => {
-      const config = getWeb3ConfigByNetwork(mockedConfig, 'mumbai');
-
-      chai.expect(config).to.eq(mockedConfig.web3.polygon);
-    });
     it('should return gnosis config for gnosis', () => {
       const config = getWeb3ConfigByNetwork(mockedConfig, 'gnosis');
 
@@ -60,6 +50,9 @@ describe('getWeb3ConfigByNetwork', () => {
     });
     it('should throw an error for non-supported network: kovan', () => {
       chai.expect(() => getWeb3ConfigByNetwork(mockedConfig, 'kovan')).to.throw(`Unsupported network: kovan`);
+    });
+    it('should throw an error for non-supported network: mumbai', () => {
+      chai.expect(() => getWeb3ConfigByNetwork(mockedConfig, 'mumbai')).to.throw(`Unsupported network: mumbai`);
     });
   });
 
@@ -114,32 +107,6 @@ describe('isSupportedChain', () => {
 
   it('should return true for supported polygon network as type', () => {
     chai.expect(isSupportedChain(supportedChainAsType)).to.eq(true);
-  });
-});
-
-describe('isSchedulerSupportedChain', () => {
-  const supportedChainNames = ['mainnet', 'goerli'];
-  const supportedChainIds = [5];
-
-  const unsupportedChains = ['kovan', 'gnosis'];
-  const nonExistingChains = ['foo', 'bar'];
-
-  const supportedChainAsType = 'polygon' as const;
-
-  [...supportedChainNames, ...supportedChainIds].forEach((network) => {
-    it(`should return true for supported network ${network}`, () => {
-      chai.expect(isSchedulerSupportedChain(network)).to.eq(true);
-    });
-  });
-
-  [...unsupportedChains, ...nonExistingChains].forEach((network) => {
-    it(`should return false for non-supported network ${network}`, () => {
-      chai.expect(isSchedulerSupportedChain(network)).to.eq(false);
-    });
-  });
-
-  it('should return true for supported polygon network as type', () => {
-    chai.expect(isSchedulerSupportedChain(supportedChainAsType)).to.eq(true);
   });
 });
 

--- a/packages/hub/services/validators/scheduled-payment.ts
+++ b/packages/hub/services/validators/scheduled-payment.ts
@@ -1,7 +1,7 @@
 import Web3 from 'web3';
 import { ScheduledPayment } from '@prisma/client';
 import { startCase } from 'lodash';
-import { convertChainIdToName, isSchedulerSupportedChain, SchedulerCapableNetworks } from '@cardstack/cardpay-sdk';
+import { convertChainIdToName, isSupportedChain, SchedulerCapableNetworks } from '@cardstack/cardpay-sdk';
 import { inject } from '@cardstack/di';
 const { isAddress } = Web3.utils;
 
@@ -90,7 +90,7 @@ export default class ScheduledPaymentValidator {
     }
 
     if (scheduledPayment.chainId) {
-      if (!isSchedulerSupportedChain(scheduledPayment.chainId)) {
+      if (!isSupportedChain(scheduledPayment.chainId)) {
         errors.chainId.push(`chain is not supported`);
       } else {
         const networkName = convertChainIdToName(scheduledPayment.chainId) as SchedulerCapableNetworks;

--- a/packages/safe-tools-client/app/services/network.ts
+++ b/packages/safe-tools-client/app/services/network.ts
@@ -2,8 +2,8 @@ import {
   getConstantByNetwork,
   Network,
   networks,
-  schedulerSupportedChainsArray,
   SchedulerCapableNetworks,
+  supportedChainsArray,
 } from '@cardstack/cardpay-sdk';
 import WalletService from '@cardstack/safe-tools-client/services/wallet';
 import { getOwner } from '@ember/application';
@@ -48,7 +48,7 @@ export default class NetworkService extends Service {
   }
 
   get supportedList() {
-    return schedulerSupportedChainsArray
+    return supportedChainsArray
       .map((networkSymbol) => ({
         name: getConstantByNetwork('name', networkSymbol),
         chainId: getConstantByNetwork('chainId', networkSymbol),

--- a/packages/safe-tools-client/app/services/wallet.ts
+++ b/packages/safe-tools-client/app/services/wallet.ts
@@ -1,9 +1,9 @@
 import {
   getConstantByNetwork,
   getSDK,
-  isSchedulerSupportedChain,
   convertChainIdToName,
   Web3Provider,
+  isSupportedChain,
 } from '@cardstack/cardpay-sdk';
 import HubAuthenticationService from '@cardstack/safe-tools-client/services/hub-authentication';
 import NetworkService from '@cardstack/safe-tools-client/services/network';
@@ -71,7 +71,7 @@ export default class Wallet extends Service {
     });
 
     this.chainConnectionManager.on('chain-changed', (chainId: number) => {
-      if (!isSchedulerSupportedChain(chainId)) {
+      if (!isSupportedChain(chainId)) {
         // TODO: improve unsupported net handling
         alert('Unsupported network! Choose a supported one and reconnect');
         this.disconnect();


### PR DESCRIPTION
This PR removes Mumbai from the list of supported chains to avoid breaking the mobile app since there's no configuration for Mumbai in the networks config array.

Because of that, the array created for the Scheduler Tool isn't necessary anymore, so we're removing it.