### PR TITLE
Retry once on gas estimation failure to protect against relayer <-> eth node connection issues

### DIFF
--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -155,7 +155,8 @@ export default class ScheduledPaymentModule {
       multiSendTransaction.value,
       multiSendTransaction.data,
       multiSendTransaction.operation,
-      gasTokenAddress
+      gasTokenAddress,
+      true
     );
     let gasCost = BigNumber.from(estimate.safeTxGas)
       .add(BigNumber.from(estimate.baseGas))
@@ -235,7 +236,8 @@ export default class ScheduledPaymentModule {
       multiSendTx.value,
       multiSendTx.data,
       multiSendTx.operation,
-      AddressZero
+      AddressZero,
+      true
     );
     let nonce = new BN('0');
     let gasPrice = '0';
@@ -321,7 +323,8 @@ export default class ScheduledPaymentModule {
       enableModuleTxs.txs[1].value,
       enableModuleTxs.txs[1].data,
       enableModuleTxs.txs[1].operation,
-      AddressZero
+      AddressZero,
+      true
     );
     let enableSPModuleGas = BigNumber.from(estimateEnableSPModule.baseGas).add(estimateEnableSPModule.safeTxGas);
 
@@ -332,7 +335,8 @@ export default class ScheduledPaymentModule {
       setGuardTxs.txs[1].value,
       setGuardTxs.txs[1].data,
       setGuardTxs.txs[1].operation,
-      AddressZero
+      AddressZero,
+      true
     );
     let setMetaGuardGas = BigNumber.from(estimateSetMetaGuard.baseGas).add(estimateSetMetaGuard.safeTxGas);
 
@@ -584,7 +588,8 @@ export default class ScheduledPaymentModule {
       '0',
       cancelScheduledPaymentData,
       Operation.CALL,
-      gasTokenAddress
+      gasTokenAddress,
+      true
     );
     let gasCost = BigNumber.from(estimate.safeTxGas)
       .add(BigNumber.from(estimate.baseGas))
@@ -720,7 +725,8 @@ export default class ScheduledPaymentModule {
       '0',
       payload,
       Operation.CALL,
-      gasTokenAddress
+      gasTokenAddress,
+      true
     );
 
     let nonce = getNextNonceFromEstimate(estimate);
@@ -760,7 +766,8 @@ export default class ScheduledPaymentModule {
       '0',
       payload,
       Operation.CALL,
-      gasTokenAddress
+      gasTokenAddress,
+      true
     );
 
     let nonce = getNextNonceFromEstimate(estimate);


### PR DESCRIPTION
Ticket: CS-5150

The problem we are experiencing is nicely described in the ticket and in the code comment, but here is the summary:

- After around 10 mins of inactivity, a request to the relayer to estimate gas for a safe transaction will fail, but after that it will succeed. This affects creating safes and scheduling payments which can randomly fail due to this issue
- The problem is where the relayer calls the node (https://github.com/safe-global/safe-eth-py/blob/8bedebca1641957bd09a5fc023462b25de0e1c5d/gnosis/safe/safe.py#L704) and the connection gets aborted with `RemoteDisconnected('Remote end closed connection without response')` 
- If the request is retried, it succeeds
- Given that it seems there is an issue with how the relayer maintains the connection with the ethereum node (@habdelra mentioned a similar issue [here](https://github.com/python/cpython/issues/85517#issuecomment-1093877874))
- The issue is the same when using a different node (we are using goerli infura, but I tried with https://goerli.blockpi.network/v1/rpc/public too)
- This behaviour has been observed in staging (https://relay-goerli.staging.stack.cards). Since we don't have a functioning production yet, I could not test there
- It is puzzling to me that when running the relayer locally (using docker-compose) the issue doesn't appear! I tried checking what could be the difference in how the connections are handled but didn't notice anything different. I'm wondering if the deployment environment in ECS has something to do with it (could the connection be running through a router/proxy that handles connections differently?) Maybe @pcjun97 has some ideas

Given I invested quite some time into this issue and couldn't get to the bottom of it I opted into adding a (idempotent) retry as a workaround.  