### PR TITLE
hub: add exponential backoff to scheduled payment (re)attempts

### DIFF
--- a/packages/hub/node-tests/routes/data-integrity-checks-test.ts
+++ b/packages/hub/node-tests/routes/data-integrity-checks-test.ts
@@ -1,3 +1,4 @@
+import cryptoRandomString from 'crypto-random-string';
 import { subMinutes } from 'date-fns';
 import shortUuid from 'short-uuid';
 import { CREATION_WITHOUT_TX_HASH_ALLOWED_MINUTES } from '../../services/data-integrity-checks/scheduled-payments';
@@ -50,7 +51,7 @@ describe('GET /api/data-integrity-checks/scheduled-payments', async function () 
         feePercentage: '0',
         salt: '54lt',
         payAt: nowUtc(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: null,

--- a/packages/hub/node-tests/routes/scheduled-payments-test.ts
+++ b/packages/hub/node-tests/routes/scheduled-payments-test.ts
@@ -711,7 +711,7 @@ describe('PATCH /api/scheduled-payments/:id', async function () {
   it('updates a scheduled payment when creation transaction hash is provided', async function () {
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -783,7 +783,7 @@ describe('PATCH /api/scheduled-payments/:id', async function () {
   it('updates a scheduled payment when cancelation transaction hash is provided', async function () {
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -887,7 +887,7 @@ describe('DELETE /api/scheduled-payments/:id', async function () {
   it('deletes a scheduled payment', async function () {
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',

--- a/packages/hub/node-tests/services/data-integrity-checks-test.ts
+++ b/packages/hub/node-tests/services/data-integrity-checks-test.ts
@@ -9,6 +9,7 @@ import DataIntegrityChecksScheduledPayments, {
   CANCELATION_UNMINED_ALLOWED_MINUTES,
 } from '../../services/data-integrity-checks/scheduled-payments';
 import shortUuid from 'short-uuid';
+import cryptoRandomString from 'crypto-random-string';
 
 describe('data integrity checks', function () {
   let prisma: ExtendedPrismaClient;
@@ -42,7 +43,7 @@ describe('data integrity checks', function () {
           feePercentage: '0',
           salt: '54lt',
           payAt: nowUtc(),
-          spHash: '0x123',
+          spHash: cryptoRandomString({ length: 10 }),
           chainId: 1,
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           creationTransactionHash: null,
@@ -65,7 +66,7 @@ describe('data integrity checks', function () {
           feePercentage: '0',
           salt: '54lt',
           payAt: nowUtc(),
-          spHash: '0x1234',
+          spHash: cryptoRandomString({ length: 10 }),
           chainId: 1,
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           creationTransactionHash: '0x123',
@@ -98,7 +99,7 @@ describe('data integrity checks', function () {
           feePercentage: '0',
           salt: '54lt',
           payAt: nowUtc(),
-          spHash: '0x123',
+          spHash: cryptoRandomString({ length: 10 }),
           chainId: 1,
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           cancelationTransactionHash: null,
@@ -121,7 +122,7 @@ describe('data integrity checks', function () {
           feePercentage: '0',
           salt: '54lt',
           payAt: nowUtc(),
-          spHash: '0x1234',
+          spHash: cryptoRandomString({ length: 10 }),
           chainId: 1,
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           cancelationTransactionHash: '0x123',
@@ -154,7 +155,7 @@ describe('data integrity checks', function () {
           feePercentage: '0',
           salt: '54lt',
           payAt: subMinutes(nowUtc(), 61),
-          spHash: '0x123',
+          spHash: cryptoRandomString({ length: 10 }),
           chainId: 1,
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           creationTransactionHash: '0x123',
@@ -186,7 +187,7 @@ describe('data integrity checks', function () {
           feePercentage: '0',
           salt: '54lt',
           payAt: subMinutes(nowUtc(), 60 * 24),
-          spHash: '0x123',
+          spHash: cryptoRandomString({ length: 10 }),
           chainId: 1,
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           creationTransactionHash: '0x123',
@@ -229,7 +230,7 @@ describe('data integrity checks', function () {
           feePercentage: '0',
           salt: '54lt',
           payAt: subMinutes(nowUtc(), 60 * 24),
-          spHash: '0x123',
+          spHash: cryptoRandomString({ length: 10 }),
           chainId: 1,
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           creationTransactionHash: '0x123',

--- a/packages/hub/node-tests/services/scheduled-payments/executor-test.ts
+++ b/packages/hub/node-tests/services/scheduled-payments/executor-test.ts
@@ -5,6 +5,8 @@ import ScheduledPaymentsExecutorService from '../../../services/scheduled-paymen
 import { setupStubWorkerClient } from '../../helpers/stub-worker-client';
 import BN from 'bn.js';
 import CrankNonceLock from '../../../services/crank-nonce-lock';
+import cryptoRandomString from 'crypto-random-string';
+import shortUuid from 'short-uuid';
 
 let sdkError: Error | null = null;
 
@@ -71,7 +73,7 @@ describe('executing scheduled payments', function () {
   it('executes a scheduled payment and spawns the task to wait for the transaction to finish', async function () {
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -84,7 +86,7 @@ describe('executing scheduled payments', function () {
         feePercentage: '0',
         salt: '54lt',
         payAt: nowUtc(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: null,
@@ -110,7 +112,7 @@ describe('executing scheduled payments', function () {
 
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -123,7 +125,7 @@ describe('executing scheduled payments', function () {
         feePercentage: '0',
         salt: '54lt',
         payAt: nowUtc(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: null,

--- a/packages/hub/node-tests/tasks/scheduled-payment-on-chain-cancelation-waiter-test.ts
+++ b/packages/hub/node-tests/tasks/scheduled-payment-on-chain-cancelation-waiter-test.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
+import cryptoRandomString from 'crypto-random-string';
 import { subDays } from 'date-fns';
+import shortUuid from 'short-uuid';
 import ScheduledPaymentOnChainCancelationWaiter from '../../tasks/scheduled-payment-on-chain-cancelation-waiter';
 import { nowUtc } from '../../utils/dates';
 import { registry, setupHub } from '../helpers/server';
@@ -41,9 +43,9 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
 
   it('returns an error if there is no cancelation tx hash', async function () {
     let prisma = await getPrisma();
-    await prisma.scheduledPayment.create({
+    let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -56,14 +58,14 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         cancelationTransactionHash: null,
       },
     });
     let task = await getContainer().instantiate(ScheduledPaymentOnChainCancelationWaiter);
-    let result = await task.perform({ scheduledPaymentId: '73994d4b-bb3a-4d73-969f-6fa24da16fb4' });
+    let result = await task.perform({ scheduledPaymentId: scheduledPayment.id });
 
     expect(result).to.deep.equal({
       status: 'failure',
@@ -73,9 +75,9 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
 
   it('returns an error if scheduled payment has been canceled more than a day ago and the cancelation transaction still has not been mined', async function () {
     let prisma = await getPrisma();
-    await prisma.scheduledPayment.create({
+    let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -89,14 +91,14 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
         salt: '54lt',
         payAt: null,
         canceledAt: subDays(nowUtc(), 2),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         cancelationTransactionHash: '0x123',
       },
     });
     let task = await getContainer().instantiate(ScheduledPaymentOnChainCancelationWaiter);
-    let result = await task.perform({ scheduledPaymentId: '73994d4b-bb3a-4d73-969f-6fa24da16fb4' });
+    let result = await task.perform({ scheduledPaymentId: scheduledPayment.id });
 
     expect(result).to.deep.equal({
       status: 'failure',
@@ -110,7 +112,7 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainCancelationWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -123,7 +125,7 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         cancelationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
@@ -149,7 +151,7 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainCancelationWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -162,7 +164,7 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         cancelationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
@@ -186,7 +188,7 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainCancelationWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -199,7 +201,7 @@ describe('ScheduledPaymentOnChainCancelationWaiterTask', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         cancelationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',

--- a/packages/hub/node-tests/tasks/scheduled-payment-on-chain-creation-waiter-test.ts
+++ b/packages/hub/node-tests/tasks/scheduled-payment-on-chain-creation-waiter-test.ts
@@ -1,4 +1,6 @@
 import { expect } from 'chai';
+import cryptoRandomString from 'crypto-random-string';
+import shortUuid from 'short-uuid';
 import ScheduledPaymentOnChainCreationWaiter from '../../tasks/scheduled-payment-on-chain-creation-waiter';
 import { registry, setupHub } from '../helpers/server';
 
@@ -42,7 +44,7 @@ describe('ScheduledPaymentOnChainCreationWaiterTask', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainCreationWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -55,7 +57,7 @@ describe('ScheduledPaymentOnChainCreationWaiterTask', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
@@ -81,7 +83,7 @@ describe('ScheduledPaymentOnChainCreationWaiterTask', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainCreationWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -94,7 +96,7 @@ describe('ScheduledPaymentOnChainCreationWaiterTask', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
@@ -118,7 +120,7 @@ describe('ScheduledPaymentOnChainCreationWaiterTask', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainCreationWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -131,7 +133,7 @@ describe('ScheduledPaymentOnChainCreationWaiterTask', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',

--- a/packages/hub/node-tests/tasks/scheduled-payment-on-chain-execution-waiter-test.ts
+++ b/packages/hub/node-tests/tasks/scheduled-payment-on-chain-execution-waiter-test.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
+import cryptoRandomString from 'crypto-random-string';
 import { subDays, subMinutes, subSeconds } from 'date-fns';
+import shortUuid from 'short-uuid';
 import shortUUID from 'short-uuid';
 import ScheduledPaymentOnChainExecutionWaiter from '../../tasks/scheduled-payment-on-chain-execution-waiter';
 import { nowUtc } from '../../utils/dates';
@@ -54,7 +56,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainExecutionWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -67,7 +69,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
@@ -104,7 +106,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainExecutionWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -117,7 +119,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
@@ -155,7 +157,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainExecutionWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -168,7 +170,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
@@ -208,7 +210,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
     let task = await getContainer().instantiate(ScheduledPaymentOnChainExecutionWaiter);
     let scheduledPayment = await prisma.scheduledPayment.create({
       data: {
-        id: '73994d4b-bb3a-4d73-969f-6fa24da16fb4',
+        id: shortUuid.uuid(),
         senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
         moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
         tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
@@ -221,7 +223,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
         feePercentage: 0,
         salt: '54lt',
         payAt: new Date(),
-        spHash: '0x123',
+        spHash: cryptoRandomString({ length: 10 }),
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',

--- a/packages/hub/services/clock.ts
+++ b/packages/hub/services/clock.ts
@@ -1,4 +1,5 @@
 import { format } from 'date-fns';
+import { nowUtc } from '../utils/dates';
 
 export class Clock {
   hrNow() {
@@ -9,6 +10,9 @@ export class Clock {
   }
   dateStringNow() {
     return format(this.now(), 'yyyy-MM-dd');
+  }
+  utcNow() {
+    return nowUtc();
   }
 }
 

--- a/packages/hub/services/scheduled-payments/fetcher.ts
+++ b/packages/hub/services/scheduled-payments/fetcher.ts
@@ -1,10 +1,10 @@
 import { inject } from '@cardstack/di';
 import { ScheduledPayment } from '@prisma/client';
 import { startOfDay, subDays } from 'date-fns';
-import { nowUtc } from '../../utils/dates';
 
 export default class ScheduledPaymentsFetcherService {
   prismaManager = inject('prisma-manager', { as: 'prismaManager' });
+  clock = inject('clock', { as: 'clock' });
   validForDays = 3;
 
   // This query fetches scheduled payments that are due to be executed now.
@@ -17,30 +17,41 @@ export default class ScheduledPaymentsFetcherService {
   // It is also important to note that validForDays tells us for how many days the payment is still valid to retry in
   // case it is failing for some reason.
 
+  // In the case of scheduled payments that failed and need to be retried, the query will return only the scheduled payments
+  // where enough time has passed since the last failed payment attempt. We allow maximum 8 failed attempts, and the time
+  // between attempts is hardcoded in the query (5 minutes, 1 hour, 5 hours, 12 hours, 12 hours, 12 hours, 12 hours, 12 hours)
   async fetchScheduledPayments(limit = 10): Promise<ScheduledPayment[]> {
     let prisma = await this.prismaManager.getClient();
-    let _nowUtc = nowUtc();
+    let now = this.clock.utcNow();
+    let nowString = now.toISOString(); // We use ISO string to make sure we operate on UTC dates only. Otherwise Prisma will use local time zone.
 
     let results: [{ id: string; started_at: Date }] = await prisma.$queryRaw`SELECT 
         scheduled_payments.id AS id,
         last_failed_payment_attempt.started_at
       FROM 
         scheduled_payments
-      LEFT JOIN (SELECT scheduled_payment_attempts.scheduled_payment_id,
-                  MAX(scheduled_payment_attempts.started_at) AS started_at
-            FROM scheduled_payment_attempts
-            WHERE scheduled_payment_attempts.status = 'failed'
-            GROUP BY scheduled_payment_id) AS last_failed_payment_attempt
+      LEFT JOIN (
+        SELECT
+          scheduled_payment_attempts.scheduled_payment_id,
+          MAX(scheduled_payment_attempts.started_at) AS started_at,
+          COUNT(*) as failed_attempts_count
+        FROM scheduled_payment_attempts
+        INNER JOIN scheduled_payments ON scheduled_payments.id = scheduled_payment_attempts.scheduled_payment_id
+        WHERE scheduled_payment_attempts.status = 'failed'
+          AND started_at >= scheduled_payments.pay_at
+        GROUP BY scheduled_payment_id) AS last_failed_payment_attempt
       ON last_failed_payment_attempt.scheduled_payment_id = scheduled_payments.id
       WHERE 
         (
-          scheduled_payments.canceled_at IS NULL 
-          AND scheduled_payments.creation_block_number > 0 
-          AND scheduled_payments.pay_at > ${startOfDay(subDays(_nowUtc, this.validForDays))}
-          AND scheduled_payments.pay_at <= ${_nowUtc}
+          scheduled_payments.canceled_at IS NULL
+          AND scheduled_payments.creation_block_number > 0
+          AND scheduled_payments.pay_at > ${startOfDay(subDays(now, this.validForDays)).toISOString()}::timestamp
+          AND scheduled_payments.pay_at <= ${nowString}::timestamp
+          AND COALESCE(failed_attempts_count, 0) < 8
+          AND ${nowString}::timestamp >= (COALESCE(last_failed_payment_attempt.started_at, to_timestamp(0)) + (interval '1 minute' * (ARRAY[0, 5, 60, 360, 720, 720, 720, 720])[COALESCE(failed_attempts_count + 1, 1)]))
           AND (
             (
-              scheduled_payments.recurring_day_of_month IS NULL 
+              scheduled_payments.recurring_day_of_month IS NULL
               AND (
                 scheduled_payments.id
               ) NOT IN (
@@ -61,8 +72,8 @@ export default class ScheduledPaymentsFetcherService {
               )
             ) 
             OR (
-              scheduled_payments.recurring_day_of_month > 0 
-              AND scheduled_payments.recurring_until >= ${_nowUtc}
+              scheduled_payments.recurring_day_of_month > 0
+              AND scheduled_payments.recurring_until >= ${nowString}::timestamp
               AND (
                 scheduled_payments.id
               ) NOT IN (
@@ -84,7 +95,6 @@ export default class ScheduledPaymentsFetcherService {
         ORDER BY last_failed_payment_attempt.started_at ASC NULLS FIRST
         LIMIT ${limit};`;
 
-    // Retrieve scheduledPayment prisma object based on filtered id
     return prisma.scheduledPayment.findMany({ where: { id: { in: results.map((result) => result.id) } } });
   }
 }

--- a/packages/hub/services/scheduled-payments/fetcher.ts
+++ b/packages/hub/services/scheduled-payments/fetcher.ts
@@ -1,6 +1,7 @@
 import { inject } from '@cardstack/di';
 import { ScheduledPayment } from '@prisma/client';
 import { startOfDay, subDays } from 'date-fns';
+import { Prisma } from '@prisma/client';
 
 export default class ScheduledPaymentsFetcherService {
   prismaManager = inject('prisma-manager', { as: 'prismaManager' });
@@ -19,11 +20,13 @@ export default class ScheduledPaymentsFetcherService {
 
   // In the case of scheduled payments that failed and need to be retried, the query will return only the scheduled payments
   // where enough time has passed since the last failed payment attempt. We allow maximum 8 failed attempts, and the time
-  // between attempts is hardcoded in the query (5 minutes, 1 hour, 5 hours, 12 hours, 12 hours, 12 hours, 12 hours, 12 hours)
+  // between attempts is defined in the calculateRetryBackoffsInMinutes method.
+
   async fetchScheduledPayments(limit = 10): Promise<ScheduledPayment[]> {
     let prisma = await this.prismaManager.getClient();
     let now = this.clock.utcNow();
     let nowString = now.toISOString(); // We use ISO string to make sure we operate on UTC dates only. Otherwise Prisma will use local time zone.
+    let retryBackoffsInMinutes = this.calculateRetryBackoffsInMinutes();
 
     let results: [{ id: string; started_at: Date }] = await prisma.$queryRaw`SELECT 
         scheduled_payments.id AS id,
@@ -47,8 +50,10 @@ export default class ScheduledPaymentsFetcherService {
           AND scheduled_payments.creation_block_number > 0
           AND scheduled_payments.pay_at > ${startOfDay(subDays(now, this.validForDays)).toISOString()}::timestamp
           AND scheduled_payments.pay_at <= ${nowString}::timestamp
-          AND COALESCE(failed_attempts_count, 0) < 8
-          AND ${nowString}::timestamp >= (COALESCE(last_failed_payment_attempt.started_at, to_timestamp(0)) + (interval '1 minute' * (ARRAY[0, 5, 60, 360, 720, 720, 720, 720])[COALESCE(failed_attempts_count + 1, 1)]))
+          AND COALESCE(failed_attempts_count, 0) < ${retryBackoffsInMinutes.length}
+          AND ${nowString}::timestamp >= (COALESCE(last_failed_payment_attempt.started_at, to_timestamp(0)) + (interval '1 minute' * (ARRAY[${Prisma.join(
+      retryBackoffsInMinutes
+    )}])[COALESCE(failed_attempts_count + 1, 1)]))
           AND (
             (
               scheduled_payments.recurring_day_of_month IS NULL
@@ -96,6 +101,14 @@ export default class ScheduledPaymentsFetcherService {
         LIMIT ${limit};`;
 
     return prisma.scheduledPayment.findMany({ where: { id: { in: results.map((result) => result.id) } } });
+  }
+
+  calculateRetryBackoffsInMinutes() {
+    let fixedPart = [0, 5, 60, 360]; // Retry immediately, then after 5 minutes, 1 hour, 6 hours
+    let fixedPartSum = fixedPart.reduce((a, b) => a + b, 0);
+    let variablePartChunksCount = Math.floor((this.validForDays * 24 * 60 - fixedPartSum) / 720);
+    let variablePart = Array(variablePartChunksCount).fill(720); // Then every 12 hours until we reach the end of validForDays
+    return [...fixedPart, ...variablePart];
   }
 }
 


### PR DESCRIPTION
Currently, the crank triggers every 5 minutes and on each run and it will fetch scheduled payments that are due to be executed at that time, and try to execute them. This also includes failed payments. 

The problem is that we don't really want to reattempt payments every 5 minutes, but to add a progressively larger delay between attempts as it is usual with such mechanisms (so that we don't overwhelm our systems).

Currently, the strategy goes like this: If the payment fails, it can be attempted again after 5 minutes. And if it still fails, it can be retried after 60 minutes after the last failure. Then, after 360 minutes (6 hours), and then every 720 minutes (12 hours) until max attempts is reached, which is 8 attempts. There is no special formula how I got these numbers, it's just something that felt good to me, and it's hardcoded within the query and easy to change if we feel the need to do that.

