### PR TITLE
[CS-5028] Moves reward explanation parser utils to SDK

### DIFF
--- a/packages/cardpay-sdk/index.ts
+++ b/packages/cardpay-sdk/index.ts
@@ -59,6 +59,7 @@ export { gasPriceInToken, getGasPricesInNativeWei, getNativeWeiInToken } from '.
 export * from './sdk/network-config-utils';
 export * from './sdk/utils/general-utils';
 export * from './sdk/scheduled-payment/utils';
+export * from './sdk/utils/reward-explanation-utils';
 export { poll } from './sdk/utils/general-utils';
 export { convertRawAmountToDecimalFormat } from './sdk/currency-utils';
 export {

--- a/packages/cardpay-sdk/sdk/utils/reward-explanation-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/reward-explanation-utils.ts
@@ -1,0 +1,30 @@
+import BigNumber from 'bignumber.js';
+
+/**
+ * parseTemplateExplanation
+ * Taken from https://gist.github.com/smeijer/6580740a0ff468960a5257108af1384e?permalink_comment_id=3437778#gistcomment-3437778
+ * @param template string such as in explanationTemplate: Earned {amount} {token} for a one-time aidrop. {rollover_amount} tokens.
+ * @param data object such as explanationData: { "amount": "100.0", "token": "0xB0427e9F03Eb448D030bE3EBC96F423857ceEb2f" }.
+ * @returns formatted string such as: Earned 100.0 CARD.CPXD for a one-time aidrop. {rollover_amount} tokens.
+ */
+export const parseTemplateExplanation = (template: string, data?: any) => {
+  // matchToken is the tokenName with brackets, as in `{a}` where token name is `a`.
+  return template.replace(/\{([^}]+)}/g, (matchedToken, tokenName) => {
+    // split and iterate on nested tokens, like `{a.b.c}`.
+    return (
+      tokenName.split('.').reduce((splittedToken: any, key: any) => {
+        return splittedToken ? splittedToken[key] : undefined;
+      }, data) ?? matchedToken // returns "untouched" token with brackets when no value can be computed.
+    );
+  });
+};
+
+/**
+ * parseExplanationAmount
+ * @param amount amount number in WEI as defined in explanationData.
+ * @param tokenDecimals places to shift the decimal point.
+ * @param resultDecimals decimal places to keep in the result
+ * @returns formatted string with amount converted to readable string.
+ */
+export const parseExplanationAmount = (amount: BigNumber.Value, tokenDecimals: number, resultDecimals = 2) =>
+  new BigNumber(amount).shiftedBy(-tokenDecimals).toFixed(resultDecimals);

--- a/packages/cardpay-sdk/tests/reward-explanation-utils-test.ts
+++ b/packages/cardpay-sdk/tests/reward-explanation-utils-test.ts
@@ -1,0 +1,59 @@
+import chai from 'chai';
+import { parseTemplateExplanation, parseExplanationAmount } from '../sdk/utils/reward-explanation-utils';
+
+describe('rewards explanation parsing', () => {
+  it('should parse a proof template with a single value data entry', () => {
+    const template = 'Template {a}';
+    const data = { a: 'Value A' };
+
+    chai.expect(parseTemplateExplanation(template, data)).to.eq('Template Value A');
+  });
+
+  it('should parse whatever values match and keep not defined values as is', () => {
+    const template = 'Template {a} {b}';
+    const data = { a: 'Value A' };
+
+    chai.expect(parseTemplateExplanation(template, data)).to.eq('Template Value A {b}');
+  });
+
+  it('should not parse values that do not correlate to the ones defined in the template', () => {
+    const template = 'Template {a}';
+    const data = { b: 'Value B' };
+
+    chai.expect(parseTemplateExplanation(template, data)).to.eq('Template {a}');
+  });
+
+  it('should return the template as is if no data is provided', () => {
+    const template = 'Template {a}';
+
+    chai.expect(parseTemplateExplanation(template, undefined)).to.eq('Template {a}');
+  });
+
+  it('should return the template replaced for sub layered values', () => {
+    const template = 'Template {a.b}';
+    const data = { a: { b: 'Value B' } };
+
+    chai.expect(parseTemplateExplanation(template, data)).to.eq('Template Value B');
+  });
+
+  it('should parse token amount to human readable string with default 2 decimals', () => {
+    const amount = '3498646326433040826368';
+    const token = '3498.65';
+
+    chai.expect(parseExplanationAmount(amount, 18, 2)).to.eq(token);
+  });
+
+  it('should parse token amount to human readable string with defined decimals', () => {
+    const amount = '3498646326433040826368';
+    const token = '3498.646';
+
+    chai.expect(parseExplanationAmount(amount, 18, 3)).to.eq(token);
+  });
+
+  it('should parse token amount to human readable string with defined decimals, and different token decimals', () => {
+    const amount = '3498646326433040826368';
+    const token = '3498646326433.0408';
+
+    chai.expect(parseExplanationAmount(amount, 9, 4)).to.eq(token);
+  });
+});


### PR DESCRIPTION
### Description

This PR moves the reward explanation parsing function from the wallet code to the SDK, so it can be reused by other clients.

Another WIP PR will be pushed soon also changing the proofs returned to also contain the parsed explanation, making the usage of rewards in the clients simpler.