### PR TITLE
Fix execution nonce issue

### DIFF
--- a/packages/hub/node-tests/services/crank-nonce-lock-test.ts
+++ b/packages/hub/node-tests/services/crank-nonce-lock-test.ts
@@ -74,12 +74,13 @@ describe('locking the nonce', function () {
 
   it(`retrieves nonce to the blockchain because account nonce in database is expired`, async function () {
     let currentNonce = 2;
+    let createdAt = subSeconds(nowUtc(), subject.nonceTTL + 60);
     await prisma.crankNonce.create({
       data: {
         chainId: chainId,
         nonce: currentNonce,
-        createdAt: subSeconds(nowUtc(), subject.nonceTTL + 60),
-        updatedAt: subSeconds(nowUtc(), subject.nonceTTL + 60),
+        createdAt,
+        updatedAt: createdAt,
       },
     });
     let testFunc = async (nonce: BN) => {
@@ -92,6 +93,7 @@ describe('locking the nonce', function () {
     });
     expect(crankNonce).not.undefined;
     expect(Number(crankNonce?.nonce ?? 0)).equal(10);
+    expect(crankNonce?.updatedAt).greaterThan(createdAt);
   });
 
   it(`increases current nonce in database`, async function () {

--- a/packages/hub/services/crank-nonce-lock.ts
+++ b/packages/hub/services/crank-nonce-lock.ts
@@ -33,6 +33,7 @@ export default class CrankNonceLock {
       },
       update: {
         nonce: BigInt(nextNonce.toString()),
+        updatedAt: nowUtc(),
       },
     });
 


### PR DESCRIPTION
Ticket: CS-5351

**Problem**
I realized the updatedAt field in the crank nonces table wasn't updated since it was created. It caused the execution process always retrieve the nonce from the RPC instead of increasing it from the database. That's why we had two or more execution payment transactions with the same nonce.
<img width="782" alt="Screenshot 2023-03-09 at 16 18 59" src="https://user-images.githubusercontent.com/12637010/223976677-279c352d-8c15-41ac-aac9-7896d4e98eee.png">

**Solution**
Prisma doesn't automatically define the updatedAt value on the update query. We have to manually define it.
