### PR TITLE
Improve messaging when errors occurr on scheduled payment form

### DIFF
--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
@@ -355,15 +355,24 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
       this.isSuccessfullyScheduled = true;
     } catch(e) {
       this.schedulingStatus = undefined;
-      let message = e.message || "An error occurred";
+
+      const knownErrorPatterns: Record<string, string> = {
+        'NotEnoughFundsForMultisigTx': 'Your safe does not have enough funds to pay for the transaction. Please add more funds to your safe and try again.',
+      }
+
+      let message = "An error occurred. Please reload the page and try again. If the problem persists, please contact support.";
+
       try {
-        let parsed = JSON.parse(message);
-        if (parsed.exception) {
-          message = `An error occurred: ${parsed.exception}`;
+        let parsed = JSON.parse(e.message);
+
+        let errorKey = Object.keys(knownErrorPatterns).find((key) => { return parsed.exception.includes(key) });
+        if (errorKey) {
+          message = knownErrorPatterns[errorKey];
         }
       } catch (e) {
         // the message wasn't valid JSON
       }
+
       this.scheduleErrorMessage = message;
 
     }

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
@@ -16,6 +16,7 @@ import SchedulePaymentFormValidator, { MaxGasFeeOption, ValidatableForm } from '
 import { use, resource } from 'ember-resources';
 import { TrackedObject } from 'tracked-built-ins';
 import { fromWei } from 'web3-utils';
+import and from 'ember-truth-helpers/helpers/and';
 import not from 'ember-truth-helpers/helpers/not';
 import { convertAmountToNativeDisplay, TransactionHash } from '@cardstack/cardpay-sdk';
 import { taskFor } from 'ember-concurrency-ts';
@@ -438,7 +439,7 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
       @maxGasPriceErrorMessage={{this.validator.maxGasPriceErrorMessage}}
       @onSchedulePayment={{perform this.schedulePaymentTask}}
       @maxGasDescriptions={{this.maxGasDescriptions}}
-      @isSubmitEnabled={{this.isValid}}
+      @isSubmitEnabled={{and this.isValid (not this.maxGasDescriptions.isLoading)}}
       @schedulingStatus={{this.schedulingStatus}}
       @networkSymbol={{this.network.symbol}}
       @walletProviderId={{this.wallet.providerId}}

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.css
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.css
@@ -43,7 +43,8 @@
   color: var(--boxel-purple-400);
   display: flex;
 }
-.schedule-payment-form-action-card--state-details__error {
+
+.schedule-payment-form-action-card-error {
   color: var(--boxel-red);
 }
 

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.css
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.css
@@ -13,7 +13,8 @@
   --boxel-field-label-align: center;
 }
 
-.schedule-payment-form-action-card .boxel-field.schedule-payment-form-action-card__frequency {
+.schedule-payment-form-action-card
+  .boxel-field.schedule-payment-form-action-card__frequency {
   --boxel-field-label-align: top;
   --boxel-field-label-padding-top: var(--boxel-sp-lg);
 }
@@ -33,6 +34,17 @@
   font: var(--boxel-font-xs);
   color: var(--boxel-purple-400);
   display: flex;
+}
+
+.schedule-payment-form-action-card--state-details {
+  padding-top: var(--boxel-sp);
+  padding-right: var(--boxel-sp);
+  font: var(--boxel-font-xs);
+  color: var(--boxel-purple-400);
+  display: flex;
+}
+.schedule-payment-form-action-card--state-details__error {
+  color: var(--boxel-red);
 }
 
 .schedule-payment-form-action-card--fee-info-icon {
@@ -65,6 +77,10 @@
   margin-right: var(--boxel-sp-xs);
   flex-grow: 0;
   flex-shrink: 0;
+}
+
+.schedule-payment-form-action-card__error-message {
+  color: var(--boxel-red);
 }
 
 .schedule-payment-form-action-card__in-progress-message {

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.gts
@@ -31,6 +31,7 @@ import formatUsd from '@cardstack/safe-tools-client/helpers/format-usd';
 import WalletService from '@cardstack/safe-tools-client/services/wallet';
 import { inject as service } from '@ember/service';
 import { MaxGasDescriptionsState } from "..";
+import FailureIcon from '@cardstack/safe-tools-client/components/icons/failure';
 
 interface Signature {
   Element: HTMLElement;
@@ -274,7 +275,13 @@ export default class SchedulePaymentFormActionCardUI extends Component<Signature
                 Normal
               </div>
               <div class="schedule-payment-form-action-card--max-gas-fee-description" data-test-max-gas-fee-normal-description>
-                {{@maxGasDescriptions.value.normal}}
+                {{#if @maxGasDescriptions.isLoading}}
+                  Loading gas price...
+                {{else if @maxGasDescriptions.error}}
+                  <span class="schedule-payment-form-action-card-error">Can't estimate gas price</span>
+                {{else}}
+                  {{@maxGasDescriptions.value.normal}}
+                {{/if}}
               </div>
             </group.Button>
             <group.Button @value="high">
@@ -282,7 +289,13 @@ export default class SchedulePaymentFormActionCardUI extends Component<Signature
                 High
               </div>
               <div class="schedule-payment-form-action-card--max-gas-fee-description" data-test-max-gas-fee-high-description>
-                {{@maxGasDescriptions.value.high}}
+                {{#if @maxGasDescriptions.isLoading}}
+                  Loading gas price...
+                {{else if @maxGasDescriptions.error}}
+                  <span class="schedule-payment-form-action-card-error">Can't estimate gas price</span>
+                {{else}}
+                  {{@maxGasDescriptions.value.high}}
+                {{/if}}
               </div>
             </group.Button>
             <group.Button @value="max">
@@ -290,18 +303,20 @@ export default class SchedulePaymentFormActionCardUI extends Component<Signature
                 Max
               </div>
               <div class="schedule-payment-form-action-card--max-gas-fee-description" data-test-max-gas-fee-max-description>
-                {{@maxGasDescriptions.value.max}}
+                {{#if @maxGasDescriptions.isLoading}}
+                  Loading gas price...
+                {{else if @maxGasDescriptions.error}}
+                  <span class="schedule-payment-form-action-card-error">Can't estimate gas price</span>
+                {{else}}
+                  {{@maxGasDescriptions.value.max}}
+                {{/if}}
               </div>
             </group.Button>
           </BoxelToggleButtonGroup>
           <div><!-- empty --></div>
-          <div class="schedule-payment-form-action-card--state-details {{if @maxGasDescriptions.error "schedule-payment-form-action-card--state-details__error"}}">
-            {{#if @maxGasDescriptions.isLoading}}
-              <BoxelLoadingIndicator />
-            {{/if}}
-
+          <div class="schedule-payment-form-action-card--state-details {{if @maxGasDescriptions.error "schedule-payment-form-action-card-error"}}">
             {{#if @maxGasDescriptions.error}}
-              There was an error estimating gas prices: {{@maxGasDescriptions.error.message}}
+              There was an error estimating gas prices. Please reload the page and try again. If the error persists, please contact support.
             {{/if}}
           </div>
           <div><!-- empty --></div>
@@ -326,6 +341,7 @@ export default class SchedulePaymentFormActionCardUI extends Component<Signature
               </ac.ActionButton>
               {{#if @scheduleErrorMessage}}
                 <ac.InfoArea data-test-error-status>
+                  <FailureIcon class='action-chin-info-icon' />
                   <span class="schedule-payment-form-action-card__error-message">
                     {{@scheduleErrorMessage}}
                   </span>

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.gts
@@ -21,7 +21,7 @@ import not from 'ember-truth-helpers/helpers/not';
 import or from 'ember-truth-helpers/helpers/or';
 import set from 'ember-set-helper/helpers/set';
 import './index.css';
-import { MaxGasFeeOption, ValidatableForm } from '../validator';
+import { ValidatableForm } from '../validator';
 import BlockExplorerButton from '@cardstack/safe-tools-client/components/block-explorer-button';
 import { SchedulerCapableNetworks, TransactionHash } from '@cardstack/cardpay-sdk';
 import cssVar from '@cardstack/boxel/helpers/css-var';

--- a/packages/safe-tools-client/app/services/scheduled-payment-sdk.ts
+++ b/packages/safe-tools-client/app/services/scheduled-payment-sdk.ts
@@ -152,30 +152,26 @@ export default class SchedulePaymentSDKService extends Service {
     recurringUntil: number | null,
     listener: SchedulePaymentProgressListener
   ): TaskGenerator<void> {
-    try {
-      const scheduledPaymentModule: ScheduledPaymentModule =
-        yield this.getSchedulePaymentModule();
-      yield scheduledPaymentModule.schedulePayment(
-        safeAddress,
-        moduleAddress,
-        tokenAddress,
-        amount.toString(),
-        payeeAddress,
-        executionGas,
-        maxGasPrice,
-        gasTokenAddress,
-        salt,
-        payAt,
-        recurringDayOfMonth,
-        recurringUntil,
-        {
-          hubUrl: config.hubUrl,
-          listener,
-        }
-      );
-    } catch (err) {
-      console.error(err);
-    }
+    const scheduledPaymentModule: ScheduledPaymentModule =
+      yield this.getSchedulePaymentModule();
+    yield scheduledPaymentModule.schedulePayment(
+      safeAddress,
+      moduleAddress,
+      tokenAddress,
+      amount.toString(),
+      payeeAddress,
+      executionGas,
+      maxGasPrice,
+      gasTokenAddress,
+      salt,
+      payAt,
+      recurringDayOfMonth,
+      recurringUntil,
+      {
+        hubUrl: config.hubUrl,
+        listener,
+      }
+    );
   }
 
   async cancelScheduledPayment(

--- a/packages/safe-tools-client/tests/acceptance/scheduling-test.ts
+++ b/packages/safe-tools-client/tests/acceptance/scheduling-test.ts
@@ -1,3 +1,4 @@
+import { delay } from '@cardstack/cardpay-sdk';
 import { Deferred } from '@cardstack/ember-shared';
 import SafesService, {
   TokenBalance,
@@ -11,6 +12,7 @@ import {
   visit,
   waitFor,
   waitUntil,
+  settled,
 } from '@ember/test-helpers';
 import { addDays } from 'date-fns';
 import { TransactionReceipt } from 'eth-testing/lib/json-rpc-methods-types';
@@ -376,6 +378,9 @@ module('Acceptance | scheduling', function (hooks) {
         )?.textContent?.trim().length;
       });
 
+      await settled();
+      await delay(500); // This shouldn't be necessary but is for some reason
+      assert.dom(SUBMIT_BUTTON).isNotDisabled();
       await click(SUBMIT_BUTTON);
       assert.dom(IN_PROGRESS_MESSAGE).hasText('Authenticating...');
       assert.dom(PAYEE_INPUT).isDisabled();
@@ -500,6 +505,10 @@ module('Acceptance | scheduling', function (hooks) {
           '[data-test-max-gas-fee-normal-description]'
         )?.textContent?.trim().length;
       });
+
+      await settled();
+      await delay(500); // This shouldn't be necessary but is for some reason
+      assert.dom(SUBMIT_BUTTON).isNotDisabled();
 
       await click(SUBMIT_BUTTON);
       assert.dom(IN_PROGRESS_MESSAGE).hasText('Authenticating...');

--- a/packages/safe-tools-client/tests/acceptance/scheduling-test.ts
+++ b/packages/safe-tools-client/tests/acceptance/scheduling-test.ts
@@ -1,4 +1,3 @@
-import { delay } from '@cardstack/cardpay-sdk';
 import { Deferred } from '@cardstack/ember-shared';
 import SafesService, {
   TokenBalance,
@@ -12,7 +11,6 @@ import {
   visit,
   waitFor,
   waitUntil,
-  settled,
 } from '@ember/test-helpers';
 import { addDays } from 'date-fns';
 import { TransactionReceipt } from 'eth-testing/lib/json-rpc-methods-types';

--- a/packages/safe-tools-client/tests/acceptance/scheduling-test.ts
+++ b/packages/safe-tools-client/tests/acceptance/scheduling-test.ts
@@ -372,15 +372,7 @@ module('Acceptance | scheduling', function (hooks) {
       ]);
       await waitFor(`[data-test-safe-address-label][title="${SAFE_ADDRESS}"]`);
       await fillInSchedulePaymentFormWithValidInfo({ type: 'one-time' });
-      await waitUntil(() => {
-        return find(
-          '[data-test-max-gas-fee-normal-description]'
-        )?.textContent?.trim().length;
-      });
-
-      await settled();
-      await delay(500); // This shouldn't be necessary but is for some reason
-      assert.dom(SUBMIT_BUTTON).isNotDisabled();
+      await waitFor(`${SUBMIT_BUTTON}:not(:disabled)`);
       await click(SUBMIT_BUTTON);
       assert.dom(IN_PROGRESS_MESSAGE).hasText('Authenticating...');
       assert.dom(PAYEE_INPUT).isDisabled();
@@ -499,16 +491,10 @@ module('Acceptance | scheduling', function (hooks) {
         FAKE_WALLET_CONNECT_ACCOUNT,
       ]);
       await waitFor(`[data-test-safe-address-label][title="${SAFE_ADDRESS}"]`);
-      await fillInSchedulePaymentFormWithValidInfo({ type: 'monthly' });
-      await waitUntil(() => {
-        return find(
-          '[data-test-max-gas-fee-normal-description]'
-        )?.textContent?.trim().length;
-      });
 
-      await settled();
-      await delay(500); // This shouldn't be necessary but is for some reason
-      assert.dom(SUBMIT_BUTTON).isNotDisabled();
+      await fillInSchedulePaymentFormWithValidInfo({ type: 'monthly' });
+
+      await waitFor(`${SUBMIT_BUTTON}:not(:disabled)`);
 
       await click(SUBMIT_BUTTON);
       assert.dom(IN_PROGRESS_MESSAGE).hasText('Authenticating...');


### PR DESCRIPTION
CS-5082

1. Show error if scheduling the payment fails for any reason:
<img width="835" alt="image" src="https://user-images.githubusercontent.com/93225030/211844843-36351d4d-fa82-446a-9324-f357d8d6f3d8.png">

2. Show error if gas estimation fails:
<img width="841" alt="image" src="https://user-images.githubusercontent.com/93225030/211844879-3ef55d38-b2ca-4bff-88ac-496c912751f2.png">

3. Show a loading indicator when gas estimation is in progress:
<img width="763" alt="image" src="https://user-images.githubusercontent.com/93225030/211844951-56c893f7-66bf-4af4-b10e-efa4a5ff24a6.png">


