### PR TITLE
Defining gas price to avoid transaction underpriced error

### DIFF
--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -1352,7 +1352,8 @@ export default class ScheduledPaymentModule {
       let response = await signer.sendTransaction({
         to: executeScheduledPaymentTx.to,
         data: executeScheduledPaymentTx.data,
-        nonce: nonce ? BigNumber.from(nonce.toString()) : undefined,
+        nonce: nonce?.toString(),
+        gasPrice: txnOptions?.gasPrice?.toString(),
       });
       if (typeof onTxnHash === 'function') {
         await onTxnHash(response.hash);

--- a/packages/cardpay-sdk/sdk/utils/general-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/general-utils.ts
@@ -38,6 +38,7 @@ export type TransactionHash = string;
 
 export interface TransactionOptions {
   nonce?: BN;
+  gasPrice?: BN;
   onNonce?: (nonce: BN) => void;
   onTxnHash?: (txnHash: TransactionHash) => unknown;
 }

--- a/packages/hub/node-tests/services/scheduled-payments/executor-test.ts
+++ b/packages/hub/node-tests/services/scheduled-payments/executor-test.ts
@@ -62,7 +62,12 @@ describe('executing scheduled payments', function () {
 
   this.beforeEach(async function () {
     subject = (await getContainer().lookup('scheduled-payment-executor')) as ScheduledPaymentsExecutorService;
-    subject.getCurrentGasPrice = async () => new BN('1000000000');
+    subject.getCurrentGasPrice = async () => {
+      return {
+        gasPrice: '1000',
+        gasPriceInGasToken: '1000000000',
+      };
+    };
     prisma = await getPrisma();
     crankNonceLock = (await getContainer().lookup('crank-nonce-lock')) as CrankNonceLock;
     crankNonceLock.withNonce = async (chainId: number, cb: (nonce: BN) => Promise<any>) => {


### PR DESCRIPTION
Ticket: CS-5358

We often got a `transaction underpriced` error when executing a scheduled payment in Polygon, It was because we didn't define the gas price fields (gas price, max fee, or max priority fee) of the transaction, and in that case, ethers will define max priority fee equal to `1500000000` which is too low if the network is busy. But if we define the gas price, the max fee and max priority fee will equal to gas price (https://github.com/ethers-io/ethers.js/blob/278f84174409b470fa7992e1f8b5693e6e5d2dac/src.ts/providers/abstract-signer.ts#L136).