### PR TITLE
safe tools: Do not render an empty header because it produces blank space

### DIFF
--- a/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-time-bracket/index.gts
+++ b/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-time-bracket/index.gts
@@ -20,7 +20,10 @@ export default class ScheduledPaymentTimeBracket extends Component<Signature> {
   <template>
     {{#if (gt @scheduledPayments.length 0)}}
       <BoxelCardContainer class="scheduled-payment-time-bracket" data-test-time-bracket={{@title}}>
-        <BoxelHeader @header={{@title}} @noBackground={{true}}/>
+        {{#if @title}}
+          <BoxelHeader @header={{@title}} @noBackground={{true}}/>
+        {{/if}}
+
         {{#each @scheduledPayments as |scheduledPayment|}}
           <ScheduledPaymentCard @scheduledPayment={{scheduledPayment}}/>
         {{/each}}


### PR DESCRIPTION
Before the fix:
<img width="413" alt="image" src="https://user-images.githubusercontent.com/273660/211509958-99a168c5-ac74-442a-af80-7daea2e8d5b8.png">

After:
<img width="437" alt="image" src="https://user-images.githubusercontent.com/273660/211510126-dcaa84fa-0fde-4631-82ce-7d090aecb8ed.png">
