### PR TITLE
Use chainId because network name is unreliable; ethers doesn't recognize "polygon" and still uses "matic"

### DIFF
--- a/packages/hub/services/data-integrity-checks/scheduled-payments.ts
+++ b/packages/hub/services/data-integrity-checks/scheduled-payments.ts
@@ -216,17 +216,19 @@ export default class DataIntegrityChecksScheduledPayments {
 
   async getRelayerFunderBalance(networkName: string): Promise<BigNumber> {
     let relayerUrl = getConstantByNetwork('relayServiceURL', networkName);
+    let chainId = getConstantByNetwork('chainId', networkName);
 
     let responseText = await (await fetch(`${relayerUrl}/v1/about`)).text();
     let relayerFunderPublicKey = JSON.parse(responseText).settings.SAFE_TX_SENDER_PUBLIC_KEY;
 
-    let provider = this.ethersProvider.getInstance(networkName);
+    let provider = this.ethersProvider.getInstance(chainId);
     return await provider.getBalance(relayerFunderPublicKey);
   }
 
   async getCrankBalance(networkName: string): Promise<BigNumber> {
+    let chainId = getConstantByNetwork('chainId', networkName);
     let crank = new Wallet(config.get('hubPrivateKey'));
-    let provider = this.ethersProvider.getInstance(networkName);
+    let provider = this.ethersProvider.getInstance(chainId);
     return await provider.getBalance(crank.address);
   }
 }

--- a/packages/hub/services/ethers-provider.ts
+++ b/packages/hub/services/ethers-provider.ts
@@ -2,7 +2,7 @@ import config from 'config';
 import { getWeb3ConfigByNetwork, JsonRpcProvider } from '@cardstack/cardpay-sdk';
 
 export default class EthersProvider {
-  getInstance(chainId: number | string) {
+  getInstance(chainId: number) {
     let rpcUrl = getWeb3ConfigByNetwork({ web3: config.get('web3') }, chainId).rpcNodeHttpsUrl;
     return new JsonRpcProvider(rpcUrl, chainId);
   }


### PR DESCRIPTION
Getting this error in production:

```
hub/server Unhandled error: Error: invalid network (argument="network", value="polygon", code=INVALID_ARGUMENT, version=providers/5.7.2)
    at Logger.makeError (/workspace/packages/hub/dist/hub.js:93630:23)
    at Logger.throwError (/workspace/packages/hub/dist/hub.js:93639:20)
    at Logger.throwArgumentError (/workspace/packages/hub/dist/hub.js:93642:21)
    at new BaseProvider (/workspace/packages/hub/dist/hub.js:95074:24)
    at new JsonRpcProvider (/workspace/packages/hub/dist/hub.js:98813:9)
    at new JsonRpcProvider (/workspace/packages/hub/dist/hub.js:665365:9)
    at EthersProvider.getInstance (/workspace/packages/hub/dist/hub.js:681443:16)
    at DataIntegrityChecksScheduledPayments.getRelayerFunderBalance (/workspace/packages/hub/dist/hub.js:680526:44)
```

Ethers.js still uses "matic" even though the network renamed to "polygon". We use "polygon" in our config so that makes instantiating providers using the name unreliable. It is better to use chain id because that doesn't change. 

Proof: https://github.com/ethers-io/ethers.js/blob/0bf53d7804109f5c0322d8c9a0c10d73abc84136/dist/ethers.js#L17925 (thanks @FadhlanR for finding this!)