### PR TITLE
Add missing HUB_URL env var to safe tools deployments

### DIFF
--- a/.github/workflows/manual-safe-tools-client.yml
+++ b/.github/workflows/manual-safe-tools-client.yml
@@ -20,6 +20,18 @@ jobs:
       - uses: ./.github/actions/setup-node-modules-cache
         with:
           yarn_lock_md5: ${{ hashFiles('yarn.lock') }}
+      - name: Set up env
+        env:
+          INPUT_ENVIRONMENT: ${{ github.event.inputs.environment }}
+        run: |
+          if [ "$INPUT_ENVIRONMENT" = "production" ]; then
+            echo "HUB_URL=https://hub.cardstack.com" >> $GITHUB_ENV
+          elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
+            echo "HUB_URL=https://hub-staging.stack.cards" >> $GITHUB_ENV
+          else
+            echo "unrecognized environment"
+            exit 1;
+          fi
 
       - name: Deploy safe-tools-client
         uses: ./.github/actions/deploy-safe-tools-client

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -418,3 +418,4 @@ jobs:
           discord_webhook: ${{ secrets.DISCORD_WEBHOOK }}
         env:
           SENTRY_DSN: ${{ secrets.SAFE_TOOLS_CLIENT_SENTRY_DSN }}
+          HUB_URL: https://hub-staging.stack.cards


### PR DESCRIPTION
The issue is that safe tools client is making requests to the hub with a broken and very wrong url:

<img width="991" alt="image" src="https://user-images.githubusercontent.com/273660/213438634-61037c80-ee11-4956-8f85-6066f34266a0.png">

It turns out `HUB_URL` is missing in the environment vars, which makes `hubUrl` undefined (`hubUrl: process.env.HUB_URL` in environment.js  
