### PR TITLE
hub: Ensure payments are executed at least 1min after payAt (defense against block time manipulation)

### DIFF
--- a/packages/hub/node-tests/routes/data-integrity-checks-test.ts
+++ b/packages/hub/node-tests/routes/data-integrity-checks-test.ts
@@ -1,3 +1,4 @@
+import cryptoRandomString from 'crypto-random-string';
 import { subMinutes } from 'date-fns';
 import shortUuid from 'short-uuid';
 import { CREATION_WITHOUT_TX_HASH_ALLOWED_MINUTES } from '../../services/data-integrity-checks/scheduled-payments';
@@ -50,7 +51,7 @@ describe('GET /api/data-integrity-checks/scheduled-payments', async function () 
         feePercentage: '0',
         salt: '54lt',
         payAt: nowUtc(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: null,

--- a/packages/hub/node-tests/routes/scheduled-payments-test.ts
+++ b/packages/hub/node-tests/routes/scheduled-payments-test.ts
@@ -711,7 +711,7 @@ describe('PATCH /api/scheduled-payments/:id', async function () {
   it('updates a scheduled payment when creation transaction hash is provided', async function () {
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -783,7 +783,7 @@ describe('PATCH /api/scheduled-payments/:id', async function () {
   it('updates a scheduled payment when cancelation transaction hash is provided', async function () {
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -887,7 +887,7 @@ describe('DELETE /api/scheduled-payments/:id', async function () {
   it('deletes a scheduled payment', async function () {
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',

--- a/packages/hub/node-tests/services/data-integrity-checks-test.ts
+++ b/packages/hub/node-tests/services/data-integrity-checks-test.ts
@@ -9,6 +9,7 @@ import DataIntegrityChecksScheduledPayments, {
   CANCELATION_UNMINED_ALLOWED_MINUTES,
 } from '../../services/data-integrity-checks/scheduled-payments';
 import shortUuid from 'short-uuid';
+import cryptoRandomString from 'crypto-random-string';
 
 describe('data integrity checks', function () {
   let prisma: ExtendedPrismaClient;
@@ -42,7 +43,7 @@ describe('data integrity checks', function () {
           feePercentage: '0',
           salt: '54lt',
           payAt: nowUtc(),
-          spHash: '0x123',
+          spHash: cryptoRandomString({ length: 10 }),
           chainId: 1,
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           creationTransactionHash: null,
@@ -65,7 +66,7 @@ describe('data integrity checks', function () {
           feePercentage: '0',
           salt: '54lt',
           payAt: nowUtc(),
-          spHash: '0x1234',
+          spHash: cryptoRandomString({ length: 10 }),
           chainId: 1,
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           creationTransactionHash: '0x123',
@@ -98,7 +99,7 @@ describe('data integrity checks', function () {
           feePercentage: '0',
           salt: '54lt',
           payAt: nowUtc(),
-          spHash: '0x123',
+          spHash: cryptoRandomString({ length: 10 }),
           chainId: 1,
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           cancelationTransactionHash: null,
@@ -121,7 +122,7 @@ describe('data integrity checks', function () {
           feePercentage: '0',
           salt: '54lt',
           payAt: nowUtc(),
-          spHash: '0x1234',
+          spHash: cryptoRandomString({ length: 10 }),
           chainId: 1,
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           cancelationTransactionHash: '0x123',
@@ -154,7 +155,7 @@ describe('data integrity checks', function () {
           feePercentage: '0',
           salt: '54lt',
           payAt: subMinutes(nowUtc(), 61),
-          spHash: '0x123',
+          spHash: cryptoRandomString({ length: 10 }),
           chainId: 1,
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           creationTransactionHash: '0x123',
@@ -186,7 +187,7 @@ describe('data integrity checks', function () {
           feePercentage: '0',
           salt: '54lt',
           payAt: subMinutes(nowUtc(), 60 * 24),
-          spHash: '0x123',
+          spHash: cryptoRandomString({ length: 10 }),
           chainId: 1,
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           creationTransactionHash: '0x123',
@@ -229,7 +230,7 @@ describe('data integrity checks', function () {
           feePercentage: '0',
           salt: '54lt',
           payAt: subMinutes(nowUtc(), 60 * 24),
-          spHash: '0x123',
+          spHash: cryptoRandomString({ length: 10 }),
           chainId: 1,
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           creationTransactionHash: '0x123',

--- a/packages/hub/node-tests/services/scheduled-payments/executor-test.ts
+++ b/packages/hub/node-tests/services/scheduled-payments/executor-test.ts
@@ -5,6 +5,8 @@ import ScheduledPaymentsExecutorService from '../../../services/scheduled-paymen
 import { setupStubWorkerClient } from '../../helpers/stub-worker-client';
 import BN from 'bn.js';
 import CrankNonceLock from '../../../services/crank-nonce-lock';
+import cryptoRandomString from 'crypto-random-string';
+import shortUuid from 'short-uuid';
 
 let sdkError: Error | null = null;
 
@@ -71,7 +73,7 @@ describe('executing scheduled payments', function () {
   it('executes a scheduled payment and spawns the task to wait for the transaction to finish', async function () {
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -84,7 +86,7 @@ describe('executing scheduled payments', function () {
         feePercentage: '0',
         salt: '54lt',
         payAt: nowUtc(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: null,
@@ -110,7 +112,7 @@ describe('executing scheduled payments', function () {
 
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -123,7 +125,7 @@ describe('executing scheduled payments', function () {
         feePercentage: '0',
         salt: '54lt',
         payAt: nowUtc(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: null,

--- a/packages/hub/node-tests/tasks/scheduled-payment-on-chain-cancelation-waiter-test.ts
+++ b/packages/hub/node-tests/tasks/scheduled-payment-on-chain-cancelation-waiter-test.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
+import cryptoRandomString from 'crypto-random-string';
 import { subDays } from 'date-fns';
+import shortUuid from 'short-uuid';
 import ScheduledPaymentOnChainCancelationWaiter from '../../tasks/scheduled-payment-on-chain-cancelation-waiter';
 import { nowUtc } from '../../utils/dates';
 import { registry, setupHub } from '../helpers/server';
@@ -41,9 +43,9 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
 
   it('returns an error if there is no cancelation tx hash', async function () {
     let prisma = await getPrisma();
-    await prisma.scheduledPayment.create({
+    let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -56,14 +58,14 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         cancelationTransactionHash: null,
       },
     });
     let task = await getContainer().instantiate(ScheduledPaymentOnChainCancelationWaiter);
-    let result = await task.perform({ scheduledPaymentId: '73994d4b-bb3a-4d73-969f-6fa24da16fb4' });
+    let result = await task.perform({ scheduledPaymentId: scheduledPayment.id });
 
     expect(result).to.deep.equal({
       status: 'failure',
@@ -73,9 +75,9 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
 
   it('returns an error if scheduled payment has been canceled more than a day ago and the cancelation transaction still has not been mined', async function () {
     let prisma = await getPrisma();
-    await prisma.scheduledPayment.create({
+    let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -89,14 +91,14 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
         salt: '54lt',
         payAt: null,
         canceledAt: subDays(nowUtc(), 2),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         cancelationTransactionHash: '0x123',
       },
     });
     let task = await getContainer().instantiate(ScheduledPaymentOnChainCancelationWaiter);
-    let result = await task.perform({ scheduledPaymentId: '73994d4b-bb3a-4d73-969f-6fa24da16fb4' });
+    let result = await task.perform({ scheduledPaymentId: scheduledPayment.id });
 
     expect(result).to.deep.equal({
       status: 'failure',
@@ -110,7 +112,7 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainCancelationWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -123,7 +125,7 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         cancelationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
@@ -149,7 +151,7 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainCancelationWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -162,7 +164,7 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         cancelationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
@@ -186,7 +188,7 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainCancelationWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -199,7 +201,7 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         cancelationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',

--- a/packages/hub/node-tests/tasks/scheduled-payment-on-chain-creation-waiter-test.ts
+++ b/packages/hub/node-tests/tasks/scheduled-payment-on-chain-creation-waiter-test.ts
@@ -1,4 +1,6 @@
 import { expect } from 'chai';
+import cryptoRandomString from 'crypto-random-string';
+import shortUuid from 'short-uuid';
 import ScheduledPaymentOnChainCreationWaiter from '../../tasks/scheduled-payment-on-chain-creation-waiter';
 import { registry, setupHub } from '../helpers/server';
 
@@ -42,7 +44,7 @@ describe('ScheduledPaymentOnChainCreationWaiterTask', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainCreationWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -55,7 +57,7 @@ describe('ScheduledPaymentOnChainCreationWaiterTask', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
@@ -81,7 +83,7 @@ describe('ScheduledPaymentOnChainCreationWaiterTask', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainCreationWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -94,7 +96,7 @@ describe('ScheduledPaymentOnChainCreationWaiterTask', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
@@ -118,7 +120,7 @@ describe('ScheduledPaymentOnChainCreationWaiterTask', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainCreationWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -131,7 +133,7 @@ describe('ScheduledPaymentOnChainCreationWaiterTask', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',

--- a/packages/hub/node-tests/tasks/scheduled-payment-on-chain-execution-waiter-test.ts
+++ b/packages/hub/node-tests/tasks/scheduled-payment-on-chain-execution-waiter-test.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
+import cryptoRandomString from 'crypto-random-string';
 import { subDays, subMinutes, subSeconds } from 'date-fns';
+import shortUuid from 'short-uuid';
 import shortUUID from 'short-uuid';
 import ScheduledPaymentOnChainExecutionWaiter from '../../tasks/scheduled-payment-on-chain-execution-waiter';
 import { nowUtc } from '../../utils/dates';
@@ -54,7 +56,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainExecutionWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -67,7 +69,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
@@ -104,7 +106,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainExecutionWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -117,7 +119,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
@@ -155,7 +157,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainExecutionWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -168,7 +170,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
@@ -208,7 +210,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainExecutionWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -221,7 +223,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',

--- a/packages/hub/services/scheduled-payments/fetcher.ts
+++ b/packages/hub/services/scheduled-payments/fetcher.ts
@@ -1,6 +1,6 @@
 import { inject } from '@cardstack/di';
 import { ScheduledPayment } from '@prisma/client';
-import { startOfDay, subDays } from 'date-fns';
+import { startOfDay, subDays, subMinutes } from 'date-fns';
 import { nowUtc } from '../../utils/dates';
 
 export default class ScheduledPaymentsFetcherService {
@@ -8,8 +8,7 @@ export default class ScheduledPaymentsFetcherService {
   validForDays = 3;
 
   // This query fetches scheduled payments that are due to be executed now.
-  // Will prioritize scheduled payments with no payment attempts.
-  // After that scheduled payments with the earlier failed payment attempts.
+  // Will prioritize scheduled payments with no payment attempts, and fter that scheduled payments with the earlier failed payment attempts.
   // Payment scheduler will periodically try to fetch these payments at regular intervals and execute them if they are due.
   // This query mostly relies on the payAt field, which is set to the time when the payment should be executed.
   // In case of one-time payments, payAt is set only initially, and then never changed.
@@ -17,6 +16,10 @@ export default class ScheduledPaymentsFetcherService {
   // It is also important to note that validForDays tells us for how many days the payment is still valid to retry in
   // case it is failing for some reason.
 
+  // We only want to fetch scheduled payments which that have payAt older or equal a minute ago. This is to
+  // satisfy the requirement in the smart contract (https://github.com/cardstack/cardstack-module-scheduled-payment/blob/main/contracts/ScheduledPaymentModule.sol)
+  // that protects against potential undesired effects of when miners manipulate the timestamp of the block in which the payment is executed, for example executing payments ahead of time
+  // or bunching many transactions together to get a bigger mining reward in the time window that block time can be manipulated (which is around 1 minute)
   async fetchScheduledPayments(limit = 10): Promise<ScheduledPayment[]> {
     let prisma = await this.prismaManager.getClient();
     let _nowUtc = nowUtc();
@@ -37,7 +40,10 @@ export default class ScheduledPaymentsFetcherService {
           scheduled_payments.canceled_at IS NULL 
           AND scheduled_payments.creation_block_number > 0 
           AND scheduled_payments.pay_at > ${startOfDay(subDays(_nowUtc, this.validForDays))}
-          AND scheduled_payments.pay_at <= ${_nowUtc}
+          AND scheduled_payments.pay_at <= ${subMinutes(
+            _nowUtc,
+            1
+          ).toISOString()}::timestamp -- 1 minute safety buffer due to a requirement in the ScheduledPayment module contract to avoid undesired effects of block time manipulation; find more details in the description above
           AND (
             (
               scheduled_payments.recurring_day_of_month IS NULL 


### PR DESCRIPTION
This PR aims to address the issue in the scheduler tool where when the payment gets executed at the full hour and it fails, but then at the next run 5 minutes after (the crank triggers every 5 minutes looking for payments to execute), it succeeds:

<img width="1106" alt="image" src="https://user-images.githubusercontent.com/273660/214029847-569ca01e-9bcc-428b-84e9-839e67a2ca65.png">

We discovered this happens because there is a revert condition in the ScheduledPaymentModule smart contract: (https://github.com/cardstack/cardstack-module-scheduled-payment/blob/main/contracts/ScheduledPaymentModule.sol#L167) which reverts payment execution if it is attempted before 1 minute has passed from the `payAt` timestamp. This is for mitigating the effects of miners' block timestamp manipulation, which could result, if I understand correctly, in executing payments ahead of time, or bunching many transactions together to get a bigger mining reward in the time window that block time can be manipulated (which is around 1 minute judging by the comment in the smart contract code mentioned above).

The obvious solution to this is to delay the execution of scheduled payments by at least one minute, which is implemented as a change in this PR in the query that returns the payments that are due to be executed now. But this comes with a downside which we need to discuss if we are ok with it. 

The crank will trigger every 5 minutes (our current cron config), looking for scheduled payments to execute. Let's say the crank will fire at 11:00 and there is a scheduled payment with 11:00:00 `payAt` value. Previously, this payment would be attempted at this step but it would result in a failure due to the revert condition described above. But with the new implementation, this payment would be left out, and it would only be picked up at 11:05 when the crank triggers again. This means the payment would get executed at 11:05 when it was supposed to be executed 11:00. It means with this change, the crank executes payments with a 5 minute delay. 

This is not ideal – ideally we should execute payments with a minimal delay, which is 1 minute when conforming to the block manipulation time buffer mentioned earlier. I can think of a couple of alternatives (as an addition to this PR):

1. Making the crank fire every minute or every 2 minutes (but we then really need the exponential backoff for retries... which is what we are planning to do anyway)
2. Introducing an artificial 1 minute delay here: https://github.com/cardstack/cardstack/blob/main/packages/hub/tasks/execute-scheduled-payments.ts#L6 - only when trying to execute payments on full hour timestamps (because scheduled payments can only be scheduled on full hours)


