### PR TITLE
hub: Do not provide payAt to recurring payments execution otherwise the SDK will error out

### DIFF
--- a/packages/hub/services/scheduled-payments/executor.ts
+++ b/packages/hub/services/scheduled-payments/executor.ts
@@ -170,6 +170,8 @@ export default class ScheduledPaymentsExecutorService {
 
       Sentry.captureMessage(`Executing a payment with params: ${JSON.stringify(params)}`); // Useful for debugging purposes (for example, to see which params were used to calculate the spHash)
 
+      let isRecurring = !!recurringDayOfMonth;
+
       let executeScheduledPayment = (nonce: BN) => {
         return new Promise<string>((resolve, reject) => {
           scheduledPaymentModule
@@ -185,7 +187,7 @@ export default class ScheduledPaymentsExecutorService {
               params.gasTokenAddress,
               params.salt,
               params.currentGasPrice,
-              params.payAt,
+              isRecurring ? null : params.payAt, // Contract will revert if both payAt and recurringDayOfMonth are set
               params.recurringDayOfMonth,
               params.recurringUntil,
               {

--- a/packages/hub/services/scheduled-payments/executor.ts
+++ b/packages/hub/services/scheduled-payments/executor.ts
@@ -185,7 +185,7 @@ export default class ScheduledPaymentsExecutorService {
               params.gasTokenAddress,
               params.salt,
               params.currentGasPrice,
-              params.recurringDayOfMonth ? null : params.payAt, // Contract will revert if both payAt and recurringDayOfMonth are set
+              params.recurringDayOfMonth ? null : params.payAt, // SDK will throw an error if both payAt and recurringDayOfMonth are set
               params.recurringDayOfMonth,
               params.recurringUntil,
               {

--- a/packages/hub/services/scheduled-payments/executor.ts
+++ b/packages/hub/services/scheduled-payments/executor.ts
@@ -170,8 +170,6 @@ export default class ScheduledPaymentsExecutorService {
 
       Sentry.captureMessage(`Executing a payment with params: ${JSON.stringify(params)}`); // Useful for debugging purposes (for example, to see which params were used to calculate the spHash)
 
-      let isRecurring = !!recurringDayOfMonth;
-
       let executeScheduledPayment = (nonce: BN) => {
         return new Promise<string>((resolve, reject) => {
           scheduledPaymentModule
@@ -187,7 +185,7 @@ export default class ScheduledPaymentsExecutorService {
               params.gasTokenAddress,
               params.salt,
               params.currentGasPrice,
-              isRecurring ? null : params.payAt, // Contract will revert if both payAt and recurringDayOfMonth are set
+              params.recurringDayOfMonth ? null : params.payAt, // Contract will revert if both payAt and recurringDayOfMonth are set
               params.recurringDayOfMonth,
               params.recurringUntil,
               {


### PR DESCRIPTION
Ticket: CS-5465

I noticed an error in scheduled payment execution in the `failure_reason` field: `When payAt is not null, recurringDayOfMonth and recurringUntil must be null`

This error is coming from the SDK. The fix is to not include `payAt` for recurring payments when executing the payment. 

