### PR TITLE
Fix schedule another payment issue

### DIFF
--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -106,6 +106,7 @@ export interface SchedulePaymentProgressListener {
 
 interface SchedulePaymentOptions {
   hubUrl?: string;
+  authToken?: string;
   listener?: SchedulePaymentProgressListener;
 }
 
@@ -973,8 +974,8 @@ export default class ScheduledPaymentModule {
   ) {
     options.listener?.onBeginHubAuthentication?.();
     let hubAuth = await getSDK('HubAuth', this.ethersProvider, options.hubUrl, this.signer);
-    let hubRootUrl = await hubAuth.getHubUrl();
-    let authToken = await hubAuth.authenticate();
+    let hubRootUrl = options.hubUrl ?? (await hubAuth.getHubUrl());
+    let authToken = options.authToken ?? (await hubAuth.authenticate());
     options.listener?.onEndHubAuthentication?.();
 
     let safeAddress: string;

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
@@ -26,6 +26,7 @@ import TokenQuantity from '@cardstack/safe-tools-client/utils/token-quantity';
 import * as Sentry from '@sentry/browser';
 import FeeCalculator, { type CurrentFees } from './fee-calculator';
 import config from '@cardstack/safe-tools-client/config/environment';
+import HubAuthenticationService from '@cardstack/safe-tools-client/services/hub-authentication';
 
 interface Signature {
   Element: HTMLElement;
@@ -64,6 +65,7 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
   @service declare wallet: WalletService;
   @service declare safes: SafesService;
   @service declare tokens: TokensService;
+  @service declare hubAuthentication: HubAuthenticationService;
   @service('token-to-usd') declare tokenToUsdService: TokenToUsdService;
   @service declare scheduledPaymentSdk: ScheduledPaymentSdkService;
   @service('scheduled-payments') declare scheduledPaymentsService: ScheduledPaymentsService;
@@ -439,6 +441,7 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
         params.payAt,
         params.recurringDayOfMonth,
         params.recurringUntil,
+        this.hubAuthentication.authToken!,
         {
           onScheduledPaymentIdReady(scheduledPaymentId: string) {
             self.lastScheduledPaymentId = scheduledPaymentId;

--- a/packages/safe-tools-client/app/services/scheduled-payment-sdk.ts
+++ b/packages/safe-tools-client/app/services/scheduled-payment-sdk.ts
@@ -155,6 +155,7 @@ export default class SchedulePaymentSDKService extends Service {
     payAt: number | null,
     recurringDayOfMonth: number | null,
     recurringUntil: number | null,
+    authToken: string,
     listener: SchedulePaymentProgressListener
   ): TaskGenerator<void> {
     const scheduledPaymentModule: ScheduledPaymentModule =
@@ -175,6 +176,7 @@ export default class SchedulePaymentSDKService extends Service {
       {
         hubUrl: config.hubUrl,
         listener,
+        authToken,
       }
     );
   }

--- a/packages/safe-tools-client/tests/acceptance/scheduling-test.ts
+++ b/packages/safe-tools-client/tests/acceptance/scheduling-test.ts
@@ -400,7 +400,6 @@ module('Acceptance | scheduling', function (hooks) {
       await fillInSchedulePaymentFormWithValidInfo({ type: 'one-time' });
       await waitFor(`${SUBMIT_BUTTON}:not(:disabled)`);
       await click(SUBMIT_BUTTON);
-      assert.dom(IN_PROGRESS_MESSAGE).hasText('Authenticating...');
       assert.dom(PAYEE_INPUT).isDisabled();
 
       await waitUntil(() =>
@@ -413,7 +412,7 @@ module('Acceptance | scheduling', function (hooks) {
 
       assert.strictEqual(
         signedHubAuthentication,
-        2,
+        1,
         'signed hub authentication'
       );
       scheduledPaymentCreateSpHashDeferred?.fulfill();


### PR DESCRIPTION
Ticket: CS-5322

**Problem**
There is a 401 error when scheduling another payment. It is caused by an invalid nonce error when authenticating to the hub. 

**Solution** 
Instead of asking for re-authentication every time the user schedules a payment, we can pass the existing hub auth token to the schedule payment function in SDK.

