### PR TITLE
[CS-5185]: Fix egde case for unsupported network through wallet connect v1

### DIFF
--- a/packages/safe-tools-client/app/services/network.ts
+++ b/packages/safe-tools-client/app/services/network.ts
@@ -73,7 +73,9 @@ export default class NetworkService extends Service {
     return this.supportedNetworks.map((network) => network.name);
   }
 
-  isSupportedNetwork(chainId: number): boolean {
+  async isSupportedNetwork(chainId: number): Promise<boolean> {
+    await this.hubConfig.remoteConfig.ready;
+
     return this.supportedNetworks.some(
       (n: NetworkInfo) => n.chainId === chainId
     );

--- a/packages/safe-tools-client/app/services/wallet.ts
+++ b/packages/safe-tools-client/app/services/wallet.ts
@@ -73,8 +73,10 @@ export default class Wallet extends Service {
       this.providerId = undefined;
     });
 
-    this.chainConnectionManager.on('chain-changed', (chainId: number) => {
-      if (!this.network.isSupportedNetwork(chainId)) {
+    this.chainConnectionManager.on('chain-changed', async (chainId: number) => {
+      const isSupported = await this.network.isSupportedNetwork(chainId);
+
+      if (!isSupported) {
         // TODO: improve unsupported net handling
         alert('Unsupported network! Choose a supported one and reconnect');
         this.disconnect();


### PR DESCRIPTION
We were not waiting for hub's remoteConfig to be fetched before checking if a network is supported, this PR updates that to avoid allowing an unsupported network and trigger an alert if that's the case.