### PR TITLE
hub: Write `tokenToUsdcRate` to payment attempts (useful for USD payment volume analytics)

### DIFF
--- a/packages/hub/config/structure.sql
+++ b/packages/hub/config/structure.sql
@@ -1256,7 +1256,8 @@ CREATE TABLE public.scheduled_payment_attempts (
     transaction_hash text,
     failure_reason text,
     scheduled_payment_id uuid NOT NULL,
-    execution_gas_price text DEFAULT '0'::text NOT NULL
+    execution_gas_price text DEFAULT '0'::text NOT NULL,
+    token_to_usdc_rate numeric
 );
 
 

--- a/packages/hub/node-tests/services/scheduled-payments/executor-test.ts
+++ b/packages/hub/node-tests/services/scheduled-payments/executor-test.ts
@@ -68,6 +68,9 @@ describe('executing scheduled payments', function () {
         gasPriceInGasToken: '1000000000',
       };
     };
+    subject.fetchTokenToUsdcRate = async () => {
+      return 1;
+    };
     prisma = await getPrisma();
     crankNonceLock = (await getContainer().lookup('crank-nonce-lock')) as CrankNonceLock;
     crankNonceLock.withNonce = async (chainId: number, cb: (nonce: BN) => Promise<any>) => {

--- a/packages/hub/node-tests/services/scheduled-payments/fetcher-test.ts
+++ b/packages/hub/node-tests/services/scheduled-payments/fetcher-test.ts
@@ -82,6 +82,10 @@ describe('fetching scheduled payments that are due', function () {
       };
     };
 
+    executor.fetchTokenToUsdcRate = async () => {
+      return 1;
+    };
+
     executor.crankNonceLock.withNonce = async () => {
       throw new Error(
         'intentional error to get into the catch block of the executor so that nextRetryAttemptAt is updated'

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -286,6 +286,7 @@ model ScheduledPaymentAttempt {
   failureReason      String?                           @map("failure_reason")
   scheduledPaymentId String                            @map("scheduled_payment_id") @db.Uuid
   executionGasPrice  String                            @default("0") @map("execution_gas_price")
+  tokenToUsdcRate    Decimal?                          @map("token_to_usdc_rate") @db.Decimal
   scheduledPayment   ScheduledPayment                  @relation(fields: [scheduledPaymentId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
   @@index([scheduledPaymentId], map: "scheduled_payment_attempts_scheduled_payment_id_index")


### PR DESCRIPTION
We'll use the rate to calculate daily payment volume in USD, in our internal analytics tool. 

I tested this with the following input:

```
// provider is connected to Polygon
Hub > await executor.fetchTokenToUsdcRate(provider, "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619") // WETH token
1911.830214182339
Hub > await executor.fetchTokenToUsdcRate(provider, "0x2791bca1f2de4661ed88a30c99a7a9449aa84174") // USDC token
1
```

The rate seems correct (1 ETH is around ~1910 USD currently, and 1 USDC is around 1 USD).

There will be an additional step to populate this column for existing (historic) scheduled payments. I'll populate those with the current rate - it shouldn't be much of a difference. 

If fetching the rate fails for some reason, the payment attempt will fail and it will be reattempted (with exponential backoff). 

