### PR TITLE
Fix scheduled recurring payment that had not been executed

### DIFF
--- a/packages/hub/node-tests/services/scheduled-payments/fetcher-test.ts
+++ b/packages/hub/node-tests/services/scheduled-payments/fetcher-test.ts
@@ -184,7 +184,18 @@ describe('fetching scheduled payments that are due', function () {
         payAt: addDays(now, 1),
       });
 
-      expect((await subject.fetchScheduledPayments(chainId)).map((sp) => sp.id)).to.deep.equal([sp1.id, sp2.id]);
+      //passes recurring until but still in the valid period
+      let sp3 = await createScheduledPayment({
+        recurringUntil: subDays(now, 1),
+        recurringDayOfMonth: now.getDate(),
+        payAt: now,
+      });
+
+      expect((await subject.fetchScheduledPayments(chainId)).map((sp) => sp.id)).to.deep.equal([
+        sp1.id,
+        sp2.id,
+        sp3.id,
+      ]);
     });
 
     it('does not fetch payments that have recurringUntil in the past', async function () {

--- a/packages/hub/node-tests/utils/scheduled-payments-test.ts
+++ b/packages/hub/node-tests/utils/scheduled-payments-test.ts
@@ -1,3 +1,4 @@
+import { subHours } from 'date-fns';
 import { calculateNextPayAt } from '../../utils/scheduled-payments';
 
 describe('ScheduledPaymentUtils', function () {
@@ -27,6 +28,14 @@ describe('ScheduledPaymentUtils', function () {
     let nextPayAt = calculateNextPayAt(prevPayAt, recurringDay);
 
     expect(nextPayAt.toISOString()).to.equal('2022-03-05T00:00:00.000Z');
+  });
+
+  it('calculates next pay at when recurring until is lower than created date', function () {
+    let createdDate = new Date(Date.parse('2022-02-05T00:00:00.000Z'));
+    let recurringUntil = subHours(createdDate, 1);
+    let nextPayAt = calculateNextPayAt(createdDate, recurringUntil.getDate(), recurringUntil);
+
+    expect(nextPayAt).to.lte(recurringUntil);
   });
 
   it('throws an error when recurring day is not in the range of 1-31', function () {

--- a/packages/hub/routes/scheduled-payments.ts
+++ b/packages/hub/routes/scheduled-payments.ts
@@ -127,8 +127,8 @@ export default class ScheduledPaymentsRoute {
       privateMemo: attrs['private-memo'],
     } as unknown as ScheduledPayment;
 
-    if (params.recurringDayOfMonth != null) {
-      params.payAt = calculateNextPayAt(new Date(), params.recurringDayOfMonth);
+    if (params.recurringDayOfMonth != null && params.recurringUntil != null) {
+      params.payAt = calculateNextPayAt(new Date(), params.recurringDayOfMonth, params.recurringUntil);
     }
 
     let errors = await this.scheduledPaymentValidator.validate(params);

--- a/packages/hub/services/scheduled-payments/fetcher.ts
+++ b/packages/hub/services/scheduled-payments/fetcher.ts
@@ -77,7 +77,7 @@ export default class ScheduledPaymentsFetcherService {
             ) 
             OR (
               scheduled_payments.recurring_day_of_month > 0
-              AND scheduled_payments.recurring_until >= ${nowString}::timestamp
+              AND DATE_TRUNC('day', scheduled_payments.recurring_until::timestamp)::date + scheduled_payments.valid_for_days  >= ${nowString}::timestamp
               AND (
                 scheduled_payments.id
               ) NOT IN (

--- a/packages/hub/services/validators/scheduled-payment.ts
+++ b/packages/hub/services/validators/scheduled-payment.ts
@@ -95,6 +95,10 @@ export default class ScheduledPaymentValidator {
       if (isAfter(scheduledPayment.payAt, aYearFromNow)) {
         errors['payAt'].push(`payment date cannot be further than 1 year in the future`);
       }
+
+      if (scheduledPayment.recurringUntil && isAfter(scheduledPayment.payAt, scheduledPayment.recurringUntil)) {
+        errors['payAt'].push(`payment date cannot be more than recurring payment end date`);
+      }
     }
 
     if (scheduledPayment.recurringUntil) {

--- a/packages/hub/utils/scheduled-payments.ts
+++ b/packages/hub/utils/scheduled-payments.ts
@@ -3,7 +3,8 @@ import { convertDateToUTC } from './dates';
 // This function will return the next payment date based on the frequency.
 // fromDate will be either the current date when a recurring scheduled is created,
 // or the date of the last payment.
-export function calculateNextPayAt(fromDate: Date, recurringDay: number) {
+// When a recurring scheduled is created the recurringUntil parameter must be not undefined.
+export function calculateNextPayAt(fromDate: Date, recurringDay: number, recurringUntil?: Date) {
   if (recurringDay < 1 || recurringDay > 31) {
     throw new Error('Recurring day must be in the range of 1-31');
   }
@@ -14,6 +15,13 @@ export function calculateNextPayAt(fromDate: Date, recurringDay: number) {
   let adjustedRecurringDay = Math.min(recurringDay, daysInMonth(fromDate));
   if (fromDate.getUTCDate() < adjustedRecurringDay) {
     nextPayAtUtc.setUTCDate(adjustedRecurringDay); // next pay this month
+  } else if (recurringUntil && fromDate > recurringUntil && fromDate.getUTCDate() === adjustedRecurringDay) {
+    // next pay is before the recurring end date
+    nextPayAtUtc.setUTCDate(adjustedRecurringDay);
+    nextPayAtUtc.setHours(recurringUntil.getHours());
+    nextPayAtUtc.setMinutes(0);
+    nextPayAtUtc.setSeconds(0);
+    nextPayAtUtc.setMilliseconds(0);
   } else {
     nextPayAtUtc.setUTCMonth(nextPayAtUtc.getUTCMonth() + 1);
     nextPayAtUtc.setUTCDate(Math.min(recurringDay, daysInMonth(nextPayAtUtc)));

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
@@ -27,6 +27,7 @@ import * as Sentry from '@sentry/browser';
 import FeeCalculator, { type CurrentFees } from './fee-calculator';
 import config from '@cardstack/safe-tools-client/config/environment';
 import HubAuthenticationService from '@cardstack/safe-tools-client/services/hub-authentication';
+import { endOfDay } from 'date-fns';
 
 interface Signature {
   Element: HTMLElement;
@@ -549,8 +550,7 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
 
     let payAt = this.selectedPaymentType === 'one-time' ? Math.round(this.paymentDate!.getTime() / 1000) : null;
     let recurringDayOfMonth = this.selectedPaymentType === 'monthly' ? this.paymentDayOfMonth! : null;
-    let recurringUntil = this.selectedPaymentType === 'monthly' ? Math.round(this.monthlyUntil!.getTime() / 1000) : null
-
+    let recurringUntil = this.selectedPaymentType === 'monthly' ? Math.round(endOfDay(this.monthlyUntil!).getTime() / 1000) : null;
     return {
       safeAddress: currentSafe.address,
       spModuleAddress: currentSafe.spModuleAddress,


### PR DESCRIPTION
Ticket: CS-5414

**Problem**
We had scheduled recurring payments that had not been executed. The following is an example:

```
|               id                  |       pay_at        | recurring_day_of_month |   recurring_until   |
| 8a84ce01-5bd5-4e05-9b5d-5060fc2095d0 | 2023-03-22 22:47:53 |                     22 | 2023-03-22 03:00:00 |
```

As can be seen, the payment date falls after the recurring end date, meaning that this payment will never be executed, since the recurring until date has already passed.

**Solution**
- [ ] The recurring until date in the safe tools should be set to the end of the day for the selected day.
- [ ] The scheduled payment fetcher should retrieve scheduled recurring payments that have already passed the recurring end date but are still within the valid period.
- [ ] When scheduling a recurring payment, the calculated payment date must be earlier than the recurring end date.
