### PR TITLE
[Chore]: Bump ts-actions/changed-files to v35

### DIFF
--- a/.github/workflows/pr-boxel.yml
+++ b/.github/workflows/pr-boxel.yml
@@ -36,10 +36,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get boxel files that changed
         id: boxel-files-that-changed
-        uses: tj-actions/changed-files@v1.1.2
+        uses: tj-actions/changed-files@v35
         with:
           files: |
-            ^packages/boxel
+            **/packages/boxel
 
   deploy-boxel-preview:
     name: Deploy a preview to S3

--- a/.github/workflows/pr-safe-tools-client.yml
+++ b/.github/workflows/pr-safe-tools-client.yml
@@ -44,10 +44,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get safe-tools-client files that changed
         id: safe-tools-client-files-that-changed
-        uses: tj-actions/changed-files@v1.1.2
+        uses: tj-actions/changed-files@v35
         with:
           files: |
-            ^packages/safe-tools-client
+            **/packages/safe-tools-client
 
   deploy-safe-tools-preview-staging:
     name: Deploy a safe-tools-client staging preview to S3

--- a/.github/workflows/pr-ssr-web.yml
+++ b/.github/workflows/pr-ssr-web.yml
@@ -57,10 +57,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get ssr-web files that changed
         id: ssr-web-files-that-changed
-        uses: tj-actions/changed-files@v1.1.2
+        uses: tj-actions/changed-files@v35
         with:
           files: |
-            ^packages/ssr-web
+            **/packages/ssr-web
 
   deploy-ssr-preview-staging:
     name: Deploy a ssr-web staging preview to S3

--- a/.github/workflows/pr-web-client.yml
+++ b/.github/workflows/pr-web-client.yml
@@ -59,10 +59,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get web client files that changed
         id: web-client-files-that-changed
-        uses: tj-actions/changed-files@v1.1.2
+        uses: tj-actions/changed-files@v35
         with:
           files: |
-            ^packages/web-client
+            **/packages/web-client
 
   deploy-web-client-preview-staging:
     name: Deploy a web-client staging preview to S3

--- a/packages/boxel/addon/components/boxel/action-chin/usage.gts
+++ b/packages/boxel/addon/components/boxel/action-chin/usage.gts
@@ -63,7 +63,6 @@ export default class ActionChinUsage extends Component<Signature> {
   <template>
     <FreestyleUsage @name="ActionChin">
       <:description>
-        TO BE REVERTED JUST TESTING THE GB ACTIONS
         Bottom action area for an action card, a.k.a the "Chin".<br><br>
         Use the API controls below to change <code>state</code> and <code>stepNumber</code>.
 

--- a/packages/boxel/addon/components/boxel/action-chin/usage.gts
+++ b/packages/boxel/addon/components/boxel/action-chin/usage.gts
@@ -63,6 +63,7 @@ export default class ActionChinUsage extends Component<Signature> {
   <template>
     <FreestyleUsage @name="ActionChin">
       <:description>
+        TO BE REVERTED JUST TESTING THE GB ACTIONS
         Bottom action area for an action card, a.k.a the "Chin".<br><br>
         Use the API controls below to change <code>state</code> and <code>stepNumber</code>.
 


### PR DESCRIPTION
This PR bumps the changed-files action, there's a dependableBot PR open #3579 which is broken since the way they track paths have changed 

I've changed something on boxel to text and a deploy was triggered 
<img width="920" alt="image" src="https://user-images.githubusercontent.com/20520102/216156837-16cce965-d416-449a-9442-10df5f8a62d7.png">
