### PR TITLE
Fix issue where completed state of scheduler form shown two buttons atop each other

### DIFF
--- a/packages/boxel/addon/components/boxel/action-chin/index.css
+++ b/packages/boxel/addon/components/boxel/action-chin/index.css
@@ -90,9 +90,10 @@
   grid-area: info;
 
   /*
-  some defaults so that people can simply enter text
+  some defaults so that people can simply enter text or buttons
   if they want to supply more complex content they should be able to overwrite it
   */
+  column-gap: var(--boxel-sp-xs);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.gts
@@ -437,16 +437,14 @@ export default class SchedulePaymentFormActionCardUI extends Component<Signature
           <ac.ActionStatusArea data-test-memorialized-status>
             Payment was successfully scheduled
           </ac.ActionStatusArea>
-          {{#if @txHash}}
-            <ac.InfoArea>
+          <ac.InfoArea>
+            {{#if @txHash}}
               <BlockExplorerButton
                 @networkSymbol={{@networkSymbol}}
                 @transactionHash={{@txHash}}
-                @kind="secondary-dark"
+                @kind="secondary-light"
               />
-            </ac.InfoArea>
-          {{/if}}
-          <ac.InfoArea>
+            {{/if}}
             <BoxelButton
               @kind="secondary-light"
               data-test-schedule-payment-form-reset-button

--- a/packages/safe-tools-client/tests/acceptance/scheduling-test.ts
+++ b/packages/safe-tools-client/tests/acceptance/scheduling-test.ts
@@ -468,13 +468,13 @@ module('Acceptance | scheduling', function (hooks) {
         .containsText('Payment was successfully scheduled');
       assert.dom(PAYEE_INPUT).isDisabled();
 
-      await click('[data-test-schedule-payment-form-reset-button]');
-      assert.dom(PAYEE_INPUT).isNotDisabled();
-      assert.dom(SUBMIT_BUTTON).hasText('Schedule Payment');
-
       // Make sure the newly created payment appears in the list of future scheduled payments
       await waitFor('[data-test-scheduled-payment-card-id="123"]');
       assert.dom('[data-test-scheduled-payment-card-id="123"]').exists();
+
+      await click('[data-test-schedule-payment-form-reset-button]');
+      assert.dom(PAYEE_INPUT).isNotDisabled();
+      assert.dom(SUBMIT_BUTTON).hasText('Schedule Payment');
     });
   });
 


### PR DESCRIPTION
Fixed:

<img width="859" alt="image" src="https://user-images.githubusercontent.com/353/213507992-3ea1666e-346f-492c-8062-afa07b2d143b.png">
