### PR TITLE
Fix reconnection issue

### DIFF
--- a/packages/safe-tools-client/app/utils/chain-connection-manager.ts
+++ b/packages/safe-tools-client/app/utils/chain-connection-manager.ts
@@ -231,7 +231,6 @@ export class ChainConnectionManager {
 
   @action onConnect(accounts: string[]) {
     if (!this.strategy) return;
-    this.addProviderToStorage(this.chainId, this.strategy.providerId);
     this.emit('connected', accounts);
 
     if (this.providerId) {
@@ -245,6 +244,9 @@ export class ChainConnectionManager {
 
   @action onChainChanged(chainId: number) {
     this.emit('chain-changed', chainId);
+
+    if (!this.strategy) return;
+    this.addProviderToStorage(chainId, this.strategy.providerId);
   }
 
   @action onWebsocketDisconnected() {


### PR DESCRIPTION
I fixed this issue by adding a provider to local storage in the `chain-changed` event, not in the `connect` event. Because in the `connect` event the chain id might be still using the default value, not the chain id that the users use in their wallet.