### PR TITLE
Add default value to execution gas price to avoid not null constraint problem for historic attempts

### DIFF
--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -1254,7 +1254,7 @@ CREATE TABLE public.scheduled_payment_attempts (
     transaction_hash text,
     failure_reason text,
     scheduled_payment_id uuid NOT NULL,
-    execution_gas_price text NOT NULL
+    execution_gas_price text DEFAULT '0'::text NOT NULL
 );
 
 

--- a/packages/hub/db/migrations/20230228132252559_add-execution-gas-price-to-scheduled-payment-attempts.ts
+++ b/packages/hub/db/migrations/20230228132252559_add-execution-gas-price-to-scheduled-payment-attempts.ts
@@ -5,7 +5,7 @@ const EXECUTION_GAS_PRICE = 'execution_gas_price';
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.addColumn(TABLE, {
-    [EXECUTION_GAS_PRICE]: { type: 'string', notNull: true },
+    [EXECUTION_GAS_PRICE]: { type: 'string', notNull: true, default: '0' },
   });
 }
 

--- a/packages/hub/node-tests/routes/scheduled-payment-attempts-test.ts
+++ b/packages/hub/node-tests/routes/scheduled-payment-attempts-test.ts
@@ -240,6 +240,7 @@ describe('GET /api/scheduled-payment-attempts', async function () {
             type: 'scheduled-payment-attempts',
             attributes: {
               'ended-at': '2022-11-22T13:14:25.000Z',
+              'execution-gas-price': '10000',
               'failure-reason': null,
               'started-at': '2022-11-22T12:14:25.000Z',
               status: 'succeeded',
@@ -259,6 +260,7 @@ describe('GET /api/scheduled-payment-attempts', async function () {
             type: 'scheduled-payment-attempts',
             attributes: {
               'ended-at': '2022-10-22T13:14:25.000Z',
+              'execution-gas-price': '10000',
               'failure-reason': null,
               'started-at': '2022-10-22T12:14:25.000Z',
               status: 'succeeded',

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -285,7 +285,7 @@ model ScheduledPaymentAttempt {
   transactionHash    String?                           @map("transaction_hash")
   failureReason      String?                           @map("failure_reason")
   scheduledPaymentId String                            @map("scheduled_payment_id") @db.Uuid
-  executionGasPrice  String                            @map("execution_gas_price")
+  executionGasPrice  String                            @default("0") @map("execution_gas_price")
   scheduledPayment   ScheduledPayment                  @relation(fields: [scheduledPaymentId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
   @@index([scheduledPaymentId], map: "scheduled_payment_attempts_scheduled_payment_id_index")


### PR DESCRIPTION
Migration will fail if the db has some attempts because we're adding a not null constraint and there is no backfill for the field. 

