### PR TITLE
Limit the value of recurring until

### DIFF
--- a/packages/hub/node-tests/routes/scheduled-payments-test.ts
+++ b/packages/hub/node-tests/routes/scheduled-payments-test.ts
@@ -312,7 +312,7 @@ describe('POST /api/scheduled-payments', async function () {
 
   it('persists a recurring scheduled payment', async function () {
     let now = new Date();
-    let calculatedPayAt = calculateNextPayAt(now, 1, addMonths(now, 5));
+    let calculatedPayAt = calculateNextPayAt(1, addMonths(now, 5));
     let spHash = cryptoRandomString({ length: 10 });
     let responsePayAt: string;
 

--- a/packages/hub/node-tests/tasks/scheduled-payment-on-chain-execution-waiter-test.ts
+++ b/packages/hub/node-tests/tasks/scheduled-payment-on-chain-execution-waiter-test.ts
@@ -43,7 +43,7 @@ class StubCardpaySDK {
   }
 }
 
-describe.only('ScheduledPaymentOnChainExecutionWaiter', function () {
+describe('ScheduledPaymentOnChainExecutionWaiter', function () {
   let { getJobIdentifiers, getJobPayloads } = setupStubWorkerClient(this);
 
   this.beforeEach(async function () {

--- a/packages/hub/node-tests/tasks/scheduled-payment-on-chain-execution-waiter-test.ts
+++ b/packages/hub/node-tests/tasks/scheduled-payment-on-chain-execution-waiter-test.ts
@@ -43,7 +43,7 @@ class StubCardpaySDK {
   }
 }
 
-describe('ScheduledPaymentOnChainExecutionWaiter', function () {
+describe.only('ScheduledPaymentOnChainExecutionWaiter', function () {
   let { getJobIdentifiers, getJobPayloads } = setupStubWorkerClient(this);
 
   this.beforeEach(async function () {
@@ -98,7 +98,7 @@ describe('ScheduledPaymentOnChainExecutionWaiter', function () {
     });
 
     expect(scheduledPaymentAttempt.status).to.eq('succeeded');
-    expect(scheduledPaymentAttempt.endedAt).to.gt(subSeconds(nowUtc(), 1));
+    expect(scheduledPaymentAttempt.endedAt).to.gte(subSeconds(nowUtc(), 1));
 
     // Reload the payment to ensure that scheduledPaymentAttemptsInLastPaymentCycleCount and nextRetryAttemptAt were updated
     scheduledPayment = (await prisma.scheduledPayment.findUnique({

--- a/packages/hub/node-tests/utils/scheduled-payments-test.ts
+++ b/packages/hub/node-tests/utils/scheduled-payments-test.ts
@@ -9,80 +9,94 @@ describe('ScheduledPaymentUtils', function () {
   // for the same reason (Z is at the end to indicate UTC time).
 
   it('calculates next pay at when current day number is lower than recurring day', function () {
-    let prevPayAt = new Date(Date.parse('2022-02-04T00:00:00.000Z'));
+    let currentDate = new Date(Date.parse('2022-02-04T00:00:00.000Z'));
 
-    let nextPayAt = calculateNextPayAt(prevPayAt, recurringDay, addMonths(prevPayAt, 5));
+    let nextPayAt = calculateNextPayAt(recurringDay, addMonths(currentDate, 5), { currentDate });
     expect(nextPayAt?.toISOString()).to.equal('2022-02-05T00:00:00.000Z');
   });
 
   it('calculates next pay at when current day number is the same as recurring day', function () {
-    let prevPayAt = new Date(Date.parse('2022-02-05T00:00:00.000Z'));
-    let nextPayAt = calculateNextPayAt(prevPayAt, recurringDay, addMonths(prevPayAt, 5));
+    let currentDate = new Date(Date.parse('2022-02-05T00:00:00.000Z'));
+    let nextPayAt = calculateNextPayAt(recurringDay, addMonths(currentDate, 5), { currentDate });
 
-    expect(nextPayAt?.toISOString()).to.equal('2022-03-05T00:00:00.000Z');
+    expect(nextPayAt?.toISOString()).to.equal('2022-02-05T00:00:00.000Z');
   });
 
   it('calculates next pay at when current day number is higher same as recurring day', function () {
-    let prevPayAt = new Date(Date.parse('2022-02-06T00:00:00.000Z'));
+    let currentDate = new Date(Date.parse('2022-02-06T00:00:00.000Z'));
 
-    let nextPayAt = calculateNextPayAt(prevPayAt, recurringDay, addMonths(prevPayAt, 5));
+    let nextPayAt = calculateNextPayAt(recurringDay, addMonths(currentDate, 5), { currentDate });
 
     expect(nextPayAt?.toISOString()).to.equal('2022-03-05T00:00:00.000Z');
   });
 
   it('calculates next pay is null when recurring until is earlier than date now', function () {
-    let createdDate = new Date(Date.parse('2022-02-05T00:00:00.000Z'));
-    let recurringUntil = subHours(createdDate, 1);
-    let nextPayAt = calculateNextPayAt(createdDate, recurringUntil.getDate(), recurringUntil);
+    let currentDate = new Date(Date.parse('2022-02-05T00:00:00.000Z'));
+    let recurringUntil = subHours(currentDate, 1);
+    let nextPayAt = calculateNextPayAt(recurringUntil.getDate(), recurringUntil, { currentDate });
 
     expect(nextPayAt).to.null;
   });
 
   it('throws an error when recurring day is not in the range of 1-31', function () {
-    let now = new Date();
-    expect(() => calculateNextPayAt(now, 0, addMonths(now, 5))).to.throw();
-    expect(() => calculateNextPayAt(now, 32, addMonths(now, 5))).to.throw();
-    expect(() => calculateNextPayAt(now, 1, addMonths(now, 5))).to.not.throw();
-    expect(() => calculateNextPayAt(now, 31, addMonths(now, 5))).to.not.throw();
+    let currentDate = new Date();
+    expect(() => calculateNextPayAt(0, addMonths(currentDate, 5), { currentDate })).to.throw();
+    expect(() => calculateNextPayAt(32, addMonths(currentDate, 5), { currentDate })).to.throw();
+    expect(() => calculateNextPayAt(1, addMonths(currentDate, 5), { currentDate })).to.not.throw();
+    expect(() => calculateNextPayAt(31, addMonths(currentDate, 5), { currentDate })).to.not.throw();
   });
 
   it('sets the last day of month when month has less days than recurringDay case 1', function () {
     // February 2022 has 28 days. If recurringDay is set to 31th, payAt should be set to 28th.
-    let startingDate = new Date(Date.UTC(2022, 1, 1)); // 2022-02-01 (months are zero-indexed)
-    let nextPayAt = calculateNextPayAt(startingDate, 31, addMonths(startingDate, 5));
+    let currentDate = new Date(Date.UTC(2022, 1, 1)); // 2022-02-01 (months are zero-indexed)
+    let nextPayAt = calculateNextPayAt(31, addMonths(currentDate, 5), { currentDate });
 
     expect(nextPayAt?.toISOString()).to.equal('2022-02-28T00:00:00.000Z');
   });
 
   it('sets the last day of month when month has less days than recurringDay case 2', function () {
     // February 2022 has 28 days. If recurringDay is set to 31th, payAt should be set to 28th.
-    let startingDate = new Date(Date.UTC(2022, 1, 27)); // 2022-02-27 (months are zero-indexed)
-    let nextPayAt = calculateNextPayAt(startingDate, 31, addMonths(startingDate, 5));
+    let currentDate = new Date(Date.UTC(2022, 1, 27)); // 2022-02-27 (months are zero-indexed)
+    let nextPayAt = calculateNextPayAt(31, addMonths(currentDate, 5), { currentDate });
 
     expect(nextPayAt?.toISOString()).to.equal('2022-02-28T00:00:00.000Z');
   });
 
   it('sets the last day of month when month has less days than recurringDay case 3', function () {
-    // February 2022 has 28 days. If recurringDay is set to 31st and we're on 28th, next payAt should be set to March 31st
-    let startingDate = new Date(Date.UTC(2022, 1, 28)); // 2022-02-28 (months are zero-indexed)
-    let nextPayAt = calculateNextPayAt(startingDate, 31, addMonths(startingDate, 5));
+    // February 2022 has 28 days. If recurringDay is set to 31st and we're on 28th, next payAt should be set to Feb 28th
+    let currentDate = new Date(Date.UTC(2022, 1, 28)); // 2022-02-28 (months are zero-indexed)
+    let nextPayAt = calculateNextPayAt(31, addMonths(currentDate, 5), { currentDate });
 
-    expect(nextPayAt?.toISOString()).to.equal('2022-03-31T00:00:00.000Z');
+    expect(nextPayAt?.toISOString()).to.equal('2022-02-28T00:00:00.000Z');
   });
 
   it('sets the last day of month when month has less days than recurringDay case 4', function () {
     // April has 30 days. If recurringDay is set to 31st, payAt should be set to 30th.
-    let startingDate = new Date(Date.UTC(2022, 3, 1)); // 2022-04-01 (months are zero-indexed)
-    let nextPayAt = calculateNextPayAt(startingDate, 31, addMonths(startingDate, 5));
+    let currentDate = new Date(Date.UTC(2022, 3, 1)); // 2022-04-01 (months are zero-indexed)
+    let nextPayAt = calculateNextPayAt(31, addMonths(currentDate, 5), { currentDate });
 
     expect(nextPayAt?.toISOString()).to.equal('2022-04-30T00:00:00.000Z');
   });
 
   it('sets the last day of month when month has less days than recurringDay case 5', function () {
-    // April has 30 days. If recurringDay is set to 31st and we're on 30th, next payAt should be set to May 31st.
-    let startingDate = new Date(Date.UTC(2022, 3, 30)); // 2022-04-30 (months are zero-indexed)
-    let nextPayAt = calculateNextPayAt(startingDate, 31, addMonths(startingDate, 5));
+    // April has 30 days. If recurringDay is set to 31st and we're on 30th, next payAt should be set to Apr 30st.
+    let currentDate = new Date(Date.UTC(2022, 3, 30)); // 2022-04-30 (months are zero-indexed)
+    let nextPayAt = calculateNextPayAt(31, addMonths(currentDate, 5), { currentDate });
 
-    expect(nextPayAt?.toISOString()).to.equal('2022-05-31T00:00:00.000Z');
+    expect(nextPayAt?.toISOString()).to.equal('2022-04-30T00:00:00.000Z');
+  });
+
+  it('calculates next pay at when last pay is defined', function () {
+    let lastPayAt = new Date(Date.parse('2022-01-05T00:00:00.000Z'));
+    let nextPayAt = calculateNextPayAt(recurringDay, addMonths(lastPayAt, 5), { lastPayAt });
+
+    expect(nextPayAt?.toISOString()).to.equal('2022-02-05T00:00:00.000Z');
+  });
+
+  it('calculates next pay at when the next month has lower days', function () {
+    let lastPayAt = new Date(Date.parse('2022-01-31T00:00:00.000Z'));
+    let nextPayAt = calculateNextPayAt(31, addMonths(lastPayAt, 5), { lastPayAt });
+
+    expect(nextPayAt?.toISOString()).to.equal('2022-02-28T00:00:00.000Z');
   });
 });

--- a/packages/hub/routes/scheduled-payments.ts
+++ b/packages/hub/routes/scheduled-payments.ts
@@ -128,7 +128,7 @@ export default class ScheduledPaymentsRoute {
     } as unknown as ScheduledPayment;
 
     if (params.recurringDayOfMonth != null && params.recurringUntil != null) {
-      params.payAt = calculateNextPayAt(new Date(), params.recurringDayOfMonth, params.recurringUntil);
+      params.payAt = calculateNextPayAt(params.recurringDayOfMonth, params.recurringUntil);
     }
 
     let errors = await this.scheduledPaymentValidator.validate(params);

--- a/packages/hub/tasks/scheduled-payment-on-chain-execution-waiter.ts
+++ b/packages/hub/tasks/scheduled-payment-on-chain-execution-waiter.ts
@@ -42,11 +42,9 @@ export default class ScheduledPaymentOnChainExecutionWaiter {
       });
 
       if (scheduledPayment.recurringDayOfMonth && scheduledPayment.recurringUntil) {
-        let nextPayAt = calculateNextPayAt(
-          new Date(),
-          scheduledPayment.recurringDayOfMonth,
-          scheduledPayment.recurringUntil
-        );
+        let nextPayAt = calculateNextPayAt(scheduledPayment.recurringDayOfMonth, scheduledPayment.recurringUntil, {
+          lastPayAt: scheduledPayment.payAt!,
+        });
         if (nextPayAt && nextPayAt <= scheduledPayment.recurringUntil) {
           await prisma.scheduledPayment.update({
             where: { id: scheduledPayment.id },

--- a/packages/hub/utils/scheduled-payments.ts
+++ b/packages/hub/utils/scheduled-payments.ts
@@ -1,30 +1,38 @@
-import { startOfDay } from 'date-fns';
+import { addMonths } from 'date-fns';
 import { convertDateToUTC } from './dates';
 
 // This function will return the next payment date based on the frequency.
 // fromDate will be either the current date when a recurring scheduled is created,
 // or the date of the last payment.
 // When a recurring scheduled is created the recurringUntil parameter must be not undefined.
-export function calculateNextPayAt(fromDate: Date, recurringDay: number, recurringUntil: Date) {
+// currentDate is needed for testing purpose.
+export function calculateNextPayAt(
+  recurringDay: number,
+  recurringUntil: Date,
+  options?: {
+    lastPayAt?: Date;
+    currentDate?: Date;
+  }
+) {
   if (recurringDay < 1 || recurringDay > 31) {
     throw new Error('Recurring day must be in the range of 1-31');
   }
-
-  let nextPayAtUtc = convertDateToUTC(fromDate);
-
-  // We take min() because some months can have less days than the recurring day (e.g. there is no Feb 31)
-  let adjustedRecurringDay = Math.min(recurringDay, daysInMonth(fromDate));
-  if (fromDate.getUTCDate() < adjustedRecurringDay) {
-    nextPayAtUtc.setUTCDate(adjustedRecurringDay); // next pay this month
-  } else {
-    nextPayAtUtc.setUTCMonth(nextPayAtUtc.getUTCMonth() + 1);
-    nextPayAtUtc.setUTCDate(Math.min(recurringDay, daysInMonth(nextPayAtUtc)));
-  }
-  nextPayAtUtc = startOfDay(nextPayAtUtc);
-
+  let nowUtc = convertDateToUTC(options?.currentDate ?? new Date());
   let recurringUntilUtc = convertDateToUTC(recurringUntil);
-  if (nextPayAtUtc <= recurringUntilUtc) {
-    return nextPayAtUtc;
+
+  let nextPayAt;
+  if (options?.lastPayAt) {
+    nextPayAt = addMonths(options.lastPayAt, 1);
+  } else if (recurringDay >= nowUtc.getDate()) {
+    nextPayAt = nowUtc;
+  } else {
+    nextPayAt = addMonths(nowUtc, 1);
+  }
+  // We take min() because some months can have less days than the recurring day (e.g. there is no Feb 31)
+  nextPayAt.setUTCDate(Math.min(recurringDay, daysInMonth(nextPayAt)));
+
+  if (nextPayAt <= recurringUntilUtc) {
+    return nextPayAt;
   } else {
     return null; // Recurring payment expired, there is no next pay date
   }

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
@@ -182,11 +182,10 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
     }
   }
 
-  //The minimum monthly until value is the month following the first month of execution.
-  //So the minimum execution of monthly payment is two times.
+  //The minimum monthly until value is the first date of execution.
   get minMonthlyUntil() {
-    let recurringStartMonth = addMonths(new Date(), 1);
-    if (this.paymentDayOfMonth && this.paymentDayOfMonth <= recurringStartMonth.getDate()) {
+    let recurringStartMonth = new Date();
+    if (this.paymentDayOfMonth && this.paymentDayOfMonth < recurringStartMonth.getDate()) {
       recurringStartMonth = addMonths(recurringStartMonth, 1);
     }
     let daysInRecurringStartMonth = getDaysInMonth(recurringStartMonth);

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
@@ -27,7 +27,7 @@ import * as Sentry from '@sentry/browser';
 import FeeCalculator, { type CurrentFees } from './fee-calculator';
 import config from '@cardstack/safe-tools-client/config/environment';
 import HubAuthenticationService from '@cardstack/safe-tools-client/services/hub-authentication';
-import { addMonths, endOfDay, getDaysInMonth, startOfMonth } from 'date-fns';
+import { addMonths, endOfDay, getDaysInMonth } from 'date-fns';
 
 interface Signature {
   Element: HTMLElement;

--- a/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
+++ b/packages/safe-tools-client/app/components/schedule-payment-form-action-card/index.gts
@@ -27,7 +27,7 @@ import * as Sentry from '@sentry/browser';
 import FeeCalculator, { type CurrentFees } from './fee-calculator';
 import config from '@cardstack/safe-tools-client/config/environment';
 import HubAuthenticationService from '@cardstack/safe-tools-client/services/hub-authentication';
-import { endOfDay } from 'date-fns';
+import { addMonths, endOfDay, getDaysInMonth, startOfMonth } from 'date-fns';
 
 interface Signature {
   Element: HTMLElement;
@@ -182,9 +182,17 @@ export default class SchedulePaymentFormActionCard extends Component<Signature> 
     }
   }
 
+  //The minimum monthly until value is the month following the first month of execution.
+  //So the minimum execution of monthly payment is two times.
   get minMonthlyUntil() {
-    let now = new Date();
-    return new Date(now.getFullYear(), now.getMonth() + 1, this.paymentDayOfMonth);
+    let recurringStartMonth = addMonths(new Date(), 1);
+    if (this.paymentDayOfMonth && this.paymentDayOfMonth <= recurringStartMonth.getDate()) {
+      recurringStartMonth = addMonths(recurringStartMonth, 1);
+    }
+    let daysInRecurringStartMonth = getDaysInMonth(recurringStartMonth);
+    let recurrsDay = Math.min(daysInRecurringStartMonth, this.paymentDayOfMonth ?? 1);
+
+    return new Date(recurringStartMonth.getFullYear(), recurringStartMonth.getMonth(), recurrsDay);
   }
 
   get maxMonthlyUntil() {

--- a/packages/safe-tools-client/app/services/scheduled-payments.ts
+++ b/packages/safe-tools-client/app/services/scheduled-payments.ts
@@ -100,6 +100,8 @@ export interface ScheduledPaymentAttemptIncludedData {
   'canceled-at': string;
   'next-retry-attempt-at': string;
   'scheduled-payment-attempts-in-last-payment-cycle-count': number;
+  'recurring-day-of-month': number;
+  'recurring-until': string;
   'last-scheduled-payment-attempt-id': string;
   'retries-left': number;
   'private-memo': string | null;
@@ -249,6 +251,8 @@ export default class ScheduledPaymentsService extends Service {
                 'scheduled-payment-attempts-in-last-payment-cycle-count'
               ]
             ),
+            recurringDayOfMonth: scheduledPayment!['recurring-day-of-month'],
+            recurringUntil: new Date(scheduledPayment!['recurring-until']),
             lastScheduledPaymentAttemptId:
               scheduledPayment!['last-scheduled-payment-attempt-id'],
             retriesLeft: Number(scheduledPayment!['retries-left']),

--- a/packages/safe-tools-client/tests/integration/components/schedule-payment-form-action-card-test.ts
+++ b/packages/safe-tools-client/tests/integration/components/schedule-payment-form-action-card-test.ts
@@ -412,10 +412,10 @@ module(
         let minMonthlyUntil;
         if (paymentDayOfMonth < now.getDate()) {
           minMonthlyUntil = new Date(
-            addMonths(now, 2).setDate(paymentDayOfMonth)
+            addMonths(now, 1).setDate(paymentDayOfMonth)
           );
         } else {
-          minMonthlyUntil = addMonths(now, 1);
+          minMonthlyUntil = now;
         }
 
         await click(`[data-test-payment-type="monthly"]`);

--- a/packages/safe-tools-client/tests/integration/components/schedule-payment-form-action-card-test.ts
+++ b/packages/safe-tools-client/tests/integration/components/schedule-payment-form-action-card-test.ts
@@ -412,10 +412,10 @@ module(
         let minMonthlyUntil;
         if (paymentDayOfMonth < now.getDate()) {
           minMonthlyUntil = new Date(
-            addMonths(now, 1).setDate(paymentDayOfMonth)
+            addMonths(now, 2).setDate(paymentDayOfMonth)
           );
         } else {
-          minMonthlyUntil = now;
+          minMonthlyUntil = addMonths(now, 1);
         }
 
         await click(`[data-test-payment-type="monthly"]`);


### PR DESCRIPTION
Ticket: CS-5467

**Problem**
Currently, If the user chooses recurs day of the month equal to the date of today, the minimum value of the recurring until is tomorrow. But in the hub, the execution day will be in the next month, so the minimum value of the recurring until must be next month. It causes the hub will throw an error with this message `must be later than the recurring date`.

**Solution**

- [x] Adjust the `calculateNextPayAt` function so the next pay date can be today or this month, not the next month.
- [x] Update minMonthlyUntil in the safe tools client. If the recurring day is earlier or equal to today, the minimum value is today, or else the next month.