### PR TITLE
safe client: reload payments list after scheduling a payment

### DIFF
--- a/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.gts
+++ b/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.gts
@@ -105,7 +105,7 @@ export default class ScheduledPaymentCard extends Component<Signature> {
     <BoxelCardContainer
       @displayBoundaries={{true}}
       class="scheduled-payment-card">
-      <div class="scheduled-payment-card__content" data-test-scheduled-payment-card>
+      <div class="scheduled-payment-card__content" data-test-scheduled-payment-card data-test-scheduled-payment-card-id={{@scheduledPayment.id}}>
         <span class="scheduled-payment-card__pay-at">{{this.paymentType}} on {{formatDate @scheduledPayment.payAt "d/M/yyyy"}}</span>
         <span class="scheduled-payment-card__payee">To: {{truncateMiddle @scheduledPayment.payeeAddress}}</span>
         <div class="scheduled-payment-card__payment-detail">

--- a/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.gts
+++ b/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.gts
@@ -22,13 +22,12 @@ import SuccessIcon from '@cardstack/safe-tools-client/components/icons/success';
 import FailureIcon from '@cardstack/safe-tools-client/components/icons/failure';
 import InfoIcon from '@cardstack/safe-tools-client/components/icons/info';
 import BoxelDropdown from '@cardstack/boxel/components/boxel/dropdown';
-
 import BoxelMenu from '@cardstack/boxel/components/boxel/menu';
 import { type ActionChinState } from '@cardstack/boxel/components/boxel/action-chin/state'
 import menuItem from '@cardstack/boxel/helpers/menu-item'
 import { array, fn } from '@ember/helper';
 import set from 'ember-set-helper/helpers/set';
-
+import ScheduledPaymentsService from '@cardstack/safe-tools-client/services/scheduled-payments';
 import { TaskGenerator } from 'ember-concurrency';
 import { task } from 'ember-concurrency-decorators';
 import * as Sentry from '@sentry/browser';
@@ -39,26 +38,27 @@ interface Signature {
   Element: HTMLElement;
   Args: {
     scheduledPayment: ScheduledPayment;
-    reloadScheduledPayments: () => void;
   }
 }
 
 export default class ScheduledPaymentCard extends Component<Signature> {
   @service declare scheduledPaymentsSdk: ScheduledPaymentsSdkService;
+  @service declare scheduledPayments: ScheduledPaymentsService;
   @service declare hubAuthentication: HubAuthenticationService;
   @service declare tokens: TokensService;
   @tracked optionsMenuOpened = false;
   @tracked isCancelPaymentModalOpen = false;
   @tracked cancelationErrorMessage?: string;
 
-  @action closeCancelScheduledPaymentModal(reload = false) {
+  @action closeCancelScheduledPaymentModal(reload: boolean) {
     this.isCancelPaymentModalOpen = false;
-    if (reload) this.args.reloadScheduledPayments();
+    if (reload) this.scheduledPayments.reloadScheduledPayments();
   }
 
   get tokenInfo() {
     let tokens = this.tokens.transactionTokens;
-    let token = tokens.find(token => token.address === this.args.scheduledPayment.tokenAddress)
+    let token = tokens.find(token => token.address === this.args.scheduledPayment.tokenAddress);
+
     if (!token) {
       throw new Error('unknown transfer token');
     }

--- a/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-time-bracket/index.gts
+++ b/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-time-bracket/index.gts
@@ -13,7 +13,6 @@ interface Signature {
   Args: {
     title: string;
     scheduledPayments: ScheduledPayment[];
-    reloadScheduledPayments: () => void;
   }
 }
 
@@ -26,7 +25,7 @@ export default class ScheduledPaymentTimeBracket extends Component<Signature> {
         {{/if}}
 
         {{#each @scheduledPayments as |scheduledPayment|}}
-          <ScheduledPaymentCard @scheduledPayment={{scheduledPayment}} @reloadScheduledPayments={{@reloadScheduledPayments}} />
+          <ScheduledPaymentCard @scheduledPayment={{scheduledPayment}} />
         {{/each}}
       </BoxelCardContainer>
     {{/if}}

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
@@ -22,6 +22,7 @@ import { taskFor } from 'ember-concurrency-ts';
 import { BigNumber } from 'ethers';
 import { task } from 'ember-concurrency-decorators';
 import perform from 'ember-concurrency/helpers/perform';
+import ScheduledPaymentsService from '@cardstack/safe-tools-client/services/scheduled-payments';
 
 interface Signature {
   Element: HTMLElement;
@@ -39,6 +40,7 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
   @service declare safes: SafesService;
   @service declare tokens: TokensService;
   @service declare scheduledPaymentsSdk: ScheduledPaymentsSdkService;
+  @service('scheduled-payments') declare scheduledPaymentsService: ScheduledPaymentsService;
   validator = new SchedulePaymentFormValidator(this);
   gasEstimation?: GasEstimationResult;
   lastScheduledPaymentId?: string;
@@ -305,7 +307,9 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
         }
       }
     )
+
     this.isSuccessfullyScheduled = true;
+    this.scheduledPaymentsService.reloadScheduledPayments();
   }
 
   @action resetForm() {

--- a/packages/safe-tools-client/tests/integration/future-payments-list-test.ts
+++ b/packages/safe-tools-client/tests/integration/future-payments-list-test.ts
@@ -35,7 +35,8 @@ let returnScheduledPaymentsUntilTomorrow = false;
 let returnOnlyLaterScheduledPayments = false;
 let dateService: FakeDateService;
 
-class ScheduledPaymentsStub extends Service {
+class ScheduledPaymentsStub extends ScheduledPaymentsService {
+  // @ts-expect-error - we're overriding this method for testing purposes
   fetchScheduledPayments = (chainId: number, minPayAt?: Date) => {
     if (returnEmptyScheduledPayments || !minPayAt) {
       return Promise.resolve([]);


### PR DESCRIPTION
Ticket: CS-5062

Reloads the future payments after scheduling so that the newly scheduled payment will appear there. 