### PR TITLE
[CS-5239]: Block submission if usdcConversion doesn't exist

### DIFF
--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
@@ -77,7 +77,7 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
 
     this.updateInterval = setInterval(() => {
       if (this.selectedGasToken) {
-        taskFor(this.tokenToUsdService.updateUsdcRate).perform(this.selectedGasToken.address); 
+        taskFor(this.tokenToUsdService.updateUsdcRate).perform(this.selectedGasToken.address);
       }
     }, INTERVAL);
   }
@@ -245,7 +245,8 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
       this.validator.isValid &&
       Boolean(this.safes.currentSafe) &&
       Boolean(this.gasEstimation) &&
-      Number(this.gasEstimation?.gas) > 0
+      Number(this.gasEstimation?.gas) > 0 &&
+      Boolean(this.usdcToGasTokenRate)
     );
   }
 


### PR DESCRIPTION
This PR validates the `usdcToGasTokenRate`, at first I went to the most complicated way to handle it, but just this flag seems to suffice, let me know if i'm missing something.