### PR TITLE
Fix out of gas error

### DIFF
--- a/packages/cardpay-cli/scheduled-payment/estimate-gas.ts
+++ b/packages/cardpay-cli/scheduled-payment/estimate-gas.ts
@@ -5,7 +5,7 @@ import { Arguments, CommandModule } from 'yargs';
 import { fromWei } from 'web3-utils';
 
 export default {
-  command: 'estimate-gas <scenario> <safeAddress>',
+  command: 'estimate-gas <scenario> <safeAddress> <tokenAddress> <gasTokenAddress>',
   describe: `Gas estimates for various scenarios in scheduled payments. This command allows you to estimate gas without sufficient transfer of tokens and gas tokens.`,
   builder(yargs: Argv) {
     return yargs
@@ -17,13 +17,23 @@ export default {
         type: 'string',
         description: 'The address of safe with SP module enabled',
       })
+      .positional('tokenAddress', {
+        type: 'string',
+        description: 'The address of the token being transferred',
+      })
+      .positional('gasTokenAddress', {
+        type: 'string',
+        description: 'The address of the gas token',
+      })
       .option('network', NETWORK_OPTION_ANY);
   },
   async handler(args: Arguments) {
-    let { network, scenario, safeAddress } = args as unknown as {
+    let { network, scenario, safeAddress, tokenAddress, gasTokenAddress } = args as unknown as {
       network: string;
       scenario: string;
       safeAddress: string | null;
+      tokenAddress: string | null;
+      gasTokenAddress: string | null;
     };
 
     let { ethersProvider, signer } = await getEthereumClients(network, getConnectionType(args));
@@ -33,6 +43,8 @@ export default {
 
     let result = await scheduledPaymentModule.estimateGas(scenario as typeof GAS_ESTIMATION_SCENARIOS[number], {
       safeAddress,
+      tokenAddress,
+      gasTokenAddress,
     });
 
     console.log(`Required gas: ${result.gas}`);

--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -1309,7 +1309,7 @@ export default class ScheduledPaymentModule {
           'chain-id': chainId,
           'safe-address': options.safeAddress,
           'token-address': options.tokenAddress,
-          'gas-token-address': options.gasTokenAddress
+          'gas-token-address': options.gasTokenAddress,
         },
       },
     };

--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -1295,6 +1295,8 @@ export default class ScheduledPaymentModule {
     scenario: GasEstimationScenario,
     options: {
       safeAddress?: string | null;
+      tokenAddress?: string | null;
+      gasTokenAddress?: string | null;
       hubUrl?: string | null;
     }
   ): Promise<GasEstimationResult> {
@@ -1306,6 +1308,8 @@ export default class ScheduledPaymentModule {
           scenario: scenario,
           'chain-id': chainId,
           'safe-address': options.safeAddress,
+          'token-address': options.tokenAddress,
+          'gas-token-address': options.gasTokenAddress
         },
       },
     };

--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -1256,7 +1256,7 @@ CREATE TABLE public.scheduled_payment_attempts (
     transaction_hash text,
     failure_reason text,
     scheduled_payment_id uuid NOT NULL,
-    execution_gas_price text NOT NULL
+    execution_gas_price text DEFAULT '0'::text NOT NULL
 );
 
 

--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -980,7 +980,9 @@ CREATE TABLE public.gas_estimation_results (
     scenario public.gas_estimation_results_scenario_enum NOT NULL,
     gas integer NOT NULL,
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    token_address text DEFAULT ''::text NOT NULL,
+    gas_token_address text DEFAULT ''::text NOT NULL
 );
 
 
@@ -1254,7 +1256,7 @@ CREATE TABLE public.scheduled_payment_attempts (
     transaction_hash text,
     failure_reason text,
     scheduled_payment_id uuid NOT NULL,
-    execution_gas_price text DEFAULT '0'::text NOT NULL
+    execution_gas_price text NOT NULL
 );
 
 
@@ -1512,7 +1514,7 @@ ALTER TABLE ONLY public.gas_estimation_results
 --
 
 ALTER TABLE ONLY public.gas_estimation_results
-    ADD CONSTRAINT gas_estimation_results_unique_chain_and_scenario UNIQUE (chain_id, scenario);
+    ADD CONSTRAINT gas_estimation_results_unique_chain_and_scenario UNIQUE (chain_id, scenario, token_address, gas_token_address);
 
 
 --
@@ -2056,6 +2058,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 51	20230131060836816_alter-gas-estimation-results-fields	2023-03-01 15:39:08.201257
 52	20230228132252559_add-execution-gas-price-to-scheduled-payment-attempts	2023-03-01 15:39:08.246772
 53	20230227121110219_add-retry-info-to-scheduled-payments	2023-03-03 14:04:50.716275
+54	20230308143158157_add-token-and-gas-token-address-to-gas-estimation-results	2023-03-08 14:50:17.546358
 \.
 
 
@@ -2063,7 +2066,7 @@ COPY public.pgmigrations (id, name, run_on) FROM stdin;
 -- Name: pgmigrations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.pgmigrations_id_seq', 53, true);
+SELECT pg_catalog.setval('public.pgmigrations_id_seq', 54, true);
 
 
 --

--- a/packages/hub/db/migrations/20230308143158157_add-token-and-gas-token-address-to-gas-estimation-results.ts
+++ b/packages/hub/db/migrations/20230308143158157_add-token-and-gas-token-address-to-gas-estimation-results.ts
@@ -1,0 +1,24 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+const TABLE = 'gas_estimation_results';
+const TOKEN_ADDRESS = 'token_address';
+const GAS_TOKEN_ADDRESS = 'gas_token_address';
+const UNIQUE_CHAIN_AND_SCENARIO = `${TABLE}_unique_chain_and_scenario`;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn(TABLE, {
+    [TOKEN_ADDRESS]: { type: 'string', notNull: true, default: '' },
+    [GAS_TOKEN_ADDRESS]: { type: 'string', notNull: true, default: '' },
+  });
+
+  pgm.dropConstraint(TABLE, UNIQUE_CHAIN_AND_SCENARIO);
+  pgm.addConstraint(TABLE, UNIQUE_CHAIN_AND_SCENARIO, {
+    unique: ['chain_id', 'scenario', 'token_address', 'gas_token_address'],
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn(TABLE, TOKEN_ADDRESS);
+  pgm.dropColumn(TABLE, GAS_TOKEN_ADDRESS);
+  pgm.dropConstraint(TABLE, UNIQUE_CHAIN_AND_SCENARIO);
+}

--- a/packages/hub/node-tests/routes/gas-estimation-test.ts
+++ b/packages/hub/node-tests/routes/gas-estimation-test.ts
@@ -213,7 +213,7 @@ describe('POST /api/gas-estimation', function () {
             },
             status: '422',
             title: 'Invalid attribute',
-          }
+          },
         ],
       });
   });

--- a/packages/hub/node-tests/routes/gas-estimation-test.ts
+++ b/packages/hub/node-tests/routes/gas-estimation-test.ts
@@ -7,6 +7,8 @@ let result: GasEstimationResult = {
   id: '1',
   scenario: GasEstimationResultsScenarioEnum.create_safe_with_module,
   chainId: 1,
+  tokenAddress: '',
+  gasTokenAddress: '',
   gas: 0,
   createdAt: nowUtc(),
   updatedAt: nowUtc(),
@@ -28,6 +30,8 @@ describe('POST /api/gas-estimation', function () {
   it('returns gas price for create a new safe scenario', async function () {
     result.scenario = GasEstimationResultsScenarioEnum.create_safe_with_module;
     result.gas = 8000000;
+    result.tokenAddress = '';
+    result.gasTokenAddress = '';
 
     await request()
       .post('/api/gas-estimation')
@@ -36,7 +40,6 @@ describe('POST /api/gas-estimation', function () {
           attributes: {
             scenario: result.scenario,
             'chain-id': result.chainId,
-            'safe-address': '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
           },
         },
       })
@@ -60,6 +63,8 @@ describe('POST /api/gas-estimation', function () {
   it('returns gas price for execute one-time payment scenario', async function () {
     result.scenario = GasEstimationResultsScenarioEnum.execute_one_time_payment;
     result.gas = 6000000;
+    result.tokenAddress = '0x8F4fdA26e5039eb0bf5dA90c3531AeB91256b56b';
+    result.gasTokenAddress = '0x8F4fdA26e5039eb0bf5dA90c3531AeB91256b56b';
 
     await request()
       .post('/api/gas-estimation')
@@ -69,6 +74,8 @@ describe('POST /api/gas-estimation', function () {
             scenario: result.scenario,
             'chain-id': result.chainId,
             'safe-address': '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+            'token-address': result.tokenAddress,
+            'gas-token-address': result.gasTokenAddress,
           },
         },
       })
@@ -92,6 +99,8 @@ describe('POST /api/gas-estimation', function () {
   it('returns gas price for execute recurring payment scenario', async function () {
     result.scenario = GasEstimationResultsScenarioEnum.execute_recurring_payment;
     result.gas = 6000000;
+    result.tokenAddress = '0x8F4fdA26e5039eb0bf5dA90c3531AeB91256b56b';
+    result.gasTokenAddress = '0x8F4fdA26e5039eb0bf5dA90c3531AeB91256b56b';
 
     await request()
       .post('/api/gas-estimation')
@@ -101,6 +110,8 @@ describe('POST /api/gas-estimation', function () {
             scenario: result.scenario,
             'chain-id': result.chainId,
             'safe-address': '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+            'token-address': result.tokenAddress,
+            'gas-token-address': result.gasTokenAddress,
           },
         },
       })
@@ -123,6 +134,8 @@ describe('POST /api/gas-estimation', function () {
 
   it('returns with errors when attrs are missing', async function () {
     result.gas = 6000000;
+    result.tokenAddress = '0x8F4fdA26e5039eb0bf5dA90c3531AeB91256b56b';
+    result.gasTokenAddress = '0x8F4fdA26e5039eb0bf5dA90c3531AeB91256b56b';
 
     await request()
       .post('/api/gas-estimation')
@@ -131,6 +144,8 @@ describe('POST /api/gas-estimation', function () {
           attributes: {
             scenario: undefined,
             'chain-id': undefined,
+            'token-address': result.tokenAddress,
+            'gas-token-address': result.gasTokenAddress,
           },
         },
       })
@@ -159,7 +174,7 @@ describe('POST /api/gas-estimation', function () {
       });
   });
 
-  it('returns with errors when safe address are missing in execution scenario', async function () {
+  it('returns with errors when address fields are missing in execution scenario', async function () {
     await request()
       .post('/api/gas-estimation')
       .send({
@@ -183,11 +198,27 @@ describe('POST /api/gas-estimation', function () {
             status: '422',
             title: 'Invalid attribute',
           },
+          {
+            detail: `token address is required in ${GasEstimationResultsScenarioEnum.execute_recurring_payment} scenario`,
+            source: {
+              pointer: '/data/attributes/token-address',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: `gas token address is required in ${GasEstimationResultsScenarioEnum.execute_recurring_payment} scenario`,
+            source: {
+              pointer: '/data/attributes/gas-token-address',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          }
         ],
       });
   });
 
-  it('returns with errors when safe address is invalid in execution scenario', async function () {
+  it('returns with errors when address fields is invalid in execution scenario', async function () {
     await request()
       .post('/api/gas-estimation')
       .send({
@@ -196,6 +227,8 @@ describe('POST /api/gas-estimation', function () {
             scenario: GasEstimationResultsScenarioEnum.execute_recurring_payment,
             'chain-id': result.chainId,
             'safe-address': 'wrong address',
+            'token-address': 'wrong address',
+            'gas-token-address': 'wrong address',
           },
         },
       })
@@ -208,6 +241,22 @@ describe('POST /api/gas-estimation', function () {
             detail: `safe address is not a valid address`,
             source: {
               pointer: '/data/attributes/safe-address',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: `token address is not a valid address`,
+            source: {
+              pointer: '/data/attributes/token-address',
+            },
+            status: '422',
+            title: 'Invalid attribute',
+          },
+          {
+            detail: `gas token address is not a valid address`,
+            source: {
+              pointer: '/data/attributes/gas-token-address',
             },
             status: '422',
             title: 'Invalid attribute',

--- a/packages/hub/node-tests/services/gas-estimation/estimation-test.ts
+++ b/packages/hub/node-tests/services/gas-estimation/estimation-test.ts
@@ -67,6 +67,8 @@ describe('estimate gas', function () {
     expect(gasEstimationResult.scenario).to.equal(gasEstimationParams.scenario);
     expect(gasEstimationResult.chainId).to.equal(gasEstimationParams.chainId);
     expect(gasEstimationResult.gas).to.equal(createSafeGas);
+    expect(gasEstimationResult.tokenAddress).to.equal('');
+    expect(gasEstimationResult.gasTokenAddress).to.equal('');
   });
 
   it('estimates gas for execute scheduled one-time payment scenario', async function () {
@@ -75,6 +77,8 @@ describe('estimate gas', function () {
       scenario: GasEstimationResultsScenarioEnum.execute_one_time_payment,
       chainId: 5,
       safeAddress: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+      tokenAddress: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
+      gasTokenAddress: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
     };
     let gasEstimationResult = await subject.estimate(gasEstimationParams);
 
@@ -89,6 +93,8 @@ describe('estimate gas', function () {
       scenario: GasEstimationResultsScenarioEnum.execute_recurring_payment,
       chainId: 5,
       safeAddress: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+      tokenAddress: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
+      gasTokenAddress: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
     };
     let gasEstimationResult = await subject.estimate(gasEstimationParams);
 
@@ -150,7 +156,37 @@ describe('estimate gas', function () {
       scenario: GasEstimationResultsScenarioEnum.execute_recurring_payment,
       chainId: 5,
       safeAddress: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+      tokenAddress: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
+      gasTokenAddress: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
     };
     await expect(subject.estimate(gasEstimationParams)).to.be.rejectedWith(`cannot find SP module in this safe`);
+  });
+
+  it('throws error if tokenAddress and gasTokenAddress are undefined in execution scenario', async function () {
+    executionGas = 1000000;
+
+    let gasEstimationParams: GasEstimationParams = {
+      scenario: GasEstimationResultsScenarioEnum.execute_one_time_payment,
+      chainId: 5,
+      safeAddress: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+    };
+    await expect(subject.estimate(gasEstimationParams)).to.be.rejectedWith(
+      'tokenAddress and gasTokenAddress is required in execute_one_time_payment'
+    );
+  });
+
+  it('throws error if tokenAddress and gasTokenAddress are blank string in execution scenario', async function () {
+    executionGas = 1000000;
+
+    let gasEstimationParams: GasEstimationParams = {
+      scenario: GasEstimationResultsScenarioEnum.execute_recurring_payment,
+      chainId: 5,
+      safeAddress: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+      tokenAddress: '',
+      gasTokenAddress: '',
+    };
+    await expect(subject.estimate(gasEstimationParams)).to.be.rejectedWith(
+      'tokenAddress and gasTokenAddress is required in execute_recurring_payment'
+    );
   });
 });

--- a/packages/hub/node-tests/services/gas-estimation/validator-test.ts
+++ b/packages/hub/node-tests/services/gas-estimation/validator-test.ts
@@ -37,8 +37,12 @@ describe('GasEstimationValidator', function () {
       safeAddress: [
         `safe address is required in ${GasEstimationResultsScenarioEnum.execute_one_time_payment} scenario`,
       ],
-      tokenAddress: [`token address is required in ${GasEstimationResultsScenarioEnum.execute_one_time_payment} scenario`],
-      gasTokenAddress: [`gas token address is required in ${GasEstimationResultsScenarioEnum.execute_one_time_payment} scenario`],
+      tokenAddress: [
+        `token address is required in ${GasEstimationResultsScenarioEnum.execute_one_time_payment} scenario`,
+      ],
+      gasTokenAddress: [
+        `gas token address is required in ${GasEstimationResultsScenarioEnum.execute_one_time_payment} scenario`,
+      ],
     });
   });
 

--- a/packages/hub/node-tests/services/gas-estimation/validator-test.ts
+++ b/packages/hub/node-tests/services/gas-estimation/validator-test.ts
@@ -19,6 +19,8 @@ describe('GasEstimationValidator', function () {
       scenario: ['scenario is required'],
       chainId: ['chain id is required'],
       safeAddress: [],
+      tokenAddress: [],
+      gasTokenAddress: [],
     });
   });
 
@@ -35,6 +37,8 @@ describe('GasEstimationValidator', function () {
       safeAddress: [
         `safe address is required in ${GasEstimationResultsScenarioEnum.execute_one_time_payment} scenario`,
       ],
+      tokenAddress: [`token address is required in ${GasEstimationResultsScenarioEnum.execute_one_time_payment} scenario`],
+      gasTokenAddress: [`gas token address is required in ${GasEstimationResultsScenarioEnum.execute_one_time_payment} scenario`],
     });
   });
 
@@ -43,6 +47,8 @@ describe('GasEstimationValidator', function () {
       scenario: GasEstimationResultsScenarioEnum.execute_one_time_payment,
       chainId: 1,
       safeAddress: 'wrong address',
+      tokenAddress: 'wrong address',
+      gasTokenAddress: 'wrong address',
     };
 
     let errors = await subject.validate(gasEstimationParams);
@@ -50,6 +56,8 @@ describe('GasEstimationValidator', function () {
       scenario: [],
       chainId: [],
       safeAddress: [`safe address is not a valid address`],
+      tokenAddress: ['token address is not a valid address'],
+      gasTokenAddress: ['gas token address is not a valid address'],
     });
   });
 });

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -285,7 +285,7 @@ model ScheduledPaymentAttempt {
   transactionHash    String?                           @map("transaction_hash")
   failureReason      String?                           @map("failure_reason")
   scheduledPaymentId String                            @map("scheduled_payment_id") @db.Uuid
-  executionGasPrice  String                            @default("0") @map("execution_gas_price")
+  executionGasPrice  String                            @map("execution_gas_price")
   scheduledPayment   ScheduledPayment                  @relation(fields: [scheduledPaymentId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
   @@index([scheduledPaymentId], map: "scheduled_payment_attempts_scheduled_payment_id_index")
@@ -357,14 +357,16 @@ model GasPrice {
 }
 
 model GasEstimationResult {
-  id        String                           @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  chainId   Int                              @map("chain_id")
-  scenario  GasEstimationResultsScenarioEnum
-  gas       Int
-  createdAt DateTime                         @default(now()) @map("created_at") @db.Timestamp(6)
-  updatedAt DateTime                         @default(now()) @map("updated_at") @db.Timestamp(6)
+  id              String                           @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  chainId         Int                              @map("chain_id")
+  scenario        GasEstimationResultsScenarioEnum
+  gas             Int
+  createdAt       DateTime                         @default(now()) @map("created_at") @db.Timestamp(6)
+  updatedAt       DateTime                         @default(now()) @map("updated_at") @db.Timestamp(6)
+  tokenAddress    String                           @default("") @map("token_address")
+  gasTokenAddress String                           @default("") @map("gas_token_address")
 
-  @@unique([chainId, scenario], map: "gas_estimation_results_unique_chain_and_scenario")
+  @@unique([chainId, scenario, tokenAddress, gasTokenAddress], map: "gas_estimation_results_unique_chain_and_scenario")
   @@map("gas_estimation_results")
 }
 

--- a/packages/hub/routes/gas-estimation.ts
+++ b/packages/hub/routes/gas-estimation.ts
@@ -19,6 +19,8 @@ export default class GasEstimationRoute {
       scenario: attrs['scenario'],
       chainId: attrs['chain-id'],
       safeAddress: attrs['safe-address'],
+      tokenAddress: attrs['token-address'],
+      gasTokenAddress: attrs['gas-token-address'],
     } as unknown as GasEstimationParams;
     let errors = await this.gasEstimationValidator.validate(params);
     let hasErrors = Object.values(errors).flatMap((i) => i).length > 0;

--- a/packages/hub/services/gas-estimation.ts
+++ b/packages/hub/services/gas-estimation.ts
@@ -65,7 +65,7 @@ export default class GasEstimationService {
       },
       update: {
         gas: gas,
-        updatedAt: nowUtc()
+        updatedAt: nowUtc(),
       },
     });
 

--- a/packages/hub/services/gas-estimation.ts
+++ b/packages/hub/services/gas-estimation.ts
@@ -4,12 +4,13 @@ import { nowUtc } from '../utils/dates';
 import config from 'config';
 import { Wallet } from 'ethers';
 import { GasEstimationResultsScenarioEnum } from '@prisma/client';
-import { getAddress } from '@cardstack/cardpay-sdk';
 
 export interface GasEstimationParams {
   scenario: GasEstimationResultsScenarioEnum;
   chainId: number;
   safeAddress?: string;
+  tokenAddress?: string;
+  gasTokenAddress?: string;
 }
 
 export default class GasEstimationService {
@@ -48,18 +49,23 @@ export default class GasEstimationService {
 
     gasLimit = await prisma.gasEstimationResult.upsert({
       where: {
-        chainId_scenario: {
+        chainId_scenario_tokenAddress_gasTokenAddress: {
           chainId: params.chainId,
           scenario: params.scenario,
+          tokenAddress: params.tokenAddress ?? '',
+          gasTokenAddress: params.gasTokenAddress ?? '',
         },
       },
       create: {
         chainId: params.chainId,
         scenario: params.scenario,
+        tokenAddress: params.tokenAddress,
+        gasTokenAddress: params.gasTokenAddress,
         gas: gas,
       },
       update: {
         gas: gas,
+        updatedAt: nowUtc()
       },
     });
 
@@ -69,6 +75,15 @@ export default class GasEstimationService {
   private async estimatePaymentExecution(params: GasEstimationParams) {
     if (!params.safeAddress) {
       throw Error(`safeAddress is required in ${params.scenario}`);
+    }
+
+    if (
+      !params.tokenAddress ||
+      params.tokenAddress === '' ||
+      !params.gasTokenAddress ||
+      params.gasTokenAddress === ''
+    ) {
+      throw Error(`tokenAddress and gasTokenAddress is required in ${params.scenario}`);
     }
 
     let spModuleAddress = await this.getSpModuleAddress(params.chainId, params.safeAddress);
@@ -84,16 +99,15 @@ export default class GasEstimationService {
     // then we would have to deposit an adequate amount of tokens to the safe in order for
     // the estimation process to work.
     let gas;
-    let usdTokenAddress = await getAddress('usdStableCoinToken', provider);
     switch (params.scenario) {
       case GasEstimationResultsScenarioEnum.execute_one_time_payment:
         gas = await scheduledPaymentModule.estimateExecutionGas(
           spModuleAddress,
-          usdTokenAddress,
+          params.tokenAddress,
           '0',
           signer.address,
           '0',
-          usdTokenAddress,
+          params.gasTokenAddress,
           'salt1',
           '0',
           Math.round(nowUtc().getTime() / 1000),
@@ -106,11 +120,11 @@ export default class GasEstimationService {
       case GasEstimationResultsScenarioEnum.execute_recurring_payment:
         gas = await scheduledPaymentModule.estimateExecutionGas(
           spModuleAddress,
-          usdTokenAddress,
+          params.tokenAddress,
           '0',
           signer.address,
           '0',
-          usdTokenAddress,
+          params.gasTokenAddress,
           'salt1',
           '0',
           null,

--- a/packages/hub/services/validators/gas-estimation.ts
+++ b/packages/hub/services/validators/gas-estimation.ts
@@ -6,7 +6,7 @@ import { GasEstimationParams } from '../gas-estimation';
 import { isSupportedChain } from '@cardstack/cardpay-sdk';
 const { isAddress } = Web3.utils;
 
-type GasEstimationAttribute = 'scenario' | 'chainId' | 'safeAddress' | 'tokenAddress' | 'gasTokenAddress';;
+type GasEstimationAttribute = 'scenario' | 'chainId' | 'safeAddress' | 'tokenAddress' | 'gasTokenAddress';
 
 type GasEstimationErrors = Record<GasEstimationAttribute, string[]>;
 
@@ -46,7 +46,9 @@ export default class GasEstimationValidator {
       let executionMandatoryAttributes: GasEstimationAttribute[] = ['tokenAddress', 'gasTokenAddress'];
       for (let attribute of executionMandatoryAttributes) {
         if (gasEstimationParams[attribute] == null) {
-          errors[attribute].push(`${startCase(attribute).toLowerCase()} is required in ${gasEstimationParams.scenario} scenario`);
+          errors[attribute].push(
+            `${startCase(attribute).toLowerCase()} is required in ${gasEstimationParams.scenario} scenario`
+          );
         }
       }
 

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
@@ -359,7 +359,7 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
     (async () => {
       try {
         state.isLoading = true;
-        this.gasEstimation = await this.scheduledPaymentSdk.getScheduledPaymentGasEstimation(scenario, selectedGasToken);
+        this.gasEstimation = await this.scheduledPaymentSdk.getScheduledPaymentGasEstimation(scenario, paymentToken, selectedGasToken);
         const { gasRangeInGasTokenUnits } = this.gasEstimation;
         state.value = {
           normal: new TokenQuantity(selectedGasToken, gasRangeInGasTokenUnits.normal),

--- a/packages/safe-tools-client/app/services/scheduled-payment-sdk.ts
+++ b/packages/safe-tools-client/app/services/scheduled-payment-sdk.ts
@@ -101,6 +101,7 @@ export default class SchedulePaymentSDKService extends Service {
   @action
   async getScheduledPaymentGasEstimation(
     scenario: GasEstimationScenario,
+    token: TokenDetail,
     gasToken: TokenDetail
   ): Promise<ServiceGasEstimationResult> {
     const scheduledPaymentModule = await this.getSchedulePaymentModule();
@@ -109,6 +110,8 @@ export default class SchedulePaymentSDKService extends Service {
       scenario,
       {
         safeAddress: this.safes.currentSafe?.address,
+        tokenAddress: token.address,
+        gasTokenAddress: gasToken.address,
         hubUrl: config.hubUrl,
       }
     );

--- a/packages/safe-tools-client/tests/integration/components/schedule-payment-form-action-card-test.ts
+++ b/packages/safe-tools-client/tests/integration/components/schedule-payment-form-action-card-test.ts
@@ -67,6 +67,7 @@ class ScheduledPaymentSDKServiceStub extends Service {
 
   async getScheduledPaymentGasEstimation(
     _scenario: GasEstimationScenario,
+    _tokenAddress: ChainAddress,
     _gasTokenAddress: ChainAddress
   ): Promise<ServiceGasEstimationResult> {
     return {


### PR DESCRIPTION
Ticket: CS-5342

**Problem**
Previously, we used USDC token to estimate the execution gas of scheduled payments, no matter what token and gas token the user used on that payment. Because we thought the transfer function of all tokens must be almost similar and the gas used would not significantly different. But from the example below, the gas can be very different.

- Payment with DAI in Polygon
```
yarn cardpay scheduled-payment estimate-execution 0xc325385c061731bd6fd17228f500f9f3c1c6e6bb 0x8f3cf7ad23cd3cadbd9735aff958023239c6a063 1000000000000000 0xf4E4c6bfd83e4D0E7a5627b631800487f4A154fD 1000 0x8f3cf7ad23cd3cadbd9735aff958023239c6a063 salt1 --payAt 1678262142 --ethersMnemonic $MNEMONIC --network polygon

Estimate scheduled payment execution gas ...
Required execution gas: 209423
```

- Payment with WETH in Polygon
```
yarn cardpay scheduled-payment estimate-execution 0xc325385c061731bd6fd17228f500f9f3c1c6e6bb 0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270 1000000000000000 0xf4E4c6bfd83e4D0E7a5627b631800487f4A154fD 1000 0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270 salt1 --payAt 1678262142 --ethersMnemonic $MNEMONIC --network polygon

Estimate scheduled payment execution gas ...
Required execution gas: 287414
```

**Solution**
Add the token address and gas token address as a parameter to the gas estimation endpoint in the hub.