### PR TITLE
Add missing checkly check in webhook that reports incidents to statuspage

### DIFF
--- a/packages/hub/routes/checkly-webhook.ts
+++ b/packages/hub/routes/checkly-webhook.ts
@@ -12,6 +12,7 @@ let log = Logger('checkly-webhook');
 type CheckName =
   | 'graph-production status check'
   | 'xdai archive health check (eth_blockNumber)'
+  | 'xdai archive health check (eth_getBlockByNumber)'
   | 'xdai non-archive health check - lively-wandering-flower (eth_blockNumber)'
   | 'relay-production health check';
 type ComponentName =
@@ -39,6 +40,12 @@ export default class ChecklyWebhookRoute {
       incidentMessage: `We are experiencing blockchain indexing delays. The blockchain index is delayed by at least ${degradedSubgraphThreshold} blocks. This will result increased transaction processing times.`,
     },
     'xdai archive health check (eth_blockNumber)': {
+      componentName: 'Archive RPC node',
+      incidentName: 'Transactions delayed',
+      incidentMessage:
+        'We are experiencing degraded service with our archive RPC node. This will result in increased transaction processing times.',
+    },
+    'xdai archive health check (eth_getBlockByNumber)': {
       componentName: 'Archive RPC node',
       incidentName: 'Transactions delayed',
       incidentMessage:


### PR DESCRIPTION
Checkly has been trying to make requests to the hub which fail with:

`Unrecognized check name: xdai archive health check (eth_getBlockByNumber)`

This resulted in statuspage updates not working (for example, it failed to resolve the incident because of that error).

This PR fixes this by adding that check to the known checks. Looks like we missed it when that check was added in infra.