### PR TITLE
safe tools client: Increase day of month recurring max range from 28 to 31

### DIFF
--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.css
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.css
@@ -70,3 +70,13 @@
 .schedule-payment-form-action-card__in-progress-message {
   max-width: 20rem;
 }
+
+.schedule-payment-form-action-card__recurring-explanation {
+  font: var(--boxel-font-xs);
+  color: var(--boxel-purple-400);
+  margin: var(--boxel-sp-xs) 0 var(--boxel-sp-sm) 0;
+}
+
+.schedule-payment-form-action-card__recurring-explanation svg {
+  margin-right: var(--boxel-sp-xxxs);
+}

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.gts
@@ -176,7 +176,7 @@ export default class SchedulePaymentFormActionCardUI extends Component<Signature
                       <BoxelField @label="Day of Month" @vertical={{true}} data-test-recurring-day-of-month>
                         <RangedNumberPicker
                           @min={{1}}
-                          @max={{28}}
+                          @max={{31}}
                           @icon="calendar"
                           @onChange={{@onSelectPaymentDayOfMonth}}
                           @value={{@paymentDayOfMonth}}

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.gts
@@ -184,6 +184,12 @@ export default class SchedulePaymentFormActionCardUI extends Component<Signature
                           data-test-input-recurring-day-of-month
                         />
                       </BoxelField>
+
+                      <div class="schedule-payment-form-action-card__recurring-explanation">
+                        {{svgJar "info" width="12px" height="12px"}}
+                        <span> To perform payments on the last day of the month, choose 31st.</span>
+                      </div>
+
                       <BoxelField @label="Until" @vertical={{true}} data-test-recurring-until>
                         <BoxelInputDate
                           @value={{@monthlyUntil}}
@@ -329,7 +335,7 @@ export default class SchedulePaymentFormActionCardUI extends Component<Signature
             </ac.InfoArea>
           </:memorialized>
         </ActionChin>
-    </BoxelActionContainer>    
+    </BoxelActionContainer>
   </template>
 }
 


### PR DESCRIPTION
To make it a bit more intuitive I think we can increase the range to 31. 

There's the obvious problem of months having different amount of days but we are handling this in the hub where the [calculateNextPayAt](https://github.com/cardstack/cardstack/blob/main/packages/hub/utils/scheduled-payments.ts#L6) function will adjust this for every month. So in case the user chooses 31st, the payment will be performed on the last day of months that have fewer days. Same for 30 and 29. I think this way is better so that we can allow users to execute payments on the actual last day of month and not on 28th as the maximum available day. 

This behaviour is pretty nicely covered in [tests](https://github.com/cardstack/cardstack/blob/main/packages/hub/node-tests/utils/scheduled-payments-test.ts).

<img width="311" alt="image" src="https://user-images.githubusercontent.com/273660/211852094-91a53b95-9e5a-42e2-9550-159f1ff011a8.png">




