### PR TITLE
[CS-5233]: Do not show native token if it's zero

### DIFF
--- a/packages/safe-tools-client/app/components/safe-info/index.gts
+++ b/packages/safe-tools-client/app/components/safe-info/index.gts
@@ -70,7 +70,7 @@ export default class SafeInfo extends Component<Signature> {
               as |balanceDecimalValue|
             }}
               {{!-- Don't show zero balances and crypto dust --}}
-              {{#if (or tokenBalance.isNativeToken (gt tokenBalance.balance 0.0001))}}
+              {{#if (gt tokenBalance.balance 0.0001)}}
                 <div class='safe-tools_safe-info-balance' data-test-token-balance={{tokenBalance.symbol}}>
                   {{balanceDecimalValue}} {{tokenBalance.symbol}}
                 </div>


### PR DESCRIPTION
Showing the empty native token gave an impression that the user should have this value, to avoid confusion this PR hides if there is no balance.