### PR TITLE
Fix sdk export 

### DIFF
--- a/packages/cardpay-sdk/package.json
+++ b/packages/cardpay-sdk/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./index.ts",
+      "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
   },


### PR DESCRIPTION
I dono why import is 'index.ts' when it is not even available in the root of the installed package (nor the dist folder). But 'dist/index.js' is available