### PR TITLE
Define refund receiver address to avoid 'GS026' error

### DIFF
--- a/packages/cardpay-sdk/sdk/reward-manager/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-manager/base.ts
@@ -680,7 +680,7 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
       estimate,
       nonce,
       fullSignature,
-      eip1271Data
+      { eip1271Data }
     );
     if (typeof onTxnHash === 'function') {
       await onTxnHash(gnosisTxn.ethereumTx.txHash);
@@ -858,7 +858,7 @@ The owner of reward safe ${safeAddress} is ${rewardSafeOwner}, but the signer is
       estimate,
       nonce,
       fullSignature,
-      eip1271Data
+      { eip1271Data }
     );
     if (typeof onTxnHash === 'function') {
       await onTxnHash(gnosisTxn.ethereumTx.txHash);

--- a/packages/cardpay-sdk/sdk/reward-pool/base.ts
+++ b/packages/cardpay-sdk/sdk/reward-pool/base.ts
@@ -646,7 +646,7 @@ The reward program ${rewardProgramId} has balance equals ${fromWei(
       estimate,
       nonce,
       fullSignature,
-      eip1271Data
+      { eip1271Data }
     );
     if (typeof onTxnHash === 'function') {
       await onTxnHash(gnosisTxn.ethereumTx.txHash);

--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -230,8 +230,10 @@ export default class ScheduledPaymentModule {
         estimate,
         nonce,
         from,
-        this.signer
-      )
+        this.signer,
+        estimate.refundReceiver
+      ),
+      { refundReceiver: estimate.refundReceiver }
     );
 
     if (typeof onTxnHash === 'function') {
@@ -694,8 +696,10 @@ export default class ScheduledPaymentModule {
         estimate,
         nonce,
         from,
-        this.signer
-      )
+        this.signer,
+        estimate.refundReceiver
+      ),
+      { refundReceiver: estimate.refundReceiver }
     );
 
     if (typeof onTxnHash === 'function') {
@@ -793,7 +797,8 @@ export default class ScheduledPaymentModule {
         estimate,
         nonce,
         from,
-        this.signer
+        this.signer,
+        estimate.refundReceiver
       )
     )[0];
 
@@ -834,7 +839,8 @@ export default class ScheduledPaymentModule {
         estimate,
         nonce,
         from,
-        this.signer
+        this.signer,
+        estimate.refundReceiver
       )
     )[0];
 
@@ -1003,7 +1009,8 @@ export default class ScheduledPaymentModule {
       Operation.CALL,
       estimate,
       nonce,
-      [signature]
+      [signature],
+      { refundReceiver: estimate.refundReceiver }
     );
 
     let txnHash = gnosisTxn.ethereumTx.txHash;
@@ -1268,7 +1275,8 @@ export default class ScheduledPaymentModule {
       Operation.CALL,
       estimate,
       nonce,
-      [signature]
+      [signature],
+      { refundReceiver: estimate.refundReceiver }
     );
 
     let txnHash = gnosisTxn.ethereumTx.txHash;

--- a/packages/cardpay-sdk/sdk/utils/safe-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/safe-utils.ts
@@ -127,6 +127,11 @@ export interface GnosisExecTx extends RelayTransaction {
   transactionHash: string;
 }
 
+export interface ExecTransactionOptions {
+  eip1271Data?: string;
+  refundReceiver?: string;
+}
+
 /**
  * @group Utils
  * @category Safe
@@ -295,7 +300,7 @@ export async function executeTransaction(
   estimate: Estimate,
   nonce: BN,
   signatures: any,
-  eip1271Data?: string
+  execTransactionOptions?: ExecTransactionOptions
 ): Promise<GnosisExecTx> {
   let relayServiceURL = await getConstant('relayServiceURL', web3OrEthersProvider);
   const url = `${relayServiceURL}/v1/safes/${from}/transactions/`;
@@ -317,8 +322,8 @@ export async function executeTransaction(
       nonce: nonce.toString(),
       signatures,
       gasToken: estimate.gasToken,
-      refundReceiver: ZERO_ADDRESS,
-      eip1271Data,
+      refundReceiver: execTransactionOptions?.refundReceiver ?? ZERO_ADDRESS,
+      eip1271Data: execTransactionOptions?.eip1271Data,
     }),
   };
   let response = await fetch(url, options);

--- a/packages/cardpay-sdk/sdk/utils/signing-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/signing-utils.ts
@@ -72,7 +72,8 @@ export async function signSafeTx(
   estimate: Estimate,
   nonce: BN,
   from: string,
-  signer?: Signer
+  signer?: Signer,
+  refundReceiver?: string
 ): Promise<Signature[]> {
   let signatures = await signSafeTxAsRSV(
     web3OrEthersProvider,
@@ -84,7 +85,7 @@ export async function signSafeTx(
     estimate.dataGas,
     estimate.gasPrice,
     estimate.gasToken,
-    ZERO_ADDRESS,
+    refundReceiver ?? ZERO_ADDRESS,
     nonce,
     from,
     safeAddress,


### PR DESCRIPTION
Ticket: [CS-5403](https://linear.app/cardstack/issue/CS-5403)

I've tested in the polygon https://polygonscan.com/tx/0xb7634aa2825005b193657a0ff9e4cb576ed212cebc21fb102efa036e2f32436b. Now the refund receiver address is defined.

<img width="1041" alt="Screenshot 2023-03-24 at 13 46 08" src="https://user-images.githubusercontent.com/12637010/227447138-51e4ce24-12e0-40f9-af20-f08e7fc4e17d.png">

