### PR TITLE
[CS-5247]: Disable submit button when there's no gas info

### DIFF
--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
@@ -234,13 +234,19 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
     return undefined;
   }
 
-  @tracked maxGasPrice: 'normal' | 'high' | 'max' | undefined;
+  @tracked maxGasPrice: 'normal' | 'high' | 'max' = 'normal'
+
   @action onUpdateMaxGasPrice(val: 'normal' | 'high' | 'max') {
     this.maxGasPrice = val;
   }
 
   get isValid(): boolean {
-    return this.validator.isValid;
+    return (
+      this.validator.isValid &&
+      Boolean(this.safes.currentSafe) &&
+      Boolean(this.gasEstimation) &&
+      Number(this.gasEstimation?.gas) > 0
+    );
   }
 
   @use configuredFees = resource(() => {
@@ -353,31 +359,16 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
   }
 
   @task *schedulePaymentTask() {
-    let { currentSafe } = this.safes;
-    if (!currentSafe) return;
-    if (!this.validator.isValid) return;
+    if (
+      !this.isValid ||
+       // Redundant to validation check but including it to narrow types for Typescript
+      !this.paymentTokenQuantity || !this.selectedGasToken || !this.safes.currentSafe || !this.gasEstimation
+    ) return;
 
-    // Redundant to validation check but including it to narrow types for Typescript
-    if (!this.paymentTokenQuantity || !this.selectedGasToken || !this.gasEstimation) return;
+    const defaultGas = BigNumber.from(0);
+    const gasRangeByMaxPrice = this.gasEstimation.gasRangeInGasTokenUnits[this.maxGasPrice];
 
-    if (Number(this.gasEstimation.gas) <= 0) return;
-    const { gasRangeInGasTokenUnits } = this.gasEstimation;
-    if (Object.keys(gasRangeInGasTokenUnits).length <= 0) return;
-
-    let maxGasPrice;
-    switch(this.maxGasPrice) {
-      case "normal":
-        maxGasPrice = gasRangeInGasTokenUnits.normal.div(this.gasEstimation.gas);
-        break;
-      case "high":
-        maxGasPrice = gasRangeInGasTokenUnits.high.div(this.gasEstimation.gas);
-        break;
-      case "max":
-        maxGasPrice = gasRangeInGasTokenUnits.max.div(this.gasEstimation.gas);
-        break;
-      default:
-        maxGasPrice = BigNumber.from(0);
-    }
+    const maxGasPriceString = String(gasRangeByMaxPrice.div(this.gasEstimation.gas) || defaultGas);
 
     const array = new Uint8Array(32);
     window.crypto.getRandomValues(array);
@@ -387,15 +378,16 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
     this.scheduleErrorMessage = undefined;
 
     try {
-      const {paymentTokenQuantity} = this;
+      const { currentSafe } = this.safes;
+
       yield taskFor(this.scheduledPaymentSdk.schedulePayment).perform(
         currentSafe.address,
         currentSafe.spModuleAddress,
-        paymentTokenQuantity.address,
-        paymentTokenQuantity.count,
+        this.paymentTokenQuantity.address,
+        this.paymentTokenQuantity.count,
         this.payeeAddress,
         Number(this.gasEstimation.gas),
-        String(maxGasPrice),
+        maxGasPriceString,
         this.selectedGasToken.address,
         salt,
         this.selectedPaymentType === 'one-time' ? Math.round(this.paymentDate!.getTime() / 1000) : null,

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
@@ -63,12 +63,13 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
   @service declare scheduledPaymentSdk: ScheduledPaymentSdkService;
   @service('scheduled-payments') declare scheduledPaymentsService: ScheduledPaymentsService;
   validator = new SchedulePaymentFormValidator(this);
-  gasEstimation?: ServiceGasEstimationResult;
+
   lastScheduledPaymentId?: string;
 
   @tracked schedulingStatus?: string;
   @tracked txHash?: TransactionHash;
   @tracked scheduleErrorMessage?: string;
+  @tracked gasEstimation?: ServiceGasEstimationResult;
 
   updateInterval: ReturnType<typeof setInterval>;
 

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.gts
@@ -242,7 +242,7 @@ export default class SchedulePaymentFormActionCardUI extends Component<Signature
             @onBlur={{set this 'hasBlurredPayeeAddress' true}}
           />
         </BoxelField>
-        <BoxelField @label="Amount" @tag="label" for="schedule-payment-form-amount">
+        <BoxelField @label="Amount">
           <BoxelInputSelectableTokenAmount
             data-test-amount-input
             @id="schedule-payment-form-amount"

--- a/packages/safe-tools-client/tests/integration/components/schedule-payment-form-action-card-test.ts
+++ b/packages/safe-tools-client/tests/integration/components/schedule-payment-form-action-card-test.ts
@@ -104,6 +104,9 @@ class SafeServiceStub extends Service {
     }
     return safes;
   }
+  get currentSafe() {
+    return this.safes?.[0];
+  }
 }
 
 let tokensService: TokensService;
@@ -199,17 +202,13 @@ module(
         // Choose USDC for the gas token
         await selectChoose('[data-test-gas-token-select]', 'USDC');
 
-        assert
-          .dom('[data-test-schedule-payment-form-submit-button]')
-          .isDisabled();
-
-        await click(
-          '[data-test-max-gas-toggle] [data-toggle-group-option="normal"]'
-        );
-
+        // Button is enabled since max-gas defaults to normal
         assert
           .dom('[data-test-schedule-payment-form-submit-button]')
           .isEnabled();
+        await click(
+          '[data-test-max-gas-toggle] [data-toggle-group-option="high"]'
+        );
 
         await fillIn('[data-test-payee-address-input]', 'Not an address');
         assert


### PR DESCRIPTION
This PR adds more validation to `isValid` to prevent the button to be enable when there's no info, currently the btn gets enabled even if  gasEstimation is missing and there's no feedback. 

It also removes the tag and label from the BoxelField Amount, since it seems to have broken the token selection, maybe we should capture a ticket to investigate that ?

<img width="500" alt="Screenshot 2023-02-08 at 16 31 36" src="https://user-images.githubusercontent.com/20520102/217638974-b80e01ba-c637-4b7f-a752-88b4d059dc2f.png">
