### PR TITLE
Add a function to estimate execution with no amount

### DIFF
--- a/packages/cardpay-cli/scheduled-payment/estimate-execution-with-no-amount.ts
+++ b/packages/cardpay-cli/scheduled-payment/estimate-execution-with-no-amount.ts
@@ -4,8 +4,7 @@ import { getEthereumClients, getConnectionType, NETWORK_OPTION_ANY } from '../ut
 import { Arguments, CommandModule } from 'yargs';
 
 export default {
-  command:
-    'estimate-execution <moduleAddress> <tokenAddress> <amount> <payeeAddress> <maxGasPrice> <gasTokenAddress> <salt>',
+  command: 'estimate-execution-with-no-amount <moduleAddress> <tokenAddress> <payeeAddress> <gasTokenAddress> <salt>',
   describe: 'Estimate gas for scheduled payment execution',
   builder(yargs: Argv) {
     return yargs
@@ -17,17 +16,17 @@ export default {
         type: 'string',
         description: 'The address of the token being transferred',
       })
-      .positional('amount', {
-        type: 'string',
-        description: 'Amount of tokens you would like transferred (in the smallest units of token)',
-      })
       .positional('payeeAddress', {
         type: 'string',
         description: 'The address of the payee of scheduled payment',
       })
-      .positional('maxGasPrice', {
-        type: 'string',
-        description: 'Maximum gas price (in the smallest units of gas token)',
+      .positional('fixedUSDFee', {
+        type: 'number',
+        description: 'Fixed USD fee (e.g. 0.25)',
+      })
+      .positional('percentageFee', {
+        type: 'number',
+        description: 'Percentage fee (e.g. 5%, 0.05)',
       })
       .positional('gasTokenAddress', {
         type: 'string',
@@ -56,9 +55,7 @@ export default {
       network,
       moduleAddress,
       tokenAddress,
-      amount,
       payeeAddress,
-      maxGasPrice,
       gasTokenAddress,
       salt,
       payAt,
@@ -68,9 +65,7 @@ export default {
       network: string;
       moduleAddress: string;
       tokenAddress: string;
-      amount: string;
       payeeAddress: string;
-      maxGasPrice: string;
       gasTokenAddress: string;
       salt: string;
       payAt?: number | null;
@@ -88,15 +83,12 @@ export default {
 
     console.log(`Estimate scheduled payment execution gas ...`);
 
-    let requiredGas = await scheduledPaymentModule.estimateExecutionGas(
+    let requiredGas = await scheduledPaymentModule.estimateExecutionGasWithNoAmount(
       moduleAddress,
       tokenAddress,
-      amount,
       payeeAddress,
-      maxGasPrice,
       gasTokenAddress,
       salt,
-      maxGasPrice,
       payAt,
       recurringDayOfMonth,
       recurringUntil

--- a/packages/cardpay-cli/scheduled-payment/index.ts
+++ b/packages/cardpay-cli/scheduled-payment/index.ts
@@ -7,6 +7,7 @@ export const command = 'scheduled-payment <command>';
 export const desc = 'Commands to interact with the scheduled payment module';
 import enableModule from './enable-module';
 import estimateExecution from './estimate-execution';
+import estimateExecutionWithNoAmount from './estimate-execution-with-no-amount';
 import estimateGas from './estimate-gas';
 import execute from './execute';
 import schedulePayment from './schedule-payment';
@@ -19,6 +20,7 @@ export const builder = function (yargs: Argv) {
     createSpHash,
     enableModule,
     estimateExecution,
+    estimateExecutionWithNoAmount,
     estimateGas,
     execute,
     schedulePayment,

--- a/packages/hub/node-tests/services/gas-estimation/estimation-test.ts
+++ b/packages/hub/node-tests/services/gas-estimation/estimation-test.ts
@@ -13,12 +13,10 @@ class StubCardpaySDK {
     switch (sdk) {
       case 'ScheduledPaymentModule':
         return Promise.resolve({
-          estimateExecutionGas: async (
+          estimateExecutionGasWithNoAmount: async (
             _moduleAddress: string,
             _tokenAddress: string,
-            _amount: string,
             _payeeAddress: string,
-            _maxGasPrice: string,
             _gasTokenAddress: string,
             _salt: string,
             _gasPrice: string,
@@ -84,7 +82,7 @@ describe('estimate gas', function () {
 
     expect(gasEstimationResult.scenario).to.equal(gasEstimationParams.scenario);
     expect(gasEstimationResult.chainId).to.equal(gasEstimationParams.chainId);
-    expect(gasEstimationResult.gas).to.equal(executionGas + 30000 + 25500);
+    expect(gasEstimationResult.gas).to.equal(executionGas + 10000);
   });
 
   it('estimates gas for execute scheduled recurring payment scenario', async function () {
@@ -100,7 +98,7 @@ describe('estimate gas', function () {
 
     expect(gasEstimationResult.scenario).to.equal(gasEstimationParams.scenario);
     expect(gasEstimationResult.chainId).to.equal(gasEstimationParams.chainId);
-    expect(gasEstimationResult.gas).to.equal(executionGas + 30000 + 25500);
+    expect(gasEstimationResult.gas).to.equal(executionGas + 10000);
   });
 
   it('retrieves gas from DB if gas exist in DB and still in valid TTL', async function () {

--- a/packages/hub/services/gas-estimation.ts
+++ b/packages/hub/services/gas-estimation.ts
@@ -101,48 +101,35 @@ export default class GasEstimationService {
     let gas;
     switch (params.scenario) {
       case GasEstimationResultsScenarioEnum.execute_one_time_payment:
-        gas = await scheduledPaymentModule.estimateExecutionGas(
+        gas = await scheduledPaymentModule.estimateExecutionGasWithNoAmount(
           spModuleAddress,
           params.tokenAddress,
-          '0',
           signer.address,
-          '0',
           params.gasTokenAddress,
           'salt1',
-          '0',
           Math.round(nowUtc().getTime() / 1000),
           null,
-          null,
-          0,
-          0
+          null
         );
         break;
       case GasEstimationResultsScenarioEnum.execute_recurring_payment:
-        gas = await scheduledPaymentModule.estimateExecutionGas(
+        gas = await scheduledPaymentModule.estimateExecutionGasWithNoAmount(
           spModuleAddress,
           params.tokenAddress,
-          '0',
           signer.address,
-          '0',
           params.gasTokenAddress,
           'salt1',
-          '0',
           null,
           28,
-          Math.round(addDays(nowUtc(), 30).getTime() / 1000),
-          0,
-          0
+          Math.round(addDays(nowUtc(), 30).getTime() / 1000)
         );
         break;
       default:
         throw Error('unknown estimation scenario');
     }
 
-    // Add 25500 to handle transfer amount and gas token is not zero.
-    // Add 30000 to make the payment gas is high enough to be executed.
-    // Other tokens have different transfer logic
-    // and will be executed through the USD conversion process.
-    return gas + 25500 + 30000;
+    // Add 10000 to make the payment gas is high enough to be executed.
+    return gas + 10000;
   }
 
   private async getSpModuleAddress(chainId: number, safeAddress: string): Promise<string> {

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
@@ -27,7 +27,6 @@ import * as Sentry from '@sentry/browser';
 import FeeCalculator, { type CurrentFees } from './fee-calculator';
 import config from '@cardstack/safe-tools-client/config/environment';
 import HubAuthenticationService from '@cardstack/safe-tools-client/services/hub-authentication';
-import { addMinutes } from 'date-fns';
 
 interface Signature {
   Element: HTMLElement;

--- a/packages/safe-tools-client/tests/integration/components/schedule-payment-form-action-card-test.ts
+++ b/packages/safe-tools-client/tests/integration/components/schedule-payment-form-action-card-test.ts
@@ -368,6 +368,8 @@ module(
         `);
         const now = new Date();
         await click(`[data-test-payment-type="one-time"]`);
+        await click(`[data-test-input-payment-date]`);
+        await click(`[data-date="${format(now, 'yyyy-MM-dd')}"]`);
         await click(`[data-test-input-specific-payment-time]`);
 
         assert


### PR DESCRIPTION
Ticket: CS-5357

To estimate the execution, it is required for the user's safe to have a sufficient token and gas token balance. However, we want users to be able to estimate even if they do not have a sufficient balance in their safe. Therefore, we decided to perform the estimation with the token and gas token amounts defined as zero. Estimating with a zero amount will skip the process of getting the exchange rate of the gas token to USD. To manually add the estimation for the exchange rate process, I added `estimateExecutionGasWithNoAmount` to the SDK.

I have tested this function in Polygon with WMATIC and DAI.

- WMATIC
```
yarn cardpay scheduled-payment estimate-execution-with-no-amount 0xc325385c061731bd6fd17228f500f9f3c1c6e6bb 0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270 0xf4E4c6bfd83e4D0E7a5627b631800487f4A154fD 0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270 salt1 --payAt 1678262142 --ethersMnemonic $MNEMONIC --network polygon
Estimate scheduled payment execution gas ...
Required execution gas: 284432
```

- DAI
```
yarn cardpay scheduled-payment estimate-execution-with-no-amount 0xc325385c061731bd6fd17228f500f9f3c1c6e6bb 0x8f3cf7ad23cd3cadbd9735aff958023239c6a063 0xf4E4c6bfd83e4D0E7a5627b631800487f4A154fD 0x8f3cf7ad23cd3cadbd9735aff958023239c6a063 salt1 --payAt 1678262142 --ethersMnemonic $MNEMONIC --network polygon
Estimate scheduled payment execution gas ...
Required execution gas: 247013
```
