### PR TITLE
feat(hub): Add 10 seconds timeout to hub status check

### DIFF
--- a/packages/hub/routes/status.ts
+++ b/packages/hub/routes/status.ts
@@ -133,12 +133,12 @@ export default class StatusRoute {
     return null;
   }
 
-  async withTimeout(p: Promise<any>): Promise<any> {
+  withTimeout(p: Promise<any>): Promise<any> {
     const t = new Promise((resolve) => {
       setTimeout(() => resolve(null), STATUS_TIMEOUT);
     });
 
-    return await Promise.race([t, p]);
+    return Promise.race([t, p]);
   }
 }
 


### PR DESCRIPTION
The status check on hub, specifically on staging, is bumping into timeout issue as sokol rpc is no longer responding properly. This PR attempts to restructure the status check flow by making all checks synchronous, and adding a configurable timeout value. Currently the value is set at 10 seconds, we might want to make that configurable via env var or a different static value.

<img width="1341" alt="Screenshot 2023-03-17 at 4 08 15 PM" src="https://user-images.githubusercontent.com/44688367/225848302-33da4e50-7c5d-43e8-b407-a4a9cc55cf13.png">