### PR TITLE
Do not include canceled payments in the "payments that should have been attempted" check

### DIFF
--- a/packages/hub/node-tests/services/data-integrity-checks-test.ts
+++ b/packages/hub/node-tests/services/data-integrity-checks-test.ts
@@ -165,6 +165,30 @@ describe('data integrity checks', function () {
         },
       });
 
+      // Below is a canceled scheduled payment that should not be considered unattempted
+      await prisma.scheduledPayment.create({
+        data: {
+          id: shortUuid.uuid(),
+          senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+          moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+          tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+          gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+          amount: '100',
+          payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+          executionGasEstimation: 100000,
+          maxGasPrice: '1000000000',
+          feeFixedUsd: '0',
+          feePercentage: '0',
+          salt: '54lt',
+          payAt: subMinutes(nowUtc(), 61),
+          spHash: cryptoRandomString({ length: 10 }),
+          chainId: 1,
+          canceledAt: nowUtc(),
+          userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+          creationTransactionHash: '0x123',
+        },
+      });
+
       let result = await service.check();
 
       expect(result).to.deep.equal({

--- a/packages/hub/services/data-integrity-checks/scheduled-payments.ts
+++ b/packages/hub/services/data-integrity-checks/scheduled-payments.ts
@@ -109,6 +109,7 @@ export default class DataIntegrityChecksScheduledPayments {
           lt: subMinutes(nowUtc(), 60),
           gt: subMinutes(nowUtc(), UNATTEMPTED_ALLOWED_MINUTES),
         },
+        canceledAt: null,
         scheduledPaymentAttempts: {
           none: {
             startedAt: {


### PR DESCRIPTION
I saw this in Checkly:

<img width="1061" alt="image" src="https://user-images.githubusercontent.com/273660/220082987-4a1c0bfd-7386-4a81-8f3d-ae8ad4ad217c.png">

But this payment had a "canceled" status. We don't want to consider such payments unattempted. 