### PR TITLE
Lower balance threshold for crank/relayer on mainnet (scheduled payments)

### DIFF
--- a/packages/hub/services/data-integrity-checks/scheduled-payments.ts
+++ b/packages/hub/services/data-integrity-checks/scheduled-payments.ts
@@ -27,12 +27,12 @@ function addToMessages(collection: any, message: string, messages: string[]) {
 // 2. Crank (i.e the hub) needs native token funds to pay for scheduled payment execution transaction gas.
 //    This gets reimbursed to the fee receiver using the user safe's gas token balance.
 function lowBalanceThreshold(networkName: SchedulerCapableNetworks) {
-  // These values are rougly defined by looking at the current average transaction gas cost and multiplying it by 1000, then rounded.
-  // This means that the relayer and the crank should have enough funds to pay for around 1000 transactions before running out of funds.
+  // These values are rougly defined by looking at the current average transaction gas cost on each network
+  // and defining them to have enough funds to pay for at least around 200-300 transactions before running out of funds, when the threshold is reached.
   // This is a very rough estimate and it should be revisited in the future when there is more activity in the payments system.
   let minThresholdBalances: Record<SchedulerCapableNetworks, BigNumber> = {
     goerli: ethers.utils.parseEther('0.5'), // goerli ether
-    mainnet: ethers.utils.parseEther('0.5'), // mainnet ether
+    mainnet: ethers.utils.parseEther('0.3'), // mainnet ether
     polygon: ethers.utils.parseEther('30'), // MATIC
   };
 


### PR DESCRIPTION
Currently, our scheduled payments Checkly alarm reports that:

>  Relayer balance low on mainnet: 0.497410141125381187 ETH; Crank balance low on mainnet: 0.492367758904139992 ETH

The process to refill that is to take/convert funds from the fee receiver and deposit native token (ether) back to the crank and the relayer. However, I checked the balance of the fee receiver and the amount is quite low (around ~50 USD worth of different tokens). So if we convert that to native token and put that amount back to the crank and the relayer, we'll probably have to do this again very soon. 

I propose a change where we lower the alarm threshold for native token balance to a lower amount so that we won't have to do that so often. Another alternative would be to simply deposit more ether into the crank/relayer but I think it's not necessary given the current level of transaction activity. 