### PR TITLE
Add estimateGas step to capture specific execution error

### DIFF
--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -1352,6 +1352,16 @@ export default class ScheduledPaymentModule {
     };
     try {
       let signer = this.signer ? this.signer : this.ethersProvider.getSigner();
+      //Since the gas limit is defined,
+      //sendTransaction won't execute the estimateGas.
+      //So we can't capture the error before the transaction is sent.
+      //To prevent that, we need to manually call the estimateGas here.
+      await signer.estimateGas({
+        to: executeScheduledPaymentTx.to,
+        data: executeScheduledPaymentTx.data,
+        nonce: nonce?.toString(),
+      });
+
       let response = await signer.sendTransaction({
         to: executeScheduledPaymentTx.to,
         data: executeScheduledPaymentTx.data,


### PR DESCRIPTION
Ticket: CS-5394

We decided to define the gas limit to prevent an out-of-gas error. But it caused the send transaction won't execute the estimate gas function, so we can't capture the specific execution error before the transaction is published. So I added a line to call the estimate gas function.