### PR TITLE
Fix internal json RPC error and other unknown errors

### DIFF
--- a/packages/hub/node-tests/tasks/scheduled-payment-on-chain-execution-waiter-test.ts
+++ b/packages/hub/node-tests/tasks/scheduled-payment-on-chain-execution-waiter-test.ts
@@ -279,4 +279,57 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
     expect(scheduledPayment.nextRetryAttemptAt).to.not.be.null;
     expect(scheduledPayment.scheduledPaymentAttemptsInLastPaymentCycleCount).to.equal(1);
   });
+
+  it('spawns a new waiter on unknown error', async function () {
+    sdkError = new Error('Unknown error');
+
+    let prisma = await getPrisma();
+    let task = await getContainer().instantiate(ScheduledPaymentOnChainExecutionWaiter);
+    let scheduledPayment = await prisma.scheduledPayment.create({
+      data: {
+        id: shortUuid.uuid(),
+        senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+        moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+        tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+        gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+        amount: '100',
+        payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+        executionGasEstimation: 100000,
+        maxGasPrice: '1000000000',
+        feeFixedUsd: 0,
+        feePercentage: 0,
+        salt: '54lt',
+        payAt: new Date(),
+        spHash: cryptoRandomString({ length: 10 }),
+        chainId: 1,
+        userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+        creationTransactionHash: '0xc13d7905be5c989378a945487cd2a1193627ae606009e28e296d48ddaec66162',
+      },
+    });
+
+    let scheduledPaymentAttempt = await prisma.scheduledPaymentAttempt.create({
+      data: {
+        id: shortUUID.uuid(),
+        startedAt: nowUtc(),
+        endedAt: null,
+        status: 'inProgress',
+        scheduledPaymentId: scheduledPayment.id,
+        transactionHash: '0x123',
+        executionGasPrice: '10000',
+      },
+    });
+
+    await task.perform({ scheduledPaymentAttemptId: scheduledPaymentAttempt.id });
+
+    scheduledPaymentAttempt = await prisma.scheduledPaymentAttempt.findUniqueOrThrow({
+      where: {
+        id: scheduledPaymentAttempt.id,
+      },
+    });
+
+    expect(scheduledPaymentAttempt.status).to.eq('inProgress');
+    expect(scheduledPaymentAttempt.endedAt).to.be.null;
+    expect(getJobIdentifiers()[0]).to.equal('scheduled-payment-on-chain-execution-waiter');
+    expect(getJobPayloads()[0]).to.deep.equal({ scheduledPaymentAttemptId: scheduledPaymentAttempt.id });
+  });
 });

--- a/packages/hub/tasks/scheduled-payment-on-chain-execution-waiter.ts
+++ b/packages/hub/tasks/scheduled-payment-on-chain-execution-waiter.ts
@@ -51,26 +51,38 @@ export default class ScheduledPaymentOnChainExecutionWaiter {
         }
       }
     } catch (error: any) {
-      // waitUntilTransactionMined will return "Transaction took too long to complete" in case it wasn't mined in 60 minutes.
-      // In this case we want to restart the task and wait some more. We could throw an error here so that the worker would restart the task, but
-      // due to the exponential-backoff it could take some time before the waiting can start again. That's why we just spawn a new task directly.
-      if (error.message.includes('took too long')) {
-        if (isBefore(paymentAttempt.startedAt!, subDays(nowUtc(), 1))) {
-          await prisma.scheduledPaymentAttempt.update({
-            data: {
-              status: 'failed',
-              failureReason: "Waited for more than 1 day for the transaction to be mined, but it wasn't",
-              endedAt: nowUtc(),
-            },
-            where: {
-              id: paymentAttempt.id,
-            },
-          });
-        } else {
-          await this.workerClient.addJob('scheduled-payment-on-chain-execution-waiter', {
-            scheduledPaymentAttemptId: paymentAttempt.id,
-          });
-        }
+      // Known errors are:
+      // - Transaction took too long to complete
+      // - Transaction with hash "${txnHash}" was reverted
+      // - UnknownHash: payment details generate unregistered spHash
+      // - InvalidPeriod: payment executed outside of valid date or period
+      // - ExceedMaxGasPrice: gasPrice must be lower than or equal maxGasPrice
+      // - PaymentExecutionFailed: safe balance is not enough to make payments and pay fees
+      // - OutOfGas: executionGas to low to execute scheduled payment
+      let knownErrors = [
+        'took too long',
+        'was reverted',
+        'UnknownHash',
+        'InvalidPeriod',
+        'ExceedMaxGasPrice',
+        'PaymentExecutionFailed',
+        'OutOfGas',
+      ];
+      let isKnownError = knownErrors.find((knownError) => error.message.includes(knownError));
+      if (isKnownError) {
+        await prisma.scheduledPaymentAttempt.update({
+          data: {
+            status: 'failed',
+            failureReason:
+              error.message.includes('took too long') && isBefore(paymentAttempt.startedAt!, subDays(nowUtc(), 1))
+                ? "Waited for more than 1 day for the transaction to be mined, but it wasn't"
+                : error.message,
+            endedAt: nowUtc(),
+          },
+          where: {
+            id: paymentAttempt.id,
+          },
+        });
 
         await prisma.scheduledPayment.update({
           where: { id: scheduledPayment.id },
@@ -78,37 +90,11 @@ export default class ScheduledPaymentOnChainExecutionWaiter {
             nextRetryAttemptAt: this.scheduledPaymentFetcher.calculateNextRetryAttemptDate(scheduledPayment),
           },
         });
-
-        return;
+      } else {
+        await this.workerClient.addJob('scheduled-payment-on-chain-execution-waiter', {
+          scheduledPaymentAttemptId: paymentAttempt.id,
+        });
       }
-
-      // Known errors are:
-      // - Transaction with hash "${txnHash}" was reverted
-      // - UnknownHash: payment details generate unregistered spHash
-      // - InvalidPeriod: payment executed outside of valid date or period
-      // - ExceedMaxGasPrice: gasPrice must be lower than or equal maxGasPrice
-      // - PaymentExecutionFailed: safe balance is not enough to make payments and pay fees
-      // - OutOfGas: executionGas to low to execute scheduled payment
-      //
-      // In these cases we want to mark the payment attempt as failed and set the next retry attempt date
-      await prisma.scheduledPaymentAttempt.update({
-        data: {
-          status: 'failed',
-          failureReason: error.message,
-          endedAt: nowUtc(),
-        },
-        where: {
-          id: paymentAttempt.id,
-        },
-      });
-
-      await prisma.scheduledPayment.update({
-        where: { id: scheduledPayment.id },
-        data: {
-          nextRetryAttemptAt: this.scheduledPaymentFetcher.calculateNextRetryAttemptDate(scheduledPayment),
-        },
-      });
-
       return; // We don't want to throw an error here because we don't want the task to be retried - the transaction has obviously failed
     }
   }

--- a/packages/hub/tasks/scheduled-payment-on-chain-execution-waiter.ts
+++ b/packages/hub/tasks/scheduled-payment-on-chain-execution-waiter.ts
@@ -67,13 +67,13 @@ export default class ScheduledPaymentOnChainExecutionWaiter {
         'OutOfGas',
       ];
       let isKnownError = knownErrors.find((knownError) => error.message.includes(knownError));
-      let isWaitTooLongError =
+      let isWaitTooLong =
         error.message.includes('took too long') && isBefore(paymentAttempt.startedAt!, subDays(nowUtc(), 1));
-      if (isKnownError || isWaitTooLongError) {
+      if (isKnownError || isWaitTooLong) {
         await prisma.scheduledPaymentAttempt.update({
           data: {
             status: 'failed',
-            failureReason: isWaitTooLongError
+            failureReason: isWaitTooLong
               ? "Waited for more than 1 day for the transaction to be mined, but it wasn't"
               : error.message,
             endedAt: nowUtc(),

--- a/packages/hub/tasks/scheduled-payment-on-chain-execution-waiter.ts
+++ b/packages/hub/tasks/scheduled-payment-on-chain-execution-waiter.ts
@@ -67,15 +67,15 @@ export default class ScheduledPaymentOnChainExecutionWaiter {
         'OutOfGas',
       ];
       let isKnownError = knownErrors.find((knownError) => error.message.includes(knownError));
-      let isWaitTooLongError = error.message.includes('took too long') && isBefore(paymentAttempt.startedAt!, subDays(nowUtc(), 1));
+      let isWaitTooLongError =
+        error.message.includes('took too long') && isBefore(paymentAttempt.startedAt!, subDays(nowUtc(), 1));
       if (isKnownError || isWaitTooLongError) {
         await prisma.scheduledPaymentAttempt.update({
           data: {
             status: 'failed',
-            failureReason:
-              isWaitTooLongError
-                ? "Waited for more than 1 day for the transaction to be mined, but it wasn't"
-                : error.message,
+            failureReason: isWaitTooLongError
+              ? "Waited for more than 1 day for the transaction to be mined, but it wasn't"
+              : error.message,
             endedAt: nowUtc(),
           },
           where: {


### PR DESCRIPTION
We had some execution attempts that we marked as failed even though it was mined. It is because we use unknown errors such as `Internal JSON RPC error` and `NoNetwork` to determine the attempt status. I think we just need to mark the attempt as failed if we found the known errors only, and create a new waiting task if we found unknown errors.