### PR TITLE
Update TokenQuantity display logic to limit output to a max of 6 significant digits

### DIFF
--- a/packages/safe-tools-client/app/utils/token-quantity.ts
+++ b/packages/safe-tools-client/app/utils/token-quantity.ts
@@ -1,6 +1,8 @@
 import { TokenDetail } from '@cardstack/cardpay-sdk';
 import { BigNumber, utils as ethersUtils } from 'ethers';
 
+const SIGNIFICANT_DIGITS = 6;
+
 export default class TokenQuantity {
   // Count is the number of tokens, denominated in the smallest unit of the token. e.g. wei for Ethereum
   constructor(public token: TokenDetail, public count: BigNumber) {}
@@ -16,7 +18,11 @@ export default class TokenQuantity {
   }
 
   get decimalString() {
-    return ethersUtils.formatUnits(this.count, this.decimals);
+    const value = ethersUtils.formatUnits(this.count, this.decimals);
+    const formattedValue = parseFloat(value)
+      .toPrecision(SIGNIFICANT_DIGITS)
+      .replace(/\.?0+$/, '');
+    return formattedValue;
   }
 
   get symbol() {

--- a/packages/safe-tools-client/tests/integration/components/payment-transactions-list-test.ts
+++ b/packages/safe-tools-client/tests/integration/components/payment-transactions-list-test.ts
@@ -316,7 +316,7 @@ module('Integration | Component | payment-transactions-list', function (hooks) {
       .dom(
         '[data-test-scheduled-payment-attempts-item="0"] [data-test-scheduled-payment-attempts-item-amount]'
       )
-      .hasText('10.0 USDC');
+      .hasText('10 USDC');
 
     assert
       .dom(

--- a/packages/safe-tools-client/tests/integration/components/schedule-payment-form-action-card-test.ts
+++ b/packages/safe-tools-client/tests/integration/components/schedule-payment-form-action-card-test.ts
@@ -559,7 +559,7 @@ module(
         });
         assert
           .dom('[data-test-summary-recipient-receives]')
-          .containsText('15.0 WETH');
+          .containsText('15 WETH');
         await waitUntil(() => {
           return find(
             '[data-test-summary-recipient-receives]'
@@ -572,11 +572,9 @@ module(
         await waitUntil(() => {
           return find(
             '[data-test-summary-estimated-gas]'
-          )?.textContent?.includes('20.0 USDC');
+          )?.textContent?.includes('20 USDC');
         });
-        assert
-          .dom('[data-test-summary-estimated-gas]')
-          .containsText('20.0 USDC');
+        assert.dom('[data-test-summary-estimated-gas]').containsText('20 USDC');
         assert.dom('[data-test-summary-estimated-gas]').containsText('$ 20.00');
         await waitUntil(() => {
           return find('[data-test-summary-fixed-fee]')?.textContent?.includes(
@@ -605,13 +603,13 @@ module(
         });
         assert
           .dom('[data-test-max-gas-toggle] [data-toggle-group-option="normal"]')
-          .containsText('20.0 USDC');
+          .containsText('20 USDC');
         assert
           .dom('[data-test-max-gas-toggle] [data-toggle-group-option="high"]')
-          .containsText('40.0 USDC');
+          .containsText('40 USDC');
         assert
           .dom('[data-test-max-gas-toggle] [data-toggle-group-option="max"]')
-          .containsText('80.0 USDC');
+          .containsText('80 USDC');
       });
 
       test('it disables submit button if gas token balance insufficient', async function (assert) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/353/225360224-86817f4a-ff6d-4ab3-a781-12a4a8caf8ad.png)

cs-5359-visual-bug-in-max-gas-cost-chooser