### PR TITLE
safe tools: Fix displaying payment execution error messages

### DIFF
--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -1278,7 +1278,7 @@ export default class ScheduledPaymentModule {
       // ExceedMaxGasPrice: gasPrice must be lower than or equal maxGasPrice
       // PaymentExecutionFailed: safe balance is not enough to make payments and pay fees
       // OutOfGas: executionGas to low to execute scheduled payment
-      throw extractSendTransactionError(e, new Interface(ScheduledPaymentABI));
+      throw new Error(extractSendTransactionError(e, new Interface(ScheduledPaymentABI)));
     }
   }
 

--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -14,7 +14,7 @@ import {
 } from './utils/module-utils';
 import {
   extractBytesLikeFromError,
-  extractSendTransactionError,
+  extractSendTransactionErrorMessage,
   generateSaltNonce,
   hubRequest,
   isTransactionHash,
@@ -1278,7 +1278,7 @@ export default class ScheduledPaymentModule {
       // ExceedMaxGasPrice: gasPrice must be lower than or equal maxGasPrice
       // PaymentExecutionFailed: safe balance is not enough to make payments and pay fees
       // OutOfGas: executionGas to low to execute scheduled payment
-      throw new Error(extractSendTransactionError(e, new Interface(ScheduledPaymentABI)));
+      throw new Error(extractSendTransactionErrorMessage(e, new Interface(ScheduledPaymentABI)));
     }
   }
 

--- a/packages/cardpay-sdk/sdk/utils/general-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/general-utils.ts
@@ -352,7 +352,7 @@ export async function sendTransaction(web3: Web3, transaction: Transaction): Pro
   return txHash;
 }
 
-export function extractSendTransactionError(revert: RevertError, abiInterface: Interface) {
+export function extractSendTransactionErrorMessage(revert: RevertError, abiInterface: Interface) {
   let error;
   let bytes = extractBytesLikeFromError(revert);
   if (bytes) {

--- a/packages/safe-tools-client/app/components/payment-transactions-list/index.gts
+++ b/packages/safe-tools-client/app/components/payment-transactions-list/index.gts
@@ -21,6 +21,7 @@ import formatDate from '@cardstack/safe-tools-client/helpers/format-date';
 import { taskFor } from 'ember-concurrency-ts';
 import { task, TaskGenerator } from 'ember-concurrency';
 import nativeUnitsToDecimal from '@cardstack/safe-tools-client/helpers/native-units-to-decimal';
+import paymentErrorMessage from '@cardstack/safe-tools-client/helpers/payment-error-message';
 import { type TokenInfo } from '@uniswap/token-lists';
 import TokensService from '@cardstack/safe-tools-client/services/tokens';
 import { subDays } from 'date-fns';
@@ -185,7 +186,7 @@ class PaymentTransactionsList extends Component {
 
                   {{#if (eq paymentAttempt.status 'failed')}}
                     <span class="transactions-table-item-status-failure-reason">
-                      ({{paymentAttempt.failureReason}})
+                      ({{paymentErrorMessage paymentAttempt.failureReason}})
                     </span>
                   {{/if}}
                 </td>

--- a/packages/safe-tools-client/app/helpers/payment-error-message.ts
+++ b/packages/safe-tools-client/app/helpers/payment-error-message.ts
@@ -13,16 +13,16 @@ export function paymentErrorMessage([failureReason]: PositionalArgs) {
   // Try to match the error message to a known error explained in a way that makes sense to the user
   if (failureReason) {
     if (failureReason.includes('InvalidPeriod'))
-      return 'Payment attempted at the wrong time'; // Could be the crank's fault. Not much the user can do about it except report it to support
+      return 'payment attempted at the wrong time'; // Could be the crank's fault. Not much the user can do about it except report it to support
     if (failureReason.includes('ExceedMaxGasPrice'))
-      return 'Current gas price exceeds the maximum specified';
+      return 'current gas price exceeds the maximum specified';
     if (failureReason.includes('PaymentExecutionFailed'))
-      return 'Funds for transfer and fees are insufficient';
+      return 'insufficient funds to execute the payment'; // This error covers 3 different failure scenarios and it is currently not possible to know which we are dealing with - insufficient funds for either of the: transfer amount, gas fee, service fee
     if (failureReason.includes('OutOfGas'))
-      return 'Execution gas is too low to execute the payment'; // Probably our fault where we estimate execution gas. Not much the user can do about it except report it to support
+      return 'execution gas is too low to execute the payment'; // Probably our fault where we estimate execution gas. Not much the user can do about it except report it to support
   }
 
-  return 'Unrecognized error';
+  return 'unrecognized error';
 }
 
 export default helper<Signature>(paymentErrorMessage);

--- a/packages/safe-tools-client/app/helpers/payment-error-message.ts
+++ b/packages/safe-tools-client/app/helpers/payment-error-message.ts
@@ -13,16 +13,23 @@ export function paymentErrorMessage([failureReason]: PositionalArgs) {
   // Try to match the error message to a known error explained in a way that makes sense to the user
   if (failureReason) {
     if (failureReason.includes('InvalidPeriod'))
-      return 'payment attempted at the wrong time'; // Could be the crank's fault. Not much the user can do about it except report it to support
+      // The crank attempted this payment at the time that the scheduled payment module smart contract did not agree with.
+      // This is indicative of a scheduling bug in the crank or in the contract.
+      // The user can't do anything to fix it but report it to support.
+      return 'attempted at the incorrect time - contact support';
     if (failureReason.includes('ExceedMaxGasPrice'))
-      return 'current gas price exceeds the maximum specified';
+      return 'gas price exceeded the maximum specified';
     if (failureReason.includes('PaymentExecutionFailed'))
-      return 'insufficient funds to execute the payment'; // This error covers 3 different failure scenarios and it is currently not possible to know which we are dealing with - insufficient funds for either of the: transfer amount, gas fee, service fee
+      // This error covers 3 different failure scenarios and it is currently not possible to know which we are
+      // dealing with. It means insufficient funds for either of the: transfer amount, gas fee, service fee
+      return 'insufficient funds to execute the payment';
     if (failureReason.includes('OutOfGas'))
-      return 'execution gas is too low to execute the payment'; // Probably our fault where we estimate execution gas. Not much the user can do about it except report it to support
+      // There is something wrong with our payment execution gas estimation. This is indicative of a bug in the smart contract or the SDK.
+      // The user can't do anything to fix it but report it to support.
+      return 'incorrect gas estimation - contact support';
   }
 
-  return 'unrecognized error - contact support';
+  return 'unknown error - contact support';
 }
 
 export default helper<Signature>(paymentErrorMessage);

--- a/packages/safe-tools-client/app/helpers/payment-error-message.ts
+++ b/packages/safe-tools-client/app/helpers/payment-error-message.ts
@@ -22,7 +22,7 @@ export function paymentErrorMessage([failureReason]: PositionalArgs) {
       return 'execution gas is too low to execute the payment'; // Probably our fault where we estimate execution gas. Not much the user can do about it except report it to support
   }
 
-  return 'unrecognized error';
+  return 'unrecognized error - contact support';
 }
 
 export default helper<Signature>(paymentErrorMessage);

--- a/packages/safe-tools-client/app/helpers/payment-error-message.ts
+++ b/packages/safe-tools-client/app/helpers/payment-error-message.ts
@@ -1,0 +1,28 @@
+import { helper } from '@ember/component/helper';
+
+type PositionalArgs = [string];
+
+interface Signature {
+  Args: {
+    Positional: PositionalArgs;
+  };
+  Return: string;
+}
+
+export function paymentErrorMessage([failureReason]: PositionalArgs) {
+  // Try to match the error message to a known error explained in a way that makes sense to the user
+  if (failureReason) {
+    if (failureReason.includes('InvalidPeriod'))
+      return 'Payment attempted at the wrong time'; // Could be the crank's fault. Not much the user can do about it except report it to support
+    if (failureReason.includes('ExceedMaxGasPrice'))
+      return 'Current gas price exceeds the maximum specified';
+    if (failureReason.includes('PaymentExecutionFailed'))
+      return 'Funds for transfer and fees are insufficient';
+    if (failureReason.includes('OutOfGas'))
+      return 'Execution gas is too low to execute the payment'; // Probably our fault where we estimate execution gas. Not much the user can do about it except report it to support
+  }
+
+  return 'Unrecognized error';
+}
+
+export default helper<Signature>(paymentErrorMessage);

--- a/packages/safe-tools-client/tests/integration/components/payment-transactions-list-test.ts
+++ b/packages/safe-tools-client/tests/integration/components/payment-transactions-list-test.ts
@@ -52,7 +52,7 @@ class ScheduledPaymentsStub extends Service {
           startedAt: subDays(now, 20),
           endedAt: addMinutes(subDays(now, 20), 120),
           status: 'failed',
-          failureReason: 'Funds too low',
+          failureReason: 'PaymentExecutionFailed',
           transactionHash: '0x123',
           scheduledPayment: {
             amount: '10000000',
@@ -145,7 +145,7 @@ module('Integration | Component | payment-transactions-list', function (hooks) {
       .dom(
         '[data-test-scheduled-payment-attempts-item="1"] [data-test-scheduled-payment-attempts-item-status]'
       )
-      .includesText('Failed (Funds too low)');
+      .includesText('Failed (insufficient funds to execute the payment)');
 
     assert
       .dom(
@@ -181,7 +181,7 @@ module('Integration | Component | payment-transactions-list', function (hooks) {
       .dom(
         '[data-test-scheduled-payment-attempts-item="0"] [data-test-scheduled-payment-attempts-item-status]'
       )
-      .includesText('Failed (Funds too low)');
+      .includesText('Failed (insufficient funds to execute the payment)');
     await click('[data-test-scheduled-payment-status-filter]');
     await click('[data-test-boxel-menu-item-text="Succeeded"]');
 


### PR DESCRIPTION
This PR addresses the bug where the payment execution failure was not displayed:

<img width="147" alt="image" src="https://user-images.githubusercontent.com/273660/218125732-ef692aa5-caa4-42b1-9700-f2e35a997e74.png">

It turns out it didn't even get written to the scheduled payment record in the hub, due to an error in the code.