### PR TITLE
Make more room for the 3-dot menu in the payment cards within the future payments list

### DIFF
--- a/packages/safe-tools-client/app/components/future-payments-list/index.css
+++ b/packages/safe-tools-client/app/components/future-payments-list/index.css
@@ -1,5 +1,5 @@
 .future-payments-list {
-  min-width: 20rem;
+  min-width: 21rem;
   max-width: 25rem;
   height: 100%;
   display: flex;

--- a/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.css
+++ b/packages/safe-tools-client/app/components/future-payments-list/scheduled-payment-card/index.css
@@ -1,5 +1,5 @@
 .scheduled-payment-card {
-  padding: var(--boxel-sp-sm) var(--boxel-sp);
+  padding: var(--boxel-sp-sm) var(--boxel-sp-lg) var(--boxel-sp-sm) var(--boxel-sp);
   margin-bottom: var(--boxel-sp-xs);
 }
 

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.css
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/ui/index.css
@@ -1,5 +1,5 @@
 .schedule-payment-form-action-card {
-  min-width: 50rem;
+  min-width: 49rem;
   max-width: none;
   flex-grow: 1;
 

--- a/packages/safe-tools-client/tests/acceptance/scheduling-test.ts
+++ b/packages/safe-tools-client/tests/acceptance/scheduling-test.ts
@@ -465,6 +465,7 @@ module('Acceptance | scheduling', function (hooks) {
           // @ts-expect-error intentionally omitting attributes because they are not needed for this test
           attributes: {
             'pay-at': addDays(Date.now(), 1).toISOString(),
+            'payee-address': '0xb794f5ea0ba39494ce839613fffba74279579268',
             amount: String(
               scheduledPaymentCreations[0].data.attributes['amount']
             ),


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/353/223857408-833d7acc-7c93-45c8-88b6-f3f34f182fa9.png)

After:

![image](https://user-images.githubusercontent.com/353/223857418-264a348d-c1cb-4d8e-a9c6-df08719ee602.png)
