### PR TITLE
hub: Allow setting a private rpc node in ethers provider 

### DIFF
--- a/packages/hub/config/custom-environment-variables.json
+++ b/packages/hub/config/custom-environment-variables.json
@@ -118,5 +118,10 @@
   },
   "rewardsIndexer": {
     "enabled": "REWARDS_INDEXER_ENABLED"
+  },
+  "hubRpcNodes": {
+    "polygon": {
+      "rpcNodeHttpsUrl": "POLYGON_HUB_RPC_NODE_HTTPS_URL"
+    }
   }
 }

--- a/packages/hub/services/ethers-provider.ts
+++ b/packages/hub/services/ethers-provider.ts
@@ -1,9 +1,21 @@
 import config from 'config';
-import { getWeb3ConfigByNetwork, JsonRpcProvider } from '@cardstack/cardpay-sdk';
+import { convertChainIdToName, getWeb3ConfigByNetwork, JsonRpcProvider } from '@cardstack/cardpay-sdk';
 
 export default class EthersProvider {
   getInstance(chainId: number) {
-    let rpcUrl = getWeb3ConfigByNetwork({ web3: config.get('web3') }, chainId).rpcNodeHttpsUrl;
+    let rpcUrl: string;
+
+    // For some networks, we want to use a private RPC node (to increase reliability), and not the one
+    // that is configured in the web3 config, because that one is public and may be unreliable
+
+    let networkName = convertChainIdToName(chainId);
+    let hubRpcNodeKey = `hubRpcNodes.${networkName}.rpcNodeHttpsUrl`;
+    if (config.has(hubRpcNodeKey)) {
+      rpcUrl = config.get('hubRpcNodes.polygon.rpcNodeHttpsUrl');
+    } else {
+      rpcUrl = getWeb3ConfigByNetwork({ web3: config.get('web3') }, chainId).rpcNodeHttpsUrl;
+    }
+
     return new JsonRpcProvider(rpcUrl, chainId);
   }
 }

--- a/waypoint.hcl
+++ b/waypoint.hcl
@@ -372,6 +372,7 @@ app "hub-event-listener" {
         POLYGON_GAS_STATION_URL          = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_polygon_gas_station_url-cUpbHc"
         POLYGON_RPC_NODE_HTTPS_URL       = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_evm_polygon_infura_https_url-wIF3tU"
         POLYGON_RPC_NODE_WSS_URL         = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_evm_polygon_infura_wss_url-UvdYiF"
+        POLYGON_HUB_RPC_NODE_HTTPS_URL   = "arn:aws:secretsmanager:us-east-1:680542703984:secret:staging_evm_polygon_infura_https_url-wIF3tU"
       }
     }
 

--- a/waypoint.prod.hcl
+++ b/waypoint.prod.hcl
@@ -385,6 +385,7 @@ app "hub-event-listener" {
         POLYGON_GAS_STATION_URL          = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_polygon_gas_station_url-j7D7GO"
         POLYGON_RPC_NODE_HTTPS_URL       = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_evm_polygon_infura_https_url-DlBN06"
         POLYGON_RPC_NODE_WSS_URL         = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_evm_polygon_infura_wss_url-ErLq0E"
+        POLYGON_HUB_RPC_NODE_HTTPS_URL   = "arn:aws:secretsmanager:us-east-1:120317779495:secret:production_evm_hub_polygon_https_url-jIVW87"
       }
     }
 


### PR DESCRIPTION
This will allow us to use Infura's RPC node in the hub internally, without leaking the url to the public.

It is to improve reliability because public RPC nodes can be unreliable, which cause issues with the scheduler tool. 

I added the private RPC URL to the secrets manager. 