### PR TITLE
sdk: Fix calculation of gas price in specified token

### DIFF
--- a/packages/cardpay-sdk/sdk/utils/conversions.ts
+++ b/packages/cardpay-sdk/sdk/utils/conversions.ts
@@ -88,8 +88,8 @@ export async function gasPriceInToken(provider: JsonRpcProvider, tokenAddress: s
   // Since tokens can have different decimals, we need to use the scalar's denominator and numerator to adjust the rate
   return rateBN
     .mul(gasPriceInNativeTokenInWei)
-    .mul(new BN(rate.scalar.denominator.toString())) // scalar's denominator is 10**(decimals of native token), for example 10**18 for ETH
-    .div(new BN(rate.scalar.numerator.toString())); // scalar's numerator is 10**(decimals of given token), for example 10**6 for USDC
+    .mul(new BN(rate.scalar.denominator.toString())) // scalar's denominator 10**(decimals of given token), for example 10**6 for USDC
+    .div(new BN(rate.scalar.numerator.toString())); // scalar's numerator is 10**(decimals of native token), for example 10**18 for ETH
 }
 
 export async function getGasPricesInNativeWei(

--- a/packages/cardpay-sdk/sdk/utils/conversions.ts
+++ b/packages/cardpay-sdk/sdk/utils/conversions.ts
@@ -80,12 +80,16 @@ export async function gasPriceInToken(provider: JsonRpcProvider, tokenAddress: s
   if (tokenAddress === wrappedNativeToken) {
     return gasPriceInNativeTokenInWei;
   }
+
   let rate = await tokenPairRate(provider, tokenAddress, wrappedNativeToken);
-  let rateAdjusted = adjustRate(rate);
-  // Convert the current gas price which is in native token to the token we want to pay the gas with.
-  return gasPriceInNativeTokenInWei
-    .mul(new BN(rateAdjusted.numerator.toString()))
-    .div(new BN(rateAdjusted.denominator.toString()));
+  let rateFraction = new Fraction(rate.numerator, rate.denominator).multiply(rate.scalar);
+  let rateBN = new BN(rateFraction.numerator.toString()).div(new BN(rateFraction.denominator.toString()));
+
+  // Since tokens can have different decimals, we need to use the scalar's denominator and numerator to adjust the rate
+  return rateBN
+    .mul(gasPriceInNativeTokenInWei)
+    .mul(new BN(rate.scalar.denominator.toString())) // scalar's denominator is 10**(decimals of native token), for example 10**18 for ETH
+    .div(new BN(rate.scalar.numerator.toString())); // scalar's numerator is 10**(decimals of given token), for example 10**6 for USDC
 }
 
 export async function getGasPricesInNativeWei(


### PR DESCRIPTION
Ticket: CS-5321

This is a solution for the bug where `gasPriceInToken` is returning the wrong price. It looks like it doesn't account for differences in the gas token decimals (WETH vs CTSC in this case). The effect of that is that payments with gas tokens that have less than 18 decimals are reverting with "max gas price exceeded" error.  

I suspect this logic broke when we [introduced changes to Uniswap SDK](https://github.com/cardstack/cardstack/commit/9b2ae255dc7f78dbbc568cf0e8b31a8913f6799a#diff-79fdeb149e79e61cffea67e82c4440def248dc110df0d01fe0a0078515d0aa85L46). 

To demonstrate the bug, this is the current result of the function that should return gas price in **gas token**:

```
await s.getCurrentGasPrice(provider, gasTokenAddress)).toString() // gasTokenAddress is '0xB0b4eD7E54641f96C134D27921764711Cb303e96' (CTSC)
=> '47275680000000'
```

You can see how apparent it is the value is wrong: CTSC has 6 decimals - if we divide `47275680000000` by `10**6` we get that the price for 1 unit of gas is `47275680` CTSC tokens 🤯

After the fix:

```
await s.getCurrentGasPrice(provider, gasTokenAddress)).toString() // gasTokenAddress is '0xB0b4eD7E54641f96C134D27921764711Cb303e96' (CTSC)
=> '47'
```

If we do the same exercise as above, we get that 1 unit of gas costs 0.000047 CTSC. If we multiply this by the gas needed to execute a payment (`180952`), we get a gas cost of `180952 * 0.000047 = 8.504744 ` CTSC. 

We can confirm this is roughly consistent with what the UI shows (the multiplier for normal cost is 2):

<img width="540" alt="image" src="https://user-images.githubusercontent.com/273660/222430626-b0effc09-be6e-4c19-bf95-88540733a14f.png">

I have also noticed the following:

1. We ended up with different ways of normalizing token decimals in the `conversions.ts` file. It looks like the alternative way is using `FixedNumber` operations. I wanted to avoid that by providing a pure BigNumber-ish calculation so that we avoid losses in precision, or unsafe operations. 
2. Safe client has its own way of normalizing token decimals in some places. Example: https://github.com/cardstack/cardstack/blob/main/packages/safe-tools-client/app/services/scheduled-payment-sdk.ts#L125-L140

Ideally we could consolidate all this logic in the SDK - we can discuss it or be aware of it. 
