### PR TITLE
safe client: Fix gas token gas price display

### DIFF
--- a/packages/safe-tools-client/app/helpers/native-units-to-decimal.ts
+++ b/packages/safe-tools-client/app/helpers/native-units-to-decimal.ts
@@ -10,16 +10,35 @@ interface Signature {
   Return: string;
 }
 
+export function roundDecimals(number: number, decimals: number) {
+  // Below is a special case for numbers betweeon 0 and 1 whose first significant decimal digit comes after the rounding point.
+  // For example we want to round to to 3 decimals, but the number is 0.0000001. In this case if we use toFixed(3),
+  // we will get 0, but in this case we want to keep 0.0000001 to not throw away the significant part.
+  if (number < 1 && number % 1 !== 0) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    const match = number.toString().match(/(\.0*)/);
+    if (match) {
+      const leadingZerosInDecimal = match[0].length - 1;
+      if (leadingZerosInDecimal > decimals) {
+        return number.toFixed(leadingZerosInDecimal + 1);
+      }
+    }
+  }
+
+  return number.toFixed(decimals);
+}
+
 export function nativeUnitsToDecimal([
   amount,
   tokenDecimals,
   decimals = undefined,
 ]: PositionalArgs) {
   const number = parseFloat(ethersUtils.formatUnits(amount, tokenDecimals));
+
   if (decimals) {
-    return number.toFixed(decimals);
+    return roundDecimals(number, decimals);
   } else {
-    return String(number % 1 === 0 ? number : number.toFixed(3));
+    return String(number % 1 === 0 ? number : roundDecimals(number, 3));
   }
 }
 

--- a/packages/safe-tools-client/tests/unit/utils/round-decimals-test.ts
+++ b/packages/safe-tools-client/tests/unit/utils/round-decimals-test.ts
@@ -1,0 +1,12 @@
+import { roundDecimals } from '@cardstack/safe-tools-client/helpers/native-units-to-decimal';
+import { module, test } from 'qunit';
+
+module('Unit | roundDecimals', () => {
+  test('rounds to decimal points', function (assert) {
+    assert.strictEqual(roundDecimals(1.23456789, 2), '1.23');
+  });
+
+  test('rounds to decimal points when significant decimal starts after the rounding point', function (assert) {
+    assert.strictEqual(roundDecimals(0.000001, 2), '0.000001');
+  });
+});


### PR DESCRIPTION
This PR fixes 2 bugs:

1. Gas tokens in the transaction lists are Unknown tokens, which has negative effects because an Unknown token has 18 decimals while USDC token for example has 6. This way the price calculations in helpers will be wrong. This is easily demonstrable by adding `{{paymentAttempt.scheduledPayment.gasToken.name}}` to the list (for inspection):

<img width="626" alt="image" src="https://user-images.githubusercontent.com/273660/228821152-ed82558a-4b48-4fb2-9e9a-4f078a00c3df.png">

Since gas tokens are loaded dynamically, the fix includes adding a loading control to the tokens resource and making sure the tokens are loaded before the scheduled payment starts the deserializing process. 

After the fix, the token is recognized correctly:

<img width="296" alt="image" src="https://user-images.githubusercontent.com/273660/228824257-2f05623f-dd30-4ac1-b5da-319dce333e45.png">

(this text is not part of the design, it's only added to demonstrate which gas token is used in the payment attempt)

2. Very small numbers are rounded to 0, for example 0.000001. In my opinion we should make an extra case for handling this one so that we don't cut off the decimals before we reach the first significant decimal. Here is an illustration of this bug ⬇️

The tooltip says:
<img width="206" alt="image" src="https://user-images.githubusercontent.com/273660/228821988-26dae335-da5a-493a-93b8-856dea7d0ae1.png">

But actually, the execution gas price is 1 (in smallest amounts of the USDC token), and the tooltip fails to reflect that:
<img width="650" alt="image" src="https://user-images.githubusercontent.com/273660/228822489-b025399c-c1bd-47b7-86e9-3d5e1ef9a61e.png">

If we convert the units from the smallest amount to decimals (human readable amount of tokens), which is 1/10**6 = 0.000001, our current rounding will round this to 0.000, which is misleading, and is shown in the first tooltip screenshot in this section. I think it would be better to not round at the rounding point in case the first significant decimal is further than that. In the 2nd commit there's a fix that makes the tooltip render with this data:

<img width="209" alt="image" src="https://user-images.githubusercontent.com/273660/228823799-ebfce20e-32c7-4ca7-8cf6-acb7ec866f81.png">




