### PR TITLE
safe client: Reload token balances: continuously, on schedule, on cancel

### DIFF
--- a/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.gts
+++ b/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.gts
@@ -17,6 +17,7 @@ import { tracked } from '@glimmer/tracking';
 import { noop } from '@cardstack/safe-tools-client/helpers/noop';
 import { taskFor } from 'ember-concurrency-ts';
 import HubAuthenticationService from '@cardstack/safe-tools-client/services/hub-authentication';
+import SafesService from '@cardstack/safe-tools-client/services/safes';
 import SuccessIcon from '@cardstack/safe-tools-client/components/icons/success';
 import FailureIcon from '@cardstack/safe-tools-client/components/icons/failure';
 import InfoIcon from '@cardstack/safe-tools-client/components/icons/info';
@@ -45,6 +46,7 @@ export default class ScheduledPaymentCard extends Component<Signature> {
   @service declare scheduledPaymentSdk: ScheduledPaymentSdkService;
   @service declare scheduledPayments: ScheduledPaymentsService;
   @service declare hubAuthentication: HubAuthenticationService;
+  @service declare safes: SafesService;
   @service declare tokens: TokensService;
   @tracked optionsMenuOpened = false;
   @tracked isCancelPaymentModalOpen = false;
@@ -77,6 +79,7 @@ export default class ScheduledPaymentCard extends Component<Signature> {
 
   @action async cancelScheduledPayment() {
     await taskFor(this.cancelScheduledPaymentTask).perform(this.args.scheduledPayment.id, this.hubAuthentication.authToken!)
+    this.safes.reloadTokenBalances();
   }
 
   get paymentCanceled() {

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
@@ -432,6 +432,7 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
         }
       )
       this.scheduledPaymentsService.reloadScheduledPayments();
+      this.safes.reloadTokenBalances();
       this.isSuccessfullyScheduled = true;
     } catch(e) {
       this.schedulingStatus = undefined;

--- a/packages/safe-tools-client/app/services/safes.ts
+++ b/packages/safe-tools-client/app/services/safes.ts
@@ -53,12 +53,12 @@ export default class SafesService extends Service {
     super(properties);
 
     // We keep reloading the token balances so that they are up do date
-    // when users add funds to the safe independently of the app
+    // when users add or remove funds in the safe independently of the app
     taskFor(this.refreshTokenBalancesIndefinitely).perform();
   }
 
   @task *refreshTokenBalancesIndefinitely(): TaskGenerator<void> {
-    while (1) {
+    while (true) {
       yield this.reloadTokenBalances();
       yield timeout(30 * 1000); // Every 30 seconds
     }

--- a/packages/safe-tools-client/app/services/wallet.ts
+++ b/packages/safe-tools-client/app/services/wallet.ts
@@ -35,7 +35,7 @@ export default class Wallet extends Service {
   @tracked safes = [];
 
   //@ts-expect-error  ethersProvider will be assigned in constructor
-  ethersProvider: Web3Provider;
+  @tracked ethersProvider: Web3Provider;
   chainConnectionManager: ChainConnectionManager;
 
   walletProviders = walletProviders.map((w) =>

--- a/packages/safe-tools-client/tests/acceptance/wallet-connection-test.ts
+++ b/packages/safe-tools-client/tests/acceptance/wallet-connection-test.ts
@@ -167,8 +167,12 @@ module('Acceptance | wallet connection', function (hooks) {
       assert.dom('[data-test-token-balance="USDT"]').hasText('10 USDT');
     });
   });
+});
 
-  module('Remembering the selected chain', function () {
+module(
+  'Acceptance | wallet connection | Remembering the selected chain',
+  function (hooks) {
+    setupApplicationTest(hooks);
     test('Defaults to mainnet', async function (assert) {
       await visit('/schedule');
       await click('[data-test-connect-wallet-button-modal-sidebar]');
@@ -183,11 +187,10 @@ module('Acceptance | wallet connection', function (hooks) {
       test('Uses localstorage value for other', async function (assert) {
         await visit('/schedule');
         await click('[data-test-connect-wallet-button-modal-sidebar]');
-
         assert
           .dom('[data-test-connect-wallet-button-modal]')
           .hasAttribute('data-test-connect-wallet-button-modal-chain-id', '5');
       });
     });
-  });
-});
+  }
+);


### PR DESCRIPTION
When user schedules or cancels a payment, their gas token balance decreases and we want this to be reflected in the sidebar, so we want to reload token balances when these actions are performed.

There is also a case where the safe has a change in token balances independently of the actions taken in this app. For this we introduce continuous refreshing of the balances - it refreshes every 30 seconds. 