### PR TITLE
safe tools: on payment cancel, remove scheduled payment from the list 

### DIFF
--- a/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.gts
+++ b/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.gts
@@ -20,6 +20,7 @@ import { taskFor } from 'ember-concurrency-ts';
 import HubAuthenticationService from '@cardstack/safe-tools-client/services/hub-authentication';
 import SuccessIcon from '@cardstack/safe-tools-client/components/icons/success';
 import FailureIcon from '@cardstack/safe-tools-client/components/icons/failure';
+import InfoIcon from '@cardstack/safe-tools-client/components/icons/info';
 import BoxelDropdown from '@cardstack/boxel/components/boxel/dropdown';
 
 import BoxelMenu from '@cardstack/boxel/components/boxel/menu';
@@ -192,6 +193,11 @@ export default class ScheduledPaymentCard extends Component<Signature> {
 
               Canceling scheduled payment...
             </i.ActionStatusArea>
+
+            <i.InfoArea>
+              <InfoIcon class='action-chin-info-icon' />
+              Canceling a payment could take up to a couple of minutes, depending on the blockchain network conditions.
+            </i.InfoArea>
           </:inProgress>
         </ActionChin>
       </BoxelActionContainer>

--- a/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.gts
+++ b/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.gts
@@ -25,7 +25,7 @@ import BoxelDropdown from '@cardstack/boxel/components/boxel/dropdown';
 import BoxelMenu from '@cardstack/boxel/components/boxel/menu';
 import { type ActionChinState } from '@cardstack/boxel/components/boxel/action-chin/state'
 import menuItem from '@cardstack/boxel/helpers/menu-item'
-import { array } from '@ember/helper';
+import { array, fn } from '@ember/helper';
 import set from 'ember-set-helper/helpers/set';
 
 import { TaskGenerator } from 'ember-concurrency';
@@ -38,6 +38,7 @@ interface Signature {
   Element: HTMLElement;
   Args: {
     scheduledPayment: ScheduledPayment;
+    reloadScheduledPayments: () => void;
   }
 }
 
@@ -49,8 +50,9 @@ export default class ScheduledPaymentCard extends Component<Signature> {
   @tracked isCancelPaymentModalOpen = false;
   @tracked cancelationErrorMessage?: string;
 
-  @action closeCancelScheduledPaymentModal() {
+  @action closeCancelScheduledPaymentModal(reload = false) {
     this.isCancelPaymentModalOpen = false;
+    if (reload) this.args.reloadScheduledPayments();
   }
 
   get tokenInfo() {
@@ -105,7 +107,7 @@ export default class ScheduledPaymentCard extends Component<Signature> {
           <img class="scheduled-payment-card__token-symbol" src={{this.tokenInfo.logoURI}} />
           <div class="scheduled-payment-card__token-amounts">
             <span class="scheduled-payment-card__token-amount">{{weiToDecimal @scheduledPayment.amount this.tokenInfo.decimals}} {{this.tokenInfo.symbol}}</span>
-            <span class="scheduled-payment-card__usd-amount">$ <TokenToUsd @tokenAddress={{@scheduledPayment.tokenAddress}} @tokenAmount={{@scheduledPayment.amount}} /> USD</span> 
+            <span class="scheduled-payment-card__usd-amount">$ <TokenToUsd @tokenAddress={{@scheduledPayment.tokenAddress}} @tokenAmount={{@scheduledPayment.amount}} /> USD</span>
           </div>
         </div>
       </div>
@@ -158,7 +160,7 @@ export default class ScheduledPaymentCard extends Component<Signature> {
                 Cancel Payment
               </a.ActionButton>
 
-              <a.CancelButton {{on 'click' this.closeCancelScheduledPaymentModal}} data-test-close-cancel-payment-modal>
+              <a.CancelButton {{on 'click' (fn this.closeCancelScheduledPaymentModal false)}} data-test-close-cancel-payment-modal>
                 Close
               </a.CancelButton>
 
@@ -167,7 +169,7 @@ export default class ScheduledPaymentCard extends Component<Signature> {
                 <span>{{this.cancelationErrorMessage}}</span>
               </a.InfoArea>
             {{else if this.paymentCanceled}}
-              <a.ActionButton {{on "click" this.closeCancelScheduledPaymentModal}} data-test-close-cancel-payment-modal>
+              <a.ActionButton {{on "click" (fn this.closeCancelScheduledPaymentModal true)}} data-test-close-cancel-payment-modal>
                 Close
               </a.ActionButton>
 
@@ -179,7 +181,7 @@ export default class ScheduledPaymentCard extends Component<Signature> {
               <a.ActionButton {{on "click" this.cancelScheduledPayment}} data-test-cancel-payment-button>
                 Cancel Payment
               </a.ActionButton>
-              <a.CancelButton {{on 'click' this.closeCancelScheduledPaymentModal}} data-test-close-cancel-payment-modal>
+              <a.CancelButton {{on 'click' (fn this.closeCancelScheduledPaymentModal false)}} data-test-close-cancel-payment-modal>
                 Close
               </a.CancelButton>
             {{/if}}

--- a/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-time-bracket/index.gts
+++ b/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-time-bracket/index.gts
@@ -12,7 +12,8 @@ interface Signature {
   Element: HTMLElement;
   Args: {
     title: string;
-    scheduledPayments: ScheduledPayment[]; 
+    scheduledPayments: ScheduledPayment[];
+    reloadScheduledPayments: () => void;
   }
 }
 
@@ -22,7 +23,7 @@ export default class ScheduledPaymentTimeBracket extends Component<Signature> {
       <BoxelCardContainer class="scheduled-payment-time-bracket" data-test-time-bracket={{@title}}>
         <BoxelHeader @header={{@title}} @noBackground={{true}}/>
         {{#each @scheduledPayments as |scheduledPayment|}}
-          <ScheduledPaymentCard @scheduledPayment={{scheduledPayment}}/>
+          <ScheduledPaymentCard @scheduledPayment={{scheduledPayment}} @reloadScheduledPayments={{@reloadScheduledPayments}} />
         {{/each}}
       </BoxelCardContainer>
     {{/if}}

--- a/packages/safe-tools-client/app/components/icons/info.gts
+++ b/packages/safe-tools-client/app/components/icons/info.gts
@@ -1,0 +1,22 @@
+import Component from '@glimmer/component';
+import { svgJar } from '@cardstack/boxel/utils/svg-jar';
+import cssVar from '@cardstack/boxel/helpers/css-var';
+
+interface Signature {
+  Element: HTMLElement;
+  Args: {
+  };
+}
+
+export default class InfoIcon extends Component<Signature> {
+  <template>
+    <div ...attributes>
+      {{svgJar
+        'info'
+        style=(cssVar
+          icon-color='var(--boxel-light)'
+        )
+      }}
+    </div>
+  </template>
+}

--- a/packages/safe-tools-client/tests/acceptance/safe-create-test.ts
+++ b/packages/safe-tools-client/tests/acceptance/safe-create-test.ts
@@ -3,6 +3,7 @@ import SafesService, {
   Safe,
   TokenBalance,
 } from '@cardstack/safe-tools-client/services/safes';
+import ScheduledPaymentsService from '@cardstack/safe-tools-client/services/scheduled-payments';
 import SchedulePaymentSDKService from '@cardstack/safe-tools-client/services/scheduled-payments-sdk';
 import WalletService from '@cardstack/safe-tools-client/services/wallet';
 import { click, visit, waitFor, TestContext } from '@ember/test-helpers';
@@ -70,6 +71,14 @@ module('Acceptance | create safe', function (hooks) {
           isNativeToken: true,
         } as unknown as TokenBalance,
       ]);
+    };
+
+    const scheduledPaymentsService = this.owner.lookup(
+      'service:scheduled-payments'
+    ) as ScheduledPaymentsService;
+
+    scheduledPaymentsService.fetchScheduledPayments = (): Promise<[]> => {
+      return Promise.resolve([]);
     };
   });
 

--- a/packages/safe-tools-client/tests/acceptance/scheduling-test.ts
+++ b/packages/safe-tools-client/tests/acceptance/scheduling-test.ts
@@ -101,6 +101,14 @@ module('Acceptance | scheduling', function (hooks) {
           })
         );
       }),
+      rest.get('/hub-test/api/scheduled-payments', (_req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            data: [],
+          })
+        );
+      }),
       rest.post('/hub-test/api/gas-estimation', (_req, res, ctx) => {
         return res(
           ctx.status(200),

--- a/packages/safe-tools-client/tests/acceptance/wallet-connection-test.ts
+++ b/packages/safe-tools-client/tests/acceptance/wallet-connection-test.ts
@@ -4,6 +4,7 @@ import SafesService, {
   Safe,
   TokenBalance,
 } from '@cardstack/safe-tools-client/services/safes';
+import ScheduledPaymentsService from '@cardstack/safe-tools-client/services/scheduled-payments';
 
 import {
   click,
@@ -66,6 +67,14 @@ module('Acceptance | wallet connection', function (hooks) {
           return Promise.resolve(true);
         },
       });
+    };
+
+    const scheduledPaymentsService = this.owner.lookup(
+      'service:scheduled-payments'
+    ) as ScheduledPaymentsService;
+
+    scheduledPaymentsService.fetchScheduledPayments = (): Promise<[]> => {
+      return Promise.resolve([]);
     };
   });
 

--- a/packages/safe-tools-client/tests/integration/future-payments-list-test.ts
+++ b/packages/safe-tools-client/tests/integration/future-payments-list-test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
+import ScheduledPaymentsService from '@cardstack/safe-tools-client/services/scheduled-payments';
 import SchedulePaymentSDKService from '@cardstack/safe-tools-client/services/scheduled-payments-sdk';
 import Service from '@ember/service';
 import { render, click, TestContext } from '@ember/test-helpers';
@@ -8,7 +9,6 @@ import {
   setupFakeDateService,
   FakeDateService,
 } from 'ember-date-service/test-support';
-
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
 
@@ -222,14 +222,27 @@ module('Integration | Component | future-payments-list', function (hooks) {
     await click('[data-test-scheduled-payment-card-options-button]');
     await click('[data-test-boxel-menu-item-text="Cancel Payment"]');
     await click('[data-test-cancel-payment-button]');
+
     assert
       .dom('[data-test-cancel-scheduled-payment-modal]')
       .includesText(
         "Your scheduled payment was canceled and removed successfully, and it won't be attempted in the future."
       );
     assert.dom('[data-test-cancel-payment-button]').doesNotExist();
+
+    // On cancel, the handler calls refreshScheduledPayments (to remove the newly canceled payment) which reads stubbed scheduled payment values from this test.
+    // To test if the list reloaded after canceling a payment we simply change the stubbed values to return no payments and assert that the list is empty, which confirms that the list reloaded.
+    const scheduledPaymentsService = this.owner.lookup(
+      'service:scheduled-payments'
+    ) as ScheduledPaymentsService;
+
+    scheduledPaymentsService.fetchScheduledPayments = (): Promise<[]> => {
+      return Promise.resolve([]);
+    };
+
     await click('[data-test-close-cancel-payment-modal]');
     assert.dom('[data-test-cancel-scheduled-payment-modal]').doesNotExist();
+    assert.dom('[data-test-scheduled-payment-card]').doesNotExist(); // Because we stubbed fetchScheduledPayments to return no payments
   });
 
   test('it shows an error when canceling fails', async function (assert) {


### PR DESCRIPTION
This PR will reload the payments list after cancelling a scheduled payment. This is so that the canceled payment won't be in the "future payments" list anymore.

Another improvement is adding a message explaining that this action could take minutes (due to waiting for confirmation):
<img width="568" alt="image" src="https://user-images.githubusercontent.com/273660/211601220-83eb75a3-1ebf-4f8f-ac93-43b1655be555.png">

