### PR TITLE
[Fix]: Clean wallet state on disconnect

### DIFF
--- a/packages/safe-tools-client/app/services/wallet.ts
+++ b/packages/safe-tools-client/app/services/wallet.ts
@@ -67,6 +67,10 @@ export default class Wallet extends Service {
 
     this.chainConnectionManager.on('disconnected', () => {
       this.isConnected = false;
+      this.safes = [];
+      this.address = undefined;
+      this.nativeTokenBalance = undefined;
+      this.providerId = undefined;
     });
 
     this.chainConnectionManager.on('chain-changed', (chainId: number) => {


### PR DESCRIPTION
This PR cleans up the wallet state when the user disconnects 