### PR TITLE
safe tools: Fix wrongly formatted "pay at" filter

### DIFF
--- a/packages/safe-tools-client/app/services/scheduled-payments.ts
+++ b/packages/safe-tools-client/app/services/scheduled-payments.ts
@@ -213,9 +213,7 @@ export default class ScheduledPaymentsService extends Service {
   ): Promise<ScheduledPayment[]> {
     let queryString = `filter[chain-id]=${chainId}`;
     if (minPayAt) {
-      queryString += `&filter[payAt][gt]=${Math.round(
-        minPayAt.getTime() / 1000
-      )}`;
+      queryString += `&filter[pay-at][gt]=${new Date().toISOString()}`;
     }
     const response = await hubRequest(
       config.hubUrl,


### PR DESCRIPTION
Ticket: CS-5152

The area where we noticed this problem was the "Future payments" which kept showing payments that were already executed. The filtering mechanism for this is: "fetch payments with payAt larger than the current time". 

The bug that broke this came in 2 parts:
- Should be `filter[pay-at][gt]` and not `filter[payAt][gt]`
- Hub expects ISO formatted time values (e.g. `'2023-01-20T10:12:43.707Z'`). This is a more verbose alternative to unix timestamps but so much better for human readability and debugging.