### PR TITLE
hub: Don't consider payment cancelations with transaction error as unmined

### DIFF
--- a/packages/hub/node-tests/services/data-integrity-checks-test.ts
+++ b/packages/hub/node-tests/services/data-integrity-checks-test.ts
@@ -106,6 +106,7 @@ describe('data integrity checks', function () {
           chainId: 1,
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           cancelationTransactionHash: null,
+          cancelationBlockNumber: null,
           canceledAt: subMinutes(nowUtc(), CANCELATION_WITHOUT_TX_HASH_ALLOWED_MINUTES + 1),
         },
       });
@@ -129,6 +130,33 @@ describe('data integrity checks', function () {
           chainId: 1,
           userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
           cancelationTransactionHash: '0x123',
+          cancelationBlockNumber: null,
+          canceledAt: subMinutes(nowUtc(), CANCELATION_UNMINED_ALLOWED_MINUTES + 1),
+        },
+      });
+
+      // A scheduled payment that has a cancelationTransactionError should not be considered unmined
+      await prisma.scheduledPayment.create({
+        data: {
+          id: shortUuid.uuid(),
+          senderSafeAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+          moduleAddress: '0x7E7d0B97D663e268bB403eb4d72f7C0C7650a6dd',
+          tokenAddress: '0xa455bbB2A81E09E0337c13326BBb302Cb37D7cf6',
+          gasTokenAddress: '0x6A50E3807FB9cD0B07a79F64e561B9873D3b132E',
+          amount: '100',
+          payeeAddress: '0x821f3Ee0FbE6D1aCDAC160b5d120390Fb8D2e9d3',
+          executionGasEstimation: 100000,
+          maxGasPrice: '1000000000',
+          feeFixedUsd: '0',
+          feePercentage: '0',
+          salt: '54lt',
+          payAt: nowUtc(),
+          spHash: cryptoRandomString({ length: 10 }),
+          chainId: 1,
+          userAddress: '0x57022DA74ec3e6d8274918C732cf8864be7da833',
+          cancelationTransactionHash: '0x123',
+          cancelationTransactionError: 'unknown error',
+          cancelationBlockNumber: null,
           canceledAt: subMinutes(nowUtc(), CANCELATION_UNMINED_ALLOWED_MINUTES + 1),
         },
       });

--- a/packages/hub/services/data-integrity-checks/scheduled-payments.ts
+++ b/packages/hub/services/data-integrity-checks/scheduled-payments.ts
@@ -98,7 +98,7 @@ export default class DataIntegrityChecksScheduledPayments {
         canceledAt: {
           lt: subMinutes(nowUtc(), CANCELATION_UNMINED_ALLOWED_MINUTES),
         },
-        creationTransactionError: null,
+        cancelationTransactionError: null,
       },
     });
 


### PR DESCRIPTION
Our checkly reports that there are unmined cancelations, but some of those have cancelation transaction errors written (insufficient funds for example). We shouldn't count these as unmined. 