### PR TITLE
Make sure to set next payment retry if payment fails in the transaction execution waiter

### DIFF
--- a/packages/hub/node-tests/tasks/scheduled-payment-on-chain-execution-waiter-test.ts
+++ b/packages/hub/node-tests/tasks/scheduled-payment-on-chain-execution-waiter-test.ts
@@ -241,6 +241,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
         chainId: 1,
         userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
         creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
+        scheduledPaymentAttemptsInLastPaymentCycleCount: 1,
       },
     });
 
@@ -268,14 +269,14 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
     expect(scheduledPaymentAttempt.failureReason).to.eq('ExceedMaxGasPrice');
     expect(scheduledPaymentAttempt.endedAt).to.not.be.null;
 
-    // Reload the payment to ensure that scheduledPaymentAttemptsInLastPaymentCycleCount and nextRetryAttemptAt were updated
+    // Reload the payment to ensure that nextRetryAttemptAt were updated
     scheduledPayment = (await prisma.scheduledPayment.findUnique({
       where: {
         id: scheduledPayment.id,
       },
     })) as ScheduledPayment;
 
-    expect(scheduledPayment.scheduledPaymentAttemptsInLastPaymentCycleCount).to.equal(0);
-    expect(scheduledPayment.nextRetryAttemptAt).to.be.null;
+    expect(scheduledPayment.nextRetryAttemptAt).to.not.be.null;
+    expect(scheduledPayment.scheduledPaymentAttemptsInLastPaymentCycleCount).to.equal(1);
   });
 });

--- a/packages/hub/node-tests/tasks/scheduled-payment-on-chain-execution-waiter-test.ts
+++ b/packages/hub/node-tests/tasks/scheduled-payment-on-chain-execution-waiter-test.ts
@@ -269,7 +269,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
     expect(scheduledPaymentAttempt.failureReason).to.eq('ExceedMaxGasPrice');
     expect(scheduledPaymentAttempt.endedAt).to.not.be.null;
 
-    // Reload the payment to ensure that nextRetryAttemptAt were updated
+    // Reload the payment to ensure that nextRetryAttemptAt was updated
     scheduledPayment = (await prisma.scheduledPayment.findUnique({
       where: {
         id: scheduledPayment.id,

--- a/packages/hub/tasks/scheduled-payment-on-chain-execution-waiter.ts
+++ b/packages/hub/tasks/scheduled-payment-on-chain-execution-waiter.ts
@@ -90,7 +90,7 @@ export default class ScheduledPaymentOnChainExecutionWaiter {
       // - PaymentExecutionFailed: safe balance is not enough to make payments and pay fees
       // - OutOfGas: executionGas to low to execute scheduled payment
       //
-      // In these cases we want to mark the payment attempt as failed and let the scheduler's logic to figure out when to try again.
+      // In these cases we want to mark the payment attempt as failed and set the next retry attempt date
       await prisma.scheduledPaymentAttempt.update({
         data: {
           status: 'failed',
@@ -99,6 +99,13 @@ export default class ScheduledPaymentOnChainExecutionWaiter {
         },
         where: {
           id: paymentAttempt.id,
+        },
+      });
+
+      await prisma.scheduledPayment.update({
+        where: { id: scheduledPayment.id },
+        data: {
+          nextRetryAttemptAt: this.scheduledPaymentFetcher.calculateNextRetryAttemptDate(scheduledPayment),
         },
       });
 


### PR DESCRIPTION
Ticket: CS-5387

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/273660/225379279-a1b008e5-ba1b-4bcb-9007-85ea99788f44.png">

Note that the "Next retry at: timestamp" is missing.

Payments that failed in the waiter task (i.e. transactions that got accepted in the pool but failed during on chain execution) did not get their `nextRetryAttemptAt` written 😬 This PR fixes that! 