### PR TITLE
safe tools client: Don't list safes with outdated scheduled payment module

### DIFF
--- a/packages/safe-tools-subgraph/README.md
+++ b/packages/safe-tools-subgraph/README.md
@@ -5,7 +5,8 @@ This project includes the subgraph necessary to generate a GraphQL based query s
 The subgraph is hosted at:
 
 - goerli: https://thegraph.com/hosted-service/subgraph/cardstack/safe-tools-goerli
-- mumbai: https://thegraph.com/hosted-service/subgraph/cardstack/safe-tools-mumbai
+- polygon: https://thegraph.com/hosted-service/subgraph/cardstack/safe-tools-polygon
+- mainnet: https://thegraph.com/hosted-service/subgraph/cardstack/safe-tools-mainnet
 
 Currently we are indexing safes that users provision using the safe tools interface. We're saving the account's address, safe address, and the scheduled payment module address and keep track of their ownership. This data is used by the safe tools for creating scheduled payments.
 

--- a/packages/safe-tools-subgraph/networks.json
+++ b/packages/safe-tools-subgraph/networks.json
@@ -1,7 +1,7 @@
 {
   "goerli": {
     "ScheduledPaymentModule": {
-      "startBlock": 7921489
+      "startBlock": 8403969
     },
     "GnosisSafe": {
       "startBlock": 7921489
@@ -17,7 +17,7 @@
   },
   "matic": {
     "ScheduledPaymentModule": {
-      "startBlock": 36621581
+      "startBlock": 38743683
     },
     "GnosisSafe": {
       "startBlock": 36621581
@@ -25,7 +25,7 @@
   },
   "mainnet": {
     "ScheduledPaymentModule": {
-      "startBlock": 16119342
+      "startBlock": 16532738
     },
     "GnosisSafe": {
       "startBlock": 16119342

--- a/packages/safe-tools-subgraph/networks.json
+++ b/packages/safe-tools-subgraph/networks.json
@@ -7,14 +7,6 @@
       "startBlock": 7921489
     }
   },
-  "mumbai": {
-    "ScheduledPaymentModule": {
-      "startBlock": 29044929
-    },
-    "GnosisSafe": {
-      "startBlock": 29044929
-    }
-  },
   "matic": {
     "ScheduledPaymentModule": {
       "startBlock": 38743683

--- a/packages/safe-tools-subgraph/package.json
+++ b/packages/safe-tools-subgraph/package.json
@@ -5,7 +5,6 @@
     "codegen": "graph codegen",
     "build": "graph build",
     "deploy:goerli": "graph deploy --product hosted-service cardstack/safe-tools-goerli",
-    "deploy:mumbai": "graph deploy --product hosted-service cardstack/safe-tools-mumbai",
     "deploy:polygon": "graph deploy --product hosted-service cardstack/safe-tools-polygon",
     "deploy:mainnet": "graph deploy --product hosted-service cardstack/safe-tools-mainnet",
     "create-local": "graph create --node http://localhost:8020/ cardstack/safe-tools",


### PR DESCRIPTION
Currently, the subgraph for safe tools client is indexing safes with scheduled payment module that were created with an old version of the scheduled payment module. That results in bugs in scheduled payment execution, for example "pool not found" error. 

We should update our goerli, mainnet and polygon safe tools subgraph to start indexing with a block number that matches the time when the newest version of the module was deployed. 

With this change the UI will only list the safes that have the newest version of scheduled payment module installed. 

Goerli:

- sp module: https://goerli.etherscan.io/address/0x4D14d82Bc37199B289db5B0bd185cB5b79893cDB
- Start block: [8403969](https://goerli.etherscan.io/block/8403969)

Polygon:

- sp module: https://polygonscan.com/address/0x4D14d82Bc37199B289db5B0bd185cB5b79893cDB
- start block: [38743683](https://polygonscan.com/block/38743683)

Mainnet:

- sp module: https://etherscan.io/address/0x4D14d82Bc37199B289db5B0bd185cB5b79893cDB
- start block: [16532738](https://etherscan.io/block/16532738)