### PR TITLE
hub: Don't consider a payment unattempted if it has a creationTransactionError

### DIFF
--- a/packages/hub/node-tests/services/data-integrity-checks-test.ts
+++ b/packages/hub/node-tests/services/data-integrity-checks-test.ts
@@ -162,6 +162,7 @@ describe('data integrity checks', function () {
           chainId: 1,
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           creationTransactionHash: '0x123',
+          creationBlockNumber: 1,
         },
       });
 
@@ -186,6 +187,32 @@ describe('data integrity checks', function () {
           canceledAt: nowUtc(),
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           creationTransactionHash: '0x123',
+          creationBlockNumber: 1,
+        },
+      });
+
+      // Below is a scheduled payment whose creation transaction was reverted, which should not be considered unattempted
+      await prisma.scheduledPayment.create({
+        data: {
+          id: shortUuid.uuid(),
+          senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+          moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+          tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+          gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+          amount: '100',
+          payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+          executionGasEstimation: 100000,
+          maxGasPrice: '1000000000',
+          feeFixedUsd: '0',
+          feePercentage: '0',
+          salt: '54lt',
+          payAt: subMinutes(nowUtc(), 61),
+          spHash: cryptoRandomString({ length: 10 }),
+          chainId: 1,
+          canceledAt: nowUtc(),
+          userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+          creationTransactionHash: '0x123',
+          creationTransactionError: 'reverted',
         },
       });
 

--- a/packages/hub/services/data-integrity-checks/scheduled-payments.ts
+++ b/packages/hub/services/data-integrity-checks/scheduled-payments.ts
@@ -111,6 +111,9 @@ export default class DataIntegrityChecksScheduledPayments {
           gt: subMinutes(nowUtc(), UNATTEMPTED_ALLOWED_MINUTES),
         },
         canceledAt: null,
+        creationTransactionError: {
+          equals: null,
+        },
         scheduledPaymentAttempts: {
           none: {
             startedAt: {


### PR DESCRIPTION
Ticket: CS-5356

Do not send alerts when the crank did not try to execute the payment for some reason in case the transaction to schedule a payment was reverted. It is wrong to expect such payments should be attempted.

Related: https://github.com/cardstack/cardstack/pull/3687