### PR TITLE
Fix wrong conversion in gas estimation

### DIFF
--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
@@ -314,12 +314,12 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
     (async () => {
       try {
         state.isLoading = true;
-        this.gasEstimation = await this.scheduledPaymentSdk.getScheduledPaymentGasEstimation(scenario, paymentToken.address, selectedGasToken.address);
-        const { gasRangeInGasTokenWei } = this.gasEstimation;
+        this.gasEstimation = await this.scheduledPaymentSdk.getScheduledPaymentGasEstimation(scenario, paymentToken, selectedGasToken);
+        const { gasRangeInGasTokenUnits } = this.gasEstimation;
         state.value = {
-          normal: new TokenQuantity(selectedGasToken, gasRangeInGasTokenWei.normal),
-          high: new TokenQuantity(selectedGasToken, gasRangeInGasTokenWei.high),
-          max: new TokenQuantity(selectedGasToken, gasRangeInGasTokenWei.max),
+          normal: new TokenQuantity(selectedGasToken, gasRangeInGasTokenUnits.normal),
+          high: new TokenQuantity(selectedGasToken, gasRangeInGasTokenUnits.high),
+          max: new TokenQuantity(selectedGasToken, gasRangeInGasTokenUnits.max),
         };
       } catch (error) {
         console.error(error);
@@ -332,7 +332,7 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
   });
 
   get gasEstimateInGasTokenUnits(): BigNumber {
-    return this.gasEstimation?.gasRangeInGasTokenWei.normal || BigNumber.from('0');
+    return this.gasEstimation?.gasRangeInGasTokenUnits.normal || BigNumber.from('0');
   }
 
   get gasEstimateTokenQuantity(): TokenQuantity|undefined {
@@ -351,19 +351,19 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
     if (!this.paymentTokenQuantity || !this.selectedGasToken || !this.gasEstimation) return;
 
     if (Number(this.gasEstimation.gas) <= 0) return;
-    const { gasRangeInGasTokenWei } = this.gasEstimation;
-    if (Object.keys(gasRangeInGasTokenWei).length <= 0) return;
+    const { gasRangeInGasTokenUnits } = this.gasEstimation;
+    if (Object.keys(gasRangeInGasTokenUnits).length <= 0) return;
 
     let maxGasPrice;
     switch(this.maxGasPrice) {
       case "normal":
-        maxGasPrice = gasRangeInGasTokenWei.normal.div(this.gasEstimation.gas);
+        maxGasPrice = gasRangeInGasTokenUnits.normal.div(this.gasEstimation.gas);
         break;
       case "high":
-        maxGasPrice = gasRangeInGasTokenWei.high.div(this.gasEstimation.gas);
+        maxGasPrice = gasRangeInGasTokenUnits.high.div(this.gasEstimation.gas);
         break;
       case "max":
-        maxGasPrice = gasRangeInGasTokenWei.max.div(this.gasEstimation.gas);
+        maxGasPrice = gasRangeInGasTokenUnits.max.div(this.gasEstimation.gas);
         break;
       default:
         maxGasPrice = BigNumber.from(0);

--- a/packages/safe-tools-client/tests/integration/components/schedule-payment-form-action-card-test.ts
+++ b/packages/safe-tools-client/tests/integration/components/schedule-payment-form-action-card-test.ts
@@ -64,7 +64,7 @@ class ScheduledPaymentSDKServiceStub extends Service {
   ): Promise<ServiceGasEstimationResult> {
     return {
       gas: BigNumber.from(127864),
-      gasRangeInGasTokenWei: {
+      gasRangeInGasTokenUnits: {
         normal: BigNumber.from('20000000'),
         high: BigNumber.from('40000000'),
         max: BigNumber.from('80000000'),


### PR DESCRIPTION
Ticket: CS-5169

**Problem**
The gas estimate is returning a very high number because we didn't convert the gas price from wei to the smallest units of the gas token. It worked fine if the gas token had the same decimals as the native token, but if it did not, the gas estimate would return a very high number.

**Solution**
Update the gas estimation to return the gas range in the smallest unit of the gas token.

**Screenshot**
![Screenshot 2023-01-30 at 15 02 37](https://user-images.githubusercontent.com/12637010/215423446-f8dfeab5-31d2-43ba-9320-d61ba53ef8b7.png)
