### PR TITLE
Only consider payment as unattempted when it has a creation block number

### DIFF
--- a/packages/hub/node-tests/services/data-integrity-checks-test.ts
+++ b/packages/hub/node-tests/services/data-integrity-checks-test.ts
@@ -213,6 +213,32 @@ describe('data integrity checks', function () {
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           creationTransactionHash: '0x123',
           creationTransactionError: 'reverted',
+          creationBlockNumber: 1,
+        },
+      });
+
+      // Below is a scheduled payment that does not have a creation block number, which should not be considered as unattempted
+      await prisma.scheduledPayment.create({
+        data: {
+          id: shortUuid.uuid(),
+          senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+          moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+          tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+          gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+          amount: '100',
+          payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+          executionGasEstimation: 100000,
+          maxGasPrice: '1000000000',
+          feeFixedUsd: '0',
+          feePercentage: '0',
+          salt: '54lt',
+          payAt: subMinutes(nowUtc(), 61),
+          spHash: cryptoRandomString({ length: 10 }),
+          chainId: 1,
+          canceledAt: nowUtc(),
+          userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+          creationTransactionHash: '0x123',
+          creationBlockNumber: null,
         },
       });
 

--- a/packages/hub/services/data-integrity-checks/scheduled-payments.ts
+++ b/packages/hub/services/data-integrity-checks/scheduled-payments.ts
@@ -114,6 +114,9 @@ export default class DataIntegrityChecksScheduledPayments {
         creationTransactionError: {
           equals: null,
         },
+        creationBlockNumber: {
+          not: null,
+        },
         scheduledPaymentAttempts: {
           none: {
             startedAt: {


### PR DESCRIPTION
Checkly is sending an alarm for "payments that weren't attempted when they should have been" for payments whose creation transactions weren't verified on chain yet (and have no `creation_block_number`). That's wrong because we don't expect such payments to be attempted. 