### PR TITLE
Fix gas estimation API

### DIFF
--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -457,7 +457,9 @@ export default class ScheduledPaymentModule {
     gasPrice: string,
     payAt?: number | null,
     recurringDayOfMonth?: number | null,
-    recurringUntil?: number | null
+    recurringUntil?: number | null,
+    feeFixedUSD?: number | null,
+    feePercentage?: number | null
   ): Promise<number> {
     if (payAt == null && (recurringDayOfMonth == null || recurringUntil == null))
       throw new Error('When payAt is null, recurringDayOfMonth and recurringUntil must have a value');
@@ -471,8 +473,10 @@ export default class ScheduledPaymentModule {
       return decodedError.args[0].toNumber();
     };
 
-    let feeFixedUSD = (await getConstant('scheduledPaymentFeeFixedUSD', this.ethersProvider)) ?? 0;
-    let feePercentage = (await getConstant('scheduledPaymentFeePercentage', this.ethersProvider)) ?? 0;
+    feeFixedUSD =
+      feeFixedUSD != null ? feeFixedUSD : (await getConstant('scheduledPaymentFeeFixedUSD', this.ethersProvider))!;
+    feePercentage =
+      feePercentage != null ? feePercentage : (await getConstant('scheduledPaymentFeeFixedUSD', this.ethersProvider))!;
     let requiredGas = 0;
     try {
       let module = new Contract(moduleAddress, ScheduledPaymentABI, this.ethersProvider);
@@ -643,8 +647,8 @@ export default class ScheduledPaymentModule {
 
     let spHash;
     let module = new Contract(moduleAddress, ScheduledPaymentABI, this.ethersProvider);
-    let feeFixedUSD = (await getConstant('scheduledPaymentFeeFixedUSD', this.ethersProvider)) ?? 0;
-    let feePercentage = (await getConstant('scheduledPaymentFeePercentage', this.ethersProvider)) ?? 0;
+    let feeFixedUSD = (await getConstant('scheduledPaymentFeeFixedUSD', this.ethersProvider))!;
+    let feePercentage = (await getConstant('scheduledPaymentFeePercentage', this.ethersProvider))!;
     if (recurringUntil) {
       spHash = await module.callStatic[
         'createSpHash(address,uint256,address,((uint256),(uint256)),uint256,uint256,address,string,uint256,uint256)'
@@ -1017,8 +1021,8 @@ export default class ScheduledPaymentModule {
     options.listener?.onBeginPrepareScheduledPayment?.();
     let signer = this.signer ? this.signer : this.ethersProvider.getSigner();
     let account = await signer.getAddress();
-    let feeFixedUSD = (await getConstant('scheduledPaymentFeeFixedUSD', this.ethersProvider)) ?? 0;
-    let feePercentage = (await getConstant('scheduledPaymentFeePercentage', this.ethersProvider)) ?? 0;
+    let feeFixedUSD = (await getConstant('scheduledPaymentFeeFixedUSD', this.ethersProvider))!;
+    let feePercentage = (await getConstant('scheduledPaymentFeePercentage', this.ethersProvider))!;
     options.listener?.onEndPrepareScheduledPayment?.();
 
     options.listener?.onBeginRegisterPaymentWithHub?.();

--- a/packages/hub/services/gas-estimation.ts
+++ b/packages/hub/services/gas-estimation.ts
@@ -98,7 +98,9 @@ export default class GasEstimationService {
           '0',
           Math.round(nowUtc().getTime() / 1000),
           null,
-          null
+          null,
+          0,
+          0
         );
         break;
       case GasEstimationResultsScenarioEnum.execute_recurring_payment:
@@ -113,7 +115,9 @@ export default class GasEstimationService {
           '0',
           null,
           28,
-          Math.round(addDays(nowUtc(), 30).getTime() / 1000)
+          Math.round(addDays(nowUtc(), 30).getTime() / 1000),
+          0,
+          0
         );
         break;
       default:


### PR DESCRIPTION
In the gas estimation API, we expect to estimate the execution of scheduled payments with the transfer value of the transfer token and gas token equal to zero. So we need to define fees as being zero, and with that, the values will be equal to zero.