### PR TITLE
Include relay/crank balance checker in scheduled payments data check

### DIFF
--- a/packages/hub/node-tests/routes/data-integrity-checks-test.ts
+++ b/packages/hub/node-tests/routes/data-integrity-checks-test.ts
@@ -1,5 +1,6 @@
 import cryptoRandomString from 'crypto-random-string';
 import { subMinutes } from 'date-fns';
+import { ethers } from 'ethers';
 import shortUuid from 'short-uuid';
 import { CREATION_WITHOUT_TX_HASH_ALLOWED_MINUTES } from '../../services/data-integrity-checks/scheduled-payments';
 import { ExtendedPrismaClient } from '../../services/prisma-manager';
@@ -8,10 +9,13 @@ import { setupHub } from '../helpers/server';
 
 describe('GET /api/data-integrity-checks/scheduled-payments', async function () {
   let prisma: ExtendedPrismaClient;
-  let { getPrisma, request } = setupHub(this);
+  let { getPrisma, request, getContainer } = setupHub(this);
 
   this.beforeEach(async function () {
     prisma = await getPrisma();
+    let service = await getContainer().lookup('data-integrity-checks-scheduled-payments');
+    service.getRelayerFunderBalance = () => Promise.resolve(ethers.utils.parseEther('1'));
+    service.getCrankBalance = () => Promise.resolve(ethers.utils.parseEther('1'));
   });
 
   it('returns operational status for provided check', async function () {

--- a/packages/hub/node-tests/services/data-integrity-checks-test.ts
+++ b/packages/hub/node-tests/services/data-integrity-checks-test.ts
@@ -261,24 +261,24 @@ describe('data integrity checks', function () {
     });
 
     it('returns a degraded check when relay funds are low', async function () {
-      service.getRelayerFunderBalance = () => Promise.resolve(ethers.utils.parseEther('0.05'));
+      service.getRelayerFunderBalance = () => Promise.resolve(ethers.utils.parseEther('0.5'));
 
       let result = await service.check();
       expect(result).to.deep.equal({
         status: 'degraded',
         name: 'scheduled-payments',
-        message: `Relayer balance low on goerli: 0.05 ETH`,
+        message: `Relayer balance low on goerli: 0.5 ETH`,
       });
     });
 
     it('returns a degraded check when crank funds are low', async function () {
-      service.getCrankBalance = () => Promise.resolve(ethers.utils.parseEther('0.05'));
+      service.getCrankBalance = () => Promise.resolve(ethers.utils.parseEther('0.5'));
 
       let result = await service.check();
       expect(result).to.deep.equal({
         status: 'degraded',
         name: 'scheduled-payments',
-        message: `Crank balance low on goerli: 0.05 ETH`,
+        message: `Crank balance low on goerli: 0.5 ETH`,
       });
     });
   });

--- a/packages/hub/services/data-integrity-checks/scheduled-payments.ts
+++ b/packages/hub/services/data-integrity-checks/scheduled-payments.ts
@@ -202,7 +202,7 @@ export default class DataIntegrityChecksScheduledPayments {
     let relayerUrl = getConstantByNetwork('relayServiceURL', networkName);
 
     let responseText = await (await fetch(`${relayerUrl}/v1/about`)).text();
-    let relayerFunderPublicKey = JSON.parse(responseText).settings.SAFE_FUNDER_PUBLIC_KEY;
+    let relayerFunderPublicKey = JSON.parse(responseText).settings.SAFE_TX_SENDER_PUBLIC_KEY;
 
     let provider = this.ethersProvider.getInstance(networkName);
     return await provider.getBalance(relayerFunderPublicKey);

--- a/packages/hub/services/ethers-provider.ts
+++ b/packages/hub/services/ethers-provider.ts
@@ -2,7 +2,7 @@ import config from 'config';
 import { getWeb3ConfigByNetwork, JsonRpcProvider } from '@cardstack/cardpay-sdk';
 
 export default class EthersProvider {
-  getInstance(chainId: number) {
+  getInstance(chainId: number | string) {
     let rpcUrl = getWeb3ConfigByNetwork({ web3: config.get('web3') }, chainId).rpcNodeHttpsUrl;
     return new JsonRpcProvider(rpcUrl, chainId);
   }


### PR DESCRIPTION
This PR adds some basic monitoring to see if our relayer and the crank have enough balance to fund scheduling tool transactions (scheduling and executing). If the balance is too low to pay for transactions gas, the scheduling or executing will stop working, so we need to make sure we are informed when topping up is needed. 

We are running a Checkly check that continuously makes requests to our data integrity checks endpoint, which includes scheduled payments check. This PR adds the balance check. If the check discovers the balance is low, we will get alarmed in our discord channels and also in PagerDuty (for production). 

The low balance threshold is currently set at 0.05 of native coin value (e.g ETH, MATIC). There will also be a process described where a person in charge will manually transfer the funds from the fee receiver to the crank/relayer when this automatic check will trigger an alarm. 

**To discuss** (I am working through these questions now but comments welcome)

Is 0.05 a good threshold for both relayer and the crank? Does that vary on different networks significantly? Ideally the threshold should be at least a multiplication of the gas cost. Would it be good to introduce separate thresholds for relayer and the crank?

