### PR TITLE
Change safe singleton version

### DIFF
--- a/packages/cardpay-sdk/contracts/addresses.ts
+++ b/packages/cardpay-sdk/contracts/addresses.ts
@@ -94,6 +94,7 @@ const SOKOL = {
 };
 const GOERLI = {
   gnosisSafeMasterCopy: '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552',
+  gnosisSafeMasterCopyL2: '0x3E5c63644E683549055b9Be8653de26E0B4CD36E',
   gnosisProxyFactory_v1_2: '0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B',
   gnosisProxyFactory_v1_3: '0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2',
   scheduledPaymentConfig: '0x856Bf7c80D9EAe82D9465F5590b5E846368745D7',
@@ -112,6 +113,7 @@ const GOERLI = {
 };
 const MUMBAI = {
   gnosisSafeMasterCopy: '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552',
+  gnosisSafeMasterCopyL2: '0x3E5c63644E683549055b9Be8653de26E0B4CD36E',
   gnosisProxyFactory_v1_2: '0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B',
   gnosisProxyFactory_v1_3: '0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2',
   scheduledPaymentConfig: '0x9c1371554F2db7F7df79cEa1c41aBaBB42EDEb9D',
@@ -133,6 +135,7 @@ const MAINNET = {
   foreignAMB: '0x4C36d2919e407f0Cc2Ee3c993ccF8ac26d9CE64e',
   chainlinkEthToUsd: '0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419',
   gnosisSafeMasterCopy: '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552',
+  gnosisSafeMasterCopyL2: '0x3E5c63644E683549055b9Be8653de26E0B4CD36E',
   gnosisProxyFactory_v1_2: '0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B',
   gnosisProxyFactory_v1_3: '0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2',
   scheduledPaymentConfig: '0xc0dd52489b04A01b9F4028849dABB46e1E54afDc',
@@ -192,6 +195,7 @@ const GNOSIS = {
 };
 const POLYGON = {
   gnosisSafeMasterCopy: '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552',
+  gnosisSafeMasterCopyL2: '0x3E5c63644E683549055b9Be8653de26E0B4CD36E',
   gnosisProxyFactory_v1_2: '0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B',
   gnosisProxyFactory_v1_3: '0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2',
   scheduledPaymentConfig: '0x143310ba9eaED49D2B544e4EC9134F5776BF0Be1',

--- a/packages/cardpay-sdk/sdk/safe-module.ts
+++ b/packages/cardpay-sdk/sdk/safe-module.ts
@@ -21,6 +21,7 @@ import {
   executeTransaction,
   gasEstimate,
   generateCreate2SafeTx,
+  getGnosisSafeMasterCopyAddress,
   getNextNonceFromEstimate,
   getSafeProxyCreationEvent,
   Operation,
@@ -155,9 +156,11 @@ export default abstract class SafeModule {
       data: setGuardTxs.txs[0].data,
     });
 
+    let gnosisSafeMasterCopyAddress = await getGnosisSafeMasterCopyAddress(this.ethersProvider);
+
     let estimateEnableSPModule = await gasEstimate(
       this.ethersProvider,
-      await getAddress('gnosisSafeMasterCopy', this.ethersProvider),
+      gnosisSafeMasterCopyAddress,
       utils.getAddress(enableModuleTxs.txs[1].to),
       enableModuleTxs.txs[1].value,
       enableModuleTxs.txs[1].data,
@@ -169,7 +172,7 @@ export default abstract class SafeModule {
 
     let estimateSetMetaGuard = await gasEstimate(
       this.ethersProvider,
-      await getAddress('gnosisSafeMasterCopy', this.ethersProvider),
+      gnosisSafeMasterCopyAddress,
       utils.getAddress(enableModuleTxs.txs[1].to),
       setGuardTxs.txs[1].value,
       setGuardTxs.txs[1].data,
@@ -295,11 +298,12 @@ export default abstract class SafeModule {
     let enableModuleTxs = await this.generateEnableModuleTxs(expectedSafeAddress, [from]);
     let setGuardTxs = await this.generateSetGuardTxs(expectedSafeAddress);
 
+    let gnosisSafeMasterCopyAddress = await getGnosisSafeMasterCopyAddress(this.ethersProvider);
     let multiSendTx = await encodeMultiSend(this.ethersProvider, [...enableModuleTxs.txs, ...setGuardTxs.txs]);
     let gnosisSafe = new Contract(expectedSafeAddress, GnosisSafeABI, this.ethersProvider);
     let estimate = await gasEstimate(
       this.ethersProvider,
-      await getAddress('gnosisSafeMasterCopy', this.ethersProvider),
+      gnosisSafeMasterCopyAddress,
       multiSendTx.to,
       multiSendTx.value,
       multiSendTx.data,
@@ -521,11 +525,13 @@ export default abstract class SafeModule {
     );
     let enableModuleTxs = await this.generateEnableModuleTxs(expectedSafeAddress, [from]);
 
+    let gnosisSafeMasterCopyAddress = await getGnosisSafeMasterCopyAddress(this.ethersProvider);
+
     let multiSendTx = await encodeMultiSend(this.ethersProvider, [...enableModuleTxs.txs]);
     let gnosisSafe = new Contract(expectedSafeAddress, GnosisSafeABI, this.ethersProvider);
     let estimate = await gasEstimate(
       this.ethersProvider,
-      await getAddress('gnosisSafeMasterCopy', this.ethersProvider),
+      gnosisSafeMasterCopyAddress,
       multiSendTx.to,
       multiSendTx.value,
       multiSendTx.data,

--- a/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
+++ b/packages/cardpay-sdk/sdk/scheduled-payment-module.ts
@@ -30,6 +30,7 @@ import {
   executeTransaction,
   gasEstimate,
   generateCreate2SafeTx,
+  getGnosisSafeMasterCopyAddress,
   getNextNonceFromEstimate,
   getSafeProxyCreationEvent,
   Operation,
@@ -260,11 +261,12 @@ export default class ScheduledPaymentModule {
     let enableModuleTxs = await this.generateEnableModuleTxs(expectedSafeAddress, [from]);
     let setGuardTxs = await this.generateSetGuardTxs(expectedSafeAddress);
 
+    let gnosisSafeMasterCopyAddress = await getGnosisSafeMasterCopyAddress(this.ethersProvider);
     let multiSendTx = await encodeMultiSend(this.ethersProvider, [...enableModuleTxs.txs, ...setGuardTxs.txs]);
     let gnosisSafe = new Contract(expectedSafeAddress, GnosisSafeABI, this.ethersProvider);
     let estimate = await gasEstimate(
       this.ethersProvider,
-      await getAddress('gnosisSafeMasterCopy', this.ethersProvider),
+      gnosisSafeMasterCopyAddress,
       multiSendTx.to,
       multiSendTx.value,
       multiSendTx.data,
@@ -349,9 +351,10 @@ export default class ScheduledPaymentModule {
       data: setGuardTxs.txs[0].data,
     });
 
+    let gnosisSafeMasterCopyAddress = await getGnosisSafeMasterCopyAddress(this.ethersProvider);
     let estimateEnableSPModule = await gasEstimate(
       this.ethersProvider,
-      await getAddress('gnosisSafeMasterCopy', this.ethersProvider),
+      gnosisSafeMasterCopyAddress,
       utils.getAddress(enableModuleTxs.txs[1].to),
       enableModuleTxs.txs[1].value,
       enableModuleTxs.txs[1].data,
@@ -363,7 +366,7 @@ export default class ScheduledPaymentModule {
 
     let estimateSetMetaGuard = await gasEstimate(
       this.ethersProvider,
-      await getAddress('gnosisSafeMasterCopy', this.ethersProvider),
+      gnosisSafeMasterCopyAddress,
       utils.getAddress(enableModuleTxs.txs[1].to),
       setGuardTxs.txs[1].value,
       setGuardTxs.txs[1].data,

--- a/packages/cardpay-sdk/sdk/utils/safe-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/safe-utils.ts
@@ -634,8 +634,8 @@ export async function getTokenBalancesForSafe(
     .filter(nonNullable);
 }
 /**
- * Utility to get gnosis safe master copy address. Gnosis has preferred to create safes using
- * L2 safe singleton which extends original safe contract with events
+ * Utility to get gnosis safe master copy address. We default to the L2 safe singleton
+ * Gnosis prefers to create safes using original safe contract
  * @group Utils
  * @category Safe
  */

--- a/packages/cardpay-sdk/sdk/utils/safe-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/safe-utils.ts
@@ -391,11 +391,8 @@ export async function generateCreate2SafeTx(
     GnosisSafeProxyFactoryABI,
     ethersProvider
   );
-  let gnosisSafeMasterCopy = new Contract(
-    await getAddress('gnosisSafeMasterCopy', ethersProvider),
-    GnosisSafeABI,
-    ethersProvider
-  );
+  let gnosisSafeMasterCopyAddress = await getGnosisSafeMasterCopyAddress(ethersProvider);
+  let gnosisSafeMasterCopy = new Contract(gnosisSafeMasterCopyAddress, GnosisSafeABI, ethersProvider);
 
   let initializer = gnosisSafeMasterCopy.interface.encodeFunctionData('setup', [
     owners,
@@ -635,4 +632,16 @@ export async function getTokenBalancesForSafe(
       return balanceSummary;
     })
     .filter(nonNullable);
+}
+/**
+ * Utility to get gnosis safe master copy address. Gnosis has preferred to create safes using
+ * L2 safe singleton which extends original safe contract with events
+ * @group Utils
+ * @category Safe
+ */
+export async function getGnosisSafeMasterCopyAddress(ethersProvider: JsonRpcProvider) {
+  return (
+    (await getAddress('gnosisSafeMasterCopyL2', ethersProvider)) ??
+    (await getAddress('gnosisSafeMasterCopy', ethersProvider))
+  );
 }

--- a/packages/cardpay-sdk/sdk/utils/safe-utils.ts
+++ b/packages/cardpay-sdk/sdk/utils/safe-utils.ts
@@ -640,8 +640,10 @@ export async function getTokenBalancesForSafe(
  * @category Safe
  */
 export async function getGnosisSafeMasterCopyAddress(ethersProvider: JsonRpcProvider) {
-  return (
-    (await getAddress('gnosisSafeMasterCopyL2', ethersProvider)) ??
-    (await getAddress('gnosisSafeMasterCopy', ethersProvider))
-  );
+  try {
+    return await getAddress('gnosisSafeMasterCopyL2', ethersProvider);
+  } catch (e) {
+    console.log("gnosis safe master copy L2 doesn't exist, defaulting to old gnosis safe master copy");
+    return await getAddress('gnosisSafeMasterCopy', ethersProvider);
+  }
 }


### PR DESCRIPTION
**Issue** 

When creating a safe via SDK, we obtain a warning. this suggest gnosis dapp may work incorrectly. 

<img width="664" alt="Screenshot 2023-04-24 at 17 15 24" src="https://user-images.githubusercontent.com/8165111/236728309-5ff09762-0cf5-43f4-993b-a5e519ed17cf.png">

The reason this occurs is because we create safe using the older safe contract master copy `0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552` for POLYGON (chainId: 137). Below is the create transaction 

<img width="1364" alt="Screenshot 2023-04-24 at 17 33 32" src="https://user-images.githubusercontent.com/8165111/236728378-47887016-d293-40e8-82a3-4d98d986de50.png">

**Change** 

We point the safe creation transactions to use a new safe contract master copy, ie [SafeL2](https://github.com/safe-global/safe-contracts/blob/main/contracts/SafeL2.sol) rather than [Safe](https://github.com/safe-global/safe-contracts/blob/main/contracts/Safe.sol). The main diff with The change will mean that we will be able to access new events pertaining to safe transactions. You can see that the safe-cli is defaulting to using l2 safe contract [here](https://github.com/5afe/safe-cli/blob/412a6b57b43258d67d67049e8dbbea4003940c4a/safe_cli/safe_creator.py#L133-L136). 

The main change is to point to the updated gnosis safe l2 contract`0x3E5c63644E683549055b9Be8653de26E0B4CD36E`. It will default to the old gnosis safe contract if the contract address cannot be found in addresses file.

```
MAINNET (chainId: 1) :0x3E5c63644E683549055b9Be8653de26E0B4CD36E
MUMBAI (chainId: 80001): 0x3E5c63644E683549055b9Be8653de26E0B4CD36E
GOERLI (chainId: 5): 0x3E5c63644E683549055b9Be8653de26E0B4CD36E
POLYGON (chainId: 137): 0x3E5c63644E683549055b9Be8653de26E0B4CD36E
// ignored some chains which are not relevant anymore
```
**Related Linear ticket**

- Ian made a change to relayer to allow some safe contract addresses [CS-5331](https://linear.app/cardstack/issue/CS-5331/update-configuration-of-the-our-polygon-and-gnosis-chain-relay) and [pr here ](https://github.com/cardstack/infra/pull/367). `0x3E5c63644E683549055b9Be8653de26E0B4CD36E` seems to be present in list of allowed singleton addresses [here](https://github.com/cardstack/infra/pull/367/files#)

**Possibly affected LIVE Services**

- payment scheduler!

**Testing** 


- [x] can create a a scheduler safe

Multi send transaction (for creation)
https://polygonscan.com/tx/0x29e8f844ba0170fb167bb862fa40a66e499080fc613747708c35690ec6204f09

The safe created is `0xEDC43a390C8eE324cC9d21C93C55c04bD6B8257f`

<img width="1105" alt="Screenshot 2023-05-09 at 16 25 12" src="https://user-images.githubusercontent.com/8165111/237039270-23477370-753b-4115-9e53-9ed58e1f4905.png">



- [x] new safe doesn't display the UI message on safe tools 

<img width="1195" alt="Screenshot 2023-05-09 at 09 30 42" src="https://user-images.githubusercontent.com/8165111/236971480-10f69f66-da26-4590-be71-da8a647d0019.png">

- [x] the safe can issue a transaction 

https://polygonscan.com/tx/0x384702f8fe2499f7dc27a17c03459ddd851e06d79f5c01fd44d85d3e3e9748d6

- [x] the safe is displayed on the safe-tools dapp

<img width="594" alt="Screenshot 2023-05-09 at 16 28 33" src="https://user-images.githubusercontent.com/8165111/237039774-efe2c16e-8290-447d-8222-19086143d57b.png">
