### PR TITLE
cardie: Add deployability for boxel-motion

### DIFF
--- a/packages/cardie/config.json
+++ b/packages/cardie/config.json
@@ -22,6 +22,10 @@
       {
         "name": "boxel-motion",
         "alias": "boxel-host"
+      },
+      {
+        "name": "boxel-motion",
+        "alias": "boxel-realm-server"
       }
     ]
   }

--- a/packages/cardie/config.json
+++ b/packages/cardie/config.json
@@ -18,6 +18,10 @@
         "name": "card-protocol-relay-service",
         "alias": "relay",
         "default_branch": "master"
+      },
+      {
+        "name": "boxel-motion",
+        "alias": "boxel-host"
       }
     ]
   }


### PR DESCRIPTION
Once cardstack/boxel-motion#178 is merged, this will let its `packages/host` Ember application be deployed with `!deploy boxel-host`. This also includes configuration to allow deployment of `packages/realm-server`, though the respective workflows and infrastructure don’t exist yet.