### PR TITLE
safe tools client: Add cancel payment option to the options menu in scheduled payment card

### DIFF
--- a/packages/boxel/addon/components/boxel/menu/index.css
+++ b/packages/boxel/addon/components/boxel/menu/index.css
@@ -29,6 +29,10 @@
   border-radius: 0 0 var(--boxel-border-radius) var(--boxel-border-radius);
 }
 
+.boxel-menu__item:only-child {
+  border-radius: var(--boxel-border-radius);
+}
+
 .boxel-menu__item > a {
   width: 100%;
   padding: var(--boxel-sp-xs) var(--boxel-sp);

--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -838,10 +838,12 @@ export default class ScheduledPaymentModule {
     });
   }
 
-  async cancelScheduledPayment(scheduledPaymentId: string, hubRootUrl?: string) {
+  async cancelScheduledPayment(scheduledPaymentId: string, hubRootUrl?: string, authToken?: string) {
     let hubAuth = await getSDK('HubAuth', this.ethersProvider, hubRootUrl, this.signer);
     hubRootUrl = await hubAuth.getHubUrl();
-    let authToken = await hubAuth.authenticate();
+    if (!authToken) {
+      authToken = await hubAuth.authenticate();
+    }
 
     let scheduledPaymentResponse = await hubRequest(
       hubRootUrl,

--- a/packages/hub/routes/scheduled-payments.ts
+++ b/packages/hub/routes/scheduled-payments.ts
@@ -67,6 +67,7 @@ export default class ScheduledPaymentsRoute {
         payAt: {
           gt: minPayAt,
         },
+        canceledAt: null,
       },
     });
 

--- a/packages/safe-tools-client/app/components/create-safe-modal/index.css
+++ b/packages/safe-tools-client/app/components/create-safe-modal/index.css
@@ -25,9 +25,10 @@
   gap: var(--boxel-sp-xxs);
 }
 
-.safe-setup-modal__section-icon {
+.action-chin-info-icon {
   --icon-stroke: var(--boxel-light);
   min-width: 16px;
+  margin-right: var(--boxel-font-size-sm);
 }
 
 .setup-safe-modal__section b {

--- a/packages/safe-tools-client/app/components/create-safe-modal/index.gts
+++ b/packages/safe-tools-client/app/components/create-safe-modal/index.gts
@@ -75,7 +75,7 @@ export default class SetupSafeModal extends Component<Signature> {
           {{else}}
             {{#if @comparingBalanceToGasCostErrorMessage}}
               <div class='safe-setup-modal__section-wallet-info'>
-                <FailureIcon class='safe-setup-modal__section-icon' />
+                <FailureIcon class='action-chin-info-icon' />
                 <p>
                   {{@comparingBalanceToGasCostErrorMessage}}
                 </p>
@@ -84,12 +84,12 @@ export default class SetupSafeModal extends Component<Signature> {
               <b>Estimated gas cost: {{@gasCostDisplay}}</b>
               <div class='safe-setup-modal__section-wallet-info'>
                 {{#if this.notEnoughBalance}}
-                  <FailureIcon class='safe-setup-modal__section-icon' />
+                  <FailureIcon class='action-chin-info-icon' />
                   <p>
                     Your wallet has insufficient funds to cover the estimated gas cost.
                   </p>
                 {{else}}
-                  <SuccessIcon class='safe-setup-modal__section-icon' />
+                  <SuccessIcon class='action-chin-info-icon' />
                   <p>
                     Your wallet has sufficient funds to cover the estimated gas cost.
                   </p>
@@ -110,12 +110,12 @@ export default class SetupSafeModal extends Component<Signature> {
 
               {{#if @provisioningOrIndexingErrorMessage}}
                 <ac.InfoArea data-test-safe-error-info>
-                  <FailureIcon class='safe-setup-modal__section-icon' />
+                  <FailureIcon class='action-chin-info-icon' />
                   {{@provisioningOrIndexingErrorMessage}}
                 </ac.InfoArea>
               {{else}}
                 <ac.InfoArea data-test-safe-success-info>
-                  <SuccessIcon class='safe-setup-modal__section-icon' />
+                  <SuccessIcon class='action-chin-info-icon' />
                   Your safe has been created and the module has been enabled. You can now schedule payments.
                 </ac.InfoArea>
               {{/if}}
@@ -134,7 +134,7 @@ export default class SetupSafeModal extends Component<Signature> {
 
               {{#if @provisioningOrIndexingErrorMessage}}
                 <ac.InfoArea data-test-safe-error-info>
-                  <FailureIcon class='safe-setup-modal__section-icon' />
+                  <FailureIcon class='action-chin-info-icon' />
                   {{@provisioningOrIndexingErrorMessage}}
                 </ac.InfoArea>
               {{/if}}

--- a/packages/safe-tools-client/app/components/future-payments-list/index.gts
+++ b/packages/safe-tools-client/app/components/future-payments-list/index.gts
@@ -99,7 +99,7 @@ export default class FuturePaymentsList extends Component<Signature> {
   });
 
   <template>
-    <BoxelActionContainer 
+    <BoxelActionContainer
       class="future-payments-list"
       as |Section ActionChin|>
       {{#if (and (not this.isScheduledPaymentsLoading) (lt this.scheduledPayments.length 1))}}

--- a/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.css
+++ b/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.css
@@ -51,3 +51,7 @@
   font: 500 var(--boxel-font-sm);
   color: var(--boxel-purple-400);
 }
+
+.cancel-scheduled-payment .boxel-action-container-section > div {
+  margin-top: 0;
+}

--- a/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.gts
+++ b/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.gts
@@ -144,7 +144,8 @@ export default class ScheduledPaymentCard extends Component<Signature> {
       >
         <Section @title="Cancel your scheduled payment">
           <div>
-            <p>You're about to cancel your payment of <strong>{{weiToDecimal @scheduledPayment.amount this.tokenInfo.decimals}} {{this.tokenInfo.symbol}}</strong> scheduled for <strong>{{formatDate @scheduledPayment.payAt "d/M/yyyy"}}</strong>.</p>
+            <p>You're about to cancel your payment of <strong>{{weiToDecimal @scheduledPayment.amount this.tokenInfo.decimals}} {{this.tokenInfo.symbol}}</strong>
+            to <span class="blockchain-address">{{truncateMiddle @scheduledPayment.payeeAddress}}</span>, scheduled for <strong>{{formatDate @scheduledPayment.payAt "d/M/yyyy"}}</strong>.</p>
 
             <p>This action will remove the scheduled payment from the scheduled payment module, and it won't be attempted in the future.</p>
           </div>

--- a/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.gts
+++ b/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.gts
@@ -1,12 +1,35 @@
 import Component from '@glimmer/component';
 import BoxelCardContainer from '@cardstack/boxel/components/boxel/card-container';
 import BoxelIconButton from '@cardstack/boxel/components/boxel/icon-button';
+import ScheduledPaymentsSdkService from '@cardstack/safe-tools-client/services/scheduled-payments-sdk';
+import BoxelLoadingIndicator from '@cardstack/boxel/components/boxel/loading-indicator';
+import BoxelActionContainer from '@cardstack/boxel/components/boxel/action-container';
+import BoxelModal from '@cardstack/boxel/components/boxel/modal';
 import { ScheduledPayment } from '@cardstack/safe-tools-client/services/scheduled-payments';
 import formatDate from '@cardstack/safe-tools-client/helpers/format-date';
 import truncateMiddle from '@cardstack/safe-tools-client/helpers/truncate-middle';
 import weiToDecimal from '@cardstack/safe-tools-client/helpers/wei-to-decimal';
 import { inject as service } from '@ember/service';
 import TokensService from '@cardstack/safe-tools-client/services/tokens';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { noop } from '@cardstack/safe-tools-client/helpers/noop';
+import { taskFor } from 'ember-concurrency-ts';
+import HubAuthenticationService from '@cardstack/safe-tools-client/services/hub-authentication';
+import SuccessIcon from '@cardstack/safe-tools-client/components/icons/success';
+import FailureIcon from '@cardstack/safe-tools-client/components/icons/failure';
+import BoxelDropdown from '@cardstack/boxel/components/boxel/dropdown';
+
+import BoxelMenu from '@cardstack/boxel/components/boxel/menu';
+import { type ActionChinState } from '@cardstack/boxel/components/boxel/action-chin/state'
+import menuItem from '@cardstack/boxel/helpers/menu-item'
+import { array } from '@ember/helper';
+import set from 'ember-set-helper/helpers/set';
+
+import { TaskGenerator } from 'ember-concurrency';
+import { task } from 'ember-concurrency-decorators';
+import * as Sentry from '@sentry/browser';
 
 import './index.css';
 
@@ -18,7 +41,16 @@ interface Signature {
 }
 
 export default class ScheduledPaymentCard extends Component<Signature> {
+  @service declare scheduledPaymentsSdk: ScheduledPaymentsSdkService;
+  @service declare hubAuthentication: HubAuthenticationService;
   @service declare tokens: TokensService;
+  @tracked optionsMenuOpened = false;
+  @tracked isCancelPaymentModalOpen = false;
+  @tracked cancelationErrorMessage?: string;
+
+  @action closeCancelScheduledPaymentModal() {
+    this.isCancelPaymentModalOpen = false;
+  }
 
   get tokenInfo() {
     let tokens = this.tokens.transactionTokens;
@@ -29,8 +61,40 @@ export default class ScheduledPaymentCard extends Component<Signature> {
     return token;
   }
 
+  get cancelPaymentState(): ActionChinState {
+    if (taskFor(this.cancelScheduledPaymentTask).isRunning) {
+      return 'in-progress';
+    }
+
+    return 'default';
+  }
+
+  @task *cancelScheduledPaymentTask(
+    scheduledPaymentId: string,
+    authToken: string
+  ): TaskGenerator<void> {
+    try {
+      yield this.scheduledPaymentsSdk.cancelScheduledPayment(scheduledPaymentId, authToken);
+    } catch (e) {
+      this.cancelationErrorMessage = "There was an error canceling your scheduled payment. Please try again, or contact support if the problem persists.";
+      Sentry.captureException(e);
+    }
+  }
+
+  @action async cancelScheduledPayment() {
+    await taskFor(this.cancelScheduledPaymentTask).perform(this.args.scheduledPayment.id, this.hubAuthentication.authToken!)
+  }
+
+  get paymentCanceled() {
+    return taskFor(this.cancelScheduledPaymentTask).last?.isSuccessful;
+  }
+
+  get cancelationError(): Error | undefined {
+    return taskFor(this.cancelScheduledPaymentTask).last?.error as Error
+  }
+
   <template>
-    <BoxelCardContainer 
+    <BoxelCardContainer
       @displayBoundaries={{true}}
       class="scheduled-payment-card">
       <div class="scheduled-payment-card__content" data-test-scheduled-payment-card>
@@ -41,16 +105,94 @@ export default class ScheduledPaymentCard extends Component<Signature> {
           <div class="scheduled-payment-card__token-amounts">
             <span class="scheduled-payment-card__token-amount">{{weiToDecimal @scheduledPayment.amount this.tokenInfo.decimals}} {{this.tokenInfo.symbol}}</span>
             {{!-- TODO: Add the right USD amount --}}
-            <span class="scheduled-payment-card__usd-amount">$ 1000 USD</span> 
+            <span class="scheduled-payment-card__usd-amount">$ 1000 USD</span>
           </div>
         </div>
       </div>
-      <BoxelIconButton
-        @icon="more-actions"
-        @height="30px"
-        aria-label="More Actions"
-      />
+
+      <BoxelDropdown>
+        <:trigger as |bindings|>
+          <BoxelIconButton
+            @icon="more-actions"
+            @height="30px"
+            {{bindings}}
+            data-test-scheduled-payment-card-options-button
+          />
+        </:trigger>
+        <:content as |dd|>
+          <BoxelMenu
+            @closeMenu={{dd.close}}
+            @items={{array
+              (menuItem
+                "Cancel Payment" (set this 'isCancelPaymentModalOpen' true)
+              )
+            }}
+          />
+        </:content>
+      </BoxelDropdown>
     </BoxelCardContainer>
+
+    <BoxelModal
+      @size='medium'
+      @isOpen={{this.isCancelPaymentModalOpen}}
+      @onClose={{noop}}
+      class="cancel-scheduled-payment"
+      data-test-cancel-scheduled-payment-modal
+    >
+      <BoxelActionContainer
+        as |Section ActionChin|
+      >
+        <Section @title="Cancel your scheduled payment">
+          <div>
+            <p>You're about to cancel your payment of <strong>{{weiToDecimal @scheduledPayment.amount this.tokenInfo.decimals}} {{this.tokenInfo.symbol}}</strong> scheduled for <strong>{{formatDate @scheduledPayment.payAt "d/M/yyyy"}}</strong>.</p>
+
+            <p>This action will remove the scheduled payment from the scheduled payment module, and it won't be attempted in the future.</p>
+          </div>
+        </Section>
+
+        <ActionChin @state={{this.cancelPaymentState}}>
+          <:default as |a|>
+            {{#if this.cancelationErrorMessage}}
+              <a.ActionButton {{on "click" this.cancelScheduledPayment}} data-test-cancel-payment-button>
+                Cancel Payment
+              </a.ActionButton>
+
+              <a.CancelButton {{on 'click' this.closeCancelScheduledPaymentModal}} data-test-close-cancel-payment-modal>
+                Close
+              </a.CancelButton>
+
+              <a.InfoArea>
+                <FailureIcon class='action-chin-info-icon' />
+                <span>{{this.cancelationErrorMessage}}</span>
+              </a.InfoArea>
+            {{else if this.paymentCanceled}}
+              <a.ActionButton {{on "click" this.closeCancelScheduledPaymentModal}} data-test-close-cancel-payment-modal>
+                Close
+              </a.ActionButton>
+
+              <a.InfoArea>
+                <SuccessIcon class='action-chin-info-icon' />
+                Your scheduled payment was canceled and removed successfully, and it won't be attempted in the future.
+              </a.InfoArea>
+            {{else}}
+              <a.ActionButton {{on "click" this.cancelScheduledPayment}} data-test-cancel-payment-button>
+                Cancel Payment
+              </a.ActionButton>
+              <a.CancelButton {{on 'click' this.closeCancelScheduledPaymentModal}} data-test-close-cancel-payment-modal>
+                Close
+              </a.CancelButton>
+            {{/if}}
+          </:default>
+          <:inProgress as |i|>
+            <i.ActionStatusArea>
+              <BoxelLoadingIndicator class="schedule-payment-form-action-card__loading-indicator" @color="var(--boxel-light)" />
+
+              Canceling scheduled payment...
+            </i.ActionStatusArea>
+          </:inProgress>
+        </ActionChin>
+      </BoxelActionContainer>
+    </BoxelModal>
   </template>
 }
 

--- a/packages/safe-tools-client/app/services/scheduled-payments-sdk.ts
+++ b/packages/safe-tools-client/app/services/scheduled-payments-sdk.ts
@@ -169,6 +169,20 @@ export default class SchedulePaymentSDKService extends Service {
       console.error(err);
     }
   }
+
+  async cancelScheduledPayment(
+    scheduledPaymentId: string,
+    authToken: string
+  ): Promise<unknown> {
+    const scheduledPaymentModule: ScheduledPaymentModule =
+      await this.getSchedulePaymentModule();
+
+    return scheduledPaymentModule.cancelScheduledPayment(
+      scheduledPaymentId,
+      config.hubUrl,
+      authToken
+    );
+  }
 }
 
 declare module '@ember/service' {

--- a/packages/safe-tools-client/app/services/scheduled-payments.ts
+++ b/packages/safe-tools-client/app/services/scheduled-payments.ts
@@ -6,6 +6,7 @@ import Service, { inject as service } from '@ember/service';
 import { BigNumber } from 'ethers';
 
 export interface ScheduledPayment {
+  id: string;
   amount: BigNumber;
   feeFixedUSD: string;
   feePercentage: string;
@@ -93,6 +94,7 @@ export type ScheduledPaymentAttemptStatus =
   | 'inProgress';
 
 export interface ScheduledPaymentResponseItem {
+  id: string;
   attributes: {
     'user-address': string;
     'sender-safe-address': string;
@@ -203,6 +205,7 @@ export default class ScheduledPaymentsService extends Service {
   ): ScheduledPayment[] {
     return response.data.map((s) => {
       return {
+        id: s.id,
         userAddress: s.attributes['user-address'],
         senderSafeAddress: s.attributes['sender-safe-address'],
         moduleAddress: s.attributes['module-address'],

--- a/packages/safe-tools-client/tests/integration/future-payments-list-test.ts
+++ b/packages/safe-tools-client/tests/integration/future-payments-list-test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
+import SchedulePaymentSDKService from '@cardstack/safe-tools-client/services/scheduled-payments-sdk';
 import Service from '@ember/service';
-import { render, TestContext } from '@ember/test-helpers';
+import { render, click, TestContext } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { addMinutes, addMonths, addHours } from 'date-fns';
 import { setupRenderingTest } from 'ember-qunit';
@@ -123,5 +124,57 @@ module('Integration | Component | future-payments-list', function (hooks) {
       ).length,
       1
     );
+  });
+
+  test('can cancel a payment', async function (assert) {
+    const scheduledPaymentsSdkService = this.owner.lookup(
+      'service:scheduled-payments-sdk'
+    ) as SchedulePaymentSDKService;
+
+    scheduledPaymentsSdkService.cancelScheduledPayment = (): Promise<void> => {
+      return Promise.resolve();
+    };
+
+    this.set('onDepositClick', () => {});
+    await render(hbs`
+      <FuturePaymentsList @onDepositClick={{this.onDepositClick}} />
+    `);
+
+    await click('[data-test-scheduled-payment-card-options-button]');
+    await click('[data-test-boxel-menu-item-text="Cancel Payment"]');
+    await click('[data-test-cancel-payment-button]');
+    assert
+      .dom('[data-test-cancel-scheduled-payment-modal]')
+      .includesText(
+        "Your scheduled payment was canceled and removed successfully, and it won't be attempted in the future."
+      );
+    assert.dom('[data-test-cancel-payment-button]').doesNotExist();
+    await click('[data-test-close-cancel-payment-modal]');
+    assert.dom('[data-test-cancel-scheduled-payment-modal]').doesNotExist();
+  });
+
+  test('it shows an error when canceling fails', async function (assert) {
+    const scheduledPaymentsSdkService = this.owner.lookup(
+      'service:scheduled-payments-sdk'
+    ) as SchedulePaymentSDKService;
+
+    scheduledPaymentsSdkService.cancelScheduledPayment = (): Promise<void> => {
+      return Promise.reject('error while canceling payment');
+    };
+
+    this.set('onDepositClick', () => {});
+    await render(hbs`
+      <FuturePaymentsList @onDepositClick={{this.onDepositClick}} />
+    `);
+
+    await click('[data-test-scheduled-payment-card-options-button]');
+    await click('[data-test-boxel-menu-item-text="Cancel Payment"]');
+    await click('[data-test-cancel-payment-button]');
+    assert
+      .dom('[data-test-cancel-scheduled-payment-modal]')
+      .includesText(
+        'There was an error canceling your scheduled payment. Please try again, or contact support if the problem persists.'
+      );
+    assert.dom('[data-test-cancel-payment-button]').exists();
   });
 });


### PR DESCRIPTION
This PR adds an option to cancel a payment.

Options menu:
<img width="394" alt="image" src="https://user-images.githubusercontent.com/273660/211014769-07b1b45d-e70d-43c3-baff-733712bf90e0.png">

Confirmation modal:
<img width="731" alt="image" src="https://user-images.githubusercontent.com/273660/211015085-70875404-bdd8-4925-9a04-add515269ddf.png">

Canceling:
<img width="724" alt="image" src="https://user-images.githubusercontent.com/273660/211014800-40f234cf-6bf6-4ef6-91d6-910743ebcb79.png">

Success:
<img width="724" alt="image" src="https://user-images.githubusercontent.com/273660/211015182-d3844dc1-7a86-4310-966c-7cebd0ab0336.png">

Failure:
<img width="723" alt="image" src="https://user-images.githubusercontent.com/273660/211015273-f642d906-8c79-40f4-b73b-50051a7e175b.png">

