### PR TITLE
Refactor schedule payment for safe module

### DIFF
--- a/packages/cardpay-sdk/sdk/claim-settlement-module.ts
+++ b/packages/cardpay-sdk/sdk/claim-settlement-module.ts
@@ -22,7 +22,7 @@ export default class ClaimSettlementModule extends SafeModule {
   constructor(ethersProvider: JsonRpcProvider, signer?: Signer) {
     super(ethersProvider, signer);
   }
-  setupArgs(safeAddress: string): SetupArgs {
+  async setupArgs(safeAddress: string): Promise<SetupArgs> {
     return {
       types: ['address', 'address', 'address'],
       values: [safeAddress, safeAddress, safeAddress],

--- a/packages/cardpay-sdk/sdk/safe-module.ts
+++ b/packages/cardpay-sdk/sdk/safe-module.ts
@@ -88,7 +88,7 @@ export default abstract class SafeModule {
     this.name = camelCase(this.constructor.name) as AddressKeys;
   }
 
-  abstract setupArgs(safeAddress: string, safeOwners?: string[]): SetupArgs;
+  abstract setupArgs(safeAddress: string, safeOwners?: string[]): Promise<SetupArgs>;
 
   async createSafeWithModuleAndGuardEstimation(contractOptions?: ContractOptions): Promise<BigNumber> {
     let signer = this.signer ? this.signer : this.ethersProvider.getSigner();
@@ -359,7 +359,7 @@ export default abstract class SafeModule {
 
   async generateEnableModuleTxs(safeAddress: string, safeOwners: string[] = []) {
     let masterCopy = new Contract(await getAddress(this.name, this.ethersProvider), this.abi, this.ethersProvider);
-    let args = this.setupArgs(safeAddress, safeOwners);
+    let args = await this.setupArgs(safeAddress, safeOwners);
     let { transaction, expectedModuleAddress } = await deployAndSetUpModule(
       this.ethersProvider,
       masterCopy,

--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -1,22 +1,14 @@
 /*global fetch */
 
-import GnosisSafeABI from '../contracts/abi/gnosis-safe';
-import MetaGuardABI from '../contracts/abi/modules/meta-guard';
 import ScheduledPaymentABI from '../contracts/abi/modules/scheduled-payment-module';
 import ScheduledPaymentConfigABI from '../contracts/abi/modules/scheduled-payment-config';
 import ScheduledPaymentExchangeABI from '../contracts/abi/modules/scheduled-payment-exchange';
 import { getAddress } from '../contracts/addresses';
 import { isAddress, toWei } from 'web3-utils';
-import {
-  deployAndSetUpModule,
-  encodeMultiSend,
-  encodeMultiSendCallOnly,
-  getModuleProxyCreationEvent,
-} from './utils/module-utils';
+import { SetupArgs } from './utils/module-utils';
 import {
   extractBytesLikeFromError,
   extractSendTransactionErrorMessage,
-  generateSaltNonce,
   hubRequest,
   isTransactionHash,
   Transaction,
@@ -25,21 +17,11 @@ import {
 } from './utils/general-utils';
 
 import { ContractOptions } from 'web3-eth-contract';
-import {
-  Estimate,
-  executeTransaction,
-  gasEstimate,
-  generateCreate2SafeTx,
-  getNextNonceFromEstimate,
-  getSafeProxyCreationEvent,
-  Operation,
-} from './utils/safe-utils';
+import { Estimate, executeTransaction, gasEstimate, getNextNonceFromEstimate, Operation } from './utils/safe-utils';
 import { BigNumber, Contract, Signer, utils } from 'ethers';
-import { signSafeTx, signSafeTxAsBytes, Signature } from './utils/signing-utils';
+import { signSafeTx, Signature } from './utils/signing-utils';
 import { convertChainIdToName, ERC20ABI, getSDK } from '..';
 import { SuccessfulTransactionReceipt } from './utils/successful-transaction-receipt';
-/* eslint-disable node/no-extraneous-import */
-import { AddressZero } from '@ethersproject/constants';
 import {
   GasEstimationScenario,
   waitUntilCancelPaymentTransactionMined,
@@ -50,6 +32,7 @@ import { Interface } from 'ethers/lib/utils';
 import JsonRpcProvider from '../providers/json-rpc-provider';
 import { getConstant, getConstantByNetwork } from './constants';
 import { getGasPricesInNativeWei, getNativeWeiInToken } from './utils/conversions';
+import SafeModule from './safe-module';
 
 export interface EnableModuleAndGuardResult {
   scheduledPaymentModuleAddress: string;
@@ -110,341 +93,20 @@ interface SchedulePaymentOptions {
   listener?: SchedulePaymentProgressListener;
 }
 
-export default class ScheduledPaymentModule {
-  constructor(private ethersProvider: JsonRpcProvider, private signer?: Signer) {
-    this.signer = signer ? signer.connect(ethersProvider) : signer;
+export default class ScheduledPaymentModule extends SafeModule {
+  safeSalt = 'cardstack-sp-create-safe';
+  moduleSalt = 'cardstack-sp-deploy-module';
+  abi = ScheduledPaymentABI;
+  constructor(ethersProvider: JsonRpcProvider, signer?: Signer) {
+    super(ethersProvider, signer);
   }
 
-  async enableModuleAndGuard(txnHash: string): Promise<EnableModuleAndGuardResult>;
-  async enableModuleAndGuard(
-    safeAddress: string,
-    gasTokenAddress: string,
-    txnOptions?: TransactionOptions,
-    contractOptions?: ContractOptions
-  ): Promise<EnableModuleAndGuardResult>;
-  async enableModuleAndGuard(
-    safeAddressOrTxnHash: string,
-    gasTokenAddress?: string,
-    txnOptions?: TransactionOptions,
-    contractOptions?: ContractOptions
-  ): Promise<EnableModuleAndGuardResult> {
-    if (isTransactionHash(safeAddressOrTxnHash)) {
-      return this.getModuleAndGuardAddressFromTxn(safeAddressOrTxnHash);
-    }
-
-    let safeAddress = safeAddressOrTxnHash;
-    if (!safeAddress) {
-      throw new Error('safeAddress must be specified');
-    }
-    if (!gasTokenAddress) {
-      throw new Error('gasTokenAddress must be specified');
-    }
-    let { nonce, onNonce, onTxnHash } = txnOptions ?? {};
-    let signer = this.signer ? this.signer : this.ethersProvider.getSigner();
-    let from = contractOptions?.from ?? (await signer.getAddress());
-
-    let enableModuleTxs = await this.generateEnableModuleTxs(safeAddress);
-    let setGuardTxs = await this.generateSetGuardTxs(safeAddress);
-
-    let multiSendTransaction = await encodeMultiSend(this.ethersProvider, [...enableModuleTxs.txs, ...setGuardTxs.txs]);
-
-    let estimate = await gasEstimate(
-      this.ethersProvider,
-      safeAddress,
-      multiSendTransaction.to,
-      multiSendTransaction.value,
-      multiSendTransaction.data,
-      multiSendTransaction.operation,
-      gasTokenAddress,
-      true
-    );
-    let gasCost = BigNumber.from(estimate.safeTxGas)
-      .add(BigNumber.from(estimate.baseGas))
-      .mul(BigNumber.from(estimate.gasPrice));
-
-    let token = new Contract(gasTokenAddress, ERC20ABI, this.ethersProvider);
-    let symbol = await token.symbol();
-    let balance = await token.callStatic.balanceOf(safeAddress);
-    let decimals = await token.callStatic.decimals();
-    if (balance.lt(gasCost)) {
-      throw new Error(
-        `Safe does not have enough balance to enable scheduled payment module. The gas token ${gasTokenAddress} balance of the safe ${safeAddress} is ${utils.formatUnits(
-          balance,
-          decimals
-        )}, the the gas cost is ${utils.formatUnits(gasCost, decimals)} ${symbol}`
-      );
-    }
-    if (nonce == null) {
-      nonce = getNextNonceFromEstimate(estimate);
-      if (typeof onNonce === 'function') {
-        onNonce(nonce);
-      }
-    }
-    let gnosisTxn = await executeTransaction(
-      this.ethersProvider,
-      safeAddress,
-      multiSendTransaction.to,
-      multiSendTransaction.data,
-      multiSendTransaction.operation,
-      estimate,
-      nonce,
-      await signSafeTx(
-        this.ethersProvider,
-        safeAddress,
-        multiSendTransaction.to,
-        multiSendTransaction.data,
-        multiSendTransaction.operation,
-        estimate,
-        nonce,
-        from,
-        this.signer
-      )
-    );
-
-    if (typeof onTxnHash === 'function') {
-      await onTxnHash(gnosisTxn.ethereumTx.txHash);
-    }
-
-    return {
-      scheduledPaymentModuleAddress: enableModuleTxs.expectedModuleAddress,
-      metaGuardAddress: setGuardTxs.expectedModuleAddress,
-    };
-  }
-
-  async createSafeWithModuleAndGuardTx(from: string): Promise<CreateSafeWithModuleAndGuardTx> {
-    let { expectedSafeAddress, create2SafeTx } = await generateCreate2SafeTx(
-      this.ethersProvider,
-      [from],
-      1,
-      AddressZero,
-      '0x',
-      AddressZero,
-      AddressZero,
-      '0',
-      AddressZero,
-      generateSaltNonce('cardstack-sp-create-safe')
-    );
-    let enableModuleTxs = await this.generateEnableModuleTxs(expectedSafeAddress, [from]);
-    let setGuardTxs = await this.generateSetGuardTxs(expectedSafeAddress);
-
-    let multiSendTx = await encodeMultiSend(this.ethersProvider, [...enableModuleTxs.txs, ...setGuardTxs.txs]);
-    let gnosisSafe = new Contract(expectedSafeAddress, GnosisSafeABI, this.ethersProvider);
-    let estimate = await gasEstimate(
-      this.ethersProvider,
-      await getAddress('gnosisSafeMasterCopy', this.ethersProvider),
-      multiSendTx.to,
-      multiSendTx.value,
-      multiSendTx.data,
-      multiSendTx.operation,
-      AddressZero,
-      true
-    );
-    let nonce = new BN('0');
-    let gasPrice = '0';
-    let [signature] = await signSafeTxAsBytes(
-      this.ethersProvider,
-      multiSendTx.to,
-      Number(multiSendTx.value),
-      multiSendTx.data,
-      multiSendTx.operation,
-      estimate.safeTxGas,
-      estimate.baseGas,
-      gasPrice,
-      estimate.gasToken,
-      estimate.refundReceiver,
-      nonce,
-      from,
-      gnosisSafe.address,
-      this.signer
-    );
-    let safeTxData = gnosisSafe.interface.encodeFunctionData('execTransaction', [
-      multiSendTx.to,
-      Number(multiSendTx.value),
-      multiSendTx.data,
-      multiSendTx.operation,
-      estimate.safeTxGas,
-      estimate.baseGas,
-      gasPrice,
-      estimate.gasToken,
-      estimate.refundReceiver,
-      signature,
-    ]);
-    let safeTx: Transaction = {
-      to: expectedSafeAddress,
-      value: '0',
-      data: safeTxData,
-      operation: Operation.CALL,
-    };
-    let multiSendCallOnlyTx = await encodeMultiSendCallOnly(this.ethersProvider, [create2SafeTx, safeTx]);
-    return {
-      multiSendCallOnlyTx,
-      expectedSafeAddress,
-      expectedSPModuleAddress: enableModuleTxs.expectedModuleAddress,
-      expectedMetaGuardAddress: setGuardTxs.expectedModuleAddress,
-    };
-  }
-
-  async createSafeWithModuleAndGuardEstimation(contractOptions?: ContractOptions): Promise<BigNumber> {
-    let signer = this.signer ? this.signer : this.ethersProvider.getSigner();
-    let from = contractOptions?.from ?? (await signer.getAddress());
-
-    let { expectedSafeAddress, create2SafeTx } = await generateCreate2SafeTx(
-      this.ethersProvider,
-      [from],
-      1,
-      AddressZero,
-      '0x',
-      AddressZero,
-      AddressZero,
-      '0',
-      AddressZero,
-      generateSaltNonce('cardstack-sp-create-safe')
-    );
-    let enableModuleTxs = await this.generateEnableModuleTxs(expectedSafeAddress, [from]);
-    let setGuardTxs = await this.generateSetGuardTxs(expectedSafeAddress);
-
-    let createSafeGas = await this.ethersProvider.estimateGas({
-      to: create2SafeTx.to,
-      data: create2SafeTx.data,
-    });
-    let deploySPModuleGas = await this.ethersProvider.estimateGas({
-      to: enableModuleTxs.txs[0].to,
-      data: enableModuleTxs.txs[0].data,
-    });
-    let deployMetaGuardGas = await this.ethersProvider.estimateGas({
-      to: setGuardTxs.txs[0].to,
-      data: setGuardTxs.txs[0].data,
-    });
-
-    let estimateEnableSPModule = await gasEstimate(
-      this.ethersProvider,
-      await getAddress('gnosisSafeMasterCopy', this.ethersProvider),
-      utils.getAddress(enableModuleTxs.txs[1].to),
-      enableModuleTxs.txs[1].value,
-      enableModuleTxs.txs[1].data,
-      enableModuleTxs.txs[1].operation,
-      AddressZero,
-      true
-    );
-    let enableSPModuleGas = BigNumber.from(estimateEnableSPModule.baseGas).add(estimateEnableSPModule.safeTxGas);
-
-    let estimateSetMetaGuard = await gasEstimate(
-      this.ethersProvider,
-      await getAddress('gnosisSafeMasterCopy', this.ethersProvider),
-      utils.getAddress(enableModuleTxs.txs[1].to),
-      setGuardTxs.txs[1].value,
-      setGuardTxs.txs[1].data,
-      setGuardTxs.txs[1].operation,
-      AddressZero,
-      true
-    );
-    let setMetaGuardGas = BigNumber.from(estimateSetMetaGuard.baseGas).add(estimateSetMetaGuard.safeTxGas);
-
-    return createSafeGas.add(deploySPModuleGas).add(deployMetaGuardGas).add(enableSPModuleGas).add(setMetaGuardGas);
-  }
-
-  async createSafeWithModuleAndGuard(
-    txnHash?: string,
-    txnOptions?: TransactionOptions,
-    contractOptions?: ContractOptions
-  ): Promise<CreateSafeWithModuleAndGuardResult> {
-    if (txnHash && isTransactionHash(txnHash)) {
-      let safeAddress = await this.getSafeAddressFromTxn(txnHash);
-      let { scheduledPaymentModuleAddress, metaGuardAddress } = await this.getModuleAndGuardAddressFromTxn(txnHash);
-      return {
-        safeAddress,
-        scheduledPaymentModuleAddress,
-        metaGuardAddress,
-      };
-    }
-
-    let { onTxnHash } = txnOptions ?? {};
-    let signer = this.signer ? this.signer : this.ethersProvider.getSigner();
-    let from = contractOptions?.from ?? (await signer.getAddress());
-
-    let { multiSendCallOnlyTx, expectedSafeAddress, expectedSPModuleAddress, expectedMetaGuardAddress } =
-      await this.createSafeWithModuleAndGuardTx(from);
-    let response = await signer.sendTransaction({
-      to: multiSendCallOnlyTx.to,
-      data: multiSendCallOnlyTx.data,
-    });
-
-    if (typeof onTxnHash === 'function') {
-      await onTxnHash(response.hash);
-    }
-
-    return {
-      safeAddress: expectedSafeAddress,
-      scheduledPaymentModuleAddress: expectedSPModuleAddress,
-      metaGuardAddress: expectedMetaGuardAddress,
-    };
-  }
-
-  async generateEnableModuleTxs(safeAddress: string, safeOwners: string[] = []) {
-    let masterCopy = new Contract(
-      await getAddress('scheduledPaymentModule', this.ethersProvider),
-      ScheduledPaymentABI,
-      this.ethersProvider
-    );
+  async setupArgs(safeAddress: string, safeOwners: string[]): Promise<SetupArgs> {
     let configAddress = await getAddress('scheduledPaymentConfig', this.ethersProvider);
     let exchangeAddress = await getAddress('scheduledPaymentExchange', this.ethersProvider);
-    let { transaction, expectedModuleAddress } = await deployAndSetUpModule(this.ethersProvider, masterCopy, {
+    return {
       types: ['address', 'address', 'address[]', 'address', 'address', 'address'],
       values: [safeAddress, safeAddress, safeOwners, safeAddress, configAddress, exchangeAddress],
-    });
-    let safe = new Contract(safeAddress, GnosisSafeABI, this.ethersProvider);
-    let enableModuleData = safe.interface.encodeFunctionData('enableModule', [expectedModuleAddress]);
-    let enableModuleTransaction = {
-      data: enableModuleData,
-      to: safeAddress,
-      value: '0',
-      operation: Operation.CALL,
-    };
-
-    return { txs: [transaction, enableModuleTransaction], expectedModuleAddress };
-  }
-
-  async generateSetGuardTxs(safeAddress: string) {
-    let masterCopy = new Contract(
-      await getAddress('metaGuard', this.ethersProvider),
-      MetaGuardABI,
-      this.ethersProvider
-    );
-    let { transaction, expectedModuleAddress } = await deployAndSetUpModule(this.ethersProvider, masterCopy, {
-      types: ['address', 'address', 'uint256', 'address[]'],
-      values: [safeAddress, safeAddress, 0, []],
-    });
-    let safe = new Contract(safeAddress, GnosisSafeABI, this.ethersProvider);
-    let setGuardData = safe.interface.encodeFunctionData('setGuard', [expectedModuleAddress]);
-    let setGuardTransaction = {
-      data: setGuardData,
-      to: safeAddress,
-      value: '0',
-      operation: Operation.CALL,
-    };
-
-    return { txs: [transaction, setGuardTransaction], expectedModuleAddress };
-  }
-
-  async getSafeAddressFromTxn(txnHash: string): Promise<string> {
-    let receipt = await waitUntilTransactionMined(this.ethersProvider, txnHash);
-    let params = await getSafeProxyCreationEvent(this.ethersProvider, receipt.logs);
-    return params[0].args.proxy;
-  }
-
-  async getModuleAndGuardAddressFromTxn(txnHash: string): Promise<EnableModuleAndGuardResult> {
-    let receipt = await waitUntilTransactionMined(this.ethersProvider, txnHash);
-    let moduleProxyCreationEvents = await getModuleProxyCreationEvent(this.ethersProvider, receipt.logs);
-    let scheduledPaymentMasterCopy = await getAddress('scheduledPaymentModule', this.ethersProvider);
-    let metaGuardMasterCopy = await getAddress('metaGuard', this.ethersProvider);
-    let scheduledPaymentModuleAddress = moduleProxyCreationEvents.find(
-      (event) => event.args['masterCopy'] === scheduledPaymentMasterCopy
-    )?.args['proxy'];
-    let metaGuardAddress = moduleProxyCreationEvents.find((event) => event.args['masterCopy'] === metaGuardMasterCopy)
-      ?.args['proxy'];
-    return {
-      scheduledPaymentModuleAddress,
-      metaGuardAddress,
     };
   }
 

--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -143,7 +143,7 @@ export default class ScheduledPaymentModule extends SafeModule {
       feePercentage != null ? feePercentage : (await getConstant('scheduledPaymentFeeFixedUSD', this.ethersProvider))!;
     let requiredGas = 0;
     try {
-      let module = new Contract(moduleAddress, ScheduledPaymentABI, this.ethersProvider);
+      let module = new Contract(moduleAddress, this.abi, this.ethersProvider);
       if (recurringDayOfMonth) {
         await module.estimateGas[
           'estimateExecutionGas(address,uint256,address,((uint256),(uint256)),uint256,address,string,uint256,uint256,uint256)'
@@ -224,7 +224,7 @@ export default class ScheduledPaymentModule extends SafeModule {
     let signer = this.signer ? this.signer : this.ethersProvider.getSigner();
     let from = contractOptions?.from ?? (await signer.getAddress());
 
-    let scheduledPaymentModule = new Contract(moduleAddress, ScheduledPaymentABI, this.ethersProvider);
+    let scheduledPaymentModule = new Contract(moduleAddress, this.abi, this.ethersProvider);
     let spHashes = await scheduledPaymentModule.getSpHashes();
     if (!spHashes.includes(spHash)) {
       throw new Error(`unknown spHash`);
@@ -310,7 +310,7 @@ export default class ScheduledPaymentModule extends SafeModule {
       throw new Error('When payAt is not null, recurringDayOfMonth and recurringUntil must be null');
 
     let spHash;
-    let module = new Contract(moduleAddress, ScheduledPaymentABI, this.ethersProvider);
+    let module = new Contract(moduleAddress, this.abi, this.ethersProvider);
     let feeFixedUSD = (await getConstant('scheduledPaymentFeeFixedUSD', this.ethersProvider))!;
     let feePercentage = (await getConstant('scheduledPaymentFeePercentage', this.ethersProvider))!;
     if (recurringUntil) {
@@ -353,7 +353,7 @@ export default class ScheduledPaymentModule extends SafeModule {
     gasTokenAddress: string,
     spHash: string
   ) {
-    let contract = new Contract(moduleAddress, ScheduledPaymentABI, this.ethersProvider);
+    let contract = new Contract(moduleAddress, this.abi, this.ethersProvider);
     let payload = contract.interface.encodeFunctionData('schedulePayment', [spHash]);
 
     let estimate = await gasEstimate(
@@ -394,7 +394,7 @@ export default class ScheduledPaymentModule extends SafeModule {
     gasTokenAddress: string,
     spHash: string
   ) {
-    let contract = new Contract(moduleAddress, ScheduledPaymentABI, this.ethersProvider);
+    let contract = new Contract(moduleAddress, this.abi, this.ethersProvider);
     let payload = contract.interface.encodeFunctionData('cancelScheduledPayment', [spHash]);
 
     let estimate = await gasEstimate(
@@ -883,7 +883,7 @@ export default class ScheduledPaymentModule extends SafeModule {
       throw new Error('When payAt is not null, recurringDayOfMonth and recurringUntil must be null');
 
     let { onTxnHash, nonce } = txnOptions ?? {};
-    let module = new Contract(moduleAddress, ScheduledPaymentABI, this.ethersProvider);
+    let module = new Contract(moduleAddress, this.abi, this.ethersProvider);
     let executeScheduledPaymentData;
     if (recurringUntil) {
       executeScheduledPaymentData = module.interface.encodeFunctionData(
@@ -946,7 +946,7 @@ export default class ScheduledPaymentModule extends SafeModule {
       // ExceedMaxGasPrice: gasPrice must be lower than or equal maxGasPrice
       // PaymentExecutionFailed: safe balance is not enough to make payments and pay fees
       // OutOfGas: executionGas to low to execute scheduled payment
-      throw new Error(extractSendTransactionErrorMessage(e, new Interface(ScheduledPaymentABI)));
+      throw new Error(extractSendTransactionErrorMessage(e, new Interface(this.abi)));
     }
   }
 


### PR DESCRIPTION
`claim-settlement-module` inherited generic functions from `safe-module` (a big chunk of code copied from schedule-payment-module).This is the refactor to get `scheudled-payment` to use the same abstract class `safe-module`