### PR TITLE
[CS-5244]: Add option to cancel failed payment

### DIFF
--- a/packages/hub/node-tests/routes/scheduled-payment-attempts-test.ts
+++ b/packages/hub/node-tests/routes/scheduled-payment-attempts-test.ts
@@ -253,6 +253,7 @@ describe('GET /api/scheduled-payment-attempts', async function () {
               'sender-safe-address': '0xc0ffee254729296a45a3885639AC7E10F9d54979',
               'sp-hash': '0x1234',
               'token-address': '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+              'canceled-at': null,
             },
           },
         ],

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -100,6 +100,7 @@
     "sane": "^4.1.0",
     "scenario-tester": "^0.4.0",
     "semver": "^7.3.5",
+    "sinon": "^11.1.2",
     "short-uuid": "^4.2.0",
     "source-map-support": "^0.5.21",
     "tmp": "^0.2.1",

--- a/packages/hub/services/serializers/scheduled-payment-serializer.ts
+++ b/packages/hub/services/serializers/scheduled-payment-serializer.ts
@@ -35,6 +35,7 @@ export default class ScheduledPaymentSerializer {
             'creation-transaction-error': model.creationTransactionError,
             'cancelation-transaction-hash': model.cancelationTransactionHash,
             'cancelation-block-number': model.cancelationBlockNumber,
+            'canceled-at': model.canceledAt,
           },
         },
       };

--- a/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.css
+++ b/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.css
@@ -61,7 +61,3 @@
   font: 500 var(--boxel-font-sm);
   color: var(--boxel-purple-400);
 }
-
-.cancel-scheduled-payment .boxel-action-container-section > div {
-  margin-top: 0;
-}

--- a/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.gts
+++ b/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.gts
@@ -1,36 +1,9 @@
 import Component from '@glimmer/component';
 import BoxelCardContainer from '@cardstack/boxel/components/boxel/card-container';
-import BoxelIconButton from '@cardstack/boxel/components/boxel/icon-button';
-import ScheduledPaymentSdkService from '@cardstack/safe-tools-client/services/scheduled-payment-sdk';
-import BoxelLoadingIndicator from '@cardstack/boxel/components/boxel/loading-indicator';
-import BoxelActionContainer from '@cardstack/boxel/components/boxel/action-container';
-import BoxelModal from '@cardstack/boxel/components/boxel/modal';
 import { ScheduledPayment } from '@cardstack/safe-tools-client/services/scheduled-payments';
 import formatDate from '@cardstack/safe-tools-client/helpers/format-date';
-import truncateMiddle from '@cardstack/safe-tools-client/helpers/truncate-middle';
-import { inject as service } from '@ember/service';
-import TokensService from '@cardstack/safe-tools-client/services/tokens';
 import tokenToUsd from '@cardstack/safe-tools-client/helpers/token-to-usd';
-import { on } from '@ember/modifier';
-import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
-import { noop } from '@cardstack/safe-tools-client/helpers/noop';
-import { taskFor } from 'ember-concurrency-ts';
-import HubAuthenticationService from '@cardstack/safe-tools-client/services/hub-authentication';
-import SafesService from '@cardstack/safe-tools-client/services/safes';
-import SuccessIcon from '@cardstack/safe-tools-client/components/icons/success';
-import FailureIcon from '@cardstack/safe-tools-client/components/icons/failure';
-import InfoIcon from '@cardstack/safe-tools-client/components/icons/info';
-import BoxelDropdown from '@cardstack/boxel/components/boxel/dropdown';
-import BoxelMenu from '@cardstack/boxel/components/boxel/menu';
-import { type ActionChinState } from '@cardstack/boxel/components/boxel/action-chin/state'
-import menuItem from '@cardstack/boxel/helpers/menu-item'
-import { array, fn } from '@ember/helper';
-import set from 'ember-set-helper/helpers/set';
-import ScheduledPaymentsService from '@cardstack/safe-tools-client/services/scheduled-payments';
-import { TaskGenerator } from 'ember-concurrency';
-import { task } from 'ember-concurrency-decorators';
-import * as Sentry from '@sentry/browser';
+import PaymentOptionsDropdown from '@cardstack/safe-tools-client/components/payment-options-dropdown';
 import TruncatedBlockchainAddress from '@cardstack/safe-tools-client/components/truncated-blockchain-address';
 
 import './index.css';
@@ -43,53 +16,6 @@ interface Signature {
 }
 
 export default class ScheduledPaymentCard extends Component<Signature> {
-  @service declare scheduledPaymentSdk: ScheduledPaymentSdkService;
-  @service declare scheduledPayments: ScheduledPaymentsService;
-  @service declare hubAuthentication: HubAuthenticationService;
-  @service declare safes: SafesService;
-  @service declare tokens: TokensService;
-  @tracked optionsMenuOpened = false;
-  @tracked isCancelPaymentModalOpen = false;
-  @tracked cancelationErrorMessage?: string;
-
-  @action closeCancelScheduledPaymentModal(reload: boolean) {
-    this.isCancelPaymentModalOpen = false;
-    if (reload) this.scheduledPayments.reloadScheduledPayments();
-  }
-
-  get cancelPaymentState(): ActionChinState {
-    if (taskFor(this.cancelScheduledPaymentTask).isRunning) {
-      return 'in-progress';
-    }
-
-    return 'default';
-  }
-
-  @task *cancelScheduledPaymentTask(
-    scheduledPaymentId: string,
-    authToken: string
-  ): TaskGenerator<void> {
-    try {
-      yield this.scheduledPaymentSdk.cancelScheduledPayment(scheduledPaymentId, authToken);
-    } catch (e) {
-      this.cancelationErrorMessage = "There was an error canceling your scheduled payment. Please try again, or contact support if the problem persists.";
-      Sentry.captureException(e);
-    }
-  }
-
-  @action async cancelScheduledPayment() {
-    await taskFor(this.cancelScheduledPaymentTask).perform(this.args.scheduledPayment.id, this.hubAuthentication.authToken!)
-    this.safes.reloadTokenBalances();
-  }
-
-  get paymentCanceled() {
-    return taskFor(this.cancelScheduledPaymentTask).last?.isSuccessful;
-  }
-
-  get cancelationError(): Error | undefined {
-    return taskFor(this.cancelScheduledPaymentTask).last?.error as Error
-  }
-
   get paymentType() {
     return this.args.scheduledPayment.recurringDayOfMonth && this.args.scheduledPayment.recurringUntil ? 'Recurring' : 'One-time';
   }
@@ -112,96 +38,8 @@ export default class ScheduledPaymentCard extends Component<Signature> {
           </div>
         </div>
       </div>
-
-      <BoxelDropdown>
-        <:trigger as |bindings|>
-          <BoxelIconButton
-            @icon="more-actions"
-            @height="30px"
-            {{bindings}}
-            data-test-scheduled-payment-card-options-button
-          />
-        </:trigger>
-        <:content as |dd|>
-          <BoxelMenu
-            @closeMenu={{dd.close}}
-            @items={{array
-              (menuItem
-                "Cancel Payment" (set this 'isCancelPaymentModalOpen' true)
-              )
-            }}
-          />
-        </:content>
-      </BoxelDropdown>
+      <PaymentOptionsDropdown @scheduledPayment={{@scheduledPayment}}/>
     </BoxelCardContainer>
-
-    <BoxelModal
-      @size='medium'
-      @isOpen={{this.isCancelPaymentModalOpen}}
-      @onClose={{noop}}
-      class="cancel-scheduled-payment"
-      data-test-cancel-scheduled-payment-modal
-    >
-      <BoxelActionContainer
-        as |Section ActionChin|
-      >
-        <Section @title="Cancel your scheduled payment">
-          <div>
-            <p>You're about to cancel your payment of <strong>{{@scheduledPayment.paymentTokenQuantity.displayable}}</strong>
-            to <span class="blockchain-address">{{truncateMiddle @scheduledPayment.payeeAddress}}</span>, scheduled for <strong>{{formatDate @scheduledPayment.payAt "d/M/yyyy"}}</strong>.</p>
-
-            <p>This action will remove the scheduled payment from the scheduled payment module, and it won't be attempted in the future.</p>
-          </div>
-        </Section>
-
-        <ActionChin @state={{this.cancelPaymentState}}>
-          <:default as |a|>
-            {{#if this.cancelationErrorMessage}}
-              <a.ActionButton {{on "click" this.cancelScheduledPayment}} data-test-cancel-payment-button>
-                Cancel Payment
-              </a.ActionButton>
-
-              <a.CancelButton {{on 'click' (fn this.closeCancelScheduledPaymentModal false)}} data-test-close-cancel-payment-modal>
-                Close
-              </a.CancelButton>
-
-              <a.InfoArea>
-                <FailureIcon class='action-chin-info-icon' />
-                <span>{{this.cancelationErrorMessage}}</span>
-              </a.InfoArea>
-            {{else if this.paymentCanceled}}
-              <a.ActionButton {{on "click" (fn this.closeCancelScheduledPaymentModal true)}} data-test-close-cancel-payment-modal>
-                Close
-              </a.ActionButton>
-
-              <a.InfoArea>
-                <SuccessIcon class='action-chin-info-icon' />
-                Your scheduled payment was canceled and removed successfully, and it won't be attempted in the future.
-              </a.InfoArea>
-            {{else}}
-              <a.ActionButton {{on "click" this.cancelScheduledPayment}} data-test-cancel-payment-button>
-                Cancel Payment
-              </a.ActionButton>
-              <a.CancelButton {{on 'click' (fn this.closeCancelScheduledPaymentModal false)}} data-test-close-cancel-payment-modal>
-                Close
-              </a.CancelButton>
-            {{/if}}
-          </:default>
-          <:inProgress as |i|>
-            <i.ActionStatusArea>
-              <BoxelLoadingIndicator class="schedule-payment-form-action-card__loading-indicator" @color="var(--boxel-light)" />
-
-              Canceling scheduled payment...
-            </i.ActionStatusArea>
-
-            <i.InfoArea>
-              <InfoIcon class='action-chin-info-icon' />
-              Canceling a payment could take up to a couple of minutes, depending on the blockchain network conditions.
-            </i.InfoArea>
-          </:inProgress>
-        </ActionChin>
-      </BoxelActionContainer>
-    </BoxelModal>
   </template>
 }
 

--- a/packages/safe-tools-client/app/components/payment-options-dropdown/index.css
+++ b/packages/safe-tools-client/app/components/payment-options-dropdown/index.css
@@ -1,0 +1,3 @@
+.cancel-scheduled-payment .boxel-action-container-section > div {
+  margin-top: 0;
+}

--- a/packages/safe-tools-client/app/components/payment-options-dropdown/index.gts
+++ b/packages/safe-tools-client/app/components/payment-options-dropdown/index.gts
@@ -4,7 +4,7 @@ import ScheduledPaymentSdkService from '@cardstack/safe-tools-client/services/sc
 import BoxelLoadingIndicator from '@cardstack/boxel/components/boxel/loading-indicator';
 import BoxelActionContainer from '@cardstack/boxel/components/boxel/action-container';
 import BoxelModal from '@cardstack/boxel/components/boxel/modal';
-import { ScheduledPayment } from '@cardstack/safe-tools-client/services/scheduled-payments';
+import { ScheduledPaymentBase } from '@cardstack/safe-tools-client/services/scheduled-payments';
 import formatDate from '@cardstack/safe-tools-client/helpers/format-date';
 import truncateMiddle from '@cardstack/safe-tools-client/helpers/truncate-middle';
 import { inject as service } from '@ember/service';
@@ -35,7 +35,7 @@ import './index.css';
 interface Signature {
   Element: HTMLElement;
   Args: {
-    scheduledPayment: ScheduledPayment;
+    scheduledPayment: ScheduledPaymentBase;
   }
 }
 

--- a/packages/safe-tools-client/app/components/payment-options-dropdown/index.gts
+++ b/packages/safe-tools-client/app/components/payment-options-dropdown/index.gts
@@ -1,0 +1,186 @@
+import Component from '@glimmer/component';
+import BoxelIconButton from '@cardstack/boxel/components/boxel/icon-button';
+import ScheduledPaymentSdkService from '@cardstack/safe-tools-client/services/scheduled-payment-sdk';
+import BoxelLoadingIndicator from '@cardstack/boxel/components/boxel/loading-indicator';
+import BoxelActionContainer from '@cardstack/boxel/components/boxel/action-container';
+import BoxelModal from '@cardstack/boxel/components/boxel/modal';
+import { ScheduledPayment } from '@cardstack/safe-tools-client/services/scheduled-payments';
+import formatDate from '@cardstack/safe-tools-client/helpers/format-date';
+import truncateMiddle from '@cardstack/safe-tools-client/helpers/truncate-middle';
+import { inject as service } from '@ember/service';
+import TokensService from '@cardstack/safe-tools-client/services/tokens';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { noop } from '@cardstack/safe-tools-client/helpers/noop';
+import { taskFor } from 'ember-concurrency-ts';
+import HubAuthenticationService from '@cardstack/safe-tools-client/services/hub-authentication';
+import SafesService from '@cardstack/safe-tools-client/services/safes';
+import SuccessIcon from '@cardstack/safe-tools-client/components/icons/success';
+import FailureIcon from '@cardstack/safe-tools-client/components/icons/failure';
+import InfoIcon from '@cardstack/safe-tools-client/components/icons/info';
+import BoxelDropdown from '@cardstack/boxel/components/boxel/dropdown';
+import BoxelMenu from '@cardstack/boxel/components/boxel/menu';
+import { type ActionChinState } from '@cardstack/boxel/components/boxel/action-chin/state'
+import menuItem from '@cardstack/boxel/helpers/menu-item'
+import { array, fn } from '@ember/helper';
+import set from 'ember-set-helper/helpers/set';
+import ScheduledPaymentsService from '@cardstack/safe-tools-client/services/scheduled-payments';
+import { TaskGenerator } from 'ember-concurrency';
+import { task } from 'ember-concurrency-decorators';
+import * as Sentry from '@sentry/browser';
+
+import './index.css';
+
+interface Signature {
+  Element: HTMLElement;
+  Args: {
+    scheduledPayment: ScheduledPayment;
+  }
+}
+
+export default class PaymentOptionsDropdown extends Component<Signature> {
+  @service declare scheduledPaymentSdk: ScheduledPaymentSdkService;
+  @service declare scheduledPayments: ScheduledPaymentsService;
+  @service declare hubAuthentication: HubAuthenticationService;
+  @service declare safes: SafesService;
+  @service declare tokens: TokensService;
+  @tracked optionsMenuOpened = false;
+  @tracked isCancelPaymentModalOpen = false;
+  @tracked cancelationErrorMessage?: string;
+
+  @action closeCancelScheduledPaymentModal(reload: boolean) {
+    this.isCancelPaymentModalOpen = false;
+    if (reload) this.scheduledPayments.reloadScheduledPayments();
+  }
+
+  get cancelPaymentState(): ActionChinState {
+    if (taskFor(this.cancelScheduledPaymentTask).isRunning) {
+      return 'in-progress';
+    }
+
+    return 'default';
+  }
+
+  @task *cancelScheduledPaymentTask(
+    scheduledPaymentId: string,
+    authToken: string
+  ): TaskGenerator<void> {
+    try {
+      yield this.scheduledPaymentSdk.cancelScheduledPayment(scheduledPaymentId, authToken);
+    } catch (e) {
+      this.cancelationErrorMessage = "There was an error canceling your scheduled payment. Please try again, or contact support if the problem persists.";
+      Sentry.captureException(e);
+    }
+  }
+
+  @action async cancelScheduledPayment() {
+    await taskFor(this.cancelScheduledPaymentTask).perform(this.args.scheduledPayment.id, this.hubAuthentication.authToken!)
+    this.safes.reloadTokenBalances();
+  }
+
+  get paymentCanceled() {
+    return taskFor(this.cancelScheduledPaymentTask).last?.isSuccessful;
+  }
+
+  get cancelationError(): Error | undefined {
+    return taskFor(this.cancelScheduledPaymentTask).last?.error as Error
+  }
+
+  <template>
+    <BoxelDropdown>
+      <:trigger as |bindings|>
+        <BoxelIconButton
+          @icon="more-actions"
+          @height="30px"
+          {{bindings}}
+          data-test-scheduled-payment-card-options-button
+        />
+      </:trigger>
+      <:content as |dd|>
+        <BoxelMenu
+          @closeMenu={{dd.close}}
+          @items={{array
+            (menuItem
+              "Cancel Payment" (set this 'isCancelPaymentModalOpen' true)
+            )
+          }}
+        />
+      </:content>
+    </BoxelDropdown>
+
+    <BoxelModal
+      @size='medium'
+      @isOpen={{this.isCancelPaymentModalOpen}}
+      @onClose={{noop}}
+      class="cancel-scheduled-payment"
+      data-test-cancel-scheduled-payment-modal
+    >
+      <BoxelActionContainer
+        as |Section ActionChin|
+      >
+        <Section @title="Cancel your scheduled payment">
+          <div>
+            <p>You're about to cancel your payment of <strong>{{@scheduledPayment.paymentTokenQuantity.displayable}}</strong>
+            to <span class="blockchain-address">{{truncateMiddle @scheduledPayment.payeeAddress}}</span>, scheduled for <strong>{{formatDate @scheduledPayment.payAt "d/M/yyyy"}}</strong>.</p>
+
+            <p>This action will remove the scheduled payment from the scheduled payment module, and it won't be attempted in the future.</p>
+          </div>
+        </Section>
+
+        <ActionChin @state={{this.cancelPaymentState}}>
+          <:default as |a|>
+            {{#if this.cancelationErrorMessage}}
+              <a.ActionButton {{on "click" this.cancelScheduledPayment}} data-test-cancel-payment-button>
+                Cancel Payment
+              </a.ActionButton>
+
+              <a.CancelButton {{on 'click' (fn this.closeCancelScheduledPaymentModal false)}} data-test-close-cancel-payment-modal>
+                Close
+              </a.CancelButton>
+
+              <a.InfoArea>
+                <FailureIcon class='action-chin-info-icon' />
+                <span>{{this.cancelationErrorMessage}}</span>
+              </a.InfoArea>
+            {{else if this.paymentCanceled}}
+              <a.ActionButton {{on "click" (fn this.closeCancelScheduledPaymentModal true)}} data-test-close-cancel-payment-modal>
+                Close
+              </a.ActionButton>
+
+              <a.InfoArea>
+                <SuccessIcon class='action-chin-info-icon' />
+                Your scheduled payment was canceled and removed successfully, and it won't be attempted in the future.
+              </a.InfoArea>
+            {{else}}
+              <a.ActionButton {{on "click" this.cancelScheduledPayment}} data-test-cancel-payment-button>
+                Cancel Payment
+              </a.ActionButton>
+              <a.CancelButton {{on 'click' (fn this.closeCancelScheduledPaymentModal false)}} data-test-close-cancel-payment-modal>
+                Close
+              </a.CancelButton>
+            {{/if}}
+          </:default>
+          <:inProgress as |i|>
+            <i.ActionStatusArea>
+              <BoxelLoadingIndicator class="schedule-payment-form-action-card__loading-indicator" @color="var(--boxel-light)" />
+
+              Canceling scheduled payment...
+            </i.ActionStatusArea>
+
+            <i.InfoArea>
+              <InfoIcon class='action-chin-info-icon' />
+              Canceling a payment could take up to a couple of minutes, depending on the blockchain network conditions.
+            </i.InfoArea>
+          </:inProgress>
+        </ActionChin>
+      </BoxelActionContainer>
+    </BoxelModal>
+  </template>
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'PaymentOptionsDropdown': typeof PaymentOptionsDropdown;
+  }
+}

--- a/packages/safe-tools-client/app/components/payment-transactions-list/index.gts
+++ b/packages/safe-tools-client/app/components/payment-transactions-list/index.gts
@@ -20,9 +20,7 @@ import { menuItemFunc, MenuItem } from '@cardstack/boxel/helpers/menu-item'
 import formatDate from '@cardstack/safe-tools-client/helpers/format-date';
 import { taskFor } from 'ember-concurrency-ts';
 import { task, TaskGenerator } from 'ember-concurrency';
-import nativeUnitsToDecimal from '@cardstack/safe-tools-client/helpers/native-units-to-decimal';
 import paymentErrorMessage from '@cardstack/safe-tools-client/helpers/payment-error-message';
-import { type TokenInfo } from '@uniswap/token-lists';
 import TokensService from '@cardstack/safe-tools-client/services/tokens';
 import { subDays } from 'date-fns';
 import { action } from '@ember/object';
@@ -63,13 +61,7 @@ class PaymentTransactionsList extends Component {
   }
 
   get paymentAttempts() {
-    if (!this.scheduledPaymentAttemptsResource.value) return [];
-
-    // Add token info to each scheduled payment attempt so that we can display the token symbol and convert the amount to decimal using nativeUnitsToDecimal
-    return this.scheduledPaymentAttemptsResource.value.map((scheduledPaymentAttempt) => {
-      const tokenInfo = this.tokens.transactionTokens.find((t) => t.address === scheduledPaymentAttempt.scheduledPayment.tokenAddress) as TokenInfo;
-      return { ...scheduledPaymentAttempt, tokenInfo };
-    });
+    return this.scheduledPaymentAttemptsResource.value || []
   }
 
   @task *loadScheduledPaymentAttemptsTask(chainId: number, status?: ScheduledPaymentAttemptStatus, startedAt?: Date): TaskGenerator<ScheduledPaymentAttempt[]> {
@@ -173,7 +165,7 @@ class PaymentTransactionsList extends Component {
                   {{paymentAttempt.scheduledPayment.payeeAddress}}
                 </td>
                 <td class="table__cell" data-test-scheduled-payment-attempts-item-amount>
-                  <strong>{{nativeUnitsToDecimal paymentAttempt.scheduledPayment.amount paymentAttempt.tokenInfo.decimals}} {{paymentAttempt.tokenInfo.symbol}}</strong>
+                  <strong>{{paymentAttempt.scheduledPayment.paymentTokenQuantity.displayable}}</strong>
                 </td>
                 <td class="table__cell" data-test-scheduled-payment-attempts-item-status>
                   {{#if (eq paymentAttempt.status 'succeeded')}}

--- a/packages/safe-tools-client/app/components/payment-transactions-list/index.gts
+++ b/packages/safe-tools-client/app/components/payment-transactions-list/index.gts
@@ -11,6 +11,7 @@ import WalletService from '@cardstack/safe-tools-client/services/wallet';
 import NetworkService from '@cardstack/safe-tools-client/services/network';
 import HubAuthenticationService from '@cardstack/safe-tools-client/services/hub-authentication';
 import ScheduledPaymentsService, { ScheduledPaymentAttempt, type ScheduledPaymentAttemptStatus } from '@cardstack/safe-tools-client/services/scheduled-payments';
+import PaymentOptionsDropdown from '@cardstack/safe-tools-client/components/payment-options-dropdown';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { TrackedObject } from 'tracked-built-ins';
@@ -191,6 +192,10 @@ class PaymentTransactionsList extends Component {
                     />
                   {{/if}}
                 </td>
+                {{!-- TODO: only show options for < 3 attempt, when this info is stored --}}
+                {{#if (eq paymentAttempt.status 'failed')}}
+                  <PaymentOptionsDropdown @scheduledPayment={{paymentAttempt.scheduledPayment}}/>
+                {{/if}}
               </tr>
             {{/each}}
           </tbody>

--- a/packages/safe-tools-client/app/components/payment-transactions-list/index.gts
+++ b/packages/safe-tools-client/app/components/payment-transactions-list/index.gts
@@ -16,6 +16,8 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { TrackedObject } from 'tracked-built-ins';
 import eq from 'ember-truth-helpers/helpers/eq';
+import and from 'ember-truth-helpers/helpers/and';
+import not from 'ember-truth-helpers/helpers/not';
 import { concat, fn } from '@ember/helper';
 import { menuItemFunc, MenuItem } from '@cardstack/boxel/helpers/menu-item'
 import formatDate from '@cardstack/safe-tools-client/helpers/format-date';
@@ -172,11 +174,13 @@ class PaymentTransactionsList extends Component {
                   {{#if (eq paymentAttempt.status 'succeeded')}}
                     🟢 <span class="transactions-table-item-status-text">Confirmed</span>
                   {{else if (eq paymentAttempt.status 'failed')}}
-                    🔴 <span class="transactions-table-item-status-text">Failed</span>
-                  {{else if (eq paymentAttempt.status 'inProgress')}}
+                    {{#if paymentAttempt.scheduledPayment.isCanceled}}
+                      🟠 <span class="transactions-table-item-status-text">Canceled</span>
+                    {{else}}
+                      🔴 <span class="transactions-table-item-status-text">Failed</span>
+                    {{/if}}
+                  {{else}}
                     🔵 <span class="transactions-table-item-status-text">Pending</span>
-                  {{else if (eq paymentAttempt.status 'canceled')}}
-                    🟠 <span class="transactions-table-item-status-text">Canceled</span>
                   {{/if}}
 
                   {{#if (eq paymentAttempt.status 'failed')}}
@@ -195,7 +199,7 @@ class PaymentTransactionsList extends Component {
                   {{/if}}
                 </td>
                 {{!-- TODO: only show options for < 3 attempt, when this info is stored --}}
-                {{#if (eq paymentAttempt.status 'failed')}}
+                {{#if (and (eq paymentAttempt.status 'failed') (not paymentAttempt.scheduledPayment.isCanceled))}}
                   <PaymentOptionsDropdown @scheduledPayment={{paymentAttempt.scheduledPayment}}/>
                 {{/if}}
               </tr>

--- a/packages/safe-tools-client/app/components/payment-transactions-list/index.gts
+++ b/packages/safe-tools-client/app/components/payment-transactions-list/index.gts
@@ -173,8 +173,10 @@ class PaymentTransactionsList extends Component {
                     🟢 <span class="transactions-table-item-status-text">Confirmed</span>
                   {{else if (eq paymentAttempt.status 'failed')}}
                     🔴 <span class="transactions-table-item-status-text">Failed</span>
-                  {{else}}
+                  {{else if (eq paymentAttempt.status 'inProgress')}}
                     🔵 <span class="transactions-table-item-status-text">Pending</span>
+                  {{else if (eq paymentAttempt.status 'canceled')}}
+                    🟠 <span class="transactions-table-item-status-text">Canceled</span>
                   {{/if}}
 
                   {{#if (eq paymentAttempt.status 'failed')}}

--- a/packages/safe-tools-client/app/services/scheduled-payments.ts
+++ b/packages/safe-tools-client/app/services/scheduled-payments.ts
@@ -23,6 +23,7 @@ export interface ScheduledPaymentBase {
   payeeAddress: string;
   payAt: Date;
   chainId: number;
+  isCanceled?: boolean;
 }
 
 export interface ScheduledPayment extends ScheduledPaymentBase {
@@ -86,6 +87,7 @@ export interface ScheduledPaymentAttemptIncludedData {
   'payee-address': string;
   'pay-at': string;
   'chain-id': string;
+  'canceled-at': string;
 }
 
 export interface ScheduledPaymentAttemptResponseIncludedItem {
@@ -205,6 +207,7 @@ export default class ScheduledPaymentsService extends Service {
           chainId: Number(scheduledPayment!['chain-id']),
           payeeAddress: scheduledPayment!['payee-address'],
           payAt: new Date(scheduledPayment!['pay-at']),
+          isCanceled: Boolean(scheduledPayment!['canceled-at']),
         },
       };
     });

--- a/packages/safe-tools-client/tests/integration/components/payment-transactions-list-test.ts
+++ b/packages/safe-tools-client/tests/integration/components/payment-transactions-list-test.ts
@@ -1,8 +1,13 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { type ScheduledPaymentAttemptStatus } from '@cardstack/safe-tools-client/services/scheduled-payments';
+import {
+  ScheduledPaymentAttempt,
+  type ScheduledPaymentAttemptStatus,
+} from '@cardstack/safe-tools-client/services/scheduled-payments';
+import TokenQuantity from '@cardstack/safe-tools-client/utils/token-quantity';
 import Service from '@ember/service';
 import { click, render, TestContext } from '@ember/test-helpers';
 import { subDays, addMinutes, format } from 'date-fns';
+import { BigNumber } from 'ethers';
 
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
@@ -24,25 +29,36 @@ class ScheduledPaymentsStub extends Service {
     chainId: number,
     status?: ScheduledPaymentAttemptStatus,
     startedAt?: Date
-  ) => {
+  ): Promise<ScheduledPaymentAttempt[]> => {
     if (returnEmptyScheduledPaymentAttempts) {
       return Promise.resolve([]);
     }
+
+    const paymentToken = {
+      address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      symbol: 'USDC',
+      name: 'Example USDC',
+      decimals: 6,
+    };
+
+    const addPaymentTokenQuantity = (amount: string) =>
+      new TokenQuantity(paymentToken, BigNumber.from(amount));
+
     return Promise.resolve(
       [
         {
           startedAt: subDays(now, 10),
           endedAt: addMinutes(subDays(now, 10), 120),
           status: 'succeeded',
-          failureReason: null,
+          failureReason: '',
           transactionHash:
             '0x6f7c54719c0901e30ef018206c37df4daa059224549a08d55acb3360f01094e2',
           scheduledPayment: {
-            amount: '10000000',
+            id: '01234',
+            paymentTokenQuantity: addPaymentTokenQuantity('10000000'),
             feeFixedUSD: '0',
             feePercentage: '0',
             gasTokenAddress: '0x123',
-            tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
             chainId,
             payeeAddress: '0xeBCC5516d44FFf5E9aBa2AcaeB65BbB49bC3EBe1',
             payAt: addMinutes(subDays(now, 10), 120),
@@ -55,11 +71,11 @@ class ScheduledPaymentsStub extends Service {
           failureReason: 'PaymentExecutionFailed',
           transactionHash: '0x123',
           scheduledPayment: {
-            amount: '10000000',
+            id: '34234',
+            paymentTokenQuantity: addPaymentTokenQuantity('10000000'),
             feeFixedUSD: '0',
             feePercentage: '0',
             gasTokenAddress: '0x123',
-            tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
             chainId,
             payeeAddress: '0xeBCC5516d44FFf5E9aBa2AcaeB65BbB49bC3EBe1',
             payAt: addMinutes(subDays(now, 20), 120),
@@ -69,14 +85,14 @@ class ScheduledPaymentsStub extends Service {
           startedAt: subDays(now, 60),
           endedAt: addMinutes(subDays(now, 60), 120),
           status: 'succeeded',
-          failureReason: undefined,
+          failureReason: '',
           transactionHash: '0x123',
           scheduledPayment: {
-            amount: '15000000',
+            id: '323232',
+            paymentTokenQuantity: addPaymentTokenQuantity('15000000'),
             feeFixedUSD: '0',
             feePercentage: '0',
             gasTokenAddress: '0x123',
-            tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
             chainId,
             payeeAddress: '0xeBCC5516d44FFf5E9aBa2AcaeB65BbB49bC3EBe1',
             payAt: addMinutes(subDays(now, 60), 120),

--- a/packages/safe-tools-client/tests/integration/components/payment-transactions-list-test.ts
+++ b/packages/safe-tools-client/tests/integration/components/payment-transactions-list-test.ts
@@ -133,7 +133,7 @@ module('Integration | Component | payment-transactions-list', function (hooks) {
       .dom(
         '[data-test-scheduled-payment-attempts-item="0"] [data-test-scheduled-payment-attempts-item-amount]'
       )
-      .hasText('10 USDC');
+      .hasText('10.0 USDC');
 
     assert
       .dom(


### PR DESCRIPTION
This PR extracts the cancel option in its own component `PaymentOptionsDropdown` and adds it to the failed row. It also combine similar types (SchedulePayment) to keep consistency across data structure. 

<img width="400" alt="image" src="https://user-images.githubusercontent.com/20520102/218571500-1426ec2b-88a9-45e2-b51a-740970849b91.png">

PS: Even though it adds a canceled state, the hub doesn't return it yet, so it won't be reflected until the hub ticket is complete.