### PR TITLE
Update walletconnect URL in the hub

### DIFF
--- a/packages/hub/config/default.cjs
+++ b/packages/hub/config/default.cjs
@@ -132,7 +132,7 @@ module.exports = {
     verificationUrl: null,
   },
   walletConnect: {
-    bridge: 'https://safe-walletconnect.gnosis.io/',
+    bridge: 'https://safe-walletconnect.safe.global/',
     clientURL: 'https://app.cardstack.com',
     clientName: 'Cardstack',
   },


### PR DESCRIPTION
Gnosis are/have updated their URLs, and we are nearing the deadline specified in their original announcement. A user is reporting issues and are seeing errors with connecting to a websocket at wss://safe-walletconnect.gnosis.io

Checking on a websocket tester (https://www.piesocket.com/websocket-tester)

This fails:

wss://safe-walletconnect.gnosis.io?env=browser&host=app.cardstack.com&protocol=wc&version=1

And this succeeds:

wss://safe-walletconnect.safe.global?env=browser&host=app.cardstack.com&protocol=wc&version=1

This matches the pattern of replacement URLs, and it matches the redirect you get for the https url

curl -Lv https://safe-walletconnect.gnosis.io
*   Trying 3.73.250.104:443...
* Connected to safe-walletconnect.gnosis.io (3.73.250.104) port 443 (#0)
[snipped handshake]
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: CN=gnosis.io
*  start date: Feb 10 00:00:00 2023 GMT
*  expire date: Aug 16 23:59:59 2023 GMT
*  subjectAltName: host "safe-walletconnect.gnosis.io" matched cert's "*.gnosis.io"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
> GET / HTTP/1.1
> Host: safe-walletconnect.gnosis.io
> User-Agent: curl/7.81.0
> Accept: */*
>

