### PR TITLE
[CS-5093] Parse reward proofs explanation data to explanation string

### DIFF
--- a/packages/cardpay-cli/rewards/claimable-proofs.ts
+++ b/packages/cardpay-cli/rewards/claimable-proofs.ts
@@ -90,7 +90,8 @@ function logProof(o: WithSymbol<Proof> | WithSymbol<ClaimableProof>, rewardPool:
       }
       explanationTemplate: ${o.explanationTemplate ?? 'Not specified'} 
       explanationData: 
-         ${JSON.stringify(o.explanationData, null, 4) ?? 'Not specified'} 
+        ${JSON.stringify(o.explanationData, null, 4) ?? 'Not specified'} 
+      parsedExplanation: ${o.parsedExplanation ?? 'Explanation missing'} 
         `);
 }
 


### PR DESCRIPTION
### Description

This PR adds a method to the SDK that takes a proof array and converts the explanation data into values that can be parsed and replaced using the explanation template.

It also logs the new value `parsedExplanation` when calling rewards from the `cardpay-cli`.

With this, clients can use the parsed string directly. Wallet App will be adjusted when the SDK gets the changes published.