### PR TITLE
Prevent 0 max gas price when scheduling with 6 decimal tokens (USDx)

### DIFF
--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
@@ -534,10 +534,15 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
   composeSchedulePaymentParams() {
     if (!this.paymentTokenQuantity || !this.selectedGasToken || !this.safes.currentSafe || !this.gasEstimation) return undefined;
 
-    const defaultGas = BigNumber.from(0);
+    // Cost of the execution transaction in gas token units by max gas cost preference (standard, high, max)
     const gasRangeByMaxPrice = this.gasEstimation.gasRangeInGasTokenUnits[this.maxGasPrice];
 
-    const maxGasPriceString = String(gasRangeByMaxPrice.div(this.gasEstimation.gas) || defaultGas);
+    // To get the max gas price in smallest units, we divide the total gas cost by units of gas needed to execute the transaction
+    // Since the amount of gas units (gasEstimation.gas) can be larger then the cost in gas units in smallest units (this can happen in case of tokens with
+    // 6 decimal places such as USDC/USDT), the result of the BigNumber integer division will be 0. But we want to define at least 1 as the max gas price
+    // in smallest units, because if we use 0, then the transaction will fail because the max gas price is too low.
+    const maxGasPriceInGasToken = gasRangeByMaxPrice.div(this.gasEstimation.gas)
+    const maxGasPriceString = (maxGasPriceInGasToken.eq(BigNumber.from(0)) ? BigNumber.from(1) : maxGasPriceInGasToken).toString();
 
     const array = new Uint8Array(32);
     window.crypto.getRandomValues(array);


### PR DESCRIPTION
This is a blocker because currently when scheduling with USDx as a gas token, max gas price will be 0 because the denominator is larger than the numerator in the integer division where we divide the gas cost by gas price. In this case, the executor will try to perform the payment using the gas price of 1 (in smallest units of USDx token), and the contract will revert because the gas price (1) is larger than max gas price (0).

This is a case of a low gas cost network and a token similarly priced as native token, but with 6 decimals (as opposed to 18). In this case we want to round up to 1 in smallest units of the token so the gas price is at least *something* and not *nothing*.

In other words the smallest unit of token is not small enough to express the gas price so we round to 1. 